### PR TITLE
Compiler option to print leading space for `print *`

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -54,6 +54,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     obj = is_included("obj")
     x86 = is_included("x86")
     bin_ = is_included("bin")
+    print_leading_space = is_included("print_leading_space")
     pass_ = test.get("pass", None)
     extrafiles = test.get("extrafiles", "").split(",")
     optimization_passes = ["flip_sign", "div_to_mul", "fma", "sign_from_value",
@@ -75,6 +76,8 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     log.debug(f"{color(style.bold)} START TEST: {color(style.reset)} {filename}")
 
     extra_args = f"--no-error-banner {show_verbose}"
+    if print_leading_space:
+        extra_args += " --print-leading-space"
 
     if tokens:
         run_test(

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1715,6 +1715,7 @@ int main(int argc, char *argv[])
         app.add_flag("--print-targets", print_targets, "Print the registered targets");
         app.add_flag("--implicit-typing", compiler_options.implicit_typing, "Allow implicit typing");
         app.add_flag("--implicit-interface", compiler_options.implicit_interface, "Allow implicit interface");
+        app.add_flag("--print-leading-space", compiler_options.print_leading_space, "Print leading white space if format is unspecified");
         app.add_flag("--verbose", compiler_options.verbose, "Print debugging statements");
         app.add_flag("--cumulative", compiler_options.pass_cumulative, "Apply all the passes cumulatively till the given pass");
 

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -49,6 +49,7 @@ struct CompilerOptions {
     bool new_parser = false;
     bool implicit_typing = false;
     bool implicit_interface = false;
+    bool print_leading_space = false;
     bool rtlib = false;
     std::string target = "";
     std::string arg_o = "";

--- a/tests/print3.f90
+++ b/tests/print3.f90
@@ -1,0 +1,12 @@
+program print_03
+    implicit none
+    integer :: x
+
+    x = 24
+
+    print *, "x is ", x
+    write (*, *) "x is ", x
+    print *, "ok"
+    write (*, *) "ok"
+
+end program

--- a/tests/reference/asr-print3-5f4fc26.json
+++ b/tests/reference/asr-print3-5f4fc26.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-print3-5f4fc26",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/print3.f90",
+    "infile_hash": "891fa35fc5d09524ef73c8c3b92bcd5a4bede01e35fdf0f116df99b2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-print3-5f4fc26.stdout",
+    "stdout_hash": "5df17837338b4c9ffbb955d6d7e59bb74b67d2a44357db5f6a71005e",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-print3-5f4fc26.stdout
+++ b/tests/reference/asr-print3-5f4fc26.stdout
@@ -1,0 +1,101 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            print_03:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4 [])
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    print_03
+                    []
+                    [(=
+                        (Var 2 x)
+                        (IntegerConstant 24 (Integer 4 []))
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(StringConstant
+                            ""
+                            (Character 1 0 () [])
+                        )
+                        (StringConstant
+                            "x is "
+                            (Character 1 5 () [])
+                        )
+                        (Var 2 x)]
+                        ()
+                        ()
+                    )
+                    (FileWrite
+                        0
+                        ()
+                        ()
+                        ()
+                        ()
+                        ()
+                        [(StringConstant
+                            ""
+                            (Character 1 0 () [])
+                        )
+                        (StringConstant
+                            "x is "
+                            (Character 1 5 () [])
+                        )
+                        (Var 2 x)]
+                        ()
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(StringConstant
+                            ""
+                            (Character 1 0 () [])
+                        )
+                        (StringConstant
+                            "ok"
+                            (Character 1 2 () [])
+                        )]
+                        ()
+                        ()
+                    )
+                    (FileWrite
+                        0
+                        ()
+                        ()
+                        ()
+                        ()
+                        ()
+                        [(StringConstant
+                            ""
+                            (Character 1 0 () [])
+                        )
+                        (StringConstant
+                            "ok"
+                            (Character 1 2 () [])
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2318,6 +2318,11 @@ ast = true
 ast_f90 = true
 
 [[test]]
+filename = "print3.f90"
+print_leading_space = true
+asr = true
+
+[[test]]
 filename = "uppercase1.f90"
 asr = true
 


### PR DESCRIPTION
closes #1744 