### PR TITLE
WASM: Add support for cpu_time

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -554,6 +554,7 @@ RUN(NAME bits_03 LABELS gfortran llvm)
 RUN(NAME bits_04 LABELS gfortran llvm)
 RUN(NAME bits_05 LABELS gfortran llvm)
 RUN(NAME cpu_time_01 LABELS gfortran llvm)
+RUN(NAME cpu_time_02_wasm LABELS wasm)
 RUN(NAME boz_01 LABELS gfortran llvm)
 
 RUN(NAME flip_sign LABELS gfortran llvm wasm)

--- a/integration_tests/cpu_time_02_wasm.f90
+++ b/integration_tests/cpu_time_02_wasm.f90
@@ -1,0 +1,15 @@
+program cpu_time_02_wasm
+use iso_fortran_env, only: dp=>real64
+implicit none
+real(dp) :: t1, t2
+interface
+    subroutine cpu_time(t) bind(c)
+        import :: dp
+        real(dp), intent(out) :: t
+    end subroutine
+end interface
+call cpu_time(t1)
+print *, "Some computation"
+call cpu_time(t2)
+print *, "Total time: ", t2-t1
+end program

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -785,6 +785,7 @@ void save_js_glue(std::string filename) {
         outputBuffer.length = 0;
     }
     const set_exit_code = (exit_code_val) => exit_code.val = exit_code_val;
+    const cpu_time = (time) => (Date.now() / 1000); // Date.now() returns milliseconds, so divide by 1000
     var imports = {
         js: {
             memory: memory,
@@ -796,6 +797,7 @@ void save_js_glue(std::string filename) {
             print_str: printStr,
             flush_buf: flushBuffer,
             set_exit_code: set_exit_code,
+            cpu_time: cpu_time
         },
     };
     return imports;

--- a/tests/reference/wat-cpu_time_02_wasm-fa2b15f.json
+++ b/tests/reference/wat-cpu_time_02_wasm-fa2b15f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "wat-cpu_time_02_wasm-fa2b15f",
+    "cmd": "lfortran --no-color --show-wat {infile}",
+    "infile": "tests/../integration_tests/cpu_time_02_wasm.f90",
+    "infile_hash": "b059b12163601924d5ef98bed17705e08c0456055aa6c59be759794b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "wat-cpu_time_02_wasm-fa2b15f.stdout",
+    "stdout_hash": "91c34b7320eaee2992c01f8eb537dd028f13618345c42ef14547465e",
+    "stderr": "wat-cpu_time_02_wasm-fa2b15f.stderr",
+    "stderr_hash": "d2c2bb6a4c550fea31d3eae3fe71cfdd2b87500e2174b4916f881472",
+    "returncode": 0
+}

--- a/tests/reference/wat-cpu_time_02_wasm-fa2b15f.stderr
+++ b/tests/reference/wat-cpu_time_02_wasm-fa2b15f.stderr
@@ -1,0 +1,19 @@
+warning: Function with no body
+ --> tests/../integration_tests/cpu_time_02_wasm.f90:6:5 - 9:19
+  |
+6 |        subroutine cpu_time(t) bind(c)
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+  |
+9 |        end subroutine
+  | ...^^^^^^^^^^^^^^^^^^^ cpu_time
+
+warning: Function with no body
+ --> tests/../integration_tests/cpu_time_02_wasm.f90:6:5 - 9:19
+  |
+6 |        subroutine cpu_time(t) bind(c)
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+  |
+9 |        end subroutine
+  | ...^^^^^^^^^^^^^^^^^^^ cpu_time

--- a/tests/reference/wat-cpu_time_02_wasm-fa2b15f.stdout
+++ b/tests/reference/wat-cpu_time_02_wasm-fa2b15f.stdout
@@ -1,0 +1,47 @@
+(module
+    (type (;0;) (func (param i32) (result)))
+    (type (;1;) (func (param i64) (result)))
+    (type (;2;) (func (param f32) (result)))
+    (type (;3;) (func (param f64) (result)))
+    (type (;4;) (func (param i32 i32) (result)))
+    (type (;5;) (func (param) (result)))
+    (type (;6;) (func (param i32) (result)))
+    (type (;7;) (func (param f64) (result f64)))
+    (type (;8;) (func (param) (result)))
+    (import "js" "print_i32" (func (;0;) (type 0)))
+    (import "js" "print_i64" (func (;1;) (type 1)))
+    (import "js" "print_f32" (func (;2;) (type 2)))
+    (import "js" "print_f64" (func (;3;) (type 3)))
+    (import "js" "print_str" (func (;4;) (type 4)))
+    (import "js" "flush_buf" (func (;5;) (type 5)))
+    (import "js" "set_exit_code" (func (;6;) (type 6)))
+    (import "js" "memory" (memory (;0;) 100 100))
+    (import "js" "cpu_time" (func (;7;) (type 7)))
+    (func $8 (type 8) (param) (result)
+        (local f64 f64)
+        local.get 0
+        call 7
+        local.set 0
+        i32.const 0
+        i32.const 16
+        call 4
+        call 5
+        local.get 1
+        call 7
+        local.set 1
+        i32.const 16
+        i32.const 12
+        call 4
+        local.get 1
+        local.get 0
+        f64.sub
+        call 3
+        call 5
+        i32.const 0
+        call 6
+        return
+    )
+    (export "_lcompilers_main" (func $8))
+    (data (;0;) (i32.const 0) "Some computation")
+    (data (;1;) (i32.const 16) "Total time: ")
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -348,6 +348,10 @@ filename = "wasm_bind_c.f90"
 wat = true
 
 [[test]]
+filename = "../integration_tests/cpu_time_02_wasm.f90"
+wat = true
+
+[[test]]
 filename = "../integration_tests/if_05.f90"
 wat = true
 


### PR DESCRIPTION
towards #555, #540 

Corresponding `PR` at `lcompilers_frontend`: https://github.com/lfortran/lcompilers_frontend/pull/36