### PR TITLE
WASM: Initial implementation of x**2

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -134,6 +134,7 @@ RUN(NAME expr_05 LABELS gfortran llvm cpp)
 RUN(NAME expr_06 LABELS gfortran llvm)
 RUN(NAME expr_07 LABELS gfortran llvm)
 RUN(NAME expr_08 LABELS gfortran llvm wasm)
+RUN(NAME expr_09 LABELS gfortran llvm wasm)
 
 RUN(NAME variables_01 LABELS gfortran llvm cpp x86)
 RUN(NAME variables_02 LABELS gfortran llvm cpp x86)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -133,6 +133,7 @@ RUN(NAME expr_04 LABELS gfortran llvm cpp)
 RUN(NAME expr_05 LABELS gfortran llvm cpp)
 RUN(NAME expr_06 LABELS gfortran llvm)
 RUN(NAME expr_07 LABELS gfortran llvm)
+RUN(NAME expr_08 LABELS gfortran llvm wasm)
 
 RUN(NAME variables_01 LABELS gfortran llvm cpp x86)
 RUN(NAME variables_02 LABELS gfortran llvm cpp x86)

--- a/integration_tests/expr_08.f90
+++ b/integration_tests/expr_08.f90
@@ -1,7 +1,13 @@
 program expr_08
 implicit none
 integer, parameter :: dp = kind(0.d0)
+real :: x4, y4
 real(dp) :: x, y
+y4 = 3
+x4 = y4 ** 2
+print *, y4, x4
+if (abs(x4 - 9) > 1e-6) error stop
+
 y = 3
 x = y**2
 print *, y, x

--- a/integration_tests/expr_08.f90
+++ b/integration_tests/expr_08.f90
@@ -1,6 +1,6 @@
 program expr_08
 implicit none
-integer, parameter :: dp = kind(0.d0)
+integer, parameter :: dp = 8 ! kind(0.d0)
 real :: x4, y4
 real(dp) :: x, y
 y4 = 3

--- a/integration_tests/expr_08.f90
+++ b/integration_tests/expr_08.f90
@@ -1,0 +1,9 @@
+program expr_08
+implicit none
+integer, parameter :: dp = kind(0.d0)
+real(dp) :: x, y
+y = 3
+x = y**2
+print *, y, x
+if (abs(x - 9) > 1e-12_dp) error stop
+end program

--- a/integration_tests/expr_09.f90
+++ b/integration_tests/expr_09.f90
@@ -1,0 +1,17 @@
+program expr_09
+implicit none
+    integer :: x4, y4
+    integer(kind=8) :: x8, y8
+
+    y4 = 5
+    x4 = y4 ** 2
+    print *, y4, x4
+
+    if (x4 /= 25) error stop
+
+    y8 = 5
+    x8 = y8**2
+    print *, y8, x8
+    if (x8 /= 25) error stop
+
+end program

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -720,9 +720,25 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     wasm::emit_f32_div(m_code_section, m_al);
                     break;
                 };
+                case ASR::binopType::Pow: {
+                    ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
+                    if (ASR::is_a<ASR::RealConstant_t>(*val)) {
+                        ASR::RealConstant_t *c = ASR::down_cast<ASR::RealConstant_t>(val);
+                        if (c->m_r == 2.0) {
+                            // drop the last stack item in the wasm stack
+                            wasm::emit_drop(m_code_section, m_al);
+                            this->visit_expr(*x.m_left);
+                            wasm::emit_f32_mul(m_code_section, m_al);
+                        } else {
+                            throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                        }
+                    } else {
+                        throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                    }
+                    break;
+                };
                 default: {
-                    // Todo: Implement Pow Operation
-                    throw CodeGenError("RealBinop: Pow Operation not yet implemented");
+                    throw CodeGenError("ICE RealBinop kind 4: unknown operation");
                 }
             }
         } else if (f->m_kind == 8) {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -661,9 +661,25 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     wasm::emit_i32_div_s(m_code_section, m_al);
                     break;
                 };
+                case ASR::binopType::Pow: {
+                    ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
+                    if (ASR::is_a<ASR::IntegerConstant_t>(*val)) {
+                        ASR::IntegerConstant_t *c = ASR::down_cast<ASR::IntegerConstant_t>(val);
+                        if (c->m_n == 2) {
+                            // drop the last stack item in the wasm stack
+                            wasm::emit_drop(m_code_section, m_al);
+                            this->visit_expr(*x.m_left);
+                            wasm::emit_i32_mul(m_code_section, m_al);
+                        } else {
+                            throw CodeGenError("ICE IntegerBinop kind 4: only x**2 implemented so far for powers");
+                        }
+                    } else {
+                        throw CodeGenError("ICE IntegerBinop kind 4: only x**2 implemented so far for powers");
+                    }
+                    break;
+                };
                 default: {
-                    // Todo: Implement Pow Operation
-                    throw CodeGenError("IntegerBinop: Pow Operation not yet implemented");
+                    throw CodeGenError("ICE IntegerBinop kind 4: unknown operation");
                 }
             }
         } else if (i->m_kind == 8) {
@@ -684,9 +700,25 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     wasm::emit_i64_div_s(m_code_section, m_al);
                     break;
                 };
+                case ASR::binopType::Pow: {
+                    ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
+                    if (ASR::is_a<ASR::IntegerConstant_t>(*val)) {
+                        ASR::IntegerConstant_t *c = ASR::down_cast<ASR::IntegerConstant_t>(val);
+                        if (c->m_n == 2) {
+                            // drop the last stack item in the wasm stack
+                            wasm::emit_drop(m_code_section, m_al);
+                            this->visit_expr(*x.m_left);
+                            wasm::emit_i64_mul(m_code_section, m_al);
+                        } else {
+                            throw CodeGenError("ICE IntegerBinop kind 8: only x**2 implemented so far for powers");
+                        }
+                    } else {
+                        throw CodeGenError("ICE IntegerBinop kind 8: only x**2 implemented so far for powers");
+                    }
+                    break;
+                };
                 default: {
-                    // Todo: Implement Pow Operation
-                    throw CodeGenError("IntegerBinop: Pow Operation not yet implemented");
+                    throw CodeGenError("ICE IntegerBinop kind 8: unknown operation");
                 }
             }
         } else {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -671,10 +671,10 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                             this->visit_expr(*x.m_left);
                             wasm::emit_i32_mul(m_code_section, m_al);
                         } else {
-                            throw CodeGenError("ICE IntegerBinop kind 4: only x**2 implemented so far for powers");
+                            throw CodeGenError("IntegerBinop kind 4: only x**2 implemented so far for powers");
                         }
                     } else {
-                        throw CodeGenError("ICE IntegerBinop kind 4: only x**2 implemented so far for powers");
+                        throw CodeGenError("IntegerBinop kind 4: only x**2 implemented so far for powers");
                     }
                     break;
                 };
@@ -710,10 +710,10 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                             this->visit_expr(*x.m_left);
                             wasm::emit_i64_mul(m_code_section, m_al);
                         } else {
-                            throw CodeGenError("ICE IntegerBinop kind 8: only x**2 implemented so far for powers");
+                            throw CodeGenError("IntegerBinop kind 8: only x**2 implemented so far for powers");
                         }
                     } else {
-                        throw CodeGenError("ICE IntegerBinop kind 8: only x**2 implemented so far for powers");
+                        throw CodeGenError("IntegerBinop kind 8: only x**2 implemented so far for powers");
                     }
                     break;
                 };

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -744,12 +744,13 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     break;
                 };
                 case ASR::binopType::Pow: {
-                    if (ASR::is_a<ASR::IntegerConstant_t>(*x.m_right)) {
-                        ASR::IntegerConstant_t *c = ASR::down_cast<ASR::IntegerConstant_t>(x.m_right);
-                        if (c->m_n == 2) {
+                    ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
+                    if (ASR::is_a<ASR::RealConstant_t>(*val)) {
+                        ASR::RealConstant_t *c = ASR::down_cast<ASR::RealConstant_t>(val);
+                        if (c->m_r == 2.0) {
                             // TODO: drop the last stack item in the wasm stack:
                             //wasm::emit_stack_drop(m_code_section, m_al);
-                            this->visit_expr(*x.m_left);
+                            //this->visit_expr(*x.m_left);
                             wasm::emit_f64_mul(m_code_section, m_al);
                         } else {
                             throw CodeGenError("RealBinop: only x**2 implemented so far for powers");

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -743,9 +743,24 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     wasm::emit_f64_div(m_code_section, m_al);
                     break;
                 };
+                case ASR::binopType::Pow: {
+                    if (ASR::is_a<ASR::IntegerConstant_t>(*x.m_right)) {
+                        ASR::IntegerConstant_t *c = ASR::down_cast<ASR::IntegerConstant_t>(x.m_right);
+                        if (c->m_n == 2) {
+                            // TODO: drop the last stack item in the wasm stack:
+                            //wasm::emit_stack_drop(m_code_section, m_al);
+                            this->visit_expr(*x.m_left);
+                            wasm::emit_f64_mul(m_code_section, m_al);
+                        } else {
+                            throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                        }
+                    } else {
+                        throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                    }
+                    break;
+                };
                 default: {
-                    // Todo: Implement Pow Operation
-                    throw CodeGenError("RealBinop: Pow Operation not yet implemented");
+                    throw CodeGenError("ICE RealBinop: unknown operation");
                 }
             }
         } else {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -748,9 +748,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     if (ASR::is_a<ASR::RealConstant_t>(*val)) {
                         ASR::RealConstant_t *c = ASR::down_cast<ASR::RealConstant_t>(val);
                         if (c->m_r == 2.0) {
-                            // TODO: drop the last stack item in the wasm stack:
-                            //wasm::emit_stack_drop(m_code_section, m_al);
-                            //this->visit_expr(*x.m_left);
+                            // drop the last stack item in the wasm stack
+                            wasm::emit_drop(m_code_section, m_al);
+                            this->visit_expr(*x.m_left);
                             wasm::emit_f64_mul(m_code_section, m_al);
                         } else {
                             throw CodeGenError("RealBinop: only x**2 implemented so far for powers");

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -203,6 +203,11 @@ void encode_section(Vec<uint8_t> &des, Vec<uint8_t> &section_content, Allocator 
     }
 }
 
+// function to emit drop instruction (it throws away a single operand on stack)
+void emit_drop(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x1A);
+}
+
 // function to emit get local variable at given index
 void emit_get_local(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     code.push_back(al, 0x20);

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -18,6 +18,7 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
     void visit_Call(uint32_t func_index) { src += indent + "call " + std::to_string(func_index); }
     void visit_Br(uint32_t label_index) { src += indent + "br " + std::to_string(label_index); }
     void visit_BrIf(uint32_t label_index) { src += indent + "br_if " + std::to_string(label_index); }
+    void visit_Drop() { src += indent + "drop"; }
     void visit_LocalGet(uint32_t localidx) { src += indent + "local.get " + std::to_string(localidx); }
     void visit_LocalSet(uint32_t localidx) { src += indent + "local.set " + std::to_string(localidx); }
     void visit_EmtpyBlockType() {}

--- a/tests/reference/wat-expr_08-74f99b7.json
+++ b/tests/reference/wat-expr_08-74f99b7.json
@@ -2,11 +2,11 @@
     "basename": "wat-expr_08-74f99b7",
     "cmd": "lfortran --no-color --show-wat {infile}",
     "infile": "tests/../integration_tests/expr_08.f90",
-    "infile_hash": "f460199051316c12de52e28e19545464f7a017f68a9a9db6a590a328",
+    "infile_hash": "f590c50e9ed3f0dd1a52d3c76822d9ba4fd30de446be80db10207cff",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr_08-74f99b7.stdout",
-    "stdout_hash": "d2c1899591dff55255f1ad1edf77d29e2b43229c88ec1f0ba4361559",
+    "stdout_hash": "ee3a6eb5ef2b9f22b63b30379ddc137614ee701142e102ed7784c647",
     "stderr": "wat-expr_08-74f99b7.stderr",
     "stderr_hash": "6ccafaa4cbd960b23882366a12e8aff41ba8375846b04e994092bdc6",
     "returncode": 0

--- a/tests/reference/wat-expr_08-74f99b7.json
+++ b/tests/reference/wat-expr_08-74f99b7.json
@@ -1,0 +1,13 @@
+{
+    "basename": "wat-expr_08-74f99b7",
+    "cmd": "lfortran --no-color --show-wat {infile}",
+    "infile": "tests/../integration_tests/expr_08.f90",
+    "infile_hash": "f460199051316c12de52e28e19545464f7a017f68a9a9db6a590a328",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "wat-expr_08-74f99b7.stdout",
+    "stdout_hash": "d2c1899591dff55255f1ad1edf77d29e2b43229c88ec1f0ba4361559",
+    "stderr": "wat-expr_08-74f99b7.stderr",
+    "stderr_hash": "6ccafaa4cbd960b23882366a12e8aff41ba8375846b04e994092bdc6",
+    "returncode": 0
+}

--- a/tests/reference/wat-expr_08-74f99b7.stderr
+++ b/tests/reference/wat-expr_08-74f99b7.stderr
@@ -1,0 +1,41 @@
+warning: Function with no body
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ char
+
+warning: Function with no body
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ move_alloc
+
+warning: WASM: Calls to C subroutine are not yet supported
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ Function: calls c_cpu_time
+
+warning: WASM: Calls to C subroutine are not yet supported
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ Function: calls c_dp_rand_num
+
+warning: WASM: Calls to C subroutine are not yet supported
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ Function: calls c_i32sys_clock
+
+warning: WASM: Calls to C subroutine are not yet supported
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ Function: calls c_i64sys_clock
+
+warning: WASM: Calls to C subroutine are not yet supported
+ --> tests/../integration_tests/expr_08.f90:1:1
+  |
+1 | program expr_08
+  | ^ Function: calls c_sp_rand_num

--- a/tests/reference/wat-expr_08-74f99b7.stdout
+++ b/tests/reference/wat-expr_08-74f99b7.stdout
@@ -5,10 +5,9 @@
     (type (;3;) (func (param f64) (result)))
     (type (;4;) (func (param i32 i32) (result)))
     (type (;5;) (func (param) (result)))
-    (type (;6;) (func (param i32) (result i32)))
-    (type (;7;) (func (param f64) (result f64)))
-    (type (;8;) (func (param f32) (result f32)))
-    (type (;9;) (func (param) (result)))
+    (type (;6;) (func (param f64) (result f64)))
+    (type (;7;) (func (param f32) (result f32)))
+    (type (;8;) (func (param) (result)))
     (import "js" "print_i32" (func (;0;) (type 0)))
     (import "js" "print_i64" (func (;1;) (type 1)))
     (import "js" "print_f32" (func (;2;) (type 2)))
@@ -16,14 +15,7 @@
     (import "js" "print_str" (func (;4;) (type 4)))
     (import "js" "flush_buf" (func (;5;) (type 5)))
     (import "js" "memory" (memory (;0;) 10 100))
-    (func $6 (type 6) (param i32) (result i32)
-        (local i32)
-        i32.const 4
-        local.set 1
-        local.get 1
-        return
-    )
-    (func $7 (type 7) (param f64) (result f64)
+    (func $6 (type 6) (param f64) (result f64)
         (local f64)
         local.get 0
         f64.const 0.000000
@@ -39,7 +31,7 @@
         local.get 1
         return
     )
-    (func $8 (type 8) (param f32) (result f32)
+    (func $7 (type 7) (param f32) (result f32)
         (local f32)
         local.get 0
         f32.const 0.000000
@@ -55,10 +47,9 @@
         local.get 1
         return
     )
-    (func $9 (type 9) (param) (result)
+    (func $8 (type 8) (param) (result)
         (local i32 f64 f32 f64 f32)
-        f64.const 0.000000
-        call 6
+        i32.const 8
         local.set 0
         f32.const 3.000000
         local.set 4
@@ -76,7 +67,7 @@
         local.get 2
         f32.const 9.000000
         f32.sub
-        call 8
+        call 7
         f32.const 0.000001
         f32.gt
         if
@@ -104,7 +95,7 @@
         local.get 1
         f64.const 9.000000
         f64.sub
-        call 7
+        call 6
         f64.const 0.000000
         f64.gt
         if
@@ -118,10 +109,9 @@
         end
         return
     )
-    (export "kind" (func $6))
-    (export "dabs" (func $7))
-    (export "sabs" (func $8))
-    (export "_lcompilers_main" (func $9))
+    (export "dabs" (func $6))
+    (export "sabs" (func $7))
+    (export "_lcompilers_main" (func $8))
     (data (;0;) (i32.const 0) "ERROR STOP")
     (data (;1;) (i32.const 10) "ERROR STOP")
 )

--- a/tests/reference/wat-expr_08-74f99b7.stdout
+++ b/tests/reference/wat-expr_08-74f99b7.stdout
@@ -1,0 +1,127 @@
+(module
+    (type (;0;) (func (param i32) (result)))
+    (type (;1;) (func (param i64) (result)))
+    (type (;2;) (func (param f32) (result)))
+    (type (;3;) (func (param f64) (result)))
+    (type (;4;) (func (param i32 i32) (result)))
+    (type (;5;) (func (param) (result)))
+    (type (;6;) (func (param i32) (result i32)))
+    (type (;7;) (func (param f64) (result f64)))
+    (type (;8;) (func (param f32) (result f32)))
+    (type (;9;) (func (param) (result)))
+    (import "js" "print_i32" (func (;0;) (type 0)))
+    (import "js" "print_i64" (func (;1;) (type 1)))
+    (import "js" "print_f32" (func (;2;) (type 2)))
+    (import "js" "print_f64" (func (;3;) (type 3)))
+    (import "js" "print_str" (func (;4;) (type 4)))
+    (import "js" "flush_buf" (func (;5;) (type 5)))
+    (import "js" "memory" (memory (;0;) 10 100))
+    (func $6 (type 6) (param i32) (result i32)
+        (local i32)
+        i32.const 4
+        local.set 1
+        local.get 1
+        return
+    )
+    (func $7 (type 7) (param f64) (result f64)
+        (local f64)
+        local.get 0
+        f64.const 0.000000
+        f64.ge
+        if
+            local.get 0
+            local.set 1
+        else
+            local.get 0
+            f64.neg
+            local.set 1
+        end
+        local.get 1
+        return
+    )
+    (func $8 (type 8) (param f32) (result f32)
+        (local f32)
+        local.get 0
+        f32.const 0.000000
+        f32.ge
+        if
+            local.get 0
+            local.set 1
+        else
+            local.get 0
+            f32.neg
+            local.set 1
+        end
+        local.get 1
+        return
+    )
+    (func $9 (type 9) (param) (result)
+        (local i32 f64 f32 f64 f32)
+        f64.const 0.000000
+        call 6
+        local.set 0
+        f32.const 3.000000
+        local.set 4
+        local.get 4
+        f32.const 2.000000
+        drop
+        local.get 4
+        f32.mul
+        local.set 2
+        local.get 4
+        call 2
+        local.get 2
+        call 2
+        call 5
+        local.get 2
+        f32.const 9.000000
+        f32.sub
+        call 8
+        f32.const 0.000001
+        f32.gt
+        if
+            i32.const 0
+            i32.const 10
+            call 4
+            call 5
+            i32.const 1
+            call 0
+            unreachable
+        end
+        f64.const 3.000000
+        local.set 3
+        local.get 3
+        f64.const 2.000000
+        drop
+        local.get 3
+        f64.mul
+        local.set 1
+        local.get 3
+        call 3
+        local.get 1
+        call 3
+        call 5
+        local.get 1
+        f64.const 9.000000
+        f64.sub
+        call 7
+        f64.const 0.000000
+        f64.gt
+        if
+            i32.const 10
+            i32.const 10
+            call 4
+            call 5
+            i32.const 1
+            call 0
+            unreachable
+        end
+        return
+    )
+    (export "kind" (func $6))
+    (export "dabs" (func $7))
+    (export "sabs" (func $8))
+    (export "_lcompilers_main" (func $9))
+    (data (;0;) (i32.const 0) "ERROR STOP")
+    (data (;1;) (i32.const 10) "ERROR STOP")
+)

--- a/tests/reference/wat-expr_09-fa1b124.json
+++ b/tests/reference/wat-expr_09-fa1b124.json
@@ -1,0 +1,13 @@
+{
+    "basename": "wat-expr_09-fa1b124",
+    "cmd": "lfortran --no-color --show-wat {infile}",
+    "infile": "tests/../integration_tests/expr_09.f90",
+    "infile_hash": "3b99f849ef5412d7fbc16bc164307d14964150e05dd203596a3e6dd8",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "wat-expr_09-fa1b124.stdout",
+    "stdout_hash": "1bc823b3c34ff6090b801d19a0ffc6e81a967637bf073df107a75343",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/wat-expr_09-fa1b124.stdout
+++ b/tests/reference/wat-expr_09-fa1b124.stdout
@@ -1,0 +1,73 @@
+(module
+    (type (;0;) (func (param i32) (result)))
+    (type (;1;) (func (param i64) (result)))
+    (type (;2;) (func (param f32) (result)))
+    (type (;3;) (func (param f64) (result)))
+    (type (;4;) (func (param i32 i32) (result)))
+    (type (;5;) (func (param) (result)))
+    (type (;6;) (func (param) (result)))
+    (import "js" "print_i32" (func (;0;) (type 0)))
+    (import "js" "print_i64" (func (;1;) (type 1)))
+    (import "js" "print_f32" (func (;2;) (type 2)))
+    (import "js" "print_f64" (func (;3;) (type 3)))
+    (import "js" "print_str" (func (;4;) (type 4)))
+    (import "js" "flush_buf" (func (;5;) (type 5)))
+    (import "js" "memory" (memory (;0;) 10 100))
+    (func $6 (type 6) (param) (result)
+        (local i32 i64 i32 i64)
+        i32.const 5
+        local.set 2
+        local.get 2
+        i32.const 2
+        drop
+        local.get 2
+        i32.mul
+        local.set 0
+        local.get 2
+        call 0
+        local.get 0
+        call 0
+        call 5
+        local.get 0
+        i32.const 25
+        i32.ne
+        if
+            i32.const 0
+            i32.const 10
+            call 4
+            call 5
+            i32.const 1
+            call 0
+            unreachable
+        end
+        i64.const 5
+        local.set 3
+        local.get 3
+        i64.const 2
+        drop
+        local.get 3
+        i64.mul
+        local.set 1
+        local.get 3
+        call 1
+        local.get 1
+        call 1
+        call 5
+        local.get 1
+        i64.const 25
+        i64.ne
+        if
+            i32.const 10
+            i32.const 10
+            call 4
+            call 5
+            i32.const 1
+            call 0
+            unreachable
+        end
+        return
+    )
+    (export "_lcompilers_main" (func $6))
+    (data (;0;) (i32.const 0) "ERROR STOP")
+    (data (;1;) (i32.const 10) "ERROR STOP")
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1678,9 +1678,13 @@ asr = true
 filename = "../integration_tests/expr_07.f90"
 asr = true
 
-#[[test]]
-#filename = "../integration_tests/expr_08.f90"
-#wasm = true
+[[test]]
+filename = "../integration_tests/expr_08.f90"
+wat = true
+
+[[test]]
+filename = "../integration_tests/expr_09.f90"
+wat = true
 
 [[test]]
 filename = "../integration_tests/modules_11.f90"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1678,6 +1678,10 @@ asr = true
 filename = "../integration_tests/expr_07.f90"
 asr = true
 
+#[[test]]
+#filename = "../integration_tests/expr_08.f90"
+#wasm = true
+
 [[test]]
 filename = "../integration_tests/modules_11.f90"
 ast = true


### PR DESCRIPTION
This `PR` adds support for `pow` when `exponent = 2` in the `wasm` backend.