### PR TITLE
LLVM: Determine if it is an argument correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -240,6 +240,7 @@ RUN(NAME arrays_11 LABELS gfortran llvm cpp)
 RUN(NAME arrays_12 LABELS gfortran) # constant arrays
 RUN(NAME arrays_13 LABELS gfortran llvm) # constant arrays
 RUN(NAME arrays_inputs_15 LABELS gfortran llvm) # constant arrays
+RUN(NAME arrays_16_func LABELS gfortran llvm)
 
 RUN(NAME arrays_intrin_01 LABELS gfortran) # minval, maxval
 RUN(NAME arrays_intrin_02 LABELS gfortran) # all, any

--- a/integration_tests/arrays_16_func.f90
+++ b/integration_tests/arrays_16_func.f90
@@ -1,0 +1,31 @@
+program arrays_16_func
+
+real :: arr(17)
+integer :: i
+real :: sum2
+
+do i = 1, 17
+    arr(i) = i
+end do
+
+call imply(arr, 17, sum2)
+
+print *, sum2
+if( sum2 /= 153 ) error stop
+
+contains
+
+subroutine imply(f1, l1out, sum2)
+    integer, intent(in) :: l1out
+    real :: f1(l1out)
+    real, intent(out) :: sum2
+    integer :: i1
+
+    sum2 = 0.0
+    do i1 = 1, l1out
+        sum2 = sum2 + f1(i1)
+    end do
+
+end subroutine
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1301,7 +1301,10 @@ public:
             uint32_t v_h = get_hash((ASR::asr_t*)v);
             LFORTRAN_ASSERT(llvm_symtab.find(v_h) != llvm_symtab.end());
             array = llvm_symtab[v_h];
-            is_argument = v->m_intent == ASRUtils::intent_in || v->m_intent == ASRUtils::intent_out;
+            is_argument = (v->m_intent == ASRUtils::intent_in)
+                 || (v->m_intent == ASRUtils::intent_out)
+                 || (v->m_intent == ASRUtils::intent_inout)
+                 || (v->m_intent == ASRUtils::intent_unspecified);
         } else {
             int64_t ptr_loads_copy = ptr_loads;
             ptr_loads = 0;


### PR DESCRIPTION
Test added (fails in main, works now).

Co-authored-by: Gagandeep Singh <gdp.1807@gmail.com>

Closes https://github.com/lfortran/lfortran/pull/141