### PR TITLE
Improving error message for templates

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3449,10 +3449,12 @@ public:
                             std::string dtype = ASRUtils::type_to_str(dest_type);
                             std::string stype = ASRUtils::type_to_str(source_type);
                             diag.add(Diagnostic(
-                                "Type mismatch in function call, the types must be compatible",
+                                "Type mismatch in function call, the function expects '" + dtype + "' but '" + stype + "' was provided",
                                 Level::Error, Stage::Semantic, {
-                                    Label("type mismatch (" + dtype + " and " + stype + ")",
-                                            {dest->base.loc, source->base.loc})
+                                    Label("type '" + dtype + "' expected, but '" + stype + "' provided",
+                                            {source->base.loc}),
+                                    Label("function definition has parameter type '" + dtype + "'",
+                                            {dest->base.loc})
                                 })
                             );
                             throw SemanticAbort();

--- a/tests/reference/asr-template_error-8ad11a2.json
+++ b/tests/reference/asr-template_error-8ad11a2.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-template_error-8ad11a2.stderr",
-    "stderr_hash": "27c1015e0ed37c6c600e20e629e701556b055bfad085c8652393b892",
+    "stderr_hash": "36382e910aa933ecabf5eabb543294d95005bb2d6aaa5ec924dc70ad",
     "returncode": 2
 }

--- a/tests/reference/asr-template_error-8ad11a2.stderr
+++ b/tests/reference/asr-template_error-8ad11a2.stderr
@@ -1,12 +1,12 @@
-semantic error: Type mismatch in function call, the types must be compatible
-  --> tests/errors/template_error.f90:45:9 - 50:1
+semantic error: Type mismatch in function call, the function expects 't' but 's' was provided
+  --> tests/errors/template_error.f90:75:55
+   |
+75 |             avg = avg_S_from_T(d1, D_divided_by_T(d1, s1), d2, D_divided_by_S(d2, s2))
+   |                                                       ^^ type 't' expected, but 's' provided
    |
 45 |            pure function D_divided_by_T(n, d) result(quotient)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
    |
 50 |    
-   | ...^ type mismatch (t and s)
-   |
-75 |             avg = avg_S_from_T(d1, D_divided_by_T(d1, s1), d2, D_divided_by_S(d2, s2))
-   |                                                       ^^ type mismatch (t and s)
+   | ...^ function definition has parameter type 't'


### PR DESCRIPTION
Building on #1168, changing the error message for functions in templates to be more legible.