### PR TITLE
Generics matrix implementation

### DIFF
--- a/integration_tests/template_compose.f90
+++ b/integration_tests/template_compose.f90
@@ -1,0 +1,43 @@
+module template_compose_m
+  implicit none
+  private
+  public :: op_t
+
+  requirement pure_oper(t, op)
+    type, deferred :: t
+    pure function op(x, y) result(z)
+      type(t), intent(in) :: x, y
+      type(t) :: z
+    end function
+  end requirement
+  
+  ! define current_template_args
+    ! define them in ast_body_visitor for now, then move them later
+  template op_t(t, plus, times)
+    ! create a type parameter x (if x is not t)
+    ! create an external symbol that points plus to op
+    ! then we can remove some fields
+    requires pure_oper(t, plus)
+    requires pure_oper(t, times)
+    private
+    public :: op_generic
+  contains
+    function op_generic(x, y) result(z)
+      type(t), intent(in) :: x, y
+      type(t) :: z
+      z = times(x, plus(x, y))
+    end function
+  end template
+
+contains
+  
+  subroutine test_template()
+  end subroutine
+  
+end module
+  
+program template_compose
+use template_compose_m
+implicit none
+
+end program template_compose

--- a/integration_tests/template_matrix.f90
+++ b/integration_tests/template_matrix.f90
@@ -1,0 +1,33 @@
+module template_matrix_m
+  implicit none
+  private
+  public :: matrix_t
+
+  requirement pure_oper(t, op)
+    type, deferred :: t
+    pure function op(x, y) result(z)
+      type(t), intent(in) :: x, y
+      type(t) :: z
+    end function
+  end requirement
+
+  requirement elemental_oper(t, op)
+    type, deferred :: t
+    elemental function op(x, y) result(z)
+      type(t), intent(in) :: x, y
+      type(t) :: z
+    end function
+  end requirement
+
+  template matrix_t(t, plus, times, n)
+    requires elemental_oper(t, plus)
+    requires elemental_oper(t, times)
+  end template
+
+end module
+
+program template_matrix
+use template_matrix_m
+implicit none
+
+end program template_matrix

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2656,6 +2656,11 @@ public:
 
     void visit_Template(const AST::Template_t &x){
         is_template = true;
+        // TODO: should namelist be replaced with args?
+        for (size_t i=0; i<x.n_namelist; i++) {
+            char *arg=x.m_namelist[i];
+            current_template_args.push_back(to_lower(arg));
+        }
         for (size_t i=0; i<x.n_decl; i++) {
             if (AST::is_a<AST::Requires_t>(*x.m_decl[i])) {
                 this->visit_unit_decl2(*x.m_decl[i]);
@@ -2677,6 +2682,7 @@ public:
         template_arg_map[to_lower(x.m_name)] = current_template_arg_map;
         template_asr_map[to_lower(x.m_name)] = current_template_asr_map;
         called_requirement.clear();
+        current_template_args.clear();
     }
 };
 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -698,6 +698,9 @@ public:
     std::map<std::string, std::map<int, std::string>> template_arg_map;
     std::vector<ASR::symbol_t*> rt_vec;
 
+    // new fields for generics
+    std::vector<std::string> current_template_args;
+
     std::map<std::string, ASR::ttype_t*> implicit_dictionary;
     std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping;
     Vec<char*> data_member_names;


### PR DESCRIPTION
To handle the matrix example in https://github.com/j3-fortran/generics/tree/7ba5a5b1f24dc4d9c200c7a1e922c0ef4ce80860/examples/linear_algebra, we need to rework how requirement and templates are treated.

(possibly adding more structures into ASR)