### PR TITLE
CI: Fix CI and upload to wasm_builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -131,12 +131,12 @@ jobs:
             source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
             node src/lfortran/tests/test_lfortran.js
 
-      - name: Upload to dev.lfortran.org
+      - name: Upload to wasm_builds
         shell: bash -l {0}
         run: |
             ci/upload_lfortran_wasm.sh
         env:
-          SSH_PRIVATE_KEY_LCOMPILERS_FRONTEND: ${{ secrets.SSH_PRIVATE_KEY_LCOMPILERS_FRONTEND }}
+          SSH_PRIVATE_KEY_WASM_BUILDS: ${{ secrets.SSH_PRIVATE_KEY_WASM_BUILDS }}
 
   debug:
     name: Check Debug build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,8 +74,8 @@ jobs:
             call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             xonsh ci\test.xsh
 
-  build_to_wasm:
-    name: Build LFortran to wasm
+  build_to_wasm_and_upload:
+    name: Build LFortran to WASM and Upload
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2

--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -45,7 +45,7 @@ else
     if [[ ${git_ref:0:11} == "refs/tags/v" ]]; then
         echo "The pipeline was triggered from a tag 'v*'"
     else
-        # We are either on a non-master branch, or tagged with a tag that does
+        # We are either on a non-main branch, or tagged with a tag that does
         # not start with v*. We skip the upload.
         echo "Not a main branch, not tagged with v*, skipping..."
         exit 0
@@ -62,6 +62,6 @@ ssh-add <(echo "$SSH_PRIVATE_KEY_LCOMPILERS_FRONTEND" | base64 -d)
 set -x
 
 
-git push ${deploy_repo_push} master:master
+git push ${deploy_repo_push} main:main
 echo "New commit pushed at:"
 echo "https://github.com/lfortran/lcompilers_frontend/commit/${dest_commit}"

--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -24,6 +24,7 @@ mkdir $HOME/repos
 cd $HOME/repos
 
 git clone ${deploy_repo_pull} wasm_builds
+mkdir -p wasm_builds/docs/${dest_dir}
 cd wasm_builds/docs/${dest_dir}
 mkdir ${git_hash}
 cp $D/src/bin/lfortran.js ${git_hash}/lfortran.js

--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -29,6 +29,8 @@ mkdir ${git_hash}
 cp $D/src/bin/lfortran.js ${git_hash}/lfortran.js
 cp $D/src/bin/lfortran.wasm ${git_hash}/lfortran.wasm
 
+python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_hash}
+
 git config user.name "Deploy"
 git config user.email "noreply@deploylfortran.com"
 COMMIT_MESSAGE="Deploying on $(date "+%Y-%m-%d %H:%M:%S")"

--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -3,11 +3,12 @@
 set -e
 set -x
 
-deploy_repo_pull="https://github.com/lfortran/lcompilers_frontend.git"
-deploy_repo_push="git@github.com:lfortran/lcompilers_frontend.git"
+deploy_repo_pull="https://github.com/lfortran/wasm_builds.git"
+deploy_repo_push="git@github.com:lfortran/wasm_builds.git"
 
 git_hash=$(git rev-parse --short "$GITHUB_SHA")
 git_ref=${GITHUB_REF}
+dest_dir="dev"
 
 lfortran_version=$(<version)
 
@@ -22,12 +23,11 @@ D=`pwd`
 mkdir $HOME/repos
 cd $HOME/repos
 
-git clone ${deploy_repo_pull} lcompilers_frontend
-cd lcompilers_frontend
-rm public/lfortran.js
-rm public/lfortran.wasm
-cp $D/src/bin/lfortran.js public/lfortran.js
-cp $D/src/bin/lfortran.wasm public/lfortran.wasm
+git clone ${deploy_repo_pull} wasm_builds
+cd wasm_builds/docs/${dest_dir}
+mkdir ${git_hash}
+cp $D/src/bin/lfortran.js ${git_hash}/lfortran.js
+cp $D/src/bin/lfortran.wasm ${git_hash}/lfortran.wasm
 
 git config user.name "Deploy"
 git config user.email "noreply@deploylfortran.com"
@@ -53,15 +53,15 @@ else
 fi
 
 set +x
-if [[ "${SSH_PRIVATE_KEY_LCOMPILERS_FRONTEND}" == "" ]]; then
-    echo "Note: SSH_PRIVATE_KEY_LCOMPILERS_FRONTEND is empty, skipping..."
+if [[ "${SSH_PRIVATE_KEY_WASM_BUILDS}" == "" ]]; then
+    echo "Note: SSH_PRIVATE_KEY_WASM_BUILDS is empty, skipping..."
     exit 0
 fi
 
-ssh-add <(echo "$SSH_PRIVATE_KEY_LCOMPILERS_FRONTEND" | base64 -d)
+ssh-add <(echo "$SSH_PRIVATE_KEY_WASM_BUILDS" | base64 -d)
 set -x
 
 
 git push ${deploy_repo_push} main:main
 echo "New commit pushed at:"
-echo "https://github.com/lfortran/lcompilers_frontend/commit/${dest_commit}"
+echo "https://github.com/lfortran/wasm_builds/commit/${dest_commit}"

--- a/ci/wasm_builds_update_json.py
+++ b/ci/wasm_builds_update_json.py
@@ -1,0 +1,25 @@
+import datetime
+from json import load, dump
+import os
+import sys
+
+dest_dir = sys.argv[1]
+version = sys.argv[2]
+lfortran_commit_sha = sys.argv[3]
+
+filename = "data.json"
+if os.path.exists(filename):
+    d = load(open(filename))
+else:
+    d = {"dev": [], "release": []}
+entry = {
+    "url": "https://lfortran.github.io/wasm_builds/%s/%s" % \
+            (dest_dir, lfortran_commit_sha),
+    "version": version,
+    "lfortran_commit_sha": lfortran_commit_sha,
+    "created": str(datetime.datetime.now())
+}
+d[dest_dir].insert(0, entry)
+print("Saving to %s." % filename)
+with open(filename, "w") as f:
+    dump(d, f, indent=4, ensure_ascii=False, sort_keys=True)


### PR DESCRIPTION
This `PR` attempts to fix the currently failing `CI`. It also brings support for uploading the built `lfortran.js` and `lfortran.wasm` to https://github.com/lfortran/wasm_builds