### PR TITLE
Add provision to update args of subroutine call when `--implicit-interface` is enabled

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1501,6 +1501,42 @@ public:
             }
         }
     }
+
+    template <typename T>
+    void update_call_args( T&x ) {
+        // iterate over body of program, check if there are any subroutine calls if yes, iterate over its args 
+        // and update the args if they are equal to the old symbol
+        if (compiler_options.implicit_interface) {
+            for (size_t i = 0; i < x->n_body; i++) {
+                ASR::stmt_t* stmt = x->m_body[i];
+                if (stmt->type == ASR::stmtType::SubroutineCall) {
+                    /*
+                        case: call func(f)
+                        where f is an implicit interface, currently f is a variable
+                    */
+                    ASR::SubroutineCall_t* subrout_call = ASR::down_cast<ASR::SubroutineCall_t>(stmt);
+                    for (size_t j = 0; j < subrout_call->n_args; j++) {
+                        ASR::call_arg_t arg = subrout_call->m_args[j];
+                        ASR::expr_t* arg_expr = arg.m_value;
+                        if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
+                            ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(arg_expr);
+                            ASR::symbol_t* arg_sym = arg_var->m_v;
+                            ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym);
+                            if (ASR::is_a<ASR::Variable_t>(*arg_sym_underlying)) {
+                                ASR::Variable_t* arg_variable = ASR::down_cast<ASR::Variable_t>(arg_sym_underlying);
+                                std::string arg_variable_name = std::string(arg_variable->m_name);
+                                ASR::symbol_t* sym = current_scope->resolve_symbol(arg_variable_name);
+                                if (sym != arg_sym) {
+                                    subrout_call->m_args[j].m_value = ASRUtils::EXPR(ASR::make_Var_t(al, arg_expr->base.loc, sym));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     void visit_Program(const AST::Program_t &x) {
         SymbolTable *old_scope = current_scope;
         ASR::symbol_t *t = current_scope->get_symbol(to_lower(x.m_name));
@@ -1522,6 +1558,8 @@ public:
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
         }
+
+        update_call_args(v);
 
         starting_m_body = nullptr;
         starting_n_body =  0;
@@ -1609,6 +1647,8 @@ public:
             visit_program_unit(*x.m_contains[i]);
         }
 
+        update_call_args(v);
+
         starting_m_body = nullptr;
         starting_n_body = 0;
         remove_common_variable_declarations(current_scope);
@@ -1656,6 +1696,8 @@ public:
                 visit_unit_decl2(*x.m_decl[i]);
             is_Function = false;
         }
+
+        update_call_args(v);
 
         starting_m_body = nullptr;
         starting_n_body = 0;

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1504,8 +1504,18 @@ public:
 
     template <typename T>
     void update_call_args( T&x ) {
-        // iterate over body of program, check if there are any subroutine calls if yes, iterate over its args 
-        // and update the args if they are equal to the old symbol
+        /*
+        Iterate over body of program, check if there are any subroutine calls if yes, iterate over its args 
+        and update the args if they are equal to the old symbol 
+        For example:
+            function func(f)
+                double precision c
+                call sub2(c)
+                print *, c(d)
+            end function
+        This function updates `sub2` to use the new symbol `c` that is now a function, not a variable.
+        */
+
         if (compiler_options.implicit_interface) {
             for (size_t i = 0; i < x->n_body; i++) {
                 ASR::stmt_t* stmt = x->m_body[i];

--- a/tests/allow_implicit_interface4.f90
+++ b/tests/allow_implicit_interface4.f90
@@ -1,0 +1,17 @@
+subroutine dqc25c(f)
+   double precision f
+   call dqk15w(f)
+   print *, f(hlgth)
+end
+
+function func(f)
+   double precision c
+   call sub2(c)
+   print *, c(d)
+end function
+
+program main
+   double precision a
+   call sub(a)
+   print *, a(b)
+end program

--- a/tests/reference/asr-allow_implicit_interface4-4615450.json
+++ b/tests/reference/asr-allow_implicit_interface4-4615450.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-allow_implicit_interface4-4615450",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/allow_implicit_interface4.f90",
+    "infile_hash": "9992b1e5744f5c2000e5692928e1413fc28b7542424999502e928afd",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-allow_implicit_interface4-4615450.stdout",
+    "stdout_hash": "3adc223166ea4bedfa3271039eb4741788b8a2f4e791e5ca9d6a873a",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-allow_implicit_interface4-4615450.stdout
+++ b/tests/reference/asr-allow_implicit_interface4-4615450.stdout
@@ -1,0 +1,577 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            dqc25c:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            dqk15w:
+                                (Function
+                                    (SymbolTable
+                                        5
+                                        {
+                                            dqk15w_arg_0:
+                                                (Variable
+                                                    5
+                                                    dqk15w_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    dqk15w
+                                    (FunctionType
+                                        [(Real 8)]
+                                        ()
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 5 dqk15w_arg_0)]
+                                    []
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            f:
+                                (Function
+                                    (SymbolTable
+                                        6
+                                        {
+                                            f_arg_0:
+                                                (Variable
+                                                    6
+                                                    f_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            f_return_var_name:
+                                                (Variable
+                                                    6
+                                                    f_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            hlgth:
+                                                (Variable
+                                                    6
+                                                    hlgth
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    f
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 8)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 6 f_arg_0)]
+                                    []
+                                    (Var 6 f_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            hlgth:
+                                (Variable
+                                    2
+                                    hlgth
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    dqc25c
+                    (FunctionType
+                        [(Real 8)]
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    [dqk15w
+                    f]
+                    [(Var 2 f)]
+                    [(SubroutineCall
+                        2 dqk15w
+                        ()
+                        [((Var 2 f))]
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(FunctionCall
+                            2 f
+                            ()
+                            [((Var 2 hlgth))]
+                            (Real 8)
+                            ()
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            func:
+                (Function
+                    (SymbolTable
+                        3
+                        {
+                            c:
+                                (Function
+                                    (SymbolTable
+                                        8
+                                        {
+                                            c_arg_0:
+                                                (Variable
+                                                    8
+                                                    c_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            c_return_var_name:
+                                                (Variable
+                                                    8
+                                                    c_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            d:
+                                                (Variable
+                                                    8
+                                                    d
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    c
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 8)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 8 c_arg_0)]
+                                    []
+                                    (Var 8 c_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            d:
+                                (Variable
+                                    3
+                                    d
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            f:
+                                (Variable
+                                    3
+                                    f
+                                    []
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            func:
+                                (Variable
+                                    3
+                                    func
+                                    []
+                                    ReturnVar
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            sub2:
+                                (Function
+                                    (SymbolTable
+                                        7
+                                        {
+                                            sub2_arg_0:
+                                                (Variable
+                                                    7
+                                                    sub2_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    sub2
+                                    (FunctionType
+                                        [(Real 8)]
+                                        ()
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 7 sub2_arg_0)]
+                                    []
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    func
+                    (FunctionType
+                        [(Real 4)]
+                        (Real 4)
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    [sub2
+                    c]
+                    [(Var 3 f)]
+                    [(SubroutineCall
+                        3 sub2
+                        ()
+                        [((Var 3 c))]
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(FunctionCall
+                            3 c
+                            ()
+                            [((Var 3 d))]
+                            (Real 8)
+                            ()
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                    (Var 3 func)
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            main:
+                (Program
+                    (SymbolTable
+                        4
+                        {
+                            a:
+                                (Function
+                                    (SymbolTable
+                                        10
+                                        {
+                                            a_arg_0:
+                                                (Variable
+                                                    10
+                                                    a_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            a_return_var_name:
+                                                (Variable
+                                                    10
+                                                    a_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    10
+                                                    b
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    a
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 8)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 10 a_arg_0)]
+                                    []
+                                    (Var 10 a_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            b:
+                                (Variable
+                                    4
+                                    b
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            sub:
+                                (Function
+                                    (SymbolTable
+                                        9
+                                        {
+                                            sub_arg_0:
+                                                (Variable
+                                                    9
+                                                    sub_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    sub
+                                    (FunctionType
+                                        [(Real 8)]
+                                        ()
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 9 sub_arg_0)]
+                                    []
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    main
+                    []
+                    [(SubroutineCall
+                        4 sub
+                        ()
+                        [((Var 4 a))]
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(FunctionCall
+                            4 a
+                            ()
+                            [((Var 4 b))]
+                            (Real 8)
+                            ()
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3216,6 +3216,10 @@ asr_implicit_interface_and_typing = true
 filename = "../integration_tests/statement_03.f90"
 asr_implicit_interface_and_typing = true
 
+[[test]]
+filename = "allow_implicit_interface4.f90"
+asr_implicit_interface_and_typing = true
+
 # Parser
 
 [[test]]


### PR DESCRIPTION
Fixes #1441.
With this LFortran now compiles all of `scipy/scipy/integrate/quadpack` to ASR.