### PR TITLE
parser_stype.h: exclude static_assert on ppc32 as well

### DIFF
--- a/src/lfortran/parser/parser_stype.h
+++ b/src/lfortran/parser/parser_stype.h
@@ -93,7 +93,7 @@ static_assert(std::is_trivial<YYSTYPE>::value);
 // Ensure the YYSTYPE size is equal to Vec<AST::ast_t*>, which is a required member, so
 // YYSTYPE has to be at least as big, but it should not be bigger, otherwise it
 // would reduce performance.
-#ifndef HAVE_BUILD_TO_WASM
+#if !defined(HAVE_BUILD_TO_WASM) && !defined(__ppc__)
 static_assert(sizeof(YYSTYPE) == sizeof(Vec<AST::ast_t*>));
 #endif
 } // namespace LCompilers::LFortran


### PR DESCRIPTION
It fails on `ppc`. Disable to unbreak the build.