### PR TITLE
Better error recovery

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -44,7 +44,8 @@ int yylex(LFortran::YYSTYPE *yylval, YYLTYPE *yyloc, LFortran::Parser &p)
 
 void yyerror(YYLTYPE *yyloc, LFortran::Parser &p, const std::string &msg)
 {
-    p.handle_yyerror(*yyloc, msg);
+    std::cout << "ERROR 3" << std::endl;
+//    p.handle_yyerror(*yyloc, msg);
 }
 
 #define YYLLOC_DEFAULT(Current, Rhs, N)                                 \
@@ -1567,6 +1568,13 @@ assign_statement
 
 assignment_statement
     : expr "=" expr { $$ = ASSIGNMENT($1, $3, @$); }
+//    | expr "=" error { $$ = ASSIGNMENT($1, $1, @$); }
+    | expr "=" error {
+        //yyerrok;
+        std::cout << "ERROR 2" << std::endl;
+        $$ = ASSIGNMENT($1, $1, @$);
+        //yyclearin;
+        }
     ;
 
 goto_statement

--- a/tests/errors/assignment_01.f90
+++ b/tests/errors/assignment_01.f90
@@ -1,0 +1,12 @@
+module assignment_01
+
+contains
+
+subroutine f(a, b)
+integer, intent(inout) :: a, b
+
+b =
+
+end subroutine
+
+end module


### PR DESCRIPTION
This example shows how to recover from errors, it creates an AST:
```console
tests/errors(error2) $ lfortran assignment_01.f90 --show-ast --indent
ERROR 3
ERROR 2
(TranslationUnit 
    [(Module 
        assignment_01 
        (TriviaNode 
            [(EndOfLine)
            (EndOfLine)] 
            []
        ) 
        [] 
        [] 
        [] 
        [(Subroutine 
            f 
            [(a)
            (b)] 
            [] 
            () 
            (TriviaNode 
                [] 
                [(EndOfLine)
                (EndOfLine)]
            ) 
            [] 
            [] 
            [] 
            [(Declaration 
                (AttrType 
                    TypeInteger 
                    [] 
                    () 
                    None
                ) 
                [(AttrIntent 
                    InOut
                )] 
                [(a 
                [] 
                [] 
                () 
                None 
                ())
                (b 
                [] 
                [] 
                () 
                None 
                ())] 
                (TriviaNode 
                    [] 
                    [(EndOfLine)
                    (EndOfLine)]
                )
            )] 
            [(= 
                0 
                b 
                b 
                (TriviaNode 
                    [] 
                    [(EndOfLine)
                    (EndOfLine)]
                )
            )] 
            []
        )]
    )]
)
```

TODO:
* [x] Put the syntax error into the diagnostics, but continue (https://github.com/lfortran/lfortran/pull/4774)
* [ ] Add a compiler option that would keep these errors but it would not exit after AST, but to ASR as well, just ignoring/recovering from the error
* [ ] Create InvalidStatement, or InvalidExpr AST nodes, and insert them into the tree with location information and any other info that we might have
* [ ] Benchmark speed for valid code to ensure there is no regression (I don't expect a significant slow down, but let's check)