### PR TITLE
REPL doesn't initialize runtime_library_dir

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -256,6 +256,7 @@ int prompt(bool verbose)
 
     Allocator al(64*1024*1024);
     CompilerOptions cu;
+    cu.runtime_library_dir = LFortran::get_runtime_library_dir();
     LFortran::FortranEvaluator e(cu);
 
     std::vector<std::string> history;


### PR DESCRIPTION
I remember doing this when implementing -I and -J but it didn't make to the final pull request. The error is that when on the REPL lfortran can't find the builtin functions like sin(), cos(), etc.