### PR TITLE
Enable the sin(0.5) test on Linux/macOS

### DIFF
--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -984,18 +984,17 @@ end function
 */
 }
 
+// This test does not work on Windows yet
+// https://github.com/lfortran/lfortran/issues/913
+#ifndef _WIN32
 TEST_CASE("FortranEvaluator 10 trig functions") {
     CompilerOptions cu;
     FortranEvaluator e(cu);
-    /*
     LFortran::Result<FortranEvaluator::EvalResult>
     r = e.evaluate2("sin(1.0)");
-    */
-    /*
     CHECK(r.ok);
     CHECK(r.result.type == FortranEvaluator::EvalResult::real4);
     CHECK(std::abs(r.result.f32 - 0.8414709848078965) < 1e-7);
-    */
     /*
     r = e.evaluate2("sin(1.d0)");
     CHECK(r.ok);
@@ -1011,3 +1010,4 @@ TEST_CASE("FortranEvaluator 10 trig functions") {
     CHECK(std::abs(r.result.f64 - 0.5403023058681398) < 1e-14);
     */
 }
+#endif


### PR DESCRIPTION
Skip on Windows for now due to #913.