### PR TITLE
Add a test for the abs(sum(x) - y) issue

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -314,6 +314,7 @@ RUN(NAME arrays_intrin_02 LABELS gfortran) # all, any
 RUN(NAME any_01 LABELS gfortran)
 RUN(NAME any_02 LABELS gfortran llvm)
 RUN(NAME sum_01 LABELS gfortran llvm)
+RUN(NAME sum_02 LABELS gfortran llvm)
 
 RUN(NAME reserved_01 LABELS gfortran llvm wasm)
 RUN(NAME reserved_02 LABELS gfortran llvm)

--- a/integration_tests/sum_02.f90
+++ b/integration_tests/sum_02.f90
@@ -1,0 +1,15 @@
+program sum_02
+
+    integer :: x(5, 10), xdiff, i, j
+
+    do i = 1, 5
+        do j = 1, 10
+            x(i, j) = i + j
+        end do
+    end do
+
+    xdiff = abs(sum(x) - 425)
+    print *, xdiff
+    if( xdiff /= 0 ) error stop
+
+end program

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -245,6 +245,7 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
         }
         result_counter += 1;
         ASR::call_arg_t new_arg;
+        LCOMPILERS_ASSERT(result_var_)
         new_arg.loc = result_var_->base.loc;
         new_arg.m_value = result_var_;
         new_args.push_back(al, new_arg);

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1555,9 +1555,8 @@ namespace IntrinsicFunctionRegistry {
             id == ASRUtils::IntrinsicFunctions::Sum ) {
             return 1;
         } else {
-            LCOMPILERS_ASSERT(false);
+            return -1;
         }
-        return -1;
     }
 
     static inline create_intrinsic_function get_create_function(const std::string& name) {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1555,8 +1555,9 @@ namespace IntrinsicFunctionRegistry {
             id == ASRUtils::IntrinsicFunctions::Sum ) {
             return 1;
         } else {
-            return -1;
+            LCOMPILERS_ASSERT(false);
         }
+        return -1;
     }
 
     static inline create_intrinsic_function get_create_function(const std::string& name) {


### PR DESCRIPTION
The last commit makes the error better. Apply this to upstream minpack plus our commit d778fdb067233c859f153e0799186387ea7d7ea4:
```diff
--- a/examples/example_hybrd.f90
+++ b/examples/example_hybrd.f90
@@ -59,8 +59,8 @@ program example_hybrd
     if (abs(fnorm - 1.1926358347598092E-008_wp) > 1e-16) error stop
     if ((abs(nfev - 14)) > 1e-16) error stop
     if ((abs(info - 1)) > 1e-16) error stop
-    print *, "sum(x) = ", sum2(x)
-    if(abs(sum2(x) - (-5.7297012139802952_wp)) >  1e-16) error stop
+    print *, "sum(x) = ", sum(x)
+    if(abs(sum(x) - (-5.7297012139802952_wp)) >  1e-16) error stop
 
 contains
 
@@ -96,13 +96,4 @@ contains
 
     end subroutine fcn
 
-    real(wp) function sum2(x) result(r)
-    real(wp), intent(in) :: x(:)
-    integer :: i
-    r = 0
-    do i = 1, size(x)
-        r = r + x(i)
-    end do
-    end function
-
 end program example_hybrd
```
This gives:
```console
$ lfortran ./examples/example_hybrd.f90
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 1944
    err = compile_to_object_file(arg_file, tmp_o, false,
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 867
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/fortran_evaluator.cpp", line 346
    compiler_options, run_fn, infile);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 7850
    pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/pass/pass_manager.h", line 273
    apply_passes(al, asr, _passes, pass_options, diagnostics);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/pass/pass_manager.h", line 146
    _passes_db[passes[i]](al, *asr, pass_options);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/pass/intrinsic_function.cpp", line 316
    ReplaceFunctionCallReturningArrayVisitor u(al, func2intrinsicid);
  File "../libasr/asr.h", line 41294
  File "../libasr/asr.h", line 4567
  File "../libasr/asr.h", line 4303
  File "../libasr/asr.h", line 41306
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/pass/intrinsic_function.cpp", line 297
    visit_stmt(*m_body[i]);
  File "../libasr/asr.h", line 4582
  File "../libasr/asr.h", line 4337
  File "../libasr/asr.h", line 41575
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/pass/intrinsic_function.cpp", line 281
    replacer.replace_expr(*current_expr);
  File "../libasr/asr.h", line 40503
  File "../libasr/asr.h", line 39479
  File "../libasr/asr.h", line 40447
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/pass/intrinsic_function.cpp", line 248
    LCOMPILERS_ASSERT(result_var_)
AssertFailed: result_var_
```