### PR TITLE
Add provision to check if value of assignment is scalar with target `ArraySection_t`

### DIFF
--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -512,8 +512,13 @@ public:
                 }
                 doloop = ASRUtils::STMT(ASR::make_DoLoop_t(al, x.base.base.loc, head, doloop_body.p, doloop_body.size()));
             }
-            pass_result.push_back(al, doloop);
-            tmp_val = nullptr;
+            if (n_dims > 0) {
+                pass_result.push_back(al, doloop);
+                tmp_val = nullptr;
+            } else {
+                // Assignment's value is a scalar (RealConstant)
+                tmp_val = const_cast<ASR::expr_t*>(&(x.base));
+            }
         }
     }
 

--- a/tests/array_section1.f90
+++ b/tests/array_section1.f90
@@ -1,0 +1,11 @@
+subroutine vecfcn(n)
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    integer :: n
+    real(wp) :: fvec(n)
+    real(wp) :: zero = 0.0_wp
+    integer :: i
+
+    fvec(2:n) = zero
+
+end subroutine vecfcn


### PR DESCRIPTION
This PR fixes #1316, but it is not yet compiled to LLVM, it generates #1318 which is independent of this one, but needs to be fixed to get this PR merged.
