### PR TITLE
WAT: verify preamble

### DIFF
--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -27,7 +27,7 @@ void WASMDecoder::load_file(std::string filename) {
 
 bool WASMDecoder::is_preamble_ok(uint32_t offset) {
     uint8_t expected_preamble[] = {0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00};
-    for (size_t i = 0; i < 8; i++) {
+    for (size_t i = 0; i < PREAMBLE_SIZE; i++) {
         uint8_t cur_byte = read_b8(wasm_bytes, offset);
         if (cur_byte != expected_preamble[i]) {
             return false;
@@ -206,12 +206,12 @@ void WASMDecoder::decode_wasm() {
     uint32_t index = 0;
     if (!is_preamble_ok(index)) {
         std::cout << "Unexpected Preamble: ";
-        for (size_t i = 0; i < 8; i++) {
+        for (size_t i = 0; i < PREAMBLE_SIZE; i++) {
             printf("0x%x, ", wasm_bytes[i]);
         }
         std::cout << "\nExpected: 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00" << std::endl;
     }
-    index += 8;
+    index += PREAMBLE_SIZE;
     while (index < wasm_bytes.size()) {
         uint32_t section_id = read_u32(wasm_bytes, index);
         uint32_t section_size = read_u32(wasm_bytes, index);

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -207,7 +207,7 @@ void WASMDecoder::decode_wasm() {
     if (!is_preamble_ok(index)) {
         std::cout << "Unexpected Preamble: ";
         for (size_t i = 0; i < PREAMBLE_SIZE; i++) {
-            printf("0x%x, ", wasm_bytes[i]);
+            printf("0x%.02X, ", wasm_bytes[i]);
         }
         std::cout << "\nExpected: 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00" << std::endl;
     }

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -225,6 +225,7 @@ class WASMDecoder {
 
     Allocator &al;
     Vec<uint8_t> wasm_bytes;
+    size_t PREAMBLE_SIZE;
 
     Vec<wasm::FuncType> func_types;
     Vec<wasm::Import> imports;
@@ -237,6 +238,7 @@ class WASMDecoder {
         var_type_to_string = {{0x7F, "i32"}, {0x7E, "i64"}, {0x7D, "f32"}, {0x7C, "f64"}};
         kind_to_string = {{0x00, "func"}, {0x01, "table"}, {0x02, "mem"}, {0x03, "global"}};
 
+        PREAMBLE_SIZE = 8 /* BYTES */;
         // wasm_bytes.reserve(al, 1024 * 128);
         // func_types.reserve(al, 1024 * 128);
         // type_indices.reserve(al, 1024 * 128);

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -245,6 +245,7 @@ class WASMDecoder {
     }
 
     void load_file(std::string filename);
+    bool is_preamble_ok(uint32_t offset);
     void decode_type_section(uint32_t offset);
     void decode_imports_section(uint32_t offset);
     void decode_function_section(uint32_t offset);


### PR DESCRIPTION
During `wasm` to `wat` conversion, we were skipping the first `eight` bytes of wasm (as they contain the magic number and wasm version). This `PR` fixes checking/verifying those `eight` bytes.
