### PR TITLE
Removing `getPointerElementType` usage in LLVM backend

### DIFF
--- a/integration_tests/arrays_13.f90
+++ b/integration_tests/arrays_13.f90
@@ -42,4 +42,3 @@ contains
     end subroutine
 
 end program
-

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -685,14 +685,19 @@ static inline std::string get_type_code(const ASR::ttype_t *t, bool use_undersco
         }
         case ASR::ttypeType::Complex: {
             ASR::Complex_t *complx = ASR::down_cast<ASR::Complex_t>(t);
-            std::string res = "r" + std::to_string(complx->m_kind * 8);
+            std::string res = "c" + std::to_string(complx->m_kind * 8);
             if( encode_dimensions_ ) {
                 encode_dimensions(complx->n_dims, res, use_underscore_sep);
             }
             return res;
         }
         case ASR::ttypeType::Logical: {
-            return "bool";
+            ASR::Logical_t* bool_ = ASR::down_cast<ASR::Logical_t>(t);
+            std::string res = "bool";
+            if( encode_dimensions_ ) {
+                encode_dimensions(bool_->n_dims, res, use_underscore_sep);
+            }
+            return res;
         }
         case ASR::ttypeType::Character: {
             return "str";
@@ -750,7 +755,11 @@ static inline std::string get_type_code(const ASR::ttype_t *t, bool use_undersco
         }
         case ASR::ttypeType::Struct: {
             ASR::Struct_t* d = ASR::down_cast<ASR::Struct_t>(t);
-            return symbol_name(d->m_derived_type);
+            std::string res = symbol_name(d->m_derived_type);
+            if( encode_dimensions_ ) {
+                encode_dimensions(d->n_dims, res, use_underscore_sep);
+            }
+            return res;
         }
         case ASR::ttypeType::Pointer: {
             ASR::Pointer_t* p = ASR::down_cast<ASR::Pointer_t>(t);
@@ -1343,11 +1352,26 @@ static inline ASR::ttype_t* duplicate_type_without_dims(Allocator& al, const ASR
             return ASRUtils::TYPE(ASR::make_Real_t(al, t->base.loc,
                         tnew->m_kind, nullptr, 0));
         }
+        case ASR::ttypeType::Complex: {
+            ASR::Complex_t* tnew = ASR::down_cast<ASR::Complex_t>(t);
+            return ASRUtils::TYPE(ASR::make_Complex_t(al, t->base.loc,
+                        tnew->m_kind, nullptr, 0));
+        }
+        case ASR::ttypeType::Logical: {
+            ASR::Logical_t* tnew = ASR::down_cast<ASR::Logical_t>(t);
+            return ASRUtils::TYPE(ASR::make_Logical_t(al, t->base.loc,
+                        tnew->m_kind, nullptr, 0));
+        }
         case ASR::ttypeType::Character: {
             ASR::Character_t* tnew = ASR::down_cast<ASR::Character_t>(t);
             return ASRUtils::TYPE(ASR::make_Character_t(al, t->base.loc,
                         tnew->m_kind, tnew->m_len, tnew->m_len_expr,
                         nullptr, 0));
+        }
+        case ASR::ttypeType::Struct: {
+            ASR::Struct_t* tstruct = ASR::down_cast<ASR::Struct_t>(t);
+            return ASRUtils::TYPE(ASR::make_Struct_t(al, t->base.loc,
+                    tstruct->m_derived_type, nullptr, 0));
         }
         case ASR::ttypeType::TypeParameter: {
             ASR::TypeParameter_t* tp = ASR::down_cast<ASR::TypeParameter_t>(t);

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -115,35 +115,21 @@ namespace LFortran {
         ) {
         }
 
-        bool SimpleCMODescriptor::is_array(llvm::Value* tmp) {
-            llvm::Type* tmp_type = nullptr;
-            if( tmp->getType()->isPointerTy() ) {
-                tmp_type = static_cast<llvm::PointerType*>(tmp->getType())->getPointerElementType();
-            } else {
-                tmp_type = tmp->getType();
-            }
-            if( tmp_type->isStructTy() ) {
-                llvm::StructType* tmp_struct_type = static_cast<llvm::StructType*>(tmp_type);
-                if( tmp_struct_type->getNumElements() > 2 &&
-                    tmp_struct_type->getElementType(2) == dim_des->getPointerTo() ) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
+        bool SimpleCMODescriptor::is_array(ASR::ttype_t* asr_type) {
+            std::string asr_type_code = ASRUtils::get_type_code(asr_type);
+            return tkr2array.find(asr_type_code) != tkr2array.end();
         }
 
         llvm::Value* SimpleCMODescriptor::
-        convert_to_argument(llvm::Value* tmp, llvm::Type* arg_type, bool data_only) {
+        convert_to_argument(llvm::Value* tmp, ASR::ttype_t* asr_arg_type,
+                            llvm::Type* arg_type, bool data_only) {
             if( data_only ) {
                 return LLVM::CreateLoad(*builder, get_pointer_to_data(tmp));
             }
             llvm::Value* arg_struct = builder->CreateAlloca(arg_type, nullptr);
             llvm::Value* first_ele_ptr = nullptr;
-            llvm::Type* tmp_type = static_cast<llvm::PointerType*>(tmp->getType())->getPointerElementType();
-            llvm::StructType* tmp_struct_type = static_cast<llvm::StructType*>(tmp_type);
+            std::string asr_arg_type_code = ASRUtils::get_type_code(ASRUtils::get_contained_type(asr_arg_type));
+            llvm::StructType* tmp_struct_type = tkr2array[asr_arg_type_code];
             if( tmp_struct_type->getElementType(0)->isArrayTy() ) {
                 first_ele_ptr = llvm_utils->create_gep(get_pointer_to_data(tmp), 0);
             } else if( tmp_struct_type->getNumElements() < 5 ) {
@@ -292,7 +278,7 @@ namespace LFortran {
         }
 
         void SimpleCMODescriptor::fill_array_details(
-        llvm::Value* arr, int n_dims,
+        llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
         std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims) {
             llvm::Value* offset_val = llvm_utils->create_gep(arr, 1);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, 0)), offset_val);
@@ -324,15 +310,12 @@ namespace LFortran {
             }
             builder->CreateStore(prod, llvm_size);
             llvm::Value* first_ptr = get_pointer_to_data(arr);
-            llvm::PointerType* first_ptr2ptr_type = static_cast<llvm::PointerType*>(first_ptr->getType());
-            llvm::PointerType* first_ptr_type = static_cast<llvm::PointerType*>(first_ptr2ptr_type->getPointerElementType());
-            llvm::Value* arr_first = builder->CreateAlloca(first_ptr_type->getPointerElementType(),
-                                                            LLVM::CreateLoad(*builder, llvm_size));
+            llvm::Value* arr_first = builder->CreateAlloca(llvm_data_type, LLVM::CreateLoad(*builder, llvm_size));
             builder->CreateStore(arr_first, first_ptr);
         }
 
         void SimpleCMODescriptor::fill_malloc_array_details(
-        llvm::Value* arr, int n_dims,
+        llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
         std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims,
         llvm::Module* module) {
             llvm::Value* num_elements = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
@@ -355,11 +338,8 @@ namespace LFortran {
             llvm::Value* ptr2firstptr = get_pointer_to_data(arr);
             llvm::AllocaInst *arg_size = builder->CreateAlloca(llvm::Type::getInt32Ty(context), nullptr);
             llvm::DataLayout data_layout(module);
-            llvm::Type* ptr2firstptr_type = ptr2firstptr->getType();
-            llvm::Type* ptr_type = static_cast<llvm::PointerType*>(ptr2firstptr_type)->getPointerElementType();
-            uint64_t size = data_layout.getTypeAllocSize(
-                                static_cast<llvm::PointerType*>(ptr_type)->
-                                getPointerElementType());
+            llvm::Type* ptr_type = llvm_data_type->getPointerTo();
+            uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);
             builder->CreateStore(num_elements, arg_size);
@@ -529,33 +509,27 @@ namespace LFortran {
             return tmp;
         }
 
-        llvm::Value* SimpleCMODescriptor::reshape(llvm::Value* array, llvm::Value* shape,
-                                                  llvm::Module* module) {
+        llvm::Value* SimpleCMODescriptor::reshape(llvm::Value* array, llvm::Type* llvm_data_type, llvm::Value* shape,
+                                                  ASR::ttype_t* asr_shape_type, llvm::Module* module) {
             llvm::Value* reshaped = builder->CreateAlloca(array->getType()->getContainedType(0), nullptr, "reshaped");
 
             // Deep copy data from array to reshaped.
             llvm::Value* num_elements = this->get_array_size(array, nullptr, 4);
 
             llvm::Value* first_ptr = this->get_pointer_to_data(reshaped);
-            llvm::PointerType* first_ptr2ptr_type = static_cast<llvm::PointerType*>(first_ptr->getType());
-            llvm::PointerType* first_ptr_type = static_cast<llvm::PointerType*>(first_ptr2ptr_type->getPointerElementType());
-            llvm::Value* arr_first = builder->CreateAlloca(first_ptr_type->getPointerElementType(), num_elements);
+            llvm::Value* arr_first = builder->CreateAlloca(llvm_data_type, num_elements);
             builder->CreateStore(arr_first, first_ptr);
 
             llvm::Value* ptr2firstptr = this->get_pointer_to_data(array);
             llvm::DataLayout data_layout(module);
-            llvm::Type* ptr2firstptr_type = ptr2firstptr->getType();
-            llvm::Type* ptr_type = static_cast<llvm::PointerType*>(ptr2firstptr_type)->getPointerElementType();
-            uint64_t size = data_layout.getTypeAllocSize(
-                                static_cast<llvm::PointerType*>(ptr_type)->
-                                getPointerElementType());
+            uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);
             builder->CreateMemCpy(LLVM::CreateLoad(*builder, first_ptr), llvm::MaybeAlign(),
                                   LLVM::CreateLoad(*builder, ptr2firstptr), llvm::MaybeAlign(),
                                   num_elements);
 
-            if( this->is_array(shape) ) {
+            if( this->is_array(asr_shape_type) ) {
                 llvm::Value* n_dims = this->get_array_size(shape, nullptr, 4);
                 llvm::Value* shape_data = LLVM::CreateLoad(*builder, this->get_pointer_to_data(shape));
                 llvm::Value* dim_des_val = llvm_utils->create_gep(reshaped, 2);

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -74,12 +74,12 @@ namespace LFortran {
                     DESCR_TYPE descr_type);
 
                 /*
-                * Checks whether the given llvm::Value* is an
+                * Checks whether the given ASR::ttype_t* is an
                 * array and follows the same structure as
                 * the current descriptor.
                 */
                 virtual
-                bool is_array(llvm::Value* tmp) = 0;
+                bool is_array(ASR::ttype_t* asr_type) = 0;
 
                 /*
                 * Converts a given array llvm::Value*
@@ -87,7 +87,8 @@ namespace LFortran {
                 */
                 virtual
                 llvm::Value* convert_to_argument(llvm::Value* tmp,
-                    llvm::Type* arg_type, bool data_only=false) = 0;
+                    ASR::ttype_t* asr_arg_type, llvm::Type* arg_type,
+                    bool data_only=false) = 0;
 
                 /*
                 * Returns the type of the argument to be
@@ -139,7 +140,7 @@ namespace LFortran {
                 */
                 virtual
                 void fill_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims) = 0;
 
                 /*
@@ -148,7 +149,7 @@ namespace LFortran {
                 */
                 virtual
                 void fill_malloc_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims,
                     llvm::Module* module) = 0;
 
@@ -252,8 +253,9 @@ namespace LFortran {
                 void set_is_allocated_flag(llvm::Value* array, uint64_t status) = 0;
 
                 virtual
-                llvm::Value* reshape(llvm::Value* array, llvm::Value* shape,
-                                    llvm::Module* module) = 0;
+                llvm::Value* reshape(llvm::Value* array, llvm::Type* llvm_data_type,
+                                     llvm::Value* shape, ASR::ttype_t* asr_shape_type,
+                                     llvm::Module* module) = 0;
 
                 virtual
                 void copy_array(llvm::Value* src, llvm::Value* dest) = 0;
@@ -291,11 +293,12 @@ namespace LFortran {
                     LLVMUtils* _llvm_utils);
 
                 virtual
-                bool is_array(llvm::Value* tmp);
+                bool is_array(ASR::ttype_t* asr_type);
 
                 virtual
                 llvm::Value* convert_to_argument(llvm::Value* tmp,
-                    llvm::Type* arg_type, bool data_only=false);
+                    ASR::ttype_t* asr_arg_type, llvm::Type* arg_type,
+                    bool data_only=false);
 
                 virtual
                 llvm::Type* get_argument_type(llvm::Type* type,
@@ -322,12 +325,12 @@ namespace LFortran {
 
                 virtual
                 void fill_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims);
 
                 virtual
                 void fill_malloc_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims,
                     llvm::Module* module);
 
@@ -382,8 +385,9 @@ namespace LFortran {
                 void set_is_allocated_flag(llvm::Value* array, uint64_t status);
 
                 virtual
-                llvm::Value* reshape(llvm::Value* array, llvm::Value* shape,
-                                    llvm::Module* module);
+                llvm::Value* reshape(llvm::Value* array, llvm::Type* llvm_data_type,
+                                     llvm::Value* shape, ASR::ttype_t* asr_shape_type,
+                                     llvm::Module* module);
 
                 virtual
                 void copy_array(llvm::Value* src, llvm::Value* dest);

--- a/tests/reference/llvm-array2-4254183.json
+++ b/tests/reference/llvm-array2-4254183.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array2-4254183.stdout",
-    "stdout_hash": "354d946cc4bcf0c2d05886702038fe74d6d9facc9152fc05194a7723",
+    "stdout_hash": "313073d515ce8b60f90d34e15dc9fe3006d83bb04131a27d597a8505",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array2-4254183.stdout
+++ b/tests/reference/llvm-array2-4254183.stdout
@@ -7,8 +7,10 @@ source_filename = "LFortran"
 %array.1 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 %array.2 = type { float*, i32, %dimension_descriptor*, i1, i32 }
 %array.3 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
-%array.4 = type { float*, i32, %dimension_descriptor*, i1, i32 }
-%array.5 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
+%array.4 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
+%array.5 = type { float*, i32, %dimension_descriptor*, i1, i32 }
+%array.6 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
+%array.7 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 
 define i32 @main() {
 .entry:
@@ -176,15 +178,15 @@ define i32 @main() {
   %96 = load i32, i32* %94, align 4
   %97 = alloca i32, i32 %96, align 4
   store i32* %97, i32** %95, align 8
-  %g = alloca %array.1, align 8
-  %98 = getelementptr %array.1, %array.1* %g, i32 0, i32 1
+  %g = alloca %array.4, align 8
+  %98 = getelementptr %array.4, %array.4* %g, i32 0, i32 1
   store i32 0, i32* %98, align 4
-  %99 = getelementptr %array.1, %array.1* %g, i32 0, i32 2
+  %99 = getelementptr %array.4, %array.4* %g, i32 0, i32 2
   %100 = alloca i32, align 4
   store i32 2, i32* %100, align 4
   %101 = load i32, i32* %100, align 4
   %102 = alloca %dimension_descriptor, i32 %101, align 8
-  %103 = getelementptr %array.1, %array.1* %g, i32 0, i32 4
+  %103 = getelementptr %array.4, %array.4* %g, i32 0, i32 4
   store i32 2, i32* %103, align 4
   store %dimension_descriptor* %102, %dimension_descriptor** %99, align 8
   %104 = load %dimension_descriptor*, %dimension_descriptor** %99, align 8
@@ -204,19 +206,19 @@ define i32 @main() {
   store i32 2, i32* %112, align 4
   %113 = alloca i32, align 4
   store i32 10, i32* %113, align 4
-  %114 = getelementptr %array.1, %array.1* %g, i32 0, i32 0
+  %114 = getelementptr %array.4, %array.4* %g, i32 0, i32 0
   %115 = load i32, i32* %113, align 4
   %116 = alloca i1, i32 %115, align 1
   store i1* %116, i1** %114, align 8
-  %h = alloca %array.4, align 8
-  %117 = getelementptr %array.4, %array.4* %h, i32 0, i32 1
+  %h = alloca %array.5, align 8
+  %117 = getelementptr %array.5, %array.5* %h, i32 0, i32 1
   store i32 0, i32* %117, align 4
-  %118 = getelementptr %array.4, %array.4* %h, i32 0, i32 2
+  %118 = getelementptr %array.5, %array.5* %h, i32 0, i32 2
   %119 = alloca i32, align 4
   store i32 3, i32* %119, align 4
   %120 = load i32, i32* %119, align 4
   %121 = alloca %dimension_descriptor, i32 %120, align 8
-  %122 = getelementptr %array.4, %array.4* %h, i32 0, i32 4
+  %122 = getelementptr %array.5, %array.5* %h, i32 0, i32 4
   store i32 3, i32* %122, align 4
   store %dimension_descriptor* %121, %dimension_descriptor** %118, align 8
   %123 = load %dimension_descriptor*, %dimension_descriptor** %118, align 8
@@ -243,19 +245,19 @@ define i32 @main() {
   store i32 4, i32* %135, align 4
   %136 = alloca i32, align 4
   store i32 24, i32* %136, align 4
-  %137 = getelementptr %array.4, %array.4* %h, i32 0, i32 0
+  %137 = getelementptr %array.5, %array.5* %h, i32 0, i32 0
   %138 = load i32, i32* %136, align 4
   %139 = alloca float, i32 %138, align 4
   store float* %139, float** %137, align 8
-  %i = alloca %array.5, align 8
-  %140 = getelementptr %array.5, %array.5* %i, i32 0, i32 1
+  %i = alloca %array.6, align 8
+  %140 = getelementptr %array.6, %array.6* %i, i32 0, i32 1
   store i32 0, i32* %140, align 4
-  %141 = getelementptr %array.5, %array.5* %i, i32 0, i32 2
+  %141 = getelementptr %array.6, %array.6* %i, i32 0, i32 2
   %142 = alloca i32, align 4
   store i32 3, i32* %142, align 4
   %143 = load i32, i32* %142, align 4
   %144 = alloca %dimension_descriptor, i32 %143, align 8
-  %145 = getelementptr %array.5, %array.5* %i, i32 0, i32 4
+  %145 = getelementptr %array.6, %array.6* %i, i32 0, i32 4
   store i32 3, i32* %145, align 4
   store %dimension_descriptor* %144, %dimension_descriptor** %141, align 8
   %146 = load %dimension_descriptor*, %dimension_descriptor** %141, align 8
@@ -282,19 +284,19 @@ define i32 @main() {
   store i32 3, i32* %158, align 4
   %159 = alloca i32, align 4
   store i32 36, i32* %159, align 4
-  %160 = getelementptr %array.5, %array.5* %i, i32 0, i32 0
+  %160 = getelementptr %array.6, %array.6* %i, i32 0, i32 0
   %161 = load i32, i32* %159, align 4
   %162 = alloca i32, i32 %161, align 4
   store i32* %162, i32** %160, align 8
-  %j = alloca %array.1, align 8
-  %163 = getelementptr %array.1, %array.1* %j, i32 0, i32 1
+  %j = alloca %array.7, align 8
+  %163 = getelementptr %array.7, %array.7* %j, i32 0, i32 1
   store i32 0, i32* %163, align 4
-  %164 = getelementptr %array.1, %array.1* %j, i32 0, i32 2
+  %164 = getelementptr %array.7, %array.7* %j, i32 0, i32 2
   %165 = alloca i32, align 4
   store i32 3, i32* %165, align 4
   %166 = load i32, i32* %165, align 4
   %167 = alloca %dimension_descriptor, i32 %166, align 8
-  %168 = getelementptr %array.1, %array.1* %j, i32 0, i32 4
+  %168 = getelementptr %array.7, %array.7* %j, i32 0, i32 4
   store i32 3, i32* %168, align 4
   store %dimension_descriptor* %167, %dimension_descriptor** %164, align 8
   %169 = load %dimension_descriptor*, %dimension_descriptor** %164, align 8
@@ -321,7 +323,7 @@ define i32 @main() {
   store i32 2, i32* %181, align 4
   %182 = alloca i32, align 4
   store i32 20, i32* %182, align 4
-  %183 = getelementptr %array.1, %array.1* %j, i32 0, i32 0
+  %183 = getelementptr %array.7, %array.7* %j, i32 0, i32 0
   %184 = load i32, i32* %182, align 4
   %185 = alloca i1, i32 %184, align 1
   store i1* %185, i1** %183, align 8

--- a/tests/reference/llvm-array2_derived-ecff8f2.json
+++ b/tests/reference/llvm-array2_derived-ecff8f2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array2_derived-ecff8f2.stdout",
-    "stdout_hash": "d7b03fbfb355bbbd66abb11981a83765f87a0bcf99722f770f011729",
+    "stdout_hash": "71aa0e55a63dadf1f2d34a96749b5523d7dabe4aa712f382fb84b0f0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array2_derived-ecff8f2.stdout
+++ b/tests/reference/llvm-array2_derived-ecff8f2.stdout
@@ -7,10 +7,18 @@ source_filename = "LFortran"
 %array.1 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 %array.2 = type { float*, i32, %dimension_descriptor*, i1, i32 }
 %array.3 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
-%array.4 = type { float*, i32, %dimension_descriptor*, i1, i32 }
-%array.5 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
-%array.6 = type { %der_type*, i32, %dimension_descriptor*, i1, i32 }
+%array.4 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
+%array.5 = type { float*, i32, %dimension_descriptor*, i1, i32 }
+%array.6 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
+%array.7 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
+%array.8 = type { %der_type*, i32, %dimension_descriptor*, i1, i32 }
 %der_type = type { i32, float }
+%array.9 = type { %der_type*, i32, %dimension_descriptor*, i1, i32 }
+%array.10 = type { %der_type*, i32, %dimension_descriptor*, i1, i32 }
+%array.11 = type { %complex_4*, i32, %dimension_descriptor*, i1, i32 }
+%complex_4 = type { float, float }
+%array.12 = type { %complex_4*, i32, %dimension_descriptor*, i1, i32 }
+%array.13 = type { %complex_4*, i32, %dimension_descriptor*, i1, i32 }
 
 define i32 @main() {
 .entry:
@@ -178,15 +186,15 @@ define i32 @main() {
   %96 = load i32, i32* %94, align 4
   %97 = alloca i32, i32 %96, align 4
   store i32* %97, i32** %95, align 8
-  %g = alloca %array.1, align 8
-  %98 = getelementptr %array.1, %array.1* %g, i32 0, i32 1
+  %g = alloca %array.4, align 8
+  %98 = getelementptr %array.4, %array.4* %g, i32 0, i32 1
   store i32 0, i32* %98, align 4
-  %99 = getelementptr %array.1, %array.1* %g, i32 0, i32 2
+  %99 = getelementptr %array.4, %array.4* %g, i32 0, i32 2
   %100 = alloca i32, align 4
   store i32 2, i32* %100, align 4
   %101 = load i32, i32* %100, align 4
   %102 = alloca %dimension_descriptor, i32 %101, align 8
-  %103 = getelementptr %array.1, %array.1* %g, i32 0, i32 4
+  %103 = getelementptr %array.4, %array.4* %g, i32 0, i32 4
   store i32 2, i32* %103, align 4
   store %dimension_descriptor* %102, %dimension_descriptor** %99, align 8
   %104 = load %dimension_descriptor*, %dimension_descriptor** %99, align 8
@@ -206,19 +214,19 @@ define i32 @main() {
   store i32 2, i32* %112, align 4
   %113 = alloca i32, align 4
   store i32 10, i32* %113, align 4
-  %114 = getelementptr %array.1, %array.1* %g, i32 0, i32 0
+  %114 = getelementptr %array.4, %array.4* %g, i32 0, i32 0
   %115 = load i32, i32* %113, align 4
   %116 = alloca i1, i32 %115, align 1
   store i1* %116, i1** %114, align 8
-  %h = alloca %array.4, align 8
-  %117 = getelementptr %array.4, %array.4* %h, i32 0, i32 1
+  %h = alloca %array.5, align 8
+  %117 = getelementptr %array.5, %array.5* %h, i32 0, i32 1
   store i32 0, i32* %117, align 4
-  %118 = getelementptr %array.4, %array.4* %h, i32 0, i32 2
+  %118 = getelementptr %array.5, %array.5* %h, i32 0, i32 2
   %119 = alloca i32, align 4
   store i32 3, i32* %119, align 4
   %120 = load i32, i32* %119, align 4
   %121 = alloca %dimension_descriptor, i32 %120, align 8
-  %122 = getelementptr %array.4, %array.4* %h, i32 0, i32 4
+  %122 = getelementptr %array.5, %array.5* %h, i32 0, i32 4
   store i32 3, i32* %122, align 4
   store %dimension_descriptor* %121, %dimension_descriptor** %118, align 8
   %123 = load %dimension_descriptor*, %dimension_descriptor** %118, align 8
@@ -245,19 +253,19 @@ define i32 @main() {
   store i32 2, i32* %135, align 4
   %136 = alloca i32, align 4
   store i32 8, i32* %136, align 4
-  %137 = getelementptr %array.4, %array.4* %h, i32 0, i32 0
+  %137 = getelementptr %array.5, %array.5* %h, i32 0, i32 0
   %138 = load i32, i32* %136, align 4
   %139 = alloca float, i32 %138, align 4
   store float* %139, float** %137, align 8
-  %i = alloca %array.5, align 8
-  %140 = getelementptr %array.5, %array.5* %i, i32 0, i32 1
+  %i = alloca %array.6, align 8
+  %140 = getelementptr %array.6, %array.6* %i, i32 0, i32 1
   store i32 0, i32* %140, align 4
-  %141 = getelementptr %array.5, %array.5* %i, i32 0, i32 2
+  %141 = getelementptr %array.6, %array.6* %i, i32 0, i32 2
   %142 = alloca i32, align 4
   store i32 3, i32* %142, align 4
   %143 = load i32, i32* %142, align 4
   %144 = alloca %dimension_descriptor, i32 %143, align 8
-  %145 = getelementptr %array.5, %array.5* %i, i32 0, i32 4
+  %145 = getelementptr %array.6, %array.6* %i, i32 0, i32 4
   store i32 3, i32* %145, align 4
   store %dimension_descriptor* %144, %dimension_descriptor** %141, align 8
   %146 = load %dimension_descriptor*, %dimension_descriptor** %141, align 8
@@ -284,19 +292,19 @@ define i32 @main() {
   store i32 2, i32* %158, align 4
   %159 = alloca i32, align 4
   store i32 8, i32* %159, align 4
-  %160 = getelementptr %array.5, %array.5* %i, i32 0, i32 0
+  %160 = getelementptr %array.6, %array.6* %i, i32 0, i32 0
   %161 = load i32, i32* %159, align 4
   %162 = alloca i32, i32 %161, align 4
   store i32* %162, i32** %160, align 8
-  %j = alloca %array.1, align 8
-  %163 = getelementptr %array.1, %array.1* %j, i32 0, i32 1
+  %j = alloca %array.7, align 8
+  %163 = getelementptr %array.7, %array.7* %j, i32 0, i32 1
   store i32 0, i32* %163, align 4
-  %164 = getelementptr %array.1, %array.1* %j, i32 0, i32 2
+  %164 = getelementptr %array.7, %array.7* %j, i32 0, i32 2
   %165 = alloca i32, align 4
   store i32 3, i32* %165, align 4
   %166 = load i32, i32* %165, align 4
   %167 = alloca %dimension_descriptor, i32 %166, align 8
-  %168 = getelementptr %array.1, %array.1* %j, i32 0, i32 4
+  %168 = getelementptr %array.7, %array.7* %j, i32 0, i32 4
   store i32 3, i32* %168, align 4
   store %dimension_descriptor* %167, %dimension_descriptor** %164, align 8
   %169 = load %dimension_descriptor*, %dimension_descriptor** %164, align 8
@@ -323,19 +331,19 @@ define i32 @main() {
   store i32 3, i32* %181, align 4
   %182 = alloca i32, align 4
   store i32 12, i32* %182, align 4
-  %183 = getelementptr %array.1, %array.1* %j, i32 0, i32 0
+  %183 = getelementptr %array.7, %array.7* %j, i32 0, i32 0
   %184 = load i32, i32* %182, align 4
   %185 = alloca i1, i32 %184, align 1
   store i1* %185, i1** %183, align 8
-  %p = alloca %array.6, align 8
-  %186 = getelementptr %array.6, %array.6* %p, i32 0, i32 1
+  %p = alloca %array.8, align 8
+  %186 = getelementptr %array.8, %array.8* %p, i32 0, i32 1
   store i32 0, i32* %186, align 4
-  %187 = getelementptr %array.6, %array.6* %p, i32 0, i32 2
+  %187 = getelementptr %array.8, %array.8* %p, i32 0, i32 2
   %188 = alloca i32, align 4
   store i32 1, i32* %188, align 4
   %189 = load i32, i32* %188, align 4
   %190 = alloca %dimension_descriptor, i32 %189, align 8
-  %191 = getelementptr %array.6, %array.6* %p, i32 0, i32 4
+  %191 = getelementptr %array.8, %array.8* %p, i32 0, i32 4
   store i32 1, i32* %191, align 4
   store %dimension_descriptor* %190, %dimension_descriptor** %187, align 8
   %192 = load %dimension_descriptor*, %dimension_descriptor** %187, align 8
@@ -348,19 +356,19 @@ define i32 @main() {
   store i32 7, i32* %196, align 4
   %197 = alloca i32, align 4
   store i32 7, i32* %197, align 4
-  %198 = getelementptr %array.6, %array.6* %p, i32 0, i32 0
+  %198 = getelementptr %array.8, %array.8* %p, i32 0, i32 0
   %199 = load i32, i32* %197, align 4
   %200 = alloca %der_type, i32 %199, align 8
   store %der_type* %200, %der_type** %198, align 8
-  %q = alloca %array.6, align 8
-  %201 = getelementptr %array.6, %array.6* %q, i32 0, i32 1
+  %q = alloca %array.9, align 8
+  %201 = getelementptr %array.9, %array.9* %q, i32 0, i32 1
   store i32 0, i32* %201, align 4
-  %202 = getelementptr %array.6, %array.6* %q, i32 0, i32 2
+  %202 = getelementptr %array.9, %array.9* %q, i32 0, i32 2
   %203 = alloca i32, align 4
   store i32 2, i32* %203, align 4
   %204 = load i32, i32* %203, align 4
   %205 = alloca %dimension_descriptor, i32 %204, align 8
-  %206 = getelementptr %array.6, %array.6* %q, i32 0, i32 4
+  %206 = getelementptr %array.9, %array.9* %q, i32 0, i32 4
   store i32 2, i32* %206, align 4
   store %dimension_descriptor* %205, %dimension_descriptor** %202, align 8
   %207 = load %dimension_descriptor*, %dimension_descriptor** %202, align 8
@@ -380,19 +388,19 @@ define i32 @main() {
   store i32 9, i32* %215, align 4
   %216 = alloca i32, align 4
   store i32 63, i32* %216, align 4
-  %217 = getelementptr %array.6, %array.6* %q, i32 0, i32 0
+  %217 = getelementptr %array.9, %array.9* %q, i32 0, i32 0
   %218 = load i32, i32* %216, align 4
   %219 = alloca %der_type, i32 %218, align 8
   store %der_type* %219, %der_type** %217, align 8
-  %r = alloca %array.6, align 8
-  %220 = getelementptr %array.6, %array.6* %r, i32 0, i32 1
+  %r = alloca %array.10, align 8
+  %220 = getelementptr %array.10, %array.10* %r, i32 0, i32 1
   store i32 0, i32* %220, align 4
-  %221 = getelementptr %array.6, %array.6* %r, i32 0, i32 2
+  %221 = getelementptr %array.10, %array.10* %r, i32 0, i32 2
   %222 = alloca i32, align 4
   store i32 3, i32* %222, align 4
   %223 = load i32, i32* %222, align 4
   %224 = alloca %dimension_descriptor, i32 %223, align 8
-  %225 = getelementptr %array.6, %array.6* %r, i32 0, i32 4
+  %225 = getelementptr %array.10, %array.10* %r, i32 0, i32 4
   store i32 3, i32* %225, align 4
   store %dimension_descriptor* %224, %dimension_descriptor** %221, align 8
   %226 = load %dimension_descriptor*, %dimension_descriptor** %221, align 8
@@ -419,19 +427,19 @@ define i32 @main() {
   store i32 3, i32* %238, align 4
   %239 = alloca i32, align 4
   store i32 84, i32* %239, align 4
-  %240 = getelementptr %array.6, %array.6* %r, i32 0, i32 0
+  %240 = getelementptr %array.10, %array.10* %r, i32 0, i32 0
   %241 = load i32, i32* %239, align 4
   %242 = alloca %der_type, i32 %241, align 8
   store %der_type* %242, %der_type** %240, align 8
-  %x = alloca %array, align 8
-  %243 = getelementptr %array, %array* %x, i32 0, i32 1
+  %x = alloca %array.11, align 8
+  %243 = getelementptr %array.11, %array.11* %x, i32 0, i32 1
   store i32 0, i32* %243, align 4
-  %244 = getelementptr %array, %array* %x, i32 0, i32 2
+  %244 = getelementptr %array.11, %array.11* %x, i32 0, i32 2
   %245 = alloca i32, align 4
   store i32 1, i32* %245, align 4
   %246 = load i32, i32* %245, align 4
   %247 = alloca %dimension_descriptor, i32 %246, align 8
-  %248 = getelementptr %array, %array* %x, i32 0, i32 4
+  %248 = getelementptr %array.11, %array.11* %x, i32 0, i32 4
   store i32 1, i32* %248, align 4
   store %dimension_descriptor* %247, %dimension_descriptor** %244, align 8
   %249 = load %dimension_descriptor*, %dimension_descriptor** %244, align 8
@@ -444,19 +452,19 @@ define i32 @main() {
   store i32 6, i32* %253, align 4
   %254 = alloca i32, align 4
   store i32 6, i32* %254, align 4
-  %255 = getelementptr %array, %array* %x, i32 0, i32 0
+  %255 = getelementptr %array.11, %array.11* %x, i32 0, i32 0
   %256 = load i32, i32* %254, align 4
-  %257 = alloca float, i32 %256, align 4
-  store float* %257, float** %255, align 8
-  %y = alloca %array.2, align 8
-  %258 = getelementptr %array.2, %array.2* %y, i32 0, i32 1
+  %257 = alloca %complex_4, i32 %256, align 8
+  store %complex_4* %257, %complex_4** %255, align 8
+  %y = alloca %array.12, align 8
+  %258 = getelementptr %array.12, %array.12* %y, i32 0, i32 1
   store i32 0, i32* %258, align 4
-  %259 = getelementptr %array.2, %array.2* %y, i32 0, i32 2
+  %259 = getelementptr %array.12, %array.12* %y, i32 0, i32 2
   %260 = alloca i32, align 4
   store i32 2, i32* %260, align 4
   %261 = load i32, i32* %260, align 4
   %262 = alloca %dimension_descriptor, i32 %261, align 8
-  %263 = getelementptr %array.2, %array.2* %y, i32 0, i32 4
+  %263 = getelementptr %array.12, %array.12* %y, i32 0, i32 4
   store i32 2, i32* %263, align 4
   store %dimension_descriptor* %262, %dimension_descriptor** %259, align 8
   %264 = load %dimension_descriptor*, %dimension_descriptor** %259, align 8
@@ -476,19 +484,19 @@ define i32 @main() {
   store i32 8, i32* %272, align 4
   %273 = alloca i32, align 4
   store i32 48, i32* %273, align 4
-  %274 = getelementptr %array.2, %array.2* %y, i32 0, i32 0
+  %274 = getelementptr %array.12, %array.12* %y, i32 0, i32 0
   %275 = load i32, i32* %273, align 4
-  %276 = alloca float, i32 %275, align 4
-  store float* %276, float** %274, align 8
-  %z = alloca %array.4, align 8
-  %277 = getelementptr %array.4, %array.4* %z, i32 0, i32 1
+  %276 = alloca %complex_4, i32 %275, align 8
+  store %complex_4* %276, %complex_4** %274, align 8
+  %z = alloca %array.13, align 8
+  %277 = getelementptr %array.13, %array.13* %z, i32 0, i32 1
   store i32 0, i32* %277, align 4
-  %278 = getelementptr %array.4, %array.4* %z, i32 0, i32 2
+  %278 = getelementptr %array.13, %array.13* %z, i32 0, i32 2
   %279 = alloca i32, align 4
   store i32 3, i32* %279, align 4
   %280 = load i32, i32* %279, align 4
   %281 = alloca %dimension_descriptor, i32 %280, align 8
-  %282 = getelementptr %array.4, %array.4* %z, i32 0, i32 4
+  %282 = getelementptr %array.13, %array.13* %z, i32 0, i32 4
   store i32 3, i32* %282, align 4
   store %dimension_descriptor* %281, %dimension_descriptor** %278, align 8
   %283 = load %dimension_descriptor*, %dimension_descriptor** %278, align 8
@@ -515,9 +523,9 @@ define i32 @main() {
   store i32 3, i32* %295, align 4
   %296 = alloca i32, align 4
   store i32 18, i32* %296, align 4
-  %297 = getelementptr %array.4, %array.4* %z, i32 0, i32 0
+  %297 = getelementptr %array.13, %array.13* %z, i32 0, i32 0
   %298 = load i32, i32* %296, align 4
-  %299 = alloca float, i32 %298, align 4
-  store float* %299, float** %297, align 8
+  %299 = alloca %complex_4, i32 %298, align 8
+  store %complex_4* %299, %complex_4** %297, align 8
   ret i32 0
 }

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "d2dd6e159275fbd67eb676467150c4a38a30cc7bed7aa135c5443d15",
+    "stdout_hash": "6d9dd6f8dcc69e8903434405532474364b6780bb86141d3fa00801a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -3,6 +3,7 @@ source_filename = "LFortran"
 
 %array = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
+%array.0 = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 
 @0 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
 @1 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
@@ -73,15 +74,15 @@ define i32 @main() {
   %28 = load i32, i32* %26, align 4
   %29 = alloca i1, i32 %28, align 1
   store i1* %29, i1** %27, align 8
-  %c = alloca %array, align 8
-  %30 = getelementptr %array, %array* %c, i32 0, i32 1
+  %c = alloca %array.0, align 8
+  %30 = getelementptr %array.0, %array.0* %c, i32 0, i32 1
   store i32 0, i32* %30, align 4
-  %31 = getelementptr %array, %array* %c, i32 0, i32 2
+  %31 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %32 = alloca i32, align 4
   store i32 2, i32* %32, align 4
   %33 = load i32, i32* %32, align 4
   %34 = alloca %dimension_descriptor, i32 %33, align 8
-  %35 = getelementptr %array, %array* %c, i32 0, i32 4
+  %35 = getelementptr %array.0, %array.0* %c, i32 0, i32 4
   store i32 2, i32* %35, align 4
   store %dimension_descriptor* %34, %dimension_descriptor** %31, align 8
   %36 = load %dimension_descriptor*, %dimension_descriptor** %31, align 8
@@ -101,7 +102,7 @@ define i32 @main() {
   store i32 2, i32* %44, align 4
   %45 = alloca i32, align 4
   store i32 4, i32* %45, align 4
-  %46 = getelementptr %array, %array* %c, i32 0, i32 0
+  %46 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %47 = load i32, i32* %45, align 4
   %48 = alloca i1, i32 %47, align 1
   store i1* %48, i1** %46, align 8
@@ -755,7 +756,7 @@ loop.body43:                                      ; preds = %loop.head42
 then44:                                           ; preds = %loop.body43
   %504 = load i32, i32* %i, align 4
   %505 = load i32, i32* %j, align 4
-  %506 = getelementptr %array, %array* %c, i32 0, i32 2
+  %506 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %507 = load %dimension_descriptor*, %dimension_descriptor** %506, align 8
   %508 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %507, i32 0
   %509 = getelementptr %dimension_descriptor, %dimension_descriptor* %508, i32 0, i32 1
@@ -775,7 +776,7 @@ then44:                                           ; preds = %loop.body43
   %523 = getelementptr %dimension_descriptor, %dimension_descriptor* %517, i32 0, i32 2
   %524 = load i32, i32* %523, align 4
   %525 = mul i32 %516, %524
-  %526 = getelementptr %array, %array* %c, i32 0, i32 0
+  %526 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %527 = load i1*, i1** %526, align 8
   %528 = getelementptr inbounds i1, i1* %527, i32 %522
   store i1 true, i1* %528, align 1
@@ -784,7 +785,7 @@ then44:                                           ; preds = %loop.body43
 else45:                                           ; preds = %loop.body43
   %529 = load i32, i32* %i, align 4
   %530 = load i32, i32* %j, align 4
-  %531 = getelementptr %array, %array* %c, i32 0, i32 2
+  %531 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %532 = load %dimension_descriptor*, %dimension_descriptor** %531, align 8
   %533 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %532, i32 0
   %534 = getelementptr %dimension_descriptor, %dimension_descriptor* %533, i32 0, i32 1
@@ -804,7 +805,7 @@ else45:                                           ; preds = %loop.body43
   %548 = getelementptr %dimension_descriptor, %dimension_descriptor* %542, i32 0, i32 2
   %549 = load i32, i32* %548, align 4
   %550 = mul i32 %541, %549
-  %551 = getelementptr %array, %array* %c, i32 0, i32 0
+  %551 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %552 = load i1*, i1** %551, align 8
   %553 = getelementptr inbounds i1, i1* %552, i32 %547
   store i1 false, i1* %553, align 1
@@ -817,7 +818,7 @@ loop.end47:                                       ; preds = %loop.head42
   br label %loop.head40
 
 loop.end48:                                       ; preds = %loop.head40
-  %554 = getelementptr %array, %array* %c, i32 0, i32 2
+  %554 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %555 = load %dimension_descriptor*, %dimension_descriptor** %554, align 8
   %556 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %555, i32 0
   %557 = getelementptr %dimension_descriptor, %dimension_descriptor* %556, i32 0, i32 1
@@ -837,7 +838,7 @@ loop.end48:                                       ; preds = %loop.head40
   %571 = getelementptr %dimension_descriptor, %dimension_descriptor* %565, i32 0, i32 2
   %572 = load i32, i32* %571, align 4
   %573 = mul i32 %564, %572
-  %574 = getelementptr %array, %array* %c, i32 0, i32 0
+  %574 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %575 = load i1*, i1** %574, align 8
   %576 = getelementptr inbounds i1, i1* %575, i32 %570
   %577 = load i1, i1* %576, align 1
@@ -852,7 +853,7 @@ else50:                                           ; preds = %loop.end48
   br label %ifcont51
 
 ifcont51:                                         ; preds = %else50, %then49
-  %578 = getelementptr %array, %array* %c, i32 0, i32 2
+  %578 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %579 = load %dimension_descriptor*, %dimension_descriptor** %578, align 8
   %580 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %579, i32 0
   %581 = getelementptr %dimension_descriptor, %dimension_descriptor* %580, i32 0, i32 1
@@ -872,7 +873,7 @@ ifcont51:                                         ; preds = %else50, %then49
   %595 = getelementptr %dimension_descriptor, %dimension_descriptor* %589, i32 0, i32 2
   %596 = load i32, i32* %595, align 4
   %597 = mul i32 %588, %596
-  %598 = getelementptr %array, %array* %c, i32 0, i32 0
+  %598 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %599 = load i1*, i1** %598, align 8
   %600 = getelementptr inbounds i1, i1* %599, i32 %594
   %601 = load i1, i1* %600, align 1
@@ -888,7 +889,7 @@ else53:                                           ; preds = %ifcont51
   br label %ifcont54
 
 ifcont54:                                         ; preds = %else53, %then52
-  %603 = getelementptr %array, %array* %c, i32 0, i32 2
+  %603 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %604 = load %dimension_descriptor*, %dimension_descriptor** %603, align 8
   %605 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %604, i32 0
   %606 = getelementptr %dimension_descriptor, %dimension_descriptor* %605, i32 0, i32 1
@@ -908,7 +909,7 @@ ifcont54:                                         ; preds = %else53, %then52
   %620 = getelementptr %dimension_descriptor, %dimension_descriptor* %614, i32 0, i32 2
   %621 = load i32, i32* %620, align 4
   %622 = mul i32 %613, %621
-  %623 = getelementptr %array, %array* %c, i32 0, i32 0
+  %623 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %624 = load i1*, i1** %623, align 8
   %625 = getelementptr inbounds i1, i1* %624, i32 %619
   %626 = load i1, i1* %625, align 1
@@ -924,7 +925,7 @@ else56:                                           ; preds = %ifcont54
   br label %ifcont57
 
 ifcont57:                                         ; preds = %else56, %then55
-  %628 = getelementptr %array, %array* %c, i32 0, i32 2
+  %628 = getelementptr %array.0, %array.0* %c, i32 0, i32 2
   %629 = load %dimension_descriptor*, %dimension_descriptor** %628, align 8
   %630 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %629, i32 0
   %631 = getelementptr %dimension_descriptor, %dimension_descriptor* %630, i32 0, i32 1
@@ -944,7 +945,7 @@ ifcont57:                                         ; preds = %else56, %then55
   %645 = getelementptr %dimension_descriptor, %dimension_descriptor* %639, i32 0, i32 2
   %646 = load i32, i32* %645, align 4
   %647 = mul i32 %638, %646
-  %648 = getelementptr %array, %array* %c, i32 0, i32 0
+  %648 = getelementptr %array.0, %array.0* %c, i32 0, i32 0
   %649 = load i1*, i1** %648, align 8
   %650 = getelementptr inbounds i1, i1* %649, i32 %644
   %651 = load i1, i1* %650, align 1

--- a/tests/reference/llvm-arrays_13-8ff7d44.json
+++ b/tests/reference/llvm-arrays_13-8ff7d44.json
@@ -2,7 +2,7 @@
     "basename": "llvm-arrays_13-8ff7d44",
     "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
     "infile": "tests/../integration_tests/arrays_13.f90",
-    "infile_hash": "3d6432b6894b4854190fa2867979e11795c57d07fc5ed3c7392cbc50",
+    "infile_hash": "6d872b651fcb2a1c4d1c226e240cb7fbb773ff63d27c72f1c286e766",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_13-8ff7d44.stdout",


### PR DESCRIPTION
https://github.com/lfortran/lfortran/issues/900