### PR TITLE
WASM, WAT: Improve code formatting

### DIFF
--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -17,51 +17,42 @@
 // #define SHOW_ASR
 
 #ifdef SHOW_ASR
-    #include <lfortran/pickle.h>
+#include <lfortran/pickle.h>
 #endif
 
 namespace LFortran {
 
 namespace {
 
-    // This exception is used to abort the visitor pattern when an error occurs.
-    class CodeGenAbort
-    {
-    };
+// This exception is used to abort the visitor pattern when an error occurs.
+class CodeGenAbort {};
 
-    // Local exception that is only used in this file to exit the visitor
-    // pattern and caught later (not propagated outside)
-    class CodeGenError {
-    public:
-        diag::Diagnostic d;
+// Local exception that is only used in this file to exit the visitor
+// pattern and caught later (not propagated outside)
+class CodeGenError {
+   public:
+    diag::Diagnostic d;
 
-    public:
-        CodeGenError(const std::string &msg)
-            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)}
-        { }
+   public:
+    CodeGenError(const std::string &msg)
+        : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)} {}
 
-        CodeGenError(const std::string &msg, const Location &loc)
-            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen, {
-                diag::Label("", {loc})
-            })}
-        { }
-    };
+    CodeGenError(const std::string &msg, const Location &loc)
+        : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen,
+                             {diag::Label("", {loc})})} {}
+};
 
 }  // namespace
 
 // Platform dependent fast unique hash:
-static uint64_t get_hash(ASR::asr_t *node)
-{
-    return (uint64_t)node;
-}
+static uint64_t get_hash(ASR::asr_t *node) { return (uint64_t)node; }
 
-struct ImportFunc{
+struct ImportFunc {
     std::string name;
     std::vector<std::pair<ASR::ttypeType, uint32_t>> param_types, result_types;
 };
 
-struct SymbolFuncInfo
-{
+struct SymbolFuncInfo {
     bool needs_declaration = true;
     bool intrinsic_function = false;
     uint32_t index = 0;
@@ -76,9 +67,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     diag::Diagnostics &diag;
 
     bool intrinsic_module;
-    SymbolTable* global_scope;
+    SymbolTable *global_scope;
     Location global_scope_loc;
-    SymbolFuncInfo* cur_sym_info;
+    SymbolFuncInfo *cur_sym_info;
     uint32_t nesting_level;
     uint32_t cur_loop_nesting_level;
     bool is_prototype_only;
@@ -105,7 +96,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     std::map<std::string, ASR::asr_t *> m_import_func_asr_map;
 
    public:
-    ASRToWASMVisitor(Allocator &al, diag::Diagnostics &diagnostics): m_al(al), diag(diagnostics) {
+    ASRToWASMVisitor(Allocator &al, diag::Diagnostics &diagnostics)
+        : m_al(al), diag(diagnostics) {
         intrinsic_module = false;
         is_prototype_only = false;
         nesting_level = 0;
@@ -116,8 +108,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         no_of_imports = 0;
         no_of_data_segments = 0;
 
-        min_no_pages = 100; // fixed 6.4 Mb memory currently
-        max_no_pages = 100; // fixed 6.4 Mb memory currently
+        min_no_pages = 100;  // fixed 6.4 Mb memory currently
+        max_no_pages = 100;  // fixed 6.4 Mb memory currently
 
         m_type_section.reserve(m_al, 1024 * 128);
         m_import_section.reserve(m_al, 1024 * 128);
@@ -127,72 +119,92 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         m_data_section.reserve(m_al, 1024 * 128);
     }
 
-    void get_wasm(Vec<uint8_t> &code){
-        code.reserve(m_al, 8U /* preamble size */ + 8U /* (section id + section size) */ * 6U /* number of sections */
-            + m_type_section.size() + m_import_section.size() + m_func_section.size()
-            + m_export_section.size() + m_code_section.size() + m_data_section.size());
+    void get_wasm(Vec<uint8_t> &code) {
+        code.reserve(m_al, 8U /* preamble size */ +
+                               8U /* (section id + section size) */ *
+                                   6U /* number of sections */
+                               + m_type_section.size() +
+                               m_import_section.size() + m_func_section.size() +
+                               m_export_section.size() + m_code_section.size() +
+                               m_data_section.size());
 
         wasm::emit_header(code, m_al);  // emit header and version
-        wasm::encode_section(code, m_type_section, m_al, 1U, no_of_types);  // no_of_types indicates total (imported + defined) no of functions
+        wasm::encode_section(
+            code, m_type_section, m_al, 1U,
+            no_of_types);  // no_of_types indicates total (imported + defined)
+                           // no of functions
         wasm::encode_section(code, m_import_section, m_al, 2U, no_of_imports);
         wasm::encode_section(code, m_func_section, m_al, 3U, no_of_functions);
         wasm::encode_section(code, m_export_section, m_al, 7U, no_of_functions);
         wasm::encode_section(code, m_code_section, m_al, 10U, no_of_functions);
-        wasm::encode_section(code, m_data_section, m_al, 11U, no_of_data_segments);
+        wasm::encode_section(code, m_data_section, m_al, 11U,
+                             no_of_data_segments);
     }
 
-    ASR::asr_t* get_import_func_var_type(std::pair<ASR::ttypeType, uint32_t> &type) {
-        switch (type.first)
-        {
-            case ASR::ttypeType::Integer: return ASR::make_Integer_t(m_al, global_scope_loc, type.second, nullptr, 0);
-            case ASR::ttypeType::Real: return ASR::make_Real_t(m_al, global_scope_loc, type.second, nullptr, 0);
-            default: throw CodeGenError("Unsupported Type in Import Function");
+    ASR::asr_t *get_import_func_var_type(
+        std::pair<ASR::ttypeType, uint32_t> &type) {
+        switch (type.first) {
+            case ASR::ttypeType::Integer:
+                return ASR::make_Integer_t(m_al, global_scope_loc, type.second,
+                                           nullptr, 0);
+            case ASR::ttypeType::Real:
+                return ASR::make_Real_t(m_al, global_scope_loc, type.second,
+                                        nullptr, 0);
+            default:
+                throw CodeGenError("Unsupported Type in Import Function");
         }
         return nullptr;
     }
 
     void import_function(ImportFunc &import_func) {
-        Vec<ASR::expr_t*> params;
+        Vec<ASR::expr_t *> params;
         params.reserve(m_al, import_func.param_types.size());
         uint32_t var_idx;
-        for(var_idx = 0; var_idx < import_func.param_types.size(); var_idx++) {
+        for (var_idx = 0; var_idx < import_func.param_types.size(); var_idx++) {
             auto param = import_func.param_types[var_idx];
             auto type = get_import_func_var_type(param);
-            auto variable = ASR::make_Variable_t(m_al, global_scope_loc, nullptr, s2c(m_al, std::to_string(var_idx)),
-                ASR::intentType::In, nullptr, nullptr, ASR::storage_typeType::Default,
-                ASRUtils::TYPE(type), ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Required, false);
-            auto var = ASR::make_Var_t(m_al, global_scope_loc, ASR::down_cast<ASR::symbol_t>(variable));
+            auto variable = ASR::make_Variable_t(
+                m_al, global_scope_loc, nullptr,
+                s2c(m_al, std::to_string(var_idx)), ASR::intentType::In,
+                nullptr, nullptr, ASR::storage_typeType::Default,
+                ASRUtils::TYPE(type), ASR::abiType::Source,
+                ASR::accessType::Public, ASR::presenceType::Required, false);
+            auto var = ASR::make_Var_t(m_al, global_scope_loc,
+                                       ASR::down_cast<ASR::symbol_t>(variable));
             params.push_back(m_al, ASRUtils::EXPR(var));
         }
 
-        auto func = ASR::make_Function_t(m_al, global_scope_loc, global_scope, s2c(m_al, import_func.name),
-                params.data(), params.size(), nullptr, 0, nullptr, 0, nullptr, ASR::abiType::Source, ASR::accessType::Public,
-                ASR::deftypeType::Implementation, nullptr, false, false, false);
+        auto func = ASR::make_Function_t(
+            m_al, global_scope_loc, global_scope, s2c(m_al, import_func.name),
+            params.data(), params.size(), nullptr, 0, nullptr, 0, nullptr,
+            ASR::abiType::Source, ASR::accessType::Public,
+            ASR::deftypeType::Implementation, nullptr, false, false, false);
         m_import_func_asr_map[import_func.name] = func;
 
-
-        wasm::emit_import_fn(m_import_section, m_al, "js", import_func.name, no_of_types);
+        wasm::emit_import_fn(m_import_section, m_al, "js", import_func.name,
+                             no_of_types);
         emit_function_prototype(*((ASR::Function_t *)func));
         no_of_imports++;
     }
 
-    void emit_imports(){
+    void emit_imports() {
         std::vector<ImportFunc> import_funcs = {
-            {"print_i32", { {ASR::ttypeType::Integer, 4} }, {}},
-            {"print_i64", { {ASR::ttypeType::Integer, 8} }, {}},
-            {"print_f32", { {ASR::ttypeType::Real, 4} }, {}},
-            {"print_f64", { {ASR::ttypeType::Real, 8} }, {}},
-            {"print_str", { {ASR::ttypeType::Integer, 4}, {ASR::ttypeType::Integer, 4} }, {}},
+            {"print_i32", {{ASR::ttypeType::Integer, 4}}, {}},
+            {"print_i64", {{ASR::ttypeType::Integer, 8}}, {}},
+            {"print_f32", {{ASR::ttypeType::Real, 4}}, {}},
+            {"print_f64", {{ASR::ttypeType::Real, 8}}, {}},
+            {"print_str",
+             {{ASR::ttypeType::Integer, 4}, {ASR::ttypeType::Integer, 4}},
+             {}},
             {"flush_buf", {}, {}},
-            {"set_exit_code", { {ASR::ttypeType::Integer, 4} }, {}}
-         };
+            {"set_exit_code", {{ASR::ttypeType::Integer, 4}}, {}}};
 
-        for (auto ImportFunc:import_funcs) {
+        for (auto ImportFunc : import_funcs) {
             import_function(ImportFunc);
         }
 
-        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", min_no_pages, max_no_pages);
+        wasm::emit_import_mem(m_import_section, m_al, "js", "memory",
+                              min_no_pages, max_no_pages);
         no_of_imports++;
     }
 
@@ -212,15 +224,16 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             is_prototype_only = true;
             {
                 // Process intrinsic modules in the right order
-                std::vector<std::string> build_order
-                    = ASRUtils::determine_module_dependencies(x);
+                std::vector<std::string> build_order =
+                    ASRUtils::determine_module_dependencies(x);
                 for (auto &item : build_order) {
-                    LFORTRAN_ASSERT(x.m_global_scope->get_scope().find(item)
-                        != x.m_global_scope->get_scope().end());
+                    LFORTRAN_ASSERT(x.m_global_scope->get_scope().find(item) !=
+                                    x.m_global_scope->get_scope().end());
                     if (startswith(item, "lfortran_intrinsic")) {
                         ASR::symbol_t *mod = x.m_global_scope->get_symbol(item);
                         if (ASR::is_a<ASR::Module_t>(*mod)) {
-                            ASR::Module_t *m = ASR::down_cast<ASR::Module_t>(mod);
+                            ASR::Module_t *m =
+                                ASR::down_cast<ASR::Module_t>(mod);
                             declare_all_functions(*(m->m_symtab));
                         }
                     }
@@ -229,7 +242,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 // then the main program:
                 for (auto &item : x.m_global_scope->get_scope()) {
                     if (ASR::is_a<ASR::Program_t>(*item.second)) {
-                        ASR::Program_t *p = ASR::down_cast<ASR::Program_t>(item.second);
+                        ASR::Program_t *p =
+                            ASR::down_cast<ASR::Program_t>(item.second);
                         declare_all_functions(*(p->m_symtab));
                     }
                 }
@@ -239,11 +253,11 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
         {
             // Process intrinsic modules in the right order
-            std::vector<std::string> build_order
-                = ASRUtils::determine_module_dependencies(x);
+            std::vector<std::string> build_order =
+                ASRUtils::determine_module_dependencies(x);
             for (auto &item : build_order) {
-                LFORTRAN_ASSERT(x.m_global_scope->get_scope().find(item)
-                    != x.m_global_scope->get_scope().end());
+                LFORTRAN_ASSERT(x.m_global_scope->get_scope().find(item) !=
+                                x.m_global_scope->get_scope().end());
                 if (startswith(item, "lfortran_intrinsic")) {
                     ASR::symbol_t *mod = x.m_global_scope->get_symbol(item);
                     this->visit_symbol(*mod);
@@ -284,7 +298,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     void declare_all_functions(const SymbolTable &symtab) {
         for (auto &item : symtab.get_scope()) {
             if (ASR::is_a<ASR::Function_t>(*item.second)) {
-                ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
+                ASR::Function_t *s =
+                    ASR::down_cast<ASR::Function_t>(item.second);
                 this->visit_Function(*s);
             }
         }
@@ -303,79 +318,82 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_Program(const ASR::Program_t &x) {
-
         // Generate the bodies of functions and subroutines
         declare_all_functions(*x.m_symtab);
 
         // Generate main program code
-        auto main_func = ASR::make_Function_t(m_al, x.base.base.loc, x.m_symtab, s2c(m_al, "_lcompilers_main"),
-            nullptr, 0, nullptr, 0, x.m_body, x.n_body, nullptr, ASR::abiType::Source, ASR::accessType::Public,
+        auto main_func = ASR::make_Function_t(
+            m_al, x.base.base.loc, x.m_symtab, s2c(m_al, "_lcompilers_main"),
+            nullptr, 0, nullptr, 0, x.m_body, x.n_body, nullptr,
+            ASR::abiType::Source, ASR::accessType::Public,
             ASR::deftypeType::Implementation, nullptr, false, false, false);
         emit_function_prototype(*((ASR::Function_t *)main_func));
         emit_function_body(*((ASR::Function_t *)main_func));
     }
 
-    void emit_var_type(Vec<uint8_t> &code, ASR::Variable_t *v){
+    void emit_var_type(Vec<uint8_t> &code, ASR::Variable_t *v) {
         // bool use_ref = (v->m_intent == LFortran::ASRUtils::intent_out ||
         //                 v->m_intent == LFortran::ASRUtils::intent_inout);
         bool is_array = ASRUtils::is_array(v->m_type);
 
         if (ASRUtils::is_pointer(v->m_type)) {
-            ASR::ttype_t *t2 = ASR::down_cast<ASR::Pointer_t>(v->m_type)->m_type;
+            ASR::ttype_t *t2 =
+                ASR::down_cast<ASR::Pointer_t>(v->m_type)->m_type;
             if (ASRUtils::is_integer(*t2)) {
                 ASR::Integer_t *t = ASR::down_cast<ASR::Integer_t>(t2);
                 // size_t size;
-                diag.codegen_warning_label("Pointers are not currently supported",
-                    {v->base.base.loc}, "emitting integer for now");
+                diag.codegen_warning_label(
+                    "Pointers are not currently supported", {v->base.base.loc},
+                    "emitting integer for now");
                 if (t->m_kind == 4) {
                     wasm::emit_b8(code, m_al, wasm::type::i32);
-                }
-                else if (t->m_kind == 8) {
+                } else if (t->m_kind == 8) {
                     wasm::emit_b8(code, m_al, wasm::type::i64);
-                }
-                else{
-                    throw CodeGenError("Integers of kind 4 and 8 only supported");
+                } else {
+                    throw CodeGenError(
+                        "Integers of kind 4 and 8 only supported");
                 }
             } else {
-                diag.codegen_error_label("Type number '"
-                    + std::to_string(v->m_type->type)
-                    + "' not supported", {v->base.base.loc}, "");
+                diag.codegen_error_label("Type number '" +
+                                             std::to_string(v->m_type->type) +
+                                             "' not supported",
+                                         {v->base.base.loc}, "");
                 throw CodeGenAbort();
             }
         } else {
             if (ASRUtils::is_integer(*v->m_type)) {
-                ASR::Integer_t* v_int = ASR::down_cast<ASR::Integer_t>(v->m_type);
+                ASR::Integer_t *v_int =
+                    ASR::down_cast<ASR::Integer_t>(v->m_type);
                 if (is_array) {
                     wasm::emit_b8(code, m_al, wasm::type::i32);
                 } else {
                     if (v_int->m_kind == 4) {
                         wasm::emit_b8(code, m_al, wasm::type::i32);
-                    }
-                    else if (v_int->m_kind == 8) {
+                    } else if (v_int->m_kind == 8) {
                         wasm::emit_b8(code, m_al, wasm::type::i64);
-                    }
-                    else{
-                        throw CodeGenError("Integers of kind 4 and 8 only supported");
+                    } else {
+                        throw CodeGenError(
+                            "Integers of kind 4 and 8 only supported");
                     }
                 }
             } else if (ASRUtils::is_real(*v->m_type)) {
-                ASR::Real_t* v_float = ASR::down_cast<ASR::Real_t>(v->m_type);
+                ASR::Real_t *v_float = ASR::down_cast<ASR::Real_t>(v->m_type);
 
                 if (is_array) {
                     wasm::emit_b8(code, m_al, wasm::type::i32);
                 } else {
                     if (v_float->m_kind == 4) {
                         wasm::emit_b8(code, m_al, wasm::type::f32);
-                    }
-                    else if(v_float->m_kind == 8){
+                    } else if (v_float->m_kind == 8) {
                         wasm::emit_b8(code, m_al, wasm::type::f64);
-                    }
-                    else {
-                        throw CodeGenError("Floating Points of kind 4 and 8 only supported");
+                    } else {
+                        throw CodeGenError(
+                            "Floating Points of kind 4 and 8 only supported");
                     }
                 }
             } else if (ASRUtils::is_logical(*v->m_type)) {
-                ASR::Logical_t* v_logical = ASR::down_cast<ASR::Logical_t>(v->m_type);
+                ASR::Logical_t *v_logical =
+                    ASR::down_cast<ASR::Logical_t>(v->m_type);
 
                 if (is_array) {
                     wasm::emit_b8(code, m_al, wasm::type::i32);
@@ -383,76 +401,98 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     // All Logicals are represented as i32 in WASM
                     if (v_logical->m_kind == 4) {
                         wasm::emit_b8(code, m_al, wasm::type::i32);
-                    }
-                    else {
+                    } else {
                         throw CodeGenError("Logicals of kind 4 only supported");
                     }
                 }
             } else if (ASRUtils::is_character(*v->m_type)) {
-                ASR::Character_t* v_int = ASR::down_cast<ASR::Character_t>(v->m_type);
+                ASR::Character_t *v_int =
+                    ASR::down_cast<ASR::Character_t>(v->m_type);
                 /* Currently Assuming character as integer of kind 1 */
 
                 if (is_array) {
-                        wasm::emit_b8(code, m_al, wasm::type::i32);
+                    wasm::emit_b8(code, m_al, wasm::type::i32);
                 } else {
                     if (v_int->m_kind == 1) {
                         wasm::emit_b8(code, m_al, wasm::type::i32);
-                    }
-                    else{
-                        throw CodeGenError("Characters of kind 1 only supported");
+                    } else {
+                        throw CodeGenError(
+                            "Characters of kind 1 only supported");
                     }
                 }
             } else {
-                // throw CodeGenError("Param, Result, Var Types other than integer, floating point and logical not yet supported");
-                diag.codegen_warning_label("Unsupported variable type: " + ASRUtils::type_to_str(v->m_type),
-                        {v->base.base.loc}, "here");
+                // throw CodeGenError("Param, Result, Var Types other than
+                // integer, floating point and logical not yet supported");
+                diag.codegen_warning_label("Unsupported variable type: " +
+                                               ASRUtils::type_to_str(v->m_type),
+                                           {v->base.base.loc}, "here");
             }
         }
     }
 
-    template<typename T>
-    void emit_local_vars(const T& x, int var_idx /* starting index for local vars */) {
+    template <typename T>
+    void emit_local_vars(const T &x,
+                         int var_idx /* starting index for local vars */) {
         /********************* Local Vars Types List *********************/
-        uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
+        uint32_t len_idx_code_section_local_vars_list =
+            wasm::emit_len_placeholder(m_code_section, m_al);
         int local_vars_cnt = 0;
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
-                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (v->m_intent == ASRUtils::intent_local || v->m_intent == ASRUtils::intent_return_var) {
-                    wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
-                    emit_var_type(m_code_section, v); // emit the type of this var
+                ASR::Variable_t *v =
+                    ASR::down_cast<ASR::Variable_t>(item.second);
+                if (v->m_intent == ASRUtils::intent_local ||
+                    v->m_intent == ASRUtils::intent_return_var) {
+                    wasm::emit_u32(m_code_section, m_al,
+                                   1U);  // count of local vars of this type
+                    emit_var_type(m_code_section,
+                                  v);  // emit the type of this var
                     m_var_name_idx_map[get_hash((ASR::asr_t *)v)] = var_idx++;
                     local_vars_cnt++;
                 }
             }
         }
         // fixup length of local vars list
-        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section_local_vars_list, local_vars_cnt);
+        wasm::emit_u32_b32_idx(m_code_section, m_al,
+                               len_idx_code_section_local_vars_list,
+                               local_vars_cnt);
 
         // initialize the value for local variables if initialization exists
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
-                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (v->m_intent == ASRUtils::intent_local || v->m_intent == ASRUtils::intent_return_var) {
-                    if(v->m_symbolic_value) {
+                ASR::Variable_t *v =
+                    ASR::down_cast<ASR::Variable_t>(item.second);
+                if (v->m_intent == ASRUtils::intent_local ||
+                    v->m_intent == ASRUtils::intent_return_var) {
+                    if (v->m_symbolic_value) {
                         this->visit_expr(*v->m_symbolic_value);
                         // Todo: Checking for Array is currently omitted
-                        LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)v)) != m_var_name_idx_map.end())
-                        wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)v)]);
+                        LFORTRAN_ASSERT(m_var_name_idx_map.find(
+                                            get_hash((ASR::asr_t *)v)) !=
+                                        m_var_name_idx_map.end())
+                        wasm::emit_set_local(
+                            m_code_section, m_al,
+                            m_var_name_idx_map[get_hash((ASR::asr_t *)v)]);
                     } else if (ASRUtils::is_array(v->m_type)) {
-                        uint32_t kind = ASRUtils::extract_kind_from_ttype_t(v->m_type);
+                        uint32_t kind =
+                            ASRUtils::extract_kind_from_ttype_t(v->m_type);
 
                         Vec<uint32_t> array_dims;
                         get_array_dims(*v, array_dims);
 
                         uint32_t total_array_size = 1;
-                        for (auto &dim:array_dims) {
-                            total_array_size *=  dim;
+                        for (auto &dim : array_dims) {
+                            total_array_size *= dim;
                         }
 
-                        LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)v)) != m_var_name_idx_map.end());
-                        wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc);
-                        wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)v)]);
+                        LFORTRAN_ASSERT(m_var_name_idx_map.find(
+                                            get_hash((ASR::asr_t *)v)) !=
+                                        m_var_name_idx_map.end());
+                        wasm::emit_i32_const(m_code_section, m_al,
+                                             avail_mem_loc);
+                        wasm::emit_set_local(
+                            m_code_section, m_al,
+                            m_var_name_idx_map[get_hash((ASR::asr_t *)v)]);
                         avail_mem_loc += kind * total_array_size;
                     }
                 }
@@ -461,7 +501,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void emit_function_prototype(const ASR::Function_t &x) {
-        SymbolFuncInfo* s = new SymbolFuncInfo;
+        SymbolFuncInfo *s = new SymbolFuncInfo;
 
         /********************* New Type Declaration *********************/
         wasm::emit_b8(m_type_section, m_al, 0x60);
@@ -473,53 +513,69 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             ASR::Variable_t *arg = ASRUtils::EXPR2VAR(x.m_args[i]);
             LFORTRAN_ASSERT(ASRUtils::is_arg_dummy(arg->m_intent));
             emit_var_type(m_type_section, arg);
-            m_var_name_idx_map[get_hash((ASR::asr_t *)arg)] = s->no_of_variables++;
-            if (arg->m_intent == ASR::intentType::Out || arg->m_intent == ASR::intentType::InOut) {
+            m_var_name_idx_map[get_hash((ASR::asr_t *)arg)] =
+                s->no_of_variables++;
+            if (arg->m_intent == ASR::intentType::Out ||
+                arg->m_intent == ASR::intentType::InOut) {
                 s->referenced_vars.push_back(m_al, arg);
             }
         }
 
         /********************* Result Types List *********************/
-        if (x.m_return_var) { // It is a function
-            wasm::emit_u32(m_type_section, m_al, 1U); // there is just one return variable
+        if (x.m_return_var) {  // It is a function
+            wasm::emit_u32(m_type_section, m_al,
+                           1U);  // there is just one return variable
             s->return_var = ASRUtils::EXPR2VAR(x.m_return_var);
             emit_var_type(m_type_section, s->return_var);
-        } else { // It is a subroutine
-            uint32_t len_idx_type_section_return_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
+        } else {  // It is a subroutine
+            uint32_t len_idx_type_section_return_types_list =
+                wasm::emit_len_placeholder(m_type_section, m_al);
             for (size_t i = 0; i < x.n_args; i++) {
                 ASR::Variable_t *arg = ASRUtils::EXPR2VAR(x.m_args[i]);
-                if (arg->m_intent == ASR::intentType::Out || arg->m_intent == ASR::intentType::InOut) {
+                if (arg->m_intent == ASR::intentType::Out ||
+                    arg->m_intent == ASR::intentType::InOut) {
                     emit_var_type(m_type_section, arg);
                 }
             }
-            wasm::fixup_len(m_type_section, m_al, len_idx_type_section_return_types_list);
+            wasm::fixup_len(m_type_section, m_al,
+                            len_idx_type_section_return_types_list);
         }
 
         /********************* Add Type to Map *********************/
         s->index = no_of_types++;
-        m_func_name_idx_map[get_hash((ASR::asr_t *)&x)] = s; // add function to map
+        m_func_name_idx_map[get_hash((ASR::asr_t *)&x)] =
+            s;  // add function to map
     }
 
     void emit_function_body(const ASR::Function_t &x) {
-        LFORTRAN_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)&x)) != m_func_name_idx_map.end());
+        LFORTRAN_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)&x)) !=
+                        m_func_name_idx_map.end());
 
         cur_sym_info = m_func_name_idx_map[get_hash((ASR::asr_t *)&x)];
 
-        /********************* Reference Function Prototype *********************/
+        /********************* Reference Function Prototype
+         * *********************/
         wasm::emit_u32(m_func_section, m_al, cur_sym_info->index);
 
         /********************* Function Body Starts Here *********************/
-        uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
+        uint32_t len_idx_code_section_func_size =
+            wasm::emit_len_placeholder(m_code_section, m_al);
 
         emit_local_vars(x, cur_sym_info->no_of_variables);
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
         if (strcmp(x.m_name, "_lcompilers_main") == 0) {
-            wasm::emit_i32_const(m_code_section,m_al, 0 /* zero exit code */);
-            wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["set_exit_code"])]->index);
+            wasm::emit_i32_const(m_code_section, m_al, 0 /* zero exit code */);
+            wasm::emit_call(
+                m_code_section, m_al,
+                m_func_name_idx_map[get_hash(
+                                        m_import_func_asr_map["set_exit_code"])]
+                    ->index);
         }
-        if ((x.n_body == 0) || ((x.n_body > 0) && !ASR::is_a<ASR::Return_t>(*x.m_body[x.n_body - 1]))) {
+        if ((x.n_body == 0) ||
+            ((x.n_body > 0) &&
+             !ASR::is_a<ASR::Return_t>(*x.m_body[x.n_body - 1]))) {
             handle_return();
         }
         wasm::emit_expr_end(m_code_section, m_al);
@@ -527,27 +583,39 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
 
         /********************* Export the function *********************/
-        wasm::emit_export_fn(m_export_section, m_al, x.m_name, cur_sym_info->index); //  add function to export
+        wasm::emit_export_fn(m_export_section, m_al, x.m_name,
+                             cur_sym_info->index);  //  add function to export
         no_of_functions++;
     }
 
-    bool is_unsupported_function(const ASR::Function_t& x) {
-        if(!x.n_body) {
-            diag.codegen_warning_label("Function with no body", {x.base.base.loc}, std::string(x.m_name));
+    bool is_unsupported_function(const ASR::Function_t &x) {
+        if (!x.n_body) {
+            diag.codegen_warning_label("Function with no body",
+                                       {x.base.base.loc},
+                                       std::string(x.m_name));
             // return true;
         }
-        if (x.m_abi == ASR::abiType::BindC && x.m_deftype == ASR::deftypeType::Interface
-            && ASRUtils::is_intrinsic_function2(&x)) {
-                diag.codegen_warning_label("WASM: C Intrinsic Functions not yet spported", { x.base.base.loc }, std::string(x.m_name));
-                return true;
+        if (x.m_abi == ASR::abiType::BindC &&
+            x.m_deftype == ASR::deftypeType::Interface &&
+            ASRUtils::is_intrinsic_function2(&x)) {
+            diag.codegen_warning_label(
+                "WASM: C Intrinsic Functions not yet spported",
+                {x.base.base.loc}, std::string(x.m_name));
+            return true;
         }
         for (size_t i = 0; i < x.n_body; i++) {
             if (x.m_body[i]->type == ASR::stmtType::SubroutineCall) {
                 auto sub_call = (const ASR::SubroutineCall_t &)(*x.m_body[i]);
-                ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(sub_call.m_name));
-                if (s->m_abi == ASR::abiType::BindC && s->m_deftype == ASR::deftypeType::Interface
-                && ASRUtils::is_intrinsic_function2(s)) {
-                    diag.codegen_warning_label("WASM: Calls to C Intrinsic Functions are not yet supported", {x.m_body[i]->base.loc}, "Function: calls " + std::string(s->m_name));
+                ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(
+                    ASRUtils::symbol_get_past_external(sub_call.m_name));
+                if (s->m_abi == ASR::abiType::BindC &&
+                    s->m_deftype == ASR::deftypeType::Interface &&
+                    ASRUtils::is_intrinsic_function2(s)) {
+                    diag.codegen_warning_label(
+                        "WASM: Calls to C Intrinsic Functions are not yet "
+                        "supported",
+                        {x.m_body[i]->base.loc},
+                        "Function: calls " + std::string(s->m_name));
                     return true;
                 }
             }
@@ -560,109 +628,164 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             return;
         }
         if (is_prototype_only) {
-            if (x.m_abi == ASR::abiType::BindC && x.m_deftype == ASR::deftypeType::Interface) {
-                wasm::emit_import_fn(m_import_section, m_al, "js", x.m_name, no_of_types);
+            if (x.m_abi == ASR::abiType::BindC &&
+                x.m_deftype == ASR::deftypeType::Interface) {
+                wasm::emit_import_fn(m_import_section, m_al, "js", x.m_name,
+                                     no_of_types);
                 no_of_imports++;
             }
             emit_function_prototype(x);
             return;
         }
-        if (x.m_abi == ASR::abiType::BindC && x.m_deftype == ASR::deftypeType::Interface) {
-            /* functions of abiType BindC and are Interfaces are already handled */
+        if (x.m_abi == ASR::abiType::BindC &&
+            x.m_deftype == ASR::deftypeType::Interface) {
+            /* functions of abiType BindC and are Interfaces are already handled
+             */
             return;
         }
         emit_function_body(x);
     }
 
-    uint32_t emit_memory_store(ASR::expr_t* v) {
+    uint32_t emit_memory_store(ASR::expr_t *v) {
         auto ttype = ASRUtils::expr_type(v);
         auto kind = ASRUtils::extract_kind_from_ttype_t(ttype);
-        switch (ttype->type)
-        {
+        switch (ttype->type) {
             case ASR::ttypeType::Integer: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_i32_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    case 8:  wasm::emit_i64_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryStore: Unsupported Integer kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_i32_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    case 8:
+                        wasm::emit_i64_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryStore: Unsupported Integer kind");
                 }
                 break;
             }
             case ASR::ttypeType::Real: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_f32_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    case 8:  wasm::emit_f64_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryStore: Unsupported Real kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_f32_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    case 8:
+                        wasm::emit_f64_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryStore: Unsupported Real kind");
                 }
                 break;
             }
             case ASR::ttypeType::Logical: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_i32_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryStore: Unsupported Logical kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_i32_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryStore: Unsupported Logical kind");
                 }
                 break;
             }
             case ASR::ttypeType::Character: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_i32_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    case 8:  wasm::emit_i64_store(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryStore: Unsupported Character kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_i32_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    case 8:
+                        wasm::emit_i64_store(m_code_section, m_al,
+                                             wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryStore: Unsupported Character kind");
                 }
                 break;
             }
             default: {
-                throw CodeGenError("MemoryStore: Type " + ASRUtils::type_to_str(ttype) + " not yet supported");
+                throw CodeGenError("MemoryStore: Type " +
+                                   ASRUtils::type_to_str(ttype) +
+                                   " not yet supported");
             }
         }
         return kind;
     }
 
-    void emit_memory_load(ASR::expr_t* v) {
+    void emit_memory_load(ASR::expr_t *v) {
         auto ttype = ASRUtils::expr_type(v);
         auto kind = ASRUtils::extract_kind_from_ttype_t(ttype);
-        switch (ttype->type)
-        {
+        switch (ttype->type) {
             case ASR::ttypeType::Integer: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_i32_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    case 8:  wasm::emit_i64_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryLoad: Unsupported Integer kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_i32_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    case 8:
+                        wasm::emit_i64_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryLoad: Unsupported Integer kind");
                 }
                 break;
             }
             case ASR::ttypeType::Real: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_f32_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    case 8:  wasm::emit_f64_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryLoad: Unsupported Real kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_f32_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    case 8:
+                        wasm::emit_f64_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError("MemoryLoad: Unsupported Real kind");
                 }
                 break;
             }
             case ASR::ttypeType::Logical: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_i32_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryLoad: Unsupported Logical kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_i32_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryLoad: Unsupported Logical kind");
                 }
                 break;
             }
             case ASR::ttypeType::Character: {
-                switch (kind)
-                {
-                    case 4: wasm::emit_i32_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    case 8:  wasm::emit_i64_load(m_code_section, m_al, wasm::mem_align::b8, 0); break;
-                    default: throw CodeGenError("MemoryLoad: Unsupported Character kind");
+                switch (kind) {
+                    case 4:
+                        wasm::emit_i32_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    case 8:
+                        wasm::emit_i64_load(m_code_section, m_al,
+                                            wasm::mem_align::b8, 0);
+                        break;
+                    default:
+                        throw CodeGenError(
+                            "MemoryLoad: Unsupported Character kind");
                 }
                 break;
             }
             default: {
-                throw CodeGenError("MemoryLoad: Type " + ASRUtils::type_to_str(ttype) + " not yet supported");
+                throw CodeGenError("MemoryLoad: Type " +
+                                   ASRUtils::type_to_str(ttype) +
+                                   " not yet supported");
             }
         }
     }
@@ -672,10 +795,15 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         if (ASR::is_a<ASR::Var_t>(*x.m_target)) {
             this->visit_expr(*x.m_value);
             ASR::Variable_t *asr_target = ASRUtils::EXPR2VAR(x.m_target);
-            LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)asr_target)) != m_var_name_idx_map.end());
-            wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)asr_target)]);
+            LFORTRAN_ASSERT(
+                m_var_name_idx_map.find(get_hash((ASR::asr_t *)asr_target)) !=
+                m_var_name_idx_map.end());
+            wasm::emit_set_local(
+                m_code_section, m_al,
+                m_var_name_idx_map[get_hash((ASR::asr_t *)asr_target)]);
         } else if (ASR::is_a<ASR::ArrayItem_t>(*x.m_target)) {
-            emit_array_item_address_onto_stack(*(ASR::down_cast<ASR::ArrayItem_t>(x.m_target)));
+            emit_array_item_address_onto_stack(
+                *(ASR::down_cast<ASR::ArrayItem_t>(x.m_target)));
             this->visit_expr(*x.m_value);
             emit_memory_store(x.m_value);
         } else {
@@ -712,22 +840,28 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 case ASR::binopType::Pow: {
                     ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
                     if (ASR::is_a<ASR::IntegerConstant_t>(*val)) {
-                        ASR::IntegerConstant_t *c = ASR::down_cast<ASR::IntegerConstant_t>(val);
+                        ASR::IntegerConstant_t *c =
+                            ASR::down_cast<ASR::IntegerConstant_t>(val);
                         if (c->m_n == 2) {
                             // drop the last stack item in the wasm stack
                             wasm::emit_drop(m_code_section, m_al);
                             this->visit_expr(*x.m_left);
                             wasm::emit_i32_mul(m_code_section, m_al);
                         } else {
-                            throw CodeGenError("IntegerBinop kind 4: only x**2 implemented so far for powers");
+                            throw CodeGenError(
+                                "IntegerBinop kind 4: only x**2 implemented so "
+                                "far for powers");
                         }
                     } else {
-                        throw CodeGenError("IntegerBinop kind 4: only x**2 implemented so far for powers");
+                        throw CodeGenError(
+                            "IntegerBinop kind 4: only x**2 implemented so far "
+                            "for powers");
                     }
                     break;
                 };
                 default: {
-                    throw CodeGenError("ICE IntegerBinop kind 4: unknown operation");
+                    throw CodeGenError(
+                        "ICE IntegerBinop kind 4: unknown operation");
                 }
             }
         } else if (i->m_kind == 8) {
@@ -751,22 +885,28 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 case ASR::binopType::Pow: {
                     ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
                     if (ASR::is_a<ASR::IntegerConstant_t>(*val)) {
-                        ASR::IntegerConstant_t *c = ASR::down_cast<ASR::IntegerConstant_t>(val);
+                        ASR::IntegerConstant_t *c =
+                            ASR::down_cast<ASR::IntegerConstant_t>(val);
                         if (c->m_n == 2) {
                             // drop the last stack item in the wasm stack
                             wasm::emit_drop(m_code_section, m_al);
                             this->visit_expr(*x.m_left);
                             wasm::emit_i64_mul(m_code_section, m_al);
                         } else {
-                            throw CodeGenError("IntegerBinop kind 8: only x**2 implemented so far for powers");
+                            throw CodeGenError(
+                                "IntegerBinop kind 8: only x**2 implemented so "
+                                "far for powers");
                         }
                     } else {
-                        throw CodeGenError("IntegerBinop kind 8: only x**2 implemented so far for powers");
+                        throw CodeGenError(
+                            "IntegerBinop kind 8: only x**2 implemented so far "
+                            "for powers");
                     }
                     break;
                 };
                 default: {
-                    throw CodeGenError("ICE IntegerBinop kind 8: unknown operation");
+                    throw CodeGenError(
+                        "ICE IntegerBinop kind 8: unknown operation");
                 }
             }
         } else {
@@ -803,22 +943,28 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 case ASR::binopType::Pow: {
                     ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
                     if (ASR::is_a<ASR::RealConstant_t>(*val)) {
-                        ASR::RealConstant_t *c = ASR::down_cast<ASR::RealConstant_t>(val);
+                        ASR::RealConstant_t *c =
+                            ASR::down_cast<ASR::RealConstant_t>(val);
                         if (c->m_r == 2.0) {
                             // drop the last stack item in the wasm stack
                             wasm::emit_drop(m_code_section, m_al);
                             this->visit_expr(*x.m_left);
                             wasm::emit_f32_mul(m_code_section, m_al);
                         } else {
-                            throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                            throw CodeGenError(
+                                "RealBinop: only x**2 implemented so far for "
+                                "powers");
                         }
                     } else {
-                        throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                        throw CodeGenError(
+                            "RealBinop: only x**2 implemented so far for "
+                            "powers");
                     }
                     break;
                 };
                 default: {
-                    throw CodeGenError("ICE RealBinop kind 4: unknown operation");
+                    throw CodeGenError(
+                        "ICE RealBinop kind 4: unknown operation");
                 }
             }
         } else if (f->m_kind == 8) {
@@ -842,17 +988,22 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 case ASR::binopType::Pow: {
                     ASR::expr_t *val = ASRUtils::expr_value(x.m_right);
                     if (ASR::is_a<ASR::RealConstant_t>(*val)) {
-                        ASR::RealConstant_t *c = ASR::down_cast<ASR::RealConstant_t>(val);
+                        ASR::RealConstant_t *c =
+                            ASR::down_cast<ASR::RealConstant_t>(val);
                         if (c->m_r == 2.0) {
                             // drop the last stack item in the wasm stack
                             wasm::emit_drop(m_code_section, m_al);
                             this->visit_expr(*x.m_left);
                             wasm::emit_f64_mul(m_code_section, m_al);
                         } else {
-                            throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                            throw CodeGenError(
+                                "RealBinop: only x**2 implemented so far for "
+                                "powers");
                         }
                     } else {
-                        throw CodeGenError("RealBinop: only x**2 implemented so far for powers");
+                        throw CodeGenError(
+                            "RealBinop: only x**2 implemented so far for "
+                            "powers");
                     }
                     break;
                 };
@@ -866,64 +1017,63 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
-         if (x.m_value) {
+        if (x.m_value) {
             visit_expr(*x.m_value);
             return;
         }
         ASR::Integer_t *i = ASR::down_cast<ASR::Integer_t>(x.m_type);
         // there seems no direct unary-minus inst in wasm, so subtracting from 0
-        if(i->m_kind == 4){
+        if (i->m_kind == 4) {
             wasm::emit_i32_const(m_code_section, m_al, 0);
             this->visit_expr(*x.m_arg);
             wasm::emit_i32_sub(m_code_section, m_al);
-        }
-        else if(i->m_kind == 8){
+        } else if (i->m_kind == 8) {
             wasm::emit_i64_const(m_code_section, m_al, 0LL);
             this->visit_expr(*x.m_arg);
             wasm::emit_i64_sub(m_code_section, m_al);
-        }
-        else{
-            throw CodeGenError("IntegerUnaryMinus: Only kind 4 and 8 supported");
+        } else {
+            throw CodeGenError(
+                "IntegerUnaryMinus: Only kind 4 and 8 supported");
         }
     }
 
     void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {
-         if (x.m_value) {
+        if (x.m_value) {
             visit_expr(*x.m_value);
             return;
         }
         ASR::Real_t *f = ASR::down_cast<ASR::Real_t>(x.m_type);
-        if(f->m_kind == 4){
+        if (f->m_kind == 4) {
             this->visit_expr(*x.m_arg);
             wasm::emit_f32_neg(m_code_section, m_al);
-        }
-        else if(f->m_kind == 8){
+        } else if (f->m_kind == 8) {
             this->visit_expr(*x.m_arg);
             wasm::emit_f64_neg(m_code_section, m_al);
-        }
-        else{
+        } else {
             throw CodeGenError("RealUnaryMinus: Only kind 4 and 8 supported");
         }
     }
 
-    template<typename T>
+    template <typename T>
     int get_kind_from_operands(const T &x) {
-        ASR::ttype_t* left_ttype = ASRUtils::expr_type(x.m_left);
+        ASR::ttype_t *left_ttype = ASRUtils::expr_type(x.m_left);
         int left_kind = ASRUtils::extract_kind_from_ttype_t(left_ttype);
 
-        ASR::ttype_t* right_ttype = ASRUtils::expr_type(x.m_right);
+        ASR::ttype_t *right_ttype = ASRUtils::expr_type(x.m_right);
         int right_kind = ASRUtils::extract_kind_from_ttype_t(right_ttype);
 
         if (left_kind != right_kind) {
-            diag.codegen_error_label("Operand kinds do not match", { x.base.base.loc }, "WASM Type Mismatch Error");
+            diag.codegen_error_label("Operand kinds do not match",
+                                     {x.base.base.loc},
+                                     "WASM Type Mismatch Error");
             throw CodeGenAbort();
         }
 
         return left_kind;
     }
 
-    template<typename T>
-    void handle_integer_compare(const T &x){
+    template <typename T>
+    void handle_integer_compare(const T &x) {
         if (x.m_value) {
             visit_expr(*x.m_value);
             return;
@@ -934,30 +1084,72 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         int a_kind = get_kind_from_operands(x);
         if (a_kind == 4) {
             switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : { wasm::emit_i32_eq(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Gt) : { wasm::emit_i32_gt_s(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::GtE) : { wasm::emit_i32_ge_s(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Lt) : { wasm::emit_i32_lt_s(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::LtE) : { wasm::emit_i32_le_s(m_code_section,m_al); break; }
-                case (ASR::cmpopType::NotEq): { wasm::emit_i32_ne(m_code_section, m_al); break; }
-                default : throw CodeGenError("handle_integer_compare: Kind 4: Unhandled switch case");
+                case (ASR::cmpopType::Eq): {
+                    wasm::emit_i32_eq(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Gt): {
+                    wasm::emit_i32_gt_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::GtE): {
+                    wasm::emit_i32_ge_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Lt): {
+                    wasm::emit_i32_lt_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::LtE): {
+                    wasm::emit_i32_le_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::NotEq): {
+                    wasm::emit_i32_ne(m_code_section, m_al);
+                    break;
+                }
+                default:
+                    throw CodeGenError(
+                        "handle_integer_compare: Kind 4: Unhandled switch "
+                        "case");
             }
         } else if (a_kind == 8) {
             switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : { wasm::emit_i64_eq(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Gt) : { wasm::emit_i64_gt_s(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::GtE) : { wasm::emit_i64_ge_s(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Lt) : { wasm::emit_i64_lt_s(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::LtE) : { wasm::emit_i64_le_s(m_code_section,m_al); break; }
-                case (ASR::cmpopType::NotEq): { wasm::emit_i64_ne(m_code_section, m_al); break; }
-                default : throw CodeGenError("handle_integer_compare: Kind 8: Unhandled switch case");
+                case (ASR::cmpopType::Eq): {
+                    wasm::emit_i64_eq(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Gt): {
+                    wasm::emit_i64_gt_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::GtE): {
+                    wasm::emit_i64_ge_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Lt): {
+                    wasm::emit_i64_lt_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::LtE): {
+                    wasm::emit_i64_le_s(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::NotEq): {
+                    wasm::emit_i64_ne(m_code_section, m_al);
+                    break;
+                }
+                default:
+                    throw CodeGenError(
+                        "handle_integer_compare: Kind 8: Unhandled switch "
+                        "case");
             }
         } else {
             throw CodeGenError("IntegerCompare: kind 4 and 8 supported only");
         }
     }
 
-    void handle_real_compare(const ASR::RealCompare_t &x){
+    void handle_real_compare(const ASR::RealCompare_t &x) {
         if (x.m_value) {
             visit_expr(*x.m_value);
             return;
@@ -968,23 +1160,63 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         int a_kind = get_kind_from_operands(x);
         if (a_kind == 4) {
             switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : { wasm::emit_f32_eq(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Gt) : { wasm::emit_f32_gt(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::GtE) : { wasm::emit_f32_ge(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Lt) : { wasm::emit_f32_lt(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::LtE) : { wasm::emit_f32_le(m_code_section,m_al); break; }
-                case (ASR::cmpopType::NotEq): { wasm::emit_f32_ne(m_code_section, m_al); break; }
-                default : throw CodeGenError("handle_real_compare: Kind 4: Unhandled switch case");
+                case (ASR::cmpopType::Eq): {
+                    wasm::emit_f32_eq(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Gt): {
+                    wasm::emit_f32_gt(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::GtE): {
+                    wasm::emit_f32_ge(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Lt): {
+                    wasm::emit_f32_lt(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::LtE): {
+                    wasm::emit_f32_le(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::NotEq): {
+                    wasm::emit_f32_ne(m_code_section, m_al);
+                    break;
+                }
+                default:
+                    throw CodeGenError(
+                        "handle_real_compare: Kind 4: Unhandled switch case");
             }
         } else if (a_kind == 8) {
             switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : { wasm::emit_f64_eq(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Gt) : { wasm::emit_f64_gt(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::GtE) : { wasm::emit_f64_ge(m_code_section, m_al); break; }
-                case (ASR::cmpopType::Lt) : { wasm::emit_f64_lt(m_code_section, m_al);  break; }
-                case (ASR::cmpopType::LtE) : { wasm::emit_f64_le(m_code_section,m_al); break; }
-                case (ASR::cmpopType::NotEq): { wasm::emit_f64_ne(m_code_section, m_al); break; }
-                default : throw CodeGenError("handle_real_compare: Kind 8: Unhandled switch case");
+                case (ASR::cmpopType::Eq): {
+                    wasm::emit_f64_eq(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Gt): {
+                    wasm::emit_f64_gt(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::GtE): {
+                    wasm::emit_f64_ge(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::Lt): {
+                    wasm::emit_f64_lt(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::LtE): {
+                    wasm::emit_f64_le(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::cmpopType::NotEq): {
+                    wasm::emit_f64_ne(m_code_section, m_al);
+                    break;
+                }
+                default:
+                    throw CodeGenError(
+                        "handle_real_compare: Kind 8: Unhandled switch case");
             }
         } else {
             throw CodeGenError("RealCompare: kind 4 and 8 supported only");
@@ -1012,7 +1244,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_LogicalBinOp(const ASR::LogicalBinOp_t &x) {
-        if(x.m_value){
+        if (x.m_value) {
             visit_expr(*x.m_value);
             return;
         }
@@ -1021,12 +1253,29 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         int a_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
         if (a_kind == 4) {
             switch (x.m_op) {
-                case (ASR::logicalbinopType::And): { wasm::emit_i32_and(m_code_section, m_al); break; }
-                case (ASR::logicalbinopType::Or): { wasm::emit_i32_or(m_code_section, m_al); break; }
-                case ASR::logicalbinopType::Xor: { wasm::emit_i32_xor(m_code_section, m_al); break; }
-                case (ASR::logicalbinopType::NEqv): { wasm::emit_i32_xor(m_code_section, m_al); break; }
-                case (ASR::logicalbinopType::Eqv): { wasm::emit_i32_eq(m_code_section, m_al); break; }
-                default : throw CodeGenError("LogicalBinOp: Kind 4: Unhandled switch case");
+                case (ASR::logicalbinopType::And): {
+                    wasm::emit_i32_and(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::logicalbinopType::Or): {
+                    wasm::emit_i32_or(m_code_section, m_al);
+                    break;
+                }
+                case ASR::logicalbinopType::Xor: {
+                    wasm::emit_i32_xor(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::logicalbinopType::NEqv): {
+                    wasm::emit_i32_xor(m_code_section, m_al);
+                    break;
+                }
+                case (ASR::logicalbinopType::Eqv): {
+                    wasm::emit_i32_eq(m_code_section, m_al);
+                    break;
+                }
+                default:
+                    throw CodeGenError(
+                        "LogicalBinOp: Kind 4: Unhandled switch case");
             }
         } else {
             throw CodeGenError("LogicalBinOp: kind 4 supported only");
@@ -1056,29 +1305,38 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             case ASR::ttypeType::Integer:
             case ASR::ttypeType::Logical:
             case ASR::ttypeType::Real: {
-                LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)v)) != m_var_name_idx_map.end());
-                wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)v)]);
+                LFORTRAN_ASSERT(
+                    m_var_name_idx_map.find(get_hash((ASR::asr_t *)v)) !=
+                    m_var_name_idx_map.end());
+                wasm::emit_get_local(
+                    m_code_section, m_al,
+                    m_var_name_idx_map[get_hash((ASR::asr_t *)v)]);
                 break;
             }
 
             default:
-                throw CodeGenError("Only Integer and Float Variable types currently supported");
+                throw CodeGenError(
+                    "Only Integer and Float Variable types currently "
+                    "supported");
         }
     }
 
     void get_array_dims(const ASR::Variable_t &x, Vec<uint32_t> &dims) {
-        ASR::dimension_t* m_dims;
-        uint32_t n_dims = ASRUtils::extract_dimensions_from_ttype(x.m_type, m_dims);
+        ASR::dimension_t *m_dims;
+        uint32_t n_dims =
+            ASRUtils::extract_dimensions_from_ttype(x.m_type, m_dims);
         dims.reserve(m_al, n_dims);
         for (uint32_t i = 0; i < n_dims; i++) {
-            ASR::expr_t* length_value = ASRUtils::expr_value(m_dims[i].m_length);
+            ASR::expr_t *length_value =
+                ASRUtils::expr_value(m_dims[i].m_length);
             uint64_t len_in_this_dim = -1;
             ASRUtils::extract_value(length_value, len_in_this_dim);
             dims.push_back(m_al, (uint32_t)len_in_this_dim);
         }
     }
 
-    // following function is useful for printing debug statements from webassembly
+    // following function is useful for printing debug statements from
+    // webassembly
     void print_wasm_debug_statement(std::string message, bool endline = true) {
         static int debug_mem_space = 10000 + avail_mem_loc;
         wasm::emit_str_const(m_data_section, m_al, debug_mem_space, message);
@@ -1087,15 +1345,23 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         no_of_data_segments++;
 
         // push string location and its size on function stack
-        wasm::emit_i32_const(m_code_section, m_al, debug_mem_space - last_str_len);
+        wasm::emit_i32_const(m_code_section, m_al,
+                             debug_mem_space - last_str_len);
         wasm::emit_i32_const(m_code_section, m_al, last_str_len);
 
         // call JavaScript print_str
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_str"])]->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["print_str"])]
+                ->index);
 
         if (endline) {
             // call JavaScript flush_buf
-            wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]->index);
+            wasm::emit_call(
+                m_code_section, m_al,
+                m_func_name_idx_map[get_hash(
+                                        m_import_func_asr_map["flush_buf"])]
+                    ->index);
         }
     }
 
@@ -1104,23 +1370,32 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     void print_mem_loc_value(uint32_t mem_loc) {
         print_wasm_debug_statement("Memory Location =", false);
         wasm::emit_i32_const(m_code_section, m_al, mem_loc);
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_i32"])]->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["print_i32"])]
+                ->index);
         print_wasm_debug_statement(", value=", false);
         wasm::emit_i32_const(m_code_section, m_al, mem_loc);
         wasm::emit_i32_load(m_code_section, m_al, wasm::mem_align::b8, 0);
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_i32"])]->index);
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["print_i32"])]
+                ->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]
+                ->index);
     }
 
     void emit_array_item_address_onto_stack(const ASR::ArrayItem_t &x) {
         this->visit_expr(*x.m_v);
-        ASR::ttype_t* ttype = ASRUtils::expr_type(x.m_v);
+        ASR::ttype_t *ttype = ASRUtils::expr_type(x.m_v);
         uint32_t kind = ASRUtils::extract_kind_from_ttype_t(ttype);
-        ASR::dimension_t* m_dims;
+        ASR::dimension_t *m_dims;
         ASRUtils::extract_dimensions_from_ttype(ttype, m_dims);
 
         wasm::emit_i32_const(m_code_section, m_al, 0);
-        for(uint32_t i = 0; i < x.n_args; i++) {
+        for (uint32_t i = 0; i < x.n_args; i++) {
             if (x.m_args[i].m_right) {
                 this->visit_expr(*x.m_args[i].m_right);
                 wasm::emit_i32_const(m_code_section, m_al, 1);
@@ -1135,7 +1410,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     jmax = i;
                 } else {
                     // Row-major order
-                    jmin = i+1;
+                    jmin = i + 1;
                     jmax = x.n_args;
                 }
 
@@ -1146,7 +1421,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
                 wasm::emit_i32_add(m_code_section, m_al);
             } else {
-                diag.codegen_warning_label("/* FIXME right index */", {x.base.base.loc}, "");
+                diag.codegen_warning_label("/* FIXME right index */",
+                                           {x.base.base.loc}, "");
             }
         }
         wasm::emit_i32_const(m_code_section, m_al, kind);
@@ -1164,8 +1440,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             this->visit_expr(*x.m_value);
             return;
         }
-        ASR::dimension_t* m_dims;
-        int n_dims = ASRUtils::extract_dimensions_from_ttype(ASRUtils::expr_type(x.m_v), m_dims);
+        ASR::dimension_t *m_dims;
+        int n_dims = ASRUtils::extract_dimensions_from_ttype(
+            ASRUtils::expr_type(x.m_v), m_dims);
         if (x.m_dim) {
             int dim_idx = -1;
             ASRUtils::extract_value(ASRUtils::expr_value(x.m_dim), dim_idx);
@@ -1173,12 +1450,14 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 throw CodeGenError("Dimension index not available");
             }
             if (!m_dims[dim_idx - 1].m_length) {
-                throw CodeGenError("Dimension length for index " + std::to_string(dim_idx) + " does not exist");
+                throw CodeGenError("Dimension length for index " +
+                                   std::to_string(dim_idx) + " does not exist");
             }
             this->visit_expr(*(m_dims[dim_idx - 1].m_length));
         } else {
             if (!m_dims[0].m_length) {
-                throw CodeGenError("Dimension length for index 0 does not exist");
+                throw CodeGenError(
+                    "Dimension length for index 0 does not exist");
             }
             this->visit_expr(*(m_dims[0].m_length));
             for (int i = 1; i < n_dims; i++) {
@@ -1195,19 +1474,24 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
     void handle_return() {
         if (cur_sym_info->return_var) {
-            LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)cur_sym_info->return_var)) != m_var_name_idx_map.end());
-            wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)cur_sym_info->return_var)]);
+            LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash(
+                                (ASR::asr_t *)cur_sym_info->return_var)) !=
+                            m_var_name_idx_map.end());
+            wasm::emit_get_local(m_code_section, m_al,
+                                 m_var_name_idx_map[get_hash(
+                                     (ASR::asr_t *)cur_sym_info->return_var)]);
         } else {
-            for(auto return_var:cur_sym_info->referenced_vars) {
-                wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)(return_var))]);
+            for (auto return_var : cur_sym_info->referenced_vars) {
+                wasm::emit_get_local(
+                    m_code_section, m_al,
+                    m_var_name_idx_map[get_hash((ASR::asr_t *)(return_var))]);
             }
         }
-        wasm::emit_b8(m_code_section, m_al, 0x0F); // emit wasm return instruction
+        wasm::emit_b8(m_code_section, m_al,
+                      0x0F);  // emit wasm return instruction
     }
 
-    void visit_Return(const ASR::Return_t & /* x */) {
-        handle_return();
-    }
+    void visit_Return(const ASR::Return_t & /* x */) { handle_return(); }
 
     void visit_IntegerConstant(const ASR::IntegerConstant_t &x) {
         int64_t val = x.m_n;
@@ -1222,7 +1506,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 break;
             }
             default: {
-                throw CodeGenError("Constant Integer: Only kind 4 and 8 supported");
+                throw CodeGenError(
+                    "Constant Integer: Only kind 4 and 8 supported");
             }
         }
     }
@@ -1240,7 +1525,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 break;
             }
             default: {
-                throw CodeGenError("Constant Real: Only kind 4 and 8 supported");
+                throw CodeGenError(
+                    "Constant Real: Only kind 4 and 8 supported");
             }
         }
     }
@@ -1259,8 +1545,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         }
     }
 
-    void visit_StringConstant(const ASR::StringConstant_t &x){
-        // Todo: Add a check here if there is memory available to store the given string
+    void visit_StringConstant(const ASR::StringConstant_t &x) {
+        // Todo: Add a check here if there is memory available to store the
+        // given string
         wasm::emit_str_const(m_data_section, m_al, avail_mem_loc, x.m_s);
         last_str_len = strlen(x.m_s);
         avail_mem_loc += last_str_len;
@@ -1268,9 +1555,10 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_ArrayConstant(const ASR::ArrayConstant_t &x) {
-        // Todo: Add a check here if there is memory available to store the given string
+        // Todo: Add a check here if there is memory available to store the
+        // given string
         uint32_t cur_mem_loc = avail_mem_loc;
-        for (size_t i=0; i<x.n_args; i++) {
+        for (size_t i = 0; i < x.n_args; i++) {
             // emit memory location to store array element
             wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc);
 
@@ -1288,18 +1576,22 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             return;
         }
 
-        ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
+        ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(
+            ASRUtils::symbol_get_past_external(x.m_name));
 
         for (size_t i = 0; i < x.n_args; i++) {
             visit_expr(*x.m_args[i].m_value);
         }
 
-        LFORTRAN_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)fn)) != m_func_name_idx_map.end())
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash((ASR::asr_t *)fn)]->index);
+        LFORTRAN_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)fn)) !=
+                        m_func_name_idx_map.end())
+        wasm::emit_call(m_code_section, m_al,
+                        m_func_name_idx_map[get_hash((ASR::asr_t *)fn)]->index);
     }
 
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {
-        ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
+        ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(
+            ASRUtils::symbol_get_past_external(x.m_name));
         // TODO: use a mapping with a hash(s) instead:
         // std::string sym_name = s->m_name;
         // if (sym_name == "exit") {
@@ -1312,31 +1604,38 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             for (size_t i = 0; i < x.n_args; i++) {
                 ASR::Variable_t *arg = ASRUtils::EXPR2VAR(s->m_args[i]);
                 if (arg->m_intent == ASRUtils::intent_out) {
-                    intent_out_passed_vars.push_back(m_al, ASRUtils::EXPR2VAR(x.m_args[i].m_value));
+                    intent_out_passed_vars.push_back(
+                        m_al, ASRUtils::EXPR2VAR(x.m_args[i].m_value));
                 }
                 visit_expr(*x.m_args[i].m_value);
             }
         } else {
-            throw CodeGenError("visitSubroutineCall: Number of arguments passed do not match the number of parameters");
+            throw CodeGenError(
+                "visitSubroutineCall: Number of arguments passed do not match "
+                "the number of parameters");
         }
 
-        LFORTRAN_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)s)) != m_func_name_idx_map.end())
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash((ASR::asr_t *)s)]->index);
-        for(auto return_var:intent_out_passed_vars) {
-            LFORTRAN_ASSERT(m_var_name_idx_map.find(get_hash((ASR::asr_t *)return_var)) != m_var_name_idx_map.end());
-            wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[get_hash((ASR::asr_t *)return_var)]);
+        LFORTRAN_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)s)) !=
+                        m_func_name_idx_map.end())
+        wasm::emit_call(m_code_section, m_al,
+                        m_func_name_idx_map[get_hash((ASR::asr_t *)s)]->index);
+        for (auto return_var : intent_out_passed_vars) {
+            LFORTRAN_ASSERT(
+                m_var_name_idx_map.find(get_hash((ASR::asr_t *)return_var)) !=
+                m_var_name_idx_map.end());
+            wasm::emit_set_local(
+                m_code_section, m_al,
+                m_var_name_idx_map[get_hash((ASR::asr_t *)return_var)]);
         }
     }
 
-    inline ASR::ttype_t* extract_ttype_t_from_expr(ASR::expr_t* expr) {
+    inline ASR::ttype_t *extract_ttype_t_from_expr(ASR::expr_t *expr) {
         return ASRUtils::expr_type(expr);
     }
 
-    void extract_kinds(const ASR::Cast_t& x,
-                       int& arg_kind, int& dest_kind)
-    {
+    void extract_kinds(const ASR::Cast_t &x, int &arg_kind, int &dest_kind) {
         dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
-        ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+        ASR::ttype_t *curr_type = extract_ttype_t_from_expr(x.m_arg);
         LFORTRAN_ASSERT(curr_type != nullptr)
         arg_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
     }
@@ -1348,242 +1647,286 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         }
         this->visit_expr(*x.m_arg);
         switch (x.m_kind) {
-            case (ASR::cast_kindType::IntegerToReal) : {
+            case (ASR::cast_kindType::IntegerToReal): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0){
-                    if( arg_kind == 4 && dest_kind == 4 ) {
+                if (arg_kind > 0 && dest_kind > 0) {
+                    if (arg_kind == 4 && dest_kind == 4) {
                         wasm::emit_f32_convert_i32_s(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 8 ) {
+                    } else if (arg_kind == 8 && dest_kind == 8) {
                         wasm::emit_f64_convert_i64_s(m_code_section, m_al);
-                    } else if( arg_kind == 4 && dest_kind == 8 ) {
+                    } else if (arg_kind == 4 && dest_kind == 8) {
                         wasm::emit_f64_convert_i32_s(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 4 ) {
+                    } else if (arg_kind == 8 && dest_kind == 4) {
                         wasm::emit_f32_convert_i64_s(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not implemented yet.";
+                        std::string msg = "Conversion from " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not implemented yet.";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::RealToInteger) : {
+            case (ASR::cast_kindType::RealToInteger): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0){
-                    if( arg_kind == 4 && dest_kind == 4 ) {
+                if (arg_kind > 0 && dest_kind > 0) {
+                    if (arg_kind == 4 && dest_kind == 4) {
                         wasm::emit_i32_trunc_f32_s(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 8 ) {
+                    } else if (arg_kind == 8 && dest_kind == 8) {
                         wasm::emit_i64_trunc_f64_s(m_code_section, m_al);
-                    } else if( arg_kind == 4 && dest_kind == 8 ) {
+                    } else if (arg_kind == 4 && dest_kind == 8) {
                         wasm::emit_i64_trunc_f32_s(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 4 ) {
+                    } else if (arg_kind == 8 && dest_kind == 4) {
                         wasm::emit_i32_trunc_f64_s(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not implemented yet.";
+                        std::string msg = "Conversion from " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not implemented yet.";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::RealToComplex) : {
+            case (ASR::cast_kindType::RealToComplex): {
                 throw CodeGenError("Complex types are not supported yet.");
                 break;
             }
-            case (ASR::cast_kindType::IntegerToComplex) : {
+            case (ASR::cast_kindType::IntegerToComplex): {
                 throw CodeGenError("Complex types are not supported yet.");
                 break;
             }
-            case (ASR::cast_kindType::IntegerToLogical) : {
+            case (ASR::cast_kindType::IntegerToLogical): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0){
-                    if( arg_kind == 4 && dest_kind == 4 ) {
+                if (arg_kind > 0 && dest_kind > 0) {
+                    if (arg_kind == 4 && dest_kind == 4) {
                         wasm::emit_i32_eqz(m_code_section, m_al);
                         wasm::emit_i32_eqz(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 4 ) {
+                    } else if (arg_kind == 8 && dest_kind == 4) {
                         wasm::emit_i32_eqz(m_code_section, m_al);
                         wasm::emit_i32_eqz(m_code_section, m_al);
                         wasm::emit_i64_extend_i32_s(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from kinds " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not supported";
+                        std::string msg = "Conversion from kinds " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not supported";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::RealToLogical) : {
+            case (ASR::cast_kindType::RealToLogical): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0){
-                    if( arg_kind == 4 && dest_kind == 4 ) {
+                if (arg_kind > 0 && dest_kind > 0) {
+                    if (arg_kind == 4 && dest_kind == 4) {
                         wasm::emit_f32_const(m_code_section, m_al, 0.0);
                         wasm::emit_f32_eq(m_code_section, m_al);
                         wasm::emit_i32_eqz(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 4 ) {
+                    } else if (arg_kind == 8 && dest_kind == 4) {
                         wasm::emit_f64_const(m_code_section, m_al, 0.0);
                         wasm::emit_f64_eq(m_code_section, m_al);
                         wasm::emit_i64_eqz(m_code_section, m_al);
                         wasm::emit_i32_wrap_i64(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from kinds " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not supported";
+                        std::string msg = "Conversion from kinds " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not supported";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::CharacterToLogical) : {
+            case (ASR::cast_kindType::CharacterToLogical): {
                 throw CodeGenError(R"""(STrings are not supported yet)""",
-                                            x.base.base.loc);
+                                   x.base.base.loc);
                 break;
             }
-            case (ASR::cast_kindType::ComplexToLogical) : {
-               throw CodeGenError("Complex types are not supported yet.");
+            case (ASR::cast_kindType::ComplexToLogical): {
+                throw CodeGenError("Complex types are not supported yet.");
                 break;
             }
-            case (ASR::cast_kindType::LogicalToInteger) : {
+            case (ASR::cast_kindType::LogicalToInteger): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0){
-                    if( arg_kind == 4 && dest_kind == 8 ) {
+                if (arg_kind > 0 && dest_kind > 0) {
+                    if (arg_kind == 4 && dest_kind == 8) {
                         wasm::emit_i64_extend_i32_s(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from kinds " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not supported";
+                        std::string msg = "Conversion from kinds " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not supported";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
                 break;
             }
-            case (ASR::cast_kindType::LogicalToReal) : {
+            case (ASR::cast_kindType::LogicalToReal): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0){
-                    if( arg_kind == 4 && dest_kind == 4 ) {
+                if (arg_kind > 0 && dest_kind > 0) {
+                    if (arg_kind == 4 && dest_kind == 4) {
                         wasm::emit_f32_convert_i32_s(m_code_section, m_al);
-                    } else if( arg_kind == 4 && dest_kind == 8 ) {
+                    } else if (arg_kind == 4 && dest_kind == 8) {
                         wasm::emit_f64_convert_i32_s(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from kinds " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not supported";
+                        std::string msg = "Conversion from kinds " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not supported";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::IntegerToInteger) : {
+            case (ASR::cast_kindType::IntegerToInteger): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0 &&
-                    arg_kind != dest_kind )
-                {
-                    if( arg_kind == 4 && dest_kind == 8 ) {
+                if (arg_kind > 0 && dest_kind > 0 && arg_kind != dest_kind) {
+                    if (arg_kind == 4 && dest_kind == 8) {
                         wasm::emit_i64_extend_i32_s(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 4 ) {
+                    } else if (arg_kind == 8 && dest_kind == 4) {
                         wasm::emit_i32_wrap_i64(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not implemented yet.";
+                        std::string msg = "Conversion from " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not implemented yet.";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::RealToReal) : {
+            case (ASR::cast_kindType::RealToReal): {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
-                if( arg_kind > 0 && dest_kind > 0 &&
-                    arg_kind != dest_kind )
-                {
-                    if( arg_kind == 4 && dest_kind == 8 ) {
+                if (arg_kind > 0 && dest_kind > 0 && arg_kind != dest_kind) {
+                    if (arg_kind == 4 && dest_kind == 8) {
                         wasm::emit_f64_promote_f32(m_code_section, m_al);
-                    } else if( arg_kind == 8 && dest_kind == 4 ) {
+                    } else if (arg_kind == 8 && dest_kind == 4) {
                         wasm::emit_f32_demote_f64(m_code_section, m_al);
                     } else {
-                        std::string msg = "Conversion from " + std::to_string(arg_kind) +
-                                          " to " + std::to_string(dest_kind) + " not implemented yet.";
+                        std::string msg = "Conversion from " +
+                                          std::to_string(arg_kind) + " to " +
+                                          std::to_string(dest_kind) +
+                                          " not implemented yet.";
                         throw CodeGenError(msg);
                     }
                 }
                 break;
             }
-            case (ASR::cast_kindType::ComplexToComplex) : {
+            case (ASR::cast_kindType::ComplexToComplex): {
                 throw CodeGenError("Complex types are not supported yet.");
                 break;
             }
-            case (ASR::cast_kindType::ComplexToReal) : {
+            case (ASR::cast_kindType::ComplexToReal): {
                 throw CodeGenError("Complex types are not supported yet.");
                 break;
             }
-            default : throw CodeGenError("Cast kind not implemented");
+            default:
+                throw CodeGenError("Cast kind not implemented");
         }
     }
 
     template <typename T>
-    void handle_print(const T &x){
-        for (size_t i=0; i<x.n_values; i++) {
+    void handle_print(const T &x) {
+        for (size_t i = 0; i < x.n_values; i++) {
             this->visit_expr(*x.m_values[i]);
             ASR::expr_t *v = x.m_values[i];
             ASR::ttype_t *t = ASRUtils::expr_type(v);
             int a_kind = ASRUtils::extract_kind_from_ttype_t(t);
 
             if (ASRUtils::is_integer(*t) || ASRUtils::is_logical(*t)) {
-                switch( a_kind ) {
-                    case 4 : {
-                        // the value is already on stack. call JavaScript print_i32
-                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_i32"])]->index);
+                switch (a_kind) {
+                    case 4: {
+                        // the value is already on stack. call JavaScript
+                        // print_i32
+                        wasm::emit_call(
+                            m_code_section, m_al,
+                            m_func_name_idx_map
+                                [get_hash(m_import_func_asr_map["print_i32"])]
+                                    ->index);
                         break;
                     }
-                    case 8 : {
-                        // the value is already on stack. call JavaScript print_i64
-                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_i64"])]->index);
+                    case 8: {
+                        // the value is already on stack. call JavaScript
+                        // print_i64
+                        wasm::emit_call(
+                            m_code_section, m_al,
+                            m_func_name_idx_map
+                                [get_hash(m_import_func_asr_map["print_i64"])]
+                                    ->index);
                         break;
                     }
                     default: {
-                        throw CodeGenError(R"""(Printing support is currently available only
+                        throw CodeGenError(
+                            R"""(Printing support is currently available only
                                             for 32, and 64 bit integer kinds.)""");
                     }
                 }
             } else if (ASRUtils::is_real(*t)) {
-                switch( a_kind ) {
-                    case 4 : {
-                        // the value is already on stack. call JavaScript print_f32
-                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_f32"])]->index);
+                switch (a_kind) {
+                    case 4: {
+                        // the value is already on stack. call JavaScript
+                        // print_f32
+                        wasm::emit_call(
+                            m_code_section, m_al,
+                            m_func_name_idx_map
+                                [get_hash(m_import_func_asr_map["print_f32"])]
+                                    ->index);
                         break;
                     }
-                    case 8 : {
-                        // the value is already on stack. call JavaScript print_f64
-                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_f64"])]->index);
+                    case 8: {
+                        // the value is already on stack. call JavaScript
+                        // print_f64
+                        wasm::emit_call(
+                            m_code_section, m_al,
+                            m_func_name_idx_map
+                                [get_hash(m_import_func_asr_map["print_f64"])]
+                                    ->index);
                         break;
                     }
                     default: {
-                        throw CodeGenError(R"""(Printing support is available only
+                        throw CodeGenError(
+                            R"""(Printing support is available only
                                             for 32, and 64 bit real kinds.)""");
                     }
                 }
             } else if (t->type == ASR::ttypeType::Character) {
                 // push string location and its size on function stack
-                wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc - last_str_len);
+                wasm::emit_i32_const(m_code_section, m_al,
+                                     avail_mem_loc - last_str_len);
                 wasm::emit_i32_const(m_code_section, m_al, last_str_len);
 
                 // call JavaScript print_str
-                wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_str"])]->index);
-
+                wasm::emit_call(
+                    m_code_section, m_al,
+                    m_func_name_idx_map[get_hash(
+                                            m_import_func_asr_map["print_str"])]
+                        ->index);
             }
         }
 
         // call JavaScript flush_buf
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]
+                ->index);
     }
 
-    void visit_Print(const ASR::Print_t &x){
+    void visit_Print(const ASR::Print_t &x) {
         if (x.m_fmt != nullptr) {
-            diag.codegen_warning_label("format string in `print` is not implemented yet and it is currently treated as '*'",
+            diag.codegen_warning_label(
+                "format string in `print` is not implemented yet and it is "
+                "currently treated as '*'",
                 {x.m_fmt->base.loc}, "treated as '*'");
         }
         handle_print(x);
@@ -1591,12 +1934,14 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
     void visit_FileWrite(const ASR::FileWrite_t &x) {
         if (x.m_fmt != nullptr) {
-            diag.codegen_warning_label("format string in `print` is not implemented yet and it is currently treated as '*'",
+            diag.codegen_warning_label(
+                "format string in `print` is not implemented yet and it is "
+                "currently treated as '*'",
                 {x.m_fmt->base.loc}, "treated as '*'");
         }
         if (x.m_unit != nullptr) {
             diag.codegen_error_label("unit in write() is not implemented yet",
-                {x.m_unit->base.loc}, "not implemented");
+                                     {x.m_unit->base.loc}, "not implemented");
             throw CodeGenAbort();
         }
         handle_print(x);
@@ -1604,15 +1949,19 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
     void visit_FileRead(const ASR::FileRead_t &x) {
         if (x.m_fmt != nullptr) {
-            diag.codegen_warning_label("format string in read() is not implemented yet and it is currently treated as '*'",
+            diag.codegen_warning_label(
+                "format string in read() is not implemented yet and it is "
+                "currently treated as '*'",
                 {x.m_fmt->base.loc}, "treated as '*'");
         }
         if (x.m_unit != nullptr) {
             diag.codegen_error_label("unit in read() is not implemented yet",
-                {x.m_unit->base.loc}, "not implemented");
+                                     {x.m_unit->base.loc}, "not implemented");
             throw CodeGenAbort();
         }
-        diag.codegen_error_label("The intrinsic function read() is not implemented yet in the LLVM backend",
+        diag.codegen_error_label(
+            "The intrinsic function read() is not implemented yet in the LLVM "
+            "backend",
             {x.base.base.loc}, "not implemented");
         throw CodeGenAbort();
     }
@@ -1622,94 +1971,116 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         n.m_s = new char[msg.length() + 1];
         strcpy(n.m_s, msg.c_str());
         visit_StringConstant(n);
-        wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc - last_str_len);
+        wasm::emit_i32_const(m_code_section, m_al,
+                             avail_mem_loc - last_str_len);
         wasm::emit_i32_const(m_code_section, m_al, last_str_len);
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["print_str"])]->index);
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["print_str"])]
+                ->index);
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(m_import_func_asr_map["flush_buf"])]
+                ->index);
     }
 
     void exit() {
-        // exit_code would be on stack, so set this exit code using set_exit_code().
-        // this exit code would be read by JavaScript glue code
-        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[get_hash(m_import_func_asr_map["set_exit_code"])]->index);
-        wasm::emit_unreachable(m_code_section, m_al); // raise trap/exception
+        // exit_code would be on stack, so set this exit code using
+        // set_exit_code(). this exit code would be read by JavaScript glue code
+        wasm::emit_call(
+            m_code_section, m_al,
+            m_func_name_idx_map[get_hash(
+                                    m_import_func_asr_map["set_exit_code"])]
+                ->index);
+        wasm::emit_unreachable(m_code_section, m_al);  // raise trap/exception
     }
 
     void visit_Stop(const ASR::Stop_t &x) {
         print_msg("STOP");
-        if (x.m_code && ASRUtils::expr_type(x.m_code)->type == ASR::ttypeType::Integer) {
+        if (x.m_code &&
+            ASRUtils::expr_type(x.m_code)->type == ASR::ttypeType::Integer) {
             this->visit_expr(*x.m_code);
         } else {
-            wasm::emit_i32_const(m_code_section, m_al, 0); // zero exit code
+            wasm::emit_i32_const(m_code_section, m_al, 0);  // zero exit code
         }
         exit();
     }
 
     void visit_ErrorStop(const ASR::ErrorStop_t & /* x */) {
         print_msg("ERROR STOP");
-        wasm::emit_i32_const(m_code_section, m_al, 1); // non-zero exit code
+        wasm::emit_i32_const(m_code_section, m_al, 1);  // non-zero exit code
         exit();
     }
 
     void visit_If(const ASR::If_t &x) {
         this->visit_expr(*x.m_test);
-        wasm::emit_b8(m_code_section, m_al, 0x04); // emit if start
-        wasm::emit_b8(m_code_section, m_al, 0x40); // empty block type
+        wasm::emit_b8(m_code_section, m_al, 0x04);  // emit if start
+        wasm::emit_b8(m_code_section, m_al, 0x40);  // empty block type
         nesting_level++;
-        for (size_t i=0; i<x.n_body; i++) {
+        for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
-        if(x.n_orelse){
-            wasm::emit_b8(m_code_section, m_al, 0x05); // starting of else
-            for (size_t i=0; i<x.n_orelse; i++) {
+        if (x.n_orelse) {
+            wasm::emit_b8(m_code_section, m_al, 0x05);  // starting of else
+            for (size_t i = 0; i < x.n_orelse; i++) {
                 this->visit_stmt(*x.m_orelse[i]);
             }
         }
         nesting_level--;
-        wasm::emit_expr_end(m_code_section, m_al); // emit if end
+        wasm::emit_expr_end(m_code_section, m_al);  // emit if end
     }
 
     void visit_WhileLoop(const ASR::WhileLoop_t &x) {
         uint32_t prev_cur_loop_nesting_level = cur_loop_nesting_level;
         cur_loop_nesting_level = nesting_level;
 
-        wasm::emit_b8(m_code_section, m_al, 0x03); // emit loop start
-        wasm::emit_b8(m_code_section, m_al, 0x40); // empty block type
+        wasm::emit_b8(m_code_section, m_al, 0x03);  // emit loop start
+        wasm::emit_b8(m_code_section, m_al, 0x40);  // empty block type
 
         nesting_level++;
 
-        this->visit_expr(*x.m_test); // emit test condition
+        this->visit_expr(*x.m_test);  // emit test condition
 
-        wasm::emit_b8(m_code_section, m_al, 0x04); // emit if
-        wasm::emit_b8(m_code_section, m_al, 0x40); // empty block type
+        wasm::emit_b8(m_code_section, m_al, 0x04);  // emit if
+        wasm::emit_b8(m_code_section, m_al, 0x40);  // empty block type
 
-        for (size_t i=0; i<x.n_body; i++) {
+        for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
 
         // From WebAssembly Docs:
-        // Unlike with other index spaces, indexing of labels is relative by nesting depth,
-        // that is, label 0 refers to the innermost structured control instruction enclosing
-        // the referring branch instruction, while increasing indices refer to those farther out.
+        // Unlike with other index spaces, indexing of labels is relative by
+        // nesting depth, that is, label 0 refers to the innermost structured
+        // control instruction enclosing the referring branch instruction, while
+        // increasing indices refer to those farther out.
 
-        wasm::emit_branch(m_code_section, m_al, nesting_level - cur_loop_nesting_level); // emit_branch and label the loop
-        wasm::emit_expr_end(m_code_section, m_al); // end if
+        wasm::emit_branch(
+            m_code_section, m_al,
+            nesting_level -
+                cur_loop_nesting_level);  // emit_branch and label the loop
+        wasm::emit_expr_end(m_code_section, m_al);  // end if
 
         nesting_level--;
-        wasm::emit_expr_end(m_code_section, m_al); // end loop
+        wasm::emit_expr_end(m_code_section, m_al);  // end loop
         cur_loop_nesting_level = prev_cur_loop_nesting_level;
     }
 
     void visit_Exit(const ASR::Exit_t & /* x */) {
-        wasm::emit_branch(m_code_section, m_al, nesting_level - cur_loop_nesting_level - 1U); // branch to end of if
+        wasm::emit_branch(m_code_section, m_al,
+                          nesting_level - cur_loop_nesting_level -
+                              1U);  // branch to end of if
     }
 
     void visit_Cycle(const ASR::Cycle_t & /* x */) {
-        wasm::emit_branch(m_code_section, m_al, nesting_level - cur_loop_nesting_level); // branch to start of loop
+        wasm::emit_branch(
+            m_code_section, m_al,
+            nesting_level - cur_loop_nesting_level);  // branch to start of loop
     }
 };
 
-Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al, diag::Diagnostics &diagnostics) {
+Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr,
+                                              Allocator &al,
+                                              diag::Diagnostics &diagnostics) {
     ASRToWASMVisitor v(al, diagnostics);
     Vec<uint8_t> wasm_bytes;
 
@@ -1721,7 +2092,8 @@ Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Alloc
 
 #ifdef SHOW_ASR
     std::cout << pickle(asr, true /* use colors */, true /* indent */,
-            true /* with_intrinsic_modules */) << std::endl;
+                        true /* with_intrinsic_modules */)
+              << std::endl;
 #endif
     try {
         v.visit_asr((ASR::asr_t &)asr);
@@ -1735,15 +2107,17 @@ Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Alloc
     return wasm_bytes;
 }
 
-Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al, const std::string &filename,
-    bool time_report, diag::Diagnostics &diagnostics) {
+Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al,
+                        const std::string &filename, bool time_report,
+                        diag::Diagnostics &diagnostics) {
     int time_visit_asr = 0;
     int time_save = 0;
 
     auto t1 = std::chrono::high_resolution_clock::now();
     Result<Vec<uint8_t>> wasm = asr_to_wasm_bytes_stream(asr, al, diagnostics);
     auto t2 = std::chrono::high_resolution_clock::now();
-    time_visit_asr = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+    time_visit_asr =
+        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     if (!wasm.ok) {
         return wasm.error;
     }
@@ -1752,12 +2126,15 @@ Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al, const std::s
         auto t1 = std::chrono::high_resolution_clock::now();
         wasm::save_bin(wasm.result, filename);
         auto t2 = std::chrono::high_resolution_clock::now();
-        time_save = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+        time_save =
+            std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                .count();
     }
 
     if (time_report) {
         std::cout << "Codegen Time report:" << std::endl;
-        std::cout << "ASR -> wasm: " << std::setw(5) << time_visit_asr << std::endl;
+        std::cout << "ASR -> wasm: " << std::setw(5) << time_visit_asr
+                  << std::endl;
         std::cout << "Save:       " << std::setw(5) << time_save << std::endl;
         int total = time_visit_asr + time_save;
         std::cout << "Total:      " << std::setw(5) << total << std::endl;

--- a/src/libasr/codegen/asr_to_wasm.h
+++ b/src/libasr/codegen/asr_to_wasm.h
@@ -5,13 +5,16 @@
 
 namespace LFortran {
 
-    // Generates a wasm binary stream from ASR
-    Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al, diag::Diagnostics &diagnostics);
+// Generates a wasm binary stream from ASR
+Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr,
+                                              Allocator &al,
+                                              diag::Diagnostics &diagnostics);
 
-    // Generates a wasm binary to `filename`
-    Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al,
-            const std::string &filename, bool time_report, diag::Diagnostics &diagnostics);
+// Generates a wasm binary to `filename`
+Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al,
+                        const std::string &filename, bool time_report,
+                        diag::Diagnostics &diagnostics);
 
-} // namespace LFortran
+}  // namespace LFortran
 
-#endif // LFORTRAN_ASR_TO_WASM_H
+#endif  // LFORTRAN_ASR_TO_WASM_H

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -6,21 +6,12 @@
 namespace LFortran {
 namespace wasm {
 
-enum type {
-    i32 = 0x7F,
-    i64 = 0x7E,
-    f32 = 0x7D,
-    f64 = 0x7C
-};
+enum type { i32 = 0x7F, i64 = 0x7E, f32 = 0x7D, f64 = 0x7C };
 
-enum mem_align {
-    b8 = 0,
-    b16 = 1,
-    b32 = 2,
-    b64 = 3
-};
+enum mem_align { b8 = 0, b16 = 1, b32 = 2, b64 = 3 };
 
-void emit_leb128_u32(Vec<uint8_t> &code, Allocator &al, uint32_t n) { // for u32
+void emit_leb128_u32(Vec<uint8_t> &code, Allocator &al,
+                     uint32_t n) {  // for u32
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
@@ -31,7 +22,7 @@ void emit_leb128_u32(Vec<uint8_t> &code, Allocator &al, uint32_t n) { // for u32
     } while (n != 0);
 }
 
-void emit_leb128_i32(Vec<uint8_t> &code, Allocator &al, int32_t n) { // for i32
+void emit_leb128_i32(Vec<uint8_t> &code, Allocator &al, int32_t n) {  // for i32
     bool more = true;
     do {
         uint8_t byte = n & 0x7f;
@@ -45,7 +36,7 @@ void emit_leb128_i32(Vec<uint8_t> &code, Allocator &al, int32_t n) { // for i32
     } while (more);
 }
 
-void emit_leb128_i64(Vec<uint8_t> &code, Allocator &al, int64_t n) { // for i64
+void emit_leb128_i64(Vec<uint8_t> &code, Allocator &al, int64_t n) {  // for i64
     bool more = true;
     do {
         uint8_t byte = n & 0x7f;
@@ -59,18 +50,18 @@ void emit_leb128_i64(Vec<uint8_t> &code, Allocator &al, int64_t n) { // for i64
     } while (more);
 }
 
-void emit_ieee754_f32(Vec<uint8_t> &code, Allocator &al, float z) { // for f32
+void emit_ieee754_f32(Vec<uint8_t> &code, Allocator &al, float z) {  // for f32
     uint8_t encoded_float[sizeof(z)];
     std::memcpy(&encoded_float, &z, sizeof(z));
-    for(auto &byte:encoded_float){
+    for (auto &byte : encoded_float) {
         code.push_back(al, byte);
     }
 }
 
-void emit_ieee754_f64(Vec<uint8_t> &code, Allocator &al, double z) { // for f64
+void emit_ieee754_f64(Vec<uint8_t> &code, Allocator &al, double z) {  // for f64
     uint8_t encoded_float[sizeof(z)];
     std::memcpy(&encoded_float, &z, sizeof(z));
-    for(auto &byte:encoded_float){
+    for (auto &byte : encoded_float) {
         code.push_back(al, byte);
     }
 }
@@ -118,12 +109,11 @@ void emit_f64(Vec<uint8_t> &code, Allocator &al, double x) {
 }
 
 // function to emit string
-void emit_str(Vec<uint8_t> &code, Allocator &al, std::string text){
+void emit_str(Vec<uint8_t> &code, Allocator &al, std::string text) {
     std::vector<uint8_t> text_bytes(text.size());
     std::memcpy(text_bytes.data(), text.data(), text.size());
     emit_u32(code, al, text_bytes.size());
-    for(auto &byte:text_bytes)
-        emit_b8(code, al, byte);
+    for (auto &byte : text_bytes) emit_b8(code, al, byte);
 }
 
 void emit_u32_b32_idx(Vec<uint8_t> &code, Allocator &al, uint32_t idx,
@@ -161,52 +151,56 @@ uint32_t emit_len_placeholder(Vec<uint8_t> &code, Allocator &al) {
     return len_idx;
 }
 
-void emit_export_fn(Vec<uint8_t> &code, Allocator &al, const std::string& name,
+void emit_export_fn(Vec<uint8_t> &code, Allocator &al, const std::string &name,
                     uint32_t idx) {
     emit_str(code, al, name);
-    emit_b8(code, al, 0x00); // for exporting function
+    emit_b8(code, al, 0x00);  // for exporting function
     emit_u32(code, al, idx);
 }
 
-void emit_import_fn(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
-                const std::string& fn_name, uint32_t type_idx)
-{
+void emit_import_fn(Vec<uint8_t> &code, Allocator &al,
+                    const std::string &mod_name, const std::string &fn_name,
+                    uint32_t type_idx) {
     emit_str(code, al, mod_name);
     emit_str(code, al, fn_name);
-    emit_b8(code, al, 0x00); // for importing function
+    emit_b8(code, al, 0x00);  // for importing function
     emit_u32(code, al, type_idx);
 }
 
-void emit_import_mem(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
-                 const std::string& mem_name, uint32_t min_no_pages, uint32_t max_no_pages = 0) {
+void emit_import_mem(Vec<uint8_t> &code, Allocator &al,
+                     const std::string &mod_name, const std::string &mem_name,
+                     uint32_t min_no_pages, uint32_t max_no_pages = 0) {
     emit_str(code, al, mod_name);
     emit_str(code, al, mem_name);
-    emit_b8(code, al, 0x02); // for importing memory
+    emit_b8(code, al, 0x02);  // for importing memory
     if (max_no_pages) {
-        emit_b8(code, al, 0x01); // for specifying min and max page limits of memory
+        emit_b8(code, al,
+                0x01);  // for specifying min and max page limits of memory
         emit_u32(code, al, min_no_pages);
         emit_u32(code, al, max_no_pages);
     } else {
-        emit_b8(code, al, 0x00); // for specifying only min page limit of memory
+        emit_b8(code, al,
+                0x00);  // for specifying only min page limit of memory
         emit_u32(code, al, min_no_pages);
     }
 }
 
-void encode_section(Vec<uint8_t> &des, Vec<uint8_t> &section_content, Allocator &al, uint32_t section_id, uint32_t no_of_elements){
-    // every section in WebAssembly is encoded by adding its section id, followed by the content size and lastly the contents
+void encode_section(Vec<uint8_t> &des, Vec<uint8_t> &section_content,
+                    Allocator &al, uint32_t section_id,
+                    uint32_t no_of_elements) {
+    // every section in WebAssembly is encoded by adding its section id,
+    // followed by the content size and lastly the contents
     emit_u32(des, al, section_id);
     emit_u32(des, al, 4U /* size of no_of_elements */ + section_content.size());
     uint32_t len_idx = emit_len_placeholder(des, al);
     emit_u32_b32_idx(des, al, len_idx, no_of_elements);
-    for(auto &byte:section_content){
+    for (auto &byte : section_content) {
         des.push_back(al, byte);
     }
 }
 
 // function to emit drop instruction (it throws away a single operand on stack)
-void emit_drop(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x1A);
-}
+void emit_drop(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x1A); }
 
 // function to emit get local variable at given index
 void emit_get_local(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
@@ -240,59 +234,94 @@ void emit_i32_const(Vec<uint8_t> &code, Allocator &al, int32_t x) {
 }
 
 // function to emit i32.clz instruction
-void emit_i32_clz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x67); }
+void emit_i32_clz(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x67);
+}
 
 // function to emit i32.ctz instruction
-void emit_i32_ctz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x68); }
+void emit_i32_ctz(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x68);
+}
 
 // function to emit i32.popcnt instruction
-void emit_i32_popcnt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x69); }
+void emit_i32_popcnt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x69);
+}
 
 // function to emit i32.add instruction
-void emit_i32_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6A); }
+void emit_i32_add(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x6A);
+}
 
 // function to emit i32.sub instruction
-void emit_i32_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6B); }
+void emit_i32_sub(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x6B);
+}
 
 // function to emit i32.mul instruction
-void emit_i32_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6C); }
+void emit_i32_mul(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x6C);
+}
 
 // function to emit i32.div_s instruction
-void emit_i32_div_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6D); }
+void emit_i32_div_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x6D);
+}
 
 // function to emit i32.div_u instruction
-void emit_i32_div_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6E); }
+void emit_i32_div_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x6E);
+}
 
 // function to emit i32.rem_s instruction
-void emit_i32_rem_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6F); }
+void emit_i32_rem_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x6F);
+}
 
 // function to emit i32.rem_u instruction
-void emit_i32_rem_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x70); }
+void emit_i32_rem_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x70);
+}
 
 // function to emit i32.and instruction
-void emit_i32_and(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x71); }
+void emit_i32_and(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x71);
+}
 
 // function to emit i32.or instruction
-void emit_i32_or(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x72); }
+void emit_i32_or(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x72);
+}
 
 // function to emit i32.xor instruction
-void emit_i32_xor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x73); }
+void emit_i32_xor(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x73);
+}
 
 // function to emit i32.shl instruction
-void emit_i32_shl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x74); }
+void emit_i32_shl(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x74);
+}
 
 // function to emit i32.shr_s instruction
-void emit_i32_shr_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x75); }
+void emit_i32_shr_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x75);
+}
 
 // function to emit i32.shr_u instruction
-void emit_i32_shr_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x76); }
+void emit_i32_shr_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x76);
+}
 
 // function to emit i32.rotl instruction
-void emit_i32_rotl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x77); }
+void emit_i32_rotl(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x77);
+}
 
 // function to emit i32.rotr instruction
-void emit_i32_rotr(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x78); }
-
+void emit_i32_rotr(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x78);
+}
 
 // function to emit a i64.const instruction
 void emit_i64_const(Vec<uint8_t> &code, Allocator &al, int64_t x) {
@@ -301,129 +330,209 @@ void emit_i64_const(Vec<uint8_t> &code, Allocator &al, int64_t x) {
 }
 
 // function to emit i64.clz instruction
-void emit_i64_clz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x79); }
+void emit_i64_clz(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x79);
+}
 
 // function to emit i64.ctz instruction
-void emit_i64_ctz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7A); }
+void emit_i64_ctz(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x7A);
+}
 
 // function to emit i64.popcnt instruction
-void emit_i64_popcnt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7B); }
+void emit_i64_popcnt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x7B);
+}
 
 // function to emit i64.add instruction
-void emit_i64_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7C); }
+void emit_i64_add(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x7C);
+}
 
 // function to emit i64.sub instruction
-void emit_i64_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7D); }
+void emit_i64_sub(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x7D);
+}
 
 // function to emit i64.mul instruction
-void emit_i64_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7E); }
+void emit_i64_mul(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x7E);
+}
 
 // function to emit i64.div_s instruction
-void emit_i64_div_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7F); }
+void emit_i64_div_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x7F);
+}
 
 // function to emit i64.div_u instruction
-void emit_i64_div_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x80); }
+void emit_i64_div_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x80);
+}
 
 // function to emit i64.rem_s instruction
-void emit_i64_rem_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x81); }
+void emit_i64_rem_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x81);
+}
 
 // function to emit i64.rem_u instruction
-void emit_i64_rem_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x82); }
+void emit_i64_rem_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x82);
+}
 
 // function to emit i64.and instruction
-void emit_i64_and(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x83); }
+void emit_i64_and(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x83);
+}
 
 // function to emit i64.or instruction
-void emit_i64_or(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x84); }
+void emit_i64_or(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x84);
+}
 
 // function to emit i64.xor instruction
-void emit_i64_xor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x85); }
+void emit_i64_xor(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x85);
+}
 
 // function to emit i64.shl instruction
-void emit_i64_shl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x86); }
+void emit_i64_shl(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x86);
+}
 
 // function to emit i64.shr_s instruction
-void emit_i64_shr_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x87); }
+void emit_i64_shr_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x87);
+}
 
 // function to emit i64.shr_u instruction
-void emit_i64_shr_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x88); }
+void emit_i64_shr_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x88);
+}
 
 // function to emit i64.rotl instruction
-void emit_i64_rotl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x89); }
+void emit_i64_rotl(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x89);
+}
 
 // function to emit i64.rotr instruction
-void emit_i64_rotr(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8A); }
+void emit_i64_rotr(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x8A);
+}
 
 /******** Integer Relational Operations ********/
 
 // function to emit i32.eqz instruction
-void emit_i32_eqz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x45); }
+void emit_i32_eqz(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x45);
+}
 
 // function to emit i32.eq instruction
-void emit_i32_eq(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x46); }
+void emit_i32_eq(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x46);
+}
 
 // function to emit i32.ne instruction
-void emit_i32_ne(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x47); }
+void emit_i32_ne(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x47);
+}
 
 // function to emit i32.lt_s instruction
-void emit_i32_lt_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x48); }
+void emit_i32_lt_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x48);
+}
 
 // function to emit i32.lt_u instruction
-void emit_i32_lt_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x49); }
+void emit_i32_lt_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x49);
+}
 
 // function to emit i32.gt_s instruction
-void emit_i32_gt_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x4A); }
+void emit_i32_gt_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x4A);
+}
 
 // function to emit i32.gt_u instruction
-void emit_i32_gt_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x4B); }
+void emit_i32_gt_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x4B);
+}
 
 // function to emit i32.le_s instruction
-void emit_i32_le_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x4C); }
+void emit_i32_le_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x4C);
+}
 
 // function to emit i32.le_u instruction
-void emit_i32_le_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x4D); }
+void emit_i32_le_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x4D);
+}
 
 // function to emit i32.ge_s instruction
-void emit_i32_ge_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x4E); }
+void emit_i32_ge_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x4E);
+}
 
 // function to emit i32.ge_u instruction
-void emit_i32_ge_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x4F); }
+void emit_i32_ge_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x4F);
+}
 
 // function to emit i64.eqz instruction
-void emit_i64_eqz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x50); }
+void emit_i64_eqz(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x50);
+}
 
 // function to emit i64.eq instruction
-void emit_i64_eq(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x51); }
+void emit_i64_eq(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x51);
+}
 
 // function to emit i64.ne instruction
-void emit_i64_ne(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x52); }
+void emit_i64_ne(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x52);
+}
 
 // function to emit i64.lt_s instruction
-void emit_i64_lt_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x53); }
+void emit_i64_lt_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x53);
+}
 
 // function to emit i64.lt_u instruction
-void emit_i64_lt_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x54); }
+void emit_i64_lt_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x54);
+}
 
 // function to emit i64.gt_s instruction
-void emit_i64_gt_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x55); }
+void emit_i64_gt_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x55);
+}
 
 // function to emit i64.gt_u instruction
-void emit_i64_gt_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x56); }
+void emit_i64_gt_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x56);
+}
 
 // function to emit i64.le_s instruction
-void emit_i64_le_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x57); }
+void emit_i64_le_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x57);
+}
 
 // function to emit i64.le_u instruction
-void emit_i64_le_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x58); }
+void emit_i64_le_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x58);
+}
 
 // function to emit i64.ge_s instruction
-void emit_i64_ge_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x59); }
+void emit_i64_ge_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x59);
+}
 
 // function to emit i64.ge_u instruction
-void emit_i64_ge_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x5A); }
+void emit_i64_ge_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x5A);
+}
 
-
-/**************************** Floating Point Operations ****************************/
+/**************************** Floating Point Operations
+ * ****************************/
 
 // function to emit a f32.const instruction
 void emit_f32_const(Vec<uint8_t> &code, Allocator &al, float x) {
@@ -432,47 +541,74 @@ void emit_f32_const(Vec<uint8_t> &code, Allocator &al, float x) {
 }
 
 // function to emit f32.abs instruction
-void emit_f32_abs(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8B); }
+void emit_f32_abs(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x8B);
+}
 
 // function to emit f32.neg instruction
-void emit_f32_neg(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8C); }
+void emit_f32_neg(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x8C);
+}
 
 // function to emit f32.ceil instruction
-void emit_f32_ceil(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8D); }
+void emit_f32_ceil(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x8D);
+}
 
 // function to emit f32.floor instruction
-void emit_f32_floor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8E); }
+void emit_f32_floor(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x8E);
+}
 
 // function to emit f32.trunc instruction
-void emit_f32_trunc(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8F); }
+void emit_f32_trunc(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x8F);
+}
 
 // function to emit f32.nearest instruction
-void emit_f32_nearest(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x90); }
+void emit_f32_nearest(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x90);
+}
 
 // function to emit f32.sqrt instruction
-void emit_f32_sqrt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x91); }
+void emit_f32_sqrt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x91);
+}
 
 // function to emit f32.add instruction
-void emit_f32_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x92); }
+void emit_f32_add(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x92);
+}
 
 // function to emit f32.sub instruction
-void emit_f32_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x93); }
+void emit_f32_sub(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x93);
+}
 
 // function to emit f32.mul instruction
-void emit_f32_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x94); }
+void emit_f32_mul(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x94);
+}
 
 // function to emit f32.div instruction
-void emit_f32_div(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x95); }
+void emit_f32_div(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x95);
+}
 
 // function to emit f32.min instruction
-void emit_f32_min(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x96); }
+void emit_f32_min(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x96);
+}
 
 // function to emit f32.max instruction
-void emit_f32_max(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x97); }
+void emit_f32_max(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x97);
+}
 
 // function to emit f32.copysign instruction
-void emit_f32_copysign(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x98); }
-
+void emit_f32_copysign(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x98);
+}
 
 // function to emit a f64.const instruction
 void emit_f64_const(Vec<uint8_t> &code, Allocator &al, double x) {
@@ -481,112 +617,166 @@ void emit_f64_const(Vec<uint8_t> &code, Allocator &al, double x) {
 }
 
 // function to emit f64.abs instruction
-void emit_f64_abs(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x99); }
+void emit_f64_abs(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x99);
+}
 
 // function to emit f64.neg instruction
-void emit_f64_neg(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9A); }
+void emit_f64_neg(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x9A);
+}
 
 // function to emit f64.ceil instruction
-void emit_f64_ceil(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9B); }
+void emit_f64_ceil(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x9B);
+}
 
 // function to emit f64.floor instruction
-void emit_f64_floor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9C); }
+void emit_f64_floor(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x9C);
+}
 
 // function to emit f64.trunc instruction
-void emit_f64_trunc(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9D); }
+void emit_f64_trunc(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x9D);
+}
 
 // function to emit f64.nearest instruction
-void emit_f64_nearest(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9E); }
+void emit_f64_nearest(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x9E);
+}
 
 // function to emit f64.sqrt instruction
-void emit_f64_sqrt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9F); }
+void emit_f64_sqrt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x9F);
+}
 
 // function to emit f64.add instruction
-void emit_f64_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA0); }
+void emit_f64_add(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA0);
+}
 
 // function to emit f64.sub instruction
-void emit_f64_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA1); }
+void emit_f64_sub(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA1);
+}
 
 // function to emit f64.mul instruction
-void emit_f64_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA2); }
+void emit_f64_mul(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA2);
+}
 
 // function to emit f64.div instruction
-void emit_f64_div(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA3); }
+void emit_f64_div(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA3);
+}
 
 // function to emit f64.min instruction
-void emit_f64_min(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA4); }
+void emit_f64_min(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA4);
+}
 
 // function to emit f64.max instruction
-void emit_f64_max(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA5); }
+void emit_f64_max(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA5);
+}
 
 // function to emit f64.copysign instruction
-void emit_f64_copysign(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA6); }
+void emit_f64_copysign(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA6);
+}
 
 /******** Float Relational Operations ********/
 
 // function to emit f32.eq instruction
-void emit_f32_eq(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x5B); }
+void emit_f32_eq(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x5B);
+}
 
 // function to emit f32.ne instruction
-void emit_f32_ne(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x5C); }
+void emit_f32_ne(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x5C);
+}
 
 // function to emit f32.lt instruction
-void emit_f32_lt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x5D); }
+void emit_f32_lt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x5D);
+}
 
 // function to emit f32.gt instruction
-void emit_f32_gt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x5E); }
+void emit_f32_gt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x5E);
+}
 
 // function to emit f32.le instruction
-void emit_f32_le(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x5F); }
+void emit_f32_le(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x5F);
+}
 
 // function to emit f32.ge instruction
-void emit_f32_ge(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x60); }
+void emit_f32_ge(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x60);
+}
 
 // function to emit f64.eq instruction
-void emit_f64_eq(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x61); }
+void emit_f64_eq(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x61);
+}
 
 // function to emit f64.ne instruction
-void emit_f64_ne(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x62); }
+void emit_f64_ne(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x62);
+}
 
 // function to emit f64.lt instruction
-void emit_f64_lt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x63); }
+void emit_f64_lt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x63);
+}
 
 // function to emit f64.gt instruction
-void emit_f64_gt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x64); }
+void emit_f64_gt(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x64);
+}
 
 // function to emit f64.le instruction
-void emit_f64_le(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x65); }
+void emit_f64_le(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x65);
+}
 
 // function to emit f64.ge instruction
-void emit_f64_ge(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x66); }
-
+void emit_f64_ge(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x66);
+}
 
 // function to emit string
-void emit_str_const(Vec<uint8_t> &code, Allocator &al, uint32_t mem_idx, const std::string &text) {
-    emit_u32(code, al, 0U); // for active mode of memory with default mem_idx of 0
-    emit_i32_const(code, al, (int32_t)mem_idx); // specifying memory location as instructions
-    emit_expr_end(code, al); // end instructions
+void emit_str_const(Vec<uint8_t> &code, Allocator &al, uint32_t mem_idx,
+                    const std::string &text) {
+    emit_u32(code, al,
+             0U);  // for active mode of memory with default mem_idx of 0
+    emit_i32_const(
+        code, al,
+        (int32_t)mem_idx);    // specifying memory location as instructions
+    emit_expr_end(code, al);  // end instructions
     emit_str(code, al, text);
 }
 
-
-void emit_unreachable(Vec<uint8_t> &code, Allocator &al){
+void emit_unreachable(Vec<uint8_t> &code, Allocator &al) {
     code.push_back(al, 0x00);
 }
 
-void emit_branch(Vec<uint8_t> &code, Allocator &al, uint32_t label_idx){
+void emit_branch(Vec<uint8_t> &code, Allocator &al, uint32_t label_idx) {
     code.push_back(al, 0x0C);
     emit_u32(code, al, label_idx);
 }
 
-void emit_branch_if(Vec<uint8_t> &code, Allocator &al, uint32_t label_idx){
+void emit_branch_if(Vec<uint8_t> &code, Allocator &al, uint32_t label_idx) {
     code.push_back(al, 0x0D);
     emit_u32(code, al, label_idx);
 }
 
-void save_js_glue(std::string filename){
+void save_js_glue(std::string filename) {
     std::string js_glue =
-R"(function define_imports(memory, outputBuffer, exit_code, stdout_print) {
+        R"(function define_imports(memory, outputBuffer, exit_code, stdout_print) {
     const printNum = (num) => outputBuffer.push(num.toString());
     const printStr = (startIdx, strSize) => outputBuffer.push(
         new TextDecoder("utf8").decode(new Uint8Array(memory.buffer, startIdx, strSize)));
@@ -630,7 +820,8 @@ async function execute_code(bytes, stdout_print) {
 
 function main() {
     const fs = require("fs");
-    const wasmBuffer = fs.readFileSync(")" + filename + R"(");
+    const wasmBuffer = fs.readFileSync(")" +
+        filename + R"(");
     execute_code(wasmBuffer, (text) => process.stdout.write(text))
         .then((exit_code) => {
             process.exit(exit_code);
@@ -646,264 +837,347 @@ main();
     out.close();
 }
 
-void save_bin(Vec<uint8_t> &code, std::string filename){
+void save_bin(Vec<uint8_t> &code, std::string filename) {
     std::ofstream out(filename);
-    out.write((const char*) code.p, code.size());
+    out.write((const char *)code.p, code.size());
     out.close();
     save_js_glue(filename);
 }
 
-/**************************** Type Conversion Operations ****************************/
+/**************************** Type Conversion Operations
+ * ****************************/
 
 // function to emit i32.wrap_i64 instruction
-void emit_i32_wrap_i64(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA7); }
+void emit_i32_wrap_i64(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA7);
+}
 
 // function to emit i32.trunc_f32_s instruction
-void emit_i32_trunc_f32_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA8); }
+void emit_i32_trunc_f32_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA8);
+}
 
 // function to emit i32.trunc_f32_u instruction
-void emit_i32_trunc_f32_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA9); }
+void emit_i32_trunc_f32_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xA9);
+}
 
 // function to emit i32.trunc_f64_s instruction
-void emit_i32_trunc_f64_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xAA); }
+void emit_i32_trunc_f64_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xAA);
+}
 
 // function to emit i32.trunc_f64_u instruction
-void emit_i32_trunc_f64_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xAB); }
+void emit_i32_trunc_f64_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xAB);
+}
 
 // function to emit i64.extend_i32_s instruction
-void emit_i64_extend_i32_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xAC); }
+void emit_i64_extend_i32_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xAC);
+}
 
 // function to emit i64.extend_i32_u instruction
-void emit_i64_extend_i32_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xAD); }
+void emit_i64_extend_i32_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xAD);
+}
 
 // function to emit i64.trunc_f32_s instruction
-void emit_i64_trunc_f32_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xAE); }
+void emit_i64_trunc_f32_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xAE);
+}
 
 // function to emit i64.trunc_f32_u instruction
-void emit_i64_trunc_f32_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xAF); }
+void emit_i64_trunc_f32_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xAF);
+}
 
 // function to emit i64.trunc_f64_s instruction
-void emit_i64_trunc_f64_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB0); }
+void emit_i64_trunc_f64_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB0);
+}
 
 // function to emit i64.trunc_f64_u instruction
-void emit_i64_trunc_f64_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB1); }
+void emit_i64_trunc_f64_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB1);
+}
 
 // function to emit f32.convert_i32_s instruction
-void emit_f32_convert_i32_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB2); }
+void emit_f32_convert_i32_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB2);
+}
 
 // function to emit f32.convert_i32_u instruction
-void emit_f32_convert_i32_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB3); }
+void emit_f32_convert_i32_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB3);
+}
 
 // function to emit f32.convert_i64_s instruction
-void emit_f32_convert_i64_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB4); }
+void emit_f32_convert_i64_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB4);
+}
 
 // function to emit f32.convert_i64_u instruction
-void emit_f32_convert_i64_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB5); }
+void emit_f32_convert_i64_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB5);
+}
 
 // function to emit f32.demote_f64 instruction
-void emit_f32_demote_f64(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB6); }
+void emit_f32_demote_f64(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB6);
+}
 
 // function to emit f64.convert_i32_s instruction
-void emit_f64_convert_i32_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB7); }
+void emit_f64_convert_i32_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB7);
+}
 
 // function to emit f64.convert_i32_u instruction
-void emit_f64_convert_i32_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB8); }
+void emit_f64_convert_i32_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB8);
+}
 
 // function to emit f64.convert_i64_s instruction
-void emit_f64_convert_i64_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xB9); }
+void emit_f64_convert_i64_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xB9);
+}
 
 // function to emit f64.convert_i64_u instruction
-void emit_f64_convert_i64_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xBA); }
+void emit_f64_convert_i64_u(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xBA);
+}
 
 // function to emit f64.promote_f32 instruction
-void emit_f64_promote_f32(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xBB); }
+void emit_f64_promote_f32(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xBB);
+}
 
 // function to emit i32.reinterpret_f32 instruction
-void emit_i32_reinterpret_f32(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xBC); }
+void emit_i32_reinterpret_f32(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xBC);
+}
 
 // function to emit i64.reinterpret_f64 instruction
-void emit_i64_reinterpret_f64(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xBD); }
+void emit_i64_reinterpret_f64(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xBD);
+}
 
 // function to emit f32.reinterpret_i32 instruction
-void emit_f32_reinterpret_i32(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xBE); }
+void emit_f32_reinterpret_i32(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xBE);
+}
 
 // function to emit f64.reinterpret_i64 instruction
-void emit_f64_reinterpret_i64(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xBF); }
+void emit_f64_reinterpret_i64(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xBF);
+}
 
 // function to emit i32.extend8_s instruction
-void emit_i32_extend8_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xC0); }
+void emit_i32_extend8_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xC0);
+}
 
 // function to emit i32.extend16_s instruction
-void emit_i32_extend16_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xC1); }
+void emit_i32_extend16_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xC1);
+}
 
 // function to emit i64.extend8_s instruction
-void emit_i64_extend8_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xC2); }
+void emit_i64_extend8_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xC2);
+}
 
 // function to emit i64.extend16_s instruction
-void emit_i64_extend16_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xC3); }
+void emit_i64_extend16_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xC3);
+}
 
 // function to emit i64.extend32_s instruction
-void emit_i64_extend32_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xC4); }
-
+void emit_i64_extend32_s(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0xC4);
+}
 
 /**************************** Memory Instructions ****************************/
 
 // function to emit i32.load instruction
-void emit_i32_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                   uint32_t mem_offset) {
     emit_b8(code, al, 0x28);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load instruction
-void emit_i64_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                   uint32_t mem_offset) {
     emit_b8(code, al, 0x29);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit f32.load instruction
-void emit_f32_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_f32_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                   uint32_t mem_offset) {
     emit_b8(code, al, 0x2A);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit f64.load instruction
-void emit_f64_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_f64_load(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                   uint32_t mem_offset) {
     emit_b8(code, al, 0x2B);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.load8_s instruction
-void emit_i32_load8_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_load8_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x2C);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.load8_u instruction
-void emit_i32_load8_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_load8_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x2D);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.load16_s instruction
-void emit_i32_load16_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_load16_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                       uint32_t mem_offset) {
     emit_b8(code, al, 0x2E);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.load16_u instruction
-void emit_i32_load16_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_load16_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                       uint32_t mem_offset) {
     emit_b8(code, al, 0x2F);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load8_s instruction
-void emit_i64_load8_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load8_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x30);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load8_u instruction
-void emit_i64_load8_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load8_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x31);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load16_s instruction
-void emit_i64_load16_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load16_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                       uint32_t mem_offset) {
     emit_b8(code, al, 0x32);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load16_u instruction
-void emit_i64_load16_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load16_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                       uint32_t mem_offset) {
     emit_b8(code, al, 0x33);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load32_s instruction
-void emit_i64_load32_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load32_s(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                       uint32_t mem_offset) {
     emit_b8(code, al, 0x34);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.load32_u instruction
-void emit_i64_load32_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_load32_u(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                       uint32_t mem_offset) {
     emit_b8(code, al, 0x35);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.store instruction
-void emit_i32_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                    uint32_t mem_offset) {
     emit_b8(code, al, 0x36);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.store instruction
-void emit_i64_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                    uint32_t mem_offset) {
     emit_b8(code, al, 0x37);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit f32.store instruction
-void emit_f32_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_f32_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                    uint32_t mem_offset) {
     emit_b8(code, al, 0x38);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit f64.store instruction
-void emit_f64_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_f64_store(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                    uint32_t mem_offset) {
     emit_b8(code, al, 0x39);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.store8 instruction
-void emit_i32_store8(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_store8(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                     uint32_t mem_offset) {
     emit_b8(code, al, 0x3A);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i32.store16 instruction
-void emit_i32_store16(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i32_store16(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x3B);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.store8 instruction
-void emit_i64_store8(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_store8(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                     uint32_t mem_offset) {
     emit_b8(code, al, 0x3C);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.store16 instruction
-void emit_i64_store16(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_store16(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x3D);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);
 }
 
 // function to emit i64.store32 instruction
-void emit_i64_store32(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align, uint32_t mem_offset) {
+void emit_i64_store32(Vec<uint8_t> &code, Allocator &al, uint32_t mem_align,
+                      uint32_t mem_offset) {
     emit_b8(code, al, 0x3E);
     emit_u32(code, al, mem_align);
     emit_u32(code, al, mem_offset);

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -54,7 +54,8 @@ class WASMDecoder {
     Vec<wasm::Code> codes;
     Vec<wasm::Data> data_segments;
 
-    WASMDecoder(Allocator &al, diag::Diagnostics &diagonostics) : al(al), diag(diagonostics) {
+    WASMDecoder(Allocator &al, diag::Diagnostics &diagonostics)
+        : al(al), diag(diagonostics) {
         var_type_to_string = {
             {0x7F, "i32"}, {0x7E, "i64"}, {0x7D, "f32"}, {0x7C, "f64"}};
         kind_to_string = {
@@ -167,7 +168,9 @@ class WASMDecoder {
                 }
 
                 default: {
-                    throw CodeGenError("Only importing functions and memory are currently supported");
+                    throw CodeGenError(
+                        "Only importing functions and memory are currently "
+                        "supported");
                 }
             }
         }
@@ -274,7 +277,8 @@ class WASMDecoder {
             for (size_t i = 0; i < PREAMBLE_SIZE; i++) {
                 fprintf(stderr, "0x%.02X, ", wasm_bytes[i]);
             }
-            throw CodeGenError("Expected: 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00");
+            throw CodeGenError(
+                "Expected: 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00");
         }
         index += PREAMBLE_SIZE;
         while (index < wasm_bytes.size()) {
@@ -410,9 +414,11 @@ class WASMDecoder {
 
 }  // namespace wasm
 
-Result<std::string> wasm_to_wat(Vec<uint8_t> &wasm_bytes, Allocator &al, diag::Diagnostics &diagnostics) {
+Result<std::string> wasm_to_wat(Vec<uint8_t> &wasm_bytes, Allocator &al,
+                                diag::Diagnostics &diagnostics) {
     wasm::WASMDecoder wasm_decoder(al, diagnostics);
-    wasm_decoder.wasm_bytes.from_pointer_n(wasm_bytes.data(), wasm_bytes.size());
+    wasm_decoder.wasm_bytes.from_pointer_n(wasm_bytes.data(),
+                                           wasm_bytes.size());
 
     std::string wat;
 

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -11,16 +11,28 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
    public:
     std::string src, indent;
 
-    WATVisitor(Vec<uint8_t> &code, uint32_t offset, std::string src, std::string indent) : BaseWASMVisitor(code, offset), src(src), indent(indent) {}
+    WATVisitor(Vec<uint8_t> &code, uint32_t offset, std::string src,
+               std::string indent)
+        : BaseWASMVisitor(code, offset), src(src), indent(indent) {}
 
     void visit_Unreachable() { src += indent + "unreachable"; }
     void visit_Return() { src += indent + "return"; }
-    void visit_Call(uint32_t func_index) { src += indent + "call " + std::to_string(func_index); }
-    void visit_Br(uint32_t label_index) { src += indent + "br " + std::to_string(label_index); }
-    void visit_BrIf(uint32_t label_index) { src += indent + "br_if " + std::to_string(label_index); }
+    void visit_Call(uint32_t func_index) {
+        src += indent + "call " + std::to_string(func_index);
+    }
+    void visit_Br(uint32_t label_index) {
+        src += indent + "br " + std::to_string(label_index);
+    }
+    void visit_BrIf(uint32_t label_index) {
+        src += indent + "br_if " + std::to_string(label_index);
+    }
     void visit_Drop() { src += indent + "drop"; }
-    void visit_LocalGet(uint32_t localidx) { src += indent + "local.get " + std::to_string(localidx); }
-    void visit_LocalSet(uint32_t localidx) { src += indent + "local.set " + std::to_string(localidx); }
+    void visit_LocalGet(uint32_t localidx) {
+        src += indent + "local.get " + std::to_string(localidx);
+    }
+    void visit_LocalSet(uint32_t localidx) {
+        src += indent + "local.set " + std::to_string(localidx);
+    }
     void visit_EmtpyBlockType() {}
     void visit_If() {
         src += indent + "if";
@@ -32,7 +44,9 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
         }
         src += indent + "end";
     }
-    void visit_Else() { src += indent.substr(0, indent.length() - 4U) + "else"; }
+    void visit_Else() {
+        src += indent.substr(0, indent.length() - 4U) + "else";
+    }
     void visit_Loop() {
         src += indent + "loop";
         {
@@ -44,7 +58,9 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
         src += indent + "end";
     }
 
-    void visit_I32Const(int32_t value) { src += indent + "i32.const " + std::to_string(value); }
+    void visit_I32Const(int32_t value) {
+        src += indent + "i32.const " + std::to_string(value);
+    }
     void visit_I32Clz() { src += indent + "i32.clz"; }
     void visit_I32Ctz() { src += indent + "i32.ctz"; }
     void visit_I32Popcnt() { src += indent + "i32.popcnt"; }
@@ -75,7 +91,9 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
     void visit_I32GeS() { src += indent + "i32.ge_s"; }
     void visit_I32GeU() { src += indent + "i32.ge_u"; }
 
-    void visit_I64Const(int64_t value) { src += indent + "i64.const " + std::to_string(value); }
+    void visit_I64Const(int64_t value) {
+        src += indent + "i64.const " + std::to_string(value);
+    }
     void visit_I64Clz() { src += indent + "i64.clz"; }
     void visit_I64Ctz() { src += indent + "i64.ctz"; }
     void visit_I64Popcnt() { src += indent + "i64.popcnt"; }
@@ -106,7 +124,9 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
     void visit_I64GeS() { src += indent + "i64.ge_s"; }
     void visit_I64GeU() { src += indent + "i64.ge_u"; }
 
-    void visit_F32Const(float value) { src += indent + "f32.const " + std::to_string(value); }
+    void visit_F32Const(float value) {
+        src += indent + "f32.const " + std::to_string(value);
+    }
     void visit_F32Add() { src += indent + "f32.add"; }
     void visit_F32Sub() { src += indent + "f32.sub"; }
     void visit_F32Mul() { src += indent + "f32.mul"; }
@@ -129,7 +149,9 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
     void visit_F32Max() { src += indent + "f32.max"; }
     void visit_F32Copysign() { src += indent + "f32.copysign"; }
 
-    void visit_F64Const(double value) { src += indent + "f64.const " + std::to_string(value); }
+    void visit_F64Const(double value) {
+        src += indent + "f64.const " + std::to_string(value);
+    }
     void visit_F64Add() { src += indent + "f64.add"; }
     void visit_F64Sub() { src += indent + "f64.sub"; }
     void visit_F64Mul() { src += indent + "f64.mul"; }
@@ -165,58 +187,104 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
     void visit_F64PromoteF32() { src += indent + "f64.promote_f32"; }
     void visit_F64DivS() { src += indent + "f64.div_s"; }
 
-    void visit_I32Load(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_F32Load(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "f32.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_F64Load(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "f64.load offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Load8S(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.load8_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Load8U(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.load8_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Load16S(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.load16_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Load16U(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.load16_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load8S(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load8_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load8U(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load8_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load16S(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load16_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load16U(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load16_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load32S(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load32_s offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Load32U(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.load32_u offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Store(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Store(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_F32Store(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "f32.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_F64Store(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "f64.store offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Store8(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.store8 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I32Store16(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i32.store16 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Store8(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.store8 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Store16(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.store16 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-    void visit_I64Store32(uint32_t mem_align, uint32_t mem_offset)
-    { src += indent + "i64.store32 offset=" + std::to_string(mem_offset) + " align=" + std::to_string(1U << mem_align); }
-
+    void visit_I32Load(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.load offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_F32Load(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "f32.load offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_F64Load(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "f64.load offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Load8S(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.load8_s offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Load8U(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.load8_u offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Load16S(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.load16_s offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Load16U(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.load16_u offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load8S(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load8_s offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load8U(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load8_u offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load16S(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load16_s offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load16U(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load16_u offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load32S(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load32_s offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Load32U(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.load32_u offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Store(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.store offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Store(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.store offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_F32Store(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "f32.store offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_F64Store(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "f64.store offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Store8(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.store8 offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I32Store16(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i32.store16 offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Store8(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.store8 offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Store16(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.store16 offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
+    void visit_I64Store32(uint32_t mem_align, uint32_t mem_offset) {
+        src += indent + "i64.store32 offset=" + std::to_string(mem_offset) +
+               " align=" + std::to_string(1U << mem_align);
+    }
 };
 
 }  // namespace WASM_INSTS_VISITOR
 
-Result<std::string> wasm_to_wat(Vec<uint8_t> &wasm_bytes, Allocator &al, diag::Diagnostics &diagnostics);
+Result<std::string> wasm_to_wat(Vec<uint8_t> &wasm_bytes, Allocator &al,
+                                diag::Diagnostics &diagnostics);
 
 }  // namespace LFortran
 

--- a/src/libasr/codegen/wasm_utils.cpp
+++ b/src/libasr/codegen/wasm_utils.cpp
@@ -77,21 +77,27 @@ uint8_t read_b8(Vec<uint8_t> &code, uint32_t &offset) {
     return code.p[offset++];
 }
 
-float read_f32(Vec<uint8_t> & code, uint32_t & offset) {
+float read_f32(Vec<uint8_t> &code, uint32_t &offset) {
     LFORTRAN_ASSERT(offset + sizeof(float) <= code.size());
     return decode_ieee754_f32(code, offset);
 }
 
-double read_f64(Vec<uint8_t> & code, uint32_t & offset) {
+double read_f64(Vec<uint8_t> &code, uint32_t &offset) {
     LFORTRAN_ASSERT(offset + sizeof(double) <= code.size());
     return decode_ieee754_f64(code, offset);
 }
 
-uint32_t read_u32(Vec<uint8_t> &code, uint32_t &offset) { return decode_leb128_u32(code, offset); }
+uint32_t read_u32(Vec<uint8_t> &code, uint32_t &offset) {
+    return decode_leb128_u32(code, offset);
+}
 
-int32_t read_i32(Vec<uint8_t> &code, uint32_t &offset) { return decode_leb128_i32(code, offset); }
+int32_t read_i32(Vec<uint8_t> &code, uint32_t &offset) {
+    return decode_leb128_i32(code, offset);
+}
 
-int64_t read_i64(Vec<uint8_t> &code, uint32_t &offset) { return decode_leb128_i64(code, offset); }
+int64_t read_i64(Vec<uint8_t> &code, uint32_t &offset) {
+    return decode_leb128_i64(code, offset);
+}
 
 void hexdump(void *ptr, int buflen) {
     unsigned char *buf = (unsigned char *)ptr;
@@ -106,7 +112,8 @@ void hexdump(void *ptr, int buflen) {
         }
         printf(" ");
         for (j = 0; j < 16; j++) {
-            if (i + j < buflen) printf("%c", isprint(buf[i + j]) ? buf[i + j] : '.');
+            if (i + j < buflen)
+                printf("%c", isprint(buf[i + j]) ? buf[i + j] : '.');
         }
         printf("\n");
     }

--- a/src/libasr/codegen/wasm_utils.h
+++ b/src/libasr/codegen/wasm_utils.h
@@ -54,9 +54,9 @@ int64_t decode_leb128_i64(Vec<uint8_t> &code, uint32_t &offset);
 
 uint8_t read_b8(Vec<uint8_t> &code, uint32_t &offset);
 
-float read_f32(Vec<uint8_t> & code, uint32_t & offset);
+float read_f32(Vec<uint8_t> &code, uint32_t &offset);
 
-double read_f64(Vec<uint8_t> & code, uint32_t & offset);
+double read_f64(Vec<uint8_t> &code, uint32_t &offset);
 
 uint32_t read_u32(Vec<uint8_t> &code, uint32_t &offset);
 


### PR DESCRIPTION
This `PR` improves the formatting of `wasm` backend related source code files. 

It uses the following style settings in `vscode`:
```bash
"C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 80 }", 

"C_Cpp.clang_format_style": "{ BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 80 }"
```