### PR TITLE
add quick fix

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -902,7 +902,7 @@ public:
                         ASR::Var_t *v = ASR::down_cast<ASR::Var_t>(object);
                         ASR::Variable_t *v2 = ASR::down_cast<ASR::Variable_t>(v->m_v);
                         v2->m_value = expression_value;
-                    } else if (ASR::is_a<ASR::ArrayItem_t>(*object)) {
+                    } else if (ASR::is_a<ASR::ArrayItem_t>(*object) && current_body != nullptr) {
                         // This is the following case:
                         // x(2) / 2 /
                         // We create an assignment node and insert into the current body.


### PR DESCRIPTION
While checking the files in `scipy/special/amos/` etc in #869 I fell on an error, and I think `current_body` is sometimes not allocated. For this I entered a simple check. However, the issue seems not too hard to surmount: The data assignment statements that throw errors are assignments to existing 1d array items with n elements. @Smit-create 