### PR TITLE
Out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,11 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
 # We don't execute this if we have a tarball
 if (LFORTRAN_BUILD_ALL)
-  execute_process(COMMAND "build0.sh")
+    find_program(BASH_BIN bash)
+    execute_process(COMMAND "${BASH_BIN}" "build0.sh" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-file(STRINGS "version" LFORTRAN_VERSION)
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/version" LFORTRAN_VERSION)
 
 project(lfortran LANGUAGES C CXX)
 


### PR DESCRIPTION
Fix bug with cmake calling build0.sh

Ensures that build0.sh is called with bash AND from the right directory.
This now allows for out-of-source builds.

Also removes the need to call `./build0.sh` in envs with bash
before calling cmake.

---

You could technically now remove all the calls to `./build0.sh`.

On a separate note, you might want to rename the calls to `python` --> `python3` in the scripts to make lfortran buildable from envs (other than anaconda) that do not have the alias setup.