### PR TITLE
Skip md files for trailing whitespace fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
+        exclude: ".md"
     -   id: end-of-file-fixer
     -   id: fix-encoding-pragma
         args: [--remove]


### PR DESCRIPTION
The trailing whitespace is used as a newline.