### PR TITLE
Introduce `ExitBlock()` as an ASR node 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -720,3 +720,5 @@ RUN(NAME array_01 LABELS gfortran llvm)
 RUN(NAME array_02 LABELS gfortran llvm)
 
 RUN(NAME do_loop_02 LABELS gfortran llvm)
+
+RUN(NAME block_07 LABELS gfortran llvm)

--- a/integration_tests/block_07.f90
+++ b/integration_tests/block_07.f90
@@ -1,0 +1,29 @@
+program main
+    implicit none
+    integer :: i, j
+    i = 0
+    j = 0
+    test: block
+        outer : do
+            i = i + 1
+            inner : do
+                j = j + 1
+                if ( j == 3 ) then
+                    exit test
+                end if
+                if (j == 5) then
+                    print *, j
+                    exit inner
+                end if
+            end do inner
+            print *, "out of inner loop"
+            if ( i == 2 ) then
+                exit outer
+            end if
+        end do outer
+        print *, "out of outer loop"
+    end block test
+    if (i /= 1) error stop
+    if (j /= 3) error stop
+    print *, "out of test block"
+end program

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -170,6 +170,7 @@ stmt
     | DoLoop(do_loop_head head, stmt* body)
     | ErrorStop(expr? code)
     | Exit()
+    | ExitBlock()
     | ForAllSingle(do_loop_head head, stmt assign_stmt)
         -- GoTo points to a GoToTarget with the corresponding target_id within
         -- the same procedure. We currently use `int` IDs to link GoTo with

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5316,18 +5316,16 @@ public:
         });
     }
 
+    void visit_ExitBlock(const ASR::ExitBlock_t & /* x */) {
+        builder->CreateBr(block_end_label);
+        llvm::BasicBlock *bb = llvm::BasicBlock::Create(context, "unreachable_after_exit_block");
+        start_new_block(bb);
+    }
+
     void visit_Exit(const ASR::Exit_t & /* x */) {
-        if ( in_block ) {
-            // If we are in a block, we need to exit the block.
-            // This is done by jumping to the end of the block.
-            builder->CreateBr(block_end_label);
-            llvm::BasicBlock *bb = llvm::BasicBlock::Create(context, "unreachable_after_exit_block");
-            start_new_block(bb);
-        } else {
-            builder->CreateBr(do_loop_end.back());
-            llvm::BasicBlock *bb = llvm::BasicBlock::Create(context, "unreachable_after_exit");
-            start_new_block(bb);
-        }
+        builder->CreateBr(do_loop_end.back());
+        llvm::BasicBlock *bb = llvm::BasicBlock::Create(context, "unreachable_after_exit");
+        start_new_block(bb);
     }
 
     void visit_Cycle(const ASR::Cycle_t & /* x */) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -232,7 +232,6 @@ public:
     int64_t ptr_loads;
     bool lookup_enum_value_for_nonints;
     bool is_assignment_target;
-    bool in_block = false;
 
     CompilerOptions &compiler_options;
 
@@ -4886,7 +4885,6 @@ public:
          *   inner most label. Instead we need to jump to the actual label
          *   provided.
          */
-        in_block = true;
         if( x.m_label != -1 ) {
             if( llvm_goto_targets.find(x.m_label) == llvm_goto_targets.end() ) {
                 llvm::BasicBlock *new_target = llvm::BasicBlock::Create(context, "goto_target");
@@ -4917,7 +4915,6 @@ public:
             builder->CreateBr(block_end);
         }
         builder->SetInsertPoint(block_end);
-        in_block=false;
     }
 
     inline void visit_expr_wrapper(const ASR::expr_t* x, bool load_ref=false) {


### PR DESCRIPTION
Fixes #1402.
With this PR, LFortran's output for [example_lmdif1.f90](https://github.com/fortran-lang/minpack/blob/main/examples/example_lmdif1.f90) aligns with GFortran.