### PR TITLE
WAT: Arrays Fix

### DIFF
--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -66,7 +66,7 @@ void WASMDecoder::decode_imports_section(uint32_t offset) {
         for (uint32_t j = 0; j < mod_name_size; j++) {
             imports.p[i].mod_name[j] = read_b8(wasm_bytes, offset);
         }
-        
+
         uint32_t name_size = read_u32(wasm_bytes, offset);
         imports.p[i].name.resize(name_size); // do not pass al to this resize as it is std::string.resize()
         for (uint32_t j = 0; j < name_size; j++) {
@@ -94,7 +94,7 @@ void WASMDecoder::decode_imports_section(uint32_t offset) {
                 }
                 break;
             }
-            
+
             default: {
                 std::cout << "Only importing functions and memory are currently supported" << std::endl;
                 LFORTRAN_ASSERT(false);
@@ -293,7 +293,7 @@ std::string WASMDecoder::get_wat() {
     }
 
     for(uint32_t i = 0; i < data_segments.size(); i++){
-        result += indent + "(data (;" + std::to_string(i) + ";) (" + data_segments[i].insts + ") \"" + data_segments[i].text + "\")"; 
+        result += indent + "(data (;" + std::to_string(i) + ";) (" + data_segments[i].insts + ") \"" + data_segments[i].text + "\")";
     }
 
     result += "\n)\n";

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -164,75 +164,52 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
     void visit_F64PromoteF32() { src += indent + "f64.promote_f32"; }
     void visit_F64DivS() { src += indent + "f64.div_s"; }
 
-    void visit_I32Load(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.load " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_F32Load(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "f32.load " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_F64Load(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "f64.load " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Load8S(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.load8_s " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Load8U(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.load8_u " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Load16S(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.load16_s " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Load16U(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.load16_u " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load8S(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load8_s " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load8U(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load8_u " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load16S(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load16_s " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load16U(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load16_u " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load32S(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load32_s " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Load32U(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.load32_u " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Store(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.store " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Store(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.store " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_F32Store(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "f32.store " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_F64Store(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "f64.store " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Store8(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.store8 " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I32Store16(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i32.store16 " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Store8(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.store8 " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Store16(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.store16 " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
-    void visit_I64Store32(uint32_t mem_align, uint32_t mem_offset) {
-        src += indent + "i64.store32 " + std::to_string(mem_align) + " " + std::to_string(mem_offset);
-    }
+    void visit_I32Load(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_F32Load(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "f32.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_F64Load(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "f64.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Load8S(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.load8_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Load8U(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.load8_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Load16S(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.load16_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Load16U(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.load16_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load8S(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load8_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load8U(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load8_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load16S(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load16_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load16U(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load16_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load32S(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load32_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Load32U(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.load32_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Store(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Store(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_F32Store(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "f32.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_F64Store(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "f64.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Store8(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.store8 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I32Store16(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i32.store16 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Store8(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.store8 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Store16(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.store16 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
+    void visit_I64Store32(uint32_t mem_align, uint32_t mem_offset)
+    { src += indent + "i64.store32 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
 
 };
 

--- a/src/libasr/codegen/wasm_utils.cpp
+++ b/src/libasr/codegen/wasm_utils.cpp
@@ -8,7 +8,7 @@ uint32_t decode_leb128_u32(Vec<uint8_t> &code, uint32_t &offset) {
     uint32_t result = 0U;
     uint32_t shift = 0U;
     while (true) {
-        uint8_t byte = code.p[offset++];
+        uint8_t byte = read_b8(code, offset);
         uint32_t slice = byte & 0x7f;
         result |= slice << shift;
         if ((byte & 0x80) == 0) {
@@ -24,7 +24,7 @@ int32_t decode_leb128_i32(Vec<uint8_t> &code, uint32_t &offset) {
     uint8_t byte;
 
     do {
-        byte = code.p[offset++];
+        byte = read_b8(code, offset);
         uint32_t slice = byte & 0x7f;
         result |= slice << shift;
         shift += 7;
@@ -44,7 +44,7 @@ int64_t decode_leb128_i64(Vec<uint8_t> &code, uint32_t &offset) {
     uint8_t byte;
 
     do {
-        byte = code.p[offset++];
+        byte = read_b8(code, offset);
         uint64_t slice = byte & 0x7f;
         result |= slice << shift;
         shift += 7;

--- a/src/libasr/wasm_instructions.txt
+++ b/src/libasr/wasm_instructions.txt
@@ -30,29 +30,29 @@
 0xFC u32:num:15 u32:tableidx:𝑥 ⇒ table.grow 𝑥
 0xFC u32:num:16 u32:tableidx:𝑥 ⇒ table.size 𝑥
 0xFC u32:num:17 u32:tableidx:𝑥 ⇒ table.fill 𝑥
-0x28 u32:align:𝒶 u32:offset:𝑜 ⇒ i32.load 𝑚
-0x29 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load 𝑚
-0x2A u32:align:𝒶 u32:offset:𝑜 ⇒ f32.load 𝑚
-0x2B u32:align:𝒶 u32:offset:𝑜 ⇒ f64.load 𝑚
-0x2C u32:align:𝒶 u32:offset:𝑜 ⇒ i32.load8_s 𝑚
-0x2D u32:align:𝒶 u32:offset:𝑜 ⇒ i32.load8_u 𝑚
-0x2E u32:align:𝒶 u32:offset:𝑜 ⇒ i32.load16_s 𝑚
-0x2F u32:align:𝒶 u32:offset:𝑜 ⇒ i32.load16_u 𝑚
-0x30 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load8_s 𝑚
-0x31 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load8_u 𝑚
-0x32 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load16_s 𝑚
-0x33 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load16_u 𝑚
-0x34 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load32_s 𝑚
-0x35 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.load32_u 𝑚
-0x36 u32:align:𝒶 u32:offset:𝑜 ⇒ i32.store 𝑚
-0x37 u32:align:𝒶 u32:offset:𝑜 ⇒ i64.store 𝑚
-0x38 u32:align:𝒶 u32:offset:𝑜 ⇒ f32.store 𝑚
-0x39 u32:align:𝒶 u32:offset:𝑜 ⇒ f64.store 𝑚
-0x3A u32:align:𝒶 u32:offset:𝑜 ⇒ i32.store8 𝑚
-0x3B u32:align:𝒶 u32:offset:𝑜 ⇒ i32.store16 𝑚
-0x3C u32:align:𝒶 u32:offset:𝑜 ⇒ i64.store8 𝑚
-0x3D u32:align:𝒶 u32:offset:𝑜 ⇒ i64.store16 𝑚
-0x3E u32:align:𝒶 u32:offset:𝑜 ⇒ i64.store32 𝑚
+0x28 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.load 𝑚
+0x29 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load 𝑚
+0x2A u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ f32.load 𝑚
+0x2B u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ f64.load 𝑚
+0x2C u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.load8_s 𝑚
+0x2D u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.load8_u 𝑚
+0x2E u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.load16_s 𝑚
+0x2F u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.load16_u 𝑚
+0x30 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load8_s 𝑚
+0x31 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load8_u 𝑚
+0x32 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load16_s 𝑚
+0x33 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load16_u 𝑚
+0x34 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load32_s 𝑚
+0x35 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.load32_u 𝑚
+0x36 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.store 𝑚
+0x37 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.store 𝑚
+0x38 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ f32.store 𝑚
+0x39 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ f64.store 𝑚
+0x3A u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.store8 𝑚
+0x3B u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i32.store16 𝑚
+0x3C u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.store8 𝑚
+0x3D u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.store16 𝑚
+0x3E u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ i64.store32 𝑚
 -- 0x3F u8:temp_byte:0x00 ⇒ memory.size
 -- 0x40 u8:temp_byte:0x00 ⇒ memory.grow
 -- 0xFC u32:num:8 u32:dataidx:𝑥 u8:temp_byte:0x00 ⇒ memory.init 𝑥
@@ -199,28 +199,28 @@
 0xFC u32:num:5 ⇒ i64.trunc_sat_f32_u
 0xFC u32:num:6 ⇒ i64.trunc_sat_f64_s
 0xFC u32:num:7 ⇒ i64.trunc_sat_f64_u
-0xFD u32:num:0 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load 𝑚
-0xFD u32:num:1 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load8x8_s 𝑚
-0xFD u32:num:2 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load8x8_u 𝑚
-0xFD u32:num:3 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load16x4_s 𝑚
-0xFD u32:num:4 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load16x4_u 𝑚
-0xFD u32:num:5 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load32x2_s 𝑚
-0xFD u32:num:6 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load32x2_u 𝑚
-0xFD u32:num:7 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load8_splat 𝑚
-0xFD u32:num:8 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load16_splat 𝑚
-0xFD u32:num:9 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load32_splat 𝑚
-0xFD u32:num:10 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load64_splat 𝑚
-0xFD u32:num:92 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load32_zero 𝑚
-0xFD u32:num:93 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.load64_zero 𝑚
-0xFD u32:num:11 u32:align:𝒶 u32:offset:𝑜 ⇒ v128.store 𝑚
-0xFD u32:num:84 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load8_lane 𝑚 𝑙
-0xFD u32:num:85 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load16_lane 𝑚 𝑙
-0xFD u32:num:86 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load32_lane 𝑚 𝑙
-0xFD u32:num:87 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load64_lane 𝑚 𝑙
-0xFD u32:num:88 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store8_lane 𝑚 𝑙
-0xFD u32:num:89 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store16_lane 𝑚 𝑙
-0xFD u32:num:90 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store32_lane 𝑚 𝑙
-0xFD u32:num:91 u32:align:𝒶 u32:offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store64_lane 𝑚 𝑙
+0xFD u32:num:0 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load 𝑚
+0xFD u32:num:1 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load8x8_s 𝑚
+0xFD u32:num:2 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load8x8_u 𝑚
+0xFD u32:num:3 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load16x4_s 𝑚
+0xFD u32:num:4 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load16x4_u 𝑚
+0xFD u32:num:5 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load32x2_s 𝑚
+0xFD u32:num:6 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load32x2_u 𝑚
+0xFD u32:num:7 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load8_splat 𝑚
+0xFD u32:num:8 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load16_splat 𝑚
+0xFD u32:num:9 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load32_splat 𝑚
+0xFD u32:num:10 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load64_splat 𝑚
+0xFD u32:num:92 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load32_zero 𝑚
+0xFD u32:num:93 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.load64_zero 𝑚
+0xFD u32:num:11 u32:mem_align:𝒶 u32:mem_offset:𝑜 ⇒ v128.store 𝑚
+0xFD u32:num:84 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load8_lane 𝑚 𝑙
+0xFD u32:num:85 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load16_lane 𝑚 𝑙
+0xFD u32:num:86 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load32_lane 𝑚 𝑙
+0xFD u32:num:87 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.load64_lane 𝑚 𝑙
+0xFD u32:num:88 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store8_lane 𝑚 𝑙
+0xFD u32:num:89 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store16_lane 𝑚 𝑙
+0xFD u32:num:90 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store32_lane 𝑚 𝑙
+0xFD u32:num:91 u32:mem_align:𝒶 u32:mem_offset:𝑜 u8:laneidx:𝑙 ⇒ v128.store64_lane 𝑚 𝑙
 -- 0xFD u32:num:12 (𝑏:byte)16 ⇒ v128.const bytes−1 i128(𝑏0 . . . 𝑏15)
 -- 0xFD u32:num:13 (u8:laneidx:𝑙)16 ⇒ i8x16.shuffle 𝑙16
 0xFD u32:num:21 u8:laneidx:𝑙 ⇒ i8x16.extract_lane_s 𝑙


### PR DESCRIPTION
The previous `PR` #49 fails with `segmentation fault` for `integration_tests/arrays_01.f90` during `wat` generation.

This `PR` fixes the bug and adds support for `wat` generation for basic arrays.