### PR TITLE
Save mod files to -J

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -671,7 +671,7 @@ int save_mod_files(const LFortran::ASR::TranslationUnit_t &u,
             std::filesystem::path fullpath = compiler_options.mod_files_dir / filename;
             {
                 std::ofstream out;
-		std::string modfile = std::string(m->m_name) + ".mod";
+		out.open(fullpath, std::ofstream::out | std::ofstream::binary);
                 out << modfile_binary;
             }
         }

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -635,7 +635,8 @@ int emit_julia(const std::string &infile, CompilerOptions &compiler_options)
     }
 }
 
-int save_mod_files(const LFortran::ASR::TranslationUnit_t &u)
+int save_mod_files(const LFortran::ASR::TranslationUnit_t &u,
+		   const LFortran::CompilerOptions compiler_options)
 {
     for (auto &item : u.m_global_scope->get_scope()) {
         if (LFortran::ASR::is_a<LFortran::ASR::Module_t>(*item.second)) {
@@ -666,11 +667,11 @@ int save_mod_files(const LFortran::ASR::TranslationUnit_t &u)
 
             LFORTRAN_ASSERT(LFortran::asr_verify(u, true, diagnostics));
 
-
-            std::string modfile = std::string(m->m_name) + ".mod";
+	    std::filesystem::path filename { std::string(m->m_name) + ".mod" };
+            std::filesystem::path fullpath = compiler_options.mod_files_dir / filename;
             {
                 std::ofstream out;
-                out.open(modfile, std::ofstream::out | std::ofstream::binary);
+		std::string modfile = std::string(m->m_name) + ".mod";
                 out << modfile_binary;
             }
         }
@@ -752,7 +753,7 @@ int compile_to_object_file(const std::string &infile,
 
     // Save .mod files
     {
-        int err = save_mod_files(*asr);
+        int err = save_mod_files(*asr, compiler_options);
         if (err) return err;
     }
 
@@ -1039,7 +1040,7 @@ int compile_to_object_file_cpp(const std::string &infile,
 
     // Save .mod files
     {
-        int err = save_mod_files(*asr);
+        int err = save_mod_files(*asr, compiler_options);
         if (err) return err;
     }
 

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -636,7 +636,7 @@ int emit_julia(const std::string &infile, CompilerOptions &compiler_options)
 }
 
 int save_mod_files(const LFortran::ASR::TranslationUnit_t &u,
-		   const LFortran::CompilerOptions compiler_options)
+		   const LFortran::CompilerOptions &compiler_options)
 {
     for (auto &item : u.m_global_scope->get_scope()) {
         if (LFortran::ASR::is_a<LFortran::ASR::Module_t>(*item.second)) {


### PR DESCRIPTION
When reworking the [Implement -I and -J (CompilerOptions edition)](https://github.com/lfortran/lfortran/pull/901) to become [Implement -I and -J (PassOptions edition)](https://github.com/lfortran/lfortran/pull/930) I forgot to copy changes to save_mod_files in lfortran.cpp. The result is that you can load from -J but not save to it.

You can use the example code in those PRs to see that my_module.mod is indeed not saved to `-J mods/`.