### PR TITLE
Bug fixes for `statement` functions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -886,3 +886,4 @@ RUN(NAME common_09 LABELS gfortran llvm)
 
 RUN(NAME statement_01 LABELS gfortran llvmImplicit)
 RUN(NAME statement_02 LABELS gfortran llvmImplicit)
+RUN(NAME statement_03 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -883,3 +883,5 @@ RUN(NAME common_06 LABELS gfortran llvm llvmImplicit)
 RUN(NAME common_07 LABELS gfortran llvmImplicit)
 RUN(NAME common_08 LABELS gfortran llvmImplicit)
 RUN(NAME common_09 LABELS gfortran llvm)
+
+RUN(NAME statement_01 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -885,3 +885,4 @@ RUN(NAME common_08 LABELS gfortran llvmImplicit)
 RUN(NAME common_09 LABELS gfortran llvm)
 
 RUN(NAME statement_01 LABELS gfortran llvmImplicit)
+RUN(NAME statement_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/statement_01.f90
+++ b/integration_tests/statement_01.f90
@@ -1,0 +1,8 @@
+double precision function alnorm()
+double precision z, zexp
+zexp(z) = dexp(z)
+return
+end
+
+program statement_01
+end program

--- a/integration_tests/statement_02.f90
+++ b/integration_tests/statement_02.f90
@@ -1,0 +1,8 @@
+subroutine gscale()
+   real fpoint
+   fpoint(i) = i
+end
+
+program statement_02
+    call gscale()
+end program

--- a/integration_tests/statement_03.f90
+++ b/integration_tests/statement_03.f90
@@ -1,0 +1,10 @@
+subroutine cumchn()
+
+   intrinsic dble
+   dg(i) = 2.0D0*dble(i)
+
+end subroutine
+
+program statement_03
+   call cumchn()
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1795,6 +1795,7 @@ public:
 
         if (sym==nullptr) {
             if (compiler_options.implicit_typing) {
+                implicit_dictionary = implicit_mapping[get_hash(parent_scope->asr_owner)];
                 type = implicit_dictionary[std::string(1, to_lower(var_name)[0])];
             } else {
                 throw SemanticError("Statement function needs to be declared.", x.base.base.loc);
@@ -1858,7 +1859,7 @@ public:
             nullptr, false, false, false, false, false,
             false, false, false);
         current_function_dependencies.clear(al);
-        parent_scope->overwrite_symbol(var_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        parent_scope->add_or_overwrite_symbol(var_name, ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
     }
 

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1756,6 +1756,7 @@ public:
 
         Vec<ASR::expr_t*> args;
         args.reserve(al, v->n_args);
+
         for (size_t i=0; i<v->n_args; i++) {
             visit_expr(*(v->m_args[i]).m_end);
             ASR::expr_t *end = ASRUtils::EXPR(tmp);
@@ -1765,6 +1766,7 @@ public:
             } else {
                 throw SemanticError("Statement function can only contain variables as arguments.", x.base.base.loc);
             }
+
             ASR::Variable_t* variable = ASR::down_cast<ASR::Variable_t>(tmp_var->m_v);
             std::string arg_name = variable->m_name;
             arg_name = to_lower(arg_name);
@@ -1778,7 +1780,11 @@ public:
                 ASR::storage_typeType::Default, ASRUtils::expr_type(end), nullptr,
                 ASR::abiType::Source, ASR::Public, ASR::presenceType::Required,
                 false);
-            current_scope->add_symbol(arg_name, ASR::down_cast<ASR::symbol_t>(arg_var));
+            if (compiler_options.implicit_typing) {
+                current_scope->add_or_overwrite_symbol(arg_name, ASR::down_cast<ASR::symbol_t>(arg_var));
+            } else {
+                current_scope->add_symbol(arg_name, ASR::down_cast<ASR::symbol_t>(arg_var));
+            }
             args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                 current_scope->get_symbol(arg_name))));
         }

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1746,6 +1746,7 @@ public:
     }
 
     void create_statement_function(const AST::Assignment_t &x) {
+        current_function_dependencies.clear(al);
         SymbolTable *parent_scope = current_scope;
         current_scope = al.make_new<SymbolTable>(parent_scope);
 
@@ -1840,7 +1841,8 @@ public:
             al, x.base.base.loc,
             /* a_symtab */ current_scope,
             /* a_name */ s2c(al, var_name),
-            nullptr, 0,
+            /* m_dependency */ current_function_dependencies.p, 
+            /* n_dependency */ current_function_dependencies.size(),
             /* a_args */ args.p,
             /* n_args */ args.size(),
             /* a_body */ body.p,
@@ -1849,6 +1851,7 @@ public:
             ASR::abiType::Source, ASR::accessType::Public, ASR::deftypeType::Implementation,
             nullptr, false, false, false, false, false,
             false, false, false);
+        current_function_dependencies.clear(al);
         parent_scope->overwrite_symbol(var_name, ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4251,6 +4251,12 @@ public:
                 && ASR::is_a<ASR::Variable_t>(*v)
                 && (!ASRUtils::is_array(ASRUtils::symbol_type(v)))
                 && (!ASRUtils::is_character(*ASRUtils::symbol_type(v)))) {
+            if (var_name == "float" || var_name == "dble") {
+                Vec<ASR::call_arg_t> args;
+                visit_expr_list(x.m_args, x.n_args, args);
+                tmp = handle_intrinsic_float(al, args, x.base.base.loc);
+                return;
+            }
             // If implicit interface is allowed, we have to handle the
             // following case here:
             // real :: x

--- a/tests/reference/asr-statement_01-00eefc8.json
+++ b/tests/reference/asr-statement_01-00eefc8.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-statement_01-00eefc8",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/statement_01.f90",
+    "infile_hash": "fa4dec1637f247dd008b3228459dec03794d377643c25b443ba26c08",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-statement_01-00eefc8.stdout",
+    "stdout_hash": "5e74d7eac58af1b860b3190ae77fdafc1be515cd412f35ca6d0d992a",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-statement_01-00eefc8.stdout
+++ b/tests/reference/asr-statement_01-00eefc8.stdout
@@ -1,0 +1,169 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            alnorm:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            alnorm:
+                                (Variable
+                                    2
+                                    alnorm
+                                    []
+                                    ReturnVar
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            zexp:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            dexp:
+                                                (ExternalSymbol
+                                                    4
+                                                    dexp
+                                                    6 dexp
+                                                    lfortran_intrinsic_math
+                                                    []
+                                                    dexp
+                                                    Private
+                                                ),
+                                            z:
+                                                (Variable
+                                                    4
+                                                    z
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            zexp_return_var_name:
+                                                (Variable
+                                                    4
+                                                    zexp_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    zexp
+                                    (FunctionType
+                                        [(Real 8)]
+                                        (Real 8)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [dexp]
+                                    [(Var 4 z)]
+                                    [(=
+                                        (Var 4 zexp_return_var_name)
+                                        (FunctionCall
+                                            4 dexp
+                                            ()
+                                            [((Var 4 z))]
+                                            (Real 8)
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 4 zexp_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    alnorm
+                    (FunctionType
+                        []
+                        (Real 8)
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    []
+                    []
+                    [(Return)]
+                    (Var 2 alnorm)
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            iso_c_binding:
+                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
+            iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
+            lfortran_intrinsic_builtin:
+                (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_math:
+                (IntrinsicModule lfortran_intrinsic_math),
+            statement_01:
+                (Program
+                    (SymbolTable
+                        3
+                        {
+                            
+                        })
+                    statement_01
+                    []
+                    []
+                )
+        })
+    []
+)

--- a/tests/reference/asr-statement_02-daaef34.json
+++ b/tests/reference/asr-statement_02-daaef34.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-statement_02-daaef34",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/statement_02.f90",
+    "infile_hash": "61034a47086bdbf3221fccdae0ad236a38d9ee626e02852cc820bc8e",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-statement_02-daaef34.stdout",
+    "stdout_hash": "6ee8fea6b9260629a60db5bd2ad257d8761e66993776c8c9a82cc653",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-statement_02-daaef34.stdout
+++ b/tests/reference/asr-statement_02-daaef34.stdout
@@ -1,0 +1,122 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            gscale:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            fpoint:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            fpoint_return_var_name:
+                                                (Variable
+                                                    4
+                                                    fpoint_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            i:
+                                                (Variable
+                                                    4
+                                                    i
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    fpoint
+                                    (FunctionType
+                                        [(Integer 4)]
+                                        (Real 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 4 i)]
+                                    [(=
+                                        (Var 4 fpoint_return_var_name)
+                                        (Cast
+                                            (Var 4 i)
+                                            IntegerToReal
+                                            (Real 4)
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 4 fpoint_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    gscale
+                    (FunctionType
+                        []
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    []
+                    []
+                    []
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            statement_02:
+                (Program
+                    (SymbolTable
+                        3
+                        {
+                            
+                        })
+                    statement_02
+                    []
+                    [(SubroutineCall
+                        1 gscale
+                        ()
+                        []
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/asr-statement_03-99c9cd3.json
+++ b/tests/reference/asr-statement_03-99c9cd3.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-statement_03-99c9cd3",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/statement_03.f90",
+    "infile_hash": "e697fc36c92b65627b5c34f4d10ea67c06141eba507c2700b01e24b8",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-statement_03-99c9cd3.stdout",
+    "stdout_hash": "b7e0935e4fd88d38d9482335823a1e2fbb889cfce53c1559c77fb06a",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-statement_03-99c9cd3.stdout
+++ b/tests/reference/asr-statement_03-99c9cd3.stdout
@@ -1,0 +1,152 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            cumchn:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            dble:
+                                (Variable
+                                    2
+                                    dble
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            dg:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            dg_return_var_name:
+                                                (Variable
+                                                    4
+                                                    dg_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            i:
+                                                (Variable
+                                                    4
+                                                    i
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    dg
+                                    (FunctionType
+                                        [(Integer 4)]
+                                        (Real 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 4 i)]
+                                    [(=
+                                        (Var 4 dg_return_var_name)
+                                        (Cast
+                                            (RealBinOp
+                                                (RealConstant
+                                                    2.000000
+                                                    (Real 8)
+                                                )
+                                                Mul
+                                                (Cast
+                                                    (Var 4 i)
+                                                    IntegerToReal
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                (Real 8)
+                                                ()
+                                            )
+                                            RealToReal
+                                            (Real 4)
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 4 dg_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    cumchn
+                    (FunctionType
+                        []
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    []
+                    []
+                    []
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            statement_03:
+                (Program
+                    (SymbolTable
+                        3
+                        {
+                            
+                        })
+                    statement_03
+                    []
+                    [(SubroutineCall
+                        1 cumchn
+                        ()
+                        []
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3212,6 +3212,10 @@ asr_implicit_interface_and_typing = true
 filename = "../integration_tests/statement_02.f90"
 asr_implicit_interface_and_typing = true
 
+[[test]]
+filename = "../integration_tests/statement_03.f90"
+asr_implicit_interface_and_typing = true
+
 # Parser
 
 [[test]]

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3208,6 +3208,10 @@ asr = true
 filename = "../integration_tests/statement_01.f90"
 asr_implicit_interface_and_typing = true
 
+[[test]]
+filename = "../integration_tests/statement_02.f90"
+asr_implicit_interface_and_typing = true
+
 # Parser
 
 [[test]]

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3204,6 +3204,10 @@ asr = true
 filename = "errors/common1.f90"
 asr = true
 
+[[test]]
+filename = "../integration_tests/statement_01.f90"
+asr_implicit_interface_and_typing = true
+
 # Parser
 
 [[test]]


### PR DESCRIPTION
Fixes #1793. Fixes #1796.
With this LFortran compile `scipy/stats/statlib` to ASR.
Fixes #1797.