### PR TITLE
Support `exit` statements for `Block_t`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -685,3 +685,4 @@ RUN(NAME modules_26 LABELS gfortran llvm)
 RUN(NAME enum_01 LABELS gfortran llvm)
 RUN(NAME enum_02 LABELS gfortran llvm EXTRAFILES
          enum_02_module.f90)
+RUN(NAME block_05 LABELS gfortran llvm)

--- a/integration_tests/block_05.f90
+++ b/integration_tests/block_05.f90
@@ -24,7 +24,14 @@ end subroutine hybrd
 
 program main
     implicit none
-    integer :: n = 1
+    integer :: n
+    n = -5
+    call hybrd(n)
+    if (n /= -2) error stop
+    n = 1
     call hybrd(n)
     if (n /= 15) error stop
+    n = 5
+    call hybrd(n)
+    if (n /= 8) error stop
 end program main

--- a/integration_tests/block_05.f90
+++ b/integration_tests/block_05.f90
@@ -1,0 +1,26 @@
+subroutine hybrd(n)
+    implicit none
+    real :: n
+
+    main : block
+        if ( n <= 0 ) then
+            exit main
+        else if ( n >= 2 ) then
+            n = n + 1
+            exit main
+        else 
+            n = n + 9
+        end if 
+        n = n + 2
+    end block main
+    n = n + 3
+    print *, "n = ", n
+
+
+end subroutine hybrd
+
+program main
+    implicit none
+    real :: n = 1
+    call hybrd(n)
+end program main

--- a/integration_tests/block_05.f90
+++ b/integration_tests/block_05.f90
@@ -1,6 +1,6 @@
 subroutine hybrd(n)
     implicit none
-    real :: n
+    integer :: n
 
     main : block
         if ( n <= 0 ) then
@@ -8,12 +8,12 @@ subroutine hybrd(n)
         else if ( n >= 2 ) then
             if ( n <= 4 ) then
                 n = n +1
-            else 
+            else
                 exit main
             end if
-        else 
+        else
             n = n + 9
-        end if 
+        end if
         n = n + 2
     end block main
     n = n + 3
@@ -24,6 +24,7 @@ end subroutine hybrd
 
 program main
     implicit none
-    real :: n = 1
+    integer :: n = 1
     call hybrd(n)
+    if (n /= 15) error stop
 end program main

--- a/integration_tests/block_05.f90
+++ b/integration_tests/block_05.f90
@@ -6,8 +6,11 @@ subroutine hybrd(n)
         if ( n <= 0 ) then
             exit main
         else if ( n >= 2 ) then
-            n = n + 1
-            exit main
+            if ( n <= 4 ) then
+                n = n +1
+            else 
+                exit main
+            end if
         else 
             n = n + 9
         end if 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4443,6 +4443,14 @@ public:
     }
 
     void visit_BlockCall(const ASR::BlockCall_t& x) {
+        /* The current `in_block` implementation has the following limitations:
+         * - Does not work for nested blocks. To fix it there, we should change
+         *   it to an integer and keep incrementing it for each block.
+         * - Combining blocks and loops.
+         * - The label in `exit` is currently ignored, so we only jump to the
+         *   inner most label. Instead we need to jump to the actual label
+         *   provided.
+         */
         in_block = true;
         if( x.m_label != -1 ) {
             if( llvm_goto_targets.find(x.m_label) == llvm_goto_targets.end() ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -230,7 +230,6 @@ public:
     bool lookup_enum_value_for_nonints;
     bool is_assignment_target;
     bool in_block = false;
-    bool is_Exit = false;
 
     CompilerOptions &compiler_options;
 
@@ -4739,7 +4738,6 @@ public:
         if ( in_block ) {
             // If we are in a block, we need to exit the block.
             // This is done by jumping to the end of the block.
-            is_Exit = true;
             builder->CreateBr(block_end_label);
             llvm::BasicBlock *bb = llvm::BasicBlock::Create(context, "unreachable_after_exit_block");
             start_new_block(bb);


### PR DESCRIPTION
Fixes #1293.
With this PR [modern_minpack/minpack.f90](https://github.com/fortran-lang/minpack/blob/c0b5aea9fcd2b83865af921a7a7e881904f8d3c2/src/minpack.f90) compiles to LLVM.