### PR TITLE
Replace `ArrayBound` correctly with dimension for arrays passed as data pointers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -240,6 +240,7 @@ RUN(NAME arrays_04_func_pass_arr_dims LABELS gfortran cpp llvm wasm)
 RUN(NAME arrays_05 LABELS gfortran llvm cpp wasm)
 RUN(NAME arrays_17 LABELS gfortran llvm)
 RUN(NAME arrays_18_func LABELS gfortran llvm)
+RUN(NAME arrays_19 LABELS gfortran llvm)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran)

--- a/integration_tests/arrays_19.f90
+++ b/integration_tests/arrays_19.f90
@@ -1,0 +1,17 @@
+program print_array
+
+integer :: xarr(3)
+xarr(1) = 1
+xarr(2) = 2
+xarr(3) = 3
+
+call f(3, xarr)
+
+contains
+
+subroutine f(n, x)
+    integer :: n, x(n)
+    print *, x
+end subroutine
+
+end program

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
@@ -98,7 +98,7 @@ class ReplaceArrayDimIntrinsicCalls: public ASR::BaseExprReplacer<ReplaceArrayDi
         ASR::ttype_t* array_type = ASRUtils::expr_type(x->m_v);
         ASR::dimension_t* dims = nullptr;
         int n = ASRUtils::extract_dimensions_from_ttype(array_type, dims);
-        bool is_argument = v->m_intent == ASRUtils::intent_in || v->m_intent == ASRUtils::intent_out;
+        bool is_argument = ASRUtils::is_arg_dummy(v->m_intent);
         if( !(n > 0 && is_argument &&
               !ASRUtils::is_dimension_empty(dims, n)) ) {
             return ;


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/955