### PR TITLE
Get enorm(m,a(1,j)) working

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2779,6 +2779,19 @@ public:
                 v = ASR::down_cast<ASR::Var_t>(var_expr)->m_v;
             } else {
                 ASR::ttype_t *var_type = ASRUtils::expr_type(var_expr);
+                if (ASRUtils::is_array(var_type)) {
+                    // For arrays like A(n, m) we use A(*) in BindC, so that
+                    // the C ABI is just a pointer
+                    var_type = ASRUtils::duplicate_type_without_dims(al, var_type, x.base.base.loc);
+                    Vec<ASR::dimension_t> dims;
+                    dims.reserve(al, 1);
+                    ASR::dimension_t dim;
+                    dim.loc = x.base.base.loc;
+                    dim.m_start = nullptr;
+                    dim.m_length = nullptr;
+                    dims.push_back(al, dim);
+                    ASRUtils::ttype_set_dimensions(var_type, dims.p, dims.size());
+                }
                 v = ASR::down_cast<ASR::symbol_t>(
                     ASR::make_Variable_t(al, x.base.base.loc,
                     current_scope, s2c(al, arg_name), LFortran::ASRUtils::intent_unspecified, nullptr, nullptr,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2783,7 +2783,7 @@ public:
                     ASR::make_Variable_t(al, x.base.base.loc,
                     current_scope, s2c(al, arg_name), LFortran::ASRUtils::intent_unspecified, nullptr, nullptr,
                     ASR::storage_typeType::Default, var_type,
-                    ASR::abiType::Source, ASR::Public, ASR::presenceType::Required,
+                    ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required,
                     false));
                 current_scope->add_symbol(arg_name, v);
             }
@@ -2801,7 +2801,7 @@ public:
             ASR::asr_t *return_var = ASR::make_Variable_t(al, x.base.base.loc,
                 current_scope, s2c(al, return_var_name), LFortran::ASRUtils::intent_return_var, nullptr, nullptr,
                 ASR::storage_typeType::Default, type,
-                ASR::abiType::Source, ASR::Public, ASR::presenceType::Required,
+                ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required,
                 false);
             current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
             to_return = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
@@ -2818,7 +2818,7 @@ public:
             /* a_body */ nullptr,
             /* n_body */ 0,
             /* a_return_var */ to_return,
-            ASR::abiType::Source, ASR::accessType::Public, ASR::deftypeType::Interface,
+            ASR::abiType::BindC, ASR::accessType::Public, ASR::deftypeType::Interface,
             nullptr, false, false, false, false, false, /* a_type_parameters */ nullptr,
             /* n_type_parameters */ 0, nullptr, 0, false);
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5849,6 +5849,11 @@ public:
                                 }
                         } else if ( x_abi == ASR::abiType::BindC ) {
                             if( arr_descr->is_array(ASRUtils::get_contained_type(arg->m_type)) ) {
+                                // TODO: we need a dedicated and robust
+                                // function that determines from ASR only
+                                // if a given array is represented by
+                                // a descriptor or with just a pointer.
+                                // Until then we use the following heuristic:
                                 bool arg_is_using_descriptor = true;
                                 if (LLVMArrUtils::is_explicit_shape(arg)) {
                                     if (arg->m_intent != intent_local) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6063,8 +6063,9 @@ public:
                                 // at the beginning of the function to avoid
                                 // using alloca inside a loop, which would
                                 // run out of stack
-                                if( ASR::is_a<ASR::ArrayItem_t>(*x.m_args[i].m_value) ||
-                                    ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value) ) {
+                                if( (ASR::is_a<ASR::ArrayItem_t>(*x.m_args[i].m_value) ||
+                                    ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value)) &&
+                                        value->getType()->isPointerTy()) {
                                     value = CreateLoad(value);
                                 }
                                 if( !ASR::is_a<ASR::CPtr_t>(*arg_type) ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5849,7 +5849,15 @@ public:
                                 }
                         } else if ( x_abi == ASR::abiType::BindC ) {
                             if( arr_descr->is_array(ASRUtils::get_contained_type(arg->m_type)) ) {
-                                tmp = CreateLoad(arr_descr->get_pointer_to_data(tmp));
+                                bool arg_is_using_descriptor = true;
+                                if (LLVMArrUtils::is_explicit_shape(arg)) {
+                                    if (arg->m_intent != intent_local) {
+                                        arg_is_using_descriptor = false;
+                                    }
+                                }
+                                if (arg_is_using_descriptor) {
+                                    tmp = CreateLoad(arr_descr->get_pointer_to_data(tmp));
+                                }
                             } else {
                                 if (orig_arg->m_abi == ASR::abiType::BindC
                                     && orig_arg->m_value_attr) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5984,8 +5984,7 @@ public:
                 ptr_loads = !LLVM::is_llvm_struct(arg_type);
                 this->visit_expr_wrapper(x.m_args[i].m_value);
                 if( x_abi == ASR::abiType::BindC ) {
-                    if( ASR::is_a<ASR::ArrayItem_t>(*x.m_args[i].m_value) ||
-                        ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value) ||
+                    if( ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value) ||
                         (ASR::is_a<ASR::CPtr_t>(*arg_type) &&
                             ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value)) ) {
                         tmp = LLVM::CreateLoad(*builder, tmp);
@@ -6069,6 +6068,9 @@ public:
                             }
                             if (orig_arg->m_abi == ASR::abiType::BindC
                                 && orig_arg->m_value_attr) {
+                                use_value = true;
+                            }
+                            if (ASR::is_a<ASR::ArrayItem_t>(*x.m_args[i].m_value)) {
                                 use_value = true;
                             }
                             if (!use_value) {

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -33,10 +33,7 @@ namespace LFortran {
                     is_ok = false;
                     break;
                 }
-                if( (m_dims[r].m_length != nullptr &&
-                    m_dims[r].m_length->type != ASR::exprType::IntegerConstant) ||
-                    (m_dims[r].m_start != nullptr &&
-                    m_dims[r].m_start->type != ASR::exprType::IntegerConstant) ) {
+                if (m_dims[r].m_length == nullptr) {
                     is_ok = false;
                     break;
                 }

--- a/tests/reference/asr-allow_implicit_interface-b700617.json
+++ b/tests/reference/asr-allow_implicit_interface-b700617.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allow_implicit_interface-b700617.stdout",
-    "stdout_hash": "16f367caf00579c393afbc4d062f3dff64ca764c095e55209e02b6d9",
+    "stdout_hash": "dbe1d0bf91291864805852605cadf9afea46e1d21d0b947f443d577f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allow_implicit_interface-b700617.stdout
+++ b/tests/reference/asr-allow_implicit_interface-b700617.stdout
@@ -29,7 +29,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -43,7 +43,7 @@
                                                     () 
                                                     Default 
                                                     (Logical 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -57,7 +57,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -70,7 +70,7 @@
                                     (Var 225 alnorm_arg_1)] 
                                     [] 
                                     (Var 225 alnorm_return_var_name) 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 
@@ -111,7 +111,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -125,7 +125,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -139,7 +139,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -153,7 +153,7 @@
                                     (Var 226 dgetrf_arg_2)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-allow_implicit_interface2-094c0f8.json
+++ b/tests/reference/asr-allow_implicit_interface2-094c0f8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allow_implicit_interface2-094c0f8.stdout",
-    "stdout_hash": "402b309cdf49fad84a4a1dcfa2b9602773ea776a160a0dd7933f6c7e",
+    "stdout_hash": "42c8917f410881e370a87eb4f2d93f597c504e2fc9736a14bf34bfdd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allow_implicit_interface2-094c0f8.stdout
+++ b/tests/reference/asr-allow_implicit_interface2-094c0f8.stdout
@@ -21,7 +21,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -35,7 +35,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -48,7 +48,7 @@
                                     (Var 3 fcn_arg_1)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-fixed_form_call1-8fadeb1.json
+++ b/tests/reference/asr-fixed_form_call1-8fadeb1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fixed_form_call1-8fadeb1.stdout",
-    "stdout_hash": "4d0cf0fe799c7fa49ce5863651fab4572bdcf62d21e429997df59de6",
+    "stdout_hash": "cdbd14c65920724d96b0c4efe1881f19deabcf5a156eed067939c80e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fixed_form_call1-8fadeb1.stdout
+++ b/tests/reference/asr-fixed_form_call1-8fadeb1.stdout
@@ -63,7 +63,7 @@
                                                     () 
                                                     Default 
                                                     (Character 1 6 () []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -77,7 +77,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -91,7 +91,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -105,7 +105,7 @@
                                     (Var 3 prinf_arg_2)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-fixed_form_call2-366730d.json
+++ b/tests/reference/asr-fixed_form_call2-366730d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fixed_form_call2-366730d.stdout",
-    "stdout_hash": "ed901914d52a52d55272b67bf8ccab7b613c7254267456b00639953a",
+    "stdout_hash": "0e62c33f05f5c3b269c21b623274438d9b8c8b0834762eb7178ed7ad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fixed_form_call2-366730d.stdout
+++ b/tests/reference/asr-fixed_form_call2-366730d.stdout
@@ -49,7 +49,7 @@
                                                     () 
                                                     Default 
                                                     (Character 1 6 () []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -63,7 +63,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -76,7 +76,7 @@
                                     (Var 3 prinf_arg_1)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-implicit_interface2-0a34057.json
+++ b/tests/reference/asr-implicit_interface2-0a34057.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface2-0a34057.stdout",
-    "stdout_hash": "472359c49377942d746e18be918eb2e3ab3bb09c20b2338ad24d7ca8",
+    "stdout_hash": "2cb296cfcf5fcebf35a070d01eeb984738bfac71c504050cde3eaba7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface2-0a34057.stdout
+++ b/tests/reference/asr-implicit_interface2-0a34057.stdout
@@ -21,7 +21,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -35,7 +35,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -47,7 +47,7 @@
                                     [(Var 3 f_arg_0)] 
                                     [] 
                                     (Var 3 f_return_var_name) 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 
@@ -74,7 +74,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -88,7 +88,7 @@
                                                     () 
                                                     Default 
                                                     (Real 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -102,7 +102,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -115,7 +115,7 @@
                                     (Var 4 g_arg_1)] 
                                     [] 
                                     (Var 4 g_return_var_name) 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-implicit_interface3-9e2dea4.json
+++ b/tests/reference/asr-implicit_interface3-9e2dea4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface3-9e2dea4.stdout",
-    "stdout_hash": "509d4ba11ae06d84e4df1c14b1a1bdf16ea4b14b9472fecbf04408df",
+    "stdout_hash": "f49c94e526dc5a8758579e31a4126c9083c2cad7d2e55c42b35739fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface3-9e2dea4.stdout
+++ b/tests/reference/asr-implicit_interface3-9e2dea4.stdout
@@ -21,7 +21,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -33,7 +33,7 @@
                                     [(Var 3 f_arg_0)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-implicit_interface4-c8961c3.json
+++ b/tests/reference/asr-implicit_interface4-c8961c3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface4-c8961c3.stdout",
-    "stdout_hash": "bd624bb1b1606a9f43ab2d606c5545c3af12097cac683f6f5c746491",
+    "stdout_hash": "29fd0abf6bd9901c935d3dfdaaf046a00f46bf11024158fa1da955a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface4-c8961c3.stdout
+++ b/tests/reference/asr-implicit_interface4-c8961c3.stdout
@@ -19,7 +19,7 @@
                                     [(Var 2 f)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 
@@ -46,7 +46,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -60,7 +60,7 @@
                                                     () 
                                                     Default 
                                                     (Real 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -74,7 +74,7 @@
                                                     () 
                                                     Default 
                                                     (Real 8 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -88,7 +88,7 @@
                                     (Var 3 f_arg_2)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 

--- a/tests/reference/asr-variable1-9579363.json
+++ b/tests/reference/asr-variable1-9579363.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-variable1-9579363.stdout",
-    "stdout_hash": "0d40c0967915fc13ea4a0535da1eb28b716c6ca8effe8ca7f500645b",
+    "stdout_hash": "073660c0992eb08ff5b72246cd3ae80f57c9f7932504b81a0cf3c422",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-variable1-9579363.stdout
+++ b/tests/reference/asr-variable1-9579363.stdout
@@ -34,9 +34,9 @@
                                                     () 
                                                     () 
                                                     Default 
-                                                    (Complex 4 [((IntegerConstant 1 (Integer 4 [])) 
-                                                    (Var 2 m))]) 
-                                                    Source 
+                                                    (Complex 4 [(() 
+                                                    ())]) 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -50,7 +50,7 @@
                                                     () 
                                                     Default 
                                                     (Integer 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -63,9 +63,9 @@
                                                     () 
                                                     () 
                                                     Default 
-                                                    (Complex 4 [((IntegerConstant 1 (Integer 4 [])) 
-                                                    (Var 2 n))]) 
-                                                    Source 
+                                                    (Complex 4 [(() 
+                                                    ())]) 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -79,7 +79,7 @@
                                                     () 
                                                     Default 
                                                     (Complex 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -93,7 +93,7 @@
                                                     () 
                                                     Default 
                                                     (Complex 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -107,7 +107,7 @@
                                                     () 
                                                     Default 
                                                     (Complex 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -121,7 +121,7 @@
                                                     () 
                                                     Default 
                                                     (Complex 4 []) 
-                                                    Source 
+                                                    BindC 
                                                     Public 
                                                     Required 
                                                     .false.
@@ -139,7 +139,7 @@
                                     (Var 3 matveca_arg_6)] 
                                     [] 
                                     () 
-                                    Source 
+                                    BindC 
                                     Public 
                                     Interface 
                                     () 


### PR DESCRIPTION
This PR fixes the implicit interface issue and minpack gets much closer to working, if not already working (more tests needed).