### PR TITLE
CI: Test modern Minpack with intrinsic sum

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -251,8 +251,8 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/modern_minpack.git
             cd modern_minpack
-            git checkout w4
-            git checkout d778fdb067233c859f153e0799186387ea7d7ea4
+            git checkout w5
+            git checkout fcde66ca86348eb0c4012dbdf0f4d8dba61261d8
             $(pwd)/../src/bin/lfortran ./src/minpack.f90 -c
             $(pwd)/../src/bin/lfortran ./examples/example_hybrd.f90
             $(pwd)/../src/bin/lfortran ./examples/example_hybrd1.f90


### PR DESCRIPTION
We now test Minpack directly from upstream, with the following commit applied:

https://github.com/Pranavchiku/modern_minpack/commit/fcde66ca86348eb0c4012dbdf0f4d8dba61261d8

Which adds checks into the examples of the type:

    if (abs(fnorm - 1.1926358347598092E-008_wp) > 1e-16) error stop
    if ((abs(info - 1)) > 1e-16) error stop
    print *, "sum(x) = ", sum(x)
    if (abs(sum(x) - (-5.7297012139802952_wp)) >  1e-16) error stop

To ensure correct results, and it uses the intrinsic abs() and sum() and it works.