### PR TITLE
Implement other error formats

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1470,6 +1470,7 @@ int main(int argc, char *argv[])
         app.add_flag("--static", static_link, "Create a static executable");
         app.add_flag("--no-warnings", compiler_options.no_warnings, "Turn off all warnings");
         app.add_flag("--no-error-banner", compiler_options.no_error_banner, "Turn off error banner");
+        app.add_option("--error-format", compiler_options.error_format, "Control how errors are produced (human, short)")->capture_default_str();
         app.add_option("--backend", arg_backend, "Select a backend (llvm, cpp, x86, wasm)")->capture_default_str();
         app.add_flag("--openmp", compiler_options.openmp, "Enable openmp");
         app.add_flag("--fast", compiler_options.fast, "Best performance (disable strict standard compliance)");

--- a/src/lfortran/tests/test_error_rendering.cpp
+++ b/src/lfortran/tests/test_error_rendering.cpp
@@ -25,7 +25,7 @@ using LFortran::LocationManager;
 TEST_CASE("Error Render: no labels") {
     std::string out, ref;
 
-    out = render_diagnostic(Diagnostic(
+    out = render_diagnostic_human(Diagnostic(
             "Error no label",
             Level::Error, Stage::Parser
         ), false
@@ -36,7 +36,7 @@ syntax error: Error no label
     CHECK(out == ref);
 
 
-    out = render_diagnostic(Diagnostic(
+    out = render_diagnostic_human(Diagnostic(
             "Error no label",
             Level::Error, Stage::Semantic
         ), false
@@ -46,7 +46,7 @@ semantic error: Error no label
 )""");
     CHECK(out == ref);
 
-    out = render_diagnostic(Diagnostic(
+    out = render_diagnostic_human(Diagnostic(
             "Error no label",
             Level::Warning, Stage::Semantic
         ), false
@@ -84,7 +84,7 @@ TEST_CASE("Error Render: primary/secondary labels, single line") {
                 Label("", {loc1})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with label no message
  --> input:1:5
@@ -102,7 +102,7 @@ semantic error: Error with label no message
                 Label("label message", {loc1, loc2})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with label and message
  --> input:1:5
@@ -119,7 +119,7 @@ semantic error: Error with label and message
                 Label("label message", {loc1, loc2, loc3})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with label and message
  --> input:1:5
@@ -140,7 +140,7 @@ semantic error: Error with label and message
                 Label("label2 message", {loc2})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with two labels and message
  --> input:1:5
@@ -162,7 +162,7 @@ semantic error: Error with two labels and message
                 Label("label3 message", {loc3})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with two labels and message
  --> input:1:5
@@ -187,7 +187,7 @@ semantic error: Error with two labels and message
                 Label("label3 secondary message", {loc3}, false)
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with two labels and message
  --> input:1:5
@@ -212,7 +212,7 @@ semantic error: Error with two labels and message
                 Label("label3 secondary message", {loc3}, false)
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with three labels and message, two spans
  --> input:1:5
@@ -255,7 +255,7 @@ TEST_CASE("Error Render: primary/secondary labels, multi line") {
                 Label("Multilines", {loc1})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with label no message
  --> input:1:5 - 2:11
@@ -276,7 +276,7 @@ semantic error: Error with label no message
                 Label("Two spans", {loc1, loc2})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with label, two spans
  --> input:1:5 - 2:11
@@ -304,7 +304,7 @@ semantic error: Error with label, two spans
                 Label("Two spans", {loc3, loc2})
             }
         );
-    out = render_diagnostic(d, input, lm, false, false);
+    out = render_diagnostic_human(d, input, lm, false, false);
     ref = S(R"""(
 semantic error: Error with label, two spans
  --> input:1:1

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -68,7 +68,7 @@ std::string Diagnostics::render(const std::string &input,
         if (compiler_options.no_warnings && d.level != Level::Error) {
             continue;
         }
-        out += render_diagnostic(d, input, lm,
+        out += render_diagnostic_human(d, input, lm,
             compiler_options.use_colors,
             compiler_options.show_stacktrace);
         if (&d != &this->diagnostics.back()) out += "\n";
@@ -124,7 +124,7 @@ void populate_spans(diag::Diagnostic &d, const LocationManager &lm,
 }
 
 // Fills Diagnostic with span details and renders it
-std::string render_diagnostic(Diagnostic &d, const std::string &input,
+std::string render_diagnostic_human(Diagnostic &d, const std::string &input,
         const LocationManager &lm, bool use_colors, bool show_stacktrace) {
     std::string out;
     if (show_stacktrace) {
@@ -133,11 +133,11 @@ std::string render_diagnostic(Diagnostic &d, const std::string &input,
     // Convert to line numbers and get source code strings
     populate_spans(d, lm, input);
     // Render the message
-    out += render_diagnostic(d, use_colors);
+    out += render_diagnostic_human(d, use_colors);
     return out;
 }
 
-std::string render_diagnostic(const Diagnostic &d, bool use_colors) {
+std::string render_diagnostic_human(const Diagnostic &d, bool use_colors) {
     std::string bold  = "\033[0;1m";
     std::string red_bold  = "\033[0;31;1m";
     std::string yellow_bold  = "\033[0;33;1m";

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -68,23 +68,31 @@ std::string Diagnostics::render(const std::string &input,
         if (compiler_options.no_warnings && d.level != Level::Error) {
             continue;
         }
-        out += render_diagnostic_human(d, input, lm,
-            compiler_options.use_colors,
-            compiler_options.show_stacktrace);
-        if (&d != &this->diagnostics.back()) out += "\n";
+        if (compiler_options.error_format == "human") {
+            out += render_diagnostic_human(d, input, lm,
+                compiler_options.use_colors,
+                compiler_options.show_stacktrace);
+            if (&d != &this->diagnostics.back()) out += "\n";
+        } else if (compiler_options.error_format == "short") {
+            out += render_diagnostic_short(d, input, lm);
+        } else {
+            throw LCompilersException("Error format not supported.");
+        }
     }
-    if (this->diagnostics.size() > 0 && !compiler_options.no_error_banner) {
-        if (!compiler_options.no_warnings || has_error()) {
-            std::string bold  = "\033[0;1m";
-            std::string reset = "\033[0;00m";
-            if (!compiler_options.use_colors) {
-                bold = "";
-                reset = "";
+    if (compiler_options.error_format == "human") {
+        if (this->diagnostics.size() > 0 && !compiler_options.no_error_banner) {
+            if (!compiler_options.no_warnings || has_error()) {
+                std::string bold  = "\033[0;1m";
+                std::string reset = "\033[0;00m";
+                if (!compiler_options.use_colors) {
+                    bold = "";
+                    reset = "";
+                }
+                out += "\n\n";
+                out += bold + "Note" + reset
+                    + ": if any of the above error or warning messages are not clear or are lacking\n";
+                out += "context please report it to us (we consider that a bug that needs to be fixed).\n";
             }
-            out += "\n\n";
-            out += bold + "Note" + reset
-                + ": if any of the above error or warning messages are not clear or are lacking\n";
-            out += "context please report it to us (we consider that a bug that needs to be fixed).\n";
         }
     }
     return out;
@@ -134,6 +142,17 @@ std::string render_diagnostic_human(Diagnostic &d, const std::string &input,
     populate_spans(d, lm, input);
     // Render the message
     out += render_diagnostic_human(d, use_colors);
+    return out;
+}
+
+// Fills Diagnostic with span details and renders it
+std::string render_diagnostic_short(Diagnostic &d, const std::string &input,
+        const LocationManager &lm) {
+    std::string out;
+    // Convert to line numbers and get source code strings
+    populate_spans(d, lm, input);
+    // Render the message
+    out += render_diagnostic_short(d);
     return out;
 }
 
@@ -317,6 +336,66 @@ std::string render_diagnostic_human(const Diagnostic &d, bool use_colors) {
             }
         } // Labels
     }
+    return out.str();
+}
+
+std::string render_diagnostic_short(const Diagnostic &d) {
+    std::stringstream out;
+
+    std::string message_type = "";
+    switch (d.level) {
+        case (Level::Error):
+            switch (d.stage) {
+                case (Stage::CPreprocessor):
+                    message_type = "C preprocessor error";
+                    break;
+                case (Stage::Prescanner):
+                    message_type = "prescanner error";
+                    break;
+                case (Stage::Tokenizer):
+                    message_type = "tokenizer error";
+                    break;
+                case (Stage::Parser):
+                    message_type = "syntax error";
+                    break;
+                case (Stage::Semantic):
+                    message_type = "semantic error";
+                    break;
+                case (Stage::ASRPass):
+                    message_type = "ASR pass error";
+                    break;
+                case (Stage::CodeGen):
+                    message_type = "code generation error";
+                    break;
+            }
+            break;
+        case (Level::Warning):
+            message_type = "warning";
+            break;
+        case (Level::Note):
+            message_type = "note";
+            break;
+        case (Level::Help):
+            message_type = "help";
+            break;
+        case (Level::Style):
+            message_type = "style suggestion";
+            break;
+    }
+
+    if (d.labels.size() > 0) {
+        Label l = d.labels[0];
+        Span s = l.spans[0];
+        // TODO: print the primary line+column here, not the first label:
+        out << s.filename << ":" << s.first_line << ":" << s.first_column;
+        if (s.first_line != s.last_line) {
+            out << " - " << s.last_line << ":" << s.last_column;
+        }
+        out << " ";
+    }
+
+    out << message_type << ": " << d.message << std::endl;
+
     return out.str();
 }
 

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -183,10 +183,10 @@ struct Diagnostics {
     }
 };
 
-std::string render_diagnostic(const Diagnostic &d, bool use_colors);
+std::string render_diagnostic_human(const Diagnostic &d, bool use_colors);
 
 // Fills Diagnostic with span details and renders it
-std::string render_diagnostic(Diagnostic &d, const std::string &input,
+std::string render_diagnostic_human(Diagnostic &d, const std::string &input,
         const LocationManager &lm, bool use_colors, bool show_stacktrace); 
 
 } // namespace diag

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -184,10 +184,13 @@ struct Diagnostics {
 };
 
 std::string render_diagnostic_human(const Diagnostic &d, bool use_colors);
+std::string render_diagnostic_short(const Diagnostic &d);
 
 // Fills Diagnostic with span details and renders it
 std::string render_diagnostic_human(Diagnostic &d, const std::string &input,
         const LocationManager &lm, bool use_colors, bool show_stacktrace); 
+std::string render_diagnostic_short(Diagnostic &d, const std::string &input,
+        const LocationManager &lm); 
 
 } // namespace diag
 } // namespace LFortran

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -31,6 +31,7 @@ struct CompilerOptions {
     bool openmp = false;
     bool no_warnings = false;
     bool no_error_banner = false;
+    std::string error_format = "human";
     bool new_parser = false;
     std::string target = "";
     Platform platform;


### PR DESCRIPTION
For now do "human" (default) and "short" (one line errors).

Example:
```console
$ lfortran --show-asr tests/errors/type_mismatch1.f90 --error-format=short
tests/errors/type_mismatch1.f90:4:1 semantic error: Type mismatch in assignment, the types must be compatible
$ lfortran --show-asr tests/errors/type_mismatch1.f90 --error-format=human
semantic error: Type mismatch in assignment, the types must be compatible
 --> tests/errors/type_mismatch1.f90:4:1
  |
4 | x = "x"
  | ^   ^^^ type mismatch (integer and character)


Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
```