### PR TITLE
More robust error messages for fixed-form

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.h
+++ b/src/lfortran/parser/fixedform_tokenizer.h
@@ -51,6 +51,12 @@ public:
         return std::string((char *)tok, cur - tok);
     }
 
+    // Return the string of the token at the given location `loc`
+    std::string token_at_loc(const Location &loc) {
+        return std::string((char *)(string_start + loc.first),
+            loc.last - loc.first + 1);
+    }
+
     // Return the current token as YYSTYPE::Str
     void token(Str &s) const
     {

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -18,7 +18,9 @@ Result<AST::TranslationUnit_t*> parse(Allocator &al, const std::string &s,
 {
     Parser p(al, diagnostics, fixed_form);
     try {
-        p.parse(s);
+        if (!p.parse(s)) {
+            return Error();
+        };
     } catch (const parser_local::TokenizerError &e) {
         Error error;
         diagnostics.diagnostics.push_back(e.d);
@@ -40,7 +42,7 @@ Result<AST::TranslationUnit_t*> parse(Allocator &al, const std::string &s,
         p.result.p, p.result.size());
 }
 
-void Parser::parse(const std::string &input)
+bool Parser::parse(const std::string &input)
 {
     inp = input;
     if (inp.size() > 0) {
@@ -51,13 +53,13 @@ void Parser::parse(const std::string &input)
     if (!fixed_form) {
         m_tokenizer.set_string(inp);
         if (yyparse(*this) == 0) {
-            return;
+            return true;
         }
     } else {
         f_tokenizer.set_string(inp);
-        f_tokenizer.tokenize_input(diag, m_a);
+        if (!f_tokenizer.tokenize_input(diag, m_a)) return false;
         if (yyparse(*this) == 0) {
-            return;
+            return true;
         }
     }
     throw parser_local::ParserError("Parsing unsuccessful (internal compiler error)");

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -651,11 +651,19 @@ void Parser::handle_yyerror(const Location &loc, const std::string &msg)
         std::string token_str;
         // Determine the unexpected token's type:
         if (this->fixed_form) {
-            unsigned int invalid_token = this->f_tokenizer.token_pos - 1;            
+            unsigned int invalid_token = this->f_tokenizer.token_pos;
+            if (invalid_token > 0) invalid_token--;
             if (invalid_token >= f_tokenizer.tokens.size()) {
-                invalid_token = f_tokenizer.tokens.size()-1;
+                invalid_token = f_tokenizer.tokens.size();
+                if (invalid_token > 0) invalid_token--;
             }
-            token = f_tokenizer.tokens[invalid_token];
+            if (f_tokenizer.tokens.size() > 0) {
+                std::cout << f_tokenizer.tokens.size() << std::endl;
+                std::cout << invalid_token << std::endl;
+                token = f_tokenizer.tokens[invalid_token];
+            } else {
+                token = END_OF_FILE;
+            }
         } else {
             LFortran::YYSTYPE yylval_;
             YYLTYPE yyloc_;

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -654,18 +654,16 @@ void Parser::handle_yyerror(const Location &loc, const std::string &msg)
         // Determine the unexpected token's type:
         if (this->fixed_form) {
             unsigned int invalid_token = this->f_tokenizer.token_pos;
-            if (invalid_token > 0) invalid_token--;
-            if (invalid_token >= f_tokenizer.tokens.size()) {
-                invalid_token = f_tokenizer.tokens.size();
-                if (invalid_token > 0) invalid_token--;
+            if (invalid_token == 0 || invalid_token > f_tokenizer.tokens.size()) {
+                message = "unknown error";
+                throw parser_local::ParserError(message, loc);
             }
-            if (f_tokenizer.tokens.size() > 0) {
-                std::cout << f_tokenizer.tokens.size() << std::endl;
-                std::cout << invalid_token << std::endl;
-                token = f_tokenizer.tokens[invalid_token];
-            } else {
-                token = END_OF_FILE;
-            }
+            invalid_token--;
+            LFORTRAN_ASSERT(invalid_token < f_tokenizer.tokens.size())
+            LFORTRAN_ASSERT(invalid_token < f_tokenizer.locations.size())
+            token = f_tokenizer.tokens[invalid_token];
+            Location loc = f_tokenizer.locations[invalid_token];
+            token_str = f_tokenizer.token_at_loc(loc);
         } else {
             LFortran::YYSTYPE yylval_;
             YYLTYPE yyloc_;

--- a/src/lfortran/parser/parser.h
+++ b/src/lfortran/parser/parser.h
@@ -32,7 +32,7 @@ public:
         result.reserve(al, 32);
     }
 
-    void parse(const std::string &input);
+    bool parse(const std::string &input);
     void handle_yyerror(const Location &loc, const std::string &msg);
 };
 

--- a/tests/errors/fixed_form_1.f
+++ b/tests/errors/fixed_form_1.f
@@ -1,0 +1,5 @@
+      program X
+      xinteger :: y
+      y = 5
+500   print *, y
+      end program

--- a/tests/errors/fixed_form_2.f
+++ b/tests/errors/fixed_form_2.f
@@ -1,0 +1,5 @@
+      program X
+      integer :: y
+      y = 5x
+500   print *, y
+      end program

--- a/tests/errors/fixed_form_3.f
+++ b/tests/errors/fixed_form_3.f
@@ -1,0 +1,6 @@
+      program X
+      integer :: y
+      y = 5
+500   print *, sin(y
+      print *, "OK"
+      end program

--- a/tests/errors/fixed_form_4.f
+++ b/tests/errors/fixed_form_4.f
@@ -1,0 +1,6 @@
+      program X
+      integer :: y
+      y = 5
+500   print *, sin), y
+      print *, "OK"
+      end program

--- a/tests/errors/fixed_form_5.f
+++ b/tests/errors/fixed_form_5.f
@@ -1,0 +1,5 @@
+      program X
+      integer :: y
+      y = 5abcdef + 3
+500   print *, y
+      end program

--- a/tests/reference/ast-fixed_form_1-3be6d43.json
+++ b/tests/reference/ast-fixed_form_1-3be6d43.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixed_form_1-3be6d43",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/fixed_form_1.f",
+    "infile_hash": "20f5de5731f83348f8c0c349bd114289e4a854a74f41d0a9a0d35903",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-fixed_form_1-3be6d43.stderr",
+    "stderr_hash": "3581bed00d0cfb8df0c21e3566f1961a3b7e69ee45ee83aff1c3470e",
+    "returncode": 2
+}

--- a/tests/reference/ast-fixed_form_1-3be6d43.json
+++ b/tests/reference/ast-fixed_form_1-3be6d43.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "ast-fixed_form_1-3be6d43.stderr",
-    "stderr_hash": "3581bed00d0cfb8df0c21e3566f1961a3b7e69ee45ee83aff1c3470e",
+    "stderr_hash": "5e8f3c9a30fc2cf296386482a81ce2b336d5efbd98ead7d9521cfd2b",
     "returncode": 2
 }

--- a/tests/reference/ast-fixed_form_1-3be6d43.stderr
+++ b/tests/reference/ast-fixed_form_1-3be6d43.stderr
@@ -3,9 +3,3 @@ tokenizer error: Expecting terminating symbol for program
   |
 2 |       xinteger :: y
   |       ^ 
-
-syntax error: End of file is unexpected here
- --> tests/errors/fixed_form_1.f:1:7
-  |
-1 |       program X
-  |       ^ 

--- a/tests/reference/ast-fixed_form_1-3be6d43.stderr
+++ b/tests/reference/ast-fixed_form_1-3be6d43.stderr
@@ -1,0 +1,11 @@
+tokenizer error: Expecting terminating symbol for program
+ --> tests/errors/fixed_form_1.f:2:7
+  |
+2 |       xinteger :: y
+  |       ^ 
+
+syntax error: End of file is unexpected here
+ --> tests/errors/fixed_form_1.f:1:7
+  |
+1 |       program X
+  |       ^ 

--- a/tests/reference/ast-fixed_form_2-1350599.json
+++ b/tests/reference/ast-fixed_form_2-1350599.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixed_form_2-1350599",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/fixed_form_2.f",
+    "infile_hash": "f8b865a6a1e302e28e80c6e5011c5559aaf98bbee4447a5c81881224",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-fixed_form_2-1350599.stderr",
+    "stderr_hash": "7b184dd4766acb5cdb47e17fdcd61853d6f051afe375e80522e62bbf",
+    "returncode": 2
+}

--- a/tests/reference/ast-fixed_form_2-1350599.stderr
+++ b/tests/reference/ast-fixed_form_2-1350599.stderr
@@ -1,0 +1,5 @@
+syntax error: Token 'x' (of type 'identifier') is unexpected here
+ --> tests/errors/fixed_form_2.f:3:12
+  |
+3 |       y = 5x
+  |            ^ 

--- a/tests/reference/ast-fixed_form_3-53e9045.json
+++ b/tests/reference/ast-fixed_form_3-53e9045.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixed_form_3-53e9045",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/fixed_form_3.f",
+    "infile_hash": "a2a456bea34619c96c4b8edc022e348d99c1b2828cb9f9cc7a4acf88",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-fixed_form_3-53e9045.stderr",
+    "stderr_hash": "2071f80077d2fdeb1b7316a12e59bf3b92d8adc30b00d8d596dff038",
+    "returncode": 2
+}

--- a/tests/reference/ast-fixed_form_3-53e9045.stderr
+++ b/tests/reference/ast-fixed_form_3-53e9045.stderr
@@ -1,0 +1,9 @@
+syntax error: Newline is unexpected here
+ --> tests/errors/fixed_form_3.f:4:21 - 5:7
+  |
+4 |    500   print *, sin(y
+  |                        ...
+...
+  |
+5 |          print *, "OK"
+  | ...^^^^^^^ 

--- a/tests/reference/ast-fixed_form_4-656a640.json
+++ b/tests/reference/ast-fixed_form_4-656a640.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixed_form_4-656a640",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/fixed_form_4.f",
+    "infile_hash": "ead212bbc34e4848d189561c4e6474149e4afb1bfeda6f7e46b90b12",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-fixed_form_4-656a640.stderr",
+    "stderr_hash": "dd0de417e4cccdc2321f322a53b4aa0c212ae0ee3dbdaf980d13ec3a",
+    "returncode": 2
+}

--- a/tests/reference/ast-fixed_form_4-656a640.stderr
+++ b/tests/reference/ast-fixed_form_4-656a640.stderr
@@ -1,0 +1,5 @@
+syntax error: Token ')' is unexpected here
+ --> tests/errors/fixed_form_4.f:4:19
+  |
+4 | 500   print *, sin), y
+  |                   ^ 

--- a/tests/reference/ast-fixed_form_5-f25edd8.json
+++ b/tests/reference/ast-fixed_form_5-f25edd8.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixed_form_5-f25edd8",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/fixed_form_5.f",
+    "infile_hash": "c978dce7f02ade3281b72a11001e4813cd7c3157f0efa065c8a137d2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-fixed_form_5-f25edd8.stderr",
+    "stderr_hash": "868271d79402bdfa652f8d86b11303134261ca5a7c28edbbd97bf884",
+    "returncode": 2
+}

--- a/tests/reference/ast-fixed_form_5-f25edd8.stderr
+++ b/tests/reference/ast-fixed_form_5-f25edd8.stderr
@@ -1,0 +1,5 @@
+syntax error: Token 'abcdef' (of type 'identifier') is unexpected here
+ --> tests/errors/fixed_form_5.f:3:12
+  |
+3 |       y = 5abcdef + 3
+  |            ^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2153,3 +2153,7 @@ asr_implicit_typing = true
 filename = "dimension_attr.f"
 ast = true
 asr = true
+
+[[test]]
+filename = "errors/fixed_form_1.f"
+ast = true

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2157,3 +2157,19 @@ asr = true
 [[test]]
 filename = "errors/fixed_form_1.f"
 ast = true
+
+[[test]]
+filename = "errors/fixed_form_2.f"
+ast = true
+
+[[test]]
+filename = "errors/fixed_form_3.f"
+ast = true
+
+[[test]]
+filename = "errors/fixed_form_4.f"
+ast = true
+
+[[test]]
+filename = "errors/fixed_form_5.f"
+ast = true


### PR DESCRIPTION
TODO:
* [x] Add tests for error messages in fixed-form
* [x] Improve the logic in this PR --- it's too complicated; essentially we cannot assume the `tokens` to contain any (or enough) tokens, so we need to handle all cases.