### PR TITLE
Implement `visit_ComplexConstructor_t` for runtime arguments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -730,3 +730,6 @@ RUN(NAME do_loop_02 LABELS gfortran llvm)
 RUN(NAME block_07 LABELS gfortran llvm)
 
 RUN(NAME complex_11 LABELS gfortran llvmImplicit)
+RUN(NAME complex_12 LABELS gfortran llvm)
+RUN(NAME complex_13 LABELS gfortran llvm)
+RUN(NAME complex_14 LABELS gfortran llvm)

--- a/integration_tests/complex_12.f90
+++ b/integration_tests/complex_12.f90
@@ -4,7 +4,7 @@ program main
     real::re,im
     re=3
     im=4
-    k = cmplx(re, im)
+    k = cmplx(re, 0) + cmplx(0, im)
     print *, k
     if (real(k) /= 3) error stop
     if (aimag(k) /= 4) error stop

--- a/integration_tests/complex_12.f90
+++ b/integration_tests/complex_12.f90
@@ -1,0 +1,11 @@
+program main
+    implicit none
+    complex(8) :: k
+    real::re,im
+    re=3
+    im=4
+    k = cmplx(re, im)
+    print *, k
+    if (real(k) /= 3) error stop
+    if (aimag(k) /= 4) error stop
+end program

--- a/integration_tests/complex_13.f90
+++ b/integration_tests/complex_13.f90
@@ -1,0 +1,10 @@
+program main
+    implicit none
+    complex(8) :: l
+    complex(4) :: z
+    l=cmplx(3,-4)
+    z=l
+    print *,z
+    if (real(z) /= 3) error stop
+    if (aimag(z) /= -4) error stop
+end program

--- a/integration_tests/complex_14.f90
+++ b/integration_tests/complex_14.f90
@@ -1,0 +1,13 @@
+SUBROUTINE CPDSA()
+    DOUBLE PRECISION PD
+    COMPLEX C
+    PD = 1.0D0
+    C = DCMPLX(PD, 0.0D0)
+    PRINT *, C
+    if (REAL(C) /= 1.0D0) ERROR STOP
+    if (AIMAG(C) /= 0.0D0) ERROR STOP
+END SUBROUTINE
+
+program main
+    call CPDSA()
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3069,7 +3069,16 @@ public:
         }
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,
                                 kind_value, nullptr, 0));
-        return ASR::make_ComplexConstructor_t(al, x.base.base.loc, x_, y_, type, nullptr);
+        ASR::expr_t* x_value = ASRUtils::expr_value(x_);
+        ASR::expr_t* y_value = ASRUtils::expr_value(y_);
+        ASR::expr_t* cc_expr = nullptr;
+        double x_value_ = 0.0;
+        double y_value_ = 0.0;
+        if (x_value && y_value && ASRUtils::extract_value(x_value, x_value_) && ASRUtils::extract_value(y_value, y_value_)) {
+            cc_expr = ASRUtils::EXPR(ASR::make_ComplexConstant_t(al, x.base.base.loc,
+                                                                 x_value_, y_value_, type));
+        }
+        return ASR::make_ComplexConstructor_t(al, x.base.base.loc, x_, y_, type, cc_expr);
     }
 
     ASR::asr_t* create_NullPointerConstant(const AST::FuncCallOrArray_t& x) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5974,7 +5974,34 @@ public:
             this->visit_expr_wrapper(x.m_value, true);
             return;
         }
-        throw CodeGenError("ComplexConstructor with runtime arguments not implemented yet.");
+        this->visit_expr_wrapper(x.m_re, true);
+        llvm::Value *re_val = tmp;
+
+        this->visit_expr_wrapper(x.m_im, true);
+        llvm::Value *im_val = tmp;
+
+        int a_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+
+        llvm::Value *re2, *im2;
+        llvm::Type *type;
+        switch( a_kind ) {
+            case 4: {
+                re2 = builder->CreateFPTrunc(re_val, llvm::Type::getFloatTy(context));
+                im2 = builder->CreateFPTrunc(im_val, llvm::Type::getFloatTy(context));
+                type = complex_type_4;
+                break;
+            }
+            case 8: {
+                re2 = builder->CreateFPExt(re_val, llvm::Type::getDoubleTy(context));
+                im2 = builder->CreateFPExt(im_val, llvm::Type::getDoubleTy(context));
+                type = complex_type_8;
+                break;
+            }
+            default: {
+                throw CodeGenError("kind type is not supported");
+            }
+        }
+        tmp = complex_from_floats(re2, im2, type);
     }
 
     void visit_ComplexConstant(const ASR::ComplexConstant_t &x) {

--- a/tests/reference/asr-complex_07-8d914e3.json
+++ b/tests/reference/asr-complex_07-8d914e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex_07-8d914e3.stdout",
-    "stdout_hash": "ccc533024a814c4991aebc126f34221549dfe1563d66e8bf565c1263",
+    "stdout_hash": "9f16d42eabb99a814cb7ac9483c95be834a8f42f136acb56d41a143f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex_07-8d914e3.stdout
+++ b/tests/reference/asr-complex_07-8d914e3.stdout
@@ -101,7 +101,11 @@
                                             (Real 4 [])
                                         )
                                         (Complex 4 [])
-                                        ()
+                                        (ComplexConstant
+                                            42.000000
+                                            0.000000
+                                            (Complex 4 [])
+                                        )
                                     )
                                     ()
                                     Save
@@ -139,7 +143,11 @@
                                             (Real 4 [])
                                         )
                                         (Complex 4 [])
-                                        ()
+                                        (ComplexConstant
+                                            3.140000
+                                            0.000000
+                                            (Complex 4 [])
+                                        )
                                     )
                                     ()
                                     Save
@@ -175,7 +183,11 @@
                                         (Var 2 real_part)
                                         (Var 2 img_part)
                                         (Complex 4 [])
-                                        ()
+                                        (ComplexConstant
+                                            42.000000
+                                            3.140000
+                                            (Complex 4 [])
+                                        )
                                     )
                                     ()
                                     Save

--- a/tests/reference/asr-sole_intrinsic-ee625f4.json
+++ b/tests/reference/asr-sole_intrinsic-ee625f4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-sole_intrinsic-ee625f4.stdout",
-    "stdout_hash": "294ab63edf75db36bde5b48dd90f179bb56fb81bbd28100bdff417d9",
+    "stdout_hash": "f3807274f2226eaffbdf574d2ba34598c17f673309d03f5c25f4600b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-sole_intrinsic-ee625f4.stdout
+++ b/tests/reference/asr-sole_intrinsic-ee625f4.stdout
@@ -111,7 +111,11 @@
                             (IntegerConstant 3 (Integer 4 []))
                             (IntegerConstant 1 (Integer 4 []))
                             (Complex 4 [])
-                            ()
+                            (ComplexConstant
+                                3.000000
+                                1.000000
+                                (Complex 4 [])
+                            )
                         )
                         ()
                     )


### PR DESCRIPTION
Fixes #1416.
Credits: @sloorush, Addition, and Continuation to PR: #1028.