### PR TITLE
openbsd: use --export-dynamic linker option

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -2,7 +2,9 @@ add_executable(lfortran lfortran.cpp)
 target_include_directories(lfortran PRIVATE "tpl")
 target_link_libraries(lfortran lfortran_lib)
 if (LFORTRAN_STATIC_BIN)
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+
         # Link statically on Linux with gcc or clang
         if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
                 CMAKE_CXX_COMPILER_ID MATCHES Clang)
@@ -11,7 +13,9 @@ if (LFORTRAN_STATIC_BIN)
     endif()
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
+    OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+
     target_link_options(lfortran PRIVATE "LINKER:--export-dynamic")
 endif()
 

--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -43,7 +43,9 @@ target_link_libraries(test_lfortran lfortran_lib p::doctest)
 add_test(test_lfortran ${PROJECT_BINARY_DIR}/test_lfortran)
 
 if (WITH_LLVM)
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+
         target_link_options(test_lfortran PRIVATE "LINKER:--export-dynamic")
     endif()
 endif()

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1005,9 +1005,9 @@ end function
 */
 }
 
-// This test does not work on Windows and OpenBSD yet
+// This test does not work on Windows yet
 // https://github.com/lfortran/lfortran/issues/913
-#if !defined(_WIN32) && !defined(__OpenBSD__)
+#if !defined(_WIN32)
 TEST_CASE("FortranEvaluator 10 trig functions") {
     CompilerOptions cu;
     cu.runtime_library_dir = LFortran::get_runtime_library_dir();


### PR DESCRIPTION
I experimented a bit regarding the `JIT session error` on OpenBSD.

It seems that LLVM code try to lookup for the symbols in the current loaded image. As there is no explicit load (via `dlopen(3)` for example), it supposes the symbols to be made available at compile-time.

I first tried to explicitly load `liblfortran_runtime.so` at runtime (with `LD_PRELOAD=path/to/lfortran/lib/liblfortran_runtime.so lfortran`), and it did the trick: LLVM is able to find the symbols.

I checked the difference in the way the binary is built on Linux and OpenBSD. In particular, Linux is using `--export-dynamic` linker option. The option makes the symbols in the dynamic symbol table.

With it, I am able to pass the `FortranEvaluator 10 trig functions` test on OpenBSD.

As the option is only passed for Linux, I assume that MacOS has a different default regarding symbols export, by I am unsure.