### PR TITLE
Show verify() errors as regular diagnostic messages

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -562,7 +562,7 @@ int emit_asr(const std::string &infile,
     LCompilers::PassOptions pass_options;
     pass_options.always_run = true;
     pass_options.run_fun = "f";
-    pass_manager.apply_passes(al, asr, pass_options);
+    pass_manager.apply_passes(al, asr, pass_options, diagnostics);
     std::cout << LFortran::pickle(*asr, compiler_options.use_colors, compiler_options.indent,
             with_intrinsic_modules) << std::endl;
     return 0;
@@ -647,13 +647,14 @@ int save_mod_files(const LFortran::ASR::TranslationUnit_t &u)
                 symtab, nullptr, 0);
             LFortran::ASR::TranslationUnit_t *tu =
                 LFortran::ASR::down_cast2<LFortran::ASR::TranslationUnit_t>(asr);
-            LFORTRAN_ASSERT(LFortran::asr_verify(*tu));
+            LFortran::diag::Diagnostics diagnostics;
+            LFORTRAN_ASSERT(LFortran::asr_verify(*tu, true, diagnostics));
 
             std::string modfile_binary = LFortran::save_modfile(*tu);
 
             m->m_symtab->parent = orig_symtab;
 
-            LFORTRAN_ASSERT(LFortran::asr_verify(u));
+            LFORTRAN_ASSERT(LFortran::asr_verify(u, true, diagnostics));
 
 
             std::string modfile = std::string(m->m_name) + ".mod";

--- a/src/lfortran/mod_to_asr.cpp
+++ b/src/lfortran/mod_to_asr.cpp
@@ -361,7 +361,8 @@ ASR::TranslationUnit_t* parse_gfortran_mod_file(Allocator &al, const std::string
     asr = ASR::make_TranslationUnit_t(al, loc,
         parent_scope, nullptr, 0);
     ASR::TranslationUnit_t *tu = down_cast2<ASR::TranslationUnit_t>(asr);
-    LFORTRAN_ASSERT(asr_verify(*tu));
+    diag::Diagnostics diagnostics;
+    LFORTRAN_ASSERT(asr_verify(*tu, true, diagnostics));
     return tu;
 
     //std::cout << format_item(mod);

--- a/src/lfortran/semantics/ast_to_asr.cpp
+++ b/src/lfortran/semantics/ast_to_asr.cpp
@@ -50,7 +50,7 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
         return res.error;
     }
     ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(unit);
-    LFORTRAN_ASSERT(asr_verify(*tu));
+    LFORTRAN_ASSERT(asr_verify(*tu, true, diagnostics));
 
     if (!symtab_only) {
         auto res = body_visitor(al, ast, diagnostics, unit, compiler_options, template_type_parameters, implicit_mapping);
@@ -59,7 +59,7 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
         } else {
             return res.error;
         }
-        LFORTRAN_ASSERT(asr_verify(*tu));
+        LFORTRAN_ASSERT(asr_verify(*tu, true, diagnostics));
     }
     return tu;
 }

--- a/src/lfortran/semantics/ast_to_asr.cpp
+++ b/src/lfortran/semantics/ast_to_asr.cpp
@@ -50,7 +50,11 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
         return res.error;
     }
     ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(unit);
-    LFORTRAN_ASSERT(asr_verify(*tu, true, diagnostics));
+#if defined(WITH_LFORTRAN_ASSERT)
+        if (!asr_verify(*tu, true, diagnostics)) {
+            return Error();
+        };
+#endif
 
     if (!symtab_only) {
         auto res = body_visitor(al, ast, diagnostics, unit, compiler_options, template_type_parameters, implicit_mapping);
@@ -59,7 +63,11 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
         } else {
             return res.error;
         }
-        LFORTRAN_ASSERT(asr_verify(*tu, true, diagnostics));
+#if defined(WITH_LFORTRAN_ASSERT)
+        if (!asr_verify(*tu, true, diagnostics)) {
+            return Error();
+        };
+#endif
     }
     return tu;
 }

--- a/src/lfortran/tests/test_ast.cpp
+++ b/src/lfortran/tests/test_ast.cpp
@@ -44,7 +44,7 @@ end program
     ASR::TranslationUnit_t* asr = TRY(LFortran::ast_to_asr(al, *ast,
         diagnostics, nullptr, false, compiler_options));
 
-    CHECK(asr_verify(*asr)); // Passes
+    CHECK(asr_verify(*asr, true, diagnostics)); // Passes
 
     // Extract the variable "x" from the "x = (2+3)*5" line:
     ASR::Program_t *prog = ASR::down_cast<ASR::Program_t>(asr->m_global_scope->get_symbol("expr2"));
@@ -54,7 +54,7 @@ end program
     v->m_v = &(prog->base); // Assign the wrong symbol to Var_t::m_v
 
     // This will be caught by the verifier
-    CHECK_THROWS_AS(asr_verify(*asr), LCompilersException);
+    CHECK_THROWS_AS(asr_verify(*asr, true, diagnostics), LCompilersException);
 }
 
 

--- a/src/lfortran/tests/test_ast.cpp
+++ b/src/lfortran/tests/test_ast.cpp
@@ -54,7 +54,7 @@ end program
     v->m_v = &(prog->base); // Assign the wrong symbol to Var_t::m_v
 
     // This will be caught by the verifier
-    CHECK_THROWS_AS(asr_verify(*asr, true, diagnostics), LCompilersException);
+    CHECK(!asr_verify(*asr, true, diagnostics));
 }
 
 

--- a/src/lfortran/tests/test_serialization.cpp
+++ b/src/lfortran/tests/test_serialization.cpp
@@ -91,7 +91,7 @@ void asr_ser(const std::string &src) {
     LFortran::ASR::TranslationUnit_t *tu
         = LFortran::ASR::down_cast2<LFortran::ASR::TranslationUnit_t>(asr_new0);
     fix_external_symbols(*tu, symtab);
-    LFORTRAN_ASSERT(LFortran::asr_verify(*tu));
+    LFORTRAN_ASSERT(LFortran::asr_verify(*tu, true, diagnostics));
 
     std::string asr_new = LFortran::pickle(*asr_new0);
 
@@ -113,7 +113,7 @@ void asr_mod(const std::string &src) {
     LFortran::ASR::TranslationUnit_t *asr2 = LFortran::load_modfile(al,
             modfile, true, symtab);
     fix_external_symbols(*asr2, symtab);
-    LFORTRAN_ASSERT(LFortran::asr_verify(*asr2));
+    LFORTRAN_ASSERT(LFortran::asr_verify(*asr2, true, diagnostics));
 
     CHECK(LFortran::pickle(*asr) == LFortran::pickle(*asr2));
 }

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -189,7 +189,8 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
     // Fix all external symbols
     fix_external_symbols(*tu, *symtab);
     if (run_verify) {
-        LFORTRAN_ASSERT(asr_verify(*tu));
+        diag::Diagnostics diagnostics;
+        LFORTRAN_ASSERT(asr_verify(*tu, true, diagnostics));
     }
     symtab->asr_owner = orig_asr_owner;
 

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -578,7 +578,8 @@ public:
 
 } // namespace ASR
 
-bool asr_verify(const ASR::TranslationUnit_t &unit, bool check_external) {
+bool asr_verify(const ASR::TranslationUnit_t &unit, bool check_external,
+            diag::Diagnostics &diagnostics) {
     ASR::VerifyVisitor v(check_external);
     v.visit_TranslationUnit(unit);
     return true;

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -3,6 +3,11 @@
 #include <libasr/asr_utils.h>
 #include <libasr/asr_verify.h>
 
+namespace {
+    class VerifyAbort
+    {
+    };
+}
 
 namespace LFortran {
 namespace ASR {
@@ -33,31 +38,27 @@ class VerifyVisitor : public BaseWalkVisitor<VerifyVisitor>
 private:
     // For checking correct parent symbtab relationship
     SymbolTable *current_symtab;
+    bool check_external;
+    diag::Diagnostics &diagnostics;
 
     // For checking that all symtabs have a unique ID.
     // We first walk all symtabs, and then we check that everything else
     // points to them (i.e., that nothing points to some symbol table that
     // is not part of this ASR).
     std::map<uint64_t,SymbolTable*> id_symtab_map;
-    bool check_external;
 public:
-    VerifyVisitor(bool check_external) : check_external{check_external} {}
+    VerifyVisitor(bool check_external, diag::Diagnostics &diagnostics) : check_external{check_external},
+        diagnostics{diagnostics} {}
 
     // Requires the condition `cond` to be true. Raise an exception otherwise.
-    void require(bool cond, const std::string &error_msg) {
+#define require(cond, error_msg) require_impl((cond), (error_msg), x.base.base.loc)
+    void require_impl(bool cond, const std::string &error_msg, const Location &loc) {
         if (!cond) {
-            throw LCompilersException("ASR verify failed: " + error_msg);
+            diagnostics.message_label("ASR verify: " + error_msg,
+                {loc}, "failed here",
+                diag::Level::Error, diag::Stage::ASRVerify);
+            throw VerifyAbort();
         }
-    }
-    void require(bool cond, const std::string &error_msg,
-                const Location &loc) {
-        std::string msg = std::to_string(loc.first) + ":"
-            + std::to_string(loc.last) + ": " + error_msg;
-        /*
-        std::string msg = std::to_string(loc.first_line) + ":"
-            + std::to_string(loc.first_column) + ": " + error_msg;
-        */
-        require(cond, msg);
     }
 
     // Returns true if the `symtab_ID` (sym->symtab->parent) is the current
@@ -218,14 +219,11 @@ public:
         }
         for (size_t i=0; i < x.n_dependencies; i++) {
             require(x.m_dependencies[i] != nullptr,
-                "A module dependency must not be a nullptr",
-                x.base.base.loc);
+                "A module dependency must not be a nullptr");
             require(std::string(x.m_dependencies[i]) != "",
-                "A module dependency must not be an empty string",
-                x.base.base.loc);
+                "A module dependency must not be an empty string");
             require(valid_name(x.m_dependencies[i]),
-                "A module dependency must be a valid string",
-                x.base.base.loc);
+                "A module dependency must be a valid string");
         }
         current_symtab = parent_symtab;
     }
@@ -401,7 +399,7 @@ public:
     }
 
     template <typename T>
-    void visit_ArrayItemSection(const T &x) {
+    void handle_ArrayItemSection(const T &x) {
         visit_expr(*x.m_v);
         for (size_t i=0; i<x.n_args; i++) {
             visit_array_index(x.m_args[i]);
@@ -410,30 +408,28 @@ public:
     }
 
     void visit_ArrayItem(const ArrayItem_t &x) {
-        visit_ArrayItemSection(x);
+        handle_ArrayItemSection(x);
     }
 
     void visit_ArraySection(const ArraySection_t &x) {
-        visit_ArrayItemSection(x);
+        handle_ArrayItemSection(x);
     }
 
     void visit_SubroutineCall(const SubroutineCall_t &x) {
         if (x.m_dt) {
-            SymbolTable *symtab = get_dt_symtab(x.m_dt, x.base.base.loc);
+            SymbolTable *symtab = get_dt_symtab(x.m_dt);
             bool result = symtab_in_scope(symtab, x.m_name);
-            ASR::symbol_t* parent = get_parent_type_dt(x.m_dt, x.base.base.loc);
+            ASR::symbol_t* parent = get_parent_type_dt(x.m_dt);
             while( !result && parent ) {
-                symtab = get_dt_symtab(parent, x.base.base.loc);
+                symtab = get_dt_symtab(parent);
                 result = symtab_in_scope(symtab, x.m_name);
-                parent = get_parent_type_dt(parent, x.base.base.loc);
+                parent = get_parent_type_dt(parent);
             }
             require(symtab_in_scope(symtab, x.m_name),
-                "SubroutineCall::m_name cannot point outside of its symbol table",
-                x.base.base.loc);
+                "SubroutineCall::m_name cannot point outside of its symbol table");
         } else {
             require(symtab_in_scope(current_symtab, x.m_name),
-                "SubroutineCall::m_name '" + std::string(symbol_name(x.m_name)) + "' cannot point outside of its symbol table",
-                x.base.base.loc);
+                "SubroutineCall::m_name '" + std::string(symbol_name(x.m_name)) + "' cannot point outside of its symbol table");
         }
         for (size_t i=0; i<x.n_args; i++) {
             if( x.m_args[i].m_value ) {
@@ -442,19 +438,18 @@ public:
         }
     }
 
-    SymbolTable *get_dt_symtab(ASR::symbol_t *dt, const Location &loc) {
+    SymbolTable *get_dt_symtab(ASR::symbol_t *dt) {
         LFORTRAN_ASSERT(dt)
         SymbolTable *symtab = ASRUtils::symbol_symtab(ASRUtils::symbol_get_past_external(dt));
-        require(symtab,
+        require_impl(symtab,
             "m_dt::m_v::m_type::class/derived_type must point to a symbol with a symbol table",
-            loc);
+            dt->base.loc);
         return symtab;
     }
 
-    SymbolTable *get_dt_symtab(ASR::expr_t *dt, const Location &loc) {
-        require(ASR::is_a<ASR::Var_t>(*dt),
-            "m_dt must point to a Var",
-            loc);
+    SymbolTable *get_dt_symtab(ASR::expr_t *dt) {
+        require_impl(ASR::is_a<ASR::Var_t>(*dt),
+            "m_dt must point to a Var", dt->base.loc);
         ASR::Var_t *var = ASR::down_cast<ASR::Var_t>(dt);
         ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(var->m_v);
         ASR::ttype_t *t2 = ASRUtils::type_get_past_pointer(v->m_type);
@@ -469,14 +464,14 @@ public:
                 break;
             }
             default :
-                require(false,
+                require_impl(false,
                     "m_dt::m_v::m_type must point to a type with a symbol table (Struct or Class)",
-                    loc);
+                    dt->base.loc);
         }
-        return get_dt_symtab(type_sym, loc);
+        return get_dt_symtab(type_sym);
     }
 
-    ASR::symbol_t *get_parent_type_dt(ASR::symbol_t *dt, const Location &loc) {
+    ASR::symbol_t *get_parent_type_dt(ASR::symbol_t *dt) {
         ASR::symbol_t *parent = nullptr;
         switch (dt->type) {
             case (ASR::symbolType::StructType): {
@@ -486,17 +481,16 @@ public:
                 break;
             }
             default :
-                require(false,
+                require_impl(false,
                     "m_dt::m_v::m_type must point to a Struct type",
-                    loc);
+                    dt->base.loc);
         }
         return parent;
     }
 
-    ASR::symbol_t *get_parent_type_dt(ASR::expr_t *dt, const Location &loc) {
-        require(ASR::is_a<ASR::Var_t>(*dt),
-            "m_dt must point to a Var",
-            loc);
+    ASR::symbol_t *get_parent_type_dt(ASR::expr_t *dt) {
+        require_impl(ASR::is_a<ASR::Var_t>(*dt),
+            "m_dt must point to a Var", dt->base.loc);
         ASR::Var_t *var = ASR::down_cast<ASR::Var_t>(dt);
         ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(var->m_v);
         ASR::ttype_t *t2 = ASRUtils::type_get_past_pointer(v->m_type);
@@ -520,35 +514,31 @@ public:
                 break;
             }
             default :
-                require(false,
+                require_impl(false,
                     "m_dt::m_v::m_type must point to a Struct type",
-                    loc);
+                    dt->base.loc);
         }
         return parent;
     }
 
     void visit_FunctionCall(const FunctionCall_t &x) {
         require(x.m_name,
-            "FunctionCall::m_name must be present",
-            x.base.base.loc);
+            "FunctionCall::m_name must be present");
         if (x.m_dt) {
-            SymbolTable *symtab = get_dt_symtab(x.m_dt, x.base.base.loc);
+            SymbolTable *symtab = get_dt_symtab(x.m_dt);
             require(symtab_in_scope(symtab, x.m_name),
-                "FunctionCall::m_name cannot point outside of its symbol table",
-                x.base.base.loc);
+                "FunctionCall::m_name cannot point outside of its symbol table");
         } else {
             require(symtab_in_scope(current_symtab, x.m_name),
                 "FunctionCall::m_name `" + std::string(symbol_name(x.m_name)) +
-                "` cannot point outside of its symbol table",
-                x.base.base.loc);
+                "` cannot point outside of its symbol table");
             // Check both `name` and `orig_name` that `orig_name` points
             // to GenericProcedure (if applicable), both external and non
             // external
             if (check_external) {
                 const ASR::symbol_t *fn = ASRUtils::symbol_get_past_external(x.m_name);
                 require(ASR::is_a<ASR::Function_t>(*fn),
-                    "FunctionCall::m_name must be a Function",
-                    x.base.base.loc);
+                    "FunctionCall::m_name must be a Function");
             }
         }
         for (size_t i=0; i<x.n_args; i++) {
@@ -580,8 +570,13 @@ public:
 
 bool asr_verify(const ASR::TranslationUnit_t &unit, bool check_external,
             diag::Diagnostics &diagnostics) {
-    ASR::VerifyVisitor v(check_external);
-    v.visit_TranslationUnit(unit);
+    ASR::VerifyVisitor v(check_external, diagnostics);
+    try {
+        v.visit_TranslationUnit(unit);
+    } catch (const VerifyAbort &) {
+        LFORTRAN_ASSERT(diagnostics.has_error())
+        return false;
+    }
     return true;
 }
 

--- a/src/libasr/asr_verify.h
+++ b/src/libasr/asr_verify.h
@@ -35,8 +35,8 @@ namespace LFortran {
     //
     //   LFORTRAN_ASSERT(asr_verify(*asr));
     //
-    bool asr_verify(const ASR::TranslationUnit_t &unit, bool
-            check_external=true);
+    bool asr_verify(const ASR::TranslationUnit_t &unit,
+        bool check_external, diag::Diagnostics &diagnostics);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6083,7 +6083,7 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     LCompilers::PassOptions pass_options;
     pass_options.run_fun = run_fn;
     pass_options.always_run = false;
-    pass_manager.apply_passes(al, &asr, pass_options);
+    pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
 
     // Uncomment for debugging the ASR after the transformation
     // std::cout << pickle(asr, true, true, true) << std::endl;

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -199,6 +199,9 @@ std::string render_diagnostic_human(const Diagnostic &d, bool use_colors) {
                 case (Stage::ASRPass):
                     message_type = "ASR pass error";
                     break;
+                case (Stage::ASRVerify):
+                    message_type = "ASR verify pass error";
+                    break;
                 case (Stage::CodeGen):
                     message_type = "code generation error";
                     break;
@@ -366,6 +369,9 @@ std::string render_diagnostic_short(const Diagnostic &d) {
                     break;
                 case (Stage::ASRPass):
                     message_type = "ASR pass error";
+                    break;
+                case (Stage::ASRVerify):
+                    message_type = "ASR verify pass error";
                     break;
                 case (Stage::CodeGen):
                     message_type = "code generation error";

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -68,7 +68,8 @@ enum Level {
  * Which stage of the compiler the error is coming from
  */
 enum Stage {
-    CPreprocessor, Prescanner, Tokenizer, Parser, Semantic, ASRPass, CodeGen
+    CPreprocessor, Prescanner, Tokenizer, Parser, Semantic, ASRPass,
+    ASRVerify, CodeGen
 };
 
 /*

--- a/src/libasr/pass/arr_slice.cpp
+++ b/src/libasr/pass/arr_slice.cpp
@@ -278,7 +278,6 @@ void pass_replace_arr_slice(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     ArrSliceVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -977,7 +977,6 @@ void pass_replace_array_op(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     ArrayOpVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/class_constructor.cpp
+++ b/src/libasr/pass/class_constructor.cpp
@@ -61,7 +61,6 @@ void pass_replace_class_constructor(Allocator &al, ASR::TranslationUnit_t &unit,
         v.is_constructor_present = false;
         v.visit_TranslationUnit(unit);
     } while( v.is_constructor_present );
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/dead_code_removal.cpp
+++ b/src/libasr/pass/dead_code_removal.cpp
@@ -103,7 +103,6 @@ void pass_dead_code_removal(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     DeadCodeRemovalVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/div_to_mul.cpp
+++ b/src/libasr/pass/div_to_mul.cpp
@@ -82,7 +82,6 @@ void pass_replace_div_to_mul(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     DivToMulVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -54,7 +54,6 @@ void pass_replace_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
         v.asr_changed = false;
         v.visit_TranslationUnit(unit);
     }
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/flip_sign.cpp
+++ b/src/libasr/pass/flip_sign.cpp
@@ -213,7 +213,6 @@ void pass_replace_flip_sign(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     FlipSignVisitor v(al, unit, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/fma.cpp
+++ b/src/libasr/pass/fma.cpp
@@ -170,7 +170,6 @@ void pass_replace_fma(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     FMAVisitor v(al, unit, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/for_all.cpp
+++ b/src/libasr/pass/for_all.cpp
@@ -47,7 +47,6 @@ void pass_replace_forall(Allocator &al, ASR::TranslationUnit_t &unit,
                          const LCompilers::PassOptions& /*pass_options*/) {
     ForAllVisitor v(al);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 } // namespace LFortran

--- a/src/libasr/pass/global_stmts.cpp
+++ b/src/libasr/pass/global_stmts.cpp
@@ -154,7 +154,6 @@ void pass_wrap_global_stmts_into_function(Allocator &al,
         }
         unit.m_items = nullptr;
         unit.n_items = 0;
-        LFORTRAN_ASSERT(asr_verify(unit));
     }
 }
 

--- a/src/libasr/pass/global_stmts_program.cpp
+++ b/src/libasr/pass/global_stmts_program.cpp
@@ -48,7 +48,6 @@ void pass_wrap_global_stmts_into_program(Allocator &al,
         /* a_body */ prog_body.p,
         /* n_body */ prog_body.n);
     unit.m_global_scope->add_symbol(prog_name, ASR::down_cast<ASR::symbol_t>(prog));
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 } // namespace LFortran

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -248,7 +248,6 @@ void pass_replace_implied_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     ImpliedDoLoopVisitor v(al, unit, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -460,7 +460,6 @@ void pass_inline_function_calls(Allocator &al, ASR::TranslationUnit_t &unit,
     v.visit_TranslationUnit(unit);
     v.configure_node_duplicator(true);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/loop_unroll.cpp
+++ b/src/libasr/pass/loop_unroll.cpp
@@ -112,7 +112,6 @@ void pass_loop_unroll(Allocator &al, ASR::TranslationUnit_t &unit,
     int64_t unroll_factor = pass_options.unroll_factor;
     LoopUnrollVisitor v(al, rl_path, unroll_factor);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/loop_vectorise.cpp
+++ b/src/libasr/pass/loop_vectorise.cpp
@@ -193,7 +193,6 @@ void pass_loop_vectorise(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     LoopVectoriseVisitor v(al, unit, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -307,13 +307,12 @@ public:
 };
 
 std::map<uint64_t, std::vector<llvm::Type*>> pass_find_nested_vars(
-        ASR::TranslationUnit_t &unit, llvm::LLVMContext &context,
+        const ASR::TranslationUnit_t &unit, llvm::LLVMContext &context,
         std::vector<uint64_t> &needed_globals,
         std::vector<uint64_t> &nested_call_out,
         std::map<uint64_t, std::vector<uint64_t>> &nesting_map) {
     NestedVarVisitor v(context, needed_globals, nested_call_out, nesting_map);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
     return v.nested_func_types;
 }
 

--- a/src/libasr/pass/nested_vars.h
+++ b/src/libasr/pass/nested_vars.h
@@ -7,7 +7,7 @@
 namespace LFortran {
 
      std::map<uint64_t, std::vector<llvm::Type*>> pass_find_nested_vars(
-             ASR::TranslationUnit_t &unit, llvm::LLVMContext &context,
+             const ASR::TranslationUnit_t &unit, llvm::LLVMContext &context,
              std::vector<uint64_t> &needed_globals, 
              std::vector<uint64_t> &nested_call_out,
              std::map<uint64_t, std::vector<uint64_t>> &nesting_map);

--- a/src/libasr/pass/param_to_const.cpp
+++ b/src/libasr/pass/param_to_const.cpp
@@ -195,10 +195,10 @@ public:
 };
 
 void pass_replace_param_to_const(Allocator &al, ASR::TranslationUnit_t &unit,
-                                 const LCompilers::PassOptions& /*pass_options*/) {
+                                 const LCompilers::PassOptions &/*pass_options*/
+                                 ) {
     VarVisitor v(al);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 } // namespace LFortran

--- a/src/libasr/pass/param_to_const.h
+++ b/src/libasr/pass/param_to_const.h
@@ -7,7 +7,8 @@
 namespace LFortran {
 
     void pass_replace_param_to_const(Allocator &al, ASR::TranslationUnit_t &unit,
-                                     const LCompilers::PassOptions& pass_options);
+                                     const LCompilers::PassOptions& pass_options
+                                     );
 
 } // namespace LFortran
 

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -421,7 +421,6 @@ void pass_array_by_data(Allocator &al, ASR::TranslationUnit_t &unit,
     w.visit_TranslationUnit(unit);
     RemoveArrayByDescriptorProceduresVisitor x(al,v);
     x.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 } // namespace LFortran

--- a/src/libasr/pass/pass_list_concat.cpp
+++ b/src/libasr/pass/pass_list_concat.cpp
@@ -237,9 +237,7 @@ void pass_list_concat(Allocator &al, ASR::TranslationUnit_t &unit,
                         const LCompilers::PassOptions& /*pass_options*/) {
     ListConcatVisitor v(al, unit);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 
 } // namespace LFortran
-

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -83,7 +83,7 @@ namespace LCompilers {
         bool apply_default_passes;
 
         void _apply_passes(Allocator& al, LFortran::ASR::TranslationUnit_t* asr,
-                           std::vector<std::string>& passes, PassOptions pass_options) {
+                           std::vector<std::string>& passes, PassOptions &pass_options) {
             pass_options.runtime_library_dir = LFortran::get_runtime_library_dir();
             for (size_t i = 0; i < passes.size(); i++) {
                 _passes_db[passes[i]](al, *asr, pass_options);

--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -83,7 +83,6 @@ void pass_replace_print_arr(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     PrintArrVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/print_list.cpp
+++ b/src/libasr/pass/print_list.cpp
@@ -204,7 +204,6 @@ void pass_replace_print_list(
     std::string rl_path = pass_options.runtime_library_dir;
     PrintListVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 }  // namespace LFortran

--- a/src/libasr/pass/select_case.cpp
+++ b/src/libasr/pass/select_case.cpp
@@ -172,7 +172,6 @@ void pass_replace_select_case(Allocator &al, ASR::TranslationUnit_t &unit,
     // to transform doubly nested loops:
     v.visit_TranslationUnit(unit);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -156,7 +156,6 @@ void pass_replace_sign_from_value(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     SignFromValueVisitor v(al, unit, rl_path);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 

--- a/src/libasr/pass/unused_functions.cpp
+++ b/src/libasr/pass/unused_functions.cpp
@@ -262,7 +262,6 @@ void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit,
             UnusedFunctionsVisitor v(al);
             v.fn_unused = fn_unused;
             v.visit_TranslationUnit(unit);
-            LFORTRAN_ASSERT(asr_verify(unit));
         }
     }
 }

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
@@ -147,7 +147,6 @@ void pass_update_array_dim_intrinsic_calls(Allocator &al, ASR::TranslationUnit_t
                                            const LCompilers::PassOptions& /*pass_options*/) {
     ArrayDimIntrinsicCallsVisitor v(al);
     v.visit_TranslationUnit(unit);
-    LFORTRAN_ASSERT(asr_verify(unit));
 }
 
 } // namespace LFortran

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -322,7 +322,8 @@ ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
     ASR::FixParentSymtabVisitor p;
     p.visit_TranslationUnit(*tu);
 
-    LFORTRAN_ASSERT(asr_verify(*tu, false));
+    diag::Diagnostics diagnostics;
+    LFORTRAN_ASSERT(asr_verify(*tu, false, diagnostics));
 
     return node;
 }

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -53,14 +53,10 @@ namespace LCompilers {
     struct PassOptions {
         std::string run_fun; // for global_stmts pass
         std::string runtime_library_dir;
-        bool always_run; // for unused_functions pass
-        bool inline_external_symbol_calls; // for inline_function_calls pass
-        int64_t unroll_factor; // for loop_unroll pass
-        bool fast; // is fast flag enabled.
-
-        PassOptions(): always_run(false), inline_external_symbol_calls(true),
-                       unroll_factor(32), fast(false)
-        {}
+        bool always_run = false; // for unused_functions pass
+        bool inline_external_symbol_calls = true; // for inline_function_calls pass
+        int64_t unroll_factor = 32; // for loop_unroll pass
+        bool fast = false; // is fast flag enabled.
     };
 
 }


### PR DESCRIPTION
This greatly simplifies development. Here is an example of a verify failure:
```console
$ make
[  2%] Building Fortran object src/CMakeFiles/minpack.dir/minpack.f90.o
[  4%] Building Fortran object src/CMakeFiles/minpack.dir/covar.f.o
[  6%] Building Fortran object src/CMakeFiles/minpack.dir/errjac.f.o
ASR verify pass error: ASR verify: The variable in ArrayItem must be an array, not a scalar
  --> /Users/ondrej/repos/lfortran/minpack/src/errjac.f:54:7
   |
54 |       dfloat(ivar) = ivar
   |       ^^^^^^^^^^^^ failed here


Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
make[2]: *** [src/CMakeFiles/minpack.dir/errjac.f.o] Error 1
make[1]: *** [src/CMakeFiles/minpack.dir/all] Error 2
make: *** [all] Error 2
```

(In color as usual.)