### PR TITLE
Allow declaration of variables with nullptr vartype in module when `--implicit-typing` is enabled

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -504,6 +504,7 @@ RUN(NAME modules_45 LABELS gfortran)
 RUN(NAME modules_48 LABELS gfortran)
 RUN(NAME modules_49 LABELS gfortran llvm NOFAST)
 RUN(NAME modules_50 LABELS gfortran)
+RUN(NAME modules_51 LABELS gfortran llvmImplicit NOFAST)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES

--- a/integration_tests/modules_51.f90
+++ b/integration_tests/modules_51.f90
@@ -1,0 +1,16 @@
+module modules_51_module
+    public :: a
+end module
+
+subroutine sub()
+    use modules_51_module
+    if (abs(a - 2.0) > 1e-8) error stop
+    print *, a
+end subroutine
+
+program modules_51
+    use modules_51_module
+    a = 2
+    call sub()
+end program
+

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1590,7 +1590,8 @@ public:
                                             "supported", x.base.base.loc);
                                 }
                                 ASR::symbol_t* sym_ = current_scope->resolve_symbol(sym);
-                                if (!sym_ && compiler_options.implicit_typing) {
+                                if (!sym_ && compiler_options.implicit_typing && sa->m_attr != AST::simple_attributeType
+                                                        ::AttrExternal) {
                                     sym_ = declare_implicit_variable(x.m_syms[i].loc, sym, ASR::intentType::Local);
                                 }
                             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1589,6 +1589,10 @@ public:
                                     throw SemanticError("Attribute declaration not "
                                             "supported", x.base.base.loc);
                                 }
+                                ASR::symbol_t* sym_ = current_scope->resolve_symbol(sym);
+                                if (!sym_ && compiler_options.implicit_typing) {
+                                    sym_ = declare_implicit_variable(x.m_syms[i].loc, sym, ASR::intentType::Local);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #1774.