### PR TITLE
CI: test Minpack's primes example

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -221,8 +221,8 @@ jobs:
         run: |
             git clone https://github.com/certik/minpack.git
             cd minpack
-            git checkout scipy26
-            git checkout 8b7559cfbc893de34f1fc9746d5f4d0c83b13431
+            git checkout scipy28
+            git checkout 6ae1a5db4377168f347526a491a37c18f200e8ac
             mkdir lf
             cd lf
             FC=$(pwd)/../../src/bin/lfortran cmake ..


### PR DESCRIPTION
We reworked this example to compile with LFortran. This example was written by me, so it is up to us how we do it, and in this test we are focusing on Minpack, not other unrelated features.

This example uncovered issue #1224, so for now we modified Minpack to use `x**0.5` instead of sqrt(), in order to get exactly the same results with LFortran and GFortran. After we implement sqrt() directly (not using x**0.5), we can revert the Minpack workaround.