### PR TITLE
Always use fixed ``nbconvert`` version in CI

### DIFF
--- a/ci/build_tmp.xsh
+++ b/ci/build_tmp.xsh
@@ -75,7 +75,7 @@ jupyter kernelspec list --json
 cd share/lfortran/nb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Demo1_out.ipynb Demo1.ipynb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Demo2_out.ipynb Demo2.ipynb
-cat Demo1_out.ipynb
+cat Demo1_out.nbconvert.ipynb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output "Hello World_out.ipynb" "Hello World.ipynb"
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output "Operators Control Flow_out.ipynb" "Operators Control Flow.ipynb"
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Variables_out.ipynb Variables.ipynb

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - toml
   - pytest
   - jupyter
-  - nbconvert!=7.3.0
+  - nbconvert=7.3.1
   - xeus=2.4.1
   - xtl
   - nlohmann_json


### PR DESCRIPTION
Coming from - https://github.com/lfortran/lfortran/pull/1532#issuecomment-1502057502 and https://github.com/lfortran/lfortran/pull/1532#issuecomment-1501988353

I investigated. `nbconvert=7.3.1` names the generated file as `Demo1_out.nbconvert.ipynb` and `nbconvert<7.3.1` names it as `Demo1_out.ipynb`. `nbconvert 7.3.1` is getting installed on the CI but the build script is written according to `nbconvert < 7.3.1`.

See,

```zsh
(lf_nbconvert) 22:32:54:~/lfortran_project/lfortran/share/lfortran/nb % jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=360 --output Demo1_out.ipynb Demo1.ipynb
[NbConvertApp] Converting notebook Demo1.ipynb to notebook
Starting xeus-fortran kernel...

If you want to connect to this kernel from an other client, you can use the /private/var/folders/9j/ksm6z1r572nbn5h4g0pl0s_h0000gn/T/tmphea24tm0.json file.
Run with XEUS 2.4.1
[NbConvertApp] Writing 14293 bytes to Demo1_out.nbconvert.ipynb
(lf_nbconvert) 22:33:07:~/lfortran_project/lfortran/share/lfortran/nb % ls
Demo1.ipynb                     Operators Control Flow.ipynb
Demo1_out.nbconvert.ipynb       Variables.ipynb
Demo2.ipynb                     input
Hello World.ipynb
(lf_nbconvert) 22:33:09:~/lfortran_project/lfortran/share/lfortran/nb % jupyter nb
convert --version
7.3.1
```