### PR TITLE
Added tests and fix for generic procedure calling in return type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -356,6 +356,8 @@ RUN(NAME modules_21 LABELS gfortran llvm EXTRAFILES
         modules_21b.f90)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
+RUN(NAME operator_overloading_06_module3 LABELS gfortran llvm EXTRAFILES
+        operator_overloading_06_module1.f90 operator_overloading_06_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES
         associate_06_module.f90)
 

--- a/integration_tests/operator_overloading_06_module1.f90
+++ b/integration_tests/operator_overloading_06_module1.f90
@@ -1,0 +1,53 @@
+module stdlib_string_type
+    type :: string_type
+        ! Use the sequence statement below as a hack to prevent extending this type.
+        ! It is not used for storage association.
+        sequence
+        character(len=:), allocatable :: raw
+    end type string_type
+
+    interface assignment(=)
+        module procedure :: assign_string_char
+    end interface assignment(=)
+
+    interface len
+        module procedure :: len_string
+    end interface len
+
+    interface char
+        module procedure :: char_string
+        module procedure :: char_string_pos
+        module procedure :: char_string_range
+    end interface char
+
+contains
+
+    pure subroutine assign_string_char(lhs, rhs)
+        type(string_type), intent(inout) :: lhs
+        character(len=*), intent(in) :: rhs
+        lhs%raw = rhs
+    end subroutine assign_string_char
+
+    pure function char_string(string) result(character_string)
+        type(string_type), intent(in) :: string
+        character(len=len(string)) :: character_string
+    end function char_string
+
+    elemental function char_string_pos(string, pos) result(character_string)
+        type(string_type), intent(in) :: string
+        integer, intent(in) :: pos
+        character(len=1) :: character_string
+    end function char_string_pos
+
+    pure function char_string_range(string, start, last) result(character_string)
+        type(string_type), intent(in) :: string
+        integer, intent(in) :: start
+        integer, intent(in) :: last
+        character(len=last-start+1) :: character_string
+    end function char_string_range
+
+    elemental function len_string(string) result(length)
+        type(string_type), intent(in) :: string
+        integer :: length
+    end function len_string
+end module

--- a/integration_tests/operator_overloading_06_module2.f90
+++ b/integration_tests/operator_overloading_06_module2.f90
@@ -1,0 +1,30 @@
+module stdlib_strings
+use stdlib_string_type, only: string_type, char
+implicit none
+
+    interface chomp
+        module procedure :: chomp_set_char_char
+        module procedure :: chomp_set_string_char
+    end interface chomp
+
+contains
+
+pure function chomp_set_string_char(string, set) result(chomped_string)
+    ! Avoid polluting the module scope and use the assignment only in this scope
+    use stdlib_string_type, only : assignment(=)
+    type(string_type), intent(in) :: string
+    character(len=1), intent(in) :: set(:)
+    type(string_type) :: chomped_string
+
+    chomped_string = chomp(char(string), set)
+end function chomp_set_string_char
+
+pure function chomp_set_char_char(string, set) result(chomped_string)
+    character(len=*), intent(in) :: string
+    character(len=1), intent(in) :: set(:)
+    character(len=:), allocatable :: chomped_string
+    integer :: last
+
+end function chomp_set_char_char
+
+end module

--- a/integration_tests/operator_overloading_06_module3.f90
+++ b/integration_tests/operator_overloading_06_module3.f90
@@ -1,0 +1,10 @@
+submodule(stdlib_string_type) stdlib_string_type_constructor
+use stdlib_strings
+implicit none
+
+contains
+
+end submodule
+
+program main
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2615,6 +2615,10 @@ public:
                 loc);
         }
         char *fn_name = ASRUtils::symbol_name(t);
+        std::string fn_name_str = std::string(fn_name);
+        if( current_scope->get_symbol(fn_name_str) != nullptr ) {
+            fn_name = s2c(al, current_scope->get_unique_name(fn_name_str));
+        }
         ASR::asr_t *fn = ASR::make_ExternalSymbol_t(
             al, t->base.loc,
             /* a_symtab */ current_scope,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1508,6 +1508,7 @@ class ReplaceArgVisitor: public ASR::BaseExprReplacer<ReplaceArgVisitor> {
             current_expr = current_expr_copy;
         }
         x->m_name = new_es;
+        x->m_original_name = nullptr;
     }
 
     void replace_Var(ASR::Var_t* x) {


### PR DESCRIPTION
Added tests and fix for generic procedure calling in return type from [gitlab/lfortran](https://gitlab.com/lfortran/lfortran/-/merge_requests/1754/diffs?commit_id=4b33cd67e2462e532c7608afc00933ba95019807)