### PR TITLE
Fix handling of nested_globals in ASR to LLVM conversion

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -609,6 +609,8 @@ RUN(NAME nested_03 LABELS gfortran llvm)
 RUN(NAME nested_04 LABELS gfortran llvm)
 RUN(NAME nested_05 LABELS gfortran llvm)
 RUN(NAME nested_06 LABELS gfortran llvm)
+RUN(NAME nested_07 LABELS gfortran llvm)
+RUN(NAME nested_08 LABELS gfortran llvm)
 
 RUN(NAME nbody LABELS gfortran llvm)
 

--- a/integration_tests/nested_07.f90
+++ b/integration_tests/nested_07.f90
@@ -1,0 +1,35 @@
+module testmod_der1
+private
+public fcn
+contains
+
+subroutine fcn(x, fvec)
+real, intent(in) :: x
+real, intent(out) :: fvec
+
+integer :: i
+
+do i = 1, 3
+    print *, "x(1) = ", x
+    fvec = x+1
+    print *, "fvec(i) = ", fvec
+end do
+
+end subroutine
+
+end module
+
+
+program main
+use testmod_der1, only: fcn
+real :: x, fvec
+! The following starting values provide a rough fit.
+x = 1.0
+
+call check_deriv()
+contains
+subroutine check_deriv()
+call fcn(x, fvec)
+end subroutine
+
+end program

--- a/integration_tests/nested_08.f90
+++ b/integration_tests/nested_08.f90
@@ -1,0 +1,38 @@
+module testmod_der1
+private
+public fcn
+contains
+
+subroutine fcn(x, fvec)
+real, intent(in) :: x(3)
+real, intent(out) :: fvec(15)
+
+integer :: i
+
+do i = 1, 3
+    fvec(i) = x(1) /( x(2) + x(3) )
+end do
+do i = 1, 3
+    if (fvec(i) /= 0.5) error stop
+end do
+end subroutine
+
+end module
+
+
+program example_lmder1
+use testmod_der1, only: fcn
+real :: x(3), fvec(15)
+! The following starting values provide a rough fit.
+x = [1.0, 1.0, 1.0]
+
+call check_deriv(x, fvec)
+contains
+subroutine check_deriv(x, fvec)
+real, intent(in) :: x(3)
+real, intent(out) :: fvec(15)
+call fcn(x, fvec)
+end subroutine
+
+end program
+    


### PR DESCRIPTION
Fixes [#1150(comment)](https://github.com/lfortran/lfortran/issues/1150#issuecomment-1472535222).
Example in #1150 works perfect, but not in `example_lmder1`