### PR TITLE
Add provision to update `Implicit_Deallocate_t` statements in function body in pass_array_by_data

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -696,3 +696,5 @@ RUN(NAME block_05 LABELS gfortran llvm)
 RUN(NAME array_section_01 LABELS gfortran llvm)
 
 RUN(NAME pass_array_by_data_01 LABELS gfortran llvm)
+
+RUN(NAME pass_array_by_data_02 LABELS gfortran llvm)

--- a/integration_tests/pass_array_by_data_02.f90
+++ b/integration_tests/pass_array_by_data_02.f90
@@ -6,7 +6,6 @@ program test_hybrd
 
     subroutine compare_solutions(x)
 
-    implicit none
     real, dimension(:), intent(in) :: x 
     real, dimension(:), allocatable :: temp
     end subroutine compare_solutions

--- a/integration_tests/pass_array_by_data_02.f90
+++ b/integration_tests/pass_array_by_data_02.f90
@@ -1,0 +1,13 @@
+program test_hybrd
+
+    implicit none
+
+    contains
+
+    subroutine compare_solutions(x)
+
+    implicit none
+    real, dimension(:), intent(in) :: x 
+    real, dimension(:), allocatable :: temp
+    end subroutine compare_solutions
+end program


### PR DESCRIPTION
Fixes #1349.