### PR TITLE
backend-cpp: install lfortran_intrinsics.h

### DIFF
--- a/src/runtime/legacy/CMakeLists.txt
+++ b/src/runtime/legacy/CMakeLists.txt
@@ -25,3 +25,9 @@ if(WITH_RUNTIME_LIBRARY)
         LIBRARY DESTINATION share/lfortran/lib
     )
 endif()
+
+# Install the header
+install(
+    FILES ../impure/lfortran_intrinsics.h
+    DESTINATION share/lfortran/lib/impure
+)


### PR DESCRIPTION
Ignore the following error.
```
$ LFORTRAN_KOKKOS_DIR=/home/test/install-prefix /home/test/install-prefix/bin/lfortran --backend=cpp ~/test.f90
a.out.tmp.o.tmp.cpp:8:10: fatal error: lfortran_intrinsics.h: No such file or directory
    8 | #include <lfortran_intrinsics.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
The command 'g++ -std=c++17 -I/home/test/install-prefix/include -I/home/test/install-prefix/bin/../share/lfortran/lib/impure -o a.out.tmp.o -c a.out.tmp.o.tmp.cpp' failed.
```