### PR TITLE
CI: test modern_minpack with every commit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -237,7 +237,7 @@ jobs:
         shell: bash -x -l {0}
         run: |
             git clone https://github.com/Pranavchiku/modern_minpack.git
-            cd ../modern_minpack
+            cd modern_minpack
             git checkout main
             git checkout cc1d79bbc92a562acefc8022834e747a6d32d112
             $(pwd)/../../src/bin/lfortran ./src/minpack.f90 -c

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -240,10 +240,10 @@ jobs:
             cd modern_minpack
             git checkout main
             git checkout cc1d79bbc92a562acefc8022834e747a6d32d112
-            $(pwd)/../../src/bin/lfortran ./src/minpack.f90 -c
-            $(pwd)/../../src/bin/lfortran ./examples/example_hybrd.f90
-            $(pwd)/../../src/bin/lfortran ./examples/example_hybrd1.f90
-            $(pwd)/../../src/bin/lfortran ./examples/example_lmdif1.f90
+            $(pwd)/../src/bin/lfortran ./src/minpack.f90 -c
+            $(pwd)/../src/bin/lfortran ./examples/example_hybrd.f90
+            $(pwd)/../src/bin/lfortran ./examples/example_hybrd1.f90
+            $(pwd)/../src/bin/lfortran ./examples/example_lmdif1.f90
 
   fpm:
     name: Check fpm Compilation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -233,6 +233,17 @@ jobs:
             examples/example_lmdif1
             examples/example_primes
             ctest
+      - name: Test Modern Minpack
+        shell: bash -x -l {0}
+        run: |
+            git clone https://github.com/Pranavchiku/modern_minpack.git
+            cd ../modern_minpack
+            git checkout main
+            git checkout cc1d79bbc92a562acefc8022834e747a6d32d112
+            $(pwd)/../../src/bin/lfortran ./src/minpack.f90 -c
+            $(pwd)/../../src/bin/lfortran ./examples/example_hybrd.f90
+            $(pwd)/../../src/bin/lfortran ./examples/example_hybrd1.f90
+            $(pwd)/../../src/bin/lfortran ./examples/example_lmdif1.f90
 
   fpm:
     name: Check fpm Compilation


### PR DESCRIPTION
This uses main branch of https://github.com/Pranavchiku/modern_minpack.git, it currently has a few commits as a workaround, and each such commit has a link to the LFortran issue that we need to fix. The workarounds are very small.