### PR TITLE
CI: Fix upload to wasm_builds

### DIFF
--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -24,11 +24,10 @@ mkdir $HOME/repos
 cd $HOME/repos
 
 git clone ${deploy_repo_pull} wasm_builds
-mkdir -p wasm_builds/docs/${dest_dir}
-cd wasm_builds/docs/${dest_dir}
-mkdir ${git_hash}
-cp $D/src/bin/lfortran.js ${git_hash}/lfortran.js
-cp $D/src/bin/lfortran.wasm ${git_hash}/lfortran.wasm
+mkdir -p wasm_builds/docs/${dest_dir}/${git_hash}
+cd wasm_builds/docs
+cp $D/src/bin/lfortran.js ${dest_dir}/${git_hash}/lfortran.js
+cp $D/src/bin/lfortran.wasm ${dest_dir}/${git_hash}/lfortran.wasm
 
 python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_hash}
 

--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -29,6 +29,7 @@ cd wasm_builds/docs
 cp $D/src/bin/lfortran.js ${dest_dir}/${git_hash}/lfortran.js
 cp $D/src/bin/lfortran.wasm ${dest_dir}/${git_hash}/lfortran.wasm
 
+echo "$git_hash" >> ${dest_dir}/latest_commit
 python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_hash}
 
 git config user.name "Deploy"


### PR DESCRIPTION
This `PR` fixes the location of `data.json` (currently being saved to `/docs/dev/`) to be saved to `/docs/`. This `PR` also adds support to the `CI` to store the `latest_commit` as well inside `/docs/dev/latest_commit`.