### PR TITLE
Fix Compiler Warnings

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1428,7 +1428,7 @@ static inline ASR::expr_t* compute_length_from_start_end(Allocator& al, ASR::exp
     ASR::expr_t* end_value = ASRUtils::expr_value(end);
     ASR::expr_t* length_value = nullptr;
     if( start_value && end_value ) {
-        int64_t start_int, end_int;
+        int64_t start_int = -1, end_int = -1;
         ASRUtils::extract_value(start_value, start_int);
         ASRUtils::extract_value(end_value, end_int);
         length_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, start->base.loc,

--- a/src/runtime/impure/lfortran_intrinsics.c
+++ b/src/runtime/impure/lfortran_intrinsics.c
@@ -652,7 +652,7 @@ LFORTRAN_API char* _lfortran_int_to_str4(int32_t num)
 LFORTRAN_API char* _lfortran_int_to_str8(int64_t num)
 {
     char* res = (char*)malloc(40);
-    sprintf(res, "%lld", num);
+    sprintf(res, "%ld", num);
     return res;
 }
 


### PR DESCRIPTION
This `PR` fixes the following compiler warnings:

At **CI**:
```bash
/lfortran/lfortran-0.16.0-212-g34f250421/src/libasr/asr_utils.h:1435:44: warning: ‘end_int’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1435 |                                    end_int - start_int + 1,
```
```bash
/lfortran/lfortran-0.16.0-212-g34f250421/src/libasr/asr_utils.h:1435:44: warning: ‘start_int’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1435 |                                    end_int - start_int + 1,
```
**Locally** as well as **CI**:
```bash
lfortran/src/runtime/impure/lfortran_intrinsics.c:655:22: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
  655 |     sprintf(res, "%lld", num);
      |                   ~~~^   ~~~
      |                      |   |
      |                      |   int64_t {aka long int}
      |                      long long int
      |                   %ld
```