### PR TITLE
WASM: Use compile-time function value

### DIFF
--- a/integration_tests/expr_08.f90
+++ b/integration_tests/expr_08.f90
@@ -1,6 +1,6 @@
 program expr_08
 implicit none
-integer, parameter :: dp = 8 ! kind(0.d0)
+integer, parameter :: dp = kind(0.d0)
 real :: x4, y4
 real(dp) :: x, y
 y4 = 3

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -1231,6 +1231,11 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_FunctionCall(const ASR::FunctionCall_t &x) {
+        if (x.m_value) {
+            this->visit_expr(*x.m_value);
+            return;
+        }
+
         ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
 
         for (size_t i = 0; i < x.n_args; i++) {

--- a/tests/reference/wat-abs_01-0c0b4df.json
+++ b/tests/reference/wat-abs_01-0c0b4df.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-abs_01-0c0b4df.stdout",
-    "stdout_hash": "8197cdfc2288b57e131592648ec79de8738d29fa6b3352cfe9fc32d9",
+    "stdout_hash": "02073e6cd83e8c946f2deac4e610c342c4593fd193d280fd071924eb",
     "stderr": "wat-abs_01-0c0b4df.stderr",
     "stderr_hash": "f99c96b98be17cc08ea5b92e5b8e75f51a091a4aba99720882cd52bb",
     "returncode": 0

--- a/tests/reference/wat-abs_01-0c0b4df.stdout
+++ b/tests/reference/wat-abs_01-0c0b4df.stdout
@@ -35,7 +35,6 @@
     (func $8 (type 8) (param) (result)
         (local f32)
         f32.const 1.500000
-        call 7
         local.set 0
         local.get 0
         call 2
@@ -52,8 +51,7 @@
             call 6
             unreachable
         end
-        f32.const -1.500000
-        call 7
+        f32.const 1.500000
         local.set 0
         local.get 0
         call 2

--- a/tests/reference/wat-abs_03-5d62cca.json
+++ b/tests/reference/wat-abs_03-5d62cca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-abs_03-5d62cca.stdout",
-    "stdout_hash": "f68a12a5f1518a59688a0698c454d51e8c8f8e577a8cb3724e18880d",
+    "stdout_hash": "14ddeae634e07fb638ddf65fb7da72087cb2e22502d2c6c974d77910",
     "stderr": "wat-abs_03-5d62cca.stderr",
     "stderr_hash": "0da48d1b92d36766d8f5004bc63a3a005d74505756a4cdcb8b00cbb7",
     "returncode": 0

--- a/tests/reference/wat-abs_03-5d62cca.stdout
+++ b/tests/reference/wat-abs_03-5d62cca.stdout
@@ -36,7 +36,6 @@
     (func $8 (type 8) (param) (result)
         (local i32)
         i32.const 2
-        call 7
         local.set 0
         local.get 0
         call 0
@@ -53,8 +52,7 @@
             call 6
             unreachable
         end
-        i32.const -2
-        call 7
+        i32.const 2
         local.set 0
         local.get 0
         call 0

--- a/tests/reference/wat-expr_08-74f99b7.json
+++ b/tests/reference/wat-expr_08-74f99b7.json
@@ -2,11 +2,11 @@
     "basename": "wat-expr_08-74f99b7",
     "cmd": "lfortran --no-color --show-wat {infile}",
     "infile": "tests/../integration_tests/expr_08.f90",
-    "infile_hash": "f590c50e9ed3f0dd1a52d3c76822d9ba4fd30de446be80db10207cff",
+    "infile_hash": "f460199051316c12de52e28e19545464f7a017f68a9a9db6a590a328",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr_08-74f99b7.stdout",
-    "stdout_hash": "773f348ffdcffaccea2172cc8cd3e65ba674d39331a572070fb83e77",
+    "stdout_hash": "b7097f0d74a0dae163dd497164700ef1054b2d1fc3e29c31d51a6d14",
     "stderr": "wat-expr_08-74f99b7.stderr",
     "stderr_hash": "6ccafaa4cbd960b23882366a12e8aff41ba8375846b04e994092bdc6",
     "returncode": 0

--- a/tests/reference/wat-expr_08-74f99b7.stdout
+++ b/tests/reference/wat-expr_08-74f99b7.stdout
@@ -6,9 +6,10 @@
     (type (;4;) (func (param i32 i32) (result)))
     (type (;5;) (func (param) (result)))
     (type (;6;) (func (param i32) (result)))
-    (type (;7;) (func (param f64) (result f64)))
-    (type (;8;) (func (param f32) (result f32)))
-    (type (;9;) (func (param) (result)))
+    (type (;7;) (func (param i32) (result i32)))
+    (type (;8;) (func (param f64) (result f64)))
+    (type (;9;) (func (param f32) (result f32)))
+    (type (;10;) (func (param) (result)))
     (import "js" "print_i32" (func (;0;) (type 0)))
     (import "js" "print_i64" (func (;1;) (type 1)))
     (import "js" "print_f32" (func (;2;) (type 2)))
@@ -17,7 +18,14 @@
     (import "js" "flush_buf" (func (;5;) (type 5)))
     (import "js" "set_exit_code" (func (;6;) (type 6)))
     (import "js" "memory" (memory (;0;) 100 100))
-    (func $7 (type 7) (param f64) (result f64)
+    (func $7 (type 7) (param i32) (result i32)
+        (local i32)
+        i32.const 4
+        local.set 1
+        local.get 1
+        return
+    )
+    (func $8 (type 8) (param f64) (result f64)
         (local f64)
         local.get 0
         f64.const 0.000000
@@ -33,7 +41,7 @@
         local.get 1
         return
     )
-    (func $8 (type 8) (param f32) (result f32)
+    (func $9 (type 9) (param f32) (result f32)
         (local f32)
         local.get 0
         f32.const 0.000000
@@ -49,7 +57,7 @@
         local.get 1
         return
     )
-    (func $9 (type 9) (param) (result)
+    (func $10 (type 10) (param) (result)
         (local i32 f64 f32 f64 f32)
         i32.const 8
         local.set 0
@@ -69,7 +77,7 @@
         local.get 2
         f32.const 9.000000
         f32.sub
-        call 8
+        call 9
         f32.const 0.000001
         f32.gt
         if
@@ -97,7 +105,7 @@
         local.get 1
         f64.const 9.000000
         f64.sub
-        call 7
+        call 8
         f64.const 0.000000
         f64.gt
         if
@@ -113,9 +121,10 @@
         call 6
         return
     )
-    (export "dabs" (func $7))
-    (export "sabs" (func $8))
-    (export "_lcompilers_main" (func $9))
+    (export "kind" (func $7))
+    (export "dabs" (func $8))
+    (export "sabs" (func $9))
+    (export "_lcompilers_main" (func $10))
     (data (;0;) (i32.const 0) "ERROR STOP")
     (data (;1;) (i32.const 10) "ERROR STOP")
 )

--- a/tests/reference/wat-types_15-abe4006.json
+++ b/tests/reference/wat-types_15-abe4006.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-types_15-abe4006.stdout",
-    "stdout_hash": "a0ae6ca9f3330af1fd2c83d1e6649d6cebf439483d810b6baf3de159",
+    "stdout_hash": "a2fe58caf56b3b069562ddbfd43e4c16a7f10aa2fefccd34aa6e4354",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-types_15-abe4006.stdout
+++ b/tests/reference/wat-types_15-abe4006.stdout
@@ -25,8 +25,7 @@
     )
     (func $8 (type 8) (param) (result)
         (local i32 i64 i64 i32 i32 f64 f64 f32 f32)
-        f64.const 0.000000
-        call 7
+        i32.const 8
         local.set 0
         i32.const 2
         local.set 4

--- a/tests/reference/wat-wasm_floats-c84c674.json
+++ b/tests/reference/wat-wasm_floats-c84c674.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-wasm_floats-c84c674.stdout",
-    "stdout_hash": "c8e922c4ea3b818e820ab65f52de1170b3575af6b1627f30e8f2e6f7",
+    "stdout_hash": "2c11bb77906ba4caf212a61da1a50fa49b3c5f7f4bb1d56dff883041",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-wasm_floats-c84c674.stdout
+++ b/tests/reference/wat-wasm_floats-c84c674.stdout
@@ -82,8 +82,7 @@
     )
     (func $14 (type 14) (param) (result)
         (local i32)
-        f64.const 0.000000
-        call 7
+        i32.const 8
         local.set 0
         f32.const -2.300000
         f32.const 5.600000


### PR DESCRIPTION
This `PR` adds support for using the `compile-time` value of a function in the `WebAssembly` Backend.