### PR TITLE
Docs: fix conjg example

### DIFF
--- a/doc/src/intrinsics/numeric/conjg.md
+++ b/doc/src/intrinsics/numeric/conjg.md
@@ -55,7 +55,7 @@ end function
 ```fortran
 program intrinsics_conjg
     implicit none
-	print *, conjg(1.0, -3.0)
+	print *, conjg((1.0, -3.0))
 end program
 ```
 


### PR DESCRIPTION
- closes #934 

Solution described in https://github.com/lfortran/lfortran/issues/934#issue-1416042128