### PR TITLE
Disable clock_gettime() on macOS

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1064,7 +1064,7 @@ LFORTRAN_API void _lfortran_cpu_time(double *t) {
 
 LFORTRAN_API void _lfortran_i32sys_clock(
         int32_t *count, int32_t *rate, int32_t *max) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MACH__)
         *count = - INT_MAX;
         *rate = 0;
         *max = 0;
@@ -1084,7 +1084,7 @@ LFORTRAN_API void _lfortran_i32sys_clock(
 
 LFORTRAN_API void _lfortran_i64sys_clock(
         uint64_t *count, int64_t *rate, int64_t *max) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MACH__)
         *count = - INT_MAX;
         *rate = 0;
         *max = 0;


### PR DESCRIPTION
macOS before 11.12 do not have it declared. Windows also does not have it, so for now we disable it.