### PR TITLE
PASS: Support ArrayConstant in print_arr

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -147,6 +147,7 @@ RUN(NAME print_02 LABELS gfortran llvm llvm2 wasm)
 RUN(NAME print_03 LABELS gfortran llvm llvm2 wasm)
 RUN(NAME print_arr_01 LABELS gfortran llvm llvm2 wasm)
 RUN(NAME print_arr_02 LABELS gfortran llvm llvm2 wasm)
+RUN(NAME print_arr_03 LABELS gfortran llvm llvm2)
 
 RUN(NAME include_01 LABELS gfortran llvm wasm)
 RUN(NAME include_02 LABELS gfortran llvm wasm)
@@ -800,6 +801,7 @@ RUN(NAME pass_array_by_data_06 LABELS gfortran llvm wasm)
 RUN(NAME implicit_deallocate_01 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm)
+RUN(NAME write_02 LABELS gfortran llvm)
 
 RUN(NAME do_loop_01 LABELS gfortran llvm)
 

--- a/integration_tests/print_arr_03.f90
+++ b/integration_tests/print_arr_03.f90
@@ -1,0 +1,35 @@
+program main
+    implicit none
+
+    print *, [4, 9]
+    print *, [[2, -2, 5, 7, [8, -9, [10]]], [3, 3], [-11]]
+    call f()
+
+    contains
+
+    subroutine f()
+        integer, allocatable :: a(:, :)
+        real :: b(2, 2)
+        integer :: i, j
+        allocate(a(5, 10))
+
+        do i = lbound(a, 1), ubound(a, 1)
+            do j = lbound(a, 2), ubound(a, 2)
+                a(i, j) = i + j
+            end do
+        end do
+
+        b(1, 1) = 1.1
+        b(1, 2) = -1.2
+        b(2, 1) = 2.1
+        b(2, 2) = -2.2
+
+        print *, [[1, a, 2, 3], a, 5, [abs(-2)]]
+        print *, "hello", ["hey", ["xyz", ["abc"]]], [[1, a, 2, 3], a, 5, [abs(-2)]], "bye"
+        print *, [2.1, [3.14, [-5.11, [abs(-21.22), [abs(21.22)]]]]]
+        print *, "Integer(2x2) ArrayConst", [[1, 2], [3, 4]], "Array End"
+        print *, "Real(2x2) ArrayVar", b, "Array End"
+        print *, "Real(2x2) ArrayConst", [[1.1, -1.2], [2.1, -2.2]], "Array End"
+        print *, "Integer(2x2), Real(2x2), ArrayConst", [[1, 2], [3, 4]], [[1.1, -1.2], [2.1, -2.2]], "ArrayEnd"
+    end subroutine
+end program

--- a/integration_tests/write_02.f90
+++ b/integration_tests/write_02.f90
@@ -1,0 +1,35 @@
+program main
+    implicit none
+
+    write (*, *), [4, 9]
+    write (*, *), [[2, -2, 5, 7, [8, -9, [10]]], [3, 3], [-11]]
+    call f()
+
+    contains
+
+    subroutine f()
+        integer, allocatable :: a(:, :)
+        real :: b(2, 2)
+        integer :: i, j
+        allocate(a(5, 10))
+
+        do i = lbound(a, 1), ubound(a, 1)
+            do j = lbound(a, 2), ubound(a, 2)
+                a(i, j) = i + j
+            end do
+        end do
+
+        b(1, 1) = 1.1
+        b(1, 2) = -1.2
+        b(2, 1) = 2.1
+        b(2, 2) = -2.2
+
+        write (*, *), [[1, a, 2, 3], a, 5, [abs(-2)]]
+        write (*, *), "hello", ["hey", ["xyz", ["abc"]]], [[1, a, 2, 3], a, 5, [abs(-2)]], "bye"
+        write (*, *), [2.1, [3.14, [-5.11, [abs(-21.22), [abs(21.22)]]]]]
+        write (*, *), "Integer(2x2) ArrayConst", [[1, 2], [3, 4]], "Array End"
+        write (*, *), "Real(2x2) ArrayVar", b, "Array End"
+        write (*, *), "Real(2x2) ArrayConst", [[1.1, -1.2], [2.1, -2.2]], "Array End"
+        write (*, *), "Integer(2x2), Real(2x2), ArrayConst", [[1, 2], [3, 4]], [[1.1, -1.2], [2.1, -2.2]], "ArrayEnd"
+    end subroutine
+end program

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -168,6 +168,11 @@ namespace LCompilers {
                 ASR::ttype_t *x_type = ASR::down_cast<ASR::StructInstanceMember_t>(x)->m_type;
                 ASR::dimension_t* m_dims;
                 get_dim_rank(x_type, m_dims, n_dims);
+            } else if (ASR::is_a<ASR::ArrayConstant_t>(*x)) {
+                ASR::ArrayConstant_t *a = ASR::down_cast<ASR::ArrayConstant_t>(x);
+                ASR::ttype_t* x_type = a->m_type;
+                ASR::dimension_t* m_dims;
+                get_dim_rank(x_type, m_dims, n_dims);
             }
             return n_dims;
         }


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/460

```bash
$ cat integration_tests/print_arr_03.f90 
program main
    implicit none
    print *, [4, 9]
    print *, [[2, -2, 5, 7, [8, -9, [10]]], [3, 3], [-11]]
end program
$ gfortran integration_tests/print_arr_03.f90 
$ ./a.out 
           4           9
           2          -2           5           7           8          -9          10           3           3         -11
$ lfortran integration_tests/print_arr_03.f90
4 9 
2 -2 5 7 8 -9 10 3 3 -11 
```