### PR TITLE
[Trivial] Rename MR to PR in governance doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,7 +3,7 @@
 ## Technical Decisions
 
 Technical decisions are made by the developer community by discussing at each
-Merge Request (MR) and arriving at a consensus. In case of disagreements, the
+Pull Request (PR) and arriving at a consensus. In case of disagreements, the
 project leader (Ondřej Čertík) will facilitate the discussion and help achieve a
 consensus. If a consensus cannot be achieved, the final decision will be made by
 the project leader.


### PR DESCRIPTION
I was reading through the governance doc and thought this should be changed since development has been completely shifted to GitHub from GitLab.