### PR TITLE
feat: add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
This will open PRs whenever there is an update on the GitHub Actions used by lfortran. It will run all your CI checks to ensure that nothing in your CI pipeline has broken.

I think you will have to enable dependabot alerts under the `Security` tab (need to have admin rights for that).