### PR TITLE
Add provision to use two different functions with same name and different arguments.

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -670,3 +670,5 @@ RUN(NAME interface_12 LABELS gfortran llvm)
 RUN(NAME private1 LABELS gfortran llvm)
 
 RUN(NAME block_04 LABELS gfortran llvm)
+
+RUN(NAME modules_25 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -671,4 +671,4 @@ RUN(NAME private1 LABELS gfortran llvm)
 
 RUN(NAME block_04 LABELS gfortran llvm)
 
-RUN(NAME modules_25 LABELS gfortran llvm)
+RUN(NAME modules_26 LABELS gfortran llvm)

--- a/integration_tests/modules_26.f90
+++ b/integration_tests/modules_26.f90
@@ -1,0 +1,53 @@
+module modern_minpack
+    implicit none
+contains
+    subroutine fdjac1(fcn)
+        implicit none
+        interface 
+            subroutine fcn(n, x)
+                implicit none
+                integer, intent(in) :: n
+                real, intent(in) :: x(n)
+            end subroutine fcn
+        end interface
+
+    end subroutine
+
+    subroutine fdjac2(fcn, m)
+
+        implicit none
+        integer, intent(in) :: m
+        interface
+            subroutine fcn(m)
+
+                implicit none
+                integer, intent(in) :: m
+            end subroutine
+        end interface
+        call fcn(m)
+
+    end subroutine fdjac2
+
+
+end module modern_minpack
+
+program main
+use modern_minpack
+implicit none
+
+call fdjac1(fcn)
+call fdjac2(fcn2, 1)
+
+contains 
+subroutine fcn(n, x)
+    implicit none
+    integer, intent(in) :: n
+    real, intent(in) :: x(n)
+end subroutine fcn
+
+subroutine fcn2(m)
+    implicit none
+    integer, intent(in) :: m
+end subroutine fcn2
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3561,10 +3561,6 @@ public:
                             ASR::Var_t *arg = down_cast<ASR::Var_t>(x.m_args[i]);
                             if ( arg->m_v == item.second ) {
                                 interface_as_arg = true;
-                                llvm::Function::arg_iterator arg_it = F->arg_begin();
-                                for (size_t j=0; j<i; j++) {
-                                    arg_it++;
-                                }
                                 llvm::FunctionType* fntype = get_function_type(*v);
                                 llvm::Function* fn = llvm::Function::Create(fntype, llvm::Function::ExternalLinkage, v->m_name, module.get());
                                 uint32_t hash = get_hash((ASR::asr_t*)v);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3554,7 +3554,27 @@ public:
                 if (is_a<ASR::Function_t>(*item.second)) {
                     ASR::Function_t *v = down_cast<ASR::Function_t>(
                             item.second);
-                    instantiate_function(*v);
+                    // check if item.second is present in x.m_args
+                    bool interface_as_arg = false;
+                    for (size_t i=0; i<x.n_args; i++) {
+                        if (is_a<ASR::Var_t>(*x.m_args[i])) {
+                            ASR::Var_t *arg = down_cast<ASR::Var_t>(x.m_args[i]);
+                            if ( arg->m_v == item.second ) {
+                                interface_as_arg = true;
+                                llvm::Function::arg_iterator arg_it = F->arg_begin();
+                                for (size_t j=0; j<i; j++) {
+                                    arg_it++;
+                                }
+                                llvm::FunctionType* fntype = get_function_type(*v);
+                                llvm::Function* fn = llvm::Function::Create(fntype, llvm::Function::ExternalLinkage, v->m_name, module.get());
+                                uint32_t hash = get_hash((ASR::asr_t*)v);
+                                llvm_symtab_fn[hash] = fn;
+                            }
+                        }
+                    } 
+                    if (!interface_as_arg) {
+                        instantiate_function(*v);
+                    }
                 }
             }
         }

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "f6c87546fb349bc37cc7703a32cc90add660d54f9e9a4dc47b7c82da",
+    "stdout_hash": "97d0a11b97814e805ae5f315109c7d2752ca7fada0a503d5efc38760",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -44,6 +44,8 @@ return:                                           ; preds = %.entry
   ret void
 }
 
+declare void @f.1(i32*)
+
 declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "f3e65775477e1b255ea0e039a1e60599c12a5aa67c32b08ea0384563",
+    "stdout_hash": "0a16e36ea1d04b0b70a0fd1e2433c7f9d83413cee9a8a968275f1485",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -86,6 +86,8 @@ return:                                           ; preds = %.entry
   ret i32 %1
 }
 
+declare i32 @f.1()
+
 define i32 @__module_recursion_03_sub1(i32* %y, i32* %iter) {
 .entry:
   %sub1 = alloca i32, align 4


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/1266.