### PR TITLE
WASM: Initial support for BlockCall

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -550,6 +550,8 @@ RUN(NAME block_01 LABELS gfortran llvm)
 RUN(NAME block_02 LABELS gfortran)
 RUN(NAME block_03 LABELS gfortran llvm)
 RUN(NAME block_04 LABELS gfortran llvm)
+RUN(NAME block_05 LABELS gfortran llvm)
+RUN(NAME block_06 LABELS gfortran llvm wasm)
 RUN(NAME associate_01 LABELS gfortran)
 RUN(NAME associate_02 LABELS gfortran llvm)
 RUN(NAME associate_03 LABELS gfortran llvm)
@@ -691,7 +693,6 @@ RUN(NAME modules_26 LABELS gfortran llvm)
 RUN(NAME enum_01 LABELS gfortran llvm)
 RUN(NAME enum_02 LABELS gfortran llvm EXTRAFILES
          enum_02_module.f90)
-RUN(NAME block_05 LABELS gfortran llvm)
 
 RUN(NAME array_section_01 LABELS gfortran llvm)
 

--- a/integration_tests/block_06.f90
+++ b/integration_tests/block_06.f90
@@ -1,0 +1,26 @@
+program block_06
+    implicit none
+    integer :: a, b
+    real :: c, d
+    a = 5
+    b = -5
+    c = 0.5
+    d = 7.5
+    block
+        integer :: x, y
+        real :: z, w
+        x = 10
+        y = -10
+        z = 2.25
+        w = -2.25
+        print *, x, y, z, w
+        print *, a, b, c, d
+
+        a = x
+        b = y
+        c = z
+        d = w
+    end block
+
+    print *, a, b, c, d
+end program block_06

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -102,7 +102,6 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     uint32_t cur_loop_nesting_level;
     bool is_prototype_only;
     bool is_local_vars_only;
-    bool is_initialize_vars_only;
     ASR::Function_t* main_func;
 
     Vec<uint8_t> m_type_section;
@@ -141,7 +140,6 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         : m_al(al), diag(diagnostics) {
         is_prototype_only = false;
         is_local_vars_only = false;
-        is_initialize_vars_only = false;
         main_func = nullptr;
         nesting_level = 0;
         cur_loop_nesting_level = 0;
@@ -1075,12 +1073,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             is_local_vars_only = false;
         }
 
-        {
-            is_initialize_vars_only = true;
-            initialize_local_vars(x.m_symtab);
-            visit_BlockStatements(x);
-            is_initialize_vars_only = false;
-        }
+        initialize_local_vars(x.m_symtab);
 
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
@@ -1157,10 +1150,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         if (is_local_vars_only) {
             emit_local_vars(block->m_symtab);
             visit_BlockStatements(*block);
-        } else if (is_initialize_vars_only) {
-            initialize_local_vars(block->m_symtab);
-            visit_BlockStatements(*block);
         } else {
+            initialize_local_vars(block->m_symtab);
             for (size_t i = 0; i < block->n_body; i++) {
                 this->visit_stmt(*block->m_body[i]);
             }

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -101,6 +101,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     uint32_t nesting_level;
     uint32_t cur_loop_nesting_level;
     bool is_prototype_only;
+    bool is_local_vars_only;
+    bool is_initialize_vars_only;
     ASR::Function_t* main_func;
 
     Vec<uint8_t> m_type_section;
@@ -138,6 +140,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     ASRToWASMVisitor(Allocator &al, diag::Diagnostics &diagnostics)
         : m_al(al), diag(diagnostics) {
         is_prototype_only = false;
+        is_local_vars_only = false;
+        is_initialize_vars_only = false;
         main_func = nullptr;
         nesting_level = 0;
         cur_loop_nesting_level = 0;
@@ -1031,6 +1035,15 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             s;  // add function to map
     }
 
+    template <typename T>
+    void visit_BlockStatements(const T& x) {
+        for (size_t i = 0; i < x.n_body; i++) {
+            if (ASR::is_a<ASR::BlockCall_t>(*x.m_body[i])) {
+                this->visit_stmt(*x.m_body[i]);
+            }
+        }
+    }
+
     void emit_function_body(const ASR::Function_t &x) {
         LCOMPILERS_ASSERT(m_func_name_idx_map.find(get_hash((ASR::asr_t *)&x)) !=
                         m_func_name_idx_map.end());
@@ -1046,21 +1059,27 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             wasm::emit_len_placeholder(m_code_section, m_al);
 
         {
+            is_local_vars_only = true;
             int params_cnt = cur_sym_info->no_of_variables;
             /********************* Local Vars Types List *********************/
             uint32_t len_idx_code_section_local_vars_list =
                 wasm::emit_len_placeholder(m_code_section, m_al);
 
             emit_local_vars(x.m_symtab);
+            visit_BlockStatements(x);
 
             // fixup length of local vars list
             wasm::emit_u32_b32_idx(m_code_section, m_al,
                                 len_idx_code_section_local_vars_list,
                                 cur_sym_info->no_of_variables - params_cnt);
+            is_local_vars_only = false;
         }
 
         {
+            is_initialize_vars_only = true;
             initialize_local_vars(x.m_symtab);
+            visit_BlockStatements(x);
+            is_initialize_vars_only = false;
         }
 
         for (size_t i = 0; i < x.n_body; i++) {
@@ -1130,6 +1149,22 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             return;
         }
         emit_function_body(x);
+    }
+
+    void visit_BlockCall(const ASR::BlockCall_t &x) {
+        LCOMPILERS_ASSERT(ASR::is_a<ASR::Block_t>(*x.m_m));
+        ASR::Block_t* block = ASR::down_cast<ASR::Block_t>(x.m_m);
+        if (is_local_vars_only) {
+            emit_local_vars(block->m_symtab);
+            visit_BlockStatements(*block);
+        } else if (is_initialize_vars_only) {
+            initialize_local_vars(block->m_symtab);
+            visit_BlockStatements(*block);
+        } else {
+            for (size_t i = 0; i < block->n_body; i++) {
+                this->visit_stmt(*block->m_body[i]);
+            }
+        }
     }
 
     uint32_t emit_memory_store(ASR::expr_t *v) {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -1085,13 +1085,13 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
+
         if (strcmp(x.m_name, "_start") == 0) {
             wasm::emit_i32_const(m_code_section, m_al, 0 /* zero exit code */);
             wasm::emit_call(m_code_section, m_al, m_import_func_idx_map[proc_exit]);
         }
-        if ((x.n_body == 0) ||
-            ((x.n_body > 0) &&
-             !ASR::is_a<ASR::Return_t>(*x.m_body[x.n_body - 1]))) {
+
+        if (x.n_body == 0 || !ASR::is_a<ASR::Return_t>(*x.m_body[x.n_body - 1])) {
             handle_return();
         }
         wasm::emit_expr_end(m_code_section, m_al);


### PR DESCRIPTION
This PR implements initial support for `visit_BlockCall` in the `wasm` backend.
- Varaibles and statements inside a block are supported (their support is yet to be verfied by adding a test case)
    - For variables declared inside the block scope, we are declaring them as local variables of the function (thus they are now available throughout the whole function scope).
- GoTo and GoToTarget are not yet supported

Related: https://github.com/lcompilers/lpython/pull/1548