### PR TITLE
test: integration test for no-var do-loop

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -163,6 +163,7 @@ RUN(NAME doloop_04 LABELS gfortran llvm)
 RUN(NAME doloop_05 LABELS gfortran llvm cpp)
 RUN(NAME doloop_06 LABELS gfortran llvm cpp wasm)
 RUN(NAME doloop_07 LABELS gfortran llvm cpp wasm)
+RUN(NAME doloop_08 LABELS gfortran llvm cpp)
 
 RUN(NAME goto_01 LABELS gfortran llvm)
 RUN(NAME goto_02 LABELS gfortran llvm)

--- a/integration_tests/doloop_08.f90
+++ b/integration_tests/doloop_08.f90
@@ -1,0 +1,11 @@
+program doloop_08
+    implicit none
+    integer :: n=10, digit, sum=0
+    do
+        if(n==0) exit
+        digit=mod(n,10)
+        sum=sum + digit
+        n=n/10
+    end do
+    print *, sum
+end program doloop_08

--- a/tests/reference/c-doloop_08-2839ed5.json
+++ b/tests/reference/c-doloop_08-2839ed5.json
@@ -1,0 +1,13 @@
+{
+    "basename": "c-doloop_08-2839ed5",
+    "cmd": "lfortran --no-color --show-c {infile}",
+    "infile": "tests/../integration_tests/doloop_08.f90",
+    "infile_hash": "6163adee7d6f662f20c16aa54f77b6af4e0b64857e28e4bca0a47c09",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": -11
+}

--- a/tests/reference/cpp-doloop_08-cf3820d.json
+++ b/tests/reference/cpp-doloop_08-cf3820d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "cpp-doloop_08-cf3820d",
+    "cmd": "lfortran --no-color --show-cpp {infile}",
+    "infile": "tests/../integration_tests/doloop_08.f90",
+    "infile_hash": "6163adee7d6f662f20c16aa54f77b6af4e0b64857e28e4bca0a47c09",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": -11
+}

--- a/tests/reference/julia-doloop_08-f0d8fe6.json
+++ b/tests/reference/julia-doloop_08-f0d8fe6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "julia-doloop_08-f0d8fe6",
+    "cmd": "lfortran --no-color --show-julia {infile}",
+    "infile": "tests/../integration_tests/doloop_08.f90",
+    "infile_hash": "6163adee7d6f662f20c16aa54f77b6af4e0b64857e28e4bca0a47c09",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": -11
+}

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -494,6 +494,12 @@ ast_f90 = true
 julia = true
 
 [[test]]
+filename = "../integration_tests/doloop_08.f90"
+c = true
+cpp = true
+julia = true
+
+[[test]]
 filename = "../integration_tests/subroutines_01.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
I've done everything mentioned in https://github.com/lfortran/lfortran/pull/823#issuecomment-1264234047 to add the test for no-var do-loop case 

I have added a small program that counts the sum of digits of a number for the test.

I have a couple of doubts:
1. When I try to generate the cpp I get this:
```
❯ lfortran --show-cpp ./integration_tests/doloop_08.f90
[1]    349292 segmentation fault (core dumped)  lfortran --show-cpp ./integration_tests/doloop_08.f90
```

2. I am not sure what labels must be added to the test in `integration_tests/CMakeLists.txt`

3. The test output looks like this which is failing
    <details>
    <summary>Test output</summary>

    ```
    ❯ ctest
    ./run_tests.py
    Test project /home/rush/Desktop/oss/lfortran
        Start 1: test_cwrapper
    1/3 Test #1: test_cwrapper ....................   Passed    0.01 sec
        Start 2: test_stacktrace
    2/3 Test #2: test_stacktrace ..................   Passed    0.00 sec
        Start 3: test_lfortran
    3/3 Test #3: test_lfortran ....................***Failed    0.07 sec

    67% tests passed, 1 tests failed out of 3

    Total Test time (real) =   0.09 sec

    The following tests FAILED:
            3 - test_lfortran (Failed)
    Errors while running CTest
    Output from these tests are in: /home/rush/Desktop/oss/lfortran/Testing/Temporary/LastTest.log
    Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
    START TEST:  subroutine1.f90
    START TEST:  ../integration_tests/template_add.f90
    START TEST:  subroutine2.f90
    START TEST:  subroutine3.f90
    START TEST:  subroutine3b.f90
    START TEST:  do1.f90
    START TEST:  do2.f90
    START TEST:  do3.f90
    START TEST:  do4.f90
    START TEST:  do5.f90
    START TEST:  do6.f90
    START TEST:  do7.f90
    ../integration_tests/template_add.f90 * ast ✓ 
    subroutine1.f90 * tokens ✓ 
    subroutine2.f90 * ast ✓ 
    subroutine3.f90 * ast ✓ 
    subroutine3b.f90 * ast ✓ 
    do3.f90 * ast ✓ 
    START TEST:  subroutine4.f90
    do5.f90 * ast ✓ 
    START TEST:  do_concurrent_reduce.f90
    do2.f90 * ast ✓ 
    START TEST:  do_concurrent_reduce2.f90
    do1.f90 * ast ✓ 
    START TEST:  do_concurrent_reduce3.f90
    do4.f90 * ast ✓ 
    START TEST:  subroutine5.f90
    do6.f90 * ast ✓ 
    START TEST:  subroutine6.f90
    subroutine3.f90 * asr ✓ 
    ../integration_tests/template_add.f90 * asr ✓ 
    START TEST:  subroutine7.f90
    subroutine4.f90 * ast ✓ 
    do_concurrent_reduce2.f90 * ast ✓ 
    do7.f90 * llvm ✓ 
    START TEST:  errors/array_size_01.f90
    subroutine3b.f90 * asr ✓ 
    subroutine1.f90 * ast ✓ 
    do_concurrent_reduce.f90 * ast ✓ 
    subroutine3.f90 * llvm ✓ 
    do_concurrent_reduce3.f90 * ast ✓ 
    subroutine5.f90 * ast ✓ 
    subroutine3b.f90 * julia ✓ 
    START TEST:  errors/array_size_02.f90
    errors/array_size_01.f90 * asr ✓ 
    START TEST:  errors/array_size_03.f90
    subroutine4.f90 * ast_f90 ✓ 
    subroutine6.f90 * ast ✓ 
    do_concurrent_reduce2.f90 * ast_f90 ✓ 
    START TEST:  errors/array_size_04.f90
    subroutine2.f90 * julia ✓ 
    START TEST:  errors/array_size_05.f90
    subroutine3.f90 * obj ✓ 
    subroutine7.f90 * ast ✓ 
    do_concurrent_reduce3.f90 * ast_f90 ✓ 
    START TEST:  errors/matrix_transpose_01.f90
    subroutine5.f90 * asr ✓ 
    errors/array_size_03.f90 * asr ✓ 
    START TEST:  errors/matrix_matmul_01.f90
    subroutine1.f90 * ast_indent ✓ 
    do_concurrent_reduce.f90 * ast_f90 ✓ 
    subroutine4.f90 * ast_openmp ✓ 
    subroutine6.f90 * ast_openmp ✓ 
    errors/array_size_02.f90 * asr ✓ 
    START TEST:  errors/matrix_matmul_02.f90
    errors/matrix_transpose_01.f90 * asr ✓ 
    START TEST:  errors/matrix_matmul_03.f90
    subroutine5.f90 * cpp ✓ 
    errors/array_size_04.f90 * asr ✓ 
    subroutine7.f90 * asr ✓ 
    errors/matrix_matmul_01.f90 * asr ✓ 
    START TEST:  errors/matrix_matmul_05.f90
    START TEST:  errors/matrix_matmul_04.f90
    errors/array_size_05.f90 * asr ✓ 
    START TEST:  errors/matrix_matmul_06.f90
    subroutine3.f90 * julia ✓ 
    START TEST:  errors/array_transfer_01.f90
    subroutine1.f90 * asr_indent ✓ 
    do_concurrent_reduce.f90 * ast_openmp ✓ 
    subroutine4.f90 * asr ✓ 
    subroutine6.f90 * cpp ✓ 
    errors/matrix_matmul_05.f90 * asr ✓ 
    START TEST:  errors/esub1.f90
    errors/matrix_matmul_02.f90 * asr ✓ 
    START TEST:  errors/esub2.f90
    errors/array_transfer_01.f90 * asr ✓ 
    errors/matrix_matmul_04.f90 * asr ✓ 
    subroutine7.f90 * julia ✓ 
    errors/matrix_matmul_03.f90 * asr ✓ 
    subroutine5.f90 * julia ✓ 
    START TEST:  errors/type_mismatch2.f90
    errors/matrix_matmul_06.f90 * asr ✓ 
    START TEST:  errors/dim_assgn_test.f90
    START TEST:  errors/redeclaration1.f90
    START TEST:  errors/type_mismatch1.f90
    subroutine1.f90 * julia ✓ 
    START TEST:  errors/subroutine5.f90
    START TEST:  errors/cpp1.f90
    do_concurrent_reduce.f90 * cpp ✓ 
    START TEST:  errors/cpp3.f90
    START TEST:  errors/cpp2.f90
    errors/esub2.f90 * tokens ✓ 
    subroutine6.f90 * julia ✓ 
    subroutine4.f90 * cpp ✓ 
    START TEST:  errors/cpp4.f90
    errors/dim_assgn_test.f90 * asr ✓ 
    START TEST:  errors/cpp5.f90
    errors/esub1.f90 * tokens ✓ 
    errors/cpp1.f90 * asr_preprocess ✓ 
    START TEST:  errors/cpp6.f90
    errors/type_mismatch2.f90 * asr ✓ 
    START TEST:  errors/cpp7.f90
    errors/cpp3.f90 * asr_preprocess ✓ 
    errors/cpp2.f90 * asr_preprocess ✓ 
    errors/redeclaration1.f90 * asr ✓ 
    errors/esub2.f90 * ast ✓ 
    START TEST:  preprocessor3.f90
    errors/subroutine5.f90 * asr ✓ 
    subroutine4.f90 * julia ✓ 
    START TEST:  preprocessor5.f90
    START TEST:  warnings/dim_assgn_test.f90
    START TEST:  preprocessor1.f90
    START TEST:  preprocessor2.f90
    errors/type_mismatch1.f90 * asr ✓ 
    START TEST:  preprocessor6.f90
    START TEST:  preprocessor4.f90
    errors/cpp4.f90 * asr_preprocess ✓ 
    START TEST:  preprocessor7.f90
    errors/cpp5.f90 * asr_preprocess ✓ 
    START TEST:  preprocessor8.f90
    errors/esub1.f90 * ast ✓ 
    START TEST:  preprocessor9.f90
    errors/cpp6.f90 * asr_preprocess ✓ 
    START TEST:  preprocessor10.f90
    preprocessor2.f90 * asr_preprocess ✓ 
    preprocessor5.f90 * asr_preprocess ✓ 
    errors/cpp7.f90 * asr_preprocess ✓ 
    START TEST:  preprocessor11.f90
    preprocessor4.f90 * asr_preprocess ✓ 
    preprocessor3.f90 * asr_preprocess ✓ 
    START TEST:  expr3.f90
    preprocessor1.f90 * asr_preprocess ✓ 
    START TEST:  expr4.f90
    START TEST:  expr2.f90
    START TEST:  preprocessor12.f90
    warnings/dim_assgn_test.f90 * asr ✓ 
    START TEST:  expr5.f90
    preprocessor6.f90 * asr_preprocess ✓ 
    START TEST:  expr6.f90
    START TEST:  expr1.f90
    preprocessor8.f90 * asr_preprocess ✓ 
    START TEST:  expr7.f90
    preprocessor7.f90 * asr_preprocess ✓ 
    preprocessor11.f90 * asr_preprocess ✓ 
    START TEST:  expr9.f90
    START TEST:  expr8.f90
    expr3.f90 * ast ✓ 
    preprocessor10.f90 * asr_preprocess ✓ 
    START TEST:  wasm1.f90
    preprocessor9.f90 * asr_preprocess ✓ 
    START TEST:  wasm_i64.f90
    expr7.f90 * tokens ✓ 
    expr6.f90 * asr ✓ 
    expr2.f90 * ast ✓ 
    expr4.f90 * ast ✓ 
    preprocessor12.f90 * asr_preprocess ✓ 
    START TEST:  wasm_unary_minus.f90
    expr5.f90 * ast ✓ 
    expr8.f90 * tokens ✓ 
    expr1.f90 * ast ✓ 
    expr3.f90 * asr ✓ 
    wasm1.f90 * wat ✓ 
    wasm_i64.f90 * wat ✓ 
    START TEST:  wasm_main_program.f90
    START TEST:  ../integration_tests/types_16.f90
    expr6.f90 * pass_global_stmts ✓ 
    expr4.f90 * asr ✓ 
    expr7.f90 * ast ✓ 
    expr8.f90 * ast ✓ 
    expr5.f90 * asr ✓ 
    expr2.f90 * asr ✓ 
    expr9.f90 * ast ✓ 
    wasm_unary_minus.f90 * wat ✓ 
    expr1.f90 * asr ✓ 
    wasm_main_program.f90 * wat ✓ 
    START TEST:  wasm_bind_c.f90
    START TEST:  ../integration_tests/cpu_time_02_wasm.f90
    expr3.f90 * pass_global_stmts ✓ 
    expr4.f90 * pass_global_stmts ✓ 
    expr6.f90 * llvm ✓ 
    START TEST:  ../integration_tests/if_05.f90
    ../integration_tests/types_16.f90 * wat ✓ 
    START TEST:  ../integration_tests/abs_01.f90
    expr5.f90 * llvm ✓ 
    expr8.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/abs_03.f90
    wasm_bind_c.f90 * wat ✓ 
    START TEST:  stop.f90
    expr9.f90 * ast_f90 ✓ 
    START TEST:  stop1.f90
    expr3.f90 * llvm ✓ 
    START TEST:  ../integration_tests/submodule_01.f90
    expr4.f90 * llvm ✓ 
    START TEST:  ../integration_tests/submodule_02.f90
    expr1.f90 * pass_global_stmts ✓ 
    expr2.f90 * pass_global_stmts ✓ 
    expr7.f90 * ast_f90 ✓ 
    START TEST:  program1.f90
    ../integration_tests/cpu_time_02_wasm.f90 * wat ✓ 
    START TEST:  program2.f90
    stop.f90 * asr ✓ 
    expr2.f90 * llvm ✓ 
    ../integration_tests/abs_03.f90 * wat ✓ 
    START TEST:  program3.f90
    ../integration_tests/submodule_02.f90 * asr ✓ 
    START TEST:  program4.f90
    stop.f90 * llvm ✓ 
    START TEST:  ../integration_tests/program_01.f90
    ../integration_tests/abs_01.f90 * wat ✓ 
    START TEST:  ../integration_tests/program_cmake_01.f90
    expr2.f90 * obj ✓ 
    START TEST:  ../integration_tests/print_01.f90
    expr5.f90 * obj ✓ 
    START TEST:  ../integration_tests/variables_03.f90
    ../integration_tests/submodule_01.f90 * ast ✓ 
    START TEST:  ../integration_tests/while_01.f90
    ../integration_tests/if_05.f90 * julia ✓ 
    ../integration_tests/program_cmake_01.f90 * ast ✓ 
    ../integration_tests/program_01.f90 * ast ✓ 
    stop1.f90 * ast ✓ 
    ../integration_tests/print_01.f90 * llvm ✓ 
    START TEST:  ../integration_tests/while_02.f90
    ../integration_tests/if_05.f90 * wat ✓ 
    START TEST:  ../integration_tests/program_cmake_02.f90
    expr1.f90 * llvm ✓ 
    START TEST:  ../integration_tests/doconcurrentloop_02.f90
    program1.f90 * ast ✓ 
    program3.f90 * ast ✓ 
    ../integration_tests/while_01.f90 * llvm ✓ 
    program2.f90 * ast ✓ 
    START TEST:  ../integration_tests/cond_02.f90
    START TEST:  ../integration_tests/doloop_01.f90
    program4.f90 * ast ✓ 
    ../integration_tests/program_cmake_01.f90 * asr ✓ 
    ../integration_tests/program_cmake_02.f90 * ast ✓ 
    START TEST:  ../integration_tests/doloop_02.f90
    ../integration_tests/variables_03.f90 * llvm ✓ 
    START TEST:  ../integration_tests/doloop_03.f90
    ../integration_tests/program_01.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/doloop_04.f90
    ../integration_tests/doconcurrentloop_02.f90 * ast ✓ 
    stop1.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/doloop_05.f90
    ../integration_tests/while_02.f90 * llvm ✓ 
    START TEST:  ../integration_tests/doloop_08.f90
    program3.f90 * asr ✓ 
    program1.f90 * asr ✓ 
    ../integration_tests/program_cmake_01.f90 * llvm ✓ 
    ../integration_tests/doloop_01.f90 * asr ✓ 
    program4.f90 * asr ✓ 
    ../integration_tests/cond_02.f90 * asr ✓ 
    ../integration_tests/doloop_02.f90 * asr ✓ 
    ../integration_tests/doconcurrentloop_02.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/subroutines_01.f90
    ../integration_tests/doloop_03.f90 * asr ✓ 
    program1.f90 * llvm ✓ 
    ../integration_tests/doloop_05.f90 * ast_f90 ✓ 
    ../integration_tests/doloop_04.f90 * ast ✓ 
    ../integration_tests/cond_02.f90 * pass_dead_code_removal ✓ 
    START TEST:  ../integration_tests/subroutines_02.f90
    program1.f90 * cpp ✓ 
    ../integration_tests/doloop_02.f90 * llvm ✓ 
    program3.f90 * cpp ✓ 
    program4.f90 * cpp ✓ 
    ../integration_tests/doloop_03.f90 * llvm ✓ 
    ../integration_tests/program_cmake_01.f90 * obj ✓ 
    ../integration_tests/subroutines_01.f90 * asr ✓ 
    ../integration_tests/doloop_01.f90 * pass_do_loops ✓ 
    ../integration_tests/doloop_05.f90 * julia ✓ 
    START TEST:  ../integration_tests/subroutines_03.f90
    ../integration_tests/doloop_04.f90 * ast_f90 ✓ 
    ../integration_tests/doloop_02.f90 * julia ✓ 
    ../integration_tests/subroutines_02.f90 * asr ✓ 
    program1.f90 * obj ✓ 
    program3.f90 * c ✓ 
    START TEST:  ../integration_tests/subroutines_04.f90
    program4.f90 * c ✓ 
    START TEST:  ../integration_tests/subroutines_05.f90
    ../integration_tests/program_cmake_01.f90 * x86 ✓ 
    START TEST:  ../integration_tests/subroutines_06.f90
    ../integration_tests/doloop_04.f90 * asr ✓ 
    START TEST:  ../integration_tests/subroutines_07.f90
    ../integration_tests/doloop_02.f90 * wat ✓ 
    START TEST:  scopes1.f90
    program1.f90 * x86 ✓ 
    START TEST:  global_scope1.f90
    ../integration_tests/subroutines_04.f90 * ast ✓ 
    ../integration_tests/doloop_03.f90 * julia ✓ 
    ../integration_tests/subroutines_06.f90 * asr ✓ 
    START TEST:  global_scope2.f90
    ../integration_tests/subroutines_03.f90 * ast ✓ 
    ../integration_tests/doloop_08.f90 * cpp ✓ 
    ../integration_tests/subroutines_02.f90 * llvm ✓ 
    ../integration_tests/subroutines_01.f90 * llvm ✓ 
    ../integration_tests/doloop_01.f90 * llvm ✓ 
    ../integration_tests/subroutines_07.f90 * asr ✓ 
    START TEST:  global_scope3.f90
    global_scope1.f90 * ast ✓ 
    global_scope2.f90 * ast ✓ 
    ../integration_tests/subroutines_05.f90 * asr ✓ 
    START TEST:  global_scope4.f90
    scopes1.f90 * asr ✓ 
    START TEST:  global_scope5.f90
    ../integration_tests/subroutines_02.f90 * julia ✓ 
    START TEST:  global_scope6.f90
    ../integration_tests/subroutines_04.f90 * asr ✓ 
    ../integration_tests/subroutines_01.f90 * julia ✓ 
    START TEST:  global_scope8.f90
    ../integration_tests/subroutines_03.f90 * julia ✓ 
    START TEST:  global_scope9.f90
    global_scope3.f90 * ast ✓ 
    ../integration_tests/doloop_03.f90 * wat ✓ 
    START TEST:  kokkos_program1.f90
    global_scope6.f90 * asr ✓ 
    global_scope1.f90 * asr ✓ 
    global_scope8.f90 * asr ✓ 
    ../integration_tests/doloop_01.f90 * julia ✓ 
    global_scope4.f90 * asr ✓ 
    global_scope2.f90 * asr ✓ 
    global_scope5.f90 * asr ✓ 
    global_scope3.f90 * asr ✓ 
    ../integration_tests/subroutines_04.f90 * llvm ✓ 
    global_scope8.f90 * pass_global_stmts ✓ 
    global_scope9.f90 * asr ✓ 
    global_scope6.f90 * pass_global_stmts ✓ 
    global_scope1.f90 * pass_global_stmts ✓ 
    global_scope2.f90 * pass_global_stmts ✓ 
    global_scope4.f90 * pass_global_stmts ✓ 
    ../integration_tests/doloop_01.f90 * wat ✓ 
    START TEST:  kokkos_program2.f90
    kokkos_program1.f90 * cpp ✓ 
    START TEST:  array1.f90
    global_scope5.f90 * pass_global_stmts ✓ 
    ../integration_tests/doloop_08.f90 * c ✓ 
    global_scope3.f90 * pass_global_stmts ✓ 
    ../integration_tests/subroutines_04.f90 * julia ✓ 
    START TEST:  array2.f90
    global_scope4.f90 * llvm ✓ 
    global_scope1.f90 * llvm ✓ 
    START TEST:  array3.f90
    global_scope9.f90 * pass_global_stmts ✓ 
    global_scope6.f90 * llvm ✓ 
    global_scope8.f90 * llvm ✓ 
    START TEST:  array2_derived.f90
    array1.f90 * ast ✓ 
    START TEST:  array4.f90
    START TEST:  array5.f90
    kokkos_program2.f90 * asr ✓ 
    global_scope2.f90 * llvm ✓ 
    START TEST:  array6.f90
    global_scope5.f90 * llvm ✓ 
    START TEST:  array7.f90
    global_scope3.f90 * llvm ✓ 
    START TEST:  array8.f90
    array2.f90 * ast ✓ 
    array4.f90 * ast ✓ 
    START TEST:  array9.f90
    array2_derived.f90 * asr ✓ 
    array6.f90 * ast ✓ 
    global_scope9.f90 * llvm ✓ 
    array1.f90 * asr ✓ 
    kokkos_program2.f90 * cpp ✓ 
    START TEST:  ../integration_tests/arrays_01.f90
    array3.f90 * tokens ✓ 
    START TEST:  ../integration_tests/arrays_05.f90
    array5.f90 * ast ✓ 
    START TEST:  ../integration_tests/arrays_01_size.f90
    array2.f90 * asr ✓ 
    array8.f90 * ast ✓ 
    array7.f90 * ast ✓ 
    ../integration_tests/arrays_01.f90 * asr ✓ 
    array1.f90 * cpp ✓ 
    array2_derived.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_02_size.f90
    array6.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/matrix_01_transpose.f90
    ../integration_tests/arrays_01_size.f90 * asr ✓ 
    array9.f90 * ast ✓ 
    array2.f90 * llvm ✓ 
    ../integration_tests/arrays_05.f90 * asr ✓ 
    array7.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/matrix_02_matmul.f90
    ../integration_tests/matrix_01_transpose.f90 * asr ✓ 
    START TEST:  ../integration_tests/array_01_pack.f90
    array8.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/array_01_transfer.f90
    array3.f90 * ast ✓ 
    ../integration_tests/arrays_02_size.f90 * asr ✓ 
    ../integration_tests/doloop_08.f90 * julia ✓ 
    START TEST:  ../integration_tests/array_02_pack.f90
    array1.f90 * julia ✓ 
    START TEST:  ../integration_tests/array_02_transfer.f90
    ../integration_tests/arrays_05.f90 * julia ✓ 
    START TEST:  ../integration_tests/array_03_transfer.f90
    ../integration_tests/arrays_01.f90 * llvm ✓ 
    ../integration_tests/arrays_01_size.f90 * llvm ✓ 
    array2.f90 * cpp ✓ 
    array9.f90 * ast_f90 ✓ 
    START TEST:  ../integration_tests/arrays_01_real.f90
    array3.f90 * asr ✓ 
    ../integration_tests/array_01_pack.f90 * asr ✓ 
    START TEST:  ../integration_tests/arrays_01_complex.f90
    ../integration_tests/array_01_transfer.f90 * asr ✓ 
    ../integration_tests/array_02_transfer.f90 * asr ✓ 
    START TEST:  ../integration_tests/array_bound_1.f90
    ../integration_tests/matrix_02_matmul.f90 * asr ✓ 
    START TEST:  ../integration_tests/arrays_op_1.f90
    START TEST:  ../integration_tests/arrays_01_logical.f90
    ../integration_tests/array_02_pack.f90 * asr ✓ 
    START TEST:  ../integration_tests/arrays_op_2.f90
    ../integration_tests/array_03_transfer.f90 * asr ✓ 
    array2.f90 * julia ✓ 
    START TEST:  ../integration_tests/arrays_op_5.f90
    array3.f90 * cpp ✓ 
    ../integration_tests/arrays_01_size.f90 * julia ✓ 
    START TEST:  ../integration_tests/arrays_op_6.f90
    ../integration_tests/arrays_02_size.f90 * julia ✓ 
    START TEST:  ../integration_tests/arrays_op_4.f90
    START TEST:  ../integration_tests/arrays_op_7.f90
    ../integration_tests/arrays_01_logical.f90 * asr ✓ 
    ../integration_tests/arrays_op_2.f90 * asr ✓ 
    ../integration_tests/arrays_01_complex.f90 * asr ✓ 
    ../integration_tests/arrays_01.f90 * cpp ✓ 
    ../integration_tests/array_bound_1.f90 * asr ✓ 
    ../integration_tests/arrays_op_1.f90 * asr ✓ 
    ../integration_tests/arrays_01_real.f90 * asr ✓ 
    ../integration_tests/arrays_op_6.f90 * asr ✓ 
    array3.f90 * julia ✓ 
    START TEST:  ../integration_tests/arrays_reshape_14.f90
    ../integration_tests/arrays_01.f90 * julia ✓ 
    START TEST:  ../integration_tests/arrays_02.f90
    ../integration_tests/arrays_01_logical.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_03_func.f90
    ../integration_tests/arrays_op_5.f90 * asr ✓ 
    ../integration_tests/arrays_op_7.f90 * asr ✓ 
    ../integration_tests/arrays_op_4.f90 * asr ✓ 
    ../integration_tests/arrays_02.f90 * ast ✓ 
    ../integration_tests/arrays_op_2.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_04_func.f90
    START TEST:  ../integration_tests/arrays_06.f90
    ../integration_tests/arrays_02.f90 * ast_f90 ✓ 
    ../integration_tests/arrays_reshape_14.f90 * asr ✓ 
    START TEST:  ../integration_tests/arrays_07.f90
    ../integration_tests/arrays_03_func.f90 * asr ✓ 
    ../integration_tests/arrays_04_func.f90 * asr ✓ 
    ../integration_tests/arrays_op_7.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_08_func.f90
    ../integration_tests/arrays_01_complex.f90 * llvm ✓ 
    ../integration_tests/array_bound_1.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_10.f90
    ../integration_tests/arrays_op_5.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_09.f90
    ../integration_tests/arrays_01_real.f90 * llvm ✓ 
    START TEST:  ../integration_tests/types_01.f90
    ../integration_tests/arrays_op_4.f90 * llvm ✓ 
    ../integration_tests/arrays_op_1.f90 * llvm ✓ 
    START TEST:  ../integration_tests/arrays_13.f90
    ../integration_tests/arrays_06.f90 * asr ✓ 
    START TEST:  ../integration_tests/types_02.f90
    START TEST:  ../integration_tests/types_03.f90
    ../integration_tests/arrays_03_func.f90 * llvm ✓ 
    ../integration_tests/arrays_10.f90 * asr ✓ 
    ../integration_tests/arrays_02.f90 * julia ✓ 
    ../integration_tests/arrays_08_func.f90 * asr ✓ 
    ../integration_tests/arrays_04_func.f90 * llvm ✓ 
    ../integration_tests/arrays_07.f90 * asr ✓ 
    ../integration_tests/arrays_13.f90 * llvm ✓ 
    ../integration_tests/types_01.f90 * asr ✓ 
    ../integration_tests/types_02.f90 * asr ✓ 
    ../integration_tests/arrays_03_func.f90 * cpp ✓ 
    ../integration_tests/arrays_09.f90 * ast ✓ 
    ../integration_tests/types_03.f90 * asr ✓ 
    ../integration_tests/arrays_04_func.f90 * cpp ✓ 
    ../integration_tests/arrays_08_func.f90 * llvm ✓ 
    ../integration_tests/types_02.f90 * llvm ✓ 
    ../integration_tests/arrays_03_func.f90 * julia ✓ 
    ../integration_tests/arrays_07.f90 * llvm ✓ 
    ../integration_tests/types_01.f90 * llvm ✓ 
    ../integration_tests/arrays_09.f90 * ast_f90 ✓ 
    ../integration_tests/types_03.f90 * llvm ✓ 
    ../integration_tests/arrays_04_func.f90 * julia ✓ 
    ../integration_tests/types_02.f90 * cpp ✓ 
    ../integration_tests/arrays_08_func.f90 * julia ✓ 
    ../integration_tests/types_03.f90 * cpp ✓ 
    ../integration_tests/types_01.f90 * cpp ✓ 
    ../integration_tests/types_02.f90 * wat ✓ 
    ../integration_tests/types_01.f90 * wat ✓ 
    ../integration_tests/types_03.f90 * wat ✓ 
    Traceback (most recent call last):
    File "/home/rush/Desktop/oss/lfortran/./run_tests.py", line 251, in <module>
        tester_main("LFortran", single_test)
    File "/home/rush/Desktop/oss/lfortran/src/libasr/compiler_tester/tester.py", line 412, in tester_main
        for f in futures:
    File "/home/rush/conda_root/envs/lf/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
        yield _result_or_cancel(fs.pop())
    File "/home/rush/conda_root/envs/lf/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
        return fut.result(timeout)
    File "/home/rush/conda_root/envs/lf/lib/python3.10/concurrent/futures/_base.py", line 451, in result
        return self.__get_result()
    File "/home/rush/conda_root/envs/lf/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
        raise self._exception
    File "/home/rush/conda_root/envs/lf/lib/python3.10/concurrent/futures/thread.py", line 58, in run
        result = self.fn(*self.args, **self.kwargs)
    File "/home/rush/Desktop/oss/lfortran/./run_tests.py", line 200, in single_test
        run_test(
    File "/home/rush/Desktop/oss/lfortran/src/libasr/compiler_tester/tester.py", line 329, in run_test
        raise RunException(
    compiler_tester.tester.RunException: Testing with reference output failed.
    ../integration_tests/arrays_op_6.f90 * llvm
    The JSON metadata differs against reference results
    Reference JSON: tests/reference/llvm-arrays_op_6-ae38631.json
    Output JSON:    tests/output/llvm-arrays_op_6-ae38631.json
    Omitting 10 identical items
    Differing items:
    {'stdout_hash': '2817109de875312680198d0b399609458a70d99f2377bf0c8c035da2'} != {'stdout_hash': '9bf76c723e0e16225d4066ad4e6e354f45b1e7ebb34c78713a9366a8'}
    Diff against: tests/reference/llvm-arrays_op_6-ae38631.stdout
    640c640
    < ; Function Attrs: nounwind readnone speculatable willreturn
    ---
    > ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
    1013c1013
    < attributes #0 = { nounwind readnone speculatable willreturn }
    ---
    > attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

    ```

    </details>

Related: 
- #821 
- #822 
- #823 

Please take a look @certik @lucifer1004 