### PR TITLE
Do not reset precedence when cast does not add parentheses

### DIFF
--- a/integration_tests/expr_11.f90
+++ b/integration_tests/expr_11.f90
@@ -1,0 +1,6 @@
+program expr_11
+! Test parantheses in expressions with type casts (#1043)
+    real*8 x
+
+    x=(2.0*x+1.0)/(x*(x+1))
+end program

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -978,11 +978,13 @@ R"(#include <stdio.h>
                     case 8: src = "(double)(" + src + ")"; break;
                     default: throw CodeGenError("Cast IntegerToReal: Unsupported Kind " + std::to_string(dest_kind));
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::RealToInteger) : {
                 int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
                 src = "(int" + std::to_string(dest_kind * 8) + "_t)(" + src + ")";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::RealToReal) : {
@@ -1005,6 +1007,7 @@ R"(#include <stdio.h>
                 } else {
                     src = "std::complex<double>(" + src + ")";
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::ComplexToReal) : {
@@ -1014,6 +1017,7 @@ R"(#include <stdio.h>
                 } else {
                     src = "std::real(" + src + ")";
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::RealToComplex) : {
@@ -1023,10 +1027,12 @@ R"(#include <stdio.h>
                 } else {
                     src = "std::complex<double>(" + src + ")";
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::LogicalToInteger) : {
                 src = "(int)(" + src + ")";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::LogicalToCharacter) : {
@@ -1044,18 +1050,22 @@ R"(#include <stdio.h>
                     case 8: src = "(double)(" + src + ")"; break;
                     default: throw CodeGenError("Cast LogicalToReal: Unsupported Kind " + std::to_string(dest_kind));
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::RealToLogical) : {
                 src = "(bool)(" + src + ")";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::CharacterToLogical) : {
                 src = "(bool)(strlen(" + src + ") > 0)";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::ComplexToLogical) : {
                 src = "(bool)(" + src + ")";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::IntegerToCharacter) : {
@@ -1074,6 +1084,7 @@ R"(#include <stdio.h>
                 } else {
                     src = "std::to_string(" + src + ")";
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::CharacterToInteger) : {
@@ -1082,6 +1093,7 @@ R"(#include <stdio.h>
                 } else {
                     src = "std::stoi(" + src + ")";
                 }
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::RealToCharacter) : {
@@ -1097,6 +1109,7 @@ R"(#include <stdio.h>
                 } else {
                     src = "std::to_string(" + src + ")";
                 }
+                last_expr_precedence = 2;
                 break;
             }
             default : throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -1102,7 +1102,6 @@ R"(#include <stdio.h>
             default : throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",
                 x.base.base.loc);
         }
-        last_expr_precedence = 2;
     }
 
     void visit_IntegerBitLen(const ASR::IntegerBitLen_t& x) {

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -990,14 +990,18 @@ R"(#include <stdio.h>
             case (ASR::cast_kindType::RealToReal) : {
                 // In C++, we do not need to cast float to float explicitly:
                 // src = src;
+                // last_expr_precedence = last_expr_precedence;
                 break;
             }
             case (ASR::cast_kindType::IntegerToInteger) : {
                 // In C++, we do not need to cast int <-> long long explicitly:
                 // src = src;
+                // last_expr_precedence = last_expr_precedence;
                 break;
             }
             case (ASR::cast_kindType::ComplexToComplex) : {
+                // src = src;
+                // last_expr_precedence = last_expr_precedence;
                 break;
             }
             case (ASR::cast_kindType::IntegerToComplex) : {
@@ -1036,11 +1040,13 @@ R"(#include <stdio.h>
                 break;
             }
             case (ASR::cast_kindType::LogicalToCharacter) : {
-                src = src + " ? \"True\" : \"False\"";
+                src = "(" + src + " ? \"True\" : \"False\")";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::IntegerToLogical) : {
                 src = "(bool)(" + src + ")";
+                last_expr_precedence = 2;
                 break;
             }
             case (ASR::cast_kindType::LogicalToReal) : {

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1535,7 +1535,6 @@ public:
                 throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",
                                    x.base.base.loc);
         }
-        last_expr_precedence = julia_prec::Base;
     }
 
     void visit_IntegerCompare(const ASR::IntegerCompare_t& x)

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1503,11 +1503,13 @@ public:
             case (ASR::cast_kindType::RealToReal): {
                 // In Julia, we do not need to cast float to float explicitly:
                 // src = src;
+                // last_expr_precedence = last_expr_precedence;
                 break;
             }
             case (ASR::cast_kindType::IntegerToInteger): {
                 // In Julia, we do not need to cast int <-> long long explicitly:
                 // src = src;
+                // last_expr_precedence = last_expr_precedence;
                 break;
             }
             case (ASR::cast_kindType::ComplexToComplex): {

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1490,12 +1490,14 @@ public:
                         throw CodeGenError("Cast IntegerToReal: Unsupported Kind "
                                            + std::to_string(dest_kind));
                 }
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             case (ASR::cast_kindType::RealToInteger): {
                 int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
                 src = "trunc" + broadcast + "(Int" + std::to_string(dest_kind * 8) + ", " + src
                       + ")";
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             case (ASR::cast_kindType::RealToReal): {
@@ -1513,22 +1515,27 @@ public:
             }
             case (ASR::cast_kindType::IntegerToComplex): {
                 src = "complex" + broadcast + "(" + src + ")";
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             case (ASR::cast_kindType::ComplexToReal): {
                 src = "real" + broadcast + "(" + src + ")";
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             case (ASR::cast_kindType::RealToComplex): {
                 src = "complex" + broadcast + "(" + src + ")";
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             case (ASR::cast_kindType::LogicalToInteger): {
                 src = "Int32" + broadcast + "(" + src + ")";
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             case (ASR::cast_kindType::IntegerToLogical): {
                 src = "Bool" + broadcast + "(" + src + ")";
+                last_expr_precedence = julia_prec::Base;
                 break;
             }
             default:

--- a/tests/reference/c-expr_11-8e5ae80.json
+++ b/tests/reference/c-expr_11-8e5ae80.json
@@ -1,0 +1,13 @@
+{
+    "basename": "c-expr_11-8e5ae80",
+    "cmd": "lfortran --no-color --show-c {infile}",
+    "infile": "tests/../integration_tests/expr_11.f90",
+    "infile_hash": "1d3eee7b6af3504909d82d761867baf90d2f74b36edc4a6eac4e341f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "c-expr_11-8e5ae80.stdout",
+    "stdout_hash": "8661d97afa847c571f75738068f76104dd1a2ebeea3ec580cdc30b6f",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/c-expr_11-8e5ae80.stdout
+++ b/tests/reference/c-expr_11-8e5ae80.stdout
@@ -1,0 +1,43 @@
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <lfortran_intrinsics.h>
+
+#define ASSERT(cond)                                                           \
+    {                                                                          \
+        if (!(cond)) {                                                         \
+            printf("%s%s", "ASSERT failed: ", __FILE__);                       \
+            printf("%s%s", "\nfunction ", __func__);                           \
+            printf("%s%d%s", "(), line number ", __LINE__, " at \n");          \
+            printf("%s%s", #cond, "\n");                                       \
+            exit(1);                                                           \
+        }                                                                      \
+    }
+#define ASSERT_MSG(cond, msg)                                                  \
+    {                                                                          \
+        if (!(cond)) {                                                         \
+            printf("%s%s", "ASSERT failed: ", __FILE__);                       \
+            printf("%s%s", "\nfunction ", __func__);                           \
+            printf("%s%d%s", "(), line number ", __LINE__, " at \n");          \
+            printf("%s%s", #cond, "\n");                                       \
+            printf("%s", "ERROR MESSAGE:\n");                                  \
+            printf("%s%s", msg, "\n");                                         \
+            exit(1);                                                           \
+        }                                                                      \
+    }
+
+
+struct dimension_descriptor
+{
+    int32_t lower_bound, length;
+};
+
+// Implementations
+int main(int argc, char* argv[])
+{
+    double x;
+    x = (  2.00000000000000000e+00*x +   1.00000000000000000e+00)/(x*(x + (double)(1)));
+    return 0;
+}

--- a/tests/reference/julia-expr_11-ab53b8f.json
+++ b/tests/reference/julia-expr_11-ab53b8f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "julia-expr_11-ab53b8f",
+    "cmd": "lfortran --no-color --show-julia {infile}",
+    "infile": "tests/../integration_tests/expr_11.f90",
+    "infile_hash": "1d3eee7b6af3504909d82d761867baf90d2f74b36edc4a6eac4e341f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "julia-expr_11-ab53b8f.stdout",
+    "stdout_hash": "f5ea828d5889a045908f3dbe3ed2fe044c6b4750d0ba83122a7b3bf0",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/julia-expr_11-ab53b8f.stdout
+++ b/tests/reference/julia-expr_11-ab53b8f.stdout
@@ -1,0 +1,6 @@
+function main()
+    local x::Float64 = 0.0
+    x = (  2.00000000000000000e+00 * x +   1.00000000000000000e+00) / (x * (x + Float64(1)))
+end
+
+main()

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1796,6 +1796,11 @@ wat = true
 julia = true
 
 [[test]]
+filename = "../integration_tests/expr_11.f90"
+c = true
+julia = true
+
+[[test]]
 filename = "../integration_tests/modules_11.f90"
 ast = true
 asr = true


### PR DESCRIPTION
Fix #1043 