### PR TITLE
CI: Minor improvement

### DIFF
--- a/ci/upload_docs.sh
+++ b/ci/upload_docs.sh
@@ -3,11 +3,11 @@
 set -e
 set -x
 
-branch_name=${GITHUB_REF##*/}
+git_ref=${GITHUB_REF}
 
-if [[ $branch_name != "main" ]]; then
+if [[ $git_ref != "refs/heads/main" ]]; then
     # Development version
-    dest_branch=${branch_name}
+    dest_branch=${git_ref}
     deploy_repo="git@gitlab.com:lfortran/web/docs.lfortran.org-testing.git"
 else
     # Release version


### PR DESCRIPTION
```bash
(base) lfortran$ export t="heads/refs/ci/git/flow/br/name" 
(base) lfortran$ echo ${t##*/}                            
name
```

When `git-flow` style branch names are used, the `branch_name` in `ci/upload_docs.sh` stores only the last part of the branch name. This PR fixes it to use the whole branch name.