### PR TITLE
Initial FunctionParam implementation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -802,7 +802,7 @@ RUN(NAME declaration_01 LABELS gfortran llvm)
 
 RUN(NAME procedure_01 LABELS gfortran llvm)
 RUN(NAME procedure_02 LABELS gfortran llvm)
-RUN(NAME procedure_03 LABELS gfortran)
+RUN(NAME procedure_03 LABELS gfortran llvm)
 
 RUN(NAME allocated_01 LABELS gfortran llvm)
 RUN(NAME allocated_02 LABELS gfortran llvm)

--- a/integration_tests/procedure_03.f90
+++ b/integration_tests/procedure_03.f90
@@ -2,7 +2,7 @@ module procedure_03_mod
 implicit none
 
 interface
-    subroutine func(n, x, y)
+    subroutine func(x, y, n)
     implicit none
     integer, intent(in) :: n
     real, intent(in) :: x(n)
@@ -18,7 +18,7 @@ contains
     real, parameter :: eps = 1e-5
     real :: a(m), b(m)
     a = [1, 2, 3]
-    call fcn(m, a, b)
+    call fcn(a, b, m)
     print *, a
     print *, b
     if ((b(1) - 3) > eps) error stop
@@ -36,10 +36,10 @@ call hybrd(fn)
 
 contains
 
-    subroutine fn(n, x, y)
-    integer, intent(in) :: n
-    real, intent(in) :: x(n)
-    real, intent(out) :: y(n)
+    subroutine fn(x, y, k)
+    integer, intent(in) :: k
+    real, intent(in) :: x(k)
+    real, intent(out) :: y(k)
     y = x * 3
     end subroutine
 

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -277,6 +277,7 @@ expr
     | DictLen(expr arg, ttype type, expr? value)
 
     | Var(symbol v)
+    | FunctionParam(int param_number, ttype type, expr? value) --- used in types
 
     | ArrayConstant(expr* args, ttype type, arraystorage storage_format)
     | ArrayItem(expr v, array_index* args, ttype type, arraystorage storage_format, expr? value)

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1819,6 +1819,10 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
             return ASRUtils::TYPE(ASR::make_Pointer_t(al, ptr->base.base.loc,
                         dup_type));
         }
+        case ASR::ttypeType::CPtr: {
+            ASR::CPtr_t* ptr = ASR::down_cast<ASR::CPtr_t>(t);
+            return ASRUtils::TYPE(ASR::make_CPtr_t(al, ptr->base.base.loc));
+        }
         case ASR::ttypeType::Const: {
             ASR::Const_t* c = ASR::down_cast<ASR::Const_t>(t);
             ASR::ttype_t* dup_type = duplicate_type(al, c->m_type, dims);

--- a/tests/reference/asr-implicit_interface5-4e61259.json
+++ b/tests/reference/asr-implicit_interface5-4e61259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface5-4e61259.stdout",
-    "stdout_hash": "369cc395025632e006e51b7500b26f5de06cae441dbe136e834a98ab",
+    "stdout_hash": "f20855a129fdd8ef8694c01ec6003df15fb7ad17ba05e9f0a20c5ca7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface5-4e61259.json
+++ b/tests/reference/asr-implicit_interface5-4e61259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface5-4e61259.stdout",
-    "stdout_hash": "f20855a129fdd8ef8694c01ec6003df15fb7ad17ba05e9f0a20c5ca7",
+    "stdout_hash": "3deb05d92ab08f71f9c0622916e9959d625c0f675d542ecb9e83d404",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface5-4e61259.stdout
+++ b/tests/reference/asr-implicit_interface5-4e61259.stdout
@@ -130,13 +130,13 @@
                     (FunctionType
                         [(Integer 4 [((IntegerConstant 1 (Integer 4 []))
                         (FunctionParam
-                            0
+                            2
                             (Integer 4 [])
                             ()
                         ))])
                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
                         (FunctionParam
-                            0
+                            2
                             (Integer 4 [])
                             ()
                         ))])

--- a/tests/reference/asr-implicit_interface5-4e61259.stdout
+++ b/tests/reference/asr-implicit_interface5-4e61259.stdout
@@ -129,9 +129,17 @@
                     implicit_interface5
                     (FunctionType
                         [(Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                        (Var 2 n))])
+                        (FunctionParam
+                            0
+                            (Integer 4 [])
+                            ()
+                        ))])
                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                        (Var 2 n))])
+                        (FunctionParam
+                            0
+                            (Integer 4 [])
+                            ()
+                        ))])
                         (Integer 4 [])]
                         ()
                         Source

--- a/tests/reference/asr-implicit_typing2-4e0bae9.json
+++ b/tests/reference/asr-implicit_typing2-4e0bae9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_typing2-4e0bae9.stdout",
-    "stdout_hash": "d541955bcea9527cf5c556eb07c339a90c48048f1cd7f614064e68c3",
+    "stdout_hash": "9527d8a1dbefbd7d16c412b5144c6018acbe37a9707973c88aa4e9fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_typing2-4e0bae9.json
+++ b/tests/reference/asr-implicit_typing2-4e0bae9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_typing2-4e0bae9.stdout",
-    "stdout_hash": "9527d8a1dbefbd7d16c412b5144c6018acbe37a9707973c88aa4e9fc",
+    "stdout_hash": "70f6a3d154e37507d9e0fdf54a8f618ddf6d8630bc7b93f8862c615b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_typing2-4e0bae9.stdout
+++ b/tests/reference/asr-implicit_typing2-4e0bae9.stdout
@@ -96,7 +96,11 @@
                         (Real 4 [])
                         (Integer 4 [])
                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                        (Var 2 n))])]
+                        (FunctionParam
+                            0
+                            (Integer 4 [])
+                            ()
+                        ))])]
                         ()
                         Source
                         Implementation
@@ -248,7 +252,11 @@
                         (Real 4 [])
                         (Integer 4 [])
                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                        (Var 3 n))])]
+                        (FunctionParam
+                            0
+                            (Integer 4 [])
+                            ()
+                        ))])]
                         (Integer 4 [])
                         Source
                         Implementation

--- a/tests/reference/asr-implicit_typing2-4e0bae9.stdout
+++ b/tests/reference/asr-implicit_typing2-4e0bae9.stdout
@@ -97,7 +97,7 @@
                         (Integer 4 [])
                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
                         (FunctionParam
-                            0
+                            2
                             (Integer 4 [])
                             ()
                         ))])]
@@ -253,7 +253,7 @@
                         (Integer 4 [])
                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
                         (FunctionParam
-                            0
+                            2
                             (Integer 4 [])
                             ()
                         ))])]

--- a/tests/reference/asr-modules_15b-5be0f8a.json
+++ b/tests/reference/asr-modules_15b-5be0f8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_15b-5be0f8a.stdout",
-    "stdout_hash": "600b88af9a317bb5072778ab17e272d3ddf4ca0bac77e4d760867704",
+    "stdout_hash": "791f2e10a28c1eb7a521f889328e7da31e6de93092cf77ce3da76126",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_15b-5be0f8a.stdout
+++ b/tests/reference/asr-modules_15b-5be0f8a.stdout
@@ -1150,7 +1150,11 @@
                                     (FunctionType
                                         [(Integer 4 [])
                                         (Real 8 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 48 n))])]
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])]
                                         (Real 8 [])
                                         BindC
                                         Interface
@@ -1634,7 +1638,11 @@
                                     (FunctionType
                                         [(Integer 4 [])
                                         (Real 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 47 n))])]
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])]
                                         (Real 4 [])
                                         BindC
                                         Interface
@@ -1798,7 +1806,11 @@
                                     (FunctionType
                                         [(Integer 4 [])
                                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 46 n))])]
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])]
                                         (Integer 4 [])
                                         BindC
                                         Interface
@@ -3110,7 +3122,11 @@
                                     (FunctionType
                                         [(Integer 4 [])
                                         (Real 8 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 63 n))])
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])
                                         (Real 8 [])]
                                         ()
                                         BindC
@@ -3522,7 +3538,11 @@
                                     (FunctionType
                                         [(Integer 4 [])
                                         (Real 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 62 n))])
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])
                                         (Real 4 [])]
                                         ()
                                         BindC
@@ -3606,7 +3626,11 @@
                                     (FunctionType
                                         [(Integer 4 [])
                                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 61 n))])
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])
                                         (Integer 4 [])]
                                         ()
                                         BindC

--- a/tests/reference/asr-redeclaration1-0adcc00.json
+++ b/tests/reference/asr-redeclaration1-0adcc00.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-redeclaration1-0adcc00.stdout",
-    "stdout_hash": "c540279c73d72e352ffb32de988c051309f3f7755e699d531a29139c",
+    "stdout_hash": "9e805c9944f6c94da2844183c03623ee8be15202153edec40154cb7c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-redeclaration1-0adcc00.json
+++ b/tests/reference/asr-redeclaration1-0adcc00.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-redeclaration1-0adcc00.stdout",
-    "stdout_hash": "92c6d4da761bb78db9efe7a6034f30c1940dc53f46220720ce1080d6",
+    "stdout_hash": "c540279c73d72e352ffb32de988c051309f3f7755e699d531a29139c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-redeclaration1-0adcc00.stdout
+++ b/tests/reference/asr-redeclaration1-0adcc00.stdout
@@ -44,7 +44,11 @@
                     redeclare1
                     (FunctionType
                         [(Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                        (Var 2 k))])
+                        (FunctionParam
+                            0
+                            (Integer 4 [])
+                            ()
+                        ))])
                         (Integer 4 [])]
                         ()
                         Source

--- a/tests/reference/asr-redeclaration1-0adcc00.stdout
+++ b/tests/reference/asr-redeclaration1-0adcc00.stdout
@@ -45,7 +45,7 @@
                     (FunctionType
                         [(Integer 4 [((IntegerConstant 1 (Integer 4 []))
                         (FunctionParam
-                            0
+                            1
                             (Integer 4 [])
                             ()
                         ))])

--- a/tests/reference/asr-template_array_03-81d3ec4.json
+++ b/tests/reference/asr-template_array_03-81d3ec4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_03-81d3ec4.stdout",
-    "stdout_hash": "a240829686b8e399b34ab50d6580e500d0f786af69f79f1e99237e5e",
+    "stdout_hash": "03b406d883e05ae82c91ae97e213808064089c344b7abdfaffa6901b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_03-81d3ec4.json
+++ b/tests/reference/asr-template_array_03-81d3ec4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_03-81d3ec4.stdout",
-    "stdout_hash": "03b406d883e05ae82c91ae97e213808064089c344b7abdfaffa6901b",
+    "stdout_hash": "98ca7e40f886d337d329a66302e03cec4d5d79d0e22eb432b23d1e4d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_03-81d3ec4.stdout
+++ b/tests/reference/asr-template_array_03-81d3ec4.stdout
@@ -985,7 +985,19 @@
                                         ))
                                         ((IntegerConstant 1 (Integer 4 []))
                                         (FunctionParam
-                                            0
+                                            1
+                                            (Integer 4 [])
+                                            ()
+                                        ))])
+                                        (Integer 4 [((IntegerConstant 1 (Integer 4 []))
+                                        (FunctionParam
+                                            1
+                                            (Integer 4 [])
+                                            ()
+                                        ))
+                                        ((IntegerConstant 1 (Integer 4 []))
+                                        (FunctionParam
+                                            2
                                             (Integer 4 [])
                                             ()
                                         ))])
@@ -997,19 +1009,7 @@
                                         ))
                                         ((IntegerConstant 1 (Integer 4 []))
                                         (FunctionParam
-                                            0
-                                            (Integer 4 [])
-                                            ()
-                                        ))])
-                                        (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (FunctionParam
-                                            0
-                                            (Integer 4 [])
-                                            ()
-                                        ))
-                                        ((IntegerConstant 1 (Integer 4 []))
-                                        (FunctionParam
-                                            0
+                                            2
                                             (Integer 4 [])
                                             ()
                                         ))])]
@@ -1348,7 +1348,22 @@
                                             ))
                                             ((IntegerConstant 1 (Integer 4 []))
                                             (FunctionParam
-                                                0
+                                                1
+                                                (Integer 4 [])
+                                                ()
+                                            ))]
+                                        )
+                                        (TypeParameter
+                                            t
+                                            [((IntegerConstant 1 (Integer 4 []))
+                                            (FunctionParam
+                                                1
+                                                (Integer 4 [])
+                                                ()
+                                            ))
+                                            ((IntegerConstant 1 (Integer 4 []))
+                                            (FunctionParam
+                                                2
                                                 (Integer 4 [])
                                                 ()
                                             ))]
@@ -1363,22 +1378,7 @@
                                             ))
                                             ((IntegerConstant 1 (Integer 4 []))
                                             (FunctionParam
-                                                0
-                                                (Integer 4 [])
-                                                ()
-                                            ))]
-                                        )
-                                        (TypeParameter
-                                            t
-                                            [((IntegerConstant 1 (Integer 4 []))
-                                            (FunctionParam
-                                                0
-                                                (Integer 4 [])
-                                                ()
-                                            ))
-                                            ((IntegerConstant 1 (Integer 4 []))
-                                            (FunctionParam
-                                                0
+                                                2
                                                 (Integer 4 [])
                                                 ()
                                             ))]

--- a/tests/reference/asr-template_array_03-81d3ec4.stdout
+++ b/tests/reference/asr-template_array_03-81d3ec4.stdout
@@ -978,17 +978,41 @@
                                         (Integer 4 [])
                                         (Integer 4 [])
                                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 17 i))
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))
                                         ((IntegerConstant 1 (Integer 4 []))
-                                        (Var 17 j))])
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])
                                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 17 j))
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))
                                         ((IntegerConstant 1 (Integer 4 []))
-                                        (Var 17 k))])
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])
                                         (Integer 4 [((IntegerConstant 1 (Integer 4 []))
-                                        (Var 17 i))
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))
                                         ((IntegerConstant 1 (Integer 4 []))
-                                        (Var 17 k))])]
+                                        (FunctionParam
+                                            0
+                                            (Integer 4 [])
+                                            ()
+                                        ))])]
                                         ()
                                         Source
                                         Implementation
@@ -1317,23 +1341,47 @@
                                         (TypeParameter
                                             t
                                             [((IntegerConstant 1 (Integer 4 []))
-                                            (Var 14 i))
+                                            (FunctionParam
+                                                0
+                                                (Integer 4 [])
+                                                ()
+                                            ))
                                             ((IntegerConstant 1 (Integer 4 []))
-                                            (Var 14 j))]
+                                            (FunctionParam
+                                                0
+                                                (Integer 4 [])
+                                                ()
+                                            ))]
                                         )
                                         (TypeParameter
                                             t
                                             [((IntegerConstant 1 (Integer 4 []))
-                                            (Var 14 j))
+                                            (FunctionParam
+                                                0
+                                                (Integer 4 [])
+                                                ()
+                                            ))
                                             ((IntegerConstant 1 (Integer 4 []))
-                                            (Var 14 k))]
+                                            (FunctionParam
+                                                0
+                                                (Integer 4 [])
+                                                ()
+                                            ))]
                                         )
                                         (TypeParameter
                                             t
                                             [((IntegerConstant 1 (Integer 4 []))
-                                            (Var 14 i))
+                                            (FunctionParam
+                                                0
+                                                (Integer 4 [])
+                                                ()
+                                            ))
                                             ((IntegerConstant 1 (Integer 4 []))
-                                            (Var 14 k))]
+                                            (FunctionParam
+                                                0
+                                                (Integer 4 [])
+                                                ()
+                                            ))]
                                         )]
                                         ()
                                         Source


### PR DESCRIPTION
The following file
```fortran
module minpack_module
    use iso_fortran_env, only: wp => real64

    implicit none

    abstract interface
        subroutine func(n, x, fvec, iflag)
            !! user-supplied subroutine for [[hybrd]], [[hybrd1]], and [[fdjac1]]
            import :: wp
            implicit none
            integer, intent(in) :: n !! the number of variables.
            real(wp), intent(in) :: x(n) !! independent variable vector
            real(wp), intent(out) :: fvec(n) !! value of function at `x`
            integer, intent(inout) :: iflag !! set to <0 to terminate execution
        end subroutine func
    
    end interface

    contains
        subroutine hybrd(fcn)
            implicit none
            procedure(func) :: fcn
        end subroutine 
end module
```
now seems to produce the correct ASR:
```console
$ lfortran --show-asr a.f90         
(TranslationUnit (SymbolTable 1 {iso_fortran_env: (IntrinsicModule lfortran_intrinsic_iso_fortran_env), minpack_module: (Module (SymbolTable 2 {func: (Function (SymbolTable 5 {fvec: (Variable 5 fvec [n] Out () () Default (Real 8 [((IntegerConstant 1 (Integer 4 [])) (Var 5 n))]) Source Public Required .false.), iflag: (Variable 5 iflag [] InOut () () Default (Integer 4 []) Source Public Required .false.), n: (Variable 5 n [] In () () Default (Integer 4 []) Source Public Required .false.), x: (Variable 5 x [n] In () () Default (Real 8 [((IntegerConstant 1 (Integer 4 [])) (Var 5 n))]) Source Public Required .false.)}) func (FunctionType [(Integer 4 []) (Real 8 [((IntegerConstant 1 (Integer 4 [])) (FunctionParam 0 (Integer 4 []) ()))]) (Real 8 [((IntegerConstant 1 (Integer 4 [])) (FunctionParam 0 (Integer 4 []) ()))]) (Integer 4 [])] () Source Interface () .false. .false. .false. .false. .false. [] [] .false.) [] [(Var 5 n) (Var 5 x) (Var 5 fvec) (Var 5 iflag)] [] () Public), hybrd: (Function (SymbolTable 6 {fcn: (Variable 6 fcn [] Unspecified () () Default (FunctionType [(Integer 4 []) (Real 8 [((IntegerConstant 1 (Integer 4 [])) (FunctionParam 0 (Integer 4 []) ()))]) (Real 8 [((IntegerConstant 1 (Integer 4 [])) (FunctionParam 0 (Integer 4 []) ()))]) (Integer 4 [])] () Source Interface () .false. .false. .false. .false. .false. [] [] .false.) Source Public Required .false.)}) hybrd (FunctionType [(FunctionType [(Integer 4 []) (Real 8 [((IntegerConstant 1 (Integer 4 [])) (FunctionParam 0 (Integer 4 []) ()))]) (Real 8 [((IntegerConstant 1 (Integer 4 [])) (FunctionParam 0 (Integer 4 []) ()))]) (Integer 4 [])] () Source Interface () .false. .false. .false. .false. .false. [] [] .false.)] () Source Implementation () .false. .false. .false. .false. .false. [] [] .false.) [] [(Var 6 fcn)] [] () Public), wp: (ExternalSymbol 2 wp 4 real64 lfortran_intrinsic_iso_fortran_env [] real64 Public)}) minpack_module [iso_fortran_env] .false. .false.)}) [])
```
The `FunctionParam` is there inside `FunctionType`, but it is correctly not there for regular variables.

TODO:
* [x] create minimal example that calls the callback and make sure it fully compiles via LLVM
* [x] implement ASR->LLVM and ASR passes for FunctionParam
* [x] call duplicate_dimensions for all types (https://github.com/lfortran/lfortran/pull/1614)
* [x] determine the arg_index properly (and add a test for this)
* [x] fix all tests
* [x] fix all integration tests

If it is too complicated to compile to LLVM, then let's only focus on ASR and finish this PR, we'll only test ASR for the above example and as long as everything else passes, we can merge it and then do ASR->LLVM in another PR.
