### PR TITLE
Fixed c_func_name for complex argument type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -373,6 +373,7 @@ RUN(NAME intrinsics_45 LABELS gfortran llvm wasm) # iso_fortran_env
 RUN(NAME intrinsics_46 LABELS gfortran llvm) # ichar & iachar
 RUN(NAME intrinsics_47 LABELS gfortran llvm) # all
 RUN(NAME intrinsics_48 LABELS gfortran llvm)
+RUN(NAME intrinsics_49 LABELS gfortran llvm)
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/intrinsics_49.f90
+++ b/integration_tests/intrinsics_49.f90
@@ -1,0 +1,36 @@
+program intrinsics_49
+    ! A test of complex and real kinds 4 and 8 sin intrinsic
+    implicit none
+    block
+        real(kind=4) :: x, y
+        complex :: z, r
+        x = 1.0
+        y = 2.0
+        z = cmplx(x, y)
+        r = sin(z)
+        if (abs(real(r) - 3.16577864) > 1e-7) error stop
+        if (abs(imag(r) - 1.95960093) > 1e-7) error stop
+    end block
+    block
+        real(kind=8) :: x, y
+        complex :: z, r
+        x = 1.0
+        y = 2.0
+        z = cmplx(x, y)
+        r = sin(z)
+        if (abs(real(r) - 3.16577864) > 1e-7) error stop
+        if (abs(imag(r) - 1.95960093) > 1e-7) error stop
+    end block
+    block
+        real(kind=4) :: x, r
+        x = 1.0
+        r = sin(x)
+        if (abs(r - 0.841470957) > 1e-7) error stop
+    end block
+    block
+        real(kind=8) :: x, r
+        x = 1.0
+        r = sin(x)
+        if (abs(r - 0.841470957) > 1e-7) error stop
+    end block
+end program

--- a/integration_tests/intrinsics_49.f90
+++ b/integration_tests/intrinsics_49.f90
@@ -8,8 +8,8 @@ program intrinsics_49
         y = 2.0
         z = cmplx(x, y)
         r = sin(z)
-        if (abs(real(r) - 3.16577864) > 1e-7) error stop
-        if (abs(imag(r) - 1.95960093) > 1e-7) error stop
+        if (abs(real(r) - 3.16577864) > 1e-6) error stop
+        if (abs(imag(r) - 1.95960093) > 1e-6) error stop
     end block
     block
         real(kind=8) :: x, y
@@ -18,19 +18,19 @@ program intrinsics_49
         y = 2.0
         z = cmplx(x, y)
         r = sin(z)
-        if (abs(real(r) - 3.16577864) > 1e-7) error stop
-        if (abs(imag(r) - 1.95960093) > 1e-7) error stop
+        if (abs(real(r) - 3.16577864) > 1e-6) error stop
+        if (abs(imag(r) - 1.95960093) > 1e-6) error stop
     end block
     block
         real(kind=4) :: x, r
         x = 1.0
         r = sin(x)
-        if (abs(r - 0.841470957) > 1e-7) error stop
+        if (abs(r - 0.841470957) > 1e-6) error stop
     end block
     block
         real(kind=8) :: x, r
         x = 1.0
         r = sin(x)
-        if (abs(r - 0.841470957) > 1e-7) error stop
+        if (abs(r - 0.841470957) > 1e-6) error stop
     end block
 end program

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -63,10 +63,22 @@ static inline ASR::expr_t* instantiate_functions(Allocator &al,
         ASR::ttype_t *arg_type, Vec<ASR::call_arg_t>& new_args,
         ASR::expr_t *value) {
     std::string c_func_name;
-    if (ASRUtils::extract_kind_from_ttype_t(arg_type) == 4) {
-        c_func_name = "_lfortran_s" + new_name;
-    } else {
-        c_func_name = "_lfortran_d" + new_name;
+    switch (arg_type->type) {
+        case ASR::ttypeType::Complex : {
+            if (ASRUtils::extract_kind_from_ttype_t(arg_type) == 4) {
+                c_func_name = "_lfortran_c" + new_name;
+            } else {
+                c_func_name = "_lfortran_z" + new_name;
+            }
+            break;
+        }
+        default : {
+            if (ASRUtils::extract_kind_from_ttype_t(arg_type) == 4) {
+                c_func_name = "_lfortran_s" + new_name;
+            } else {
+                c_func_name = "_lfortran_d" + new_name;
+            }
+        }
     }
     new_name = "_lcompilers_" + new_name;
     // Check if Function is already defined.


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/1452

This pull request is to fix issue #1452 which is an incorrect call to intrinsic functions in llvm. A small change to instantiate_functions in intrinsic_function_registry.h is all that is needed to fix the issue.