### PR TITLE
remove march=native hard coding

### DIFF
--- a/cmake/UserOverride.cmake
+++ b/cmake/UserOverride.cmake
@@ -9,7 +9,7 @@
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # g++
     set(common "-Wall -Wextra")
-    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -march=native -funroll-loops -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -funroll-loops -DNDEBUG")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common} -g -ggdb")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     # icpc
@@ -19,7 +19,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
     # clang
     set(common "-Wall -Wextra")
-    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -march=native -funroll-loops -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -funroll-loops -DNDEBUG")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common} -g -ggdb")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
     # pgcpp


### PR DESCRIPTION
This PR removes `-march=native` hard coding. 
On the one hand, `-march=native` does not work with Clang on M1 Macs. 

Additionally,  this option makes "Release" binaries not very portable to older CPUs (e.g. for conda-forge or other package managers).

I think this should only ever be set by a user that wants maximum performance.