### PR TITLE
Add provision to visit "stmt" in "BlockCall_t"

### DIFF
--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -211,6 +211,16 @@ public:
         require(symtab_in_scope(current_symtab, x.m_m),
             "Block " + std::string(ASRUtils::symbol_name(x.m_m)) +
             " should resolve in current scope.");
+        SymbolTable *parent_symtab = current_symtab;
+        ASR::Block_t* block = ASR::down_cast<ASR::Block_t>(x.m_m);
+        if ( block ) {
+            current_symtab = block->m_symtab;
+            for (size_t i=0; i<block->n_body; i++) {
+                visit_stmt(*(block->m_body[i]));
+            }
+            current_symtab = parent_symtab;
+        }
+
     }
 
     void visit_Module(const Module_t &x) {

--- a/tests/block2.f90
+++ b/tests/block2.f90
@@ -1,0 +1,15 @@
+subroutine hybrd()
+    implicit none
+    real :: ratio, delta
+
+    interface 
+        subroutine fcn(n)
+        integer, intent(in) :: n
+        end subroutine fcn
+    end interface
+
+    main : block
+        delta = abs(ratio)
+    end block main
+
+end subroutine

--- a/tests/reference/asr-block2-2b330cc.json
+++ b/tests/reference/asr-block2-2b330cc.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-block2-2b330cc",
+    "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/block2.f90",
+    "infile_hash": "f226e55b99771ba4b72596b4730aff7cc4a90424918f2b71111d33f1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-block2-2b330cc.stdout",
+    "stdout_hash": "a0914d5b50bd0300e57b24a575b90243f6312b3c8a0b82daef993a80",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-block2-2b330cc.stdout
+++ b/tests/reference/asr-block2-2b330cc.stdout
@@ -1,0 +1,151 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            hybrd:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            block:
+                                (Block
+                                    (SymbolTable
+                                        4
+                                        {
+                                            abs:
+                                                (ExternalSymbol
+                                                    4
+                                                    abs
+                                                    6 abs
+                                                    lfortran_intrinsic_math
+                                                    []
+                                                    abs
+                                                    Private
+                                                ),
+                                            abs@sabs:
+                                                (ExternalSymbol
+                                                    4
+                                                    abs@sabs
+                                                    6 sabs
+                                                    lfortran_intrinsic_math
+                                                    []
+                                                    sabs
+                                                    Private
+                                                )
+                                        })
+                                    block
+                                    [(=
+                                        (Var 2 delta)
+                                        (FunctionCall
+                                            4 abs@sabs
+                                            4 abs
+                                            [((Var 2 ratio))]
+                                            (Real 4 [])
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                ),
+                            delta:
+                                (Variable
+                                    2
+                                    delta
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4 [])
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            fcn:
+                                (Function
+                                    (SymbolTable
+                                        3
+                                        {
+                                            n:
+                                                (Variable
+                                                    3
+                                                    n
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4 [])
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    fcn
+                                    []
+                                    [(Var 3 n)]
+                                    []
+                                    ()
+                                    Source
+                                    Public
+                                    Interface
+                                    ()
+                                    .false.
+                                    .false.
+                                    .false.
+                                    .false.
+                                    .false.
+                                    []
+                                    []
+                                    .false.
+                                ),
+                            ratio:
+                                (Variable
+                                    2
+                                    ratio
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4 [])
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    hybrd
+                    [abs@sabs]
+                    []
+                    [(BlockCall
+                        -1
+                        2 block
+                    )]
+                    ()
+                    Source
+                    Public
+                    Implementation
+                    ()
+                    .false.
+                    .false.
+                    .false.
+                    .false.
+                    .false.
+                    []
+                    []
+                    .false.
+                ),
+            iso_c_binding:
+                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
+            iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
+            lfortran_intrinsic_builtin:
+                (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_math:
+                (IntrinsicModule lfortran_intrinsic_math)
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2819,3 +2819,7 @@ asr = true
 [[test]]
 filename = "../integration_tests/private1.f90"
 asr = true
+
+[[test]]
+filename = "block2.f90"
+asr = true


### PR DESCRIPTION
Fixes #1259.
Bam! With this PR LFortran can now compile `minpack.f90` of modern minpack to ASR.