### PR TITLE
update whereami to ba364cd54fd431c76c045393b6522b4bff547f50 (2022-02-18)

### DIFF
--- a/src/bin/tpl/whereami/whereami.cpp
+++ b/src/bin/tpl/whereami/whereami.cpp
@@ -12,6 +12,15 @@
 extern "C" {
 #endif
 
+#if defined(__linux__) || defined(__CYGWIN__)
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#elif defined(__APPLE__)
+#undef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE
+#define _DARWIN_BETTER_REALPATH
+#endif
+
 #if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
 #include <stdlib.h>
 #endif
@@ -50,6 +59,7 @@ extern "C" {
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif // NOMINMAX
+
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -61,6 +71,7 @@ extern "C" {
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#include <stdbool.h>
 
 static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
 {
@@ -68,8 +79,9 @@ static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, i
   wchar_t buffer2[MAX_PATH];
   wchar_t* path = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     DWORD size;
     int length_, length__;
@@ -125,14 +137,12 @@ static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, i
     }
 
     length = length__;
-
-    break;
   }
 
   if (path != buffer1)
     WAI_FREE(path);
 
-  return length;
+  return ok ? length : -1;
 }
 
 WAI_NOINLINE WAI_FUNCSPEC
@@ -177,6 +187,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #define __STDC_FORMAT_MACROS
 #endif
 #include <inttypes.h>
+#include <stdbool.h>
 
 #if !defined(WAI_PROC_SELF_EXE)
 #if defined(__sun)
@@ -192,8 +203,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char buffer[PATH_MAX];
   char* resolved = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     resolved = realpath(WAI_PROC_SELF_EXE, buffer);
     if (!resolved)
@@ -218,11 +230,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
-  return length;
+  return ok ? length : -1;
 }
 
 #if !defined(WAI_PROC_SELF_MAPS_RETRY)
@@ -242,6 +252,7 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
 #include <sys/mman.h>
 #include <unistd.h>
 #endif
+#include <stdbool.h>
 
 WAI_NOINLINE WAI_FUNCSPEC
 int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
@@ -357,20 +368,17 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
       break;
   }
 
-  if (maps)
-    fclose(maps);
-
   return length;
 }
 
 #elif defined(__APPLE__)
 
-#define _DARWIN_BETTER_REALPATH
 #include <mach-o/dyld.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <stdbool.h>
 
 WAI_FUNCSPEC
 int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
@@ -380,8 +388,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char* path = buffer1;
   char* resolved = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     uint32_t size = (uint32_t)sizeof(buffer1);
     if (_NSGetExecutablePath(path, &size) == -1)
@@ -414,14 +423,12 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
   if (path != buffer1)
     WAI_FREE(path);
 
-  return length;
+  return ok ? length : -1;
 }
 
 WAI_NOINLINE WAI_FUNCSPEC
@@ -475,6 +482,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <stdbool.h>
 
 #if !defined(WAI_PROC_SELF_EXE)
 #define WAI_PROC_SELF_EXE "/proc/self/exefile"
@@ -488,8 +496,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char* resolved = NULL;
   FILE* self_exe = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     self_exe = fopen(WAI_PROC_SELF_EXE, "r");
     if (!self_exe)
@@ -521,13 +530,11 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
   fclose(self_exe);
 
-  return length;
+  return ok ? length : -1;
 }
 
 WAI_FUNCSPEC
@@ -575,7 +582,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 }
 
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || \
-      defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
 
 #include <limits.h>
 #include <stdlib.h>
@@ -583,6 +590,116 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <dlfcn.h>
+#include <stdbool.h>
+
+#if defined(__OpenBSD__)
+
+#include <unistd.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[4096];
+  char buffer2[PATH_MAX];
+  char buffer3[PATH_MAX];
+  char** argv = (char**)buffer1;
+  char* resolved = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
+    size_t size;
+
+    if (sysctl(mib, 4, NULL, &size, NULL, 0) != 0)
+        break;
+
+    if (size > sizeof(buffer1))
+    {
+      argv = (char**)WAI_MALLOC(size);
+      if (!argv)
+        break;
+    }
+
+    if (sysctl(mib, 4, argv, &size, NULL, 0) != 0)
+        break;
+
+    if (strchr(argv[0], '/'))
+    {
+      resolved = realpath(argv[0], buffer2);
+      if (!resolved)
+        break;
+    }
+    else
+    {
+      const char* PATH = getenv("PATH");
+      if (!PATH)
+        break;
+
+      size_t argv0_length = strlen(argv[0]);
+
+      const char* begin = PATH;
+      while (1)
+      {
+        const char* separator = strchr(begin, ':');
+        const char* end = separator ? separator : begin + strlen(begin);
+
+        if (end - begin > 0)
+        {
+          if (*(end -1) == '/')
+            --end;
+
+          if (((end - begin) + 1 + argv0_length + 1) <= sizeof(buffer2))
+          {
+            memcpy(buffer2, begin, end - begin);
+            buffer2[end - begin] = '/';
+            memcpy(buffer2 + (end - begin) + 1, argv[0], argv0_length + 1);
+
+            resolved = realpath(buffer2, buffer3);
+            if (resolved)
+              break;
+          }
+        }
+
+        if (!separator)
+          break;
+
+        begin = ++separator;
+      }
+
+      if (!resolved)
+        break;
+    }
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (argv != (char**)buffer1)
+    WAI_FREE(argv);
+
+  return ok ? length : -1;
+}
+
+#else
 
 WAI_FUNCSPEC
 int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
@@ -592,8 +709,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char* path = buffer1;
   char* resolved = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
 #if defined(__NetBSD__)
     int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
@@ -602,7 +720,7 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
 #endif
     size_t size = sizeof(buffer1);
 
-    if (sysctl(mib, (u_int)(sizeof(mib) / sizeof(mib[0])), path, &size, NULL, 0) != 0)
+    if (sysctl(mib, 4, path, &size, NULL, 0) != 0)
         break;
 
     resolved = realpath(path, buffer2);
@@ -628,15 +746,12 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
-  if (path != buffer1)
-    WAI_FREE(path);
-
-  return length;
+  return ok ? length : -1;
 }
+
+#endif
 
 WAI_NOINLINE WAI_FUNCSPEC
 int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)


### PR DESCRIPTION
it mostly adds support to OpenBSD

I tried to keep the local modifications (`NOMINMAX` definition in `_WIN32`,  `sys/limits.h` include removal and explicit `PATH_MAX` definition).