### PR TITLE
proper OpenBSD support

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1579,6 +1579,7 @@ int main(int argc, char *argv[])
                 case (LFortran::Platform::macOS_ARM) : std::cout << "macOS ARM"; break;
                 case (LFortran::Platform::Windows) : std::cout << "Windows"; break;
                 case (LFortran::Platform::FreeBSD) : std::cout << "FreeBSD"; break;
+                case (LFortran::Platform::OpenBSD) : std::cout << "OpenBSD"; break;
             }
             std::cout << std::endl;
 #ifdef HAVE_LFORTRAN_LLVM

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1005,9 +1005,9 @@ end function
 */
 }
 
-// This test does not work on Windows yet
+// This test does not work on Windows and OpenBSD yet
 // https://github.com/lfortran/lfortran/issues/913
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__OpenBSD__)
 TEST_CASE("FortranEvaluator 10 trig functions") {
     CompilerOptions cu;
     cu.runtime_library_dir = LFortran::get_runtime_library_dir();

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -13,7 +13,8 @@ enum Platform {
     macOS_Intel,
     macOS_ARM,
     Windows,
-    FreeBSD
+    FreeBSD,
+    OpenBSD,
 };
 
 Platform get_platform();

--- a/src/libasr/utils2.cpp
+++ b/src/libasr/utils2.cpp
@@ -39,22 +39,20 @@ bool present(Vec<char*> &v, const char* name) {
 
 Platform get_platform()
 {
-#ifdef _WIN32
+#if defined(_WIN32)
     return Platform::Windows;
-#else
-#    ifdef __APPLE__
-#        ifdef __aarch64__
+#elif defined(__APPLE__)
+#    ifdef __aarch64__
     return Platform::macOS_ARM;
-#        else
-    return Platform::macOS_Intel;
-#        endif
 #    else
-#        ifdef __FreeBSD__
-    return Platform::FreeBSD;
-#        else
-    return Platform::Linux;
-#        endif
+    return Platform::macOS_Intel;
 #    endif
+#elif defined(__FreeBSD__)
+    return Platform::FreeBSD;
+#elif defined(__OpenBSD__)
+    return Platform::OpenBSD;
+#else
+    return Platform::Linux;
 #endif
 }
 


### PR DESCRIPTION
- add OpenBSD platform to have proper `lfortran --version` output
```
LFortran version: 0.18.0-b58397ba-dirty
Platform: OpenBSD
Default target: amd64-unknown-openbsd7.2
```

- disable "FortranEvaluator 10 trig functions" test on OpenBSD as it fails with JIT error
```
JIT session error: Symbols not found: [ _lfortran_cacos, _lfortran_cacosh, _lfortran_caimag, _lfortran_casin, _lfortran_casinh, _lfortran_catan, _lfortran_catanh, _lfortran_ccos, _lfortran_ccosh, _lfortran_cexp, _lfortran_clog, _lfortran_cpu_time, _lfortran_csin, _lfortran_csinh, _lfortran_csqrt, _lfortran_ctan, _lfortran_ctanh, _lfortran_dacos, _lfortran_dacosh, _lfortran_dasin, _lfortran_dasinh, _lfortran_datan, _lfortran_datan2, _lfortran_datanh, _lfortran_dcos, _lfortran_dcosh, _lfortran_derf, _lfortran_derfc, _lfortran_dexp, _lfortran_dgamma, _lfortran_dlog, _lfortran_dlog10, _lfortran_dlog_gamma, _lfortran_dp_rand_num, _lfortran_dsin, _lfortran_dsinh, _lfortran_dtan, _lfortran_dtanh, _lfortran_i32sys_clock, _lfortran_i64sys_clock, _lfortran_printf, _lfortran_sacos, _lfortran_sacosh, _lfortran_sasin, _lfortran_sasinh, _lfortran_satan, _lfortran_satan2, _lfortran_satanh, _lfortran_scos, _lfortran_scosh, _lfortran_serf, _lfortran_serfc, _lfortran_sexp, _lfortran_sgamma, _lfortran_slog, _lfortran_slog10, _lfortran_slog_gamma, _lfortran_sp_rand_num, _lfortran_ssin, _lfortran_ssinh, _lfortran_stan, _lfortran_stanh, _lfortran_zacos, _lfortran_zacosh, _lfortran_zaimag, _lfortran_zasin, _lfortran_zasinh, _lfortran_zatan, _lfortran_zatanh, _lfortran_zcos, _lfortran_zcosh, _lfortran_zexp, _lfortran_zlog, _lfortran_zsin, _lfortran_zsinh, _lfortran_zsqrt, _lfortran_ztan, _lfortran_ztanh ]
```

The test suite still doesn't pass out-of-box:
- cmake problem with guessed flags (on `cmake 3.24.2`): I need to strip `-Wl,...` passed flags to make the tests runs
- the default stack size of OpenBSD is low (4096kb) and some tests doesn't run with it (but adjusting the stack size before running the tests permits to run them)