### PR TITLE
Remove parser.output from the source tarball

### DIFF
--- a/ci/create_source_tarball0.sh
+++ b/ci/create_source_tarball0.sh
@@ -4,6 +4,9 @@ set -ex
 
 cmake -E make_directory $dest
 
+# Remove files we do not want
+cmake -E rm src/lfortran/parser/parser.output
+
 # Copy Directories:
 cmake -E copy_directory src $dest/src
 cmake -E copy_directory share $dest/share


### PR DESCRIPTION
The file is 8.3MB large, so this is a good saving.