### PR TITLE
Implementation of `procedure(fn) :: x` (III)

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1343,9 +1343,11 @@ public:
                         Vec<ASR::dimension_t> m_dims;
                         m_dims.reserve(al, 1);
                         std::string assoc_variable_name = std::string(assoc_variable->m_name);
+                        ASR::symbol_t *type_declaration;
                         selector_type = determine_type(type_stmt_type->base.base.loc,
                                                        assoc_variable_name,
-                                                       type_stmt_type->m_vartype, false, m_dims);
+                                                       type_stmt_type->m_vartype, false, m_dims,
+                                                       type_declaration);
                         SetChar assoc_deps;
                         assoc_deps.reserve(al, 1);
                         ASRUtils::collect_variable_dependencies(al, assoc_deps, selector_type);

--- a/tests/reference/asr-functions_16-f863e4a.json
+++ b/tests/reference/asr-functions_16-f863e4a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_16-f863e4a.stdout",
-    "stdout_hash": "b256165e581a5a7ff0370cba117bddd9d5f9d7cc4985e6ae902d10ef",
+    "stdout_hash": "48a02a74c2ecd7035f91ff673acdfd8cbd06bcc2d25c19fbb3e663a7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_16-f863e4a.stdout
+++ b/tests/reference/asr-functions_16-f863e4a.stdout
@@ -343,7 +343,7 @@
                                                         []
                                                         .false.
                                                     )
-                                                    ()
+                                                    2 compare_less
                                                     Source
                                                     Public
                                                     Required
@@ -711,7 +711,7 @@
                                                         []
                                                         .false.
                                                     )
-                                                    ()
+                                                    2 compare_less
                                                     Source
                                                     Public
                                                     Optional


### PR DESCRIPTION
Populate `type_declaration` for Function. Tests updated.