### PR TITLE
CI: run run_tests in serial

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -177,7 +177,7 @@ jobs:
         shell: bash -l {0}
         run: |
             ctest
-            ./run_tests.py
+            ./run_tests.py -s
             cd integration_tests
             ./run_tests.py -b llvm
 

--- a/ci/build.xsh
+++ b/ci/build.xsh
@@ -120,7 +120,7 @@ src/bin/lfortran integration_tests/intrinsics_04.f90 -o intrinsics_04
 # Run all tests (does not work on Windows yet):
 cmake --version
 if not $IS_WIN:
-    ./run_tests.py
+    ./run_tests.py -s
 
     cd integration_tests
     mkdir build-lfortran-llvm

--- a/ci/test.xsh
+++ b/ci/test.xsh
@@ -41,7 +41,7 @@ src/bin/lfortran integration_tests/intrinsics_04.f90 -o intrinsics_04
 # Run all tests (does not work on Windows yet):
 cmake --version
 if not $IS_WIN:
-    ./run_tests.py
+    ./run_tests.py -s
 
     cd integration_tests
     mkdir build-lfortran-llvm


### PR DESCRIPTION
This should make the tests hopefully robust at the CI. The parallel race conditions are still there and need to be fixed eventually.

Towards #1218 and #1229.