### PR TITLE
Fix `sqrt(epsilon(1._dp))`

### DIFF
--- a/integration_tests/intrinsics_34.f90
+++ b/integration_tests/intrinsics_34.f90
@@ -8,6 +8,6 @@ program intrinsics_34
 
     ! Below numbers are corresponding output of gfortran and not magic numbers.
     if (abs(epsilon(x) - 1.19209290E-07) > 1e-7) error stop
-    if (abs(epsilon(y) - 2.2204460492503131E-016) > 1e-15) error stop
+    if (abs(epsilon(y) - 2.2204460492503131E-016_dp) > 1e-15_dp) error stop
     if (abs((epsilon(1._dp) ** 0.5_dp) - 1.4901161193847656E-008_dp) > 1e-15_dp) error stop
 end program

--- a/integration_tests/intrinsics_34.f90
+++ b/integration_tests/intrinsics_34.f90
@@ -9,5 +9,5 @@ program intrinsics_34
     ! Below numbers are corresponding output of gfortran and not magic numbers.
     if (abs(epsilon(x) - 1.19209290E-07) > 1e-7) error stop
     if (abs(epsilon(y) - 2.2204460492503131E-016) > 1e-15) error stop
-    if (abs((epsilon(1._dp) ** 0.5) - 1.4901161193847656E-008) > 1e-15) error stop
+    if (abs((epsilon(1._dp) ** 0.5_dp) - 1.4901161193847656E-008_dp) > 1e-15_dp) error stop
 end program

--- a/integration_tests/intrinsics_34.f90
+++ b/integration_tests/intrinsics_34.f90
@@ -1,6 +1,13 @@
 program intrinsics_34
+    integer, parameter :: dp=kind(0d0)
     real :: x = 3.143
-    real(8) :: y = 2.33
+    real(dp) :: y = 2.33
     print *, epsilon(x)
     print *, epsilon(y)
+    print *, epsilon(1._dp) ** 0.5 !Part of Minpack
+
+    ! Below numbers are corresponding output of gfortran and not magic numbers.
+    if (abs(epsilon(x) - 1.19209290E-07) > 1e-7) error stop
+    if (abs(epsilon(y) - 2.2204460492503131E-016) > 1e-15) error stop
+    if (abs((epsilon(1._dp) ** 0.5) - 1.4901161193847656E-008) > 1e-15) error stop
 end program

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -906,11 +906,11 @@ TRIG2(sqrt, dsqrt)
         }
         ASR::Real_t* t_real = ASR::down_cast<ASR::Real_t>(t);
         if( t_real->m_kind == 4 ) {
-            float epsilon_val = std::numeric_limits<float>::min();
+            float epsilon_val = std::numeric_limits<float>::epsilon();
             return ASR::down_cast<ASR::expr_t>(
                     ASR::make_RealConstant_t(al, loc, epsilon_val, t));
         } else if( t_real->m_kind == 8 ) {
-            double epsilon_val = std::numeric_limits<double>::min();
+            double epsilon_val = std::numeric_limits<double>::epsilon();
             return ASR::down_cast<ASR::expr_t>(
                     ASR::make_RealConstant_t(al, loc, epsilon_val, t));
         } else {

--- a/tests/reference/asr-intrinsics_34-daa20c0.json
+++ b/tests/reference/asr-intrinsics_34-daa20c0.json
@@ -2,11 +2,11 @@
     "basename": "asr-intrinsics_34-daa20c0",
     "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_34.f90",
-    "infile_hash": "44268c572f1e8d1a0fd2e6f429d0b261bbf840fc385ec8100a7c5a96",
+    "infile_hash": "ce6c8b5bd29d9a2c453e232989c21f29c64019b536215775b3c94229",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_34-daa20c0.stdout",
-    "stdout_hash": "a2a53fdb19572696915542b4acdd0080ab11378b76af285ded2df99f",
+    "stdout_hash": "c40a2a15a3c8eb10656e79b8d6041d7152aa5955f70cc4e88125de54",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_34-daa20c0.json
+++ b/tests/reference/asr-intrinsics_34-daa20c0.json
@@ -2,11 +2,11 @@
     "basename": "asr-intrinsics_34-daa20c0",
     "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_34.f90",
-    "infile_hash": "ce6c8b5bd29d9a2c453e232989c21f29c64019b536215775b3c94229",
+    "infile_hash": "b5ac9ea3ec2758f2b774401a5e70d007023974e74b9903bfb4bcb384",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_34-daa20c0.stdout",
-    "stdout_hash": "c40a2a15a3c8eb10656e79b8d6041d7152aa5955f70cc4e88125de54",
+    "stdout_hash": "02a71361ab3848475bc10ac09c929ca83a8ff1e15c004faa3f3abf5d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_34-daa20c0.stdout
+++ b/tests/reference/asr-intrinsics_34-daa20c0.stdout
@@ -289,17 +289,9 @@
                                         ()
                                     )
                                     Sub
-                                    (Cast
-                                        (RealConstant
-                                            0.000000
-                                            (Real 4 [])
-                                        )
-                                        RealToReal
+                                    (RealConstant
+                                        0.000000
                                         (Real 8 [])
-                                        (RealConstant
-                                            0.000000
-                                            (Real 8 [])
-                                        )
                                     )
                                     (Real 8 [])
                                     (RealConstant
@@ -315,17 +307,9 @@
                                 ()
                             )
                             Gt
-                            (Cast
-                                (RealConstant
-                                    0.000000
-                                    (Real 4 [])
-                                )
-                                RealToReal
+                            (RealConstant
+                                0.000000
                                 (Real 8 [])
-                                (RealConstant
-                                    0.000000
-                                    (Real 8 [])
-                                )
                             )
                             (Logical 4 [])
                             (LogicalConstant
@@ -360,17 +344,9 @@
                                             ()
                                         )
                                         Pow
-                                        (Cast
-                                            (RealConstant
-                                                0.500000
-                                                (Real 4 [])
-                                            )
-                                            RealToReal
+                                        (RealConstant
+                                            0.500000
                                             (Real 8 [])
-                                            (RealConstant
-                                                0.500000
-                                                (Real 8 [])
-                                            )
                                         )
                                         (Real 8 [])
                                         (RealConstant
@@ -379,17 +355,9 @@
                                         )
                                     )
                                     Sub
-                                    (Cast
-                                        (RealConstant
-                                            0.000000
-                                            (Real 4 [])
-                                        )
-                                        RealToReal
+                                    (RealConstant
+                                        0.000000
                                         (Real 8 [])
-                                        (RealConstant
-                                            0.000000
-                                            (Real 8 [])
-                                        )
                                     )
                                     (Real 8 [])
                                     (RealConstant
@@ -405,17 +373,9 @@
                                 ()
                             )
                             Gt
-                            (Cast
-                                (RealConstant
-                                    0.000000
-                                    (Real 4 [])
-                                )
-                                RealToReal
+                            (RealConstant
+                                0.000000
                                 (Real 8 [])
-                                (RealConstant
-                                    0.000000
-                                    (Real 8 [])
-                                )
                             )
                             (Logical 4 [])
                             (LogicalConstant

--- a/tests/reference/asr-intrinsics_34-daa20c0.stdout
+++ b/tests/reference/asr-intrinsics_34-daa20c0.stdout
@@ -7,11 +7,66 @@
                     (SymbolTable
                         2
                         {
+                            abs:
+                                (ExternalSymbol
+                                    2
+                                    abs
+                                    13 abs
+                                    lfortran_intrinsic_math
+                                    []
+                                    abs
+                                    Private
+                                ),
+                            abs@dabs:
+                                (ExternalSymbol
+                                    2
+                                    abs@dabs
+                                    13 dabs
+                                    lfortran_intrinsic_math
+                                    []
+                                    dabs
+                                    Private
+                                ),
+                            abs@sabs:
+                                (ExternalSymbol
+                                    2
+                                    abs@sabs
+                                    13 sabs
+                                    lfortran_intrinsic_math
+                                    []
+                                    sabs
+                                    Private
+                                ),
+                            dp:
+                                (Variable
+                                    2
+                                    dp
+                                    []
+                                    Local
+                                    (FunctionCall
+                                        2 kind
+                                        ()
+                                        [((RealConstant
+                                            0.000000
+                                            (Real 8 [])
+                                        ))]
+                                        (Integer 4 [])
+                                        (IntegerConstant 8 (Integer 4 []))
+                                        ()
+                                    )
+                                    (IntegerConstant 8 (Integer 4 []))
+                                    Parameter
+                                    (Integer 4 [])
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             epsilon:
                                 (ExternalSymbol
                                     2
                                     epsilon
-                                    4 epsilon
+                                    13 epsilon
                                     lfortran_intrinsic_math
                                     []
                                     epsilon
@@ -21,7 +76,7 @@
                                 (ExternalSymbol
                                     2
                                     epsilon@depsilon
-                                    4 depsilon
+                                    13 depsilon
                                     lfortran_intrinsic_math
                                     []
                                     depsilon
@@ -31,10 +86,20 @@
                                 (ExternalSymbol
                                     2
                                     epsilon@sepsilon
-                                    4 sepsilon
+                                    13 sepsilon
                                     lfortran_intrinsic_math
                                     []
                                     sepsilon
+                                    Private
+                                ),
+                            kind:
+                                (ExternalSymbol
+                                    2
+                                    kind
+                                    4 kind
+                                    lfortran_intrinsic_kind
+                                    []
+                                    kind
                                     Private
                                 ),
                             x:
@@ -83,7 +148,7 @@
                                 )
                         })
                     intrinsics_34
-                    []
+                    [lfortran_intrinsic_kind]
                     [(Print
                         ()
                         [(FunctionCall
@@ -115,6 +180,253 @@
                         )]
                         ()
                         ()
+                    )
+                    (Print
+                        ()
+                        [(RealBinOp
+                            (FunctionCall
+                                2 epsilon@depsilon
+                                2 epsilon
+                                [((RealConstant
+                                    1.000000
+                                    (Real 8 [])
+                                ))]
+                                (Real 8 [])
+                                (RealConstant
+                                    0.000000
+                                    (Real 8 [])
+                                )
+                                ()
+                            )
+                            Pow
+                            (Cast
+                                (RealConstant
+                                    0.500000
+                                    (Real 4 [])
+                                )
+                                RealToReal
+                                (Real 8 [])
+                                (RealConstant
+                                    0.500000
+                                    (Real 8 [])
+                                )
+                            )
+                            (Real 8 [])
+                            (RealConstant
+                                0.000000
+                                (Real 8 [])
+                            )
+                        )]
+                        ()
+                        ()
+                    )
+                    (If
+                        (RealCompare
+                            (FunctionCall
+                                2 abs@sabs
+                                2 abs
+                                [((RealBinOp
+                                    (FunctionCall
+                                        2 epsilon@sepsilon
+                                        2 epsilon
+                                        [((Var 2 x))]
+                                        (Real 4 [])
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4 [])
+                                        )
+                                        ()
+                                    )
+                                    Sub
+                                    (RealConstant
+                                        0.000000
+                                        (Real 4 [])
+                                    )
+                                    (Real 4 [])
+                                    (RealConstant
+                                        -0.000000
+                                        (Real 4 [])
+                                    )
+                                ))]
+                                (Real 4 [])
+                                (RealConstant
+                                    0.000000
+                                    (Real 4 [])
+                                )
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000000
+                                (Real 4 [])
+                            )
+                            (Logical 4 [])
+                            (LogicalConstant
+                                .false.
+                                (Logical 4 [])
+                            )
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (RealCompare
+                            (FunctionCall
+                                2 abs@dabs
+                                2 abs
+                                [((RealBinOp
+                                    (FunctionCall
+                                        2 epsilon@depsilon
+                                        2 epsilon
+                                        [((Var 2 y))]
+                                        (Real 8 [])
+                                        (RealConstant
+                                            0.000000
+                                            (Real 8 [])
+                                        )
+                                        ()
+                                    )
+                                    Sub
+                                    (Cast
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4 [])
+                                        )
+                                        RealToReal
+                                        (Real 8 [])
+                                        (RealConstant
+                                            0.000000
+                                            (Real 8 [])
+                                        )
+                                    )
+                                    (Real 8 [])
+                                    (RealConstant
+                                        0.000000
+                                        (Real 8 [])
+                                    )
+                                ))]
+                                (Real 8 [])
+                                (RealConstant
+                                    0.000000
+                                    (Real 8 [])
+                                )
+                                ()
+                            )
+                            Gt
+                            (Cast
+                                (RealConstant
+                                    0.000000
+                                    (Real 4 [])
+                                )
+                                RealToReal
+                                (Real 8 [])
+                                (RealConstant
+                                    0.000000
+                                    (Real 8 [])
+                                )
+                            )
+                            (Logical 4 [])
+                            (LogicalConstant
+                                .false.
+                                (Logical 4 [])
+                            )
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (RealCompare
+                            (FunctionCall
+                                2 abs@dabs
+                                2 abs
+                                [((RealBinOp
+                                    (RealBinOp
+                                        (FunctionCall
+                                            2 epsilon@depsilon
+                                            2 epsilon
+                                            [((RealConstant
+                                                1.000000
+                                                (Real 8 [])
+                                            ))]
+                                            (Real 8 [])
+                                            (RealConstant
+                                                0.000000
+                                                (Real 8 [])
+                                            )
+                                            ()
+                                        )
+                                        Pow
+                                        (Cast
+                                            (RealConstant
+                                                0.500000
+                                                (Real 4 [])
+                                            )
+                                            RealToReal
+                                            (Real 8 [])
+                                            (RealConstant
+                                                0.500000
+                                                (Real 8 [])
+                                            )
+                                        )
+                                        (Real 8 [])
+                                        (RealConstant
+                                            0.000000
+                                            (Real 8 [])
+                                        )
+                                    )
+                                    Sub
+                                    (Cast
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4 [])
+                                        )
+                                        RealToReal
+                                        (Real 8 [])
+                                        (RealConstant
+                                            0.000000
+                                            (Real 8 [])
+                                        )
+                                    )
+                                    (Real 8 [])
+                                    (RealConstant
+                                        0.000000
+                                        (Real 8 [])
+                                    )
+                                ))]
+                                (Real 8 [])
+                                (RealConstant
+                                    0.000000
+                                    (Real 8 [])
+                                )
+                                ()
+                            )
+                            Gt
+                            (Cast
+                                (RealConstant
+                                    0.000000
+                                    (Real 4 [])
+                                )
+                                RealToReal
+                                (Real 8 [])
+                                (RealConstant
+                                    0.000000
+                                    (Real 8 [])
+                                )
+                            )
+                            (Logical 4 [])
+                            (LogicalConstant
+                                .false.
+                                (Logical 4 [])
+                            )
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
                     )]
                 ),
             iso_c_binding:
@@ -123,6 +435,8 @@
                 (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
             lfortran_intrinsic_builtin:
                 (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_kind:
+                (IntrinsicModule lfortran_intrinsic_kind),
             lfortran_intrinsic_math:
                 (IntrinsicModule lfortran_intrinsic_math)
         })


### PR DESCRIPTION
Fixes #1122.
With this, we get [`minpack/example_lmdif1`](https://github.com/certik/minpack/blob/scipy21/examples/example_lmdif1.f90) aligned with GFortran by every bit.

Clean PR for #1176.