### PR TITLE
Efficient check to correct FunctionCall::m_name in ``pass_array_by_data``

### DIFF
--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -88,9 +88,14 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
             }
             ASR::FunctionCall_t& xx = const_cast<ASR::FunctionCall_t&>(x);
             ASR::symbol_t* x_sym = xx.m_name;
-            std::string x_sym_name = std::string(ASRUtils::symbol_name(x_sym));
-            if( current_proc_scope->get_symbol(x_sym_name) != x_sym ) {
-                xx.m_name = current_proc_scope->get_symbol(x_sym_name);
+            SymbolTable* x_sym_symtab = ASRUtils::symbol_parent_symtab(x_sym);
+            if( x_sym_symtab->get_counter() != current_proc_scope->get_counter() ) {
+                // xx.m_name points to the function/procedure present inside
+                // original function's symtab. Make it point to the new function's
+                // symtab.
+                std::string x_sym_name = std::string(ASRUtils::symbol_name(x_sym));
+                xx.m_name = current_proc_scope->resolve_symbol(x_sym_name);
+                LCOMPILERS_ASSERT(xx.m_name != nullptr);
             }
         }
 

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -91,8 +91,8 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
             SymbolTable* x_sym_symtab = ASRUtils::symbol_parent_symtab(x_sym);
             if( x_sym_symtab->get_counter() != current_proc_scope->get_counter() ) {
                 // xx.m_name points to the function/procedure present inside
-                // original function's symtab. Make it point to the new function's
-                // symtab.
+                // original function's symtab. Make it point to the symbol in
+                // new function's symtab.
                 std::string x_sym_name = std::string(ASRUtils::symbol_name(x_sym));
                 xx.m_name = current_proc_scope->resolve_symbol(x_sym_name);
                 LCOMPILERS_ASSERT(xx.m_name != nullptr);


### PR DESCRIPTION
On the basis of https://github.com/lfortran/lfortran/pull/1306#discussion_r1125369932, https://github.com/lfortran/lfortran/pull/1306#discussion_r1125397862 and https://github.com/lfortran/lfortran/pull/1306#discussion_r1125400248. Now `resolve_symbol` will only be called if we know for sure that the `FunctionCall::m_name` parent's symtab isn't the same as current scope.