### PR TITLE
Distinguish between adding and overwriting symbols

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1596,7 +1596,7 @@ public:
             ASR::abiType::Source, ASR::accessType::Public, ASR::deftypeType::Implementation,
             nullptr, false, false, false, false, false, /* a_type_parameters */ nullptr,
             /* n_type_parameters */ 0, nullptr, 0, false, false, false);
-        parent_scope->add_symbol(var_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        parent_scope->overwrite_symbol(var_name, ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
     }
 
@@ -1847,7 +1847,7 @@ public:
                 original_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(al,
                     p->base.base.loc, current_scope, s2c(al, s_name), original_sym,
                     s2c(al, original_sym_owner_name), nullptr, 0, p->m_name, ASR::accessType::Private));
-                current_scope->add_symbol(s_name, original_sym);
+                current_scope->add_or_overwrite_symbol(s_name, original_sym);
                 int idx;
                 if( x.n_member >= 1 ) {
                     idx = ASRUtils::select_generic_procedure(args_with_mdt, *p, x.base.base.loc,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3780,7 +3780,7 @@ public:
             );
         std::string sym = fn_name;
 
-        current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(fn));
+        current_scope->add_or_overwrite_symbol(sym, ASR::down_cast<ASR::symbol_t>(fn));
         ASR::symbol_t *v = ASR::down_cast<ASR::symbol_t>(fn);
         if (current_module) {
             // We are in body visitor

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1454,7 +1454,7 @@ public:
                     es0->m_original_name,
                     dflt_access
                     );
-                current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(es));
+                current_scope->add_or_overwrite_symbol(sym, ASR::down_cast<ASR::symbol_t>(es));
             } else if( ASR::is_a<ASR::StructType_t>(*item.second) ) {
                 ASR::StructType_t *mv = ASR::down_cast<ASR::StructType_t>(item.second);
                 // `mv` is the Variable in a module. Now we construct
@@ -1710,7 +1710,7 @@ public:
                 m->m_name, nullptr, 0, mfn->m_name,
                 dflt_access
                 );
-            current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));
+            current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));
         } else if (ASR::is_a<ASR::Variable_t>(*t)) {
             if (current_scope->get_symbol(local_sym) != nullptr) {
                 throw SemanticError("Variable already defined", loc);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1290,7 +1290,7 @@ public:
             ASR::asr_t *v = ASR::make_GenericProcedure_t(al, loc,
                 current_scope, generic_name,
                 symbols.p, symbols.size(), ASR::Public);
-            current_scope->add_symbol(sym_name_str, ASR::down_cast<ASR::symbol_t>(v));
+            current_scope->add_or_overwrite_symbol(sym_name_str, ASR::down_cast<ASR::symbol_t>(v));
         }
     }
 
@@ -1561,7 +1561,7 @@ public:
                     ASR::asr_t *ep = ASR::make_GenericProcedure_t(
                         al, t->base.loc, current_scope, s2c(al, local_sym),
                         gp_procs.p, gp_procs.size(), dflt_access);
-                    current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(ep));
+                    current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(ep));
                 } else {
                     LCOMPILERS_ASSERT(ASR::is_a<ASR::GenericProcedure_t>(*gp_sym));
                     ASR::GenericProcedure_t* gp = ASR::down_cast<ASR::GenericProcedure_t>(gp_sym);

--- a/src/libasr/asr_scopes.h
+++ b/src/libasr/asr_scopes.h
@@ -69,7 +69,21 @@ struct SymbolTable {
         scope.erase(name);
     }
 
+    // Add a new symbol that did not exist before
     void add_symbol(const std::string &name, ASR::symbol_t* symbol) {
+        LCOMPILERS_ASSERT(scope.find(name) == scope.end())
+        scope[name] = symbol;
+    }
+
+    // Overwrite an existing symbol
+    void overwrite_symbol(const std::string &name, ASR::symbol_t* symbol) {
+        LCOMPILERS_ASSERT(scope.find(name) != scope.end())
+        scope[name] = symbol;
+    }
+
+    // Use as the last resort, prefer to always either add a new symbol
+    // or overwrite an existing one, not both
+    void add_or_overwrite_symbol(const std::string &name, ASR::symbol_t* symbol) {
         scope[name] = symbol;
     }
 

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -890,7 +890,7 @@ class ArrayOpVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisit
                                                 if ( sym->type == ASR::symbolType::Function ) {
                                                     ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(sym);
                                                     ASR::symbol_t* s_func = create_subroutine_from_function(ASR::down_cast<ASR::Function_t>(sym));
-                                                    subrout_func->m_symtab->add_symbol(func->m_name, s_func);
+                                                    subrout_func->m_symtab->overwrite_symbol(func->m_name, s_func);
                                                     subrout_func->m_args[arg_index] = ASR::down_cast<ASR::expr_t>(ASR::make_Var_t(al, var->base.base.loc, s_func));
                                                 }
                                             }
@@ -908,7 +908,7 @@ class ArrayOpVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisit
             // of the function (which returned array) now points
             // to the newly created subroutine.
             for( auto& item: replace_vec ) {
-                current_scope->add_symbol(item.first, item.second);
+                current_scope->overwrite_symbol(item.first, item.second);
             }
 
             for (auto &item : x.m_symtab->get_scope()) {

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -378,7 +378,7 @@ namespace LCompilers {
                                                         s2c(al, sym), t,
                                                         s2c(al, module_name), nullptr, 0, s2c(al, remote_sym),
                                                         ASR::accessType::Private);
-            current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(fn));
+            current_scope->add_or_overwrite_symbol(sym, ASR::down_cast<ASR::symbol_t>(fn));
             v = ASR::down_cast<ASR::symbol_t>(fn);
             current_scope = current_scope_copy;
             return v;


### PR DESCRIPTION
add_symbol: symbol did not exist before
overwrite_symbol: symbol existed before
add_or_overwrite_symbol: symbol might or might not exist before

The most clean approach is using `add_symbol` or `overwrite_symbol`, and they enforce the convention with an assert statement.

Only use add_or_overwrite_symbol() as the last resort and document why the symbol can be overwritten in the same symbol table, but only sometimes. Often times this signals a bug in our code, we should have created a unique symbol name first.