### PR TITLE
Disallow access to private variables `use foo, only:y`

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1577,6 +1577,9 @@ public:
             Str name;
             name.from_str(al, local_sym);
             char *cname = name.c_str(al);
+            if (mv->m_access == ASR::accessType::Private) {
+                throw SemanticError("Private variable `" + local_sym + "` cannot be imported", loc);
+            }
             ASR::asr_t *v = ASR::make_ExternalSymbol_t(
                 al, mv->base.base.loc,
                 /* a_symtab */ current_scope,

--- a/tests/errors/private2.f90
+++ b/tests/errors/private2.f90
@@ -1,0 +1,9 @@
+module foo2
+    private
+    real :: y = 2
+end module
+    
+program test
+    use foo2, only: y
+    print *, y
+end program

--- a/tests/reference/asr-private2-2935bf3.json
+++ b/tests/reference/asr-private2-2935bf3.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-private2-2935bf3",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/private2.f90",
+    "infile_hash": "34984962bf015cefb96abba7000799bbabd4618eb80e4484fb5ca4bd",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-private2-2935bf3.stderr",
+    "stderr_hash": "4c2f89bda14c9decfc88e5a2793f7faa82c2dfc93b0264d7eeb2f1ff",
+    "returncode": 2
+}

--- a/tests/reference/asr-private2-2935bf3.stderr
+++ b/tests/reference/asr-private2-2935bf3.stderr
@@ -1,0 +1,5 @@
+semantic error: Private variable `y` cannot be imported
+ --> tests/errors/private2.f90:7:5
+  |
+7 |     use foo2, only: y
+  |     ^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2795,3 +2795,7 @@ asr_implicit_interface = true
 [[test]]
 filename = "errors/private1.f90"
 asr = true
+
+[[test]]
+filename = "errors/private2.f90"
+asr = true


### PR DESCRIPTION
Fixes #1250.