### PR TITLE
CI: Install and use specific node version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,6 +113,10 @@ jobs:
 
             ./emsdk activate 3.1.35
 
+            ./emsdk install node-14.18.2-64bit
+
+            ./emsdk activate node-14.18.2-64bit
+
       - name: Show Emscripten and Node Info
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
It temporarily fixes the failing CI in main branch https://github.com/lfortran/lfortran/actions/runs/4673006168. A robust approach could/would be to debug what causes the github CI to fail when using node versions other than `14.18.2`.

Related https://github.com/lcompilers/lpython/pull/1699.

Also https://github.com/emscripten-core/emsdk/pull/829#issuecomment-1504472139.