### PR TITLE
Fix Data Attr Initialization

### DIFF
--- a/integration_tests/data_01.f90
+++ b/integration_tests/data_01.f90
@@ -1,7 +1,7 @@
 program data_01
-integer :: x
-real :: y, z, c1(4), bf1, xx90, xx95
-data x /1/
+integer :: x, td
+real :: y, z, c1(4), bf1, xx90, xx95, b, p
+data x, td, b /1, 4, 3/
 data y, z /2.0, 3.0/
 data c1 /0.0, 0.22, -0.14, -0.21/
 data bf1 /0.8/, xx90, xx95 /0.55, 0.62/
@@ -15,4 +15,6 @@ if (abs(c1(4)+0.21) > 1e-5) error stop
 if (abs(bf1-0.8) > 1e-5) error stop
 if (abs(xx90-0.55) > 1e-5) error stop
 if (abs(xx95-0.62) > 1e-5) error stop
+p = b ** (td-1)
+if (abs(p-27.0) > 1e-5) error stop
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -963,9 +963,9 @@ public:
                                         throw SemanticError("Type mismatch during data initialization",
                                             x.base.base.loc);
                                     }
-                                    ASR::expr_t* value_value = ASRUtils::expr_value(value);
-                                    if (value_value) {
-                                        body.push_back(al, value_value);
+                                    ASR::expr_t* expression_value = ASRUtils::expr_value(value);
+                                    if (expression_value) {
+                                        body.push_back(al, expression_value);
                                     } else {
                                         throw SemanticError("The value in data must be a constant",
                                             x.base.base.loc);
@@ -1006,9 +1006,16 @@ public:
                         // The `visit_expr` ensures it resolves as an expression
                         // which must be a `Var_t` pointing to a `Variable_t`,
                         // so no checks are needed:
+                        ImplicitCastRules::set_converted_value(al, x.base.base.loc, &value,
+                                                ASRUtils::expr_type(value), ASRUtils::expr_type(object));
+                        ASR::expr_t* expression_value = ASRUtils::expr_value(value);
+                        if (!expression_value) {
+                            throw SemanticError("The value in data must be a constant",
+                                x.base.base.loc);
+                        }
                         ASR::Var_t *v = ASR::down_cast<ASR::Var_t>(object);
                         ASR::Variable_t *v2 = ASR::down_cast<ASR::Variable_t>(v->m_v);
-                        v2->m_value = value;
+                        v2->m_value = expression_value;
                     }
                 } else {
                     throw SemanticError("Attribute declaration not supported",


### PR DESCRIPTION
This PR generates ASR for `scipy/odr/odrpack/d_mprec.f`:
```
% lfortran --implicit-typing --fixed-form --show-asr scipy/odr/odrpack/d_mprec.f --show-stacktrace 
(TranslationUnit (SymbolTable 1 {dmprec: (Function (SymbolTable 2 {b: (Variable 2 b Local () (RealConstant 2.000000 (Real 8 [])) Default (Real 8 []) Source Public Required .false.), dmprec: (Variable 2 dmprec ReturnVar () () Default (Real 8 []) Source Public Required .false.), td: (Variable 2 td Local () (IntegerConstant 53 (Integer 4 [])) Default (Integer 4 []) Source Public Required .false.), ts: (Variable 2 ts Local () (IntegerConstant 24 (Integer 4 [])) Default (Integer 4 []) Source Public Required .false.)}) dmprec [] [] [(= (Var 2 dmprec) (RealBinOp (Var 2 b) Pow (Cast (IntegerBinOp (IntegerConstant 1 (Integer 4 [])) Sub (Var 2 td) (Integer 4 []) (IntegerConstant -52 (Integer 4 []))) IntegerToReal (Real 8 []) (RealConstant -52.000000 (Real 8 []))) (Real 8 []) (RealConstant 0.000000 (Real 8 []))) ()) (Return)] (Var 2 dmprec) Source Public Implementation () .false. .false. .false.)}) [])

```