### PR TITLE
CI: Fix: Overwrite the latest_commit file

### DIFF
--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -29,7 +29,7 @@ cd wasm_builds/docs
 cp $D/src/bin/lfortran.js ${dest_dir}/${git_hash}/lfortran.js
 cp $D/src/bin/lfortran.wasm ${dest_dir}/${git_hash}/lfortran.wasm
 
-echo "$git_hash" >> ${dest_dir}/latest_commit
+echo "$git_hash" > ${dest_dir}/latest_commit # overwrite the file instead of appending to it
 python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_hash}
 
 git config user.name "Deploy"


### PR DESCRIPTION
We recently faced an outage at `dev.lfortran.org` due to appending to (instead of overwriting) the `latest_commit` at `wasm_builds` repository. This `PR` fixes the `CI` to (hopefully) overwrite the file.

More details at: https://github.com/lfortran/lcompilers_frontend/issues/32

The erroneous `CI` logic was written by me  and I sincerely apologize for the inconvenience caused.