### PR TITLE
Implementation of `procedure(fn) :: x` (I)

### DIFF
--- a/doc/src/asr/asr_nodes/expression_nodes/Var.md
+++ b/doc/src/asr/asr_nodes/expression_nodes/Var.md
@@ -1,6 +1,7 @@
 # Var
 
-LFortran variable.
+**Var** is an expression node that represents a reference to a declared
+variable, function, enum, etc.
 
 ## Declaration
 
@@ -22,59 +23,110 @@ The return value is the expression that the Var represents.
 
 ## Description
 
-**IntegerBinOp** represents LFortran variable. It can be:
+`Var` represents a declaration when used within an expression. Every
+declaration is represented in the symbol table, for example:
 
-1. `INTEGER`
-2. `REAL`
-3. `COMPLEX`
-4. `LOGICAL`
-5. `CHARACTER`
+* `integer :: x`: here `x` is represented by `Variable`, which has `type` as an
+  "Integer" type, `type_declaration` is empty
+* `procedure(fn) :: x`: here `x` is represented by `Variable`, which has `type`
+  as a "FunctionType" type, and `type_declaration` as a "Function" symbol
+  representing the interface declaration "fn"
+* `function my_fn(...) ... end function`: represented by `Function`
 
-A Fortran variable can be considered as a box that is capable of holding a single
-value of certain type. Thus, a variable has a name, the variable name and a type.
+When these are to be used in an expression, one uses `Var` which points to one
+of these.
+
+For example, if we have a declaration `integer :: x`, then the assignment `x =
+5` is represented as `(Assignment (Var 2 x) (IntegerConstant 5 (Integer 4 []))
+())`. Here `Var` points to the `Variable` symbol in the symbol table. See below
+for a full example.
+
+Another example: if `procedure(fn), pointer :: f`, then `f => myf` is
+represented by `(Associate (Var 2 f) (Var 2 myf))`, where `myf` is a
+`Function`.
+
+Most often `Var` points to a `Variable`. For referencing functions it points to
+`Function`. For enums it points to `Enum`. These can be hidden behind
+`ExternalSymbol`. It cannot point to any other symbol.
 
 ## Types
 
-Only accepts symbol name for LFortran variable.
+`Var`'s argument `v` can point to the following symbols (and nothing else):
+* `Variable` (for expressions like `2*x+5` where `x` is a variable)
+* `Function` (for expressions like `myf`, where `myf` is a user defined
+  function, such as passing it as a callback argument to a function call `call
+  f(myf)`, or assigning to a pointer procedure variable `f => myf`)
+* `Enum`
+* `ExternalSymbol` (the above symbols can be behind an `ExternalSymbol` if they
+  are declared in another module)
 
 ## Examples
 
 ```fortran
-character(len = 5), parameter :: intro = "I've "
+program test_var
+integer :: x
+x = 5
+print *, 3*x+5
+end program
 ```
 
 ASR:
 
-```fortran
+```
 (TranslationUnit
     (SymbolTable
         1
         {
-            intro:
-                (Variable
-                    1
-                    intro
-                    Local
-                    (StringConstant
-                        "I've "
-                        (Character 1 5 () [])
+            test_var:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4 [])
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    test_var
+                    []
+                    [(=
+                        (Var 2 x)
+                        (IntegerConstant 5 (Integer 4 []))
+                        ()
                     )
-                    (StringConstant
-                        "I've "
-                        (Character 1 5 () [])
-                    )
-                    Parameter
-                    (Character 1 5 () [])
-                    Source
-                    Public
-                    Required
-                    .false.
+                    (Print
+                        ()
+                        [(IntegerBinOp
+                            (IntegerBinOp
+                                (IntegerConstant 3 (Integer 4 []))
+                                Mul
+                                (Var 2 x)
+                                (Integer 4 [])
+                                ()
+                            )
+                            Add
+                            (IntegerConstant 5 (Integer 4 []))
+                            (Integer 4 [])
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
                 )
-
         })
     []
 )
-
 ```
 
 ## See Also

--- a/doc/src/asr/asr_nodes/expression_nodes/Var.md
+++ b/doc/src/asr/asr_nodes/expression_nodes/Var.md
@@ -131,3 +131,4 @@ ASR:
 
 ## See Also
 
+[Variable](../symbol_nodes/Variable.md)

--- a/doc/src/asr/asr_nodes/symbol_nodes/Variable.md
+++ b/doc/src/asr/asr_nodes/symbol_nodes/Variable.md
@@ -1,6 +1,6 @@
 # Variable
 
-Variable symbol, a **symbol** node.
+Variable is a **symbol** node representing a variable declaration.
 
 ## Declaration
 
@@ -41,15 +41,29 @@ constant (e.g., can contain binary operations, other variables, etc.)
 
 `value_attr` if true, this parameter has a `value` attribute set
 
+`type_declaration` null for primitive types; for composite types that are
+declared elsewhere in the program (struct, function, enum) it points to the
+symbol that declares the type
+
 ### Return values
 
 None.
 
 ## Description
 
-The `Variable` node is used to represent any variable in the program. It
-contais information about the type, visibility, compile time value, etc.
+The `Variable` node is used to represent a declaration of any variable in the
+program. It contais information about the type, visibility, compile time value,
+etc. The type of the variable can be any of the primitive types like integer,
+real, complex, pointers, arrays and other more complicated types like
+struct, classes, enums and function pointers.
 
+`Variable` has a type, like `StructType`. If the type is declared elsewhere
+than the variable (such as struct, function or enum), the `type_declaration`
+member points to the symbol that declares the type; otherwise
+`type_declaration` is null.
+
+When you want to use a variable in an expression, use the `Var` expression node
+to represent it.
 
 ## Examples
 
@@ -123,4 +137,4 @@ ASR:
 ```
 ## See Also
 
-[Module](Module.md), [Function](Function.md).
+[Var](../expression_nodes/Var.md)

--- a/doc/src/asr/asr_nodes/symbol_nodes/symbol_nodes.md
+++ b/doc/src/asr/asr_nodes/symbol_nodes/symbol_nodes.md
@@ -6,7 +6,7 @@ maxdepth: 1
 ---
 Block.md
 ExternalSymbol.md
-variable.md
+Variable.md
 program.md
 symbol.md
 ```

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -785,3 +785,5 @@ RUN(NAME array_op_03 LABELS gfortran llvm wasm)
 RUN(NAME array_op_04 LABELS gfortran llvm)
 
 RUN(NAME declaration_01 LABELS gfortran llvm)
+
+RUN(NAME procedure_01 LABELS gfortran)

--- a/integration_tests/procedure_01.f90
+++ b/integration_tests/procedure_01.f90
@@ -1,0 +1,40 @@
+module procedure_01_module
+implicit none
+
+abstract interface
+    integer function fn(n)
+    integer, intent(in) :: n
+    end function
+end interface
+
+contains
+
+    integer function plus(f, x)
+    procedure(fn) :: f
+    integer, intent(in) :: x
+    plus = f(x+4)
+    end function
+
+end module
+
+program procedure_01
+use procedure_01_module, only: plus
+implicit none
+
+integer :: i
+
+i = plus(myf, 5)
+
+print *, i
+
+if (i /= 18) error stop
+
+contains
+
+
+    integer function myf(n)
+    integer, intent(in) :: n
+    myf = 2*n
+    end function
+
+end program

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -651,11 +651,14 @@ public:
         require(x.m_v != nullptr,
             "Var_t::m_v cannot be nullptr");
         std::string x_mv_name = ASRUtils::symbol_name(x.m_v);
-        require(is_a<Variable_t>(*x.m_v) || is_a<ExternalSymbol_t>(*x.m_v)
-                || is_a<Function_t>(*x.m_v) || is_a<ASR::EnumType_t>(*x.m_v),
-            "Var_t::m_v " + x_mv_name + " does not point to a Variable_t, ExternalSymbol_t, " \
-            "Function_t, Subroutine_t or EnumType_t");
-
+        ASR::symbol_t *s = x.m_v;
+        if (check_external) {
+            s = ASRUtils::symbol_get_past_external(x.m_v);
+        }
+        require(is_a<Variable_t>(*s) || is_a<Function_t>(*s)
+                || is_a<ASR::EnumType_t>(*s) || is_a<ASR::ExternalSymbol_t>(*s),
+            "Var_t::m_v " + x_mv_name + " does not point to a Variable_t, " \
+            "Function_t, or EnumType_t (possibly behind ExternalSymbol_t)");
         require(symtab_in_scope(current_symtab, x.m_v),
             "Var::m_v `" + x_mv_name + "` cannot point outside of its symbol table");
         variable_dependencies.push_back(x_mv_name);


### PR DESCRIPTION
Towards #1247.

This PR adds tests and documentation, but the implementation itself requires `type_declaration`, which we will add in the next PR.

We documented the ASR design of this feature in the doc directory and we improved the documentation overall as well.

In future PRs:

* Add `type_declaration` to Variable (already documented in this PR)
* Get basic usage of `procedure(fn) :: x` in function arguments working (requires `type_declaration`)
* Add a test for calling the `procedure(fn) :: f` function using keyword arguments like `f(a=5)` (requires `type_declaration`)
* Add a test for procedure pointers: `procedure(fn), pointer :: f; f => my_fn; call f(a=5)`
* Even later: Implement Lambda functions, as expressions, possibly unify with Function