### PR TITLE
Add provision to disallow importing private variables.

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1354,16 +1354,19 @@ public:
                 current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(ep));
             } else if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *mvar = ASR::down_cast<ASR::Variable_t>(item.second);
-                ASR::asr_t *var = ASR::make_ExternalSymbol_t(
-                    al, mvar->base.base.loc,
-                    /* a_symtab */ current_scope,
-                    /* a_name */ mvar->m_name,
-                    (ASR::symbol_t*)mvar,
-                    m->m_name, nullptr, 0, mvar->m_name,
-                    dflt_access
-                    );
-                std::string sym = to_lower(mvar->m_name);
-                current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(var));
+                // check if m_access of mvar is public
+                if ( mvar->m_access == ASR::accessType::Public ) {
+                    ASR::asr_t *var = ASR::make_ExternalSymbol_t(
+                        al, mvar->base.base.loc,
+                        /* a_symtab */ current_scope,
+                        /* a_name */ mvar->m_name,
+                        (ASR::symbol_t*)mvar,
+                        m->m_name, nullptr, 0, mvar->m_name,
+                        dflt_access
+                        );
+                    std::string sym = to_lower(mvar->m_name);
+                    current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(var));
+                }
             } else if (ASR::is_a<ASR::ExternalSymbol_t>(*item.second)) {
                 // We have to "repack" the ExternalSymbol so that it lives in the
                 // local symbol table

--- a/tests/errors/private1.f90
+++ b/tests/errors/private1.f90
@@ -1,0 +1,24 @@
+module foo1
+
+    private
+
+    real :: x = 1
+
+end module
+
+module foo2
+
+    use foo1
+
+    real :: y = 2
+
+end module
+
+program test
+
+    use foo2
+
+    x = 5
+    write(*,*) x, y
+
+end program

--- a/tests/reference/asr-private1-d595bcb.json
+++ b/tests/reference/asr-private1-d595bcb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-private1-d595bcb",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/private1.f90",
+    "infile_hash": "2d80d22188cbb5b29b17cef6855c9098194d5fe89b0bf9b14d7a8af2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-private1-d595bcb.stderr",
+    "stderr_hash": "cedaa206aa9e964748ccb604498e30d1fc7d09fbb7c67218381a600d",
+    "returncode": 2
+}

--- a/tests/reference/asr-private1-d595bcb.stderr
+++ b/tests/reference/asr-private1-d595bcb.stderr
@@ -1,0 +1,5 @@
+semantic error: Variable 'x' is not declared
+  --> tests/errors/private1.f90:21:5
+   |
+21 |     x = 5
+   |     ^ 'x' is undeclared

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2791,3 +2791,7 @@ asr = true
 [[test]]
 filename = "allow_implicit_interface3.f90"
 asr_implicit_interface = true
+
+[[test]]
+filename = "errors/private1.f90"
+asr = true


### PR DESCRIPTION
Fixes #1239.

As of now, I made a check for only `Variable_t`.