### PR TITLE
Add allocate statement in ``integration_tests/modules_35.f90`` for safety

### DIFF
--- a/integration_tests/modules_35.f90
+++ b/integration_tests/modules_35.f90
@@ -25,6 +25,7 @@ end module M_CLI2_21
 program modules_35
     use M_CLI2_21
     character(len=5), allocatable :: string(:)
+    allocate(string(2))
 
     print *, "executing modules_35"
     call get_args_fixed_length_a_array(string)

--- a/tests/reference/asr-modules_35-2a0333c.json
+++ b/tests/reference/asr-modules_35-2a0333c.json
@@ -2,11 +2,11 @@
     "basename": "asr-modules_35-2a0333c",
     "cmd": "lfortran --indent --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/modules_35.f90",
-    "infile_hash": "4e1cb1787da1e45d4e7989a3563caded0c685cfb805b4c3bfbea009b",
+    "infile_hash": "ac2ec2104388f2a3f3b39603c341b1ca3a2f5de691e8bf3c9687275f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_35-2a0333c.stdout",
-    "stdout_hash": "c629886bdd1d3cb4f6b4078e81f7900e4a21ae2601186ff018649618",
+    "stdout_hash": "f4fcfc97876d028edd82fe6b45919be02bc2e5f5e74ce1970037e3b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_35-2a0333c.stdout
+++ b/tests/reference/asr-modules_35-2a0333c.stdout
@@ -207,7 +207,15 @@
                         })
                     modules_35
                     [m_cli2_21]
-                    [(Print
+                    [(Allocate
+                        [((Var 4 string)
+                        [((IntegerConstant 1 (Integer 4 []))
+                        (IntegerConstant 2 (Integer 4 [])))])]
+                        ()
+                        ()
+                        ()
+                    )
+                    (Print
                         ()
                         [(StringConstant
                             "executing modules_35"

--- a/tests/reference/pass_implied_do_loops-modules_35-fde962b.json
+++ b/tests/reference/pass_implied_do_loops-modules_35-fde962b.json
@@ -2,11 +2,11 @@
     "basename": "pass_implied_do_loops-modules_35-fde962b",
     "cmd": "lfortran --pass=implied_do_loops --indent --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/modules_35.f90",
-    "infile_hash": "4e1cb1787da1e45d4e7989a3563caded0c685cfb805b4c3bfbea009b",
+    "infile_hash": "ac2ec2104388f2a3f3b39603c341b1ca3a2f5de691e8bf3c9687275f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_implied_do_loops-modules_35-fde962b.stdout",
-    "stdout_hash": "0341b10cdae730a1b7df7516cbea16624ba18096cae09d049dad2839",
+    "stdout_hash": "069261ca0d2363c2fa58adc759a7f98fd0967995c1f51ae83164043a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_implied_do_loops-modules_35-fde962b.stdout
+++ b/tests/reference/pass_implied_do_loops-modules_35-fde962b.stdout
@@ -189,7 +189,15 @@
                         })
                     modules_35
                     [m_cli2_21]
-                    [(Print
+                    [(Allocate
+                        [((Var 4 string)
+                        [((IntegerConstant 1 (Integer 4 []))
+                        (IntegerConstant 2 (Integer 4 [])))])]
+                        ()
+                        ()
+                        ()
+                    )
+                    (Print
                         ()
                         [(StringConstant
                             "executing modules_35"


### PR DESCRIPTION
See, https://github.com/lfortran/lfortran/actions/runs/4587462208/jobs/8100987850?pr=1480