### PR TITLE
Changes for printing of ``i8`` and ``i16`` integers in LLVM

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5760,11 +5760,11 @@ public:
             } else if (ASRUtils::is_integer(*t)) {
                 switch( a_kind ) {
                     case 1 : {
-                        fmt.push_back("%d");
+                        fmt.push_back("%hhi");
                         break;
                     }
                     case 2 : {
-                        fmt.push_back("%d");
+                        fmt.push_back("%hi");
                         break;
                     }
                     case 4 : {


### PR DESCRIPTION
Corresponding LPython PR - https://github.com/lcompilers/lpython/pull/1355