### PR TITLE
Build to WASM: Initialize compiler_options.runtime_library_dir

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1331,6 +1331,7 @@ namespace wasm {
 #define INITIALIZE_VARS CompilerOptions compiler_options; \
                         compiler_options.use_colors = true; \
                         compiler_options.indent = true; \
+                        compiler_options.runtime_library_dir = LFortran::get_runtime_library_dir(); \
                         LFortran::FortranEvaluator fe(compiler_options); \
                         LFortran::LocationManager lm; \
                         LFortran::diag::Diagnostics diagnostics; \


### PR DESCRIPTION
It seems in https://github.com/lfortran/lfortran/pull/930, the `runtime_library_dir` was incorporated into the `compiler_options`. With that change, for `EMSCRIPTEN_KEEPALIVE` functions, the `runtime_library_dir` was not being initialized. This `PR` (hopefully) fixes it.