### PR TITLE
WASM: Support bind C for array passing to JavaScript

### DIFF
--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -542,13 +542,13 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_Function(const ASR::Function_t &x) {
-#ifndef HAVE_BUILD_TO_WASM
-        if (is_unsupported_function(x)) {
+#ifdef HAVE_BUILD_TO_WASM
+        if (x.m_abi == ASR::abiType::BindC && x.m_deftype == ASR::deftypeType::Interface) {
+            add_func_to_imports(x);
             return;
         }
 #else
-        if (x.m_abi == ASR::abiType::BindC && x.m_deftype == ASR::deftypeType::Interface) {
-            add_func_to_imports(x);
+        if (is_unsupported_function(x)) {
             return;
         }
 #endif

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -1100,21 +1100,15 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         uint32_t kind = ASRUtils::extract_kind_from_ttype_t(ttype);
         ASR::dimension_t* m_dims;
         ASRUtils::extract_dimensions_from_ttype(ttype, m_dims);
-        if (x.m_args[0].m_right) {
-            this->visit_expr(*x.m_args[0].m_right);
-            wasm::emit_i32_const(m_code_section, m_al, 1);
-            wasm::emit_i32_sub(m_code_section, m_al);
-        } else {
-            diag.codegen_warning_label("/* FIXME right index */", {x.base.base.loc}, "");
-        }
 
-        for(uint32_t i = 1; i < x.n_args; i++) {
+        wasm::emit_i32_const(m_code_section, m_al, 0);
+        for(uint32_t i = 0; i < x.n_args; i++) {
             if (x.m_args[i].m_right) {
                 this->visit_expr(*x.m_args[i].m_right);
                 wasm::emit_i32_const(m_code_section, m_al, 1);
                 wasm::emit_i32_sub(m_code_section, m_al);
 
-                for (int j = i - 1; j >= 0; j--) {
+                for (size_t j = i + 1; j < x.n_args; j++) {
                     this->visit_expr(*m_dims[j].m_length);
                     wasm::emit_i32_mul(m_code_section, m_al);
                 }

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -148,23 +148,23 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void add_func_to_imports(const ASR::Function_t &x) {
-        ImportFunc imp_fun;
-        imp_fun.name = x.m_name;
+        ImportFunc import_func;
+        import_func.name = x.m_name;
         for(size_t i = 0; i < x.n_args; i++) {
             ASR::ttype_t* ttype = ASRUtils::expr_type(x.m_args[i]);
-            imp_fun.param_types.push_back({ttype->type, ASRUtils::extract_kind_from_ttype_t(ttype)});
+            import_func.param_types.push_back({ttype->type, ASRUtils::extract_kind_from_ttype_t(ttype)});
         }
 
         // Todo: Result types are currenty not supported
-        import_function(imp_fun);
+        import_function(import_func);
     }
 
-    void import_function(ImportFunc &imp_fun) {
+    void import_function(ImportFunc &import_func) {
         Vec<ASR::expr_t*> params;
-        params.reserve(m_al, imp_fun.param_types.size());
+        params.reserve(m_al, import_func.param_types.size());
         uint32_t var_idx;
-        for(var_idx = 0; var_idx < imp_fun.param_types.size(); var_idx++) {
-            auto param = imp_fun.param_types[var_idx];
+        for(var_idx = 0; var_idx < import_func.param_types.size(); var_idx++) {
+            auto param = import_func.param_types[var_idx];
             auto type = get_import_func_var_type(x, param);
             auto variable = ASR::make_Variable_t(m_al, x.base.base.loc, nullptr, s2c(m_al, std::to_string(var_idx)),
                 ASR::intentType::In, nullptr, nullptr, ASR::storage_typeType::Default,
@@ -174,13 +174,13 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             params.push_back(m_al, ASRUtils::EXPR(var));
         }
 
-        auto func = ASR::make_Function_t(m_al, x.base.base.loc, x.m_global_scope, s2c(m_al, imp_fun.name),
+        auto func = ASR::make_Function_t(m_al, x.base.base.loc, x.m_global_scope, s2c(m_al, import_func.name),
                 params.data(), params.size(), nullptr, 0, nullptr, 0, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                 ASR::deftypeType::Implementation, nullptr, false, false, false);
-        m_import_func_asr_map[imp_fun.name] = func;
+        m_import_func_asr_map[import_func.name] = func;
 
 
-        wasm::emit_import_fn(m_import_section, m_al, "js", imp_fun.name, no_of_types);
+        wasm::emit_import_fn(m_import_section, m_al, "js", import_func.name, no_of_types);
         emit_function_prototype(*((ASR::Function_t *)func));
         no_of_imports++;
     }

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -55,7 +55,7 @@ static uint64_t get_hash(ASR::asr_t *node)
     return (uint64_t)node;
 }
 
-struct import_func{
+struct ImportFunc{
     std::string name;
     std::vector<std::pair<ASR::ttypeType, uint32_t>> param_types, result_types;
 };
@@ -148,7 +148,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void add_func_to_imports(const ASR::Function_t &x) {
-        import_func imp_fun;
+        ImportFunc imp_fun;
         imp_fun.name = x.m_name;
         for(size_t i = 0; i < x.n_args; i++) {
             ASR::ttype_t* ttype = ASRUtils::expr_type(x.m_args[i]);
@@ -159,7 +159,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         import_function(imp_fun);
     }
 
-    void import_function(import_func &imp_fun) {
+    void import_function(ImportFunc &imp_fun) {
         Vec<ASR::expr_t*> params;
         params.reserve(m_al, imp_fun.param_types.size());
         uint32_t var_idx;
@@ -186,7 +186,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void emit_imports(const ASR::TranslationUnit_t &x){
-        std::vector<import_func> import_funcs = {
+        std::vector<ImportFunc> import_funcs = {
             {"print_i32", { {ASR::ttypeType::Integer, 4} }, {}},
             {"print_i64", { {ASR::ttypeType::Integer, 8} }, {}},
             {"print_f32", { {ASR::ttypeType::Real, 4} }, {}},
@@ -196,8 +196,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             {"set_exit_code", { {ASR::ttypeType::Integer, 4} }, {}}
          };
 
-        for (auto import_func:import_funcs) {
-            import_function(import_func);
+        for (auto ImportFunc:import_funcs) {
+            import_function(ImportFunc);
         }
 
         wasm::emit_import_mem(m_import_section, m_al, "js", "memory", min_no_pages, max_no_pages);

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -147,6 +147,18 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         return nullptr;
     }
 
+    void add_func_to_imports(const ASR::Function_t &x) {
+        import_func imp_fun;
+        imp_fun.name = x.m_name;
+        for(size_t i = 0; i < x.n_args; i++) {
+            ASR::ttype_t* ttype = ASRUtils::expr_type(x.m_args[i]);
+            imp_fun.param_types.push_back({ttype->type, ASRUtils::extract_kind_from_ttype_t(ttype)});
+        }
+
+        // Todo: Result types are currenty not supported
+        import_function(imp_fun);
+    }
+
     void import_function(import_func &imp_fun) {
         Vec<ASR::expr_t*> params;
         params.reserve(m_al, imp_fun.param_types.size());


### PR DESCRIPTION
This `PR` adds support of using `bind(c)` in the `wasm` backend to import functions from `JavaScript`.

More details at https://gitlab.com/lfortran/lfortran/-/issues/761