### PR TITLE
Fix a compiler warning

### DIFF
--- a/src/runtime/impure/lfortran_intrinsics.c
+++ b/src/runtime/impure/lfortran_intrinsics.c
@@ -652,7 +652,8 @@ LFORTRAN_API char* _lfortran_int_to_str4(int32_t num)
 LFORTRAN_API char* _lfortran_int_to_str8(int64_t num)
 {
     char* res = (char*)malloc(40);
-    sprintf(res, "%ld", num);
+    long long num2 = num;
+    sprintf(res, "%lld", num2);
     return res;
 }
 


### PR DESCRIPTION
    .../lfortran/src/runtime/impure/lfortran_intrinsics.c:655:25: warning: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Wformat]
        sprintf(res, "%ld", num);
                      ~~~   ^~~
                      %lld