### PR TITLE
Fix a compiler warning

### DIFF
--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -51,7 +51,7 @@ namespace {
 }
 
 // Platform dependent fast unique hash:
-static uint64_t get_hash(ASR::asr_t *node)
+static inline uint64_t get_hash(ASR::asr_t *node)
 {
     return (uint64_t)node;
 }


### PR DESCRIPTION
Must use "static inline"