### PR TITLE
Implementation of max0() using IntrinsicFunction

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -439,7 +439,7 @@ RUN(NAME intrinsics_48 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_49 LABELS gfortran llvm)
 RUN(NAME intrinsics_50 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_51 LABELS gfortran llvm NOFAST)
-RUN(NAME intrinsics_52 LABELS gfortran ) # max0
+RUN(NAME intrinsics_52 LABELS gfortran llvm) # max0
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -439,8 +439,7 @@ RUN(NAME intrinsics_48 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_49 LABELS gfortran llvm)
 RUN(NAME intrinsics_50 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_51 LABELS gfortran llvm NOFAST)
-RUN(NAME intrinsics_52 LABELS gfortran llvm) # min0, max0
-RUN(NAME intrinsics_53 LABELS gfortran llvm NOFAST) # repeat
+RUN(NAME intrinsics_52 LABELS gfortran ) # max0
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -439,7 +439,9 @@ RUN(NAME intrinsics_48 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_49 LABELS gfortran llvm)
 RUN(NAME intrinsics_50 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_51 LABELS gfortran llvm NOFAST)
-RUN(NAME intrinsics_52 LABELS gfortran llvm) # max0
+RUN(NAME intrinsics_52 LABELS gfortran)
+RUN(NAME intrinsics_53 LABELS gfortran llvm NOFAST) # repeat
+RUN(NAME intrinsics_54 LABELS gfortran llvm) #max0
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/intrinsics_52.f90
+++ b/integration_tests/intrinsics_52.f90
@@ -13,10 +13,4 @@ if (max0(a,b) /= a) error stop
 if (max0(a,b,c) /= c) error stop
 if (max0(d,e,f,a,b,c) /= e) error stop
 
-if (min0(10,20) /= 10) error stop
-if (min0(3,5,4) /= 3) error stop
-if (min0(a,b) /= b) error stop
-if (min0(c,b,a) /= b) error stop
-if (min0(d,e,f,a,b,c) /= f) error stop
-
 end

--- a/integration_tests/intrinsics_52.f90
+++ b/integration_tests/intrinsics_52.f90
@@ -13,4 +13,10 @@ if (max0(a,b) /= a) error stop
 if (max0(a,b,c) /= c) error stop
 if (max0(d,e,f,a,b,c) /= e) error stop
 
+if (min0(10,20) /= 10) error stop
+if (min0(3,5,4) /= 3) error stop
+if (min0(a,b) /= b) error stop
+if (min0(c,b,a) /= b) error stop
+if (min0(d,e,f,a,b,c) /= f) error stop
+
 end

--- a/integration_tests/intrinsics_54.f90
+++ b/integration_tests/intrinsics_54.f90
@@ -1,0 +1,16 @@
+program intrinsics_54
+   integer :: a, b, c, d, e, f
+   a = 2
+   b = -3
+   c = 5
+   d = 10
+   e = 20
+   f = -30
+
+   if (max0(10,20) /= 20) error stop
+   if (max0(3,5,4) /= 5) error stop
+   if (max0(a,b) /= a) error stop
+   if (max0(a,b,c) /= c) error stop
+   if (max0(d,e,f,a,b,c) /= e) error stop
+
+end

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -713,6 +713,8 @@ public:
                  IntrinsicSignature({"mask"}, 1, 2)}},
         {"product", {IntrinsicSignature({"dim", "mask"}, 1, 3),
                  IntrinsicSignature({"mask"}, 1, 2)}},
+        // max0 can accept any arbitrary number of arguments 2<=x<=100
+        {"max0", {IntrinsicSignature({}, 2, 100)}},
     };
 
 

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1368,7 +1368,10 @@ namespace Max {
              "ASR Verify: Arguments to max0 must be of real or integer type",
             x.base.base.loc, diagnostics);
         for(size_t i=0;i<x.n_args;i++){
-            ASRUtils::require_impl(ASRUtils::expr_type(x.m_args[i]) == ASRUtils::expr_type(x.m_args[0]),
+            ASRUtils::require_impl((ASR::is_a<ASR::Real_t>(*ASRUtils::expr_type(x.m_args[i])) &&
+                                            ASR::is_a<ASR::Real_t>(*ASRUtils::expr_type(x.m_args[0]))) ||
+                                        (ASR::is_a<ASR::Integer_t>(*ASRUtils::expr_type(x.m_args[i])) &&
+                                         ASR::is_a<ASR::Integer_t>(*ASRUtils::expr_type(x.m_args[0]))),
             "ASR Verify: All arguments must be of the same type",
             x.base.base.loc, diagnostics);
         }
@@ -1399,6 +1402,9 @@ namespace Max {
     static inline ASR::asr_t* create_Max(
         Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args,
         const std::function<void (const std::string &, const Location &)> err) {
+        for(size_t i=0; i<100;i++){
+            args.erase(nullptr);
+        }
         Vec<ASR::expr_t*> arg_values;
         arg_values.reserve(al, args.size());
         for(size_t i=0;i<args.size();i++){
@@ -1415,6 +1421,7 @@ namespace Max {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types,
         Vec<ASR::call_arg_t>& new_args, int64_t overload_id, ASR::expr_t* compile_time_value) {
         // TODO
+        return nullptr;
     }
 
 }  // namespace max0

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1367,7 +1367,7 @@ namespace Max {
             ASR::is_a<ASR::Integer_t>(*ASRUtils::expr_type(x.m_args[0])),
              "ASR Verify: Arguments to max0 must be of real or integer type",
             x.base.base.loc, diagnostics);
-        for(int i=0;i<x.n_args;i++){
+        for(size_t i=0;i<x.n_args;i++){
             ASRUtils::require_impl(ASRUtils::expr_type(x.m_args[i]) == ASRUtils::expr_type(x.m_args[0]),
             "ASR Verify: All arguments must be of the same type",
             x.base.base.loc, diagnostics);
@@ -1401,7 +1401,7 @@ namespace Max {
         const std::function<void (const std::string &, const Location &)> err) {
         Vec<ASR::expr_t*> arg_values;
         arg_values.reserve(al, args.size());
-        for(int i=0;i<args.size();i++){
+        for(size_t i=0;i<args.size();i++){
             ASR::expr_t *arg_value = ASRUtils::expr_value(args[i]);
             arg_values.push_back(al, arg_value);
         }

--- a/tests/reference/asr-intrinsic_implicit-77de888.json
+++ b/tests/reference/asr-intrinsic_implicit-77de888.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsic_implicit-77de888.stdout",
-    "stdout_hash": "f45433a9dc69552f3c8ba4f263f4126a95ea151c403a939afa443aec",
+    "stdout_hash": "ecef2c1b17199737c5982ed7c079161cca556e545322128b3119a011",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsic_implicit-77de888.stdout
+++ b/tests/reference/asr-intrinsic_implicit-77de888.stdout
@@ -40,34 +40,20 @@
                                     .false.
                                 ),
                             max0:
-                                (ExternalSymbol
+                                (Variable
                                     2
                                     max0
-                                    4 max0
-                                    lfortran_intrinsic_math2
                                     []
-                                    max0
-                                    Private
-                                ),
-                            max0@imax:
-                                (ExternalSymbol
-                                    2
-                                    max0@imax
-                                    4 imax
-                                    lfortran_intrinsic_math2
-                                    []
-                                    imax
-                                    Private
-                                ),
-                            max0@imax_3_args:
-                                (ExternalSymbol
-                                    2
-                                    max0@imax_3_args
-                                    4 imax_3_args
-                                    lfortran_intrinsic_math2
-                                    []
-                                    imax_3_args
-                                    Private
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
                                 )
                         })
                     fppasu
@@ -84,20 +70,18 @@
                         .false.
                         .false.
                     )
-                    [max0@imax
-                    max0@imax_3_args]
+                    []
                     []
                     [(=
                         (Var 2 a)
                         (Cast
-                            (FunctionCall
-                                2 max0@imax
-                                2 max0
-                                [((IntegerConstant 1 (Integer 4)))
-                                ((IntegerConstant 2 (Integer 4)))]
+                            (IntrinsicFunction
+                                Max
+                                [(IntegerConstant 1 (Integer 4))
+                                (IntegerConstant 2 (Integer 4))]
+                                0
                                 (Integer 4)
                                 (IntegerConstant 2 (Integer 4))
-                                ()
                             )
                             IntegerToReal
                             (Real 4)
@@ -111,25 +95,27 @@
                     (=
                         (Var 2 b)
                         (Cast
-                            (FunctionCall
-                                2 max0@imax_3_args
-                                2 max0
-                                [((IntegerConstant 1 (Integer 4)))
-                                ((IntegerBinOp
+                            (IntrinsicFunction
+                                Max
+                                [(IntegerConstant 1 (Integer 4))
+                                (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
                                     Div
                                     (IntegerConstant 2 (Integer 4))
                                     (Integer 4)
                                     (IntegerConstant 1 (Integer 4))
-                                ))
-                                ((IntegerConstant 1 (Integer 4)))]
+                                )
+                                (IntegerConstant 1 (Integer 4))]
+                                0
                                 (Integer 4)
-                                ()
-                                ()
+                                (IntegerConstant 1 (Integer 4))
                             )
                             IntegerToReal
                             (Real 4)
-                            ()
+                            (RealConstant
+                                1.000000
+                                (Real 4)
+                            )
                         )
                         ()
                     )]
@@ -138,15 +124,7 @@
                     .false.
                     .false.
                     ()
-                ),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math2:
-                (IntrinsicModule lfortran_intrinsic_math2),
-            lfortran_intrinsic_math3:
-                (IntrinsicModule lfortran_intrinsic_math3)
+                )
         })
     []
 )


### PR DESCRIPTION
Will fix #1739
Work in Progress

The ```max0``` and ```min0``` Fortran functions can accept any arbitrary number of arguments.
@czgdp1807 Can you please review this and guide me with the implementation of the  ```instantiate_Max()``` function? How would I write that?