### PR TITLE
Passes `-target` to the cc linker

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1170,7 +1170,7 @@ int link_executable(const std::vector<std::string> &infiles,
             char *env_CC = std::getenv("LFORTRAN_CC");
             if (env_CC) CC = env_CC;
             std::string base_path = "\"" + runtime_library_dir + "\"";
-            std::string options;
+            std::string options = " --target " + compiler_options.target;
             std::string runtime_lib = "lfortran_runtime";
             if (static_executable) {
                 if (compiler_options.platform != LFortran::Platform::macOS_Intel

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1166,12 +1166,15 @@ int link_executable(const std::vector<std::string> &infiles,
                 return 10;
             }
         } else {
-            std::string CC = "cc";
+            std::string CC = "clang";
             char *env_CC = std::getenv("LFORTRAN_CC");
             if (env_CC) CC = env_CC;
             std::string base_path = "\"" + runtime_library_dir + "\"";
-            std::string options = " --target " + compiler_options.target;
+            std::string options;
             std::string runtime_lib = "lfortran_runtime";
+	    if (compiler_options.target != "") {
+	      options = " -target " + compiler_options.target;
+	    }
             if (static_executable) {
                 if (compiler_options.platform != LFortran::Platform::macOS_Intel
                 && compiler_options.platform != LFortran::Platform::macOS_ARM) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1172,9 +1172,9 @@ int link_executable(const std::vector<std::string> &infiles,
             std::string base_path = "\"" + runtime_library_dir + "\"";
             std::string options;
             std::string runtime_lib = "lfortran_runtime";
-	    if (compiler_options.target != "") {
-	      options = " -target " + compiler_options.target;
-	    }
+            if (compiler_options.target != "") {
+                options = " -target " + compiler_options.target;
+            }
             if (static_executable) {
                 if (compiler_options.platform != LFortran::Platform::macOS_Intel
                 && compiler_options.platform != LFortran::Platform::macOS_ARM) {


### PR DESCRIPTION
For now you need to pass the -c option and manually link with a runtime compiled to the target. You can use -v to get the linker command line.
Runtime cross compilation and automatic selection based on target is coming soon.