### PR TITLE
Fix lfortran_str_slice

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -784,6 +784,7 @@ LFORTRAN_API char* _lfortran_str_copy(char* s, int32_t idx1, int32_t idx2) {
 LFORTRAN_API char* _lfortran_str_slice(char* s, int32_t idx1, int32_t idx2, int32_t step,
                         bool idx1_present, bool idx2_present) {
     int s_len = strlen(s);
+    idx2++;
     if (step == 0) {
         printf("slice step cannot be zero\n");
         exit(1);


### PR DESCRIPTION
cc @czgdp1807 
https://github.com/lcompilers/lpython/pull/1051#discussion_r987731423
I haven't added a test for this because LFortran does not generate an ASR node for `StringSection` in Fortran frontend.