### PR TITLE
LLVM: Temporarily comment out unused parameter

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -386,7 +386,7 @@ public:
             llvm::Value* end = tmp;
             llvm_dims.push_back(std::make_pair(start, end));
         }
-        arr_descr->fill_array_details(arr, m_dims, n_dims, llvm_dims);
+        arr_descr->fill_array_details(arr, n_dims, llvm_dims);
     }
 
     /*

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -291,7 +291,7 @@ namespace LFortran {
         }
 
         void SimpleCMODescriptor::fill_array_details(
-        llvm::Value* arr, ASR::dimension_t* m_dims, int n_dims,
+        llvm::Value* arr, ASR::dimension_t* /* m_dims */, int n_dims,
         std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims) {
             llvm::Value* offset_val = llvm_utils->create_gep(arr, 1);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, 0)), offset_val);

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -291,7 +291,7 @@ namespace LFortran {
         }
 
         void SimpleCMODescriptor::fill_array_details(
-        llvm::Value* arr, ASR::dimension_t* /* m_dims */, int n_dims,
+        llvm::Value* arr, int n_dims,
         std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims) {
             llvm::Value* offset_val = llvm_utils->create_gep(arr, 1);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, 0)), offset_val);

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -139,7 +139,7 @@ namespace LFortran {
                 */
                 virtual
                 void fill_array_details(
-                    llvm::Value* arr, ASR::dimension_t* m_dims, int n_dims,
+                    llvm::Value* arr, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims) = 0;
 
                 /*
@@ -317,7 +317,7 @@ namespace LFortran {
 
                 virtual
                 void fill_array_details(
-                    llvm::Value* arr, ASR::dimension_t* m_dims, int n_dims,
+                    llvm::Value* arr, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims);
 
                 virtual


### PR DESCRIPTION
It seems, with recent changes in #8 , a parameter of `SimpleCMODescriptor::fill_array_details()` is unused.

While building `LFortran`, I am receiving an `unused parameter warning`. This `PR` temporarily fixes the warning.

CC: @czgdp1807 