### PR TITLE
Implement runtime polymorphism for function calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -629,6 +629,7 @@ RUN(NAME class_01 LABELS gfortran)
 RUN(NAME class_02 LABELS gfortran llvm)
 RUN(NAME class_03 LABELS gfortran)
 RUN(NAME class_04 LABELS gfortran)
+RUN(NAME class_05 LABELS gfortran llvm)
 
 RUN(NAME kwargs_01 LABELS gfortran llvm wasm)
 RUN(NAME kwargs_02 LABELS gfortran)

--- a/integration_tests/class_05.f90
+++ b/integration_tests/class_05.f90
@@ -1,0 +1,76 @@
+! Source - Page 44 of https://personalpages.manchester.ac.uk/staff/david.d.apsley/lectures/fortran/fortranB.pdf
+module Defs
+   implicit none
+   private
+   public point, point2d, point3d
+
+    type, abstract :: point
+        contains
+        procedure(func), deferred :: radius
+    end type point
+
+    abstract interface
+        real function func( this )
+            import point
+            class(point) this
+        end function func
+    end interface
+
+    type, extends(point) :: point2d
+        real x, y
+    contains
+        procedure :: radius => r2d
+    end type point2d
+
+    type, extends(point2d) :: point3d
+        real z
+    contains
+        procedure :: radius => r3d
+    end type point3d
+
+contains
+
+    real function r2d( this )
+        class(point2d) this
+        r2d = sqrt( this%x ** 2 + this%y ** 2 )
+    end function r2d
+
+    real function r3d( this )
+        class(point3d) this
+        r3d = sqrt( this%x ** 2 + this%y ** 2 + this%z ** 2 )
+    end function r3d
+
+end module Defs
+
+program main
+use Defs
+implicit none
+
+    class(point), pointer :: ptr
+
+    ! TODO: Re-enable after fixing class_constructor.cpp
+    type(point2d), target :: p2d ! = point2d( 3, 4 )
+    type(point3d), target :: p3d ! = point3d( 3, 4, 5 )
+
+    real :: result
+
+    p2d = point2d( 3.0, 4.0 )
+    ! TODO: Re-enable after fixing class_constructor pass
+    ! p3d = point3d( 3.0, 4.0, 5.0 )
+    p3d%x = 3.0
+    p3d%y = 4.0
+    p3d%z = 5.0
+
+    print *, p2d%x, p2d%y
+    print *, p3d%x, p3d%y, p3d%z
+
+    ptr => p2d
+    result = ptr%radius()
+    print *, "2-d radius is ", result
+    if( abs(result - 5.0) > 1e-8 ) error stop
+
+    ptr => p3d
+    result = ptr%radius()
+    print *, "3-d radius is ", result
+    if( abs(result - 7.07106781) > 1e-8 ) error stop
+end program main

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1725,7 +1725,7 @@ public:
                 current_scope = al.make_new<SymbolTable>(parent_scope);
                 ASR::asr_t* dtype = ASR::make_StructType_t(al, loc, current_scope,
                                                 s2c(al, to_lower(derived_type_name)), nullptr, 0, nullptr, 0,
-                                                ASR::abiType::Source, dflt_access, false, nullptr, nullptr);
+                                                ASR::abiType::Source, dflt_access, false, true, nullptr, nullptr);
                 v = ASR::down_cast<ASR::symbol_t>(dtype);
                 parent_scope->add_symbol(derived_type_name, v);
                 current_scope = parent_scope;

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -72,6 +72,7 @@ public:
     std::map<AST::intrinsicopType, std::vector<std::string>> overloaded_op_procs;
     std::map<std::string, std::vector<std::string>> defined_op_procs;
     std::map<std::string, std::map<std::string, std::map<std::string, std::string>>> class_procedures;
+    std::map<std::string, std::vector<std::string>> class_deferred_procedures;
     std::vector<std::string> assgn_proc_names;
     std::string dt_name;
     bool in_submodule = false;
@@ -944,6 +945,7 @@ public:
         current_scope = al.make_new<SymbolTable>(parent_scope);
         data_member_names.reserve(al, 0);
         is_derived_type = true;
+        bool is_abstract = false;
         dt_name = to_lower(x.m_name);
         AST::AttrExtends_t *attr_extend = nullptr;
         for( size_t i = 0; i < x.n_attrtype; i++ ) {
@@ -955,6 +957,11 @@ public:
                     }
                     attr_extend = (AST::AttrExtends_t*)(&(x.m_attrtype[i]->base));
                     break;
+                }
+                case AST::decl_attributeType::SimpleAttribute: {
+                    AST::SimpleAttribute_t* simple_attr =
+                        AST::down_cast<AST::SimpleAttribute_t>(x.m_attrtype[i]);
+                    is_abstract = simple_attr->m_attr == AST::simple_attributeType::AttrAbstract;
                 }
                 default:
                     break;
@@ -1009,7 +1016,7 @@ public:
         tmp = ASR::make_StructType_t(al, x.base.base.loc, current_scope,
             s2c(al, to_lower(x.m_name)), struct_dependencies.p, struct_dependencies.size(),
             data_member_names.p, data_member_names.size(),
-            ASR::abiType::Source, dflt_access, false, nullptr, parent_sym);
+            ASR::abiType::Source, dflt_access, false, is_abstract, nullptr, parent_sym);
             parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
         is_derived_type = false;
@@ -1047,6 +1054,13 @@ public:
                         LCOMPILERS_ASSERT(class_procedures[dt_name][use_sym_name].find("pass") == class_procedures[dt_name][use_sym_name].end());
                         class_procedures[dt_name][use_sym_name]["pass"] = std::string(attr_pass->m_name);
                         break ;
+                    }
+                    case AST::decl_attributeType::SimpleAttribute: {
+                        AST::SimpleAttribute_t* attr_deferred = AST::down_cast<AST::SimpleAttribute_t>(x.m_attr[i]);
+                        if( attr_deferred->m_attr == AST::simple_attributeType::AttrDeferred ) {
+                            class_deferred_procedures[dt_name].push_back(use_sym_name);
+                        }
+                        break;
                     }
                     default: {
                         break ;
@@ -1364,9 +1378,17 @@ public:
                 if( pname.second.find("pass") != pname.second.end() ) {
                     pass_arg_name = s2c(al, pname.second["pass"]);
                 }
+                bool is_deferred = false;
+                if( class_deferred_procedures.find(proc.first) != class_deferred_procedures.end() &&
+                    std::find(class_deferred_procedures[proc.first].begin(),
+                              class_deferred_procedures[proc.first].end(), pname.first) !=
+                              class_deferred_procedures[proc.first].end() ) {
+                    is_deferred = true;
+                }
                 ASR::asr_t *v = ASR::make_ClassProcedure_t(al, loc,
                     clss->m_symtab, name, pass_arg_name,
-                    proc_name, proc_sym, ASR::abiType::Source);
+                    proc_name, proc_sym, ASR::abiType::Source,
+                    is_deferred);
                 ASR::symbol_t *cls_proc_sym = ASR::down_cast<ASR::symbol_t>(v);
                 clss->m_symtab->add_symbol(pname.first, cls_proc_sym);
             }

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -95,7 +95,7 @@ symbol
         symbol external, identifier module_name, identifier* scope_names,
         identifier original_name, access access)
     | StructType(symbol_table symtab, identifier name, identifier* dependencies,
-        identifier* members, abi abi, access access, bool is_packed,
+        identifier* members, abi abi, access access, bool is_packed, bool is_abstract,
         expr? alignment, symbol? parent)
     | EnumType(symbol_table symtab, identifier name, identifier* dependencies,
         identifier* members, abi abi, access access, enumtype enum_value_type,
@@ -107,7 +107,7 @@ symbol
         abi abi, access access, presence presence, bool value_attr)
     | ClassType(symbol_table symtab, identifier name, abi abi, access access)
     | ClassProcedure(symbol_table parent_symtab, identifier name, identifier? self_argument,
-        identifier proc_name, symbol proc, abi abi)
+        identifier proc_name, symbol proc, abi abi, bool is_deferred)
     | AssociateBlock(symbol_table symtab, identifier name, stmt* body)
     | Block(symbol_table symtab, identifier name, stmt* body)
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -244,6 +244,7 @@ public:
     std::map<ASR::symbol_t*, std::map<SymbolTable*, std::vector<llvm::Value*>>> class2vtab;
     std::map<ASR::symbol_t*, llvm::Type*> type2vtabtype;
     std::map<ASR::symbol_t*, int> type2vtabid;
+    std::map<ASR::symbol_t*, std::map<std::string, int64_t>> vtabtype2procidx;
     llvm::Type* current_select_type_block_type;
     std::string current_select_type_block_der_type;
 
@@ -867,6 +868,19 @@ public:
         }
         llvm::StructType* der_type_llvm = llvm::StructType::create(context, member_types, der_type_name);
         name2dertype[der_type_name] = der_type_llvm;
+        if( is_pointer ) {
+            return der_type_llvm->getPointerTo();
+        }
+        return (llvm::Type*) der_type_llvm;
+    }
+
+    llvm::Type* getClassType(ASR::StructType_t* der_type, bool is_pointer=false) {
+        std::string der_type_name = std::string(der_type->m_name) + std::string("_polymorphic");
+        llvm::StructType* der_type_llvm = nullptr;
+        if( name2dertype.find(der_type_name) != name2dertype.end() ) {
+            der_type_llvm = name2dertype[der_type_name];
+        }
+        LCOMPILERS_ASSERT(der_type_llvm != nullptr);
         if( is_pointer ) {
             return der_type_llvm->getPointerTo();
         }
@@ -3030,8 +3044,9 @@ public:
             return ;
         }
         if( type2vtabtype.find(struct_type_sym) == type2vtabtype.end() ) {
+            std::vector<llvm::Type*> type_vec = {getIntType(8)};
             type2vtabtype[struct_type_sym] = llvm::StructType::create(
-                                                context, {getIntType(8)},
+                                                context, type_vec,
                                                 std::string("__vtab_") +
                                                 std::string(struct_type_t->m_name));
         }
@@ -3781,6 +3796,14 @@ public:
             F = llvm_symtab_fn[h];
         } else {
             llvm::FunctionType* function_type = get_function_type(x);
+            if( ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface ) {
+                ASR::FunctionType_t* asr_function_type = ASRUtils::get_FunctionType(x);
+                for( size_t i = 0; i < asr_function_type->n_arg_types; i++ ) {
+                    if( ASR::is_a<ASR::Class_t>(*asr_function_type->m_arg_types[i]) ) {
+                        return ;
+                    }
+                }
+            }
             std::string fn_name;
             if (ASRUtils::get_FunctionType(x)->m_abi == ASR::abiType::BindC) {
                 if (ASRUtils::get_FunctionType(x)->m_bindc_name) {
@@ -4341,8 +4364,10 @@ public:
             ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(
                     ASRUtils::type_get_past_pointer(asr_value->m_type));
             ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(struct_t->m_derived_type);
-            LCOMPILERS_ASSERT(type2vtab.find(struct_sym) != type2vtab.end() &&
-                type2vtab[struct_sym].find(current_scope) != type2vtab[struct_sym].end() );
+            if (type2vtab.find(struct_sym) == type2vtab.end() ||
+                type2vtab[struct_sym].find(current_scope) == type2vtab[struct_sym].end()) {
+                create_vtab_for_struct_type(struct_sym, current_scope);
+            }
             llvm::Value* vtab_obj = type2vtab[struct_sym][current_scope];
             llvm::Value* struct_type_hash = CreateLoad(llvm_utils->create_gep(vtab_obj, 0));
             builder->CreateStore(struct_type_hash, vtab_address_ptr);
@@ -7312,6 +7337,99 @@ public:
         return CreateCallUtil(fn->getFunctionType(), fn, args, asr_return_type);
     }
 
+    void visit_RuntimePolymorphicFunctionCall(const ASR::FunctionCall_t& x, std::string proc_sym_name) {
+        std::vector<std::pair<llvm::Value*, ASR::symbol_t*>> vtabs;
+        ASR::Var_t* dt_Var = ASR::down_cast<ASR::Var_t>(x.m_dt);
+        ASR::symbol_t* dt_sym = ASRUtils::symbol_get_past_external(dt_Var->m_v);
+        ASR::StructType_t* dt_sym_type = nullptr;
+        ASR::ttype_t* dt_ttype_t = ASRUtils::type_get_past_pointer(
+                                        ASRUtils::symbol_type(dt_sym));
+        if( ASR::is_a<ASR::Struct_t>(*dt_ttype_t) ) {
+            ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(dt_ttype_t);
+            dt_sym_type = ASR::down_cast<ASR::StructType_t>(
+                ASRUtils::symbol_get_past_external(struct_t->m_derived_type));
+        } else if( ASR::is_a<ASR::Class_t>(*dt_ttype_t) ) {
+            ASR::Class_t* class_t = ASR::down_cast<ASR::Class_t>(dt_ttype_t);
+            dt_sym_type = ASR::down_cast<ASR::StructType_t>(
+                ASRUtils::symbol_get_past_external(class_t->m_class_type));
+        }
+        LCOMPILERS_ASSERT(dt_sym_type != nullptr);
+        for( auto& item: type2vtab ) {
+            ASR::StructType_t* a_dt = ASR::down_cast<ASR::StructType_t>(item.first);
+            if( !a_dt->m_is_abstract &&
+                (a_dt == dt_sym_type ||
+                ASRUtils::is_parent(a_dt, dt_sym_type) ||
+                ASRUtils::is_parent(dt_sym_type, a_dt)) ) {
+                for( auto& item2: item.second ) {
+                    if( item2.first == current_scope ) {
+                        vtabs.push_back(std::make_pair(item2.second, item.first));
+                    }
+                }
+            }
+        }
+
+        uint64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = 0;
+        visit_Var(*dt_Var);
+        ptr_loads = ptr_loads_copy;
+        llvm::Value* llvm_dt = tmp;
+        tmp = builder->CreateAlloca(get_type_from_ttype_t_util(x.m_type));
+        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
+        for( size_t i = 0; i < vtabs.size(); i++ ) {
+            llvm::Function *fn = builder->GetInsertBlock()->getParent();
+
+            llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
+            llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
+
+            llvm::Value* vptr_int_hash = CreateLoad(llvm_utils->create_gep(llvm_dt, 0));
+            llvm::Value* dt_data = CreateLoad(llvm_utils->create_gep(llvm_dt, 1));
+            ASR::ttype_t* selector_var_type = ASRUtils::expr_type(x.m_dt);
+            if( ASRUtils::is_array(selector_var_type) ) {
+                vptr_int_hash = CreateLoad(llvm_utils->create_gep(vptr_int_hash, 0));
+            }
+            ASR::symbol_t* type_sym = ASRUtils::symbol_get_past_external(vtabs[i].second);
+            llvm::Value* type_sym_vtab = vtabs[i].first;
+            llvm::Value* cond = builder->CreateICmpEQ(
+                                    vptr_int_hash,
+                                    CreateLoad(
+                                        llvm_utils->create_gep(type_sym_vtab, 0) ) );
+
+            builder->CreateCondBr(cond, thenBB, elseBB);
+            builder->SetInsertPoint(thenBB);
+            {
+                std::vector<llvm::Value*> args;
+                ASR::StructType_t* struct_type_t = ASR::down_cast<ASR::StructType_t>(type_sym);
+                llvm::Type* target_dt_type = getStructType(struct_type_t, true);
+                llvm::Type* target_class_dt_type = getClassType(struct_type_t);
+                llvm::Value* target_dt = builder->CreateAlloca(target_class_dt_type);
+                llvm::Value* target_dt_hash_ptr = llvm_utils->create_gep(target_dt, 0);
+                builder->CreateStore(vptr_int_hash, target_dt_hash_ptr);
+                llvm::Value* target_dt_data_ptr = llvm_utils->create_gep(target_dt, 1);
+                builder->CreateStore(builder->CreateBitCast(dt_data, target_dt_type),
+                                     target_dt_data_ptr);
+                args.push_back(target_dt);
+                ASR::symbol_t* s_class_proc = struct_type_t->m_symtab->resolve_symbol(proc_sym_name);
+                ASR::symbol_t* s_proc = ASRUtils::symbol_get_past_external(
+                    ASR::down_cast<ASR::ClassProcedure_t>(s_class_proc)->m_proc);
+                uint32_t h = get_hash((ASR::asr_t*) s_proc);
+                llvm::Function* fn = llvm_symtab_fn[h];
+                ASR::Function_t* s = ASR::down_cast<ASR::Function_t>(s_proc);
+                LCOMPILERS_ASSERT(s != nullptr);
+                std::vector<llvm::Value *> args2 = convert_call_args(x, true);
+                args.insert(args.end(), args2.begin(), args2.end());
+                ASR::ttype_t *return_var_type0 = EXPR2VAR(s->m_return_var)->m_type;
+                builder->CreateStore(CreateCallUtil(fn, args, return_var_type0), tmp);
+            }
+            builder->CreateBr(mergeBB);
+
+            start_new_block(elseBB);
+            current_select_type_block_type = nullptr;
+            current_select_type_block_der_type.clear();
+        }
+        start_new_block(mergeBB);
+        tmp = CreateLoad(tmp);
+    }
+
     void visit_FunctionCall(const ASR::FunctionCall_t &x) {
         if( ASRUtils::is_intrinsic_optimization(x.m_name) ) {
             ASR::Function_t* routine = ASR::down_cast<ASR::Function_t>(
@@ -7322,11 +7440,25 @@ public:
         }
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);
-            return;
+            return ;
         }
+
+        const ASR::symbol_t *proc_sym = symbol_get_past_external(x.m_name);
+        std::string proc_sym_name = "";
+        bool is_deferred = false;
+        if( ASR::is_a<ASR::ClassProcedure_t>(*proc_sym) ) {
+            ASR::ClassProcedure_t* class_proc =
+                ASR::down_cast<ASR::ClassProcedure_t>(proc_sym);
+            is_deferred = class_proc->m_is_deferred;
+            proc_sym_name = class_proc->m_name;
+        }
+        if( is_deferred ) {
+            visit_RuntimePolymorphicFunctionCall(x, proc_sym_name);
+            return ;
+        }
+
         ASR::Function_t *s = nullptr;
         std::vector<llvm::Value*> args;
-        const ASR::symbol_t *proc_sym = symbol_get_past_external(x.m_name);
         if (ASR::is_a<ASR::Function_t>(*proc_sym)) {
             s = ASR::down_cast<ASR::Function_t>(proc_sym);
         } else {
@@ -7364,7 +7496,7 @@ public:
                 return ;
             }
         }
-        if (parent_function){
+        if (parent_function) {
             push_nested_stack(parent_function);
         }
         bool intrinsic_function = ASRUtils::is_intrinsic_function2(s);

--- a/tests/reference/asr-array2_derived-0245556.json
+++ b/tests/reference/asr-array2_derived-0245556.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array2_derived-0245556.stdout",
-    "stdout_hash": "5f6a3da4f3cff26f5c81af63487756699dbd3bc33331870d6439222b",
+    "stdout_hash": "f98fabfeb5d2b0a944a4532b30038392606244e28047987a551d4b82",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array2_derived-0245556.stdout
+++ b/tests/reference/asr-array2_derived-0245556.stdout
@@ -114,6 +114,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-arrays_23-b542514.json
+++ b/tests/reference/asr-arrays_23-b542514.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_23-b542514.stdout",
-    "stdout_hash": "33956071db24d44ed0116edbfb72b8172916fada6cc0120853d647dd",
+    "stdout_hash": "23ad943d26234566f81cde7b2a53a065b1f9f854634af8adc1dcb8cc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_23-b542514.stdout
+++ b/tests/reference/asr-arrays_23-b542514.stdout
@@ -297,6 +297,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-class_01-233a8ad.json
+++ b/tests/reference/asr-class_01-233a8ad.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_01-233a8ad.stdout",
-    "stdout_hash": "aeef1c6cd12a7a9489fefb780094ab68752d2df30259f160bf80b423",
+    "stdout_hash": "fbee3510ae3c2e5856b8494bd4bf8bb55e09e70fefb103f8be51b4ac",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_01-233a8ad.stdout
+++ b/tests/reference/asr-class_01-233a8ad.stdout
@@ -128,6 +128,7 @@
                                                     circle_area
                                                     2 circle_area
                                                     Source
+                                                    .false.
                                                 ),
                                             print:
                                                 (ClassProcedure
@@ -137,6 +138,7 @@
                                                     circle_print
                                                     2 circle_print
                                                     Source
+                                                    .false.
                                                 ),
                                             radius:
                                                 (Variable
@@ -159,6 +161,7 @@
                                     [radius]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-class_02-4331b31.json
+++ b/tests/reference/asr-class_02-4331b31.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_02-4331b31.stdout",
-    "stdout_hash": "6565ffc6eb45355917d56fbd26aa37ac9920bd521cd91ebe4115b96e",
+    "stdout_hash": "a6b20d5d44be02b58dba59b8f921a76adf60345ec4cd229e88dcc474",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_02-4331b31.stdout
+++ b/tests/reference/asr-class_02-4331b31.stdout
@@ -45,6 +45,7 @@
                                                     circle_area
                                                     2 circle_area
                                                     Source
+                                                    .false.
                                                 ),
                                             circle_print:
                                                 (ClassProcedure
@@ -54,6 +55,7 @@
                                                     circle_print
                                                     2 circle_print
                                                     Source
+                                                    .false.
                                                 ),
                                             radius:
                                                 (Variable
@@ -76,6 +78,7 @@
                                     [radius]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-class_03-205b2ce.json
+++ b/tests/reference/asr-class_03-205b2ce.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_03-205b2ce.stdout",
-    "stdout_hash": "6b8ef5d0cf0d7d62aa45bdc62fa6e3e3c856b5065664f0f50fba8f24",
+    "stdout_hash": "5975ff83c80bb5f20d4d27bbb500279b2f4471fac20dd4987fe77e2a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_03-205b2ce.stdout
+++ b/tests/reference/asr-class_03-205b2ce.stdout
@@ -89,6 +89,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -166,6 +167,7 @@
                                     sgender]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-class_04-033ae97.json
+++ b/tests/reference/asr-class_04-033ae97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_04-033ae97.stdout",
-    "stdout_hash": "31525fff75c8694ea9cf6629a800fb04ba05f53a4e4c3c9899e17e3c",
+    "stdout_hash": "c03df1c36532b153e532c019393f36d5a372d60d61b9c9e81c2e269c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_04-033ae97.stdout
+++ b/tests/reference/asr-class_04-033ae97.stdout
@@ -94,6 +94,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -124,6 +125,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     2 bar_a
                                 ),
@@ -153,6 +155,7 @@
                                     [c]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     2 bar_b
@@ -205,6 +208,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -238,6 +242,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     2 foo_a
                                 ),
@@ -270,6 +275,7 @@
                                     [m_bar_c]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     2 foo_b

--- a/tests/reference/asr-dependency_test_01-80e1f61.json
+++ b/tests/reference/asr-dependency_test_01-80e1f61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-dependency_test_01-80e1f61.stdout",
-    "stdout_hash": "a68cadf9be83326e16304745a2f0c9a160c5fd9c66c8854fca3ac516",
+    "stdout_hash": "abe6575a3a81592b18d65e9c24c9629ca3a51b535574732fe2b6bdc8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-dependency_test_01-80e1f61.stdout
+++ b/tests/reference/asr-dependency_test_01-80e1f61.stdout
@@ -161,6 +161,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -245,6 +246,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -268,6 +270,7 @@
                                                     add_dependency
                                                     2 add_dependency
                                                     Source
+                                                    .false.
                                                 ),
                                             cache:
                                                 (Variable
@@ -333,6 +336,7 @@
                                                     find_dependency
                                                     2 find_dependency
                                                     Source
+                                                    .false.
                                                 ),
                                             ndep:
                                                 (Variable
@@ -390,6 +394,7 @@
                                     cache]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-derived_type1-0b4c060.json
+++ b/tests/reference/asr-derived_type1-0b4c060.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_type1-0b4c060.stdout",
-    "stdout_hash": "3e46a5c785a19758c5576a524b628408b3a35b41d6d541ec34534cf1",
+    "stdout_hash": "b9a894b819cfeaf78a1f4fcf4222bb6522c7bfb64a408bff0b5eb9fe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_type1-0b4c060.stdout
+++ b/tests/reference/asr-derived_type1-0b4c060.stdout
@@ -66,6 +66,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-derived_types_01-a1b2a29.json
+++ b/tests/reference/asr-derived_types_01-a1b2a29.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_01-a1b2a29.stdout",
-    "stdout_hash": "5b6a71c98be2b818dfd982bab99d79a62fe1e06fa7a919aed067bbd5",
+    "stdout_hash": "cee6358a4468fb3f0bb98ef42351f783ea7f6ed2e7a8d27b90962bb2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_01-a1b2a29.stdout
+++ b/tests/reference/asr-derived_types_01-a1b2a29.stdout
@@ -644,6 +644,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -692,6 +693,7 @@
                                     d]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -762,6 +764,7 @@
                                     l]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_03-37895d2.json
+++ b/tests/reference/asr-derived_types_03-37895d2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_03-37895d2.stdout",
-    "stdout_hash": "e57039f58d598786ae04e493aa1b574e7a8e7ce845acfa8913fb1274",
+    "stdout_hash": "e3efc3243d0e6216648c575b09188f6fc9c3bf9cd1541ed6c7ad62f2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_03-37895d2.stdout
+++ b/tests/reference/asr-derived_types_03-37895d2.stdout
@@ -52,6 +52,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -86,6 +87,7 @@
                                                     [i]
                                                     Source
                                                     Public
+                                                    .false.
                                                     .false.
                                                     ()
                                                     ()
@@ -164,6 +166,7 @@
                                                     [i]
                                                     Source
                                                     Public
+                                                    .false.
                                                     .false.
                                                     ()
                                                     ()

--- a/tests/reference/asr-derived_types_04-2d77333.json
+++ b/tests/reference/asr-derived_types_04-2d77333.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-2d77333.stdout",
-    "stdout_hash": "75d55b3cf394fefd1f58a0a83075f97bf56da1e0babfd04b5c325614",
+    "stdout_hash": "6ec32292f4291bdc087b80bea601cd01cba777c02c7bc5b5de224ef1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-2d77333.stdout
+++ b/tests/reference/asr-derived_types_04-2d77333.stdout
@@ -86,6 +86,7 @@
                                                     all_abstract
                                                     2 all_abstract
                                                     Source
+                                                    .true.
                                                 ),
                                             num_bits:
                                                 (Variable
@@ -109,6 +110,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-derived_types_04-f1d65ad.json
+++ b/tests/reference/asr-derived_types_04-f1d65ad.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-f1d65ad.stdout",
-    "stdout_hash": "4ad084f955b01020b50c11523616f70077cdac082756a3deac5c5b6f",
+    "stdout_hash": "342aba29ac12e285456d97b126f7f13405a04e2c4fef0918a5900931",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-f1d65ad.stdout
+++ b/tests/reference/asr-derived_types_04-f1d65ad.stdout
@@ -1033,6 +1033,7 @@
                                                     date_to_string
                                                     2 date_to_string
                                                     Source
+                                                    .false.
                                                 ),
                                             year:
                                                 (Variable
@@ -1064,6 +1065,7 @@
                                     day]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -1117,6 +1119,7 @@
                                                     datetime_to_string
                                                     2 datetime_to_string
                                                     Source
+                                                    .false.
                                                 ),
                                             ~assign:
                                                 (CustomOperator
@@ -1133,6 +1136,7 @@
                                     time]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -1210,6 +1214,7 @@
                                                     time_to_string
                                                     2 time_to_string
                                                     Source
+                                                    .false.
                                                 ),
                                             zone:
                                                 (Variable
@@ -1243,6 +1248,7 @@
                                     zone]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_05-4f2285c.json
+++ b/tests/reference/asr-derived_types_05-4f2285c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_05-4f2285c.stdout",
-    "stdout_hash": "7f9c9ba1287c5ddb263c3dda1412a8c8d51393fc0dd168fcb32c6adc",
+    "stdout_hash": "517189ed6149e3daff64b09ecc81f235b86a7fe43057dab00e15344a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_05-4f2285c.stdout
+++ b/tests/reference/asr-derived_types_05-4f2285c.stdout
@@ -309,6 +309,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-derived_types_06-22b43e4.json
+++ b/tests/reference/asr-derived_types_06-22b43e4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-22b43e4.stdout",
-    "stdout_hash": "e7a09037363f723de830f0154f072321f0c94edd2d42cbe55ef05ef7",
+    "stdout_hash": "aad89679c9b5c1031976e4090e883021ec69aa6a2f6daf298b3ad38d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-22b43e4.stdout
+++ b/tests/reference/asr-derived_types_06-22b43e4.stdout
@@ -1041,6 +1041,7 @@
                                                     date_to_string
                                                     7 date_to_string
                                                     Source
+                                                    .false.
                                                 ),
                                             year:
                                                 (Variable
@@ -1072,6 +1073,7 @@
                                     day]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -1125,6 +1127,7 @@
                                                     datetime_to_string
                                                     7 datetime_to_string
                                                     Source
+                                                    .false.
                                                 ),
                                             ~assign:
                                                 (CustomOperator
@@ -1141,6 +1144,7 @@
                                     time]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -1218,6 +1222,7 @@
                                                     time_to_string
                                                     7 time_to_string
                                                     Source
+                                                    .false.
                                                 ),
                                             zone:
                                                 (Variable
@@ -1251,6 +1256,7 @@
                                     zone]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_06-a77d24a.json
+++ b/tests/reference/asr-derived_types_06-a77d24a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-a77d24a.stdout",
-    "stdout_hash": "88949d1330d2b2f1fc526c0668bdc39147b556d656e7ae3fea8a9b9f",
+    "stdout_hash": "c542f2535b81b1ecb63a207fd5cd3c217cfeb809ed16f5728f4ed73c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-a77d24a.stdout
+++ b/tests/reference/asr-derived_types_06-a77d24a.stdout
@@ -43,6 +43,7 @@
                                                     Source
                                                     Public
                                                     .false.
+                                                    .true.
                                                     ()
                                                     ()
                                                 )

--- a/tests/reference/asr-derived_types_07-004752c.json
+++ b/tests/reference/asr-derived_types_07-004752c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-004752c.stdout",
-    "stdout_hash": "110b1a9a94bdf63dcddbd8e20768e9bd328c5e6fd0b563be503c2274",
+    "stdout_hash": "069f394ab80e3cf1376cdafd2b63c500d7fd52a19ec809c54e6545ea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-004752c.stdout
+++ b/tests/reference/asr-derived_types_07-004752c.stdout
@@ -177,6 +177,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-derived_types_07-f9282aa.json
+++ b/tests/reference/asr-derived_types_07-f9282aa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-f9282aa.stdout",
-    "stdout_hash": "4ed1754c5b68ed41d04db0fbf2dc956c663d4f76f882da859eced563",
+    "stdout_hash": "7bd54262c94ac3455ef3cc7b210c1b888b48fc979accd03bd014b718",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-f9282aa.stdout
+++ b/tests/reference/asr-derived_types_07-f9282aa.stdout
@@ -461,6 +461,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -520,6 +521,7 @@
                                     lst]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -689,6 +691,7 @@
                                                     destroy
                                                     6 destroy
                                                     Source
+                                                    .false.
                                                 ),
                                             raw:
                                                 (Variable
@@ -711,6 +714,7 @@
                                     [raw]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     6 toml_value
@@ -943,6 +947,7 @@
                                                     destroy
                                                     2 destroy
                                                     Source
+                                                    .true.
                                                 ),
                                             key:
                                                 (Variable
@@ -967,6 +972,7 @@
                                                     match_key
                                                     2 match_key
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     toml_value
@@ -975,6 +981,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-derived_types_08-3466b0c.json
+++ b/tests/reference/asr-derived_types_08-3466b0c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_08-3466b0c.stdout",
-    "stdout_hash": "466875cdad539a7c24ed64602f662d871014fed6372149751eedadf0",
+    "stdout_hash": "121f9191020197d14b2038bacac5501f605ff9d92bd7b73a20035d18",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_08-3466b0c.stdout
+++ b/tests/reference/asr-derived_types_08-3466b0c.stdout
@@ -532,6 +532,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     2 shape
                                 ),
@@ -578,6 +579,7 @@
                                                     initialize_subrout
                                                     2 initialize_subrout
                                                     Source
+                                                    .false.
                                                 ),
                                             x:
                                                 (Variable
@@ -618,6 +620,7 @@
                                     y]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_11-8524582.json
+++ b/tests/reference/asr-derived_types_11-8524582.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_11-8524582.stdout",
-    "stdout_hash": "4c721535dc251872cba9cfa3da2bde89ce0dd9a8def17dbf4daf1513",
+    "stdout_hash": "53b19c7ff1669b3f84c5e73558ff5118b9a8d7aebb17815ad85081cb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_11-8524582.stdout
+++ b/tests/reference/asr-derived_types_11-8524582.stdout
@@ -109,6 +109,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-derived_types_14-515b614.json
+++ b/tests/reference/asr-derived_types_14-515b614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_14-515b614.stdout",
-    "stdout_hash": "0f397f6992b61596a01034dacea758edcc258ea5f661e070866faff7",
+    "stdout_hash": "bf947afe770f1da83163b0153cc699e16d48090f6ebaefa2c9ac100a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_14-515b614.stdout
+++ b/tests/reference/asr-derived_types_14-515b614.stdout
@@ -114,6 +114,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-derived_types_15-3ec44d3.json
+++ b/tests/reference/asr-derived_types_15-3ec44d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_15-3ec44d3.stdout",
-    "stdout_hash": "3cfa654707842664f7563c56fa9a6326b0b910511a3e3b783bc84b9b",
+    "stdout_hash": "dbc1fa44e3a25b388495f195aa5ad3660c5eee486cf07ebe826f1c2e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_15-3ec44d3.stdout
+++ b/tests/reference/asr-derived_types_15-3ec44d3.stdout
@@ -283,6 +283,7 @@
                                                     multiply
                                                     2 multiply
                                                     Source
+                                                    .false.
                                                 ),
                                             sqrt_subtract:
                                                 (ClassProcedure
@@ -292,6 +293,7 @@
                                                     sqrt_subtract
                                                     2 sqrt_subtract
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     t_1
@@ -299,6 +301,7 @@
                                     [i]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_16_module-47448d4.json
+++ b/tests/reference/asr-derived_types_16_module-47448d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_16_module-47448d4.stdout",
-    "stdout_hash": "912ca38fb23c0eecfa4520fa357893a7305cf3a40766cf2d08938e1a",
+    "stdout_hash": "9fc97b153dd9dbc48391b8d8e047aabc4a5d7d22ca6e303d2dce8766",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_16_module-47448d4.stdout
+++ b/tests/reference/asr-derived_types_16_module-47448d4.stdout
@@ -268,6 +268,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-derived_types_17-e392c83.json
+++ b/tests/reference/asr-derived_types_17-e392c83.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_17-e392c83.stdout",
-    "stdout_hash": "6ed0dbe81e95cc3a429e675e725aa310be2be410ecd7abc903ef0394",
+    "stdout_hash": "dd002916d474b3206579b6a8983dda94426020bbe444ea234c6e9968",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_17-e392c83.stdout
+++ b/tests/reference/asr-derived_types_17-e392c83.stdout
@@ -231,6 +231,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-derived_types_18-fadee40.json
+++ b/tests/reference/asr-derived_types_18-fadee40.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_18-fadee40.stdout",
-    "stdout_hash": "77e1dfe23e5d97ac9a056ac9a8e88397ea558d9106609f69136d6f88",
+    "stdout_hash": "e4e6656e80d747133b0cf3df863ed0cbd5ef0576e5de67333fedfd3f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_18-fadee40.stdout
+++ b/tests/reference/asr-derived_types_18-fadee40.stdout
@@ -214,6 +214,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -243,6 +244,7 @@
                                     [r]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     2 t_1

--- a/tests/reference/asr-derived_types_19-33438e3.json
+++ b/tests/reference/asr-derived_types_19-33438e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_19-33438e3.stdout",
-    "stdout_hash": "b5f394b2cc1540a4a84c913ea1ddb42b987969ffb899a943e79a4da9",
+    "stdout_hash": "39e21ddb4e0bb489e7d87f21de5c7d423461e84ee8f922f7d30a3560",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_19-33438e3.stdout
+++ b/tests/reference/asr-derived_types_19-33438e3.stdout
@@ -168,6 +168,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     4 toml_value
                                 ),
@@ -283,6 +284,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-fn6-5b1f799.json
+++ b/tests/reference/asr-fn6-5b1f799.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn6-5b1f799.stdout",
-    "stdout_hash": "233313392c784378d7520001f0e55923509fcac6c1ff9fedc9453e3c",
+    "stdout_hash": "3a5433f7925ad43be9b2acb301bd95812ad5188cdc87eb439faf6180",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn6-5b1f799.stdout
+++ b/tests/reference/asr-fn6-5b1f799.stdout
@@ -199,6 +199,7 @@
                                                     Source
                                                     Public
                                                     .false.
+                                                    .true.
                                                     ()
                                                     ()
                                                 )
@@ -1088,6 +1089,7 @@
                                                     Source
                                                     Public
                                                     .false.
+                                                    .true.
                                                     ()
                                                     ()
                                                 )

--- a/tests/reference/asr-functions_16-f863e4a.json
+++ b/tests/reference/asr-functions_16-f863e4a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_16-f863e4a.stdout",
-    "stdout_hash": "2256df9b95ab7fd0cd2c967feef713bd0007f9fc5248a646220e98ae",
+    "stdout_hash": "1488f9cee67d71ddfdfc0f733f27670dba80152e7790815ef8c04301",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_16-f863e4a.stdout
+++ b/tests/reference/asr-functions_16-f863e4a.stdout
@@ -1131,6 +1131,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-generic_name_01-3bbd36d.json
+++ b/tests/reference/asr-generic_name_01-3bbd36d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generic_name_01-3bbd36d.stdout",
-    "stdout_hash": "96900c63b3c70b6362541339304101f9bf46144366f75b15e7d1415b",
+    "stdout_hash": "cca12513c8106b407f78a49ef03aa639186c4abb62a6b1b0c64026c6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generic_name_01-3bbd36d.stdout
+++ b/tests/reference/asr-generic_name_01-3bbd36d.stdout
@@ -53,6 +53,7 @@
                                                     integer_add_subrout
                                                     2 integer_add_subrout
                                                     Source
+                                                    .false.
                                                 ),
                                             r:
                                                 (Variable
@@ -77,6 +78,7 @@
                                                     real_add_subrout
                                                     2 real_add_subrout
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     complextype
@@ -85,6 +87,7 @@
                                     i]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-kwargs_02-5f7dccf.json
+++ b/tests/reference/asr-kwargs_02-5f7dccf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-kwargs_02-5f7dccf.stdout",
-    "stdout_hash": "e4af5fbc7755d5ee605d26dbfd8e18748a1dcb2e97f558390dbf6a33",
+    "stdout_hash": "80cd2c5cffeac5dca0d1954a1294cd35004163546f2437d8bb2461c0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-kwargs_02-5f7dccf.stdout
+++ b/tests/reference/asr-kwargs_02-5f7dccf.stdout
@@ -235,6 +235,7 @@
                                                     add_log_file
                                                     2 add_log_file
                                                     Source
+                                                    .false.
                                                 ),
                                             log_io_error:
                                                 (ClassProcedure
@@ -244,6 +245,7 @@
                                                     log_io_error
                                                     2 log_io_error
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     logger_type
@@ -251,6 +253,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules1-8325b4a.json
+++ b/tests/reference/asr-modules1-8325b4a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules1-8325b4a.stdout",
-    "stdout_hash": "24c394359d7d71e29eea620603e13d8f6b9dfc9b7802ae84240691d9",
+    "stdout_hash": "b5fef728fc838896434226cc3626bc254199715664139804ed4d92d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules1-8325b4a.stdout
+++ b/tests/reference/asr-modules1-8325b4a.stdout
@@ -86,6 +86,7 @@
                                                     f
                                                     8 f
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     t1
@@ -93,6 +94,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -262,6 +264,7 @@
                                     [val]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules2-f9ba4aa.json
+++ b/tests/reference/asr-modules2-f9ba4aa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules2-f9ba4aa.stdout",
-    "stdout_hash": "918eb06d16aa9efedd01c2dbeb945acf34307f3b75f9107c1ef49201",
+    "stdout_hash": "94c7da55101d59986c022a539604cbf03d1d7e04c775b099662a08a5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules2-f9ba4aa.stdout
+++ b/tests/reference/asr-modules2-f9ba4aa.stdout
@@ -104,6 +104,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     10 toml_structure
                                 ),
@@ -120,6 +121,7 @@
                                                     destroy
                                                     10 destroy
                                                     Source
+                                                    .true.
                                                 )
                                         })
                                     toml_structure
@@ -128,6 +130,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )
@@ -392,6 +395,7 @@
                                                     destroy
                                                     2 destroy
                                                     Source
+                                                    .false.
                                                 ),
                                             list:
                                                 (Variable
@@ -417,6 +421,7 @@
                                     [list]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     2 toml_value
@@ -519,6 +524,7 @@
                                                     destroy
                                                     4 destroy
                                                     Source
+                                                    .true.
                                                 ),
                                             key:
                                                 (Variable
@@ -542,6 +548,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-modules3-8c02fda.json
+++ b/tests/reference/asr-modules3-8c02fda.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules3-8c02fda.stdout",
-    "stdout_hash": "02d074143dcf93f00fa6853316857ade620a04721ccf93e3a480022c",
+    "stdout_hash": "4393f15b2a8ab64655c578b6ba5e1a656401937631d31b4aa7ae0d05",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules3-8c02fda.stdout
+++ b/tests/reference/asr-modules3-8c02fda.stdout
@@ -104,6 +104,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     43 toml_structure
                                 ),
@@ -120,6 +121,7 @@
                                                     destroy
                                                     43 destroy
                                                     Source
+                                                    .true.
                                                 )
                                         })
                                     toml_structure
@@ -128,6 +130,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )
@@ -464,6 +467,7 @@
                                                     destroy
                                                     4 destroy
                                                     Source
+                                                    .false.
                                                 ),
                                             list:
                                                 (Variable
@@ -489,6 +493,7 @@
                                     [list]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     4 toml_value
@@ -592,6 +597,7 @@
                                                     destroy
                                                     9 destroy
                                                     Source
+                                                    .true.
                                                 ),
                                             key:
                                                 (Variable
@@ -615,6 +621,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-modules4-0279cc8.json
+++ b/tests/reference/asr-modules4-0279cc8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules4-0279cc8.stdout",
-    "stdout_hash": "5061a647b794dcbd878e4c6065823318979d00ea0566f32737e4d6c4",
+    "stdout_hash": "8ba38ee59da9218ffa3605215439c6a3106ca1afdbe8c3459026daef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules4-0279cc8.stdout
+++ b/tests/reference/asr-modules4-0279cc8.stdout
@@ -104,6 +104,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     43 toml_structure
                                 ),
@@ -120,6 +121,7 @@
                                                     destroy
                                                     43 destroy
                                                     Source
+                                                    .true.
                                                 )
                                         })
                                     toml_structure
@@ -128,6 +130,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )
@@ -454,6 +457,7 @@
                                                     destroy
                                                     4 destroy
                                                     Source
+                                                    .false.
                                                 ),
                                             list:
                                                 (Variable
@@ -479,6 +483,7 @@
                                     [list]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     4 toml_value
@@ -718,6 +723,7 @@
                                                     destroy
                                                     48 destroy
                                                     Source
+                                                    .false.
                                                 ),
                                             raw:
                                                 (Variable
@@ -741,6 +747,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     48 toml_value
                                 ),
@@ -757,6 +764,7 @@
                                                     destroy
                                                     48 destroy
                                                     Source
+                                                    .true.
                                                 ),
                                             key:
                                                 (Variable
@@ -780,6 +788,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )
@@ -859,6 +868,7 @@
                                                     destroy
                                                     9 destroy
                                                     Source
+                                                    .true.
                                                 ),
                                             key:
                                                 (Variable
@@ -882,6 +892,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-modules_24-a9644cf.json
+++ b/tests/reference/asr-modules_24-a9644cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_24-a9644cf.stdout",
-    "stdout_hash": "fb12bd73051965bac7ba94410bb9b6c9e259ccb008339da17dee5bd8",
+    "stdout_hash": "340beb80444e73d24f61ccd5ed92c207424067bd156a7d6e60f88148",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_24-a9644cf.stdout
+++ b/tests/reference/asr-modules_24-a9644cf.stdout
@@ -231,6 +231,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -273,6 +274,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 ),
@@ -288,6 +290,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     2 toml_tokenizer

--- a/tests/reference/asr-modules_25-82bf795.json
+++ b/tests/reference/asr-modules_25-82bf795.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_25-82bf795.stdout",
-    "stdout_hash": "6c9745c584d5e76508a109b6671b5e00baf97f0a51586193798ee40f",
+    "stdout_hash": "47723dfc6dd32f1cbc35f8dbb0c775789420a94b1970ba94ca707890",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_25-82bf795.stdout
+++ b/tests/reference/asr-modules_25-82bf795.stdout
@@ -193,6 +193,7 @@
                                                     next_token
                                                     4 next_token
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     toml_character_tokenizer
@@ -200,6 +201,7 @@
                                     [conf]
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     4 toml_tokenizer
@@ -440,6 +442,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -483,6 +486,7 @@
                                                     next_token
                                                     8 next_token
                                                     Source
+                                                    .true.
                                                 )
                                         })
                                     toml_tokenizer
@@ -491,6 +495,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 ),
@@ -507,6 +512,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .true.
                                     ()
                                     8 toml_tokenizer
                                 )

--- a/tests/reference/asr-modules_28-6796127.json
+++ b/tests/reference/asr-modules_28-6796127.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_28-6796127.stdout",
-    "stdout_hash": "0df48f87e8fd8e82a1c8bc4841ce194d981e8224ee847c111d32362b",
+    "stdout_hash": "698a819ff5aadd5cc3753d959a64171b9e42da0132e0da0632fce891",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_28-6796127.stdout
+++ b/tests/reference/asr-modules_28-6796127.stdout
@@ -172,6 +172,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )
@@ -248,6 +249,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -277,6 +279,7 @@
                                     [message]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -564,6 +567,7 @@
                                     [inline]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules_29-9f2099b.json
+++ b/tests/reference/asr-modules_29-9f2099b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_29-9f2099b.stdout",
-    "stdout_hash": "06d3e556211b50cd0deb760b32a2577693acdabdb7f6d403aa5e9be2",
+    "stdout_hash": "eb6147958c7f795ebbf570a6136e210f7aa58cec5bdff304a2eb37f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_29-9f2099b.stdout
+++ b/tests/reference/asr-modules_29-9f2099b.stdout
@@ -172,6 +172,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )
@@ -248,6 +249,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -277,6 +279,7 @@
                                     [message]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -565,6 +568,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )
@@ -677,6 +681,7 @@
                                     dependency]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules_30-1e195bc.json
+++ b/tests/reference/asr-modules_30-1e195bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_30-1e195bc.stdout",
-    "stdout_hash": "a77f861127c9ec37dc18b10180ac7467fc9e4e0afe85174dcea43735",
+    "stdout_hash": "65714738ff2020bda2cf7e9e4c2df488ed616b6889c4f36066f0d839",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_30-1e195bc.stdout
+++ b/tests/reference/asr-modules_30-1e195bc.stdout
@@ -199,6 +199,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )
@@ -457,6 +458,7 @@
                                     executable]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules_31-6c2c0a3.json
+++ b/tests/reference/asr-modules_31-6c2c0a3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_31-6c2c0a3.stdout",
-    "stdout_hash": "abe00569fd970f1e5ebf423223d74b6093bffc00928ca7eeaa9d69ae",
+    "stdout_hash": "99f563f27d9ce657371ece5a68dbedf9fed130afcad53db620face90",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_31-6c2c0a3.stdout
+++ b/tests/reference/asr-modules_31-6c2c0a3.stdout
@@ -268,6 +268,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .true.
                                     ()
                                     ()
                                 ),
@@ -331,6 +332,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     4 fpm_cmd_settings
                                 )
@@ -387,6 +389,7 @@
                                     path]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -471,6 +474,7 @@
                                     update]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     9 dependency_config_t
@@ -574,6 +578,7 @@
                                                     update_dependency
                                                     9 update_dependency
                                                     Source
+                                                    .false.
                                                 ),
                                             verbosity:
                                                 (Variable
@@ -601,6 +606,7 @@
                                     cache]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -631,6 +637,7 @@
                                     [message]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules_32-10505cf.json
+++ b/tests/reference/asr-modules_32-10505cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_32-10505cf.stdout",
-    "stdout_hash": "9b79fb043a1b8875b3b3493d2d6c6c61a7c0bac682025e3deba9609a",
+    "stdout_hash": "79024313715541b930f28ad5cecd0f715fdb613369484ab13b89922c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_32-10505cf.stdout
+++ b/tests/reference/asr-modules_32-10505cf.stdout
@@ -46,6 +46,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -91,6 +92,7 @@
                                     version]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules_33-c987382.json
+++ b/tests/reference/asr-modules_33-c987382.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_33-c987382.stdout",
-    "stdout_hash": "c9ef151200f04eccae642da69325a89892b35ec49e75e2cd11aee0b8",
+    "stdout_hash": "7947a830c5f170077bbdce87aafe87ff4c3aba7d998697175259253b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_33-c987382.stdout
+++ b/tests/reference/asr-modules_33-c987382.stdout
@@ -276,6 +276,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -360,6 +361,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     7 dependency_config_t
                                 ),
@@ -384,6 +386,7 @@
                                                     add_project
                                                     7 add_project
                                                     Source
+                                                    .false.
                                                 ),
                                             add_project_dependencies:
                                                 (ClassProcedure
@@ -393,6 +396,7 @@
                                                     add_project_dependencies
                                                     7 add_project_dependencies
                                                     Source
+                                                    .false.
                                                 ),
                                             cache:
                                                 (Variable
@@ -488,6 +492,7 @@
                                                     update_dependency
                                                     7 update_dependency
                                                     Source
+                                                    .false.
                                                 ),
                                             verbosity:
                                                 (Variable
@@ -515,6 +520,7 @@
                                     cache]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -546,6 +552,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -575,6 +582,7 @@
                                     [name]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()
@@ -835,6 +843,7 @@
                                     include_tests]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-modules_34-7505d1c.json
+++ b/tests/reference/asr-modules_34-7505d1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_34-7505d1c.stdout",
-    "stdout_hash": "c47b81b5d01a39999a9069921f1d117a103bde13c120b263f0b83c30",
+    "stdout_hash": "07fb19ddff9cc793eaa7391463828bc70ad5599aa0fcac7a4a82b6bc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_34-7505d1c.stdout
+++ b/tests/reference/asr-modules_34-7505d1c.stdout
@@ -95,6 +95,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -511,6 +512,7 @@
                                                     to_string
                                                     10 to_string
                                                     Source
+                                                    .false.
                                                 )
                                         })
                                     version_t
@@ -518,6 +520,7 @@
                                     [num]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-operator_overloading_04-51050f2.json
+++ b/tests/reference/asr-operator_overloading_04-51050f2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-operator_overloading_04-51050f2.stdout",
-    "stdout_hash": "154ae9f2d8c6e099ee8f6d98837a0c70f4ddaab0bed84c72b84ae5c9",
+    "stdout_hash": "2ca9db398d155d5436e570cda3d93ca33414fb5ee980935670eb6e7e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-operator_overloading_04-51050f2.stdout
+++ b/tests/reference/asr-operator_overloading_04-51050f2.stdout
@@ -132,6 +132,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-select_type_01-fec2d3a.json
+++ b/tests/reference/asr-select_type_01-fec2d3a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_01-fec2d3a.stdout",
-    "stdout_hash": "e5c79e32a6f231d8331eb9afba7bd2d7df3a100dd2150a015f361cc3",
+    "stdout_hash": "d5ed6bf4c15968f554e101f4c897c4a727a39f732f05753fa148cc15",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_01-fec2d3a.stdout
+++ b/tests/reference/asr-select_type_01-fec2d3a.stdout
@@ -54,6 +54,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -121,6 +122,7 @@
                                     [j]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     2 base

--- a/tests/reference/asr-select_type_02-507a333.json
+++ b/tests/reference/asr-select_type_02-507a333.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_02-507a333.stdout",
-    "stdout_hash": "00dc62472bb816ebbc4c68b78d28cd929df6f9d2ee2981c2a31e0524",
+    "stdout_hash": "f283b55a6692567a8a23887e2499b44f7ad28c98a7be6c2b77b7f381",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_02-507a333.stdout
+++ b/tests/reference/asr-select_type_02-507a333.stdout
@@ -60,6 +60,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )
@@ -140,6 +141,7 @@
                                     [color]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     4 point
@@ -254,6 +256,7 @@
                                     [z]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     4 point

--- a/tests/reference/asr-select_type_03-e2e16a3.json
+++ b/tests/reference/asr-select_type_03-e2e16a3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_03-e2e16a3.stdout",
-    "stdout_hash": "f425a5b41c7dfefd1d3de80dde920b751b2cc1ca012394c3b07bb386",
+    "stdout_hash": "1a508fe83d6d53b0fd9cb1982210a3247ece20ab9f1df4e0bee403c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_03-e2e16a3.stdout
+++ b/tests/reference/asr-select_type_03-e2e16a3.stdout
@@ -54,6 +54,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -450,6 +451,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     2 toml_value
                                 ),
@@ -495,6 +497,7 @@
                                     float]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-select_type_04-8388300.json
+++ b/tests/reference/asr-select_type_04-8388300.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-8388300.stdout",
-    "stdout_hash": "93c4187519d4435c8c0af091a299f77013417b0bbe50738ed72ccde4",
+    "stdout_hash": "3ffe0c811f2f1e6e6188bf7bf3841633492d453d0614715ae2d1547a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-8388300.stdout
+++ b/tests/reference/asr-select_type_04-8388300.stdout
@@ -54,6 +54,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -452,6 +453,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     4 toml_value
                                 ),
@@ -497,6 +499,7 @@
                                     float]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-string1-489c714.json
+++ b/tests/reference/asr-string1-489c714.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string1-489c714.stdout",
-    "stdout_hash": "2a9f04d8eeb5b728c427d852424903b053f36587b5b13efe7d18da4f",
+    "stdout_hash": "243c43c3a921fcc19e3c1214a3fb53bd99fc5fd08ad1e3306125ef09",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string1-489c714.stdout
+++ b/tests/reference/asr-string1-489c714.stdout
@@ -359,6 +359,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-string2-ccc8ec4.json
+++ b/tests/reference/asr-string2-ccc8ec4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-ccc8ec4.stdout",
-    "stdout_hash": "d5635df19b3ec1172d1f3b3c51666f3ce861960dd9af4c46c080f272",
+    "stdout_hash": "acfc358f0581cb7dd2076f45e26c42fc064c66e4d2b7449a0034f1c2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-ccc8ec4.stdout
+++ b/tests/reference/asr-string2-ccc8ec4.stdout
@@ -618,6 +618,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-string_14-d4e7527.json
+++ b/tests/reference/asr-string_14-d4e7527.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_14-d4e7527.stdout",
-    "stdout_hash": "a8abec4e4dc1bb16e9d026e1a13711fe0fe0f3d13b6d16a9aac5340a",
+    "stdout_hash": "f836cdc79063b53a4809ee2a03e39b874cdede3a1fbc258366024b30",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_14-d4e7527.stdout
+++ b/tests/reference/asr-string_14-d4e7527.stdout
@@ -196,6 +196,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-string_17-f3c0915.json
+++ b/tests/reference/asr-string_17-f3c0915.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_17-f3c0915.stdout",
-    "stdout_hash": "84dce5449c574d77f4b8f860e1840537191d70b9facfae0d9f5d49b7",
+    "stdout_hash": "618880e5dc15a5ec9aff3a6f8ed622dba67bb89eb1357753fa8733a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_17-f3c0915.stdout
+++ b/tests/reference/asr-string_17-f3c0915.stdout
@@ -310,6 +310,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-string_19-5592188.json
+++ b/tests/reference/asr-string_19-5592188.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_19-5592188.stdout",
-    "stdout_hash": "f9c08428f2b81120dc6f0e0e888518cb3c1463893568c18e0c42c23c",
+    "stdout_hash": "0b0de705bc9bd6903f5a01ad97a47abb21bd22865ba610fa0ff94842",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_19-5592188.stdout
+++ b/tests/reference/asr-string_19-5592188.stdout
@@ -203,6 +203,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 )

--- a/tests/reference/asr-submodule_02-65cd3d0.json
+++ b/tests/reference/asr-submodule_02-65cd3d0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_02-65cd3d0.stdout",
-    "stdout_hash": "19899cae7f14e6e6d59f5b7012dbe0a2bc3eeeac1da9a10848ff5938",
+    "stdout_hash": "2b0747d4f398a7e055a13196c06d95a53d9e12bb88a1e3f3a2030e25",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_02-65cd3d0.stdout
+++ b/tests/reference/asr-submodule_02-65cd3d0.stdout
@@ -58,6 +58,7 @@
                                     Source
                                     Public
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_add-b53d132.json
+++ b/tests/reference/asr-template_add-b53d132.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_add-b53d132.stdout",
-    "stdout_hash": "52c1230dee5bd74c31654b8dfb98de77a0bd43fc5973c9326fefb0fb",
+    "stdout_hash": "f6cb82465dc1c5865703df0ca963a00cf8d193cba4ecf4a0bc12ad11",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_add-b53d132.stdout
+++ b/tests/reference/asr-template_add-b53d132.stdout
@@ -666,6 +666,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_array_01-34da72f.json
+++ b/tests/reference/asr-template_array_01-34da72f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_01-34da72f.stdout",
-    "stdout_hash": "d2f16732ffc2e0d3a07692ab3c40c47e4734089e5a704e3936f25f2b",
+    "stdout_hash": "cbc251c0317932684102a5f94c5707be532c55253f7ebb72f98c3afc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_01-34da72f.stdout
+++ b/tests/reference/asr-template_array_01-34da72f.stdout
@@ -300,6 +300,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_array_02-4b894a8.json
+++ b/tests/reference/asr-template_array_02-4b894a8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_02-4b894a8.stdout",
-    "stdout_hash": "be7eda64f10aef0da0572b5ee762f59f944b4dcc034ee1c2b9ee412d",
+    "stdout_hash": "167b54b52bb49975f64b6990fa8ec04a06caba654cdd5e5d4d2fd93b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_02-4b894a8.stdout
+++ b/tests/reference/asr-template_array_02-4b894a8.stdout
@@ -850,6 +850,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_array_03-81d3ec4.json
+++ b/tests/reference/asr-template_array_03-81d3ec4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_03-81d3ec4.stdout",
-    "stdout_hash": "fe3afd3761ffd2f6e8e438f34d22656481be346a28cdc403bd3f4f1e",
+    "stdout_hash": "41b32c810dc6afc552289d076efbec352fc45302579b7df9b842f379",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_03-81d3ec4.stdout
+++ b/tests/reference/asr-template_array_03-81d3ec4.stdout
@@ -1555,6 +1555,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_array_04-bb5f542.json
+++ b/tests/reference/asr-template_array_04-bb5f542.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_04-bb5f542.stdout",
-    "stdout_hash": "20c677b2400c09fdc386c864fae802e44ce6ea32dfe710179924282c",
+    "stdout_hash": "f9283e63b45e9f57a1a0a493d6a77f5ae5945e4b6769a2ae4dac8f9b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_04-bb5f542.stdout
+++ b/tests/reference/asr-template_array_04-bb5f542.stdout
@@ -566,6 +566,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_nested-3a03184.json
+++ b/tests/reference/asr-template_nested-3a03184.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_nested-3a03184.stdout",
-    "stdout_hash": "42e8976659d5da35fd8eb15c5956983f516861c652011c8c5bc56790",
+    "stdout_hash": "37696ca579a4190a204c52f3f7b05dc181f679ad6ff60ab1e7a14013",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_nested-3a03184.stdout
+++ b/tests/reference/asr-template_nested-3a03184.stdout
@@ -692,6 +692,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),

--- a/tests/reference/asr-template_travel-f827c57.json
+++ b/tests/reference/asr-template_travel-f827c57.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_travel-f827c57.stdout",
-    "stdout_hash": "cc137724091c1583cd637ffea007e3736ac2f388302ab473efa51d0e",
+    "stdout_hash": "046b9552d8952ff1e1f7d97546ddf14a867029ce363a7dde1b65db32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_travel-f827c57.stdout
+++ b/tests/reference/asr-template_travel-f827c57.stdout
@@ -1412,6 +1412,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -1852,6 +1853,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),
@@ -1877,6 +1879,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     ()
                                     ()

--- a/tests/reference/asr-template_triple-7144cb3.json
+++ b/tests/reference/asr-template_triple-7144cb3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_triple-7144cb3.stdout",
-    "stdout_hash": "c25059300d4cf12949cb91f277221540d1e16697f34308f777e7e76d",
+    "stdout_hash": "1e10d7147f7c712aaf66aa86cb6e5f85c70eef78a9e0d78c0b6f3ff8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_triple-7144cb3.stdout
+++ b/tests/reference/asr-template_triple-7144cb3.stdout
@@ -1448,6 +1448,7 @@
                                     Source
                                     Private
                                     .false.
+                                    .false.
                                     ()
                                     ()
                                 ),


### PR DESCRIPTION
This is the initial implementation. Other things like going up the hierarchy ladder if the current class doesn't have a function implemented is yet to be implemented.
The approach is very simple, its just like select-type. Inside each if-else-if ladder block we know which type is present and then the call correct method. So no need to update virtual tables, just compare the types at runtime and then you always know which method is being called from the ASR.

I didn't feel the need to go with the approach of C++/C where they store function pointers inside virtual tables as the same thing is achieved with a simpler logic as described above. Also since we already us that approach in select-type, so I thought to re-use it here as well.