### PR TITLE
Add provision to get compile time value of Cast(ArrayConstant[]) while declaring variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -779,3 +779,5 @@ RUN(NAME array_op_01 LABELS gfortran llvm)
 RUN(NAME array_op_02 LABELS gfortran llvm)
 RUN(NAME array_op_03 LABELS gfortran llvm)
 RUN(NAME array_op_04 LABELS gfortran llvm)
+
+RUN(NAME declaration_01 LABELS gfortran llvm)

--- a/integration_tests/declaration_01.f90
+++ b/integration_tests/declaration_01.f90
@@ -1,0 +1,6 @@
+program main
+real :: y(2) = real([2, 3])
+if (abs(y(1) - 2.0) > 1e-7) error stop
+if (abs(y(2) - 3.0) > 1e-7) error stop
+print *, y
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3283,7 +3283,7 @@ public:
                             this->visit_expr_wrapper(v->m_symbolic_value, true);
                         }
                         llvm::Value *init_value = tmp;
-                        if (ASR::is_a<ASR::ArrayConstant_t>(*v->m_symbolic_value)) {
+                        if (ASR::is_a<ASR::ArrayConstant_t>(*v->m_symbolic_value) || ( v->m_value && ASR::is_a<ASR::ArrayConstant_t>(*v->m_value) )) {
                             target_var = arr_descr->get_pointer_to_data(target_var);
                         }
                         builder->CreateStore(init_value, target_var);


### PR DESCRIPTION
Fixes #1559