### PR TITLE
Use correct ``ExternalSymbol`` for nested variables in a given scope 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -648,6 +648,7 @@ RUN(NAME nested_07 LABELS gfortran llvm)
 RUN(NAME nested_08 LABELS gfortran llvm)
 RUN(NAME nested_09 LABELS gfortran llvm)
 RUN(NAME nested_10 LABELS gfortran llvm)
+RUN(NAME nested_11 LABELS gfortran llvm)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm)
 RUN(NAME nested_vars2 LABELS gfortran llvm)

--- a/integration_tests/nested_11.f90
+++ b/integration_tests/nested_11.f90
@@ -1,0 +1,36 @@
+module base
+implicit none
+
+    integer, public :: a = 10
+
+end module
+
+module intermediate
+use base, only: a
+implicit none
+private
+end module
+
+program nested_11
+use base
+implicit none
+
+    interface
+        subroutine sub2
+          use intermediate
+          implicit none
+        end subroutine sub2
+    end interface
+
+    call sub
+
+contains
+
+    subroutine sub
+        use intermediate
+        implicit none
+        print *, a
+        if( a /= 10 ) error stop
+    end subroutine
+
+end program


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/1596