### PR TITLE
CI: test Minpack with every commit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -181,6 +181,54 @@ jobs:
             cd integration_tests
             ./run_tests.py -b llvm
 
+  minpack:
+    name: Check Minpack Compilation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/provision-with-micromamba@v12
+        with:
+          environment-file: ci/environment_linux.yml
+          extra-specs: |
+            python=3.10
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-${{ matrix.os }}
+
+      - name: Build Linux
+        shell: bash -l {0}
+        run: |
+            ./build0.sh
+            cmake . -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_LLVM=yes \
+              -DLFORTRAN_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+            cmake --build . -j16 --target install
+
+      - name: Test Minpack
+        shell: bash -x -l {0}
+        run: |
+            git clone https://github.com/certik/minpack.git
+            cd minpack
+            git checkout scipy24
+            git checkout c5b5f86be92fd80aa0449aa24a44d6209b277633
+            mkdir lf
+            cd lf
+            FC=$(PWD)/../../src/bin/lfortran cmake ..
+            make
+            examples/example_hybrd
+
   test_llvm_10:
     name: Test LLVM 10
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,7 +225,7 @@ jobs:
             git checkout c5b5f86be92fd80aa0449aa24a44d6209b277633
             mkdir lf
             cd lf
-            FC=$(PWD)/../../src/bin/lfortran cmake ..
+            FC=$(pwd)/../../src/bin/lfortran cmake ..
             make
             examples/example_hybrd
 


### PR DESCRIPTION
This uses the scipy24 branch of Minpack at https://github.com/certik/minpack, it currently has a few commits as a workaround, and each such commit has a link to the LFortran issue that we need to fix. The workarounds are very small.