### PR TITLE
WASM: Enable supporting integration_tests

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -114,38 +114,38 @@ endmacro(RUN)
 # GFortran + LFortran LLVM + LFortran C++
 
 RUN(NAME program_cmake_01 LABELS gfortran llvm cpp x86 wasm)
-RUN(NAME program_cmake_02 LABELS gfortran llvm cpp x86)
+RUN(NAME program_cmake_02 LABELS gfortran llvm cpp x86 wasm)
 
 RUN(NAME error_stop_01 FAIL LABELS gfortran llvm cpp x86 wasm llvm2)
 RUN(NAME error_stop_02 FAIL LABELS llvm wasm llvm2)
 RUN(NAME stop_01 LABELS llvm wasm llvm2)
 
-RUN(NAME print_01 LABELS gfortran llvm cpp llvm2)
+RUN(NAME print_01 LABELS gfortran llvm cpp llvm2 wasm)
 RUN(NAME print_02 LABELS gfortran llvm llvm2)
 
 RUN(NAME cond_01 LABELS gfortran llvm cpp x86 wasm)
 RUN(NAME cond_02 LABELS gfortran llvm wasm)
 
-RUN(NAME expr_01 FAIL LABELS gfortran llvm cpp x86)
-RUN(NAME expr_02 LABELS gfortran llvm cpp x86)
-RUN(NAME expr_03 LABELS gfortran llvm cpp x86)
-RUN(NAME expr_04 LABELS gfortran llvm cpp)
-RUN(NAME expr_05 LABELS gfortran llvm cpp)
-RUN(NAME expr_06 LABELS gfortran llvm)
-RUN(NAME expr_07 LABELS gfortran llvm)
+RUN(NAME expr_01 FAIL LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME expr_02 LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME expr_03 LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME expr_04 LABELS gfortran llvm cpp wasm)
+RUN(NAME expr_05 LABELS gfortran llvm cpp) # it contains pow, wasm supports only x**2
+RUN(NAME expr_06 LABELS gfortran llvm wasm)
+RUN(NAME expr_07 LABELS gfortran llvm wasm)
 RUN(NAME expr_08 LABELS gfortran llvm wasm)
 RUN(NAME expr_09 LABELS gfortran llvm wasm)
 
 RUN(NAME data_01 LABELS gfortran llvm)
-RUN(NAME minmax_01 LABELS gfortran llvm)
+RUN(NAME minmax_01 LABELS gfortran llvm wasm)
 RUN(NAME arithmetic_if_01 LABELS gfortran llvm)
 RUN(NAME arithmetic_if_02 LABELS gfortran llvm)
 RUN(NAME arithmetic_if_03 LABELS gfortran llvm)
 RUN(NAME arithmetic_if_04 LABELS gfortran llvm)
 
-RUN(NAME variables_01 LABELS gfortran llvm cpp x86)
-RUN(NAME variables_02 LABELS gfortran llvm cpp x86)
-RUN(NAME variables_03 LABELS gfortran llvm cpp)
+RUN(NAME variables_01 LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME variables_02 LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME variables_03 LABELS gfortran llvm cpp wasm)
 
 RUN(NAME if_01 LABELS gfortran llvm cpp x86 wasm)
 RUN(NAME if_02 FAIL LABELS gfortran llvm cpp x86 wasm)
@@ -153,8 +153,8 @@ RUN(NAME if_03 FAIL LABELS gfortran llvm cpp x86 wasm)
 RUN(NAME if_04 LABELS gfortran llvm cpp x86 wasm)
 RUN(NAME if_05 LABELS gfortran llvm cpp wasm)
 
-RUN(NAME while_01 LABELS gfortran llvm cpp x86)
-RUN(NAME while_02 LABELS gfortran llvm cpp)
+RUN(NAME while_01 LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME while_02 LABELS gfortran llvm cpp wasm)
 
 RUN(NAME doloop_01 LABELS gfortran llvm cpp x86 wasm)
 RUN(NAME doloop_02 LABELS gfortran llvm cpp x86 wasm)
@@ -175,25 +175,25 @@ RUN(NAME subroutines_04 LABELS gfortran llvm wasm)
 RUN(NAME subroutines_06 LABELS gfortran)
 RUN(NAME subroutines_07 LABELS gfortran)
 
-RUN(NAME functions_01 LABELS gfortran llvm cpp x86)
-RUN(NAME functions_02 LABELS gfortran llvm)
+RUN(NAME functions_01 LABELS gfortran llvm cpp x86 wasm)
+RUN(NAME functions_02 LABELS gfortran llvm wasm)
 RUN(NAME functions_03 LABELS gfortran llvm)
 RUN(NAME functions_04 LABELS gfortran llvm)
-RUN(NAME functions_05 LABELS gfortran llvm)
+RUN(NAME functions_05 LABELS gfortran llvm wasm)
 RUN(NAME functions_06 LABELS gfortran)
 RUN(NAME functions_07 LABELS gfortran llvm)
 RUN(NAME functions_08 LABELS gfortran llvm)
 RUN(NAME functions_09 LABELS gfortran)
 RUN(NAME functions_10 LABELS gfortran)
-RUN(NAME functions_11 LABELS gfortran llvm)
+RUN(NAME functions_11 LABELS gfortran llvm wasm)
 
 
-RUN(NAME types_01 LABELS gfortran llvm cpp)
-RUN(NAME types_02 LABELS gfortran llvm cpp)
-RUN(NAME types_03 LABELS gfortran llvm cpp)
-RUN(NAME types_04 LABELS gfortran llvm cpp)
-RUN(NAME types_05 LABELS gfortran llvm cpp)
-RUN(NAME types_06 LABELS gfortran llvm cpp)
+RUN(NAME types_01 LABELS gfortran llvm cpp wasm)
+RUN(NAME types_02 LABELS gfortran llvm cpp wasm)
+RUN(NAME types_03 LABELS gfortran llvm cpp wasm)
+RUN(NAME types_04 LABELS gfortran llvm cpp wasm)
+RUN(NAME types_05 LABELS gfortran llvm cpp wasm)
+RUN(NAME types_06 LABELS gfortran llvm cpp wasm)
 
 # GFortran + LFortran C++
 RUN(NAME doconcurrentloop_01 LABELS gfortran cpp)
@@ -248,7 +248,7 @@ RUN(NAME arrays_16_func LABELS gfortran llvm)
 RUN(NAME arrays_intrin_01 LABELS gfortran) # minval, maxval
 RUN(NAME arrays_intrin_02 LABELS gfortran) # all, any
 
-RUN(NAME reserved_01 LABELS gfortran)
+RUN(NAME reserved_01 LABELS gfortran llvm wasm)
 RUN(NAME reserved_02 LABELS gfortran llvm)
 RUN(NAME reserved_03 LABELS gfortran)
 
@@ -261,15 +261,15 @@ RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran)
 RUN(NAME submodule_03 LABELS gfortran)
 
-RUN(NAME floor_01 LABELS gfortran llvm) # floor body
-RUN(NAME floor_02 LABELS gfortran llvm) # floor symboltable
-RUN(NAME floor_03 LABELS gfortran)
+RUN(NAME floor_01 LABELS gfortran llvm wasm) # floor body
+RUN(NAME floor_02 LABELS gfortran llvm wasm) # floor symboltable
+RUN(NAME floor_03 LABELS gfortran wasm)
 
 RUN(NAME modulo_01 LABELS gfortran llvm)
 
-RUN(NAME int_01 LABELS gfortran llvm) # int body
-RUN(NAME int_02 LABELS gfortran) # int symboltable
-RUN(NAME int_03 LABELS gfortran llvm) # large int
+RUN(NAME int_01 LABELS gfortran llvm wasm) # int body
+RUN(NAME int_02 LABELS gfortran wasm) # int symboltable
+RUN(NAME int_03 LABELS gfortran llvm) # large int and prints array
 
 RUN(NAME intrinsics_01 LABELS gfortran) # sqrt, abs, log
 RUN(NAME intrinsics_02 LABELS gfortran llvm) # sin
@@ -278,13 +278,13 @@ RUN(NAME intrinsics_04 LABELS gfortran llvm) # tan
 RUN(NAME intrinsics_04s LABELS gfortran llvm) # ctan
 RUN(NAME intrinsics_05 LABELS gfortran llvm) # hyperbolics
 RUN(NAME intrinsics_06 LABELS gfortran llvm) # inverse trignometric
-RUN(NAME intrinsics_07 LABELS gfortran) # kind
-RUN(NAME intrinsics_08 LABELS gfortran) # tiny symboltable
-RUN(NAME intrinsics_09 LABELS gfortran) # tiny body
-RUN(NAME intrinsics_10 LABELS gfortran llvm) # real body
-RUN(NAME intrinsics_11 LABELS gfortran llvm) # real symboltable
-RUN(NAME intrinsics_12 LABELS gfortran llvm) # kind body
-RUN(NAME intrinsics_13 LABELS gfortran) # kind symboltable
+RUN(NAME intrinsics_07 LABELS gfortran wasm) # kind
+RUN(NAME intrinsics_08 LABELS gfortran wasm) # tiny symboltable
+RUN(NAME intrinsics_09 LABELS gfortran wasm) # tiny body
+RUN(NAME intrinsics_10 LABELS gfortran llvm wasm) # real body
+RUN(NAME intrinsics_11 LABELS gfortran llvm wasm) # real symboltable
+RUN(NAME intrinsics_12 LABELS gfortran llvm wasm) # kind body
+RUN(NAME intrinsics_13 LABELS gfortran wasm) # kind symboltable
 RUN(NAME intrinsics_14 LABELS gfortran llvm) # selected_real,int_kind body
 RUN(NAME intrinsics_15 LABELS gfortran llvm) # real
 RUN(NAME intrinsics_16 LABELS gfortran) # aimag
@@ -294,20 +294,20 @@ RUN(NAME intrinsics_18c LABELS gfortran llvm)
 RUN(NAME intrinsics_19 LABELS gfortran llvm)
 RUN(NAME intrinsics_19c LABELS gfortran llvm)
 RUN(NAME intrinsics_20 LABELS gfortran llvm)
-RUN(NAME intrinsics_21 LABELS gfortran llvm)
-RUN(NAME intrinsics_22 LABELS gfortran llvm)
-RUN(NAME intrinsics_23 LABELS gfortran llvm) # huge
+RUN(NAME intrinsics_21 LABELS gfortran llvm wasm) # modulo and mod
+RUN(NAME intrinsics_22 LABELS gfortran llvm wasm)
+RUN(NAME intrinsics_23 LABELS gfortran llvm wasm) # huge
 RUN(NAME intrinsics_24 LABELS gfortran llvm) # System_clock
 RUN(NAME intrinsics_25 LABELS gfortran llvm) # ishft
 RUN(NAME intrinsics_26 LABELS gfortran llvm)
 RUN(NAME intrinsics_27 LABELS gfortran)
-RUN(NAME intrinsics_28 LABELS gfortran llvm)
+RUN(NAME intrinsics_28 LABELS gfortran llvm wasm)
 RUN(NAME intrinsics_29 LABELS gfortran llvm) # random_number
 RUN(NAME intrinsics_30 LABELS gfortran llvm)
-RUN(NAME intrinsics_31 LABELS gfortran llvm)
+RUN(NAME intrinsics_31 LABELS gfortran llvm wasm)
 RUN(NAME intrinsics_32 LABELS gfortran)
 RUN(NAME intrinsics_33 LABELS gfortran llvm)
-RUN(NAME intrinsics_34 LABELS gfortran llvm)
+RUN(NAME intrinsics_34 LABELS gfortran llvm wasm)
 RUN(NAME intrinsics_35 LABELS gfortran)
 RUN(NAME intrinsics_36 LABELS gfortran llvm) # adjustl
 RUN(NAME intrinsics_37 LABELS gfortran)
@@ -318,14 +318,14 @@ RUN(NAME intrinsics_41 LABELS gfortran) # command_argument_count
 RUN(NAME intrinsics_42 LABELS gfortran) # hypot
 RUN(NAME intrinsics_43 LABELS gfortran) # dim
 RUN(NAME intrinsics_44 LABELS gfortran) # cshift
-RUN(NAME intrinsics_45 LABELS gfortran llvm) # iso_fortran_env
+RUN(NAME intrinsics_45 LABELS gfortran llvm wasm) # iso_fortran_env
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)
-RUN(NAME parameter_03 LABELS gfortran llvm)
-RUN(NAME parameter_04 LABELS gfortran llvm) # selected_real,int_kind symboltable
-RUN(NAME parameter_05 LABELS gfortran llvm) # Implicit IntegerToReal
+RUN(NAME parameter_03 LABELS gfortran llvm wasm)
+RUN(NAME parameter_04 LABELS gfortran llvm wasm) # selected_real,int_kind symboltable
+RUN(NAME parameter_05 LABELS gfortran llvm wasm) # Implicit IntegerToReal
 
 RUN(NAME modules_01 LABELS gfortran llvm)
 RUN(NAME modules_02 LABELS gfortran llvm)
@@ -389,7 +389,7 @@ RUN(NAME subroutines_03 LABELS gfortran)
 
 RUN(NAME parsing_01 LABELS gfortran)
 RUN(NAME parsing_02 LABELS gfortran)
-RUN(NAME parsing_03 LABELS gfortran llvm)
+RUN(NAME parsing_03 LABELS gfortran llvm wasm)
 
 RUN(NAME interface_01 LABELS gfortran llvm)
 RUN(NAME interface_02 LABELS gfortran llvm)
@@ -413,9 +413,9 @@ RUN(NAME types_08 LABELS gfortran)
 RUN(NAME types_09 LABELS gfortran)
 RUN(NAME types_10 LABELS gfortran)
 RUN(NAME types_11 LABELS gfortran)
-RUN(NAME types_12 LABELS gfortran llvm)
+RUN(NAME types_12 LABELS gfortran llvm wasm)
 RUN(NAME types_13 LABELS gfortran)
-RUN(NAME types_14 LABELS gfortran llvm)
+RUN(NAME types_14 LABELS gfortran llvm wasm)
 RUN(NAME types_16 LABELS gfortran llvm wasm)
 
 RUN(NAME complex_01 LABELS gfortran llvm)
@@ -432,10 +432,10 @@ RUN(NAME complex_mul_test LABELS gfortran llvm)
 RUN(NAME complex_div_test LABELS gfortran llvm)
 RUN(NAME complex_pow_test LABELS gfortran llvm)
 
-RUN(NAME logical1 LABELS gfortran llvm)
-RUN(NAME logical2 LABELS gfortran llvm)
-RUN(NAME logical3 LABELS gfortran llvm)
-RUN(NAME logical4 LABELS gfortran llvm)
+RUN(NAME logical1 LABELS gfortran llvm wasm)
+RUN(NAME logical2 LABELS gfortran llvm wasm)
+RUN(NAME logical3 LABELS gfortran llvm wasm)
+RUN(NAME logical4 LABELS gfortran llvm wasm)
 
 # `reduce` is not supported by GFortran yet:
 # RUN(NAME doconcurrentloop_02 LABELS gfortran)
@@ -451,13 +451,13 @@ RUN(NAME derived_types_08 LABELS gfortran)
 RUN(NAME derived_types_09 LABELS gfortran EXTRAFILES
         derived_types_09b.f90 derived_types_09c.f90)
 
-RUN(NAME line_continuation_01 LABELS gfortran llvm)
-RUN(NAME line_continuation_02 LABELS gfortran llvm)
-RUN(NAME line_continuation_03 LABELS gfortran llvm)
+RUN(NAME line_continuation_01 LABELS gfortran llvm wasm)
+RUN(NAME line_continuation_02 LABELS gfortran llvm wasm)
+RUN(NAME line_continuation_03 LABELS gfortran llvm wasm)
 
 RUN(NAME program_01 LABELS gfortran)
 RUN(NAME init_values LABELS gfortran llvm)
-RUN(NAME param_pass_01 LABELS gfortran)
+RUN(NAME param_pass_01 LABELS gfortran llvm wasm)
 
 RUN(NAME allocate_01 LABELS gfortran llvm)
 RUN(NAME allocate_02 LABELS gfortran llvm)
@@ -472,17 +472,17 @@ RUN(NAME associate_03 LABELS gfortran llvm)
 RUN(NAME associate_04 LABELS gfortran llvm)
 RUN(NAME associate_05 LABELS gfortran)
 
-RUN(NAME real_dp LABELS gfortran llvm)
+RUN(NAME real_dp LABELS gfortran llvm wasm)
 RUN(NAME bin_op_real_dp LABELS gfortran llvm)
-RUN(NAME const_real_dp LABELS gfortran llvm)
-RUN(NAME real_dp_param LABELS gfortran llvm)
-RUN(NAME int_dp LABELS gfortran llvm)
-RUN(NAME int_dp_param LABELS gfortran llvm)
+RUN(NAME const_real_dp LABELS gfortran llvm wasm)
+RUN(NAME real_dp_param LABELS gfortran llvm wasm)
+RUN(NAME int_dp LABELS gfortran llvm wasm)
+RUN(NAME int_dp_param LABELS gfortran llvm wasm)
 RUN(NAME complex_dp LABELS gfortran llvm)
 RUN(NAME bin_op_complex_dp LABELS gfortran llvm)
 RUN(NAME complex_dp_param LABELS gfortran llvm)
-RUN(NAME const_kind_01 LABELS gfortran llvm)
-RUN(NAME const_kind_02 LABELS gfortran llvm)
+RUN(NAME const_kind_01 LABELS gfortran llvm wasm)
+RUN(NAME const_kind_02 LABELS gfortran llvm wasm)
 RUN(NAME const_array_01 LABELS gfortran llvm)
 RUN(NAME const_array_02 LABELS gfortran llvm)
 
@@ -523,24 +523,24 @@ RUN(NAME recursion_01 LABELS gfortran llvm)
 RUN(NAME recursion_02 LABELS gfortran llvm)
 RUN(NAME recursion_03 LABELS gfortran llvm)
 
-RUN(NAME return_01 LABELS gfortran llvm)
-RUN(NAME return_02 LABELS gfortran llvm)
-RUN(NAME return_03 LABELS gfortran llvm)
-RUN(NAME return_04 LABELS gfortran llvm)
+RUN(NAME return_01 LABELS gfortran llvm wasm)
+RUN(NAME return_02 LABELS gfortran llvm) # contains module
+RUN(NAME return_03 LABELS gfortran llvm wasm)
+RUN(NAME return_04 LABELS gfortran llvm wasm)
 
 RUN(NAME class_01 LABELS gfortran)
 RUN(NAME class_02 LABELS gfortran llvm)
 RUN(NAME class_03 LABELS gfortran)
 RUN(NAME class_04 LABELS gfortran)
 
-RUN(NAME kwargs_01 LABELS gfortran llvm)
+RUN(NAME kwargs_01 LABELS gfortran llvm wasm)
 RUN(NAME kwargs_02 LABELS gfortran)
 
-RUN(NAME test_iso_c_binding LABELS gfortran llvm)
-RUN(NAME test_iso_fortran_env LABELS gfortran llvm)
+RUN(NAME test_iso_c_binding LABELS gfortran llvm wasm)
+RUN(NAME test_iso_fortran_env LABELS gfortran llvm wasm)
 
 RUN(NAME abs_01 LABELS gfortran llvm wasm)
-RUN(NAME abs_02 LABELS gfortran llvm) # for wasm, currently we get type mismatch error
+RUN(NAME abs_02 LABELS gfortran llvm wasm)
 RUN(NAME abs_03 LABELS gfortran llvm wasm)
 RUN(NAME sqrt_01 LABELS gfortran llvm)
 RUN(NAME sqrt_02 LABELS gfortran llvm)
@@ -556,11 +556,11 @@ RUN(NAME bits_05 LABELS gfortran llvm)
 RUN(NAME cpu_time_01 LABELS gfortran llvm)
 RUN(NAME boz_01 LABELS gfortran llvm)
 
-RUN(NAME flip_sign LABELS gfortran llvm)
-RUN(NAME div_to_mul LABELS gfortran llvm)
-RUN(NAME fma LABELS gfortran llvm)
-RUN(NAME loop_unroll_small LABELS gfortran llvm)
+RUN(NAME flip_sign LABELS gfortran llvm wasm)
+RUN(NAME div_to_mul LABELS gfortran llvm wasm)
+RUN(NAME fma LABELS gfortran llvm wasm)
+RUN(NAME loop_unroll_small LABELS gfortran llvm wasm)
 RUN(NAME loop_unroll_large LABELS gfortran llvm)
-RUN(NAME sign_from_value LABELS gfortran llvm)
+RUN(NAME sign_from_value LABELS gfortran llvm wasm)
 
 RUN(NAME rewind_inquire_flush LABELS gfortran)


### PR DESCRIPTION
This `PR` enables `wasm` backend for supporting tests in `integration_tests/CMakeLists.txt`.