### PR TITLE
Changes for supporting data only array members for BindC structs

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -173,6 +173,9 @@ static inline ASR::abiType expr_abi(ASR::expr_t* e) {
         case ASR::exprType::ArrayReshape: {
             return ASRUtils::expr_abi(ASR::down_cast<ASR::ArrayReshape_t>(e)->m_array);
         }
+        case ASR::exprType::GetPointer: {
+            return ASRUtils::expr_abi(ASR::down_cast<ASR::GetPointer_t>(e)->m_arg);
+        }
         default:
             throw LCompilersException("Cannot extract the ABI of " +
                     std::to_string(e->type) + " expression.");
@@ -1437,11 +1440,29 @@ static inline bool is_fixed_size_array(ASR::dimension_t* m_dims, size_t n_dims) 
     }
     for( size_t i = 0; i < n_dims; i++ ) {
         int64_t dim_size = -1;
+        if( m_dims[i].m_length == nullptr ) {
+            return false;
+        }
         if( !ASRUtils::extract_value(ASRUtils::expr_value(m_dims[i].m_length), dim_size) ) {
             return false;
         }
     }
     return true;
+}
+
+static inline int64_t get_fixed_size_of_array(ASR::dimension_t* m_dims, size_t n_dims) {
+    if( n_dims == 0 ) {
+        return 0;
+    }
+    int64_t array_size = 1;
+    for( size_t i = 0; i < n_dims; i++ ) {
+        int64_t dim_size = -1;
+        if( !ASRUtils::extract_value(ASRUtils::expr_value(m_dims[i].m_length), dim_size) ) {
+            return -1;
+        }
+        array_size *= dim_size;
+    }
+    return array_size;
 }
 
 inline int extract_n_dims_from_ttype(ASR::ttype_t *x) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -170,6 +170,9 @@ static inline ASR::abiType expr_abi(ASR::expr_t* e) {
         case ASR::exprType::StructInstanceMember: {
             return ASRUtils::symbol_abi(ASR::down_cast<ASR::StructInstanceMember_t>(e)->m_m);
         }
+        case ASR::exprType::ArrayReshape: {
+            return ASRUtils::expr_abi(ASR::down_cast<ASR::ArrayReshape_t>(e)->m_array);
+        }
         default:
             throw LCompilersException("Cannot extract the ABI of " +
                     std::to_string(e->type) + " expression.");

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -282,19 +282,26 @@ public:
                 if( is_array ) {
                     bool is_fixed_size = true;
                     dims = convert_dims_c(t->n_dims, t->m_dims, v_m_type, is_fixed_size, true);
-                    std::string encoded_type_name = "r" + std::to_string(t->m_kind * 8);
-                    bool is_struct_type_member = ASR::is_a<ASR::StructType_t>(
-                         *ASR::down_cast<ASR::symbol_t>(v.m_parent_symtab->asr_owner));
-                    if( !force_declare ) {
-                        force_declare_name = std::string(v.m_name);
+                    if( v.m_abi == ASR::abiType::BindC && is_fixed_size ) {
+                        if( !force_declare ) {
+                            force_declare_name = std::string(v.m_name);
+                        }
+                        sub = type_name + " " + force_declare_name + dims;
+                    } else {
+                        std::string encoded_type_name = "r" + std::to_string(t->m_kind * 8);
+                        bool is_struct_type_member = ASR::is_a<ASR::StructType_t>(
+                            *ASR::down_cast<ASR::symbol_t>(v.m_parent_symtab->asr_owner));
+                        if( !force_declare ) {
+                            force_declare_name = std::string(v.m_name);
+                        }
+                        generate_array_decl(sub, force_declare_name, type_name, dims,
+                                            encoded_type_name, t->m_dims, t->n_dims,
+                                            use_ref, dummy,
+                                            (v.m_intent != ASRUtils::intent_in &&
+                                            v.m_intent != ASRUtils::intent_inout &&
+                                            v.m_intent != ASRUtils::intent_out &&
+                                            !is_struct_type_member) || force_declare, is_fixed_size);
                     }
-                    generate_array_decl(sub, force_declare_name, type_name, dims,
-                                        encoded_type_name, t->m_dims, t->n_dims,
-                                        use_ref, dummy,
-                                        (v.m_intent != ASRUtils::intent_in &&
-                                        v.m_intent != ASRUtils::intent_inout &&
-                                        v.m_intent != ASRUtils::intent_out &&
-                                        !is_struct_type_member) || force_declare, is_fixed_size);
                 } else {
                     bool is_fixed_size = true;
                     dims = convert_dims_c(t->n_dims, t->m_dims, v_m_type, is_fixed_size);
@@ -308,13 +315,26 @@ public:
                 if( is_array ) {
                     bool is_fixed_size = true;
                     dims = convert_dims_c(t->n_dims, t->m_dims, v_m_type, is_fixed_size, true);
-                    std::string encoded_type_name = "c" + std::to_string(t->m_kind * 8);
-                    generate_array_decl(sub, std::string(v.m_name), type_name, dims,
-                                        encoded_type_name, t->m_dims, t->n_dims,
-                                        use_ref, dummy,
-                                        v.m_intent != ASRUtils::intent_in &&
-                                        v.m_intent != ASRUtils::intent_inout,
-                                        is_fixed_size);
+                    if( v.m_abi == ASR::abiType::BindC && is_fixed_size ) {
+                        if( !force_declare ) {
+                            force_declare_name = std::string(v.m_name);
+                        }
+                        sub = type_name + " " + force_declare_name + dims;
+                    } else {
+                        std::string encoded_type_name = "c" + std::to_string(t->m_kind * 8);
+                        bool is_struct_type_member = ASR::is_a<ASR::StructType_t>(
+                            *ASR::down_cast<ASR::symbol_t>(v.m_parent_symtab->asr_owner));
+                        if( !force_declare ) {
+                            force_declare_name = std::string(v.m_name);
+                        }
+                        generate_array_decl(sub, force_declare_name, type_name, dims,
+                                            encoded_type_name, t->m_dims, t->n_dims,
+                                            use_ref, dummy,
+                                            (v.m_intent != ASRUtils::intent_in &&
+                                            v.m_intent != ASRUtils::intent_inout &&
+                                            v.m_intent != ASRUtils::intent_out &&
+                                            !is_struct_type_member) || force_declare, is_fixed_size);
+                    }
                 } else {
                     bool is_fixed_size = true;
                     dims = convert_dims_c(t->n_dims, t->m_dims, v_m_type, is_fixed_size);

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -146,11 +146,15 @@ public:
                 ASR::Variable_t* mem_var = ASR::down_cast<ASR::Variable_t>(itr.second);
                 std::string mem_var_name = current_scope->get_unique_name(itr.first + std::to_string(counter));
                 counter += 1;
+                ASR::dimension_t* m_dims = nullptr;
+                size_t n_dims = ASRUtils::extract_dimensions_from_ttype(mem_type, m_dims);
                 sub += indent + convert_variable_decl(*mem_var, true, true, true, true, mem_var_name) + ";\n";
                 if( mem_var->m_abi == ASR::abiType::BindC &&
-                    ASR::is_a<ASR::Integer_t>(*mem_var->m_type) &&
-                    ASRUtils::extract_kind_from_ttype_t(mem_var->m_type) == 1 ) {
-                    sub += indent + "strcpy(" + name + "->" + itr.first + ", " + mem_var_name + ");\n";
+                    ASRUtils::is_fixed_size_array(m_dims, n_dims) ) {
+                    int64_t fixed_size_array = ASRUtils::get_fixed_size_of_array(m_dims, n_dims);
+                    sub += indent + "memcpy(" + name + "->" + itr.first + ", " + mem_var_name + ", " +
+                                std::to_string(fixed_size_array) + "*sizeof(" +
+                                CUtils::get_c_type_from_ttype_t(mem_type) + "));\n";
                 } else {
                     sub += indent + name + "->" + itr.first + " = " + mem_var_name + ";\n";
                 }
@@ -246,11 +250,11 @@ public:
                 if( is_array ) {
                     bool is_fixed_size = true;
                     dims = convert_dims_c(t->n_dims, t->m_dims, v_m_type, is_fixed_size, true);
-                    if( t->m_kind == 1 && v.m_abi == ASR::abiType::BindC && is_fixed_size ) {
+                    if( v.m_abi == ASR::abiType::BindC && is_fixed_size ) {
                         if( !force_declare ) {
                             force_declare_name = std::string(v.m_name);
                         }
-                        sub = "char " + force_declare_name + dims;
+                        sub = type_name + " " + force_declare_name + dims;
                     } else {
                         std::string encoded_type_name = "i" + std::to_string(t->m_kind * 8);
                         bool is_struct_type_member = ASR::is_a<ASR::StructType_t>(
@@ -1045,11 +1049,9 @@ R"(
         ASR::ttype_t* x_mv_type = ASRUtils::expr_type(x.m_v);
         ASR::dimension_t* m_dims;
         int n_dims = ASRUtils::extract_dimensions_from_ttype(x_mv_type, m_dims);
-        bool is_i8_array = (ASR::is_a<ASR::Integer_t>(*x_mv_type) &&
-                            ASRUtils::extract_kind_from_ttype_t(x_mv_type) == 1 &&
-                            ASRUtils::is_fixed_size_array(m_dims, n_dims) &&
-                            ASRUtils::expr_abi(x.m_v) == ASR::abiType::BindC);
-        if( is_i8_array ) {
+        bool is_data_only_array = (ASRUtils::is_fixed_size_array(m_dims, n_dims) &&
+                                   ASRUtils::expr_abi(x.m_v) == ASR::abiType::BindC);
+        if( is_data_only_array ) {
             out += "[";
         } else {
             out += "->data[";
@@ -1063,7 +1065,7 @@ R"(
                 src = "/* FIXME right index */";
             }
 
-            if( is_i8_array ) {
+            if( is_data_only_array ) {
                 current_index += src;
                 for( size_t j = i + 1; j < x.n_args; j++ ) {
                     int64_t dim_size;

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -709,34 +709,37 @@ R"(#include <stdio.h>
                                     value + ") + 1 ) * sizeof(char));\n";
                 }
                 if( ASRUtils::is_array(m_target_type) && ASRUtils::is_array(m_value_type) ) {
-                    bool is_target_i8_array = (ASR::is_a<ASR::Integer_t>(*m_target_type) &&
-                                        ASRUtils::extract_kind_from_ttype_t(m_target_type) == 1 &&
-                                        ASRUtils::expr_abi(x.m_target) == ASR::abiType::BindC);
-                    bool is_value_i8_array = (ASR::is_a<ASR::Integer_t>(*m_value_type) &&
-                                            ASRUtils::extract_kind_from_ttype_t(m_value_type) == 1 &&
-                                            ASRUtils::expr_abi(x.m_value) == ASR::abiType::BindC);
-                    bool is_target_fixed_size = false, is_value_fixed_size = false;
-                    if( is_target_i8_array ) {
-                        ASR::Integer_t* target_integer_t = ASR::down_cast<ASR::Integer_t>(m_target_type);
-                        if( ASRUtils::is_fixed_size_array(target_integer_t->m_dims, target_integer_t->n_dims) ) {
-                            is_target_fixed_size = true;
+                    ASR::dimension_t* m_target_dims = nullptr;
+                    size_t n_target_dims = ASRUtils::extract_dimensions_from_ttype(m_target_type, m_target_dims);
+                    ASR::dimension_t* m_value_dims = nullptr;
+                    size_t n_value_dims = ASRUtils::extract_dimensions_from_ttype(m_value_type, m_value_dims);
+                    bool is_target_data_only_array = (ASRUtils::expr_abi(x.m_target) == ASR::abiType::BindC &&
+                                                      ASRUtils::is_fixed_size_array(m_target_dims, n_target_dims));
+                    bool is_value_data_only_array = (ASRUtils::expr_abi(x.m_value) == ASR::abiType::BindC &&
+                                                     ASRUtils::is_fixed_size_array(m_value_dims, n_value_dims));
+                    if( is_target_data_only_array || is_value_data_only_array ) {
+                        int64_t target_size = -1, value_size = -1;
+                        if( !is_target_data_only_array ) {
+                            target = target + "->data";
+                        } else {
+                            target_size = ASRUtils::get_fixed_size_of_array(m_target_dims, n_target_dims);
                         }
-                    }
-                    if( is_value_i8_array ) {
-                        ASR::Integer_t* value_integer_t = ASR::down_cast<ASR::Integer_t>(m_value_type);
-                        if( ASRUtils::is_fixed_size_array(value_integer_t->m_dims, value_integer_t->n_dims) ) {
-                            is_value_fixed_size = true;
+                        if( !is_value_data_only_array ) {
+                            value = value + "->data";
+                        } else {
+                            value_size = ASRUtils::get_fixed_size_of_array(m_value_dims, n_value_dims);
                         }
-                    }
-                    if( (is_target_i8_array && is_target_fixed_size) ||
-                        (is_value_i8_array && is_value_fixed_size) ) {
-                        if( !(is_target_i8_array && is_target_fixed_size) ) {
-                            target = "(char*) " + target + "->data";
+                        if( target_size != -1 && value_size != -1 ) {
+                            LFORTRAN_ASSERT(target_size == value_size);
                         }
-                        if( !(is_value_i8_array && is_value_fixed_size) ) {
-                            value = "(char*) " + value + "->data";
+                        int64_t array_size = -1;
+                        if( target_size != -1 ) {
+                            array_size = target_size;
+                        } else {
+                            array_size = value_size;
                         }
-                        src += indent + "strcpy(" + target + ", " + value + ");\n";
+                        src += indent + "memcpy(" + target + ", " + value + ", " + std::to_string(array_size) + "*sizeof(" +
+                                    CUtils::get_c_type_from_ttype_t(m_target_type) + "));\n";
                     } else {
                         src += alloc + indent + c_ds_api->get_deepcopy(m_target_type, value, target) + "\n";
                     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1818,16 +1818,14 @@ public:
                 ptr_loads = ptr_loads_copy;
                 indices.push_back(tmp);
             }
-            int a_kind = ASRUtils::extract_kind_from_ttype_t(x_mv_type);
-            bool is_i8_array = (ASR::is_a<ASR::Integer_t>(*x_mv_type) && a_kind == 1 &&
-                                ASRUtils::expr_abi(x.m_v) == ASR::abiType::BindC);
+            bool is_data_only_array = ASRUtils::expr_abi(x.m_v) == ASR::abiType::BindC;
             if (ASR::is_a<ASR::Pointer_t>(*x_mv_type) ||
-                (is_i8_array && ASR::is_a<ASR::StructInstanceMember_t>(*x.m_v))) {
+                (is_data_only_array && ASR::is_a<ASR::StructInstanceMember_t>(*x.m_v))) {
                 array = CreateLoad(array);
             }
             is_data_only = is_data_only || (is_argument &&
                             !ASRUtils::is_dimension_empty(m_dims, n_dims));
-            is_data_only = is_data_only || is_i8_array;
+            is_data_only = is_data_only || is_data_only_array;
             Vec<llvm::Value*> llvm_diminfo;
             llvm_diminfo.reserve(al, 2 * x.n_args + 1);
             if( is_data_only ) {
@@ -2443,8 +2441,8 @@ public:
                 n_dims = v_type->n_dims;
                 a_kind = v_type->m_kind;
                 if( n_dims > 0 ) {
-                    if( a_kind == 1 && m_abi == ASR::abiType::BindC ) {
-                        llvm_type = llvm::Type::getInt8PtrTy(context);
+                    if( m_abi == ASR::abiType::BindC ) {
+                        llvm_type = get_el_type(asr_type)->getPointerTo();
                     } else {
                         is_array_type = true;
                         llvm::Type* el_type = get_el_type(asr_type);
@@ -2704,9 +2702,7 @@ public:
                 // Assume that struct member array is not allocatable
                 ASR::dimension_t* m_dims = nullptr;
                 size_t n_dims = ASRUtils::extract_dimensions_from_ttype(symbol_type, m_dims);
-                int a_kind = ASRUtils::extract_kind_from_ttype_t(symbol_type);
                 bool is_data_only = (ASRUtils::symbol_abi(item.second) == ASR::abiType::BindC &&
-                                    a_kind == 1 && ASR::is_a<ASR::Integer_t>(*symbol_type) &&
                                     ASRUtils::is_fixed_size_array(m_dims, n_dims));
                 fill_array_details_(ptr_member, m_dims, n_dims, false, true, false, symbol_type, is_data_only);
             } else if( ASR::is_a<ASR::Struct_t>(*symbol_type) ) {
@@ -4123,16 +4119,12 @@ public:
         if( ASRUtils::is_array(target_type) &&
             ASRUtils::is_array(value_type) &&
             ASRUtils::check_equal_type(target_type, value_type) ) {
-            int target_kind = ASRUtils::extract_kind_from_ttype_t(target_type);
-            int value_kind = ASRUtils::extract_kind_from_ttype_t(value_type);
             bool data_only_copy = false;
-            bool is_target_i8_array = (ASR::is_a<ASR::Integer_t>(*target_type) && target_kind == 1 &&
-                                    ASRUtils::expr_abi(x.m_target) == ASR::abiType::BindC);
-            bool is_value_i8_array = (ASR::is_a<ASR::Integer_t>(*value_type) && value_kind == 1 &&
-                                    ASRUtils::expr_abi(x.m_value) == ASR::abiType::BindC);
-            if( is_target_i8_array || is_value_i8_array ) {
+            bool is_target_data_only_array = ASRUtils::expr_abi(x.m_target) == ASR::abiType::BindC;
+            bool is_value_data_only_array = ASRUtils::expr_abi(x.m_value) == ASR::abiType::BindC;
+            if( is_target_data_only_array || is_value_data_only_array ) {
                 llvm::Value *target_data = nullptr, *value_data = nullptr, *llvm_size = nullptr;
-                if( is_target_i8_array ) {
+                if( is_target_data_only_array ) {
                     target_data = target;
                     ASR::dimension_t* target_dims = nullptr;
                     int target_ndims = ASRUtils::extract_dimensions_from_ttype(target_type, target_dims);
@@ -4154,7 +4146,7 @@ public:
                 } else {
                     target_data = LLVM::CreateLoad(*builder, arr_descr->get_pointer_to_data(target));
                 }
-                if( is_value_i8_array ) {
+                if( is_value_data_only_array ) {
                     value_data = value;
                     ASR::dimension_t* value_dims = nullptr;
                     int value_ndims = ASRUtils::extract_dimensions_from_ttype(value_type, value_dims);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2464,13 +2464,17 @@ public:
                 n_dims = v_type->n_dims;
                 a_kind = v_type->m_kind;
                 if( n_dims > 0 ) {
-                    is_array_type = true;
-                    llvm::Type* el_type = get_el_type(asr_type);
-                    if( m_storage == ASR::storage_typeType::Allocatable ) {
-                        is_malloc_array_type = true;
-                        llvm_type = arr_descr->get_malloc_array_type(asr_type, el_type);
+                    if( m_abi == ASR::abiType::BindC ) {
+                        llvm_type = get_el_type(asr_type)->getPointerTo();
                     } else {
-                        llvm_type = arr_descr->get_array_type(asr_type, el_type);
+                        is_array_type = true;
+                        llvm::Type* el_type = get_el_type(asr_type);
+                        if( m_storage == ASR::storage_typeType::Allocatable ) {
+                            is_malloc_array_type = true;
+                            llvm_type = arr_descr->get_malloc_array_type(asr_type, el_type);
+                        } else {
+                            llvm_type = arr_descr->get_array_type(asr_type, el_type);
+                        }
                     }
                 } else {
                     llvm_type = getFPType(a_kind);
@@ -2483,13 +2487,17 @@ public:
                 n_dims = v_type->n_dims;
                 a_kind = v_type->m_kind;
                 if( n_dims > 0 ) {
-                    is_array_type = true;
-                    llvm::Type* el_type = get_el_type(asr_type);
-                    if( m_storage == ASR::storage_typeType::Allocatable ) {
-                        is_malloc_array_type = true;
-                        llvm_type = arr_descr->get_malloc_array_type(asr_type, el_type);
+                    if( m_abi == ASR::abiType::BindC ) {
+                        llvm_type = get_el_type(asr_type)->getPointerTo();
                     } else {
-                        llvm_type = arr_descr->get_array_type(asr_type, el_type);
+                        is_array_type = true;
+                        llvm::Type* el_type = get_el_type(asr_type);
+                        if( m_storage == ASR::storage_typeType::Allocatable ) {
+                            is_malloc_array_type = true;
+                            llvm_type = arr_descr->get_malloc_array_type(asr_type, el_type);
+                        } else {
+                            llvm_type = arr_descr->get_array_type(asr_type, el_type);
+                        }
                     }
                 } else {
                     llvm_type = getComplexType(a_kind);


### PR DESCRIPTION
Corresponding LPython PR - https://github.com/lcompilers/lpython/pull/1382