### PR TITLE
libasr/diagnostics: fix error message formatting

### DIFF
--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -90,8 +90,8 @@ std::string Diagnostics::render(const std::string &input,
                 }
                 out += "\n\n";
                 out += bold + "Note" + reset
-                    + ": if any of the above error or warning messages are not clear or are lacking\n";
-                out += "context please report it to us (we consider that a bug that needs to be fixed).\n";
+                    + ": if any of the above error or warning messages are not clear or are lacking "
+                    "context please report it to us (we consider that a bug that needs to be fixed).\n";
             }
         }
     }


### PR DESCRIPTION
Came across this small issue with the error message formatting because I use a very small and tall terminal window.

The error message looked like this for me:
![image](https://user-images.githubusercontent.com/54478821/193502186-f83457df-a018-4172-8c56-d1545edb28bf.png)

This new line after "lacking" is unnecessary and might be distracting.

So I changed it so that it comes in a single line and does not go beyond the point in the code base so it is easily readable in the codebase as well

It looks like this now:
![image](https://user-images.githubusercontent.com/54478821/193502339-6eb205f3-d8ec-44b8-906e-fc1fb3a7fdae.png)
