### PR TITLE
do not ignore pointer attribute on character

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -426,6 +426,7 @@ RUN(NAME types_12 LABELS gfortran llvm wasm)
 RUN(NAME types_13 LABELS gfortran)
 RUN(NAME types_14 LABELS gfortran llvm wasm)
 RUN(NAME types_16 LABELS gfortran llvm wasm)
+RUN(NAME types_17 LABELS gfortran llvm)
 
 RUN(NAME complex_01 LABELS gfortran llvm)
 RUN(NAME complex_02 LABELS gfortran llvm)

--- a/integration_tests/types_17.f90
+++ b/integration_tests/types_17.f90
@@ -1,0 +1,14 @@
+program types_17
+  implicit none
+
+contains
+  subroutine f1()
+    integer, pointer :: ptr
+    nullify(ptr)
+  end subroutine
+
+  subroutine f2()
+    character(len=2), pointer :: ptr
+    nullify(ptr)
+  end subroutine
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1460,6 +1460,10 @@ public:
                 char_data->type = type;
                 type_info.push_back(char_data);
             }
+            if (is_pointer) {
+                type = LFortran::ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
+                    type));
+            }
         } else if (sym_type->m_type == AST::decl_typeType::TypeType) {
             LFORTRAN_ASSERT(sym_type->m_name);
             std::string derived_type_name = to_lower(sym_type->m_name);


### PR DESCRIPTION
it permits to properly parse variable declaration like `character(len=n,kind=c_char), pointer :: sptr`.

found while trying to build `fpm`. it failed to build [src/fpm_strings.f90](https://github.com/fortran-lang/fpm/blob/6c51ebb5d844b9e7ff070b4b629ed2d5d973d8b2/src/fpm_strings.f90#L171-L179) (it still fail, but on the next error):

```fortran
function f_string_cptr_n(cptr, n) result(s)
    type(c_ptr), intent(in), value :: cptr
    integer(kind=c_size_t), intent(in) :: n
    character(len=n,kind=c_char) :: s
    character(len=n,kind=c_char), pointer :: sptr

    call c_f_pointer(cptr, sptr)
    s = sptr
end function
```

with:
```
semantic error: fptr is not a pointer.
   --> ./src/fpm_strings.f90:177:28
    |
177 |     call c_f_pointer(cptr, sptr)
    |                            ^^^^ 
```