### PR TITLE
WASM: Improvements and Refactor

### DIFF
--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -378,6 +378,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
         wasm::emit_u32(m_func_section, m_al, no_of_types); // reference the added type
         m_func_name_idx_map[get_hash((ASR::asr_t *)&x)] = s; // add function to map
+
+        no_of_types++;
     }
 
     template<typename T>
@@ -402,6 +404,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
 
         wasm::emit_export_fn(m_export_section, m_al, x.m_name, no_of_types); //  add function to export
+
+        no_of_functions++;
     }
 
     void visit_Function(const ASR::Function_t &x) {
@@ -409,9 +413,6 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
         emit_function_prototype(x);
         emit_function_body(x);
-
-        no_of_types++;
-        no_of_functions++;
     }
 
     void visit_Subroutine(const ASR::Subroutine_t & /* x */) {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -44,12 +44,16 @@ namespace {
 
 }  // namespace
 
+// Platform dependent fast unique hash:
+static uint64_t get_hash(ASR::asr_t *node)
+{
+    return (uint64_t)node;
+}
 
 struct import_func{
     std::string name;
     std::vector<uint8_t> param_types, result_types;
 };
-
 
 class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
    public:

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -63,6 +63,7 @@ struct SymbolInfo
     uint32_t no_of_variables = 0;
     SymbolInfo(){}
     SymbolInfo(uint32_t idx): index(idx) {}
+    SymbolInfo(uint32_t idx, uint32_t no_of_vars): index(idx), no_of_variables(no_of_vars) {}
 };
 
 class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
@@ -363,7 +364,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             ASR::Variable_t *arg = ASRUtils::EXPR2VAR(x.m_args[i]);
             LFORTRAN_ASSERT(ASRUtils::is_arg_dummy(arg->m_intent));
             emit_var_type(m_type_section, arg);
-            m_var_name_idx_map[get_hash((ASR::asr_t *)arg)] = s.no_of_variables++;
+            m_var_name_idx_map[get_hash((ASR::asr_t *)arg)] = i;
         }
 
         /********************* Result Types List *********************/
@@ -377,7 +378,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         }
 
         /********************* Add Type to Map *********************/
-        SymbolInfo s(no_of_types);
+        SymbolInfo s(no_of_types, x.n_args);
         m_func_name_idx_map[get_hash((ASR::asr_t *)&x)] = s; // add function to map
         no_of_types++;
     }

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -354,8 +354,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
     template<typename T>
     void emit_function_prototype(const T& x) {
-        wasm::emit_b8(m_type_section, m_al, 0x60);  // new type declaration starts here
-        SymbolInfo s(no_of_types);
+        /********************* New Type Declaration *********************/
+        wasm::emit_b8(m_type_section, m_al, 0x60);
 
         /********************* Parameter Types List *********************/
         wasm::emit_u32(m_type_section, m_al, x.n_args);
@@ -376,6 +376,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             return_var = nullptr;
         }
 
+        /********************* Add Type to Map *********************/
+        SymbolInfo s(no_of_types);
         m_func_name_idx_map[get_hash((ASR::asr_t *)&x)] = s; // add function to map
         no_of_types++;
     }
@@ -386,7 +388,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
         auto sym_info =  m_func_name_idx_map[get_hash((ASR::asr_t *)&x)];
 
-        wasm::emit_u32(m_func_section, m_al, sym_info.index); // reference the added type
+        /********************* Reference Function Prototype *********************/
+        wasm::emit_u32(m_func_section, m_al, sym_info.index);
 
         /********************* Function Body Starts Here *********************/
         uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
@@ -405,8 +408,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         wasm::emit_expr_end(m_code_section, m_al);
         wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
 
+        /********************* Export the function *********************/
         wasm::emit_export_fn(m_export_section, m_al, x.m_name, sym_info.index); //  add function to export
-
         no_of_functions++;
     }
 

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -306,7 +306,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     template<typename T>
-    void emit_local_vars(const T& x, int cur_idx) {
+    void emit_local_vars(const T& x, int var_idx /* starting index for local vars */) {
         /********************* Local Vars Types List *********************/
         uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
         int local_vars_cnt = 0;
@@ -316,7 +316,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 if (v->m_intent == ASRUtils::intent_local || v->m_intent == ASRUtils::intent_return_var) {
                     wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
                     emit_var_type(m_code_section, v); // emit the type of this var
-                    m_var_name_idx_map[get_hash((ASR::asr_t *)v)] = cur_idx++;
+                    m_var_name_idx_map[get_hash((ASR::asr_t *)v)] = var_idx++;
                     local_vars_cnt++;
                 }
             }

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -306,14 +306,14 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     template<typename T>
-    void emit_local_vars(const T& x, int cur_idx, bool is_main_func) {
+    void emit_local_vars(const T& x, int cur_idx) {
         /********************* Local Vars Types List *********************/
         uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
         int local_vars_cnt = 0;
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (is_main_func || v->m_intent == LFortran::ASRUtils::intent_local
+                if (v->m_intent == LFortran::ASRUtils::intent_local
                                  || v->m_intent == LFortran::ASRUtils::intent_return_var) {
                     wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
                     emit_var_type(m_code_section, v); // emit the type of this var
@@ -329,7 +329,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (is_main_func || v->m_intent == LFortran::ASRUtils::intent_local
+                if (v->m_intent == LFortran::ASRUtils::intent_local
                                  || v->m_intent == LFortran::ASRUtils::intent_return_var) {
                     if(v->m_symbolic_value) {
                         this->visit_expr(*v->m_symbolic_value);
@@ -384,7 +384,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         /********************* Function Body Starts Here *********************/
         uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
 
-        emit_local_vars(x, sym_info.no_of_variables, false);
+        emit_local_vars(x, sym_info.no_of_variables);
 
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -186,7 +186,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         {
             // Process intrinsic modules in the right order
             std::vector<std::string> build_order
-                = LFortran::ASRUtils::determine_module_dependencies(x);
+                = ASRUtils::determine_module_dependencies(x);
             for (auto &item : build_order) {
                 LFORTRAN_ASSERT(x.m_global_scope->get_scope().find(item)
                     != x.m_global_scope->get_scope().end());
@@ -313,8 +313,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (v->m_intent == LFortran::ASRUtils::intent_local
-                                 || v->m_intent == LFortran::ASRUtils::intent_return_var) {
+                if (v->m_intent == ASRUtils::intent_local || v->m_intent == ASRUtils::intent_return_var) {
                     wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
                     emit_var_type(m_code_section, v); // emit the type of this var
                     m_var_name_idx_map[get_hash((ASR::asr_t *)v)] = cur_idx++;
@@ -329,8 +328,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (v->m_intent == LFortran::ASRUtils::intent_local
-                                 || v->m_intent == LFortran::ASRUtils::intent_return_var) {
+                if (v->m_intent == ASRUtils::intent_local || v->m_intent == ASRUtils::intent_return_var) {
                     if(v->m_symbolic_value) {
                         this->visit_expr(*v->m_symbolic_value);
                         // Todo: Checking for Array is currently omitted
@@ -417,7 +415,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         this->visit_expr(*x.m_value);
         // this->visit_expr(*x.m_target);
         if (ASR::is_a<ASR::Var_t>(*x.m_target)) {
-            ASR::Variable_t *asr_target = LFortran::ASRUtils::EXPR2VAR(x.m_target);
+            ASR::Variable_t *asr_target = ASRUtils::EXPR2VAR(x.m_target);
             LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)asr_target)) != m_var_name_idx_map.end());
             wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)asr_target)]);
         } else if (ASR::is_a<ASR::ArrayItem_t>(*x.m_target)) {
@@ -812,7 +810,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_FunctionCall(const ASR::FunctionCall_t &x) {
-        ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(LFortran::ASRUtils::symbol_get_past_external(x.m_name));
+        ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
 
         for (size_t i = 0; i < x.n_args; i++) {
             visit_expr(*x.m_args[i].m_value);

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -381,47 +381,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     void visit_Function(const ASR::Function_t &x) {
         m_var_name_idx_map.clear(); // clear all previous variable and their indices
 
-        wasm::emit_b8(m_type_section, m_al, 0x60);  // new type declaration starts here
-
-        m_func_name_idx_map[x.m_name] = cur_func_idx; // add func to map early to support recursive func calls
-
-        /********************* Parameter Types List *********************/
-        uint32_t len_idx_type_section_param_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
-        int cur_idx = 0;
-        for (size_t i = 0; i < x.n_args; i++) {
-            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
-            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
-            emit_var_type(m_type_section, arg);
-            m_var_name_idx_map[arg->m_name] = cur_idx++;
-        }
-        wasm::fixup_len(m_type_section, m_al, len_idx_type_section_param_types_list);
-
-        /********************* Result Types List *********************/
-        uint32_t len_idx_type_section_return_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
-        return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
-        emit_var_type(m_type_section, return_var);
-        wasm::fixup_len(m_type_section, m_al, len_idx_type_section_return_types_list);
-
-        /********************* Function Body Starts Here *********************/
-        uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
-
-        emit_local_vars(x, cur_idx, false);
-
-        for (size_t i = 0; i < x.n_body; i++) {
-            this->visit_stmt(*x.m_body[i]);
-        }
-
-        if(x.n_body <= 0 || (x.m_body[x.n_body - 1]->type != ASR::stmtType::Return)){
-            ASR::Return_t temp;
-            visit_Return(temp);
-        }
-
-        wasm::emit_expr_end(m_code_section, m_al);
-        wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
-
-        wasm::emit_u32(m_func_section, m_al, cur_func_idx);
-
-        wasm::emit_export_fn(m_export_section, m_al, x.m_name, cur_func_idx);
+        emit_function_prototype(x);
+        emit_function_body(x);
 
         cur_func_idx++;
         no_of_functions++;

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -383,16 +383,14 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
 
         emit_local_vars(x, sym_info.no_of_variables);
-
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
-
-        if(x.n_body <= 0 || (x.m_body[x.n_body - 1]->type != ASR::stmtType::Return)){
+        if ((x.n_body > 0) && (x.m_body[x.n_body - 1]->type != ASR::stmtType::Return)) {
             handle_return();
         }
-
         wasm::emit_expr_end(m_code_section, m_al);
+
         wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
 
         /********************* Export the function *********************/


### PR DESCRIPTION
This `PR` refactors and improves the `WebAssembly` Backend.

**Highlights**:
- The maps `m_var_name_idx_map` and `m_func_name_idx_map` now use/support keys hashed using `get_hash()`. This hopefully/possibly reduces the possibilities of collision in these maps.
-  New functions `emit_function_prototype()` and ` emit_function_body()` have been added/defined which make it possible to independently define the function prototype and the function bodies. This hopefully/possibly encourages code reuse.
- The concept of `SymbolInfo` (used by the `C` and `CPP` Backends) is also introduced in this `PR`.

**Notes**:
- `visit_Subroutine()` is not yet implemented. I will implement it in upcoming `PR`/`PRs`.
- It seems this `PR` contains considerable refactoring and the upcoming `PRs` might significantly depend on this `PR`. It would be very helpful if we could possibly review and possibly merge this `PR` early.