### PR TITLE
do_loop_02: Fix infinite loop

### DIFF
--- a/integration_tests/do_loop_02.f90
+++ b/integration_tests/do_loop_02.f90
@@ -2,9 +2,9 @@ program main
     implicit none
     integer :: i, j
     i = 0
-    j = 0
     outer : do
         i = i + 1
+        j = 0
         inner : do
             j = j + 1
             if (j == 5) then


### PR DESCRIPTION
The "j" loop was looping over all integers, wrapping around to negative integers and continuing to zero. It took over a second to run. Now it behaves as intended and runs immediately.