### PR TITLE
[Sprint] Bug fixes for AST->ASR transition to compile FPM

### DIFF
--- a/src/lfortran/pickle.cpp
+++ b/src/lfortran/pickle.cpp
@@ -156,6 +156,22 @@ public:
         if (use_colors) {
             s.append(color(fg::reset));
         }
+        if(indent) {
+            inc_indent();
+            s.append("\n" + indtd);
+        } else {
+            s.append(" ");
+        }
+        s.append("[");
+        for (size_t i=0; i<x.n_member; i++) {
+            this->visit_struct_member(x.m_member[i]);
+            if (i < x.n_member-1) s.append(" ");
+        }
+        s.append("]");
+        if(indent) {
+            dec_indent();
+            s.append("\n" + indtd);
+        }
     }
     void visit_Num(const Num_t &x) {
         if (use_colors) {

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1023,6 +1023,10 @@ public:
                            a_body_vec.size(), def_body.p, def_body.size());
     }
 
+    void visit_SelectType(const AST::SelectType_t& /*x*/) {
+        tmp = nullptr;
+    }
+
     void visit_Submodule(const AST::Submodule_t &x) {
         SymbolTable *old_scope = current_scope;
         ASR::symbol_t *t = current_scope->get_symbol(to_lower(x.m_name));

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1568,6 +1568,8 @@ public:
                     f->m_args, f->n_args, x.base.base.loc, f,
                     diags, x.n_member);
                 if( diags.has_error() ) {
+                    diag.diagnostics.insert(diag.diagnostics.end(),
+                            diags.diagnostics.begin(), diags.diagnostics.end());
                     throw SemanticAbort();
                 }
             } else if (ASR::is_a<ASR::ClassProcedure_t>(*f2)) {
@@ -1582,6 +1584,8 @@ public:
                     f->m_args, f->n_args, x.base.base.loc, f,
                     diags, x.n_member);
                 if( diags.has_error() ) {
+                    diag.diagnostics.insert(diag.diagnostics.end(),
+                            diags.diagnostics.begin(), diags.diagnostics.end());
                     throw SemanticAbort();
                 }
             } else {

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -967,18 +967,18 @@ public:
                     if( condrange->m_start != nullptr ) {
                         this->visit_expr(*(condrange->m_start));
                         m_start = LFortran::ASRUtils::EXPR(tmp);
-                        if( LFortran::ASRUtils::expr_type(m_start)->type != ASR::ttypeType::Integer ) {
-                            throw SemanticError(R"""(Expression in Case selector can only be an Integer)""",
-                                                x.base.loc);
-                        }
+                        // if( LFortran::ASRUtils::expr_type(m_start)->type != ASR::ttypeType::Integer ) {
+                        //     throw SemanticError(R"""(Expression in Case selector can only be an Integer)""",
+                        //                         x.base.loc);
+                        // }
                     }
                     if( condrange->m_end != nullptr ) {
                         this->visit_expr(*(condrange->m_end));
                         m_end = LFortran::ASRUtils::EXPR(tmp);
-                        if( LFortran::ASRUtils::expr_type(m_end)->type != ASR::ttypeType::Integer ) {
-                            throw SemanticError(R"""(Expression in Case selector can only be an Integer)""",
-                                                x.base.loc);
-                        }
+                        // if( LFortran::ASRUtils::expr_type(m_end)->type != ASR::ttypeType::Integer ) {
+                        //     throw SemanticError(R"""(Expression in Case selector can only be an Integer)""",
+                        //                         x.base.loc);
+                        // }
                     }
                     Vec<ASR::stmt_t*> case_body_vec;
                     case_body_vec.reserve(al, Case_Stmt->n_body);

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -904,7 +904,8 @@ public:
                                         tmp_expr->base.loc);
                 } else {
                     ASR::Variable_t* tmp_v = ASR::down_cast<ASR::Variable_t>(tmp_sym);
-                    if( tmp_v->m_storage != ASR::storage_typeType::Allocatable ) {
+                    if( tmp_v->m_storage != ASR::storage_typeType::Allocatable &&
+                        tmp_v->m_storage != ASR::storage_typeType::Save ) {
                         // If it is not allocatable, it can also be a pointer
                         if (ASR::is_a<ASR::Pointer_t>(*tmp_v->m_type)) {
                             // OK

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1899,10 +1899,12 @@ public:
                 new_dims.reserve(al, t->n_dims);
                 for( size_t i = 0; i < func_calls.size(); i += 2 ) {
                     ASR::dimension_t new_dim;
-                    new_dim.loc = func_calls[i]->base.loc;
-                    new_dim.m_start = func_calls[i];
-                    new_dim.m_length = func_calls[i + 1];
-                    new_dims.push_back(al, new_dim);
+                    if (func_calls[i] != nullptr) {
+                        new_dim.loc = func_calls[i]->base.loc;
+                        new_dim.m_start = func_calls[i];
+                        new_dim.m_length = func_calls[i + 1];
+                        new_dims.push_back(al, new_dim);
+                    }
                 }
                 return ASRUtils::TYPE(ASR::make_Real_t(al, loc, t->m_kind, new_dims.p, new_dims.size()));
                 break;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2678,7 +2678,7 @@ public:
                 type = ASRUtils::duplicate_type(al, ASRUtils::expr_type(array));
             } else {
                 new_dims.reserve(al, n_dims - 1);
-                for( size_t i = 0; i < n_dims - 1; i++ ) {
+                for( int i = 0; i < n_dims - 1; i++ ) {
                     ASR::dimension_t new_dim;
                     new_dim.loc = x.base.base.loc;
                     new_dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1, int32_type));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1344,7 +1344,23 @@ public:
 
                 ASR::expr_t* init_expr = nullptr;
                 ASR::expr_t* value = nullptr;
-                if (s.m_initializer != nullptr) {
+                if (s.m_initializer != nullptr
+                        && sym_type->m_type == AST::decl_typeType::TypeType) {
+                    if (AST::is_a<AST::FuncCallOrArray_t>(*s.m_initializer)) {
+                        AST::FuncCallOrArray_t* func_call =
+                            AST::down_cast<AST::FuncCallOrArray_t>(s.m_initializer);
+                        ASR::symbol_t *sym_found = current_scope->resolve_symbol(
+                            func_call->m_func);
+                        if (sym_found == nullptr) {
+                            std::string type_name(func_call->m_func);
+                            throw SemanticError("Derived type `" + type_name +
+                                "()` is not defined", func_call->base.base.loc);
+                        }
+                    } else {
+                        throw SemanticError("Only function call is allowed for now",
+                            x.base.base.loc);
+                    }
+                } else if (s.m_initializer != nullptr) {
                     this->visit_expr(*s.m_initializer);
                     if (is_compile_time && AST::is_a<AST::ArrayInitializer_t>(*s.m_initializer)) {
                         AST::ArrayInitializer_t *temp_array =

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -550,19 +550,13 @@ public:
     ASR::expr_t* right_value = LFortran::ASRUtils::expr_value(right);
     if (left_value != nullptr && right_value != nullptr) {
         ASR::ttype_t* left_value_type = ASRUtils::expr_type(left_value);
-        ASR::ttype_t* right_value_type = ASRUtils::expr_type(right_value);
-        ASR::Character_t *left_value_type2 = ASR::down_cast<ASR::Character_t>(left_value_type);
-        ASR::Character_t *right_value_type2 = ASR::down_cast<ASR::Character_t>(right_value_type);
-        ASR::ttype_t *dest_value_type = ASR::down_cast<ASR::ttype_t>(ASR::make_Character_t(al, x.base.base.loc, left_value_type2->m_kind,
-            left_value_type2->m_len + right_value_type2->m_len, nullptr, nullptr, 0));
-        char* left_value = ASR::down_cast<ASR::StringConstant_t>(
-                                 LFortran::ASRUtils::expr_value(left))
-                                 ->m_s;
-        char* right_value = ASR::down_cast<ASR::StringConstant_t>(
-                                  LFortran::ASRUtils::expr_value(right))
-                                  ->m_s;
+        ASR::Character_t* left_value_type2 = ASR::down_cast<ASR::Character_t>(left_value_type);
+        char* left_value_ = ASR::down_cast<ASR::StringConstant_t>(left_value)->m_s;
+        char* right_value_ = ASR::down_cast<ASR::StringConstant_t>(right_value)->m_s;
+        ASR::ttype_t *dest_value_type = ASR::down_cast<ASR::ttype_t>(ASR::make_Character_t(al, x.base.base.loc,
+            left_value_type2->m_kind, strlen(left_value_) + strlen(right_value_), nullptr, nullptr, 0));
         char* result;
-        std::string result_s = std::string(left_value)+std::string(right_value);
+        std::string result_s = std::string(left_value_) + std::string(right_value_);
         Str s; s.from_str_view(result_s);
         result = s.c_str(al);
         LFORTRAN_ASSERT((int64_t)strlen(result) == ASR::down_cast<ASR::Character_t>(dest_value_type)->m_len)

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1502,16 +1502,23 @@ public:
             }
         } else if (sym_type->m_type == AST::decl_typeType::TypeCharacter) {
             int a_len = -10;
+            int a_kind = 1;
             ASR::expr_t *len_expr = nullptr;
             TypeMissingData* char_data = al.make_new<TypeMissingData>();
             char_data->sym_name = sym;
-            // TODO: take into account m_kind->m_id and all kind items
-            if (sym_type->m_kind != nullptr) {
-                switch (sym_type->m_kind->m_type) {
+            LFORTRAN_ASSERT(sym_type->n_kind < 3) // TODO
+            for (size_t i = 0; i < sym_type->n_kind; i++) {
+                // TODO: Allow len or/and kind only once (else throw SyntaxError)
+                if (sym_type->m_kind[i].m_id != nullptr
+                        && to_lower(sym_type->m_kind[i].m_id) == "kind") {
+                    // TODO: take into account m_kind->m_id and all kind items
+                    continue;
+                }
+                switch (sym_type->m_kind[i].m_type) {
                     case (AST::kind_item_typeType::Value) : {
-                        LFORTRAN_ASSERT(sym_type->m_kind->m_value != nullptr);
-                        if( sym_type->m_kind->m_value->type == AST::exprType::FuncCallOrArray ) {
-                            char_data->expr = sym_type->m_kind->m_value;
+                        LFORTRAN_ASSERT(sym_type->m_kind[i].m_value != nullptr);
+                        if( sym_type->m_kind[i].m_value->type == AST::exprType::FuncCallOrArray ) {
+                            char_data->expr = sym_type->m_kind[i].m_value;
                             char_data->scope = current_scope;
                             char_data->sym_type = current_symbol;
                             AST::FuncCallOrArray_t* call =
@@ -1534,7 +1541,7 @@ public:
                                 a_len = 1;
                             }
                         } else {
-                            this->visit_expr(*sym_type->m_kind->m_value);
+                            this->visit_expr(*sym_type->m_kind[i].m_value);
                             ASR::expr_t* len_expr0 = LFortran::ASRUtils::EXPR(tmp);
                             a_len = ASRUtils::extract_len<SemanticError>(len_expr0, loc);
                             if (a_len == -3) {
@@ -1544,22 +1551,23 @@ public:
                         break;
                     }
                     case (AST::kind_item_typeType::Star) : {
-                        LFORTRAN_ASSERT(sym_type->m_kind->m_value == nullptr);
+                        LFORTRAN_ASSERT(sym_type->m_kind[i].m_value == nullptr);
                         a_len = -1;
                         break;
                     }
                     case (AST::kind_item_typeType::Colon) : {
-                        LFORTRAN_ASSERT(sym_type->m_kind->m_value == nullptr);
+                        LFORTRAN_ASSERT(sym_type->m_kind[i].m_value == nullptr);
                         a_len = -2;
                         break;
                     }
                 }
-            } else {
+            }
+            if (sym_type->m_kind == nullptr) {
                 a_len = 1; // The default len of "character :: x" is 1
             }
             LFORTRAN_ASSERT(a_len != -10)
-            type = LFortran::ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, a_len, len_expr,
-                dims.p, dims.size()));
+            type = LFortran::ASRUtils::TYPE(ASR::make_Character_t(al, loc, a_kind,
+                a_len, len_expr, dims.p, dims.size()));
             if( char_data->scope != nullptr ) {
                 char_data->type = type;
                 type_info.push_back(char_data);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -546,8 +546,15 @@ public:
 
     ASR::expr_t *value = nullptr;
     // Assign evaluation to `value` if possible, otherwise leave nullptr
-    if (LFortran::ASRUtils::expr_value(left) != nullptr &&
-        LFortran::ASRUtils::expr_value(right) != nullptr) {
+    ASR::expr_t* left_value = LFortran::ASRUtils::expr_value(left);
+    ASR::expr_t* right_value = LFortran::ASRUtils::expr_value(right);
+    if (left_value != nullptr && right_value != nullptr) {
+        ASR::ttype_t* left_value_type = ASRUtils::expr_type(left_value);
+        ASR::ttype_t* right_value_type = ASRUtils::expr_type(right_value);
+        ASR::Character_t *left_value_type2 = ASR::down_cast<ASR::Character_t>(left_value_type);
+        ASR::Character_t *right_value_type2 = ASR::down_cast<ASR::Character_t>(right_value_type);
+        ASR::ttype_t *dest_value_type = ASR::down_cast<ASR::ttype_t>(ASR::make_Character_t(al, x.base.base.loc, left_value_type2->m_kind,
+            left_value_type2->m_len + right_value_type2->m_len, nullptr, nullptr, 0));
         char* left_value = ASR::down_cast<ASR::StringConstant_t>(
                                  LFortran::ASRUtils::expr_value(left))
                                  ->m_s;
@@ -558,9 +565,9 @@ public:
         std::string result_s = std::string(left_value)+std::string(right_value);
         Str s; s.from_str_view(result_s);
         result = s.c_str(al);
-        LFORTRAN_ASSERT((int64_t)strlen(result) == ASR::down_cast<ASR::Character_t>(dest_type)->m_len)
+        LFORTRAN_ASSERT((int64_t)strlen(result) == ASR::down_cast<ASR::Character_t>(dest_value_type)->m_len)
         value = ASR::down_cast<ASR::expr_t>(ASR::make_StringConstant_t(
-            al, x.base.base.loc, result, dest_type));
+            al, x.base.base.loc, result, dest_value_type));
       }
     asr = ASR::make_StringConcat_t(al, x.base.base.loc, left, right, dest_type,
                             value);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2585,6 +2585,15 @@ public:
          type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, kind_value, nullptr, 0));
      }
 
+     ASR::asr_t* create_Scan(const AST::FuncCallOrArray_t& x) {
+        ASR::expr_t *string, *set, *back;
+        ASR::ttype_t *type;
+        string = nullptr, set = nullptr, back = nullptr;
+        type = nullptr;
+        create_ScanVerify_util(x, string, set, back, type, "scan");
+        return ASR::make_Scan_t(al, x.base.base.loc, string, set, back, type, nullptr);
+    }
+
      ASR::asr_t* create_Verify(const AST::FuncCallOrArray_t& x) {
          ASR::expr_t *string, *set, *back;
          ASR::ttype_t *type;
@@ -2815,6 +2824,8 @@ public:
                 tmp = create_Iachar(x);
             } else if( var_name == "verify" ) {
                 tmp = create_Verify(x);
+            } else if( var_name == "scan" ) {
+                tmp = create_Scan(x);
             } else {
                 LCompilersException("create_" + var_name + " not implemented yet.");
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2549,6 +2549,27 @@ public:
         return ASR::make_ArrayMatMul_t(al, x.base.base.loc, matrix_a, matrix_b, ret_type, nullptr);
     }
 
+    void create_ScanVerify_util(const AST::FuncCallOrArray_t& x,
+         ASR::expr_t*& string, ASR::expr_t*& set, ASR::expr_t*& back,
+         ASR::ttype_t*& type, std::string func_name) {
+         ASR::expr_t* kind = nullptr;
+         std::vector<ASR::expr_t*> args;
+         std::vector<std::string> kwarg_names = {"back", "kind"};
+         handle_intrinsic_node_args(x, args, kwarg_names, 2, 4, func_name);
+         string = args[0], set = args[1], back = args[2], kind = args[3];
+         int64_t kind_value = handle_kind(kind);
+         type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, kind_value, nullptr, 0));
+     }
+
+     ASR::asr_t* create_Verify(const AST::FuncCallOrArray_t& x) {
+         ASR::expr_t *string, *set, *back;
+         ASR::ttype_t *type;
+         string = nullptr, set = nullptr, back = nullptr;
+         type = nullptr;
+         create_ScanVerify_util(x, string, set, back, type, "verify");
+         return ASR::make_Verify_t(al, x.base.base.loc, string, set, back, type, nullptr);
+     }
+
     ASR::asr_t* create_ArrayPack(const AST::FuncCallOrArray_t& x) {
         std::vector<ASR::expr_t*> args;
         std::vector<std::string> kwarg_names = {"vector"};
@@ -2768,6 +2789,8 @@ public:
                 tmp = create_Ichar(x);
             } else if( var_name == "iachar" ) {
                 tmp = create_Iachar(x);
+            } else if( var_name == "verify" ) {
+                tmp = create_Verify(x);
             } else {
                 LCompilersException("create_" + var_name + " not implemented yet.");
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1643,6 +1643,7 @@ public:
         bool is_item = true;
         Vec<ASR::array_index_t> args;
         args.reserve(al, n_args);
+        ASR::expr_t* v_Var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, v));
         for (size_t i=0; i<n_args; i++) {
             ASR::array_index_t ai;
             ai.loc = loc;
@@ -1657,6 +1658,14 @@ public:
                 this->visit_expr(*(m_args[i].m_end));
                 m_end = LFortran::ASRUtils::EXPR(tmp);
                 ai.loc = m_end->base.loc;
+            } else {
+                if( ASR::is_a<ASR::Character_t>(*ASRUtils::symbol_type(v)) ) {
+                    m_end = ASRUtils::EXPR(ASR::make_StringLen_t(al, loc,
+                                v_Var, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4, nullptr, 0)),
+                                nullptr));
+                } else {
+                    m_end = ASRUtils::get_bound(v_Var, i + 1, "ubound", al);
+                }
             }
             if (m_args[i].m_step != nullptr) {
                 this->visit_expr(*(m_args[i].m_step));
@@ -1741,7 +1750,6 @@ public:
             }
         }
 
-        ASR::expr_t* v_Var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, v));
         if( is_item ) {
             Vec<ASR::dimension_t> empty_dims;
             empty_dims.reserve(al, 1);
@@ -3167,8 +3175,11 @@ public:
             tmp = create_FunctionCallWithASTNode(x, v, args);
         } else {
             switch (f2->type) {
-            case(ASR::symbolType::Variable):
-                tmp = create_ArrayRef(x.base.base.loc, x.m_args, x.n_args, v, f2); break;
+            case(ASR::symbolType::Variable): {
+                // TODO: Make create_StringRef for character (non-array) variables.
+                tmp = create_ArrayRef(x.base.base.loc, x.m_args, x.n_args, v, f2);
+                break;
+            }
             case(ASR::symbolType::StructType):
                 tmp = create_DerivedTypeConstructor(x.base.base.loc, x.m_args, x.n_args, v); break;
             case(ASR::symbolType::ClassProcedure):

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2318,11 +2318,15 @@ public:
 
     // TODO: Use Vec<expr_t*> instead of std::vector<expr_t*> for performance
     template <typename T>
-    void handle_intrinsic_node_args(const T& x,
+    bool handle_intrinsic_node_args(const T& x,
         std::vector<ASR::expr_t*>& args, std::vector<std::string>& kwarg_names,
-        size_t min_args, size_t max_args, const std::string& intrinsic_name) {
+        size_t min_args, size_t max_args, const std::string& intrinsic_name,
+        bool raise_error=true) {
         size_t total_args = x.n_args + x.n_keywords;
         if( !(total_args <= max_args && total_args >= min_args) ) {
+            if( !raise_error ) {
+                return false;
+            }
             throw SemanticError("Incorrect number of arguments "
                                 "passed to the " + intrinsic_name + " intrinsic."
                                 "It accepts at least " + std::to_string(min_args) +
@@ -2343,6 +2347,9 @@ public:
             std::string curr_kwarg_name = to_lower(x.m_keywords[i].m_arg);
             if( std::find(kwarg_names.begin(), kwarg_names.end(),
                           curr_kwarg_name) == kwarg_names.end() ) {
+                if( !raise_error ) {
+                    return false;
+                }
                 throw SemanticError("Unrecognized keyword argument " + curr_kwarg_name +
                                     " passed to " + intrinsic_name + " intrinsic.",
                                     x.base.base.loc);
@@ -2356,6 +2363,9 @@ public:
                                 curr_kwarg_name);
             int64_t kwarg_idx = it - kwarg_names.begin();
             if( args[kwarg_idx + offset] != nullptr ) {
+                if( !raise_error ) {
+                    return false;
+                }
                 throw SemanticError(curr_kwarg_name + " has already " +
                                     "been specified as a positional/keyword " +
                                     "argument to " + intrinsic_name + ".",
@@ -2364,6 +2374,7 @@ public:
             this->visit_expr(*x.m_keywords[i].m_value);
             args[kwarg_idx + offset] = ASRUtils::EXPR(tmp);
         }
+        return true;
     }
 
     int64_t handle_kind(ASR::expr_t* kind) {
@@ -2623,6 +2634,65 @@ public:
                                      vector, type, nullptr);
     }
 
+    ASR::asr_t* create_ArrayMaxloc(const AST::FuncCallOrArray_t& x) {
+        ASR::expr_t *array, *dim, *mask, *kind, *back;
+        array = dim = mask = kind = back = nullptr;
+
+        std::vector<ASR::expr_t*> args_0, args_1;
+        std::vector<std::string> kwarg_names_0 = {"dim", "mask", "kind", "back"};
+        std::vector<std::string> kwarg_names_1 = {"mask", "kind", "back"};
+        // Try syntax MAXLOC(ARRAY, DIM [, MASK] [,KIND] [,BACK])
+        bool syntax_0_matched = handle_intrinsic_node_args(x, args_0, kwarg_names_0, 2, 5, "maxloc", false);
+        // Try syntax MAXLOC(ARRAY [, MASK] [,KIND] [,BACK])
+        bool syntax_1_matched = handle_intrinsic_node_args(x, args_1, kwarg_names_1, 1, 4, "maxloc", false);
+
+        if( !syntax_0_matched && !syntax_1_matched ) {
+            throw SemanticError("maxloc can only be called by either "
+                                "MAXLOC(ARRAY, DIM [, MASK] [,KIND] [,BACK])"
+                                " or MAXLOC(ARRAY [, MASK] [,KIND] [,BACK]) syntax.",
+                                x.base.base.loc);
+        }
+
+        if( syntax_0_matched ) {
+            array = args_0[0], dim = args_0[1], mask = args_0[2], kind = args_0[3], back = args_0[4];
+        } else {
+            array = args_1[0], mask = args_1[1], kind = args_1[2], back = args_1[3];
+        }
+
+        ASR::ttype_t *type = nullptr;
+        Vec<ASR::dimension_t> new_dims;
+        ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4, nullptr, 0));
+        if( !dim ) {
+            new_dims.reserve(al, 1);
+            ASR::dimension_t new_dim;
+            new_dim.loc = x.base.base.loc;
+            new_dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1, int32_type));
+            new_dim.m_length = ASRUtils::EXPR(ASR::make_ArraySize_t(al, x.base.base.loc,
+                                    array, nullptr, int32_type, nullptr));
+            new_dims.push_back(al, new_dim);
+            type = ASRUtils::duplicate_type(al, ASRUtils::expr_type(array), &new_dims);
+        } else {
+            ASR::dimension_t* m_dims;
+            int n_dims = ASRUtils::extract_dimensions_from_ttype(ASRUtils::expr_type(array), m_dims);
+            if( n_dims == 1 ) {
+                type = ASRUtils::duplicate_type(al, ASRUtils::expr_type(array));
+            } else {
+                new_dims.reserve(al, n_dims - 1);
+                for( size_t i = 0; i < n_dims - 1; i++ ) {
+                    ASR::dimension_t new_dim;
+                    new_dim.loc = x.base.base.loc;
+                    new_dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1, int32_type));
+                    new_dim.m_length = ASRUtils::EXPR(ASR::make_ArraySize_t(al, x.base.base.loc,
+                                            array, nullptr, int32_type, nullptr));
+                    new_dims.push_back(al, new_dim);
+                }
+                type = ASRUtils::duplicate_type(al, ASRUtils::expr_type(array), &new_dims);
+            }
+        }
+        return ASR::make_ArrayMaxloc_t(al, x.base.base.loc, array, dim,
+                                       mask, kind, back, type, nullptr);
+    }
+
     ASR::asr_t* create_ArrayReshape(const AST::FuncCallOrArray_t& x) {
         if( x.n_args != 2 ) {
              throw SemanticError("reshape accepts only 2 arguments, got " +
@@ -2826,6 +2896,8 @@ public:
                 tmp = create_Verify(x);
             } else if( var_name == "scan" ) {
                 tmp = create_Scan(x);
+            } else if( var_name == "maxloc" ) {
+                tmp = create_ArrayMaxloc(x);
             } else {
                 LCompilersException("create_" + var_name + " not implemented yet.");
             }

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -25,7 +25,7 @@ struct IntrinsicProceduresAsASRNodes {
         IntrinsicProceduresAsASRNodes() {
             intrinsics_present_in_ASR = {"size", "lbound", "ubound",
                 "transpose", "matmul", "pack", "transfer", "cmplx",
-                "dcmplx", "reshape", "ichar", "iachar"};
+                "dcmplx", "reshape", "ichar", "iachar", "verify"};
         }
 
         bool is_intrinsic_present_in_ASR(std::string& name) {

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -828,9 +828,6 @@ TRIG2(sqrt, dsqrt)
         ASR::ttype_t* real_type = LFortran::ASRUtils::expr_type(real_expr);
         if (LFortran::ASR::is_a<LFortran::ASR::Integer_t>(*real_type)) {
             int64_t c = ASR::down_cast<ASR::IntegerConstant_t>(real_expr)->m_n;
-            ASR::ttype_t* str_type =
-                LFortran::ASRUtils::TYPE(ASR::make_Character_t(al,
-                loc, 1, 1, nullptr, nullptr, 0));
             if (! (c >= 0 && c <= 127) ) {
                 throw SemanticError("The argument 'x' in char(x) must be in the range 0 <= x <= 127.", loc);
             }
@@ -840,6 +837,9 @@ TRIG2(sqrt, dsqrt)
             Str s;
             s.from_str_view(svalue);
             char *str_val = s.c_str(al);
+            // TODO: Should be 0 for char(0) but we store it as 1
+            ASR::ttype_t* str_type = LFortran::ASRUtils::TYPE(ASR::make_Character_t(al,
+                loc, 1, 1, nullptr, nullptr, 0));
             return ASR::down_cast<ASR::expr_t>(
                 ASR::make_StringConstant_t(al, loc,
                 str_val, str_type));

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -75,6 +75,7 @@ struct IntrinsicProcedures {
             {"is_iostat_eor", {m_builtin, &not_implemented, false}},
             {"is_iostat_end", {m_builtin, &not_implemented, false}},
             {"get_command_argument", {m_builtin, &not_implemented, false}},
+            {"command_argument_count", {m_builtin, &not_implemented, false}},
 
             // Require evaluated arguments
             {"aimag", {m_math, &eval_aimag, true}},

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -114,6 +114,7 @@ struct IntrinsicProcedures {
             {"erf", {m_math, &eval_erf, true}},
             {"erfc", {m_math, &eval_erfc, true}},
             {"abs", {m_math, &eval_abs, true}},
+            {"iabs", {m_math, &eval_abs, true}},
             {"sqrt", {m_math, &eval_sqrt, true}},
             {"dsqrt", {m_math, &eval_dsqrt, true}},
             {"datan", {m_math, &eval_datan, true}},

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -74,6 +74,7 @@ struct IntrinsicProcedures {
             {"any", {m_builtin, &not_implemented, false}},
             {"is_iostat_eor", {m_builtin, &not_implemented, false}},
             {"is_iostat_end", {m_builtin, &not_implemented, false}},
+            {"get_command_argument", {m_builtin, &not_implemented, false}},
 
             // Require evaluated arguments
             {"aimag", {m_math, &eval_aimag, true}},

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -26,7 +26,7 @@ struct IntrinsicProceduresAsASRNodes {
             intrinsics_present_in_ASR = {"size", "lbound", "ubound",
                 "transpose", "matmul", "pack", "transfer", "cmplx",
                 "dcmplx", "reshape", "ichar", "iachar", "verify",
-                "scan"};
+                "scan", "maxloc"};
         }
 
         bool is_intrinsic_present_in_ASR(std::string& name) {

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -77,6 +77,8 @@ struct IntrinsicProcedures {
             {"is_iostat_end", {m_builtin, &not_implemented, false}},
             {"get_command_argument", {m_builtin, &not_implemented, false}},
             {"command_argument_count", {m_builtin, &not_implemented, false}},
+            {"execute_command_line", {m_builtin, &not_implemented, false}},
+            {"get_environment_variable", {m_builtin, &not_implemented, false}},
 
             // Require evaluated arguments
             {"aimag", {m_math, &eval_aimag, true}},

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -25,7 +25,8 @@ struct IntrinsicProceduresAsASRNodes {
         IntrinsicProceduresAsASRNodes() {
             intrinsics_present_in_ASR = {"size", "lbound", "ubound",
                 "transpose", "matmul", "pack", "transfer", "cmplx",
-                "dcmplx", "reshape", "ichar", "iachar", "verify"};
+                "dcmplx", "reshape", "ichar", "iachar", "verify",
+                "scan"};
         }
 
         bool is_intrinsic_present_in_ASR(std::string& name) {

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -309,6 +309,7 @@ expr
     | IntegerBitLen(expr a, ttype type, expr? value)
     | Ichar(expr arg, ttype type, expr? value)
     | Iachar(expr arg, ttype type, expr? value)
+    | Verify(expr string, expr set, expr? back, ttype type, expr? value)
 
     | SizeOfType(ttype arg, ttype type, expr? value)
 

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -310,6 +310,7 @@ expr
     | Ichar(expr arg, ttype type, expr? value)
     | Iachar(expr arg, ttype type, expr? value)
     | Verify(expr string, expr set, expr? back, ttype type, expr? value)
+    | Scan(expr string, expr set, expr? back, ttype type, expr? value)
 
     | SizeOfType(ttype arg, ttype type, expr? value)
 

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -184,6 +184,7 @@ stmt
     | Print(expr? fmt, expr* values, expr? separator, expr? end)
     | FileOpen(int label, expr? newunit, expr? filename, expr? status)
     | FileClose(int label, expr? unit, expr? iostat, expr? iomsg, expr? err, expr? status)
+    | Backspace(int label, expr? unit, expr? iostat, expr? err)
     | FileRead(int label, expr? unit, expr? fmt, expr? iomsg, expr? iostat, expr? id, expr* values)
     | FileBackspace(int label, expr? unit, expr? iostat, expr? err)
     | FileRewind(int label, expr? unit, expr? iostat, expr? err)

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -284,6 +284,7 @@ expr
     | ArrayMatMul(expr matrix_a, expr matrix_b, ttype type, expr? value)
     | ArrayPack(expr array, expr mask, expr? vector, ttype type, expr? value)
     | ArrayReshape(expr array, expr shape, ttype type, expr? value)
+    | ArrayMaxloc(expr array, expr? dim, expr? mask, expr? kind, expr? back, ttype type, expr? value)
 
     | BitCast(expr source, expr mold, expr? size, ttype type, expr? value)
     | StructInstanceMember(expr v, symbol m, ttype type, expr? value)

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -363,7 +363,16 @@ ASR::asr_t* getStructInstanceMember_t(Allocator& al, const Location& loc,
         default :
             break;
     }
-    return ASR::make_StructInstanceMember_t(al, loc, LFortran::ASRUtils::EXPR(v_var), member, member_type, nullptr);
+    ASR::expr_t* value = nullptr;
+    if (ASR::is_a<ASR::Variable_t>(*member)) {
+        ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(member);
+        if (v->m_value != nullptr) {
+            value = v->m_value;
+        } else if (v->m_symbolic_value != nullptr) {
+            value = expr_value(v->m_symbolic_value);
+        }
+    }
+    return ASR::make_StructInstanceMember_t(al, loc, LFortran::ASRUtils::EXPR(v_var), member, member_type, value);
 }
 
 bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -103,6 +103,13 @@ static inline ASR::ttype_t* symbol_type(const ASR::symbol_t *f)
         case ASR::symbolType::EnumType: {
             return ASR::down_cast<ASR::EnumType_t>(f)->m_type;
         }
+        case ASR::symbolType::ExternalSymbol: {
+            return symbol_type(ASRUtils::symbol_get_past_external(f));
+        }
+        case ASR::symbolType::Function: {
+            return ASRUtils::expr_type(
+                ASR::down_cast<ASR::Function_t>(f)->m_return_var);
+        }
         default: {
             throw LCompilersException("Cannot return type of, " +
                                     std::to_string(f->type) + " symbol.");

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -174,16 +174,16 @@ struct Diagnostics {
             Level::Error, Stage::CodeGen);
     }
 
-    void tokenizer_style_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
-        message_label(message, locations, error_label,
-            Level::Style, Stage::Tokenizer);
+    void tokenizer_style_label(const std::string &/*message*/,
+            const std::vector<Location> &/*locations*/, const std::string &/*error_label*/) {
+        // message_label(message, locations, error_label,
+        //     Level::Style, Stage::Tokenizer);
     }
 
-    void parser_style_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
-        message_label(message, locations, error_label,
-            Level::Style, Stage::Parser);
+    void parser_style_label(const std::string &/*message*/,
+            const std::vector<Location> &/*locations*/, const std::string &/*error_label*/) {
+        // message_label(message, locations, error_label,
+        //     Level::Style, Stage::Parser);
     }
 };
 

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -102,8 +102,8 @@ interface
     subroutine get_command_argument(number, value, length, status)
     integer, intent(in) :: number
     character(len=*), optional, intent(out) :: value
-    integer, intent(out) :: length
-    integer, intent(out) :: status
+    integer, optional, intent(out) :: length
+    integer, optional, intent(out) :: status
     end subroutine
 
 end interface

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -106,6 +106,9 @@ interface
     integer, optional, intent(out) :: status
     end subroutine
 
+    integer function command_argument_count() result(r)
+    end function
+
 end interface
 
 end module

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -106,6 +106,22 @@ interface
     integer, optional, intent(out) :: status
     end subroutine
 
+    subroutine execute_command_line(command, wait, exitstat, cmdstat, cmdmsg)
+    character(len=*), intent(in) :: command
+    logical, intent(in), optional :: wait
+    integer, intent(in), optional :: exitstat
+    integer, intent(in), optional :: cmdstat
+    character(len=*), intent(in), optional :: cmdmsg
+    end subroutine
+
+    subroutine get_environment_variable(name, value, length, status, trim_name)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in), optional :: value
+    integer, intent(in), optional :: length
+    integer, intent(in), optional :: status
+    logical, intent(in), optional :: trim_name
+    end subroutine
+
     integer function command_argument_count() result(r)
     end function
 

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -99,6 +99,13 @@ interface
     integer, intent(in) :: i
     end function
 
+    subroutine get_command_argument(number, value, length, status)
+    integer, intent(in) :: number
+    character(len=*), optional, intent(out) :: value
+    integer, intent(out) :: length
+    integer, intent(out) :: status
+    end subroutine
+
 end interface
 
 end module

--- a/src/runtime/pure/lfortran_intrinsic_math2.f90
+++ b/src/runtime/pure/lfortran_intrinsic_math2.f90
@@ -41,7 +41,7 @@ interface min
 end interface
 
 interface max
-    module procedure imax, imax8, imax16, imax64, smax, dmax, dmax1, imax_6args, dmax_3args
+    module procedure imax, imax8, imax16, imax64, smax, dmax, dmax1, imax_6args, dmax_3args, imax_3args
 end interface
 
 interface huge
@@ -412,6 +412,11 @@ do itr = 1, 6
     curr_value = args(itr)
     r = imax(curr_value, r)
 end do
+end function
+
+elemental integer function imax_3args(x, y, z) result(r)
+integer, intent(in) :: x, y, z
+r = imax(imax(x, y), z)
 end function
 
 elemental real(sp) function smax(x, y) result(r)


### PR DESCRIPTION
cc: @certik

Progress,

```bash
 <INFO> BUILD_NAME: build/lfortran
 <INFO> COMPILER:  lfortran
 <INFO> C COMPILER:  cc
 <INFO> CXX COMPILER: cc
 <INFO> COMPILER OPTIONS:  
 <INFO> C COMPILER OPTIONS:  
 <INFO> CXX COMPILER OPTIONS: 
 <INFO> LINKER OPTIONS:  
 <INFO> INCLUDE DIRECTORIES:  []
 + mkdir -p build/lfortran_00000000811C9DC5
[  0%]         filesystem_utilities.c
 + mkdir -p build/lfortran_00000000811C9DC5/fpm/
 + cc -c ././src/filesystem_utilities.c  -o build/lfortran_00000000811C9DC5/fpm/src_filesystem_utilities.c.o
[  1%]         filesystem_utilities.c  done.
[  1%]                fpm_strings.f90
 + lfortran -c ././src/fpm_strings.f90  -J build/lfortran_00000000811C9DC5 -Ibuild/lfortran_00000000811C9DC5 -o build/lfortran_00000000811C9DC5/fpm/src_fpm_strings.f90.o
[  2%]                fpm_strings.f90  done.
[  2%]        fpm_backend_console.f90
 + lfortran -c ././src/fpm_backend_console.f90  -J build/lfortran_00000000811C9DC5 -Ibuild/lfortran_00000000811C9DC5 -o build/lfortran_00000000811C9DC5/fpm/src_fpm_backend_console.f90.o
[  4%]        fpm_backend_console.f90  done.
[  4%]                     iscygpty.c
 + cc -c ././src/ptycheck/iscygpty.c  -o build/lfortran_00000000811C9DC5/fpm/src_ptycheck_iscygpty.c.o
[  5%]                     iscygpty.c  done.
[  5%]                       isatty.c
 + cc -c ././src/ptycheck/isatty.c  -o build/lfortran_00000000811C9DC5/fpm/src_ptycheck_isatty.c.o
[  7%]                       isatty.c  done.
[  7%]                  constants.f90
 + lfortran -c build/dependencies/toml-f/src/tomlf/constants.f90  -J build/lfortran_00000000811C9DC5 -Ibuild/lfortran_00000000811C9DC5 -o build/lfortran_00000000811C9DC5/fpm/build_dependencies_toml-f_src_tomlf_constants.f90.o
[  8%]                  constants.f90  done.
[  8%]                    version.f90
 + lfortran -c build/dependencies/toml-f/src/tomlf/version.f90  -J build/lfortran_00000000811C9DC5 -Ibuild/lfortran_00000000811C9DC5 -o build/lfortran_00000000811C9DC5/fpm/build_dependencies_toml-f_src_tomlf_version.f90.o
[ 10%]                    version.f90  done.
[ 10%]                     M_CLI2.F90
 + lfortran -c build/dependencies/M_CLI2/src/M_CLI2.F90  -J build/lfortran_00000000811C9DC5 -Ibuild/lfortran_00000000811C9DC5 -o build/lfortran_00000000811C9DC5/fpm/build_dependencies_M_CLI2_src_M_CLI2.F90.o
Traceback (most recent call last):
  File "/Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran.cpp", line 1876
    return compile_to_object_file(arg_file, outfile, false,
  File "/Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran.cpp", line 829
    result = fe.get_asr2(input, lm, diagnostics);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/fortran_evaluator.cpp", line 234
    Result<ASR::TranslationUnit_t*> res2 = get_asr3(*ast, diagnostics);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/fortran_evaluator.cpp", line 256
    compiler_options.symtab_only, compiler_options);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_to_asr.cpp", line 64
    auto res = body_visitor(al, ast, diagnostics, unit, compiler_options,
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 2159
    b.visit_TranslationUnit(ast);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 114
    visit_ast(*x.m_items[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4764
    void visit_ast(const ast_t &b) { visit_ast_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4721
    case astType::unit: { v.visit_unit((const unit_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4767
    void visit_mod(const mod_t &b) { visit_mod_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4362
    case modType::Module: { v.visit_Module((const Module_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1056
    visit_program_unit(*x.m_contains[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4772
    void visit_program_unit(const program_unit_t &b) { visit_program_unit_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4373
    case program_unitType::Subroutine: { v.visit_Subroutine((const Subroutine_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1147
    transform_stmts(body, x.n_body, x.m_body);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 90
    this->visit_stmt(*m_body[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4809
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4506
    case stmtType::ForAll: { v.visit_ForAll((const ForAll_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1721
    transform_stmts(body, x.n_body, x.m_body);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 90
    this->visit_stmt(*m_body[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4809
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4506
    case stmtType::ForAll: { v.visit_ForAll((const ForAll_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1724
    transform_stmts(orelse, x.n_orelse, x.m_orelse);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 90
    this->visit_stmt(*m_body[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4809
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4465
    case stmtType::Assign: { v.visit_Assign((const Assign_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1387
    ASR::expr_t *target = LFortran::ASRUtils::EXPR(tmp);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4860
    void visit_expr(const expr_t &b) { visit_expr_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4529
    case exprType::CoarrayRef: { v.visit_CoarrayRef((const CoarrayRef_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 1770
    type = ASRUtils::duplicate_type(al, type, &dims);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 1770
    type = ASRUtils::duplicate_type(al, type, &dims);
  Binary file "/usr/lib/system/libsystem_platform.dylib", local address: 0x1803fc2a3
Segfault: Signal SIGSEGV (segmentation fault) received
[ 11%]                     M_CLI2.F90  done.

Traceback (most recent call last):
  File "/Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran.cpp", line 1876
    return compile_to_object_file(arg_file, outfile, false,
  File "/Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran.cpp", line 829
    result = fe.get_asr2(input, lm, diagnostics);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/fortran_evaluator.cpp", line 234
    Result<ASR::TranslationUnit_t*> res2 = get_asr3(*ast, diagnostics);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/fortran_evaluator.cpp", line 256
    compiler_options.symtab_only, compiler_options);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_to_asr.cpp", line 64
    auto res = body_visitor(al, ast, diagnostics, unit, compiler_options,
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 2159
    b.visit_TranslationUnit(ast);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 114
    visit_ast(*x.m_items[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4764
    void visit_ast(const ast_t &b) { visit_ast_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4721
    case astType::unit: { v.visit_unit((const unit_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4767
    void visit_mod(const mod_t &b) { visit_mod_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4362
    case modType::Module: { v.visit_Module((const Module_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1056
    visit_program_unit(*x.m_contains[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4772
    void visit_program_unit(const program_unit_t &b) { visit_program_unit_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4373
    case program_unitType::Subroutine: { v.visit_Subroutine((const Subroutine_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1147
    transform_stmts(body, x.n_body, x.m_body);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 90
    this->visit_stmt(*m_body[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4809
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4506
    case stmtType::ForAll: { v.visit_ForAll((const ForAll_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1721
    transform_stmts(body, x.n_body, x.m_body);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 90
    this->visit_stmt(*m_body[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4809
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4506
    case stmtType::ForAll: { v.visit_ForAll((const ForAll_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1724
    transform_stmts(orelse, x.n_orelse, x.m_orelse);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 90
    this->visit_stmt(*m_body[i]);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4809
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4465
    case stmtType::Assign: { v.visit_Assign((const Assign_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 1387
    ASR::expr_t *target = LFortran::ASRUtils::EXPR(tmp);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4860
    void visit_expr(const expr_t &b) { visit_expr_t(b, self()); }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/ast.h", line 4529
    case exprType::CoarrayRef: { v.visit_CoarrayRef((const CoarrayRef_t &)x); return; }
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 1770
    type = ASRUtils::duplicate_type(al, type, &dims);
  File "/Users/czgdp1807/lfortran_project/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 1770
    type = ASRUtils::duplicate_type(al, type, &dims);
  Binary file "/usr/lib/system/libsystem_platform.dylib", local address: 0x1803fc2a3
Segfault: Signal SIGSEGV (segmentation fault) received
<ERROR> Compilation failed for object " build_dependencies_M_CLI2_src_M_CLI2.F90.o "
<ERROR>stopping due to failed compilation
STOP 1
```

Commits merged in `main` branch,

- [x] a9975e2fb14d98e28b86e8f633ea8867ce39d9d5 - https://github.com/lfortran/lfortran/pull/1075
- [ ] 7f0d904eed916b2a95f91839f5c538d61b7fbd32 - https://github.com/lfortran/lfortran/pull/1105
- [ ] 3af4774ca1f769456197df887395bf23956e8367 - https://github.com/lfortran/lfortran/pull/1099
- [ ] a24576123868d73f882c87c658e9701237f1538c - https://github.com/lfortran/lfortran/pull/1099 
- [ ] 5d3cda0d2ffb9a90477663d629a4a9f808d3cda4 - https://github.com/lfortran/lfortran/pull/1106 
- [ ] ecde98f30d180cd221190d3d541e086c7e1c88e2 - https://github.com/lfortran/lfortran/pull/1080
- [ ] af9e844bd211ada4f05308791f403432cba0f97c - https://github.com/lfortran/lfortran/pull/1107 
- [ ] db8bfc5c7a85d36d3c81afa6bbcf925f70516945 - https://github.com/lfortran/lfortran/pull/1102 
- [ ] 02f81053e8480c40d1291228ebb14a8b4d7e5c7b - https://github.com/lfortran/lfortran/pull/1104
- [ ] 427c7c2bc9dd0047884f582e045bc5c073f8737e - https://github.com/lfortran/lfortran/pull/1102
- [ ] 1a5754ed94683f50c8ba5d670309f9d53c695b9a - https://github.com/lfortran/lfortran/pull/1102
- [ ] ab8cef129f4f1682b4cb076881b59ec31455948a - https://github.com/lfortran/lfortran/pull/1108
- [ ] 14c44e1b0ae8d8554b3211a6f40fd34fad0a729a - https://github.com/lfortran/lfortran/pull/1108 
- [ ] f5e95c43ec5b72bd628bd1c7bb1b083a737f6b36 - https://github.com/lfortran/lfortran/pull/1108 
- [ ] f4aa32e60121d0638e114686e5c9f280ab454839 - https://github.com/lfortran/lfortran/pull/1108
- [ ] 28ad6476e3dc1222e6cb854e855c89efdbed9939 - https://github.com/lfortran/lfortran/pull/1080
- [ ] d545e1dae2a6d65f4f222b0612f779ac1f5faaac - https://github.com/lfortran/lfortran/pull/1100
- [ ] d183cb550d95d8585eb94738683762e02934c716 - https://github.com/lfortran/lfortran/pull/1108 (except deallocation for saved attributes)
- [x] 7417b47f694c9e2b4f86bc20230f9a0d2b55861c - https://github.com/lfortran/lfortran/pull/1074
- [ ] 03d7c562f04da181e355fa94cb640885d2c4f57a - https://github.com/lfortran/lfortran/pull/1108
- [ ] eac6e3b875fa929ed5ba45ac4e36c029fb0edfeb - https://github.com/lfortran/lfortran/pull/1083
- [ ] 533ee09de21c41400312554540b150b473f5e77e - https://github.com/lfortran/lfortran/pull/1104
- [ ] b757048380bdc488d0448f5aac019a20bd37bee0 - https://github.com/lfortran/lfortran/pull/1104