### PR TITLE
LLVM: Enable debugging information

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1574,7 +1574,6 @@ int main(int argc, char *argv[])
         bool arg_c = false;
         bool arg_v = false;
         bool arg_E = false;
-        bool arg_g = false;
         std::vector<std::string> arg_l;
         std::vector<std::string> arg_L;
         std::vector<std::string> arg_files;
@@ -1633,7 +1632,7 @@ int main(int argc, char *argv[])
         app.add_option("-L", arg_L, "Library path option");
         app.add_option("-I", compiler_options.include_dirs, "Include path");
         app.add_option("-J", compiler_options.mod_files_dir, "Where to save mod files");
-        app.add_flag("-g", arg_g, "Compile with debugging information");
+        app.add_flag("-g", compiler_options.emit_debug_info, "Compile with debugging information");
         app.add_option("-D", compiler_options.c_preprocessor_defines, "Define <macro>=<value> (or 1 if <value> omitted)")->allow_extra_args(false);
         app.add_flag("--version", arg_version, "Display compiler version information");
 
@@ -1778,6 +1777,11 @@ int main(int argc, char *argv[])
             return python_wrapper(arg_pywrap_file, arg_pywrap_array_order,
                 compiler_options);
         }
+
+        if (compiler_options.emit_debug_info) {
+            compiler_options.emit_debug_line_column = true;
+        }
+
 
         if (arg_backend == "llvm") {
             backend = Backend::llvm;


### PR DESCRIPTION
Thanks to #1333 we can test this PR as follows on Apple M1:
```console
$ lfortran -g integration_tests/array_section_01.f90 -o x
$ lldb x
(lldb) target create "x"
Current executable set to '/Users/ondrej/repos/lfortran/lfortran/x' (arm64).
(lldb) run
Process 90808 launched: '/Users/ondrej/repos/lfortran/lfortran/x' (arm64)
Process 90808 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x10000004c)
    frame #0: 0x0000000100003e70 x`vecfcn(__1_k=19, fvec=0) at array_section_01.f90:6:5
   3   	    integer :: n
   4   	    real :: fvec(n)
   5   	
-> 6   	    fvec(2:n) = 0.0
   7   	    print *, fvec
   8   	
   9   	end subroutine vecfcn
Target 0: (x) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x10000004c)
  * frame #0: 0x0000000100003e70 x`vecfcn(__1_k=19, fvec=0) at array_section_01.f90:6:5
    frame #1: 0x0000000100003f40 x`main at array_section_01.f90:12:5
    frame #2: 0x00000001000110f4 dyld`start + 520
```