### PR TITLE
Fix: avoid n-d array name collisions (#747)

### DIFF
--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -49,10 +49,23 @@ std::string format_type(const std::string &dims, const std::string &type,
     return fmt;
 }
 
-std::string remove_characters(std::string s, char c)
-{
-    s.erase(remove(s.begin(), s.end(), c), s.end());
-    return s;
+std::string trim_dims(std::string &dims) {
+    std::string trimmed;
+    bool last_is_digit = true;
+    size_t i = 0;
+    while (!isdigit(dims[i])) i++;
+    for (; i < dims.size(); i++) {
+        if (isdigit(dims[i])) {
+            if (!last_is_digit) {
+                trimmed += "_";
+                last_is_digit = true;
+            }
+            trimmed.push_back(dims[i]);
+        } else {
+            last_is_digit = false;
+        }
+    }
+    return trimmed;
 }
 
 class ASRToCPPVisitor : public BaseCCPPVisitor<ASRToCPPVisitor>
@@ -118,9 +131,7 @@ public:
 
         std::string struct_name;
         std::string new_array_type;
-        std::string dims_copy = remove_characters(dims, '[');
-        dims_copy = remove_characters(dims_copy, ']');
-        dims_copy = remove_characters(dims_copy, '*');
+        std::string dims_copy = trim_dims(dims);
         std::string name = encoded_type_name + "_" + dims_copy + "_" + std::to_string(n_dims);
         struct_name = "struct " + name;
         std::string array_data = format_type("*", type_name, "data", false, false, true, "*");

--- a/tests/reference/cpp-array1-d75d040.json
+++ b/tests/reference/cpp-array1-d75d040.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-array1-d75d040.stdout",
-    "stdout_hash": "c0b8568c8de994afb31b2a2535aaa7b4b1ad950ebb16baad5c8e97d5",
+    "stdout_hash": "dfe4d569e21393e6c55e845f8fc185453a01464264654413938ebe4f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-array1-d75d040.stdout
+++ b/tests/reference/cpp-array1-d75d040.stdout
@@ -33,23 +33,23 @@ struct f32_5_1
 };
 
 
-struct f32_23_2
+struct f32_2_3_2
 {
     Kokkos::View<float*>* data;
     dimension_descriptor dims[2];
     bool is_allocated;
 
-    f32_23_2(Kokkos::View<float*>* data_): data{data_} {};
+    f32_2_3_2(Kokkos::View<float*>* data_): data{data_} {};
 };
 
 
-struct f32_123_3
+struct f32_1_2_3_3
 {
     Kokkos::View<float*>* data;
     dimension_descriptor dims[3];
     bool is_allocated;
 
-    f32_123_3(Kokkos::View<float*>* data_): data{data_} {};
+    f32_1_2_3_3(Kokkos::View<float*>* data_): data{data_} {};
 };
 
 
@@ -63,23 +63,23 @@ struct i32_3_1
 };
 
 
-struct i32_63_2
+struct i32_6_3_2
 {
     Kokkos::View<int32_t*>* data;
     dimension_descriptor dims[2];
     bool is_allocated;
 
-    i32_63_2(Kokkos::View<int32_t*>* data_): data{data_} {};
+    i32_6_3_2(Kokkos::View<int32_t*>* data_): data{data_} {};
 };
 
 
-struct i32_432_3
+struct i32_4_3_2_3
 {
     Kokkos::View<int32_t*>* data;
     dimension_descriptor dims[3];
     bool is_allocated;
 
-    i32_432_3(Kokkos::View<int32_t*>* data_): data{data_} {};
+    i32_4_3_2_3(Kokkos::View<int32_t*>* data_): data{data_} {};
 };
 
 // Forward declarations
@@ -101,15 +101,15 @@ void main2() {
     e->dims[0].lower_bound = 1;
     e->dims[0].length = 5;
     Kokkos::View<float*> e2_data("e2_data", 6);
-    f32_23_2 e2_value(&e2_data);
-    f32_23_2* e2 = &e2_value;
+    f32_2_3_2 e2_value(&e2_data);
+    f32_2_3_2* e2 = &e2_value;
     e2->dims[0].lower_bound = 1;
     e2->dims[0].length = 2;
     e2->dims[1].lower_bound = 1;
     e2->dims[1].length = 3;
     Kokkos::View<float*> e3_data("e3_data", 6);
-    f32_123_3 e3_value(&e3_data);
-    f32_123_3* e3 = &e3_value;
+    f32_1_2_3_3 e3_value(&e3_data);
+    f32_1_2_3_3* e3 = &e3_value;
     e3->dims[0].lower_bound = 1;
     e3->dims[0].length = 1;
     e3->dims[1].lower_bound = 1;
@@ -123,15 +123,15 @@ void main2() {
     g->dims[0].lower_bound = 1;
     g->dims[0].length = 3;
     Kokkos::View<int32_t*> g2_data("g2_data", 18);
-    i32_63_2 g2_value(&g2_data);
-    i32_63_2* g2 = &g2_value;
+    i32_6_3_2 g2_value(&g2_data);
+    i32_6_3_2* g2 = &g2_value;
     g2->dims[0].lower_bound = 1;
     g2->dims[0].length = 6;
     g2->dims[1].lower_bound = 1;
     g2->dims[1].length = 3;
     Kokkos::View<int32_t*> g3_data("g3_data", 24);
-    i32_432_3 g3_value(&g3_data);
-    i32_432_3* g3 = &g3_value;
+    i32_4_3_2_3 g3_value(&g3_data);
+    i32_4_3_2_3* g3 = &g3_value;
     g3->dims[0].lower_bound = 1;
     g3->dims[0].length = 4;
     g3->dims[1].lower_bound = 1;

--- a/tests/reference/cpp-array2-9a93c4d.json
+++ b/tests/reference/cpp-array2-9a93c4d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-array2-9a93c4d.stdout",
-    "stdout_hash": "b4fb1fc389310cce23bcfdacb1f82e3e5a8bfd50514d2dd3a94a354a",
+    "stdout_hash": "44dff95c62acee9d7231a3e3e02baaed530a44fce2e844c9efe4e5b2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-array2-9a93c4d.stdout
+++ b/tests/reference/cpp-array2-9a93c4d.stdout
@@ -43,43 +43,43 @@ struct i32_3_1
 };
 
 
-struct f32_23_2
+struct f32_2_3_2
 {
     Kokkos::View<float*>* data;
     dimension_descriptor dims[2];
     bool is_allocated;
 
-    f32_23_2(Kokkos::View<float*>* data_): data{data_} {};
+    f32_2_3_2(Kokkos::View<float*>* data_): data{data_} {};
 };
 
 
-struct i32_34_2
+struct i32_3_4_2
 {
     Kokkos::View<int32_t*>* data;
     dimension_descriptor dims[2];
     bool is_allocated;
 
-    i32_34_2(Kokkos::View<int32_t*>* data_): data{data_} {};
+    i32_3_4_2(Kokkos::View<int32_t*>* data_): data{data_} {};
 };
 
 
-struct f32_234_3
+struct f32_2_3_4_3
 {
     Kokkos::View<float*>* data;
     dimension_descriptor dims[3];
     bool is_allocated;
 
-    f32_234_3(Kokkos::View<float*>* data_): data{data_} {};
+    f32_2_3_4_3(Kokkos::View<float*>* data_): data{data_} {};
 };
 
 
-struct i32_343_3
+struct i32_3_4_3_3
 {
     Kokkos::View<int32_t*>* data;
     dimension_descriptor dims[3];
     bool is_allocated;
 
-    i32_343_3(Kokkos::View<int32_t*>* data_): data{data_} {};
+    i32_3_4_3_3(Kokkos::View<int32_t*>* data_): data{data_} {};
 };
 
 // Forward declarations
@@ -107,23 +107,23 @@ void main2() {
     c->dims[0].length = 3;
     Kokkos::View<bool[2]>& d;
     Kokkos::View<float*> e_data("e_data", 6);
-    f32_23_2 e_value(&e_data);
-    f32_23_2* e = &e_value;
+    f32_2_3_2 e_value(&e_data);
+    f32_2_3_2* e = &e_value;
     e->dims[0].lower_bound = 1;
     e->dims[0].length = 2;
     e->dims[1].lower_bound = 1;
     e->dims[1].length = 3;
     Kokkos::View<int32_t*> f_data("f_data", 12);
-    i32_34_2 f_value(&f_data);
-    i32_34_2* f = &f_value;
+    i32_3_4_2 f_value(&f_data);
+    i32_3_4_2* f = &f_value;
     f->dims[0].lower_bound = 1;
     f->dims[0].length = 3;
     f->dims[1].lower_bound = 1;
     f->dims[1].length = 4;
     Kokkos::View<bool[5][2]>& g;
     Kokkos::View<float*> h_data("h_data", 24);
-    f32_234_3 h_value(&h_data);
-    f32_234_3* h = &h_value;
+    f32_2_3_4_3 h_value(&h_data);
+    f32_2_3_4_3* h = &h_value;
     h->dims[0].lower_bound = 1;
     h->dims[0].length = 2;
     h->dims[1].lower_bound = 1;
@@ -131,8 +131,8 @@ void main2() {
     h->dims[2].lower_bound = 1;
     h->dims[2].length = 4;
     Kokkos::View<int32_t*> i_data("i_data", 36);
-    i32_343_3 i_value(&i_data);
-    i32_343_3* i = &i_value;
+    i32_3_4_3_3 i_value(&i_data);
+    i32_3_4_3_3* i = &i_value;
     i->dims[0].lower_bound = 1;
     i->dims[0].length = 3;
     i->dims[1].lower_bound = 1;


### PR DESCRIPTION
Implement new `trim_dims` to avoid array name collisions.