### PR TITLE
Improves plain text diagnostics

### DIFF
--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -8,8 +8,8 @@
 
 namespace LFortran::diag {
 
-const static std::string redon  = "\033[0;31m";
-const static std::string redoff = "\033[0;00m";
+const static std::string redon  = ColorsANSI::RED;
+const static std::string redoff = ColorsANSI::RESET;
 
 std::string highlight_line(const std::string &line,
         const size_t first_column,
@@ -82,8 +82,8 @@ std::string Diagnostics::render(const std::string &input,
     if (compiler_options.error_format == "human") {
         if (this->diagnostics.size() > 0 && !compiler_options.no_error_banner) {
             if (!compiler_options.no_warnings || has_error()) {
-                std::string bold  = "\033[0;1m";
-                std::string reset = "\033[0;00m";
+                std::string bold  = ColorsANSI::BOLD;
+                std::string reset = ColorsANSI::RESET;
                 if (!compiler_options.use_colors) {
                     bold = "";
                     reset = "";
@@ -157,12 +157,12 @@ std::string render_diagnostic_short(Diagnostic &d, const std::string &input,
 }
 
 std::string render_diagnostic_human(const Diagnostic &d, bool use_colors) {
-    std::string bold  = "\033[0;1m";
-    std::string red_bold  = "\033[0;31;1m";
-    std::string yellow_bold  = "\033[0;33;1m";
-    std::string green_bold  = "\033[0;32;1m";
-    std::string blue_bold  = "\033[0;34;1m";
-    std::string reset = "\033[0;00m";
+    std::string bold  = ColorsANSI::BOLD;
+    std::string red_bold  = ColorsANSI::BOLDCYAN;
+    std::string yellow_bold  = ColorsANSI::BOLDYELLOW;
+    std::string green_bold  = ColorsANSI::BOLDGREEN;
+    std::string blue_bold  = ColorsANSI::BOLDBLUE;
+    std::string reset = ColorsANSI::RESET;
     if (!use_colors) {
         bold = "";
         red_bold = "";
@@ -312,13 +312,9 @@ std::tuple<std::string, std::string, std::string> diag_level_to_str(const Diagno
     std::string message_type = "";
     std::string primary_color = "";
     std::string type_color = "";
-    std::string bold  = "\033[0;1m";
-    std::string red_bold  = "\033[0;31;1m";
-    std::string yellow_bold  = "\033[0;33;1m";
-    std::string green_bold  = "\033[0;32;1m";
     switch (d.level) {
         case (Level::Error):
-            primary_color = red_bold;
+            primary_color = ColorsANSI::BOLDRED;
             type_color = primary_color;
             switch (d.stage) {
                 case (Stage::CPreprocessor):
@@ -345,23 +341,23 @@ std::tuple<std::string, std::string, std::string> diag_level_to_str(const Diagno
             }
             break;
         case (Level::Warning):
-            primary_color = yellow_bold;
+            primary_color = ColorsANSI::BOLDYELLOW;
             type_color = primary_color;
             message_type = "warning";
             break;
         case (Level::Note):
-            primary_color = bold;
+            primary_color = ColorsANSI::BOLD;
             type_color = primary_color;
             message_type = "note";
             break;
         case (Level::Help):
-            primary_color = bold;
+            primary_color = ColorsANSI::BOLD;
             type_color = primary_color;
             message_type = "help";
             break;
         case (Level::Style):
-            primary_color = green_bold;
-            type_color = yellow_bold;
+            primary_color = ColorsANSI::BOLDGREEN;
+            type_color = ColorsANSI::BOLDYELLOW;
             message_type = "style suggestion";
             break;
     }

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -386,15 +386,14 @@ std::string render_diagnostic_short(const Diagnostic &d) {
             break;
     }
 
+    // Message anatomy:
+    // <filename>:<line start>-<end>:<column start>-<end>: <severity>: <message>
     if (d.labels.size() > 0) {
         Label l = d.labels[0];
         Span s = l.spans[0];
         // TODO: print the primary line+column here, not the first label:
-        out << s.filename << ":" << s.first_line << ":" << s.first_column;
-        if (s.first_line != s.last_line) {
-            out << " - " << s.last_line << ":" << s.last_column;
-        }
-        out << " ";
+        out << s.filename << ":" << s.first_line << "-" << s.last_line << ":";
+        out << s.first_column << "-" << s.last_column << ": ";
     }
 
     out << message_type << ": " << d.message << std::endl;

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -184,6 +184,27 @@ struct Diagnostics {
     }
 };
 
+struct ColorsANSI {
+    inline static const std::string RESET       = "\033[0;0m";
+    inline static const std::string BLACK       = "\033[0;30m";    /* Black */
+    inline static const std::string RED         = "\033[0;31m";    /* Red */
+    inline static const std::string GREEN       = "\033[0;32m";    /* Green */
+    inline static const std::string YELLOW      = "\033[0;33m";    /* Yellow */
+    inline static const std::string BLUE        = "\033[0;34m";    /* Blue */
+    inline static const std::string MAGENTA     = "\033[0;35m";    /* Magenta */
+    inline static const std::string CYAN        = "\033[0;36m";    /* Cyan */
+    inline static const std::string WHITE       = "\033[0;37m";    /* White */
+    inline static const std::string BOLD        = "\033[0;1m";     /* Bold */
+    inline static const std::string BOLDBLACK   = "\033[0;30;1m";  /* Bold Black */
+    inline static const std::string BOLDRED     = "\033[0;31;1m";  /* Bold Red */
+    inline static const std::string BOLDGREEN   = "\033[0;32;1m";  /* Bold Green */
+    inline static const std::string BOLDYELLOW  = "\033[0;33;1m";  /* Bold Yellow */
+    inline static const std::string BOLDBLUE    = "\033[0;34;1m";  /* Bold Blue */
+    inline static const std::string BOLDMAGENTA = "\033[0;35;1m";  /* Bold Magenta */
+    inline static const std::string BOLDCYAN    = "\033[0;36;1m";  /* Bold Cyan */
+    inline static const std::string BOLDWHITE   = "\033[0;37;1m";  /* Bold White */
+};
+
 std::string render_diagnostic_human(const Diagnostic &d, bool use_colors);
 std::string render_diagnostic_short(const Diagnostic &d);
 

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -1,6 +1,7 @@
 #ifndef LFORTRAN_DIAGNOSTICS_H
 #define LFORTRAN_DIAGNOSTICS_H
 
+#include <tuple>
 #include <libasr/location.h>
 #include <libasr/stacktrace.h>
 
@@ -191,6 +192,39 @@ std::string render_diagnostic_human(Diagnostic &d, const std::string &input,
         const LocationManager &lm, bool use_colors, bool show_stacktrace); 
 std::string render_diagnostic_short(Diagnostic &d, const std::string &input,
         const LocationManager &lm); 
+/**
+ * @brief Convert diagnostic `Level` i.e. severity to string and color accordingly.
+ *
+ * This method defines the Severity part of the REGEX linters must implement.
+ * Any changes to this method must be reflected in the linters.
+ *
+ * @param d Diagnostic object.
+ * @return std::tuple<std::string, std::string, std::string>
+ * message_type, primary color & type color
+ *
+ * Possible `messages_types` and their severities are:
+ * - Severity: Error
+ *    + C preprocessor error
+ *    + prescanner error
+ *    + tokenizer error
+ *    + syntax error
+ *    + semantic error
+ *    + ASR pass error
+ *    + code generation error
+ *
+ * - Severity: Warning
+ *    + warning
+ *
+ * - Severity: Note
+ *    + note
+ *
+ * - Severity: Help
+ *    + help
+ *
+ * - Severity: Style
+ *    + style suggestion
+ */
+std::tuple<std::string, std::string, std::string> diag_level_to_str(const Diagnostic &d);
 
 } // namespace diag
 } // namespace LFortran


### PR DESCRIPTION
This is an improvement on PR #47.

## Changes

### Improving plain-text diagnostics message

We want the diagnostics to provide the entire Range of the diagnostic. If the It is okay if the start and end locations are the same
these messages are mostly aimed towards other tools e.g. linter and not humans.

### Diagnostic level to string

I moved the creation of `message_type` into a single routine to decrease the chances of "human" and "short"
error formats getting out of sync.

### Using `struct` for ANSI in `diagnostics.cpp`

I also replaced the hard-coded ANSI codes with a struct in diagnostics but
there is an existing `terminal.h` consider using that instead
of the ColorsANSI or the hardcoded colors.

Alternatively, one can use an external library like
rang: https://github.com/agauniyal/rang

That change can be ignored by dropping commit 1cbeb578f886bb3d1e92b27033f6347d65259cc8

## TODO

- [ ] Add option to only check for semantics and report diagnostics. No compilation, no other output.
