### PR TITLE
WASM: Support runtime library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ output
 *.smod
 *.js
 *.wasm
+*.data
 /.ccls-cache/
 .cache/
 ext/

--- a/build_to_wasm.sh
+++ b/build_to_wasm.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
+
+./build1.sh
+
+mkdir -p src/bin/asset_dir
+cp src/runtime/*.mod src/bin/asset_dir
+git clean -dfx -e src/bin/asset_dir
 
 emcmake cmake \
     -DCMAKE_BUILD_TYPE=Debug \

--- a/build_to_wasm.sh
+++ b/build_to_wasm.sh
@@ -2,7 +2,15 @@
 
 set -ex
 
-./build1.sh
+cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DWITH_LLVM=yes \
+    -DLFORTRAN_BUILD_ALL=yes \
+    -DWITH_STACKTRACE=no \
+    -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
+    -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+    .
+cmake --build . -j16 --target install
 
 mkdir -p src/bin/asset_dir
 cp src/runtime/*.mod src/bin/asset_dir

--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -28,6 +28,7 @@ mkdir -p wasm_builds/docs/${dest_dir}/${git_hash}
 cd wasm_builds/docs
 cp $D/src/bin/lfortran.js ${dest_dir}/${git_hash}/lfortran.js
 cp $D/src/bin/lfortran.wasm ${dest_dir}/${git_hash}/lfortran.wasm
+cp $D/src/bin/lfortran.data ${dest_dir}/${git_hash}/lfortran.data
 
 echo "$git_hash" > ${dest_dir}/latest_commit # overwrite the file instead of appending to it
 python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_hash}

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -149,14 +149,14 @@ if (HAVE_BUILD_TO_WASM)
     #     "-s WASM_BIGINT" # Allow use of i64 integers. ASR is needing this option to be enabled.
     #     "-s EXPORTED_RUNTIME_METHODS=['cwrap']" # Export cwarp. cwarp helps us to call our EMSCRIPTEN_KEEPALIVE functions
     # )
-    
+
     # Some extra flags below that we may need in future. But these may/might increase the code size
     # "--preload-file ./asset_dir"
     # "-s SAFE_HEAP=1"
     # "-s \"EXPORTED_RUNTIME_METHODS=['ccall']\""
     # "-s EXPORTED_FUNCTIONS=\"['_free', '_malloc']\""
-    
-    # Notes: 
+
+    # Notes:
     # STANDALONE_WASM is disabling support for exceptions, so it is currently omitted
     # In build_to_wasm.sh, we need CMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" flags for exception support
     set(WASM_COMPILE_FLAGS "-g0 -fexceptions")

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -161,7 +161,7 @@ if (HAVE_BUILD_TO_WASM)
     # In build_to_wasm.sh, we need CMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" flags for exception support
     set(WASM_COMPILE_FLAGS "-g0 -fexceptions")
     set(WASM_LINK_FLAGS
-      "-g0 -Oz -fexceptions --embed-file asset_dir -Wall -Wextra --no-entry -s ASSERTIONS -s ALLOW_MEMORY_GROWTH=1 -s WASM_BIGINT -s \"EXPORTED_RUNTIME_METHODS=['cwrap']\""
+      "-g0 -Oz -fexceptions --preload-file asset_dir -Wall -Wextra --no-entry -s ASSERTIONS -s ALLOW_MEMORY_GROWTH=1 -s WASM_BIGINT -s \"EXPORTED_RUNTIME_METHODS=['cwrap']\""
     )
     set_target_properties(lfortran PROPERTIES COMPILE_FLAGS ${WASM_COMPILE_FLAGS})
     set_target_properties(lfortran PROPERTIES LINK_FLAGS ${WASM_LINK_FLAGS})

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -161,7 +161,7 @@ if (HAVE_BUILD_TO_WASM)
     # In build_to_wasm.sh, we need CMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" flags for exception support
     set(WASM_COMPILE_FLAGS "-g0 -fexceptions")
     set(WASM_LINK_FLAGS
-      "-g0 -Oz -fexceptions -Wall -Wextra --no-entry -s ASSERTIONS -s ALLOW_MEMORY_GROWTH=1 -s WASM_BIGINT -s \"EXPORTED_RUNTIME_METHODS=['cwrap']\""
+      "-g0 -Oz -fexceptions --embed-file asset_dir -Wall -Wextra --no-entry -s ASSERTIONS -s ALLOW_MEMORY_GROWTH=1 -s WASM_BIGINT -s \"EXPORTED_RUNTIME_METHODS=['cwrap']\""
     )
     set_target_properties(lfortran PROPERTIES COMPILE_FLAGS ${WASM_COMPILE_FLAGS})
     set_target_properties(lfortran PROPERTIES LINK_FLAGS ${WASM_LINK_FLAGS})

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -39,6 +39,9 @@ void get_executable_path(std::string &executable_path, int &dirname_length)
 
 std::string get_runtime_library_dir()
 {
+#ifdef HAVE_BUILD_TO_WASM
+    return "asset_dir";
+#endif
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_DIR");
     if (env_p) return env_p;
 


### PR DESCRIPTION
towards #540 

This `PR` adds support of `preloading` the `runtime` library with `lfortran.js` and `lfortran.wasm`.

Corresponding `PR` at `lcompilers_frontend`: https://github.com/lfortran/lcompilers_frontend/pull/37