### PR TITLE
CI: Fix macos warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 12.0
 
 jobs:
   Build:


### PR DESCRIPTION
Fixes the following warnings

```
ld: warning: dylib (/Users/runner/work/lfortran/lfortran/src/runtime/liblfortran_runtime.dylib) was built for newer macOS version (12.6) than being linked (12.0)
```