### PR TITLE
Fixes in `ImpliedDoLoop`.

### DIFF
--- a/integration_tests/implied_do_loops1.f90
+++ b/integration_tests/implied_do_loops1.f90
@@ -1,4 +1,5 @@
 program implied_do_loop1
+	integer :: j
 	integer :: a(10)=(/(j,j=1,10)/)
 	print*, (a(j),j=1,10)
 end program

--- a/integration_tests/implied_do_loops2.f90
+++ b/integration_tests/implied_do_loops2.f90
@@ -1,8 +1,7 @@
 program implied_do_loop2
-
+	integer :: i, j
 	integer, dimension(3,5) :: array
-	array = reshape([(i,(i+j,j=1,4),i=1,3)], shape(array))
-
+	array = reshape([(i,(i+j,j=1,4),i=1,3)], (/3,5/))
 	print *, array
 
 end program

--- a/integration_tests/implied_do_loops3.f90
+++ b/integration_tests/implied_do_loops3.f90
@@ -1,5 +1,6 @@
 program implied_do_loop3
 
+	integer::i,j,k
 	real:: a(3) = (/(j*3,j=1,3)/)
 	real:: b(3) = (/(j*2,j=1,3)/)
 

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1720,46 +1720,6 @@ public:
                 body.size());
     }
 
-    void visit_ImpliedDoLoop(const AST::ImpliedDoLoop_t& x) {
-        Vec<ASR::expr_t*> a_values_vec;
-        ASR::expr_t *a_start, *a_end, *a_increment;
-        a_start = a_end = a_increment = nullptr;
-        a_values_vec.reserve(al, x.n_values);
-        for( size_t i = 0; i < x.n_values; i++ ) {
-            this->visit_expr(*(x.m_values[i]));
-            a_values_vec.push_back(al, LFortran::ASRUtils::EXPR(tmp));
-        }
-        this->visit_expr(*(x.m_start));
-        a_start = LFortran::ASRUtils::EXPR(tmp);
-        this->visit_expr(*(x.m_end));
-        a_end = LFortran::ASRUtils::EXPR(tmp);
-        if( x.m_increment != nullptr ) {
-            this->visit_expr(*(x.m_increment));
-            a_increment = LFortran::ASRUtils::EXPR(tmp);
-        }
-        ASR::expr_t** a_values = a_values_vec.p;
-        size_t n_values = a_values_vec.size();
-        // std::string a_var_name = std::to_string(iloop_counter) + std::string(x.m_var);
-        // iloop_counter += 1;
-        // Str a_var_name_f;
-        // a_var_name_f.from_str(al, a_var_name);
-        // ASR::asr_t* a_variable = ASR::make_Variable_t(al, x.base.base.loc, current_scope, a_var_name_f.c_str(al),
-        //                                                 ASR::intentType::Local, nullptr,
-        //                                                 ASR::storage_typeType::Default, LFortran::ASRUtils::expr_type(a_start),
-        //                                                 ASR::abiType::Source, ASR::Public);
-        std::string var_name = to_lower(x.m_var);
-        if (current_scope->get_symbol(var_name) == nullptr) {
-            throw SemanticError("The implied do loop variable '" + var_name + "' is not declared", x.base.base.loc);
-        };
-
-        LFORTRAN_ASSERT(current_scope->get_symbol(var_name) != nullptr);
-        ASR::symbol_t* a_sym = current_scope->get_symbol(var_name);
-        // current_scope->scope[a_var_name] = a_sym;
-        ASR::expr_t* a_var = LFortran::ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, a_sym));
-        tmp = ASR::make_ImpliedDoLoop_t(al, x.base.base.loc, a_values, n_values,
-                                            a_var, a_start, a_end, a_increment,
-                                            LFortran::ASRUtils::expr_type(a_start), nullptr);
-    }
 
     void visit_DoLoop(const AST::DoLoop_t &x) {
         ASR::expr_t *var, *start, *end;

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -509,7 +509,6 @@ public:
         return r;
     }
     
-    
     void visit_Function(const AST::Function_t &x) {
         if (compiler_options.implicit_typing) {
             Location a_loc = x.base.base.loc;

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -509,46 +509,6 @@ public:
         return r;
     }
     
-    void visit_ImpliedDoLoop(const AST::ImpliedDoLoop_t& x) {
-        Vec<ASR::expr_t*> a_values_vec;
-        ASR::expr_t *a_start, *a_end, *a_increment;
-        a_start = a_end = a_increment = nullptr;
-        a_values_vec.reserve(al, x.n_values);
-        for( size_t i = 0; i < x.n_values; i++ ) {
-            this->visit_expr(*(x.m_values[i]));
-            a_values_vec.push_back(al, LFortran::ASRUtils::EXPR(tmp));
-        }
-        this->visit_expr(*(x.m_start));
-        a_start = LFortran::ASRUtils::EXPR(tmp);
-        this->visit_expr(*(x.m_end));
-        a_end = LFortran::ASRUtils::EXPR(tmp);
-        if( x.m_increment != nullptr ) {
-            this->visit_expr(*(x.m_increment));
-            a_increment = LFortran::ASRUtils::EXPR(tmp);
-        }
-        ASR::expr_t** a_values = a_values_vec.p;
-        size_t n_values = a_values_vec.size();
-        // std::string a_var_name = std::to_string(iloop_counter) + std::string(x.m_var);
-        // iloop_counter += 1;
-        // Str a_var_name_f;
-        // a_var_name_f.from_str(al, a_var_name);
-        // ASR::asr_t* a_variable = ASR::make_Variable_t(al, x.base.base.loc, current_scope, a_var_name_f.c_str(al),
-        //                                                 ASR::intentType::Local, nullptr,
-        //                                                 ASR::storage_typeType::Default, LFortran::ASRUtils::expr_type(a_start),
-        //                                                 ASR::abiType::Source, ASR::Public);
-        std::string var_name = to_lower(x.m_var);
-        if (current_scope->get_symbol(var_name) == nullptr) {
-            throw SemanticError("The implied do loop variable '" + var_name + "' is not declared", x.base.base.loc);
-        };
-
-        LFORTRAN_ASSERT(current_scope->get_symbol(var_name) != nullptr);
-        ASR::symbol_t* a_sym = current_scope->get_symbol(var_name);
-        // current_scope->scope[a_var_name] = a_sym;
-        ASR::expr_t* a_var = LFortran::ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, a_sym));
-        tmp = ASR::make_ImpliedDoLoop_t(al, x.base.base.loc, a_values, n_values,
-                                            a_var, a_start, a_end, a_increment,
-                                            LFortran::ASRUtils::expr_type(a_start), nullptr);
-    }
     
     void visit_Function(const AST::Function_t &x) {
         if (compiler_options.implicit_typing) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -509,6 +509,47 @@ public:
         return r;
     }
     
+    void visit_ImpliedDoLoop(const AST::ImpliedDoLoop_t& x) {
+        Vec<ASR::expr_t*> a_values_vec;
+        ASR::expr_t *a_start, *a_end, *a_increment;
+        a_start = a_end = a_increment = nullptr;
+        a_values_vec.reserve(al, x.n_values);
+        for( size_t i = 0; i < x.n_values; i++ ) {
+            this->visit_expr(*(x.m_values[i]));
+            a_values_vec.push_back(al, LFortran::ASRUtils::EXPR(tmp));
+        }
+        this->visit_expr(*(x.m_start));
+        a_start = LFortran::ASRUtils::EXPR(tmp);
+        this->visit_expr(*(x.m_end));
+        a_end = LFortran::ASRUtils::EXPR(tmp);
+        if( x.m_increment != nullptr ) {
+            this->visit_expr(*(x.m_increment));
+            a_increment = LFortran::ASRUtils::EXPR(tmp);
+        }
+        ASR::expr_t** a_values = a_values_vec.p;
+        size_t n_values = a_values_vec.size();
+        // std::string a_var_name = std::to_string(iloop_counter) + std::string(x.m_var);
+        // iloop_counter += 1;
+        // Str a_var_name_f;
+        // a_var_name_f.from_str(al, a_var_name);
+        // ASR::asr_t* a_variable = ASR::make_Variable_t(al, x.base.base.loc, current_scope, a_var_name_f.c_str(al),
+        //                                                 ASR::intentType::Local, nullptr,
+        //                                                 ASR::storage_typeType::Default, LFortran::ASRUtils::expr_type(a_start),
+        //                                                 ASR::abiType::Source, ASR::Public);
+        std::string var_name = to_lower(x.m_var);
+        if (current_scope->get_symbol(var_name) == nullptr) {
+            throw SemanticError("The implied do loop variable '" + var_name + "' is not declared", x.base.base.loc);
+        };
+
+        LFORTRAN_ASSERT(current_scope->get_symbol(var_name) != nullptr);
+        ASR::symbol_t* a_sym = current_scope->get_symbol(var_name);
+        // current_scope->scope[a_var_name] = a_sym;
+        ASR::expr_t* a_var = LFortran::ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, a_sym));
+        tmp = ASR::make_ImpliedDoLoop_t(al, x.base.base.loc, a_values, n_values,
+                                            a_var, a_start, a_end, a_increment,
+                                            LFortran::ASRUtils::expr_type(a_start), nullptr);
+    }
+    
     void visit_Function(const AST::Function_t &x) {
         if (compiler_options.implicit_typing) {
             Location a_loc = x.base.base.loc;

--- a/tests/reference/asr-implied_do_loops1-f5adada.json
+++ b/tests/reference/asr-implied_do_loops1-f5adada.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-implied_do_loops1-f5adada",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/implied_do_loops1.f90",
+    "infile_hash": "f1f36f6247d2f472227a0434b3b6bfbf7cba7de1c5cd2be0acec1f17",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-implied_do_loops1-f5adada.stdout",
+    "stdout_hash": "afb8c3ffaabba3467b46f0cba6751faf249e09ee8121d021e38e3dd4",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-implied_do_loops1-f5adada.stdout
+++ b/tests/reference/asr-implied_do_loops1-f5adada.stdout
@@ -1,0 +1,82 @@
+(TranslationUnit 
+    (SymbolTable
+        1
+        {
+            implied_do_loop1:
+                (Program 
+                    (SymbolTable
+                        2
+                        {
+                            a:
+                                (Variable 
+                                    2 
+                                    a 
+                                    Local 
+                                    (ArrayConstant 
+                                        [(ImpliedDoLoop 
+                                            [(Var 2 j)] 
+                                            (Var 2 j) 
+                                            (IntegerConstant 1 (Integer 4 [])) 
+                                            (IntegerConstant 10 (Integer 4 [])) 
+                                            () 
+                                            (Integer 4 []) 
+                                            ()
+                                        )] 
+                                        (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                        (IntegerConstant 1 (Integer 4 [])))]) 
+                                        ColMajor
+                                    ) 
+                                    () 
+                                    Save 
+                                    (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 10 (Integer 4 [])))]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            j:
+                                (Variable 
+                                    2 
+                                    j 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 []) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                )
+                            
+                        }) 
+                    implied_do_loop1 
+                    [] 
+                    [(Print 
+                        () 
+                        [(ImpliedDoLoop 
+                            [(ArrayItem 
+                                (Var 2 a) 
+                                [(() 
+                                (Var 2 j) 
+                                ())] 
+                                (Integer 4 []) 
+                                ColMajor 
+                                ()
+                            )] 
+                            (Var 2 j) 
+                            (IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 10 (Integer 4 [])) 
+                            () 
+                            (Integer 4 []) 
+                            ()
+                        )] 
+                        () 
+                        ()
+                    )]
+                )
+            
+        }) 
+    []
+)

--- a/tests/reference/asr-implied_do_loops2-edb5843.json
+++ b/tests/reference/asr-implied_do_loops2-edb5843.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-implied_do_loops2-edb5843",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/implied_do_loops2.f90",
+    "infile_hash": "52395150c001e73afe37bfe9d3ea099d5e75e2704bd1733457496ad2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-implied_do_loops2-edb5843.stdout",
+    "stdout_hash": "6a8cd272b9554f7ea3c21eeac9230261f1d86fd0474c3dbca6f0faf3",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-implied_do_loops2-edb5843.stdout
+++ b/tests/reference/asr-implied_do_loops2-edb5843.stdout
@@ -1,0 +1,114 @@
+(TranslationUnit 
+    (SymbolTable
+        1
+        {
+            implied_do_loop2:
+                (Program 
+                    (SymbolTable
+                        2
+                        {
+                            array:
+                                (Variable 
+                                    2 
+                                    array 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 3 (Integer 4 [])))
+                                    ((IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 5 (Integer 4 [])))]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            i:
+                                (Variable 
+                                    2 
+                                    i 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 []) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            j:
+                                (Variable 
+                                    2 
+                                    j 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 []) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                )
+                            
+                        }) 
+                    implied_do_loop2 
+                    [] 
+                    [(= 
+                        (Var 2 array) 
+                        (ArrayReshape 
+                            (ArrayConstant 
+                                [(ImpliedDoLoop 
+                                    [(Var 2 i)
+                                    (ImpliedDoLoop 
+                                        [(IntegerBinOp 
+                                            (Var 2 i) 
+                                            Add 
+                                            (Var 2 j) 
+                                            (Integer 4 []) 
+                                            ()
+                                        )] 
+                                        (Var 2 j) 
+                                        (IntegerConstant 1 (Integer 4 [])) 
+                                        (IntegerConstant 4 (Integer 4 [])) 
+                                        () 
+                                        (Integer 4 []) 
+                                        ()
+                                    )] 
+                                    (Var 2 i) 
+                                    (IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 3 (Integer 4 [])) 
+                                    () 
+                                    (Integer 4 []) 
+                                    ()
+                                )] 
+                                (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 1 (Integer 4 [])))]) 
+                                ColMajor
+                            ) 
+                            (ArrayConstant 
+                                [(IntegerConstant 3 (Integer 4 []))
+                                (IntegerConstant 5 (Integer 4 []))] 
+                                (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 2 (Integer 4 [])))]) 
+                                ColMajor
+                            ) 
+                            (Integer 4 [(() 
+                            ())]) 
+                            ()
+                        ) 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(Var 2 array)] 
+                        () 
+                        ()
+                    )]
+                )
+            
+        }) 
+    []
+)

--- a/tests/reference/asr-implied_do_loops3-2a10d65.json
+++ b/tests/reference/asr-implied_do_loops3-2a10d65.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-implied_do_loops3-2a10d65",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/implied_do_loops3.f90",
+    "infile_hash": "77a6a1521629dd10e76d0ea911c82c418bdf86f5c4f6d7b45e9e7d23",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-implied_do_loops3-2a10d65.stdout",
+    "stdout_hash": "61bf56edd97d28e0e7fe474258d18a332057e6ca657f892f697e1bda",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-implied_do_loops3-2a10d65.stdout
+++ b/tests/reference/asr-implied_do_loops3-2a10d65.stdout
@@ -1,0 +1,402 @@
+(TranslationUnit 
+    (SymbolTable
+        1
+        {
+            implied_do_loop3:
+                (Program 
+                    (SymbolTable
+                        2
+                        {
+                            a:
+                                (Variable 
+                                    2 
+                                    a 
+                                    Local 
+                                    (Cast 
+                                        (ArrayConstant 
+                                            [(ImpliedDoLoop 
+                                                [(IntegerBinOp 
+                                                    (Var 2 j) 
+                                                    Mul 
+                                                    (IntegerConstant 3 (Integer 4 [])) 
+                                                    (Integer 4 []) 
+                                                    ()
+                                                )] 
+                                                (Var 2 j) 
+                                                (IntegerConstant 1 (Integer 4 [])) 
+                                                (IntegerConstant 3 (Integer 4 [])) 
+                                                () 
+                                                (Integer 4 []) 
+                                                ()
+                                            )] 
+                                            (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                            (IntegerConstant 1 (Integer 4 [])))]) 
+                                            ColMajor
+                                        ) 
+                                        IntegerToReal 
+                                        (Real 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                        (IntegerConstant 3 (Integer 4 [])))]) 
+                                        ()
+                                    ) 
+                                    () 
+                                    Save 
+                                    (Real 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 3 (Integer 4 [])))]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            b:
+                                (Variable 
+                                    2 
+                                    b 
+                                    Local 
+                                    (Cast 
+                                        (ArrayConstant 
+                                            [(ImpliedDoLoop 
+                                                [(IntegerBinOp 
+                                                    (Var 2 j) 
+                                                    Mul 
+                                                    (IntegerConstant 2 (Integer 4 [])) 
+                                                    (Integer 4 []) 
+                                                    ()
+                                                )] 
+                                                (Var 2 j) 
+                                                (IntegerConstant 1 (Integer 4 [])) 
+                                                (IntegerConstant 3 (Integer 4 [])) 
+                                                () 
+                                                (Integer 4 []) 
+                                                ()
+                                            )] 
+                                            (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                            (IntegerConstant 1 (Integer 4 [])))]) 
+                                            ColMajor
+                                        ) 
+                                        IntegerToReal 
+                                        (Real 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                        (IntegerConstant 3 (Integer 4 [])))]) 
+                                        ()
+                                    ) 
+                                    () 
+                                    Save 
+                                    (Real 4 [((IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 3 (Integer 4 [])))]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            i:
+                                (Variable 
+                                    2 
+                                    i 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 []) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            j:
+                                (Variable 
+                                    2 
+                                    j 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 []) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            k:
+                                (Variable 
+                                    2 
+                                    k 
+                                    Local 
+                                    () 
+                                    () 
+                                    Default 
+                                    (Integer 4 []) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                )
+                            
+                        }) 
+                    implied_do_loop3 
+                    [] 
+                    [(Print 
+                        () 
+                        [(StringConstant 
+                            "Loop 1" 
+                            (Character 1 6 () [])
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(ImpliedDoLoop 
+                            [(Var 2 i)
+                            (ImpliedDoLoop 
+                                [(IntegerBinOp 
+                                    (Var 2 i) 
+                                    Mul 
+                                    (Var 2 j) 
+                                    (Integer 4 []) 
+                                    ()
+                                )] 
+                                (Var 2 j) 
+                                (IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 3 (Integer 4 [])) 
+                                () 
+                                (Integer 4 []) 
+                                ()
+                            )] 
+                            (Var 2 i) 
+                            (IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 3 (Integer 4 [])) 
+                            () 
+                            (Integer 4 []) 
+                            ()
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(StringConstant 
+                            "Loop 2" 
+                            (Character 1 6 () [])
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(ImpliedDoLoop 
+                            [(ImpliedDoLoop 
+                                [(RealBinOp 
+                                    (ArrayItem 
+                                        (Var 2 a) 
+                                        [(() 
+                                        (Var 2 i) 
+                                        ())] 
+                                        (Real 4 []) 
+                                        ColMajor 
+                                        ()
+                                    ) 
+                                    Mul 
+                                    (ArrayItem 
+                                        (Var 2 b) 
+                                        [(() 
+                                        (Var 2 j) 
+                                        ())] 
+                                        (Real 4 []) 
+                                        ColMajor 
+                                        ()
+                                    ) 
+                                    (Real 4 []) 
+                                    ()
+                                )] 
+                                (Var 2 j) 
+                                (IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 2 (Integer 4 [])) 
+                                () 
+                                (Integer 4 []) 
+                                ()
+                            )] 
+                            (Var 2 i) 
+                            (IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 3 (Integer 4 [])) 
+                            () 
+                            (Integer 4 []) 
+                            ()
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(StringConstant 
+                            "Loop 3" 
+                            (Character 1 6 () [])
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(ImpliedDoLoop 
+                            [(ImpliedDoLoop 
+                                [(RealBinOp 
+                                    (ArrayItem 
+                                        (Var 2 a) 
+                                        [(() 
+                                        (Var 2 i) 
+                                        ())] 
+                                        (Real 4 []) 
+                                        ColMajor 
+                                        ()
+                                    ) 
+                                    Mul 
+                                    (ArrayItem 
+                                        (Var 2 b) 
+                                        [(() 
+                                        (Var 2 j) 
+                                        ())] 
+                                        (Real 4 []) 
+                                        ColMajor 
+                                        ()
+                                    ) 
+                                    (Real 4 []) 
+                                    ()
+                                )] 
+                                (Var 2 i) 
+                                (IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 3 (Integer 4 [])) 
+                                () 
+                                (Integer 4 []) 
+                                ()
+                            )] 
+                            (Var 2 j) 
+                            (IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 2 (Integer 4 [])) 
+                            () 
+                            (Integer 4 []) 
+                            ()
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(StringConstant 
+                            "Loop4" 
+                            (Character 1 5 () [])
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(ImpliedDoLoop 
+                            [(Var 2 i)
+                            (ImpliedDoLoop 
+                                [(IntegerBinOp 
+                                    (Var 2 i) 
+                                    Add 
+                                    (Var 2 j) 
+                                    (Integer 4 []) 
+                                    ()
+                                )
+                                (ImpliedDoLoop 
+                                    [(IntegerBinOp 
+                                        (IntegerBinOp 
+                                            (Var 2 i) 
+                                            Add 
+                                            (Var 2 j) 
+                                            (Integer 4 []) 
+                                            ()
+                                        ) 
+                                        Add 
+                                        (Var 2 k) 
+                                        (Integer 4 []) 
+                                        ()
+                                    )] 
+                                    (Var 2 k) 
+                                    (IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 4 (Integer 4 [])) 
+                                    () 
+                                    (Integer 4 []) 
+                                    ()
+                                )] 
+                                (Var 2 j) 
+                                (IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 2 (Integer 4 [])) 
+                                () 
+                                (Integer 4 []) 
+                                ()
+                            )] 
+                            (Var 2 i) 
+                            (IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 3 (Integer 4 [])) 
+                            () 
+                            (Integer 4 []) 
+                            ()
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(StringConstant 
+                            "Loop5" 
+                            (Character 1 5 () [])
+                        )] 
+                        () 
+                        ()
+                    )
+                    (Print 
+                        () 
+                        [(ImpliedDoLoop 
+                            [(Var 2 i)
+                            (ImpliedDoLoop 
+                                [(IntegerBinOp 
+                                    (Var 2 i) 
+                                    Mul 
+                                    (Var 2 j) 
+                                    (Integer 4 []) 
+                                    ()
+                                )
+                                (ImpliedDoLoop 
+                                    [(IntegerBinOp 
+                                        (IntegerBinOp 
+                                            (Var 2 i) 
+                                            Mul 
+                                            (Var 2 j) 
+                                            (Integer 4 []) 
+                                            ()
+                                        ) 
+                                        Add 
+                                        (Var 2 k) 
+                                        (Integer 4 []) 
+                                        ()
+                                    )] 
+                                    (Var 2 k) 
+                                    (IntegerConstant 1 (Integer 4 [])) 
+                                    (IntegerConstant 4 (Integer 4 [])) 
+                                    () 
+                                    (Integer 4 []) 
+                                    ()
+                                )] 
+                                (Var 2 j) 
+                                (IntegerConstant 1 (Integer 4 [])) 
+                                (IntegerConstant 2 (Integer 4 [])) 
+                                () 
+                                (Integer 4 []) 
+                                ()
+                            )] 
+                            (Var 2 i) 
+                            (IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 3 (Integer 4 [])) 
+                            () 
+                            (Integer 4 []) 
+                            ()
+                        )] 
+                        () 
+                        ()
+                    )]
+                )
+            
+        }) 
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2583,3 +2583,15 @@ ast_no_prescan = true
 filename = "no_prescan_include2.f90"
 ast = true
 ast_no_prescan = true
+
+[[test]]
+filename = "../integration_tests/implied_do_loops1.f90"
+asr = true
+
+[[test]]
+filename = "../integration_tests/implied_do_loops2.f90"
+asr = true
+
+[[test]]
+filename = "../integration_tests/implied_do_loops3.f90"
+asr = true


### PR DESCRIPTION
This PR solves  [#981 (comment) ](https://github.com/lfortran/lfortran/issues/981#issuecomment-1304725752), AST->ASR passes for ImpliedDoLoop works.