### PR TITLE
Refactor: WASM: Extract common return

### DIFF
--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -886,13 +886,12 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         if (cur_sym_info->return_var) {
             LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)cur_sym_info->return_var)) != m_var_name_idx_map.end());
             wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)cur_sym_info->return_var)]);
-            wasm::emit_b8(m_code_section, m_al, 0x0F); // emit wasm return instruction
         } else if(cur_sym_info->is_subroutine) {
             for(auto return_var:cur_sym_info->subroutine_return_vars) {
                 wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)(return_var))]);
             }
-            wasm::emit_b8(m_code_section, m_al, 0x0F); // emit wasm return instruction
         }
+        wasm::emit_b8(m_code_section, m_al, 0x0F); // emit wasm return instruction
     }
 
     void visit_Return(const ASR::Return_t & /* x */) {

--- a/tests/reference/wat-abs_01-0c0b4df.json
+++ b/tests/reference/wat-abs_01-0c0b4df.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-abs_01-0c0b4df.stdout",
-    "stdout_hash": "31f584007ffd6e0f2e6633f41d0f889c8b0d0d893a7fdbc11096383b",
+    "stdout_hash": "50568072d38b71f1157153278ac767aa522777b959b588cbb390954c",
     "stderr": "wat-abs_01-0c0b4df.stderr",
     "stderr_hash": "ec68e4fd4ba3567af8d45d3ffa3bc8bb8720fa29859302749e63fea9",
     "returncode": 0

--- a/tests/reference/wat-abs_01-0c0b4df.stdout
+++ b/tests/reference/wat-abs_01-0c0b4df.stdout
@@ -68,6 +68,7 @@
             call 0
             unreachable
         end
+        return
     )
     (export "sabs" (func $6))
     (export "_lcompilers_main" (func $7))

--- a/tests/reference/wat-abs_03-5d62cca.json
+++ b/tests/reference/wat-abs_03-5d62cca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-abs_03-5d62cca.stdout",
-    "stdout_hash": "9349db79c9d73d623d6afbd6a27796ff76d8195d2303d26d88f32e3c",
+    "stdout_hash": "31d44995fef92df28f6670d981b584fdc7995d578bc7a5ad8ccc9b2e",
     "stderr": "wat-abs_03-5d62cca.stderr",
     "stderr_hash": "b3dba0aaa910a5cc1365aab5d3e6411211536e6bc07af4e699024a53",
     "returncode": 0

--- a/tests/reference/wat-abs_03-5d62cca.stdout
+++ b/tests/reference/wat-abs_03-5d62cca.stdout
@@ -69,6 +69,7 @@
             call 0
             unreachable
         end
+        return
     )
     (export "iabs" (func $6))
     (export "_lcompilers_main" (func $7))

--- a/tests/reference/wat-doloop_01-4e94eaf.json
+++ b/tests/reference/wat-doloop_01-4e94eaf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-doloop_01-4e94eaf.stdout",
-    "stdout_hash": "cefd292676ab80679c9b55cdd8f9fa79d63732e7d46205f14c199ddc",
+    "stdout_hash": "8085988cfee0f65749703c4b7470cd1e8429565eb904cc938eed6bec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-doloop_01-4e94eaf.stdout
+++ b/tests/reference/wat-doloop_01-4e94eaf.stdout
@@ -444,6 +444,7 @@
         local.get 1
         call 0
         call 5
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "ERROR STOP")

--- a/tests/reference/wat-doloop_02-1ee6409.json
+++ b/tests/reference/wat-doloop_02-1ee6409.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-doloop_02-1ee6409.stdout",
-    "stdout_hash": "99ad70c9f2184d52668c52a174ca95e09f20d9a50a8eecdb90bc50ca",
+    "stdout_hash": "eb1e20c69a395aca061cc83faa5d3728342324071484f415c266de6e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-doloop_02-1ee6409.stdout
+++ b/tests/reference/wat-doloop_02-1ee6409.stdout
@@ -178,6 +178,7 @@
         local.get 0
         call 0
         call 5
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "ERROR STOP")

--- a/tests/reference/wat-doloop_03-e0c63db.json
+++ b/tests/reference/wat-doloop_03-e0c63db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-doloop_03-e0c63db.stdout",
-    "stdout_hash": "2738f4434d17f2fe1fce0cd80127caa4a6414a98168e979e5bb7f538",
+    "stdout_hash": "635256cce1a7b3416e305dcda37437209e2227e4a23dcb188ca5d88f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-doloop_03-e0c63db.stdout
+++ b/tests/reference/wat-doloop_03-e0c63db.stdout
@@ -155,6 +155,7 @@
         local.get 1
         call 0
         call 5
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "ERROR STOP")

--- a/tests/reference/wat-if_04-1d3b97a.json
+++ b/tests/reference/wat-if_04-1d3b97a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-if_04-1d3b97a.stdout",
-    "stdout_hash": "718c58f2aaa4b29f0b144ceaed5bc4ddf9d0de8206248a3b36f13605",
+    "stdout_hash": "4b0ea47dbfa74f8e5d48bdc7edbd608651b02686b3e51be7d2d108fc",
     "stderr": "wat-if_04-1d3b97a.stderr",
     "stderr_hash": "8b854a8be811f407b5f543a37121d6b73b7265ed8b67dc1c76a42d63",
     "returncode": 0

--- a/tests/reference/wat-if_04-1d3b97a.stdout
+++ b/tests/reference/wat-if_04-1d3b97a.stdout
@@ -100,6 +100,7 @@
                 end
             end
         end
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "1")

--- a/tests/reference/wat-if_05-865c1b8.json
+++ b/tests/reference/wat-if_05-865c1b8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-if_05-865c1b8.stdout",
-    "stdout_hash": "95b25eb2199dc501e33cf018906b0031ce4acb979f81bef2e2bfc795",
+    "stdout_hash": "1e0a2adebe2f9675cf9a7637f1ce7d3399d522a10d2468cba79b89f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-if_05-865c1b8.stdout
+++ b/tests/reference/wat-if_05-865c1b8.stdout
@@ -112,6 +112,7 @@
                 call 5
             end
         end
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "x: Single Line If")

--- a/tests/reference/wat-logical1-ef567ea.json
+++ b/tests/reference/wat-logical1-ef567ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical1-ef567ea.stdout",
-    "stdout_hash": "2f3331b9dfa8f547921276714e79f3a1acfe2e30d7da698901d21bb8",
+    "stdout_hash": "64c56586cbf9cc93fa137f21677737b156ea1a95901efb6045664382",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-logical1-ef567ea.stdout
+++ b/tests/reference/wat-logical1-ef567ea.stdout
@@ -24,6 +24,7 @@
         local.get 1
         call 0
         call 5
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-logical2-3eb78d2.json
+++ b/tests/reference/wat-logical2-3eb78d2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical2-3eb78d2.stdout",
-    "stdout_hash": "9959cf4d067f69f53a7bad1e9c7d7f8d7a7a442372882eeb4f9bbe3f",
+    "stdout_hash": "59bec991a79538053cc8abb188b7d2b380e5b514799549372c7a863f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-logical2-3eb78d2.stdout
+++ b/tests/reference/wat-logical2-3eb78d2.stdout
@@ -33,6 +33,7 @@
             call 4
             call 5
         end
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "Line 1 - Condition is true")

--- a/tests/reference/wat-logical3-ce72150.json
+++ b/tests/reference/wat-logical3-ce72150.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical3-ce72150.stdout",
-    "stdout_hash": "b815a540177ae89f239f071922781685b9b51623467ae410efe53115",
+    "stdout_hash": "4eefc03d2d286eb4d61f170dd2b0b44804a2fda10fcaa21f6a4ddad7",
     "stderr": "wat-logical3-ce72150.stderr",
     "stderr_hash": "bfef4a46078cd921dcbfcade08fa1a2cf35ff66f6c17e1411ae172c5",
     "returncode": 0

--- a/tests/reference/wat-logical3-ce72150.stdout
+++ b/tests/reference/wat-logical3-ce72150.stdout
@@ -217,6 +217,7 @@
             call 4
             call 5
         end
+        return
     )
     (export "_lcompilers_main" (func $6))
     (data (;0;) (i32.const 0) "Line 1 - Condition is true")

--- a/tests/reference/wat-logical4-64da104.json
+++ b/tests/reference/wat-logical4-64da104.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical4-64da104.stdout",
-    "stdout_hash": "cee9d4bfbffe93c1721540be82339fa4cb52d726cb3443540b1a37d1",
+    "stdout_hash": "2322e156df2e37693f20baed2f569676b95b1e618b33caf1da4445c9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-logical4-64da104.stdout
+++ b/tests/reference/wat-logical4-64da104.stdout
@@ -34,6 +34,7 @@
         local.get 2
         call 0
         call 5
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-types_01-c4e1000.json
+++ b/tests/reference/wat-types_01-c4e1000.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_01-c4e1000.stdout",
-    "stdout_hash": "b1740864e37d238d065cf500b273f139b4a6c26ff9709dd313093849",
+    "stdout_hash": "65627d4f3e3dfc5b029327118da4580a0fed0b9470b2cd64be31d892",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_01-c4e1000.stdout
+++ b/tests/reference/wat-types_01-c4e1000.stdout
@@ -21,6 +21,7 @@
         local.set 0
         f32.const 1.000000
         local.set 0
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-types_02-48df0cb.json
+++ b/tests/reference/wat-types_02-48df0cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_02-48df0cb.stdout",
-    "stdout_hash": "d0bbe1c023f0b7f58a61f6a38834970e9aaa611c11dc905063c88887",
+    "stdout_hash": "fc1062dc103d77c32c616e9ec118eb30f279b4ae32bcc228bcb5951b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_02-48df0cb.stdout
+++ b/tests/reference/wat-types_02-48df0cb.stdout
@@ -22,6 +22,7 @@
         local.get 0
         f32.convert_i32_s
         local.set 1
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-types_03-e07ce23.json
+++ b/tests/reference/wat-types_03-e07ce23.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_03-e07ce23.stdout",
-    "stdout_hash": "42da60bcd7f5b0676558d5b2bd440a05cba7a7284dccfcb680a0c94e",
+    "stdout_hash": "f1de2eaf62a6f4e12b517808c7a4d92ba2cc98d5fa9e131c064cdf8e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_03-e07ce23.stdout
+++ b/tests/reference/wat-types_03-e07ce23.stdout
@@ -26,6 +26,7 @@
         local.get 0
         call 0
         call 5
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-types_04-054550e.json
+++ b/tests/reference/wat-types_04-054550e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_04-054550e.stdout",
-    "stdout_hash": "3e6548ab40829b148699f22c0ee350abf8852e50bc11fb4e89b9b6de",
+    "stdout_hash": "b1ede9cf7cf06e60f81fbdbb6ef3b300f2db10e76be8a1b1a323aa54",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_04-054550e.stdout
+++ b/tests/reference/wat-types_04-054550e.stdout
@@ -95,6 +95,7 @@
         f32.convert_i32_s
         f32.div
         local.set 2
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-types_05-884adc8.json
+++ b/tests/reference/wat-types_05-884adc8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_05-884adc8.stdout",
-    "stdout_hash": "7162864116fa7862e17c1f647ba40445cbf37a603a036694aad84c3f",
+    "stdout_hash": "b3074e0e674c7f6e0ebc88854aae9d058e47c528e95e6c33cde8f57a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_05-884adc8.stdout
+++ b/tests/reference/wat-types_05-884adc8.stdout
@@ -43,6 +43,7 @@
         local.set 0
         i32.const 0
         local.set 0
+        return
     )
     (export "_lcompilers_main" (func $6))
 )

--- a/tests/reference/wat-types_15-abe4006.json
+++ b/tests/reference/wat-types_15-abe4006.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_15-abe4006.stdout",
-    "stdout_hash": "091c223a69b1e02aaebda4c6151fce6d13d977211e29c4a65a2b8900",
+    "stdout_hash": "1568df48adb7721b4337f7cc89735f1b5efeb86634b0a88f79ce506a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_15-abe4006.stdout
+++ b/tests/reference/wat-types_15-abe4006.stdout
@@ -123,6 +123,7 @@
         local.get 5
         call 3
         call 5
+        return
     )
     (export "kind" (func $6))
     (export "_lcompilers_main" (func $7))

--- a/tests/reference/wat-wasm1-8a138d6.json
+++ b/tests/reference/wat-wasm1-8a138d6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm1-8a138d6.stdout",
-    "stdout_hash": "225dd68affdd36b857ba167e12f492024c7a79d6033d77e98f44e53c",
+    "stdout_hash": "b07cedea023c3ca896b9753ce52007f95a77a758b11b20b475834e67",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm1-8a138d6.stdout
+++ b/tests/reference/wat-wasm1-8a138d6.stdout
@@ -91,6 +91,7 @@
         call 10
         call 0
         call 5
+        return
     )
     (export "a_sqr" (func $6))
     (export "add" (func $7))

--- a/tests/reference/wat-wasm_floats-c84c674.json
+++ b/tests/reference/wat-wasm_floats-c84c674.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_floats-c84c674.stdout",
-    "stdout_hash": "7c4d3b1da1ad499fefb243238bd7f0325e22a73b89892714bab1446e",
+    "stdout_hash": "a1aebcd5b2a688115867b2367fbb61d7d759315845897d5b7700533b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_floats-c84c674.stdout
+++ b/tests/reference/wat-wasm_floats-c84c674.stdout
@@ -101,6 +101,7 @@
         call 12
         call 3
         call 5
+        return
     )
     (export "kind" (func $6))
     (export "a_sqr" (func $7))

--- a/tests/reference/wat-wasm_i64-3afdb24.json
+++ b/tests/reference/wat-wasm_i64-3afdb24.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_i64-3afdb24.stdout",
-    "stdout_hash": "251e830ea5dfefbb873a3baa8115f2e54e6d5ac35bdfcf5c8712740e",
+    "stdout_hash": "5fb5b1c37a08c16ad8173e35680cd16f3e4ac76cacc3b6c1512fc7a8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_i64-3afdb24.stdout
+++ b/tests/reference/wat-wasm_i64-3afdb24.stdout
@@ -61,6 +61,7 @@
         call 8
         call 1
         call 5
+        return
     )
     (export "a_sqr_i64" (func $6))
     (export "add_i64" (func $7))

--- a/tests/reference/wat-wasm_main_program-7a34895.json
+++ b/tests/reference/wat-wasm_main_program-7a34895.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_main_program-7a34895.stdout",
-    "stdout_hash": "6e158c8f04b994dcf3f5a7312b54faa6f01e2ab358651aae78ee8410",
+    "stdout_hash": "f23be4516a557c0b86ade17463589d483f26d36eac3827e2d329bc46",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_main_program-7a34895.stdout
+++ b/tests/reference/wat-wasm_main_program-7a34895.stdout
@@ -67,6 +67,7 @@
         i32.const 4
         call 4
         call 5
+        return
     )
     (export "sqr" (func $6))
     (export "_lcompilers_main" (func $7))

--- a/tests/reference/wat-wasm_unary_minus-81a29ff.json
+++ b/tests/reference/wat-wasm_unary_minus-81a29ff.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_unary_minus-81a29ff.stdout",
-    "stdout_hash": "ea142765b118f299aca2349c778ce9159e41776666275a320ff8b3c6",
+    "stdout_hash": "1a161b51cbbfccd6cc04bf3aec4cf68a85c32df3263e8e6c3eed20cd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_unary_minus-81a29ff.stdout
+++ b/tests/reference/wat-wasm_unary_minus-81a29ff.stdout
@@ -60,6 +60,7 @@
         call 8
         call 1
         call 5
+        return
     )
     (export "get_num_neg_i32" (func $6))
     (export "get_num_neg_i64" (func $7))


### PR DESCRIPTION
This `PR` does a minor refactor. This is/was part of #21. But since many tests were changing due to this refactor, I am submitting it as a separate `PR`.