### PR TITLE
Enable LLVM 15 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,6 +222,47 @@ jobs:
             cd integration_tests
             ./run_tests.py -b llvm
 
+  test_llvm_15:
+    name: Test LLVM 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/provision-with-micromamba@v12
+        with:
+          environment-file: ci/environment_linux_llvm15.yml
+          extra-specs: |
+            python=3.10
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-${{ matrix.os }}
+
+      - name: Build Linux
+        shell: bash -l {0}
+        run: |
+            ./build0.sh
+            cmake . -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_LLVM=yes \
+              -DLFORTRAN_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+            cmake --build . -j16 --target install
+
+      - name: Test Linux
+        shell: bash -l {0}
+        run: |
+            cd integration_tests
+            ./run_tests.py -b llvm
+
   gfortran:
     name: Test integration_tests with GFortran
     runs-on: ubuntu-latest

--- a/ci/environment_linux_llvm15.yml
+++ b/ci/environment_linux_llvm15.yml
@@ -1,0 +1,20 @@
+name: lf
+channels:
+  - conda-forge
+dependencies:
+  - llvmdev=15
+  - toml
+  - pytest
+  - jupyter
+  - xeus=2.4.1
+  - xtl
+  - nlohmann_json
+  - cppzmq
+  - jupyter_kernel_test
+  - xonsh
+  - re2c
+  - numpy
+  - bison=3.4
+  - rapidjson
+  - ninja
+  - zlib

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -1,0 +1,20 @@
+name: lf
+channels:
+  - conda-forge
+dependencies:
+  - llvmdev=15
+  - toml
+  - pytest
+  - jupyter
+  - xeus=2.4.1
+  - xtl
+  - nlohmann_json
+  - cppzmq
+  - jupyter_kernel_test
+  - xonsh
+  - re2c
+  - numpy
+  - bison=3.4
+  - rapidjson
+  - ninja
+  - zlib

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6079,6 +6079,9 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
         LCompilers::PassManager& pass_manager,
         Platform platform, const std::string &run_fn)
 {
+#if LLVM_VERSION_MAJOR >= 15
+    context.setOpaquePointers(false);
+#endif
     ASRToLLVMVisitor v(al, context, platform, diagnostics);
     LCompilers::PassOptions pass_options;
     pass_options.run_fun = run_fn;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2814,7 +2814,7 @@ public:
                 }
                 if( is_array_type && arg->m_type->type != ASR::ttypeType::Pointer ) {
                     if( x.m_abi == ASR::abiType::Source ) {
-                        llvm::Type* orig_type = static_cast<llvm::PointerType*>(type)->getElementType();
+                        llvm::Type* orig_type = static_cast<llvm::PointerType*>(type)->getPointerElementType();
                         type = arr_descr->get_argument_type(orig_type, m_h, arg->m_name, arr_arg_type_cache);
                         is_array_type = false;
                     } else if( x.m_abi == ASR::abiType::Intrinsic &&
@@ -3453,8 +3453,8 @@ public:
                 llvm_shape = tmp;
             }
             llvm::Type* llvm_fptr_type = llvm_fptr->getType();
-            llvm_fptr_type = static_cast<llvm::PointerType*>(llvm_fptr_type)->getElementType();
-            llvm_fptr_type = static_cast<llvm::PointerType*>(llvm_fptr_type)->getElementType();
+            llvm_fptr_type = static_cast<llvm::PointerType*>(llvm_fptr_type)->getPointerElementType();
+            llvm_fptr_type = static_cast<llvm::PointerType*>(llvm_fptr_type)->getPointerElementType();
             llvm::Value* fptr_array = builder->CreateAlloca(llvm_fptr_type);
             ASR::dimension_t* fptr_dims;
             int fptr_rank = ASRUtils::extract_dimensions_from_ttype(
@@ -3473,7 +3473,7 @@ public:
                 shape_data = CreateLoad(arr_descr->get_pointer_to_data(llvm_shape));
             }
             llvm_cptr = builder->CreateBitCast(llvm_cptr,
-                            static_cast<llvm::PointerType*>(fptr_data->getType())->getElementType());
+                            static_cast<llvm::PointerType*>(fptr_data->getType())->getPointerElementType());
             builder->CreateStore(llvm_cptr, fptr_data);
             for( int i = 0; i < fptr_rank; i++ ) {
                 llvm::Value* curr_dim = llvm::ConstantInt::get(context, llvm::APInt(32, i));
@@ -3496,7 +3496,7 @@ public:
             llvm::Value* llvm_fptr = tmp;
             ptr_loads = ptr_loads_copy;
             llvm_cptr = builder->CreateBitCast(llvm_cptr,
-                            static_cast<llvm::PointerType*>(llvm_fptr->getType())->getElementType());
+                            static_cast<llvm::PointerType*>(llvm_fptr->getType())->getPointerElementType());
             builder->CreateStore(llvm_cptr, llvm_fptr);
         }
     }
@@ -5461,7 +5461,7 @@ public:
                                 if( arr_descr->is_array(tmp) ) {
                                     tmp = CreateLoad(arr_descr->get_pointer_to_data(tmp));
                                     llvm::PointerType* tmp_type = static_cast<llvm::PointerType*>(tmp->getType());
-                                    if( tmp_type->getElementType()->isArrayTy() ) {
+                                    if( tmp_type->getPointerElementType()->isArrayTy() ) {
                                         tmp = llvm_utils->create_gep(tmp, 0);
                                     }
                                 } else {
@@ -5688,7 +5688,7 @@ public:
         llvm::Value* int_var = builder->CreateBitCast(CreateLoad(variable), shifted_signal->getType());
         tmp = builder->CreateXor(shifted_signal, int_var);
         llvm::PointerType* variable_type = static_cast<llvm::PointerType*>(variable->getType());
-        builder->CreateStore(builder->CreateBitCast(tmp, variable_type->getElementType()), variable);
+        builder->CreateStore(builder->CreateBitCast(tmp, variable_type->getPointerElementType()), variable);
     }
 
     void generate_fma(ASR::call_arg_t* m_args) {

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -118,7 +118,7 @@ namespace LFortran {
         bool SimpleCMODescriptor::is_array(llvm::Value* tmp) {
             llvm::Type* tmp_type = nullptr;
             if( tmp->getType()->isPointerTy() ) {
-                tmp_type = static_cast<llvm::PointerType*>(tmp->getType())->getElementType();
+                tmp_type = static_cast<llvm::PointerType*>(tmp->getType())->getPointerElementType();
             } else {
                 tmp_type = tmp->getType();
             }
@@ -142,7 +142,7 @@ namespace LFortran {
             }
             llvm::Value* arg_struct = builder->CreateAlloca(arg_type, nullptr);
             llvm::Value* first_ele_ptr = nullptr;
-            llvm::Type* tmp_type = static_cast<llvm::PointerType*>(tmp->getType())->getElementType();
+            llvm::Type* tmp_type = static_cast<llvm::PointerType*>(tmp->getType())->getPointerElementType();
             llvm::StructType* tmp_struct_type = static_cast<llvm::StructType*>(tmp_type);
             if( tmp_struct_type->getElementType(0)->isArrayTy() ) {
                 first_ele_ptr = llvm_utils->create_gep(get_pointer_to_data(tmp), 0);
@@ -325,8 +325,8 @@ namespace LFortran {
             builder->CreateStore(prod, llvm_size);
             llvm::Value* first_ptr = get_pointer_to_data(arr);
             llvm::PointerType* first_ptr2ptr_type = static_cast<llvm::PointerType*>(first_ptr->getType());
-            llvm::PointerType* first_ptr_type = static_cast<llvm::PointerType*>(first_ptr2ptr_type->getElementType());
-            llvm::Value* arr_first = builder->CreateAlloca(first_ptr_type->getElementType(),
+            llvm::PointerType* first_ptr_type = static_cast<llvm::PointerType*>(first_ptr2ptr_type->getPointerElementType());
+            llvm::Value* arr_first = builder->CreateAlloca(first_ptr_type->getPointerElementType(),
                                                             LLVM::CreateLoad(*builder, llvm_size));
             builder->CreateStore(arr_first, first_ptr);
         }
@@ -356,10 +356,10 @@ namespace LFortran {
             llvm::AllocaInst *arg_size = builder->CreateAlloca(llvm::Type::getInt32Ty(context), nullptr);
             llvm::DataLayout data_layout(module);
             llvm::Type* ptr2firstptr_type = ptr2firstptr->getType();
-            llvm::Type* ptr_type = static_cast<llvm::PointerType*>(ptr2firstptr_type)->getElementType();
+            llvm::Type* ptr_type = static_cast<llvm::PointerType*>(ptr2firstptr_type)->getPointerElementType();
             uint64_t size = data_layout.getTypeAllocSize(
                                 static_cast<llvm::PointerType*>(ptr_type)->
-                                getElementType());
+                                getPointerElementType());
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);
             builder->CreateStore(num_elements, arg_size);
@@ -538,17 +538,17 @@ namespace LFortran {
 
             llvm::Value* first_ptr = this->get_pointer_to_data(reshaped);
             llvm::PointerType* first_ptr2ptr_type = static_cast<llvm::PointerType*>(first_ptr->getType());
-            llvm::PointerType* first_ptr_type = static_cast<llvm::PointerType*>(first_ptr2ptr_type->getElementType());
-            llvm::Value* arr_first = builder->CreateAlloca(first_ptr_type->getElementType(), num_elements);
+            llvm::PointerType* first_ptr_type = static_cast<llvm::PointerType*>(first_ptr2ptr_type->getPointerElementType());
+            llvm::Value* arr_first = builder->CreateAlloca(first_ptr_type->getPointerElementType(), num_elements);
             builder->CreateStore(arr_first, first_ptr);
 
             llvm::Value* ptr2firstptr = this->get_pointer_to_data(array);
             llvm::DataLayout data_layout(module);
             llvm::Type* ptr2firstptr_type = ptr2firstptr->getType();
-            llvm::Type* ptr_type = static_cast<llvm::PointerType*>(ptr2firstptr_type)->getElementType();
+            llvm::Type* ptr_type = static_cast<llvm::PointerType*>(ptr2firstptr_type)->getPointerElementType();
             uint64_t size = data_layout.getTypeAllocSize(
                                 static_cast<llvm::PointerType*>(ptr_type)->
-                                getElementType());
+                                getPointerElementType());
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);
             builder->CreateMemCpy(LLVM::CreateLoad(*builder, first_ptr), llvm::MaybeAlign(),


### PR DESCRIPTION
Add a CI test and update the code to compile. We support all LLVM 11 - 15. For LLVM 11 everything works. For LLVM 14 and 15 only integration tests pass (we test at the CI), but interactivity does not work and reference tests don't pass, because each LLVM version outputs slightly different LLVM IR code.

I think a good way to move forward is to keep the latest LLVM version always working for everything and just keep updating our tests. And for older versions keep as much working as possible, but reference tests will not work.