### PR TITLE
ASR: Add IntrinsicFunctionSqrt

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2934,6 +2934,24 @@ public:
         return ASR::make_Iachar_t(al, x.base.base.loc, arg, type, iachar_value);
     }
 
+    ASR::asr_t* create_IntrinsicFunctionSqrt(const AST::FuncCallOrArray_t& x) {
+        std::vector<ASR::expr_t*> args;
+        std::vector<std::string> kwarg_names;
+        handle_intrinsic_node_args(x, args, kwarg_names, 1, 1, "sqrt");
+        ASR::expr_t *arg = args[0];
+        int64_t kind_value = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(arg));
+        ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc,
+                                kind_value, nullptr, 0));
+        ASR::expr_t* sqrt_value = nullptr;
+        ASR::expr_t* arg_value = ASRUtils::expr_value(arg);
+        if( arg_value ) {
+            double rv = ASR::down_cast<ASR::RealConstant_t>(arg_value)->m_r;
+            sqrt_value = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc,
+                                std::sqrt(rv), type));
+        }
+        return ASR::make_IntrinsicFunctionSqrt_t(al, x.base.base.loc, arg, type, sqrt_value);
+    }
+
     ASR::asr_t* create_ScanVerify_util(const AST::FuncCallOrArray_t& x, std::string func_name) {
         ASR::expr_t *string, *set, *back, *kind;
         ASR::ttype_t *type;
@@ -3023,6 +3041,8 @@ public:
                 tmp = create_NullPointerConstant(x);
             } else if( var_name == "associated" ) {
                 tmp = create_Associated(x);
+            } else if( var_name == "_lfortran_sqrt" ) {
+                tmp = create_IntrinsicFunctionSqrt(x);
             } else {
                 LCompilersException("create_" + var_name + " not implemented yet.");
             }

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -27,7 +27,7 @@ struct IntrinsicProceduresAsASRNodes {
             intrinsics_present_in_ASR = {"size", "lbound", "ubound",
                 "transpose", "matmul", "pack", "transfer", "cmplx",
                 "dcmplx", "reshape", "ichar", "iachar", "maxloc",
-                "null", "associated"};
+                "null", "associated", "_lfortran_sqrt"};
 
             kind_based_intrinsics = {"scan", "verify"};
         }

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -319,6 +319,8 @@ expr
     | PointerNullConstant(ttype type)
     | PointerAssociated(expr ptr, expr? tgt, ttype type, expr? value)
 
+    | IntrinsicFunctionSqrt(expr arg, ttype type, expr? value)
+
 
 -- `len` in Character:
 -- >=0 ... the length of the string, known at compile time

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1162,6 +1162,17 @@ public:
         src += indent + "exit(1)\n";
     }
 
+    void visit_IntrinsicFunctionSqrt(const ASR::IntrinsicFunctionSqrt_t &x) {
+        /*
+        if (x.m_value) {
+            this->visit_expr(*x.m_value);
+            return;
+        }
+        */
+        this->visit_expr(*x.m_arg);
+        src = "sqrt(" + src + ")";
+    }
+
     void visit_ImpliedDoLoop(const ASR::ImpliedDoLoop_t& /*x*/)
     {
         std::string indent(indentation_level * indentation_spaces, ' ');

--- a/src/runtime/impure/lfortran_intrinsic_math.f90
+++ b/src/runtime/impure/lfortran_intrinsic_math.f90
@@ -229,20 +229,12 @@ end function
 
 elemental real(sp) function ssqrt(x) result(r)
 real(sp), intent(in) :: x
-if (x >= 0) then
-    r = x**(1._sp/2)
-else
-    error stop "sqrt(x) for x < 0 is not allowed"
-end if
+r = _lfortran_sqrt(x)
 end function
 
 elemental real(dp) function dsqrt(x) result(r)
 real(dp), intent(in) :: x
-if (x >= 0) then
-    r = x**(1._dp/2)
-else
-    error stop "sqrt(x) for x < 0 is not allowed"
-end if
+r = _lfortran_sqrt(x)
 end function
 
 elemental complex(sp) function csqrt(x) result(r)

--- a/tests/reference/julia-arrays_02-849d7b0.json
+++ b/tests/reference/julia-arrays_02-849d7b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "julia-arrays_02-849d7b0.stdout",
-    "stdout_hash": "bd215e16c4ff930ada33791182bddfd8bd27c401b70ed09c1b31facb",
+    "stdout_hash": "4647ef592cce4ad7702e8c2eb76086605d7856d7395e30d106d06f6a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/julia-arrays_02-849d7b0.stdout
+++ b/tests/reference/julia-arrays_02-849d7b0.stdout
@@ -442,12 +442,7 @@ end
 
 function dsqrt(x::Float64)::Float64
     local r::Float64 = 0.0
-    if x ≥ Float64(0)
-        r = x ^ (  1.00000000000000000e+00 / Float64(2))
-    else
-        println(Base.stderr, "ERROR STOP")
-        exit(1)
-    end
+    r = sqrt(x)
     return r
 end
 
@@ -731,12 +726,7 @@ end
 
 function ssqrt(x::Float32)::Float32
     local r::Float32 = 0.0
-    if x ≥ Float32(0)
-        r = x ^ (  1.00000000000000000e+00 / Float32(2))
-    else
-        println(Base.stderr, "ERROR STOP")
-        exit(1)
-    end
+    r = sqrt(x)
     return r
 end
 


### PR DESCRIPTION
Construct IntrinsicFunctionSqrt in the frontend, implement in LLVM and Julia backends. All integration tests pass. Reference tests updated.

This change allows Minpack to reproduce exactly the same results as GFortran.

Fixes #1224.