### PR TITLE
CI: Only compile if the mod file does not exist

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -159,7 +159,9 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, update_reference: bool
 
                 if len(extrafile_) > 0:
                     extrafile_ = os.path.join("tests", extrafile_)
-                    run_cmd("lfortran -c {}".format(extrafile_))
+                    modfile = extrafile_[:-4] + ".mod"
+                    if not os.path.exists(modfile):
+                        run_cmd("lfortran -c {}".format(extrafile_))
 
             if not skip_test:
                 run_test(


### PR DESCRIPTION
This is not the full fix, as it can still fail if the other process is still writing the mod file and we are already reading it. The robust solution is to name the mod file uniquely per test and use it. That requires more extensive modification.

Also currently the mod files are saved in the current directory, which is not clean. The mod files should be stored in `tests/output`.

Towards #1218.