### PR TITLE
Fix argument conversion for data only arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -237,6 +237,7 @@ RUN(NAME arrays_04_func LABELS gfortran cpp llvm wasm)
 RUN(NAME arrays_04_func_pass_arr_dims LABELS gfortran cpp llvm wasm)
 RUN(NAME arrays_05 LABELS gfortran llvm cpp wasm)
 RUN(NAME arrays_17 LABELS gfortran llvm)
+RUN(NAME arrays_18_func LABELS gfortran llvm)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran)

--- a/integration_tests/arrays_18_func.f90
+++ b/integration_tests/arrays_18_func.f90
@@ -1,0 +1,24 @@
+program arrays_18_func
+
+real :: y(20)
+real :: a(20)
+integer :: i
+call f(a, 20, y, 1)
+do i = 1, 20
+    if (2 * y(i) /= a(i)) error stop
+end do
+
+    contains
+
+recursive subroutine f(a, n, x, i)
+    integer :: n, i
+    real :: a(:)
+    real :: x(n)
+    x(i) = i
+    a(i) = 2 * i
+    if (i < n) then
+        call f(a, n, x, i + 1)
+    end if
+end subroutine
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5526,8 +5526,16 @@ public:
                         uint32_t h = get_hash((ASR::asr_t*)arg);
                         if (llvm_symtab.find(h) != llvm_symtab.end()) {
                             tmp = llvm_symtab[h];
+                            bool is_data_only_array = false;
+                            ASR::dimension_t* dims_arg = nullptr;
+                            size_t n_arg = ASRUtils::extract_dimensions_from_ttype(arg->m_type, dims_arg);
+                            if( ASRUtils::is_arg_dummy(arg->m_intent) &&
+                                !ASRUtils::is_dimension_empty(dims_arg, n_arg) ) {
+                                is_data_only_array = true;
+                            }
                             if( x_abi == ASR::abiType::Source &&
-                                arr_descr->is_array(arg->m_type) ) {
+                                arr_descr->is_array(arg->m_type) &&
+                                !is_data_only_array ) {
                                 llvm::Type* new_arr_type = arr_arg_type_cache[m_h][orig_arg_name];
                                 ASR::dimension_t* dims;
                                 size_t n;


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/944
Closes https://github.com/lfortran/lfortran/pull/945

Before LLVM 15 we used to directly query LLVM type to check whether an array variable is a data only array (i.e., just a pointer to data) or a descriptor array (i.e., a struct of data pointer, and dimensional information). Since LLVM 15 we are not supposed to do that. In https://github.com/lfortran/lfortran/commit/cf481fd69d4b6cd781eb0734997599421ceacc1b, data only arrays also passed the `arr_descr->is_array(...)` check but they shouldn't. In this PR we make sure that we only call `arr_descr->convert_to_argument(...)` only for descriptor arrays. See the updated if check for the same.

`minpack` (commit - 8217d0822a1ec01d71d0aa006a6ffe3134fcbd13) compilation status using this PR is,

```bash
[  2%] Building Fortran object src/CMakeFiles/minpack.dir/minpack.f90.o
[  4%] Building Fortran object src/CMakeFiles/minpack.dir/covar.f.o
[  6%] Building Fortran object src/CMakeFiles/minpack.dir/errjac.f.o
[  8%] Building Fortran object src/CMakeFiles/minpack.dir/hybipt.f.o
[ 10%] Building Fortran object src/CMakeFiles/minpack.dir/lhesfcn.f.o
[ 12%] Building Fortran object src/CMakeFiles/minpack.dir/lmdipt.f.o
[ 14%] Building Fortran object src/CMakeFiles/minpack.dir/ocpipt.f.o
[ 16%] Building Fortran object src/CMakeFiles/minpack.dir/r1updt.f.o
[ 18%] Building Fortran object src/CMakeFiles/minpack.dir/vecjac.f.o
[ 20%] Building Fortran object src/CMakeFiles/minpack.dir/chkder.f.o
[ 22%] Building Fortran object src/CMakeFiles/minpack.dir/dmchar.f.o
[ 24%] Building Fortran object src/CMakeFiles/minpack.dir/fdjac1.f.o
[ 26%] Building Fortran object src/CMakeFiles/minpack.dir/hybrd1.f.o
[ 28%] Building Fortran object src/CMakeFiles/minpack.dir/lmder1.f.o
[ 30%] Building Fortran object src/CMakeFiles/minpack.dir/lmpar.f.o
[ 32%] Building Fortran object src/CMakeFiles/minpack.dir/qform.f.o
[ 34%] Building Fortran object src/CMakeFiles/minpack.dir/rwupdt.f.o
[ 36%] Building Fortran object src/CMakeFiles/minpack.dir/dogleg.f.o
[ 38%] Building Fortran object src/CMakeFiles/minpack.dir/fdjac2.f.o
[ 40%] Building Fortran object src/CMakeFiles/minpack.dir/hybrd.f.o
[ 42%] Building Fortran object src/CMakeFiles/minpack.dir/lmder.f.o
[ 44%] Building Fortran object src/CMakeFiles/minpack.dir/lmstr1.f.o
[ 46%] Building Fortran object src/CMakeFiles/minpack.dir/qrfac.f.o
[ 48%] Building Fortran object src/CMakeFiles/minpack.dir/ssqfcn.f.o
[ 51%] Building Fortran object src/CMakeFiles/minpack.dir/dpmpar.f.o
[ 53%] Building Fortran object src/CMakeFiles/minpack.dir/grdfcn.f.o
[ 55%] Building Fortran object src/CMakeFiles/minpack.dir/hybrj1.f.o
[ 57%] Building Fortran object src/CMakeFiles/minpack.dir/lmdif1.f.o
[ 59%] Building Fortran object src/CMakeFiles/minpack.dir/lmstr.f.o
[ 61%] Building Fortran object src/CMakeFiles/minpack.dir/qrsolv.f.o
[ 63%] Building Fortran object src/CMakeFiles/minpack.dir/ssqjac.f.o
[ 65%] Building Fortran object src/CMakeFiles/minpack.dir/enorm.f.o
[ 67%] Building Fortran object src/CMakeFiles/minpack.dir/hesfcn.f.o
[ 69%] Building Fortran object src/CMakeFiles/minpack.dir/hybrj.f.o
[ 71%] Building Fortran object src/CMakeFiles/minpack.dir/lmdif.f.o
[ 73%] Building Fortran object src/CMakeFiles/minpack.dir/objfcn.f.o
[ 75%] Building Fortran object src/CMakeFiles/minpack.dir/r1mpyq.f.o
[ 77%] Building Fortran object src/CMakeFiles/minpack.dir/vecfcn.f.o
[ 79%] Linking Fortran static library libminpack.a
[ 79%] Built target minpack
Scanning dependencies of target example_lmdif1
[ 81%] Building Fortran object examples/CMakeFiles/example_lmdif1.dir/example_lmdif1.f90.o
.
.
.
code generation error: asr_to_llvm: module failed verification. Error:
FPExt only operates on FP
  %158 = fpext %array.0* %x to double



Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
make[2]: *** [examples/CMakeFiles/example_lmdif1.dir/build.make:75: examples/CMakeFiles/example_lmdif1.dir/example_lmdif1.f90.o] Error 5
make[1]: *** [CMakeFiles/Makefile2:124: examples/CMakeFiles/example_lmdif1.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```