### PR TITLE
Synchronizing libasr's template instantiation with LPython

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3693,8 +3693,6 @@ public:
 
             asr = ASR::make_IntegerBinOp_t(al, x.base.base.loc, left, op, right, dest_type, value);
 
-        } else if (ASRUtils::is_generic(*left_type) || ASRUtils::is_generic(*right_type)){
-            asr = ASR::make_TemplateBinOp_t(al, x.base.base.loc, left, op, right, dest_type, value);
         } else if (ASRUtils::is_real(*dest_type)) {
 
             if (ASRUtils::expr_value(left) != nullptr && ASRUtils::expr_value(right) != nullptr) {

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -248,7 +248,6 @@ expr
     | LogicalNot(expr arg, ttype type, expr? value)
     | LogicalCompare(expr left, cmpop op, expr right, ttype type, expr? value)
     | LogicalBinOp(expr left, logicalbinop op, expr right, ttype type, expr? value)
-    | TemplateBinOp(expr left, binop op, expr right, ttype type, expr? value)
 
     | ListConstant(expr* args, ttype type)
     | ListLen(expr arg, ttype type, expr? value)

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -243,34 +243,6 @@ public:
         ASR::expr_t* value = duplicate_expr(x->m_value);
         ASR::expr_t* dt = duplicate_expr(x->m_dt);
         std::string call_name = ASRUtils::symbol_name(x->m_name);
-        if ((name && ASRUtils::is_restriction_function(name) && rt_subs.find(call_name) == rt_subs.end()) ||
-            !name) {
-            if (call_name.compare("add") == 0) {
-                ASR::expr_t* left_arg = duplicate_expr(x->m_args[0].m_value);
-                ASR::expr_t* right_arg = duplicate_expr(x->m_args[1].m_value);
-                ASR::ttype_t* left_type = substitute_type(ASRUtils::expr_type(left_arg));
-                ASR::ttype_t* right_type = substitute_type(ASRUtils::expr_type(right_arg));
-                if ((ASRUtils::is_integer(*left_type) && ASRUtils::is_integer(*right_type)) ||
-                        (ASRUtils::is_real(*left_type) && ASRUtils::is_real(*right_type))) {
-                    return make_BinOp_helper(left_arg, right_arg, ASR::binopType::Add, x->base.base.loc);
-                } else {
-                    throw SemanticError("Intrinsic plus not yet supported for this type", x->base.base.loc);
-                }
-            } else if (call_name.compare("zero") == 0) {
-                ASR::expr_t* arg = duplicate_expr(x->m_args[0].m_value);
-                ASR::ttype_t* arg_type = substitute_type(ASRUtils::expr_type(arg));
-                if (ASRUtils::is_integer(*arg_type)) {
-                    return ASR::make_IntegerConstant_t(al, x->base.base.loc, 0, arg_type);
-                } else if (ASRUtils::is_real(*arg_type)) {
-                    return ASR::make_RealConstant_t(al, x->base.base.loc, 0, arg_type);
-                }
-            } else if (call_name.compare("div") == 0) {
-                ASR::expr_t* left_arg = duplicate_expr(x->m_args[0].m_value);
-                ASR::expr_t* right_arg = duplicate_expr(x->m_args[1].m_value);
-                return make_BinOp_helper(left_arg, right_arg, ASR::binopType::Div, x->base.base.loc);
-            }
-            LCOMPILERS_ASSERT(false); // should never happen
-        }
         if (ASRUtils::is_restriction_function(name)) {
             name = rt_subs[call_name];
         } else if (ASRUtils::is_generic_function(name)) {

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -246,7 +246,7 @@ public:
         if (ASRUtils::is_restriction_function(name)) {
             name = rt_subs[call_name];
         } else if (ASRUtils::is_generic_function(name)) {
-            std::string nested_func_name = "__lfortran_generic_" + sym_name;
+            std::string nested_func_name = "__asr_generic_" + sym_name;
             ASR::symbol_t* name2 = ASRUtils::symbol_get_past_external(name);
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(name2);
             FunctionInstantiator nested_tf(al, subs, rt_subs, func_scope, nested_func_name);

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -204,12 +204,6 @@ public:
         return ASR::make_Assignment_t(al, x->base.base.loc, target, value, overloaded);
     }
 
-    ASR::asr_t* duplicate_TemplateBinOp(ASR::TemplateBinOp_t *x) {
-        ASR::expr_t *left = duplicate_expr(x->m_left);
-        ASR::expr_t *right = duplicate_expr(x->m_right);
-        return make_BinOp_helper(left, right, x->m_op, x->base.base.loc);
-    }
-
     ASR::asr_t* duplicate_DoLoop(ASR::DoLoop_t *x) {
         Vec<ASR::stmt_t*> m_body;
         m_body.reserve(al, x->n_body);

--- a/tests/reference/asr-template_nested-3a03184.json
+++ b/tests/reference/asr-template_nested-3a03184.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_nested-3a03184.stdout",
-    "stdout_hash": "768d0a1b19c9aa9b1fb26e5c9c41a49d178522372970353c8a375d5f",
+    "stdout_hash": "4930bc780244deb6183463fc21ec2b0b1438fb6ca9a36de149e1fd6b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_nested-3a03184.stdout
+++ b/tests/reference/asr-template_nested-3a03184.stdout
@@ -90,7 +90,7 @@
                     (SymbolTable
                         2
                         {
-                            __lfortran_generic_add_generic:
+                            __asr_generic_add_generic:
                                 (Function
                                     (SymbolTable
                                         11
@@ -141,7 +141,7 @@
                                                     .false.
                                                 )
                                         })
-                                    __lfortran_generic_add_generic
+                                    __asr_generic_add_generic
                                     [func_arg_real]
                                     [(Var 11 x)
                                     (Var 11 y)]
@@ -321,13 +321,13 @@
                                                 )
                                         })
                                     add_real
-                                    [__lfortran_generic_add_generic]
+                                    [__asr_generic_add_generic]
                                     [(Var 10 x)
                                     (Var 10 y)]
                                     [(=
                                         (Var 10 z)
                                         (FunctionCall
-                                            2 __lfortran_generic_add_generic
+                                            2 __asr_generic_add_generic
                                             ()
                                             [((Var 10 x))
                                             ((Var 10 y))]

--- a/tests/reference/asr-template_travel-f827c57.json
+++ b/tests/reference/asr-template_travel-f827c57.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_travel-f827c57.stdout",
-    "stdout_hash": "f029519dd6bbb61c92a51550e1cf757cf846b3ffe2723a56a502a147",
+    "stdout_hash": "1f113d65539464b964a9462e2c4bb445e861ad7424a1772a54b498ee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_travel-f827c57.stdout
+++ b/tests/reference/asr-template_travel-f827c57.stdout
@@ -313,7 +313,7 @@
                     (SymbolTable
                         15
                         {
-                            __lfortran_generic_avg_s_from_t:
+                            __asr_generic_avg_s_from_t:
                                 (Function
                                     (SymbolTable
                                         20
@@ -394,7 +394,7 @@
                                                     .false.
                                                 )
                                         })
-                                    __lfortran_generic_avg_s_from_t
+                                    __asr_generic_avg_s_from_t
                                     [add_real
                                     slash_real]
                                     [(Var 20 d1)
@@ -536,7 +536,7 @@
                                                 )
                                         })
                                     avg_real_s_from_s
-                                    [__lfortran_generic_avg_s_from_t
+                                    [__asr_generic_avg_s_from_t
                                     slash_real]
                                     [(Var 19 d1)
                                     (Var 19 s1)
@@ -545,7 +545,7 @@
                                     [(=
                                         (Var 19 avg)
                                         (FunctionCall
-                                            15 __lfortran_generic_avg_s_from_t
+                                            15 __asr_generic_avg_s_from_t
                                             ()
                                             [((Var 19 d1))
                                             ((FunctionCall


### PR DESCRIPTION
#1199: unify `instantiate_Function`
Removed functionalities unique to LPython from the template instantiation in libasr.