### PR TITLE
Fix expression replacer for multi-layer replacements of expressions

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1881,10 +1881,10 @@ class ReplaceArgVisitor: public ASR::BaseExprReplacer<ReplaceArgVisitor> {
         }
         // The following substitutes args from the current scope
         for (size_t i = 0; i < x->n_args; i++) {
-            current_expr_copy = current_expr;
+            ASR::expr_t** current_expr_copy_ = current_expr;
             current_expr = &(x->m_args[i].m_value);
             replace_expr(x->m_args[i].m_value);
-            current_expr = current_expr_copy;
+            current_expr = current_expr_copy_;
         }
         x->m_name = new_es;
     }


### PR DESCRIPTION
Found in https://github.com/lfortran/lfortran/pull/1045#discussion_r1034093434

Earlier I was using `current_expr_copy` as a state of the class `BaseExprReplacer`. I did this to avoid re-definition errors of `current_expr_copy` by C++ compilers. This caused loss of original expressions once we moved deeper into the expression tree. However now I use local variables and declare always new ones by suffixing `current_expr_copy` with `_[counter]`. **This avoids re-definition errors by C++ compiler and allows replacement of expressions having very deep trees in ASR.**