### PR TITLE
Fix Symbols not found for FreeBSD (idem OpenBSD)

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -3,6 +3,7 @@ target_include_directories(lfortran PRIVATE "tpl")
 target_link_libraries(lfortran lfortran_lib)
 if (LFORTRAN_STATIC_BIN)
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
         OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 
         # Link statically on Linux with gcc or clang
@@ -14,6 +15,7 @@ if (LFORTRAN_STATIC_BIN)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
+    OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
     OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 
     target_link_options(lfortran PRIVATE "LINKER:--export-dynamic")

--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_test(test_lfortran ${PROJECT_BINARY_DIR}/test_lfortran)
 
 if (WITH_LLVM)
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
         OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 
         target_link_options(test_lfortran PRIVATE "LINKER:--export-dynamic")


### PR DESCRIPTION
See https://github.com/lfortran/lfortran/issues/509 .

The patch from @semarie for OpenBSD is also fine for FreeBSD.