### PR TITLE
Gcc doesn't use --target

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1224,10 +1224,6 @@ int link_executable(const std::vector<std::string> &infiles,
             char *env_CC = std::getenv("LFORTRAN_CC");
             if (env_CC) CC = env_CC;
 
-            if (compiler_options.target != "" && link_with_gcc) {
-                options = " --target " + compiler_options.target;
-            }
-
             if (compiler_options.target != "" && !link_with_gcc) {
                 options = " -target " + compiler_options.target;
             }


### PR DESCRIPTION
This was inserted by mistake when testing on macOS where gcc is a front for clang. Cross compilation with gcc uses a different binary for the target architecture.

I will reopen the cross compilation PR after this is merged.