### PR TITLE
bug(build): fixes Windows bash env initialisation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,7 @@ jobs:
             sel(unix): bison=3.4
             sel(unix): rapidjson
             sel(win): m2-bison=3.0.4
+            sel(win): m2-filesystem
             sel(win): rapidjson
 
       - uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
m2-bison installs m2-bash, which overrides the default bash shell on
Windows. You need to install m2-filesystem to properly
initialise the m2-bash environment.