### PR TITLE
WASM: Supporting specifying max no of memory pages

### DIFF
--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -103,6 +103,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     uint32_t last_str_len;
     uint32_t avail_mem_loc;
 
+    uint32_t min_no_pages;
+    uint32_t max_no_pages;
+
     std::map<uint64_t, uint32_t> m_var_name_idx_map;
     std::map<uint64_t, SymbolInfo *> m_func_name_idx_map;
     std::map<std::string, ASR::asr_t *> m_import_func_asr_map;
@@ -117,6 +120,10 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         no_of_functions = 0;
         no_of_imports = 0;
         no_of_data_segments = 0;
+
+        min_no_pages = 10;
+        max_no_pages = 100;
+
         m_type_section.reserve(m_al, 1024 * 128);
         m_import_section.reserve(m_al, 1024 * 128);
         m_func_section.reserve(m_al, 1024 * 128);
@@ -185,7 +192,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             no_of_imports++;
         }
 
-        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", 10U /* min page limit */, 100U /* max page limit */);
+        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", min_no_pages, max_no_pages);
         no_of_imports++;
     }
 

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -185,7 +185,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             no_of_imports++;
         }
 
-        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", 10U /* min page limit */, 10U /* max page limit */);
+        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", 10U /* min page limit */, 100U /* max page limit */);
         no_of_imports++;
     }
 

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -178,17 +178,17 @@ void emit_import_fn(Vec<uint8_t> &code, Allocator &al, const std::string &mod_na
 }
 
 void emit_import_mem(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
-                 const std::string& mem_name, uint32_t min_limit, uint32_t max_limit = 0) {
+                 const std::string& mem_name, uint32_t min_no_pages, uint32_t max_no_pages = 0) {
     emit_str(code, al, mod_name);
     emit_str(code, al, mem_name);
     emit_b8(code, al, 0x02); // for importing memory
-    if (max_limit) {
+    if (max_no_pages) {
         emit_b8(code, al, 0x01); // for specifying min and max page limits of memory
-        emit_u32(code, al, min_limit);
-        emit_u32(code, al, max_limit);
+        emit_u32(code, al, min_no_pages);
+        emit_u32(code, al, max_no_pages);
     } else {
         emit_b8(code, al, 0x00); // for specifying only min page limit of memory
-        emit_u32(code, al, min_limit);
+        emit_u32(code, al, min_no_pages);
     }
 }
 

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -178,13 +178,18 @@ void emit_import_fn(Vec<uint8_t> &code, Allocator &al, const std::string &mod_na
 }
 
 void emit_import_mem(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
-                 const std::string& mem_name, uint32_t min_limit, uint32_t /* max_limit */) {
+                 const std::string& mem_name, uint32_t min_limit, uint32_t max_limit = 0) {
     emit_str(code, al, mod_name);
     emit_str(code, al, mem_name);
     emit_b8(code, al, 0x02); // for importing memory
-    emit_b8(code, al, 0x00); // for specifying min page limit of memory
-    // max page limit can also be specifid, but currently omitting it.
-    emit_u32(code, al, min_limit);
+    if (max_limit) {
+        emit_b8(code, al, 0x01); // for specifying min and max page limits of memory
+        emit_u32(code, al, min_limit);
+        emit_u32(code, al, max_limit);
+    } else {
+        emit_b8(code, al, 0x00); // for specifying only min page limit of memory
+        emit_u32(code, al, min_limit);
+    }
 }
 
 void encode_section(Vec<uint8_t> &des, Vec<uint8_t> &section_content, Allocator &al, uint32_t section_id, uint32_t no_of_elements){

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -255,7 +255,8 @@ std::string WASMDecoder::get_wat() {
             result += "(func (;" + std::to_string(i) + ";) (type " + std::to_string(imports[i].type_idx) + ")))";
         }
         else if(imports[i].kind == 0x02){
-            result += "(memory (;0;) " + std::to_string(imports[i].mem_page_size_limits.first) + "))";
+            result += "(memory (;0;) " + std::to_string(imports[i].mem_page_size_limits.first) + " "
+                                       + std::to_string(imports[i].mem_page_size_limits.second) + "))";
         }
     }
 

--- a/tests/reference/wat-abs_01-0c0b4df.json
+++ b/tests/reference/wat-abs_01-0c0b4df.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-abs_01-0c0b4df.stdout",
-    "stdout_hash": "50568072d38b71f1157153278ac767aa522777b959b588cbb390954c",
+    "stdout_hash": "24fe1d47c6d9ab127aacd07dcdc11b5eec58063364f35f1a96b147c1",
     "stderr": "wat-abs_01-0c0b4df.stderr",
     "stderr_hash": "f99c96b98be17cc08ea5b92e5b8e75f51a091a4aba99720882cd52bb",
     "returncode": 0

--- a/tests/reference/wat-abs_01-0c0b4df.stdout
+++ b/tests/reference/wat-abs_01-0c0b4df.stdout
@@ -13,7 +13,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param f32) (result f32)
         (local f32)
         local.get 0

--- a/tests/reference/wat-abs_03-5d62cca.json
+++ b/tests/reference/wat-abs_03-5d62cca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-abs_03-5d62cca.stdout",
-    "stdout_hash": "31d44995fef92df28f6670d981b584fdc7995d578bc7a5ad8ccc9b2e",
+    "stdout_hash": "146a3e731c0cef9c92ec6bff2bdf7b9d52df5e89e52846c11ca654f9",
     "stderr": "wat-abs_03-5d62cca.stderr",
     "stderr_hash": "0da48d1b92d36766d8f5004bc63a3a005d74505756a4cdcb8b00cbb7",
     "returncode": 0

--- a/tests/reference/wat-abs_03-5d62cca.stdout
+++ b/tests/reference/wat-abs_03-5d62cca.stdout
@@ -13,7 +13,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i32) (result i32)
         (local i32)
         local.get 0

--- a/tests/reference/wat-doloop_01-4e94eaf.json
+++ b/tests/reference/wat-doloop_01-4e94eaf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-doloop_01-4e94eaf.stdout",
-    "stdout_hash": "8085988cfee0f65749703c4b7470cd1e8429565eb904cc938eed6bec",
+    "stdout_hash": "9e970d9c2cd6828e48721b1e156206f78bdba80ce80ee6d87fd5d6a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-doloop_01-4e94eaf.stdout
+++ b/tests/reference/wat-doloop_01-4e94eaf.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32)
         i32.const 0

--- a/tests/reference/wat-doloop_02-1ee6409.json
+++ b/tests/reference/wat-doloop_02-1ee6409.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-doloop_02-1ee6409.stdout",
-    "stdout_hash": "eb1e20c69a395aca061cc83faa5d3728342324071484f415c266de6e",
+    "stdout_hash": "ea1fde515a0fa85383304bb55d7e0338f7f8784f00efd17fcec177a2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-doloop_02-1ee6409.stdout
+++ b/tests/reference/wat-doloop_02-1ee6409.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32 i32 i32)
         i32.const 0

--- a/tests/reference/wat-doloop_03-e0c63db.json
+++ b/tests/reference/wat-doloop_03-e0c63db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-doloop_03-e0c63db.stdout",
-    "stdout_hash": "635256cce1a7b3416e305dcda37437209e2227e4a23dcb188ca5d88f",
+    "stdout_hash": "6c786d98e42712e0d95ad4866204aca9ab45863de5285b63600934c5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-doloop_03-e0c63db.stdout
+++ b/tests/reference/wat-doloop_03-e0c63db.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32)
         i32.const 0

--- a/tests/reference/wat-empty-681c1d1.json
+++ b/tests/reference/wat-empty-681c1d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-empty-681c1d1.stdout",
-    "stdout_hash": "e10ff0f4210f3e3f88d6bd4ecc5116acd8412394427418714928f9b9",
+    "stdout_hash": "3572355777682beb7e78a67c580ab402ba1c060ece76f4e0090c06e8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-empty-681c1d1.stdout
+++ b/tests/reference/wat-empty-681c1d1.stdout
@@ -11,5 +11,5 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
 )

--- a/tests/reference/wat-if_04-1d3b97a.json
+++ b/tests/reference/wat-if_04-1d3b97a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-if_04-1d3b97a.stdout",
-    "stdout_hash": "4b0ea47dbfa74f8e5d48bdc7edbd608651b02686b3e51be7d2d108fc",
+    "stdout_hash": "f98ff68c033ea907980ec3d346a4acd78afada7f0c782fb283194dff",
     "stderr": "wat-if_04-1d3b97a.stderr",
     "stderr_hash": "8b854a8be811f407b5f543a37121d6b73b7265ed8b67dc1c76a42d63",
     "returncode": 0

--- a/tests/reference/wat-if_04-1d3b97a.stdout
+++ b/tests/reference/wat-if_04-1d3b97a.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32)
         i32.const 1

--- a/tests/reference/wat-if_05-865c1b8.json
+++ b/tests/reference/wat-if_05-865c1b8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-if_05-865c1b8.stdout",
-    "stdout_hash": "1e0a2adebe2f9675cf9a7637f1ce7d3399d522a10d2468cba79b89f9",
+    "stdout_hash": "b744413ee8021bbbe7c9f27d3a48c9e86bea275a0472e421850a25a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-if_05-865c1b8.stdout
+++ b/tests/reference/wat-if_05-865c1b8.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32)
         i32.const 1

--- a/tests/reference/wat-logical1-ef567ea.json
+++ b/tests/reference/wat-logical1-ef567ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical1-ef567ea.stdout",
-    "stdout_hash": "64c56586cbf9cc93fa137f21677737b156ea1a95901efb6045664382",
+    "stdout_hash": "cca77ffc181a2eb70ec932b04f9b552b7fe4941f93b450e9631d6a3f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-logical1-ef567ea.stdout
+++ b/tests/reference/wat-logical1-ef567ea.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32)
         i32.const 1

--- a/tests/reference/wat-logical2-3eb78d2.json
+++ b/tests/reference/wat-logical2-3eb78d2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical2-3eb78d2.stdout",
-    "stdout_hash": "59bec991a79538053cc8abb188b7d2b380e5b514799549372c7a863f",
+    "stdout_hash": "5f94a064cc3a33ca8d0dfc37b3169301b3998509b8d562a2e5841d2f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-logical2-3eb78d2.stdout
+++ b/tests/reference/wat-logical2-3eb78d2.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32)
         i32.const 1

--- a/tests/reference/wat-logical3-ce72150.json
+++ b/tests/reference/wat-logical3-ce72150.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical3-ce72150.stdout",
-    "stdout_hash": "4eefc03d2d286eb4d61f170dd2b0b44804a2fda10fcaa21f6a4ddad7",
+    "stdout_hash": "1dbf35ee643b20e83dbd70642484e59f5b5a32b0d902f8b0b5343141",
     "stderr": "wat-logical3-ce72150.stderr",
     "stderr_hash": "bfef4a46078cd921dcbfcade08fa1a2cf35ff66f6c17e1411ae172c5",
     "returncode": 0

--- a/tests/reference/wat-logical3-ce72150.stdout
+++ b/tests/reference/wat-logical3-ce72150.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32)
         i32.const 1

--- a/tests/reference/wat-logical4-64da104.json
+++ b/tests/reference/wat-logical4-64da104.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-logical4-64da104.stdout",
-    "stdout_hash": "2322e156df2e37693f20baed2f569676b95b1e618b33caf1da4445c9",
+    "stdout_hash": "4793aeff51aa1d640934240bcaa02c288decce6b00747e1afd01cf31",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-logical4-64da104.stdout
+++ b/tests/reference/wat-logical4-64da104.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 i32 i32)
         i32.const 2

--- a/tests/reference/wat-types_01-c4e1000.json
+++ b/tests/reference/wat-types_01-c4e1000.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_01-c4e1000.stdout",
-    "stdout_hash": "65627d4f3e3dfc5b029327118da4580a0fed0b9470b2cd64be31d892",
+    "stdout_hash": "ec68167c5e56cd64d2bf073c155b7e26b656e312c837d4eaea12b855",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_01-c4e1000.stdout
+++ b/tests/reference/wat-types_01-c4e1000.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local f32)
         f32.const 1.000000

--- a/tests/reference/wat-types_02-48df0cb.json
+++ b/tests/reference/wat-types_02-48df0cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_02-48df0cb.stdout",
-    "stdout_hash": "fc1062dc103d77c32c616e9ec118eb30f279b4ae32bcc228bcb5951b",
+    "stdout_hash": "bc6361f50823e43a192266841347d0a4e91f54af8a62fcac8a180509",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_02-48df0cb.stdout
+++ b/tests/reference/wat-types_02-48df0cb.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 f32)
         i32.const 1

--- a/tests/reference/wat-types_03-e07ce23.json
+++ b/tests/reference/wat-types_03-e07ce23.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_03-e07ce23.stdout",
-    "stdout_hash": "f1de2eaf62a6f4e12b517808c7a4d92ba2cc98d5fa9e131c064cdf8e",
+    "stdout_hash": "fe4fc1b54aa869689b8e7842f49dae671a20191958307b77a61f4b8e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_03-e07ce23.stdout
+++ b/tests/reference/wat-types_03-e07ce23.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 f32)
         f32.const 1.500000

--- a/tests/reference/wat-types_04-054550e.json
+++ b/tests/reference/wat-types_04-054550e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_04-054550e.stdout",
-    "stdout_hash": "b1ede9cf7cf06e60f81fbdbb6ef3b300f2db10e76be8a1b1a323aa54",
+    "stdout_hash": "b6fcc289ccc6dcc39c853ef27e0e471fd46e391ded995e9ac9d373f7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_04-054550e.stdout
+++ b/tests/reference/wat-types_04-054550e.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 f32 f32)
         f32.const 1.500000

--- a/tests/reference/wat-types_05-884adc8.json
+++ b/tests/reference/wat-types_05-884adc8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_05-884adc8.stdout",
-    "stdout_hash": "b3074e0e674c7f6e0ebc88854aae9d058e47c528e95e6c33cde8f57a",
+    "stdout_hash": "540f9c85fd9698344caa0341f3d8eb257130b0de3d4c6df552c27bff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_05-884adc8.stdout
+++ b/tests/reference/wat-types_05-884adc8.stdout
@@ -12,7 +12,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param) (result)
         (local i32 f32)
         f32.const 2.000000

--- a/tests/reference/wat-types_15-abe4006.json
+++ b/tests/reference/wat-types_15-abe4006.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_15-abe4006.stdout",
-    "stdout_hash": "1568df48adb7721b4337f7cc89735f1b5efeb86634b0a88f79ce506a",
+    "stdout_hash": "c07d9894bcce22ebbba45cb25173aafe78ad06efdf5d8361f8bf0201",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_15-abe4006.stdout
+++ b/tests/reference/wat-types_15-abe4006.stdout
@@ -13,7 +13,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i32) (result i32)
         (local i32)
         i32.const 4

--- a/tests/reference/wat-wasm1-8a138d6.json
+++ b/tests/reference/wat-wasm1-8a138d6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm1-8a138d6.stdout",
-    "stdout_hash": "b07cedea023c3ca896b9753ce52007f95a77a758b11b20b475834e67",
+    "stdout_hash": "f4d22c552709850528ab576438381b829d054835779927ae87bb778b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm1-8a138d6.stdout
+++ b/tests/reference/wat-wasm1-8a138d6.stdout
@@ -17,7 +17,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i32) (result i32)
         (local i32)
         local.get 0

--- a/tests/reference/wat-wasm_floats-c84c674.json
+++ b/tests/reference/wat-wasm_floats-c84c674.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_floats-c84c674.stdout",
-    "stdout_hash": "a1aebcd5b2a688115867b2367fbb61d7d759315845897d5b7700533b",
+    "stdout_hash": "9bdeea3f864ea6a47086dc15f84e4afd1653c3eb5ffe378d47e3e156",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_floats-c84c674.stdout
+++ b/tests/reference/wat-wasm_floats-c84c674.stdout
@@ -19,7 +19,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i32) (result i32)
         (local i32)
         i32.const 4

--- a/tests/reference/wat-wasm_i64-3afdb24.json
+++ b/tests/reference/wat-wasm_i64-3afdb24.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_i64-3afdb24.stdout",
-    "stdout_hash": "5fb5b1c37a08c16ad8173e35680cd16f3e4ac76cacc3b6c1512fc7a8",
+    "stdout_hash": "06cd7ca44deade79593f7a7f9723dcbb5bb52d1a9167bde0e521d2a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_i64-3afdb24.stdout
+++ b/tests/reference/wat-wasm_i64-3afdb24.stdout
@@ -15,7 +15,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i64) (result i64)
         (local i64)
         local.get 0

--- a/tests/reference/wat-wasm_main_program-7a34895.json
+++ b/tests/reference/wat-wasm_main_program-7a34895.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_main_program-7a34895.stdout",
-    "stdout_hash": "f23be4516a557c0b86ade17463589d483f26d36eac3827e2d329bc46",
+    "stdout_hash": "7fbdc89e1d79d046fddffc8985bcde490c873f615ebba01c1d6dad1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_main_program-7a34895.stdout
+++ b/tests/reference/wat-wasm_main_program-7a34895.stdout
@@ -13,7 +13,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i32) (result i32)
         (local i32)
         local.get 0

--- a/tests/reference/wat-wasm_unary_minus-81a29ff.json
+++ b/tests/reference/wat-wasm_unary_minus-81a29ff.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_unary_minus-81a29ff.stdout",
-    "stdout_hash": "1a161b51cbbfccd6cc04bf3aec4cf68a85c32df3263e8e6c3eed20cd",
+    "stdout_hash": "79228d98eacd9ec3c6937894e5d9fdcd3daa22896ae6fd15c7d2efcc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_unary_minus-81a29ff.stdout
+++ b/tests/reference/wat-wasm_unary_minus-81a29ff.stdout
@@ -15,7 +15,7 @@
     (import "js" "print_f64" (func (;3;) (type 3)))
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
-    (import "js" "memory" (memory (;0;) 10))
+    (import "js" "memory" (memory (;0;) 10 100))
     (func $6 (type 6) (param i32) (result i32)
         (local i32)
         i32.const 0


### PR DESCRIPTION
This `PR` adds support of specifying max no of memory pages in the `wasm` backend. We already had some support for the `max no of memory pages` in `wasm` as well as `wat` backends (for example: https://github.com/lfortran/lfortran/blob/main/src/libasr/codegen/wasm_to_wat.cpp#L91-L93), this `PR` refines/adds-on-to that support.