### PR TITLE
CI: Support integration tests testing for WASM

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,7 +118,7 @@ jobs:
             cd integration_tests
             ./run_tests.py -b llvm
 
-  llvm_14:
+  test_llvm_14:
     name: Test LLVM 14
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -217,6 +217,14 @@ jobs:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
 
+      - name: Display Versions
+        shell: bash -l {0}
+        run: |
+          set -ex
+          emcc --version
+          em++ --version
+          node --version
+
       - name: Build Linux
         shell: bash -l {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -197,6 +197,48 @@ jobs:
         run: |
             xonsh ci/test_cpp_version.xsh
 
+  test_wasm:
+    name: Test WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/provision-with-micromamba@v12
+        with:
+          environment-file: ci/environment_linux.yml
+          extra-specs: |
+            python=3.10
+            emscripten
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-${{ matrix.os }}
+
+      - name: Build Linux
+        shell: bash -l {0}
+        run: |
+            ./build0.sh
+            cmake . -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_LLVM=no \
+              -DLFORTRAN_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+            cmake --build . -j16 --target install
+
+      - name: Test Linux
+        shell: bash -l {0}
+        run: |
+            cd integration_tests
+            ./run_tests.py -b wasm
+
   upload_tarball:
     name: Upload Tarball
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,7 +230,7 @@ jobs:
             ./build0.sh
             cmake . -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DWITH_LLVM=no \
+              -DWITH_LLVM=yes \
               -DLFORTRAN_BUILD_ALL=yes \
               -DWITH_STACKTRACE=no \
               -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -210,19 +210,18 @@ jobs:
           environment-file: ci/environment_linux.yml
           extra-specs: |
             python=3.10
-            emscripten
+            nodejs
 
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
 
-      - name: Display Versions
+      - name: Show Node Info
         shell: bash -l {0}
         run: |
           set -ex
-          emcc --version
-          em++ --version
+          which node
           node --version
 
       - name: Build Linux

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -69,7 +69,19 @@ macro(RUN)
         endif()
 
         if ((LFORTRAN_BACKEND STREQUAL "wasm"))
-            add_test(${name} node --experimental-wasm-bigint ${CURRENT_BINARY_DIR}/${name}.js)
+            find_program(WASM_EXEC_RUNTIME node)
+            execute_process(COMMAND "${WASM_EXEC_RUNTIME}" --version
+                            OUTPUT_VARIABLE WASM_EXEC_VERSION
+                            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            string(COMPARE GREATER_EQUAL "${WASM_EXEC_VERSION}"
+                                    "v16.0.0" IS_NODE_ABOVE_16)
+
+            if (NOT IS_NODE_ABOVE_16)
+                message(STATUS "${WASM_EXEC_RUNTIME} version: ${WASM_EXEC_VERSION}")
+                set(WASM_EXEC_FLAGS "--experimental-wasm-bigint")
+            endif()
+
+            add_test(${name} ${WASM_EXEC_RUNTIME} ${WASM_EXEC_FLAGS} ${CURRENT_BINARY_DIR}/${name}.js)
         else()
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         endif()

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(lfort C Fortran)
 

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1174,8 +1174,8 @@ int link_executable(const std::vector<std::string> &infiles,
                 CC = "gcc";
             } else {
                 CC = "clang";
-            }  
-	    
+            }
+
             char *env_CC = std::getenv("LFORTRAN_CC");
             if (env_CC) CC = env_CC;
 
@@ -1323,14 +1323,6 @@ EMSCRIPTEN_KEEPALIVE char* emit_cpp_from_source(char *input) {
 EMSCRIPTEN_KEEPALIVE char* emit_c_from_source(char *input) {
     INITIALIZE_VARS;
     LFortran::Result<std::string> r = fe.get_c(input, lm, diagnostics, 1);
-    out = diagnostics.render(input, lm, compiler_options);
-    if (r.ok) { out += r.result; }
-    return &out[0];
-}
-
-EMSCRIPTEN_KEEPALIVE char* emit_llvm_from_source(char *input) {
-    INITIALIZE_VARS;
-    LFortran::Result<std::string> r = fe.get_llvm(input, lm, diagnostics);
     out = diagnostics.render(input, lm, compiler_options);
     if (r.ok) { out += r.result; }
     return &out[0];


### PR DESCRIPTION
This `PR` adds support for `wasm` `integration_tests` testing at the `CI`.