### PR TITLE
Warning instead of an error for unit in write

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5564,9 +5564,8 @@ public:
                 {x.m_fmt->base.loc}, "treated as '*'");
         }
         if (x.m_unit != nullptr) {
-            diag.codegen_error_label("unit in write() is not implemented yet",
-                {x.m_unit->base.loc}, "not implemented");
-            throw CodeGenAbort();
+            diag.codegen_warning_label("unit in write() is not implemented yet, using stdout for now",
+                {x.m_unit->base.loc}, "using stdout for now");
         }
         handle_print(x);
     }


### PR DESCRIPTION
The error message looks like this:
```
warning: unit in write() is not implemented yet, using stdout for now
  --> /Users/ondrej/repos/lfortran/minpack/examples/example_hybrd1.f90:39:12
   |
39 |     write (nwrite, 1000) fnorm, info !, (x(j), j=1, n)
   |            ^^^^^^ using stdout for now


Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
```