### PR TITLE
Use m_vartype (ArrayInitializer) to get the initializer type.

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -245,6 +245,7 @@ RUN(NAME arrays_05 LABELS gfortran llvm cpp wasm)
 RUN(NAME arrays_17 LABELS gfortran llvm)
 RUN(NAME arrays_18_func LABELS gfortran llvm)
 RUN(NAME arrays_19 LABELS gfortran llvm)
+RUN(NAME arrays_20 LABELS gfortran llvm)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran)

--- a/integration_tests/arrays_20.f90
+++ b/integration_tests/arrays_20.f90
@@ -1,0 +1,12 @@
+program arrays_20
+    implicit none
+
+    integer, allocatable          :: list_integer(:)
+    logical, allocatable          :: list_logical(:)
+    character(len=5), allocatable :: list_character(:)
+
+    list_integer   = [integer ::]
+    list_logical   = [logical ::]
+    list_character = [character(len=len(list_character)) ::]
+
+end program arrays_20

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1748,6 +1748,10 @@ public:
         }
         Vec<ASR::dimension_t> dims;
         dims.reserve(al, 1);
+        if (x.m_vartype != nullptr) {
+            std::string sym = "";
+            type = determine_type(x.base.base.loc, sym, x.m_vartype, false, dims);
+        }
         ASR::dimension_t dim;
         dim.loc = x.base.base.loc;
         ASR::ttype_t *int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1491,7 +1491,25 @@ public:
                             char_data->expr = sym_type->m_kind->m_value;
                             char_data->scope = current_scope;
                             char_data->sym_type = current_symbol;
-                            a_len = 1;
+                            AST::FuncCallOrArray_t* call =
+                                AST::down_cast<AST::FuncCallOrArray_t>(
+                                sym_type->m_kind->m_value);
+                            if (AST::is_a<AST::Name_t>(*call->m_args->m_end)) {
+                                ASR::symbol_t* sym = current_scope->get_symbol(
+                                    AST::down_cast<AST::Name_t>(call->m_args->m_end)->m_id);
+                                if (sym != nullptr) {
+                                    sym = ASRUtils::symbol_get_past_external(sym);
+                                    ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(
+                                        ASRUtils::symbol_get_past_external(sym));
+                                    if (ASR::is_a<ASR::Character_t>(*v->m_type)) {
+                                        a_len = ASR::down_cast<ASR::Character_t>(
+                                            v->m_type)->m_len;
+                                    }
+                                }
+                            }
+                            if (a_len == -10) {
+                                a_len = 1;
+                            }
                         } else {
                             this->visit_expr(*sym_type->m_kind->m_value);
                             ASR::expr_t* len_expr0 = LFortran::ASRUtils::EXPR(tmp);

--- a/tests/reference/asr-arrays_20-cb6ba8f.json
+++ b/tests/reference/asr-arrays_20-cb6ba8f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_20-cb6ba8f.stdout",
-    "stdout_hash": "d9874b3bd08b6c72b9295e87dd817e63f6a619278fb9687d34577958",
+    "stdout_hash": "8f8b9822a5d0bfc7d9557af24f7b383a62fa18a059bc9aba75dfa77d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_20-cb6ba8f.json
+++ b/tests/reference/asr-arrays_20-cb6ba8f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-arrays_20-cb6ba8f",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/arrays_20.f90",
+    "infile_hash": "9b510b477f3e38a2dd4c07f275793e897a598f8252fcfa0870a55899",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-arrays_20-cb6ba8f.stdout",
+    "stdout_hash": "d9874b3bd08b6c72b9295e87dd817e63f6a619278fb9687d34577958",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-arrays_20-cb6ba8f.stdout
+++ b/tests/reference/asr-arrays_20-cb6ba8f.stdout
@@ -1,0 +1,101 @@
+(TranslationUnit 
+    (SymbolTable
+        1
+        {
+            arrays_20:
+                (Program 
+                    (SymbolTable
+                        2
+                        {
+                            list_character:
+                                (Variable 
+                                    2 
+                                    list_character 
+                                    [] 
+                                    Local 
+                                    () 
+                                    () 
+                                    Allocatable 
+                                    (Character 1 5 () [(() 
+                                    ())]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            list_integer:
+                                (Variable 
+                                    2 
+                                    list_integer 
+                                    [] 
+                                    Local 
+                                    () 
+                                    () 
+                                    Allocatable 
+                                    (Integer 4 [(() 
+                                    ())]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                ), 
+                            list_logical:
+                                (Variable 
+                                    2 
+                                    list_logical 
+                                    [] 
+                                    Local 
+                                    () 
+                                    () 
+                                    Allocatable 
+                                    (Logical 4 [(() 
+                                    ())]) 
+                                    Source 
+                                    Public 
+                                    Required 
+                                    .false.
+                                )
+                            
+                        }) 
+                    arrays_20 
+                    [] 
+                    [(= 
+                        (Var 2 list_integer) 
+                        (ArrayConstant 
+                            [] 
+                            (Integer 4 [((IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 0 (Integer 4 [])))]) 
+                            ColMajor
+                        ) 
+                        ()
+                    )
+                    (= 
+                        (Var 2 list_logical) 
+                        (ArrayConstant 
+                            [] 
+                            (Logical 4 [((IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 0 (Integer 4 [])))]) 
+                            ColMajor
+                        ) 
+                        ()
+                    )
+                    (= 
+                        (Var 2 list_character) 
+                        (ArrayConstant 
+                            [] 
+                            (Character 1 1 () [((IntegerConstant 1 (Integer 4 [])) 
+                            (IntegerConstant 0 (Integer 4 [])))]) 
+                            ColMajor
+                        ) 
+                        ()
+                    )
+                    (ImplicitDeallocate 
+                        [2 list_character
+                        2 list_integer
+                        2 list_logical]
+                    )]
+                )
+            
+        }) 
+    []
+)

--- a/tests/reference/asr-arrays_20-cb6ba8f.stdout
+++ b/tests/reference/asr-arrays_20-cb6ba8f.stdout
@@ -83,7 +83,7 @@
                         (Var 2 list_character) 
                         (ArrayConstant 
                             [] 
-                            (Character 1 1 () [((IntegerConstant 1 (Integer 4 [])) 
+                            (Character 1 5 () [((IntegerConstant 1 (Integer 4 [])) 
                             (IntegerConstant 0 (Integer 4 [])))]) 
                             ColMajor
                         ) 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -839,6 +839,10 @@ filename = "../integration_tests/arrays_13.f90"
 llvm = true
 
 [[test]]
+filename = "../integration_tests/arrays_20.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/types_01.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/1065