### PR TITLE
Fixed-form tokenizer: handle CR properly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.sh text eol=lf
+tests/**/*.f90 -text
+tests/**/*.f -text

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1,3 +1,11 @@
+/*
+This is a fixed-form tokenizer. It accepts a prescanned source code that removes
+all whitespace.  It uses a hand written recursive descent parser to figure out
+how to properly tokenize the input. It returns a list of tokens that are then
+fed ioto our Bison parser, that is shared with the free-form parser.
+
+Note: The prescanner removes CR, so we only handle LF here.
+*/
 #include <limits>
 #include <utility>
 

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -336,10 +336,9 @@ struct FixedFormRecursiveDescent {
     bool next_is_eol(unsigned char *cur) {
         if (*cur == '\n') {
             return true;
-        } else if (*cur == '\r' && *(cur+1) == '\n') {
-            return true;
+        } else {
+            return false;
         }
-        return false;
     }
 
     bool is_integer(const std::string &s) const {
@@ -872,7 +871,7 @@ struct FixedFormRecursiveDescent {
                 // If we are at the end of the statement, then this must
                 // be a function call. Otherwise it's something else,
                 // such as assignment (=, or =>).
-                if (*cur == '\n' || *cur == ';') {
+                if (next_is_eol(cur) || *cur == ';') {
                     return true;
                 }
             }

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -173,7 +173,7 @@ LineType determine_line_type(const unsigned char *pos)
             pos++;
             col+=1;
         }
-        if (*pos == '\n' || *pos == '\0') return LineType::Comment;
+        if (*pos == '\n' || *pos == '\0' || (*pos == '\r' && *(pos+1) == '\n')) return LineType::Comment;
         if (*pos == '!' && col != 6) return LineType::Comment;
         if (col == 6) {
             if (*pos == ' ' || *pos == '0') {
@@ -253,6 +253,11 @@ void copy_rest_of_line(std::string &out, const std::string &s, size_t &pos,
             return;
         } else if (s[pos] == ' ') {
             // Skip white space in a fixed-form parser
+            pos++;
+            lm.files.back().out_start.push_back(out.size());
+            lm.files.back().in_start.push_back(pos);
+        } else if (s[pos] == '\r') {
+            // Skip CR in a fixed-form parser
             pos++;
             lm.files.back().out_start.push_back(out.size());
             lm.files.back().in_start.push_back(pos);

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -348,9 +348,10 @@ std::string prescan(const std::string &s, LocationManager &lm,
          *
          *   * Removes all whitespace
          *   * Joins continuation lines
-         *   * Removes comments
+         *   * Removes comments and empty lines
          *   * Handles the first 6 columns
          *   * Converts to lowercase
+         *   * Removes all CR characters
          *
          * features which are currently not yet implemented:
          *

--- a/tests/fixed_form/crlf1.f
+++ b/tests/fixed_form/crlf1.f
@@ -1,0 +1,4 @@
+      PROGRAM p
+
+      CALL f()
+      END

--- a/tests/reference/ast-crlf1-0461359.json
+++ b/tests/reference/ast-crlf1-0461359.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-crlf1-0461359",
+    "cmd": "lfortran --indent --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/fixed_form/crlf1.f",
+    "infile_hash": "137ef00eb5d20b96070b7a3753e6f4e2967db640fd0fad4f8f1aeeae",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "ast-crlf1-0461359.stdout",
+    "stdout_hash": "3a60c9dd71688dcba2e3415e5505feb9648222568bd06f5bd3d7cdc8",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/ast-crlf1-0461359.stdout
+++ b/tests/reference/ast-crlf1-0461359.stdout
@@ -1,0 +1,18 @@
+(TranslationUnit
+    [(Program
+        p
+        ()
+        []
+        []
+        []
+        [(SubroutineCall
+            0
+            f
+            []
+            []
+            []
+            ()
+        )]
+        []
+    )]
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2612,6 +2612,10 @@ filename = "fixed_form/error_stop2.f"
 ast = true
 
 [[test]]
+filename = "fixed_form/crlf1.f"
+ast = true
+
+[[test]]
 filename = "parameter1.f90"
 ast = true
 asr = true


### PR DESCRIPTION
We remove CR in the fixed-form prescanner, and in the fixed-form tokenizer we only handle LF, not CR. This seems to robustly parse fixed-form input source code with CRLF.

Fixes #1252.