### PR TITLE
Implement multi-argument min0 and max0 using lfortran_intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -430,7 +430,7 @@ RUN(NAME intrinsics_48 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_49 LABELS gfortran llvm)
 RUN(NAME intrinsics_50 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_51 LABELS gfortran llvm NOFAST)
-RUN(NAME intrinsics_52 LABELS gfortran ) # min0, max0
+RUN(NAME intrinsics_52 LABELS gfortran llvm) # min0, max0
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -430,6 +430,7 @@ RUN(NAME intrinsics_48 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_49 LABELS gfortran llvm)
 RUN(NAME intrinsics_50 LABELS gfortran llvm NOFAST)
 RUN(NAME intrinsics_51 LABELS gfortran llvm NOFAST)
+RUN(NAME intrinsics_52 LABELS gfortran ) # min0, max0
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/intrinsics_52.f90
+++ b/integration_tests/intrinsics_52.f90
@@ -1,0 +1,22 @@
+program intrinsics_52
+integer :: a, b, c, d, e, f
+a = 2
+b = -3
+c = 5
+d = 10
+e = 20
+f = -30
+
+if (max0(10,20) /= 20) error stop
+if (max0(3,5,4) /= 5) error stop
+if (max0(a,b) /= a) error stop
+if (max0(a,b,c) /= c) error stop
+if (max0(d,e,f,a,b,c) /= e) error stop
+
+if (min0(10,20) /= 10) error stop
+if (min0(3,5,4) /= 3) error stop
+if (min0(a,b) /= b) error stop
+if (min0(c,b,a) /= b) error stop
+if (min0(d,e,f,a,b,c) /= f) error stop
+
+end

--- a/src/runtime/pure/lfortran_intrinsic_math2.f90
+++ b/src/runtime/pure/lfortran_intrinsic_math2.f90
@@ -45,6 +45,14 @@ interface max
     module procedure imax, imax8, imax16, imax64, smax, dmax, dmax1, imax_3_args, imax_6args, dmax_3args
 end interface
 
+interface max0
+    module procedure imax, imax8, imax16, imax64, imax_3_args, imax_6args
+end interface
+
+interface min0
+    module procedure imin, imin8, imin16, imin64, imin_3_args, imin_6args
+end interface
+
 interface huge
     module procedure i32huge, i64huge, sphuge, dphuge
 end interface
@@ -325,6 +333,11 @@ else
 end if
 end function
 
+elemental integer function imin_3_args(x, y, z) result(r)
+integer, intent(in) :: x, y, z
+r = imin(imin(x, y), z)
+end function
+
 elemental integer function imin_6args(a, b, c, d, e, f) result(r)
 integer, intent(in) :: a, b, c, d, e, f
 integer :: args(6)
@@ -347,24 +360,6 @@ end function
 elemental integer function imax(x, y) result(r)
 integer, intent(in) :: x, y
 if (x > y) then
-    r = x
-else
-    r = y
-end if
-end function
-
-elemental integer function max0(x, y) result(r)
-integer, intent(in) :: x, y
-if (x > y) then
-    r = x
-else
-    r = y
-end if
-end function
-
-elemental integer function min0(x, y) result(r)
-integer, intent(in) :: x, y
-if (x < y) then
     r = x
 else
     r = y

--- a/tests/fixed_form/intrinsic_implicit.f
+++ b/tests/fixed_form/intrinsic_implicit.f
@@ -1,0 +1,7 @@
+!   Test combination of implicit-interface and intrinsic functions
+!   Check if intrinsic function is used when it is declared as an integer
+      subroutine fppasu()
+      integer max0
+      a = max0(1,2)
+      b = max0(1,2/2,1)
+      end

--- a/tests/reference/asr-external3-2aafcb3.json
+++ b/tests/reference/asr-external3-2aafcb3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external3-2aafcb3.stdout",
-    "stdout_hash": "66671beb9b9693c86c908f38154b760af68e883cd096f82babed3a5c",
+    "stdout_hash": "d54e1236397ed92271e2c34e9fceaffe098ed17f2bee072a92dfd496",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external3-2aafcb3.stdout
+++ b/tests/reference/asr-external3-2aafcb3.stdout
@@ -42,133 +42,6 @@
                             bcorr:
                                 (Function
                                     (SymbolTable
-                                        6
-                                        {
-                                            a:
-                                                (Variable
-                                                    6
-                                                    a
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            b:
-                                                (Variable
-                                                    6
-                                                    b
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            bcorr_arg_0:
-                                                (Variable
-                                                    6
-                                                    bcorr_arg_0
-                                                    []
-                                                    Unspecified
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            bcorr_arg_1:
-                                                (Variable
-                                                    6
-                                                    bcorr_arg_1
-                                                    []
-                                                    Unspecified
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            bcorr_return_var_name:
-                                                (Variable
-                                                    6
-                                                    bcorr_return_var_name
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 8)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    bcorr
-                                    (FunctionType
-                                        [(Real 4)
-                                        (Real 4)]
-                                        (Real 8)
-                                        BindC
-                                        Interface
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                    )
-                                    []
-                                    [(Var 6 bcorr_arg_0)
-                                    (Var 6 bcorr_arg_1)]
-                                    []
-                                    (Var 6 bcorr_return_var_name)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            brcmp1:
-                                (Variable
-                                    2
-                                    brcmp1
-                                    []
-                                    ReturnVar
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 8)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                ),
-                            exp:
-                                (Function
-                                    (SymbolTable
                                         4
                                         {
                                             a:
@@ -203,139 +76,12 @@
                                                     Required
                                                     .false.
                                                 ),
-                                            bcorr:
-                                                (Function
-                                                    (SymbolTable
-                                                        5
-                                                        {
-                                                            a:
-                                                                (Variable
-                                                                    5
-                                                                    a
-                                                                    []
-                                                                    Local
-                                                                    ()
-                                                                    ()
-                                                                    Default
-                                                                    (Real 4)
-                                                                    ()
-                                                                    Source
-                                                                    Public
-                                                                    Required
-                                                                    .false.
-                                                                ),
-                                                            b:
-                                                                (Variable
-                                                                    5
-                                                                    b
-                                                                    []
-                                                                    Local
-                                                                    ()
-                                                                    ()
-                                                                    Default
-                                                                    (Real 4)
-                                                                    ()
-                                                                    Source
-                                                                    Public
-                                                                    Required
-                                                                    .false.
-                                                                ),
-                                                            bcorr_arg_0:
-                                                                (Variable
-                                                                    5
-                                                                    bcorr_arg_0
-                                                                    []
-                                                                    Unspecified
-                                                                    ()
-                                                                    ()
-                                                                    Default
-                                                                    (Real 4)
-                                                                    ()
-                                                                    BindC
-                                                                    Public
-                                                                    Required
-                                                                    .false.
-                                                                ),
-                                                            bcorr_arg_1:
-                                                                (Variable
-                                                                    5
-                                                                    bcorr_arg_1
-                                                                    []
-                                                                    Unspecified
-                                                                    ()
-                                                                    ()
-                                                                    Default
-                                                                    (Real 4)
-                                                                    ()
-                                                                    BindC
-                                                                    Public
-                                                                    Required
-                                                                    .false.
-                                                                ),
-                                                            bcorr_return_var_name:
-                                                                (Variable
-                                                                    5
-                                                                    bcorr_return_var_name
-                                                                    []
-                                                                    ReturnVar
-                                                                    ()
-                                                                    ()
-                                                                    Default
-                                                                    (Real 8)
-                                                                    ()
-                                                                    BindC
-                                                                    Public
-                                                                    Required
-                                                                    .false.
-                                                                )
-                                                        })
-                                                    bcorr
-                                                    (FunctionType
-                                                        [(Real 4)
-                                                        (Real 4)]
-                                                        (Real 8)
-                                                        BindC
-                                                        Interface
-                                                        ()
-                                                        .false.
-                                                        .false.
-                                                        .false.
-                                                        .false.
-                                                        .false.
-                                                        .false.
-                                                    )
-                                                    []
-                                                    [(Var 5 bcorr_arg_0)
-                                                    (Var 5 bcorr_arg_1)]
-                                                    []
-                                                    (Var 5 bcorr_return_var_name)
-                                                    Public
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            exp_arg_0:
+                                            bcorr_arg_0:
                                                 (Variable
                                                     4
-                                                    exp_arg_0
+                                                    bcorr_arg_0
                                                     []
                                                     Unspecified
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 8)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            exp_return_var_name:
-                                                (Variable
-                                                    4
-                                                    exp_return_var_name
-                                                    []
-                                                    ReturnVar
                                                     ()
                                                     ()
                                                     Default
@@ -345,12 +91,45 @@
                                                     Public
                                                     Required
                                                     .false.
+                                                ),
+                                            bcorr_arg_1:
+                                                (Variable
+                                                    4
+                                                    bcorr_arg_1
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            bcorr_return_var_name:
+                                                (Variable
+                                                    4
+                                                    bcorr_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
                                                 )
                                         })
-                                    exp
+                                    bcorr
                                     (FunctionType
-                                        [(Real 8)]
-                                        (Real 4)
+                                        [(Real 4)
+                                        (Real 4)]
+                                        (Real 8)
                                         BindC
                                         Interface
                                         ()
@@ -362,13 +141,46 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 4 exp_arg_0)]
+                                    [(Var 4 bcorr_arg_0)
+                                    (Var 4 bcorr_arg_1)]
                                     []
-                                    (Var 4 exp_return_var_name)
+                                    (Var 4 bcorr_return_var_name)
                                     Public
                                     .false.
                                     .false.
                                     ()
+                                ),
+                            brcmp1:
+                                (Variable
+                                    2
+                                    brcmp1
+                                    []
+                                    ReturnVar
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            exp:
+                                (Variable
+                                    2
+                                    exp
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
                                 )
                         })
                     brcmp1
@@ -385,33 +197,26 @@
                         .false.
                         .false.
                     )
-                    [bcorr
-                    exp]
+                    [bcorr]
                     []
                     [(=
                         (Var 2 brcmp1)
-                        (Cast
-                            (FunctionCall
-                                2 exp
-                                ()
-                                [((RealUnaryMinus
-                                    (FunctionCall
-                                        2 bcorr
-                                        ()
-                                        [((Var 2 a))
-                                        ((Var 2 b))]
-                                        (Real 8)
-                                        ()
-                                        ()
-                                    )
+                        (IntrinsicFunction
+                            Exp
+                            [(RealUnaryMinus
+                                (FunctionCall
+                                    2 bcorr
+                                    ()
+                                    [((Var 2 a))
+                                    ((Var 2 b))]
                                     (Real 8)
                                     ()
-                                ))]
-                                (Real 4)
+                                    ()
+                                )
+                                (Real 8)
                                 ()
-                                ()
-                            )
-                            RealToReal
+                            )]
+                            0
                             (Real 8)
                             ()
                         )

--- a/tests/reference/asr-fn5-3d75eb7.json
+++ b/tests/reference/asr-fn5-3d75eb7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn5-3d75eb7.stdout",
-    "stdout_hash": "a7c5a392fa57c0e133983cc2c9ce87bb4838d343f72d8763b60638d7",
+    "stdout_hash": "a4775661b9dd1340eecc146ed3199134b594a60bbb13f9121b21d74b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn5-3d75eb7.stdout
+++ b/tests/reference/asr-fn5-3d75eb7.stdout
@@ -16,7 +16,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     len
-                                                    75 len
+                                                    74 len
                                                     lfortran_intrinsic_builtin
                                                     []
                                                     len
@@ -26,7 +26,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     len_repeati32
-                                                    101 len_repeati32
+                                                    100 len_repeati32
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_repeati32
@@ -36,7 +36,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     len_trim
-                                                    101 len_trim
+                                                    100 len_trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_trim
@@ -114,7 +114,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     present
-                                                    75 present
+                                                    74 present
                                                     lfortran_intrinsic_builtin
                                                     []
                                                     present
@@ -124,7 +124,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     repeat
-                                                    101 repeat
+                                                    100 repeat
                                                     lfortran_intrinsic_string
                                                     []
                                                     repeat
@@ -134,7 +134,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     repeat@repeati32
-                                                    101 repeati32
+                                                    100 repeati32
                                                     lfortran_intrinsic_string
                                                     []
                                                     repeati32
@@ -191,7 +191,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     trim
-                                                    101 trim
+                                                    100 trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     trim
@@ -441,7 +441,7 @@
                                                 (ExternalSymbol
                                                     4
                                                     len
-                                                    75 len
+                                                    74 len
                                                     lfortran_intrinsic_builtin
                                                     []
                                                     len
@@ -451,7 +451,7 @@
                                                 (ExternalSymbol
                                                     4
                                                     len_trim
-                                                    101 len_trim
+                                                    100 len_trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_trim
@@ -541,7 +541,7 @@
                                                 (ExternalSymbol
                                                     4
                                                     trim
-                                                    101 trim
+                                                    100 trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     trim

--- a/tests/reference/asr-intrinsic_implicit-77de888.json
+++ b/tests/reference/asr-intrinsic_implicit-77de888.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsic_implicit-77de888",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/fixed_form/intrinsic_implicit.f",
+    "infile_hash": "cf2b571b90ea857371007c5f6126ddea21ed3e4d39304e52025c2858",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-intrinsic_implicit-77de888.stdout",
+    "stdout_hash": "f45433a9dc69552f3c8ba4f263f4126a95ea151c403a939afa443aec",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-intrinsic_implicit-77de888.stdout
+++ b/tests/reference/asr-intrinsic_implicit-77de888.stdout
@@ -1,0 +1,152 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            fppasu:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            a:
+                                (Variable
+                                    2
+                                    a
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            b:
+                                (Variable
+                                    2
+                                    b
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            max0:
+                                (ExternalSymbol
+                                    2
+                                    max0
+                                    4 max0
+                                    lfortran_intrinsic_math2
+                                    []
+                                    max0
+                                    Private
+                                ),
+                            max0@imax:
+                                (ExternalSymbol
+                                    2
+                                    max0@imax
+                                    4 imax
+                                    lfortran_intrinsic_math2
+                                    []
+                                    imax
+                                    Private
+                                ),
+                            max0@imax_3_args:
+                                (ExternalSymbol
+                                    2
+                                    max0@imax_3_args
+                                    4 imax_3_args
+                                    lfortran_intrinsic_math2
+                                    []
+                                    imax_3_args
+                                    Private
+                                )
+                        })
+                    fppasu
+                    (FunctionType
+                        []
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    [max0@imax
+                    max0@imax_3_args]
+                    []
+                    [(=
+                        (Var 2 a)
+                        (Cast
+                            (FunctionCall
+                                2 max0@imax
+                                2 max0
+                                [((IntegerConstant 1 (Integer 4)))
+                                ((IntegerConstant 2 (Integer 4)))]
+                                (Integer 4)
+                                (IntegerConstant 2 (Integer 4))
+                                ()
+                            )
+                            IntegerToReal
+                            (Real 4)
+                            (RealConstant
+                                2.000000
+                                (Real 4)
+                            )
+                        )
+                        ()
+                    )
+                    (=
+                        (Var 2 b)
+                        (Cast
+                            (FunctionCall
+                                2 max0@imax_3_args
+                                2 max0
+                                [((IntegerConstant 1 (Integer 4)))
+                                ((IntegerBinOp
+                                    (IntegerConstant 2 (Integer 4))
+                                    Div
+                                    (IntegerConstant 2 (Integer 4))
+                                    (Integer 4)
+                                    (IntegerConstant 1 (Integer 4))
+                                ))
+                                ((IntegerConstant 1 (Integer 4)))]
+                                (Integer 4)
+                                ()
+                                ()
+                            )
+                            IntegerToReal
+                            (Real 4)
+                            ()
+                        )
+                        ()
+                    )]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
+            lfortran_intrinsic_builtin:
+                (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_math2:
+                (IntrinsicModule lfortran_intrinsic_math2),
+            lfortran_intrinsic_math3:
+                (IntrinsicModule lfortran_intrinsic_math3)
+        })
+    []
+)

--- a/tests/reference/asr-string_19-d880475.json
+++ b/tests/reference/asr-string_19-d880475.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_19-d880475.stdout",
-    "stdout_hash": "2cbd0512af82b614b203a3e5c18d109f9aa2a4dd7d68ea9d2a86103b",
+    "stdout_hash": "11030168d0bd84219c7269e9bd059043a452f33bcf1b66093af04848",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_19-d880475.stdout
+++ b/tests/reference/asr-string_19-d880475.stdout
@@ -13,11 +13,11 @@
             stdlib_strings_use:
                 (Program
                     (SymbolTable
-                        109
+                        108
                         {
                             char:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     char
                                     2 char
                                     string_19_stdlib_string_type
@@ -27,7 +27,7 @@
                                 ),
                             char_string:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     char_string
                                     2 char_string
                                     string_19_stdlib_string_type
@@ -37,7 +37,7 @@
                                 ),
                             compute_lps:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     compute_lps
                                     6 compute_lps
                                     string_19_stdlib_strings
@@ -47,7 +47,7 @@
                                 ),
                             compute_lps_use:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     compute_lps_use
                                     6 compute_lps_use
                                     string_19_stdlib_strings
@@ -57,7 +57,7 @@
                                 ),
                             compute_lps_use1:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     compute_lps_use1
                                     6 compute_lps_use1
                                     string_19_stdlib_strings
@@ -67,7 +67,7 @@
                                 ),
                             len:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     len
                                     2 len
                                     string_19_stdlib_string_type
@@ -77,7 +77,7 @@
                                 ),
                             len_string:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     len_string
                                     2 len_string
                                     string_19_stdlib_string_type
@@ -87,7 +87,7 @@
                                 ),
                             padl:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     padl
                                     6 padl
                                     string_19_stdlib_strings
@@ -97,7 +97,7 @@
                                 ),
                             padl_char_default:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     padl_char_default
                                     6 padl_char_default
                                     string_19_stdlib_strings
@@ -107,7 +107,7 @@
                                 ),
                             padl_char_pad_with:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     padl_char_pad_with
                                     6 padl_char_pad_with
                                     string_19_stdlib_strings
@@ -117,7 +117,7 @@
                                 ),
                             padl_string_default:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     padl_string_default
                                     6 padl_string_default
                                     string_19_stdlib_strings
@@ -127,7 +127,7 @@
                                 ),
                             padl_string_pad_with:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     padl_string_pad_with
                                     6 padl_string_pad_with
                                     string_19_stdlib_strings
@@ -137,7 +137,7 @@
                                 ),
                             string_type:
                                 (ExternalSymbol
-                                    109
+                                    108
                                     string_type
                                     2 string_type
                                     string_19_stdlib_string_type

--- a/tests/reference/asr-template_triple-54fa485.json
+++ b/tests/reference/asr-template_triple-54fa485.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_triple-54fa485.stdout",
-    "stdout_hash": "981d018f5a34807153c3d130a74d42d6bf78286d75e6738d4921502d",
+    "stdout_hash": "8d7b0e808b0f9c4bec9ca697e02fac29bb7513e766e5bdbab349d486",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_triple-54fa485.stdout
+++ b/tests/reference/asr-template_triple-54fa485.stdout
@@ -2205,6 +2205,87 @@
                             triple_add_l:
                                 (Function
                                     (SymbolTable
+                                        123
+                                        {
+                                            result:
+                                                (Variable
+                                                    123
+                                                    result
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            t:
+                                                (Variable
+                                                    123
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    triple_add_l
+                                    (FunctionType
+                                        [(Integer 4)]
+                                        (Integer 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [add_integer]
+                                    [(Var 123 t)]
+                                    [(=
+                                        (Var 123 result)
+                                        (FunctionCall
+                                            24 add_integer
+                                            ()
+                                            [((FunctionCall
+                                                24 add_integer
+                                                ()
+                                                [((Var 123 t))
+                                                ((Var 123 t))]
+                                                (Integer 4)
+                                                ()
+                                                ()
+                                            ))
+                                            ((Var 123 t))]
+                                            (Integer 4)
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 123 result)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            triple_add_r:
+                                (Function
+                                    (SymbolTable
                                         124
                                         {
                                             result:
@@ -2240,7 +2321,7 @@
                                                     .false.
                                                 )
                                         })
-                                    triple_add_l
+                                    triple_add_r
                                     (FunctionType
                                         [(Integer 4)]
                                         (Integer 4)
@@ -2261,7 +2342,8 @@
                                         (FunctionCall
                                             24 add_integer
                                             ()
-                                            [((FunctionCall
+                                            [((Var 124 t))
+                                            ((FunctionCall
                                                 24 add_integer
                                                 ()
                                                 [((Var 124 t))
@@ -2269,8 +2351,7 @@
                                                 (Integer 4)
                                                 ()
                                                 ()
-                                            ))
-                                            ((Var 124 t))]
+                                            ))]
                                             (Integer 4)
                                             ()
                                             ()
@@ -2283,331 +2364,7 @@
                                     .false.
                                     ()
                                 ),
-                            triple_add_r:
-                                (Function
-                                    (SymbolTable
-                                        125
-                                        {
-                                            result:
-                                                (Variable
-                                                    125
-                                                    result
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                ),
-                                            t:
-                                                (Variable
-                                                    125
-                                                    t
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    triple_add_r
-                                    (FunctionType
-                                        [(Integer 4)]
-                                        (Integer 4)
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                    )
-                                    [add_integer]
-                                    [(Var 125 t)]
-                                    [(=
-                                        (Var 125 result)
-                                        (FunctionCall
-                                            24 add_integer
-                                            ()
-                                            [((Var 125 t))
-                                            ((FunctionCall
-                                                24 add_integer
-                                                ()
-                                                [((Var 125 t))
-                                                ((Var 125 t))]
-                                                (Integer 4)
-                                                ()
-                                                ()
-                                            ))]
-                                            (Integer 4)
-                                            ()
-                                            ()
-                                        )
-                                        ()
-                                    )]
-                                    (Var 125 result)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
                             triple_max_l:
-                                (Function
-                                    (SymbolTable
-                                        128
-                                        {
-                                            result:
-                                                (Variable
-                                                    128
-                                                    result
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                ),
-                                            t:
-                                                (Variable
-                                                    128
-                                                    t
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    triple_max_l
-                                    (FunctionType
-                                        [(Real 4)]
-                                        (Real 4)
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                    )
-                                    [max_real]
-                                    [(Var 128 t)]
-                                    [(=
-                                        (Var 128 result)
-                                        (FunctionCall
-                                            24 max_real
-                                            ()
-                                            [((FunctionCall
-                                                24 max_real
-                                                ()
-                                                [((Var 128 t))
-                                                ((Var 128 t))]
-                                                (Real 4)
-                                                ()
-                                                ()
-                                            ))
-                                            ((Var 128 t))]
-                                            (Real 4)
-                                            ()
-                                            ()
-                                        )
-                                        ()
-                                    )]
-                                    (Var 128 result)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            triple_max_r:
-                                (Function
-                                    (SymbolTable
-                                        129
-                                        {
-                                            result:
-                                                (Variable
-                                                    129
-                                                    result
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                ),
-                                            t:
-                                                (Variable
-                                                    129
-                                                    t
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    triple_max_r
-                                    (FunctionType
-                                        [(Real 4)]
-                                        (Real 4)
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                    )
-                                    [max_real]
-                                    [(Var 129 t)]
-                                    [(=
-                                        (Var 129 result)
-                                        (FunctionCall
-                                            24 max_real
-                                            ()
-                                            [((Var 129 t))
-                                            ((FunctionCall
-                                                24 max_real
-                                                ()
-                                                [((Var 129 t))
-                                                ((Var 129 t))]
-                                                (Real 4)
-                                                ()
-                                                ()
-                                            ))]
-                                            (Real 4)
-                                            ()
-                                            ()
-                                        )
-                                        ()
-                                    )]
-                                    (Var 129 result)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            triple_minus_l:
-                                (Function
-                                    (SymbolTable
-                                        126
-                                        {
-                                            result:
-                                                (Variable
-                                                    126
-                                                    result
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                ),
-                                            t:
-                                                (Variable
-                                                    126
-                                                    t
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    triple_minus_l
-                                    (FunctionType
-                                        [(Real 4)]
-                                        (Real 4)
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                    )
-                                    [minus_real]
-                                    [(Var 126 t)]
-                                    [(=
-                                        (Var 126 result)
-                                        (FunctionCall
-                                            24 minus_real
-                                            ()
-                                            [((FunctionCall
-                                                24 minus_real
-                                                ()
-                                                [((Var 126 t))
-                                                ((Var 126 t))]
-                                                (Real 4)
-                                                ()
-                                                ()
-                                            ))
-                                            ((Var 126 t))]
-                                            (Real 4)
-                                            ()
-                                            ()
-                                        )
-                                        ()
-                                    )]
-                                    (Var 126 result)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            triple_minus_r:
                                 (Function
                                     (SymbolTable
                                         127
@@ -2645,6 +2402,249 @@
                                                     .false.
                                                 )
                                         })
+                                    triple_max_l
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [max_real]
+                                    [(Var 127 t)]
+                                    [(=
+                                        (Var 127 result)
+                                        (FunctionCall
+                                            24 max_real
+                                            ()
+                                            [((FunctionCall
+                                                24 max_real
+                                                ()
+                                                [((Var 127 t))
+                                                ((Var 127 t))]
+                                                (Real 4)
+                                                ()
+                                                ()
+                                            ))
+                                            ((Var 127 t))]
+                                            (Real 4)
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 127 result)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            triple_max_r:
+                                (Function
+                                    (SymbolTable
+                                        128
+                                        {
+                                            result:
+                                                (Variable
+                                                    128
+                                                    result
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            t:
+                                                (Variable
+                                                    128
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    triple_max_r
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [max_real]
+                                    [(Var 128 t)]
+                                    [(=
+                                        (Var 128 result)
+                                        (FunctionCall
+                                            24 max_real
+                                            ()
+                                            [((Var 128 t))
+                                            ((FunctionCall
+                                                24 max_real
+                                                ()
+                                                [((Var 128 t))
+                                                ((Var 128 t))]
+                                                (Real 4)
+                                                ()
+                                                ()
+                                            ))]
+                                            (Real 4)
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 128 result)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            triple_minus_l:
+                                (Function
+                                    (SymbolTable
+                                        125
+                                        {
+                                            result:
+                                                (Variable
+                                                    125
+                                                    result
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            t:
+                                                (Variable
+                                                    125
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    triple_minus_l
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [minus_real]
+                                    [(Var 125 t)]
+                                    [(=
+                                        (Var 125 result)
+                                        (FunctionCall
+                                            24 minus_real
+                                            ()
+                                            [((FunctionCall
+                                                24 minus_real
+                                                ()
+                                                [((Var 125 t))
+                                                ((Var 125 t))]
+                                                (Real 4)
+                                                ()
+                                                ()
+                                            ))
+                                            ((Var 125 t))]
+                                            (Real 4)
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 125 result)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            triple_minus_r:
+                                (Function
+                                    (SymbolTable
+                                        126
+                                        {
+                                            result:
+                                                (Variable
+                                                    126
+                                                    result
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            t:
+                                                (Variable
+                                                    126
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
                                     triple_minus_r
                                     (FunctionType
                                         [(Real 4)]
@@ -2660,18 +2660,18 @@
                                         .false.
                                     )
                                     [minus_real]
-                                    [(Var 127 t)]
+                                    [(Var 126 t)]
                                     [(=
-                                        (Var 127 result)
+                                        (Var 126 result)
                                         (FunctionCall
                                             24 minus_real
                                             ()
-                                            [((Var 127 t))
+                                            [((Var 126 t))
                                             ((FunctionCall
                                                 24 minus_real
                                                 ()
-                                                [((Var 127 t))
-                                                ((Var 127 t))]
+                                                [((Var 126 t))
+                                                ((Var 126 t))]
                                                 (Real 4)
                                                 ()
                                                 ()
@@ -2682,7 +2682,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 127 result)
+                                    (Var 126 result)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/pass_flip_sign-expr_13-e24d940.json
+++ b/tests/reference/pass_flip_sign-expr_13-e24d940.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_flip_sign-expr_13-e24d940.stdout",
-    "stdout_hash": "392d40238cc1c93e0689aa315f2584f7c3b29b02e0f096b8e1c98dad",
+    "stdout_hash": "abf61b67d79f42f71094e5cff9e33513e5db0945ee03989b14b3fedc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_flip_sign-expr_13-e24d940.stdout
+++ b/tests/reference/pass_flip_sign-expr_13-e24d940.stdout
@@ -185,7 +185,7 @@
                                 (ExternalSymbol
                                     2
                                     flipsign@flipsigni32r32
-                                    99 flipsigni32r32
+                                    98 flipsigni32r32
                                     lfortran_intrinsic_optimization
                                     []
                                     flipsigni32r32
@@ -540,7 +540,7 @@
                 (ExternalSymbol
                     1
                     flipsign
-                    99 flipsign
+                    98 flipsign
                     lfortran_intrinsic_optimization
                     []
                     flipsign

--- a/tests/reference/pass_flip_sign-flip_sign-16b288c.json
+++ b/tests/reference/pass_flip_sign-flip_sign-16b288c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_flip_sign-flip_sign-16b288c.stdout",
-    "stdout_hash": "7d09db586141474040a2335f7b00adfa7a4610a5d2be35883ed43e97",
+    "stdout_hash": "280f3005a071481f1f4f4ff0b98abcac857a7b9afb5e94afd787dcae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_flip_sign-flip_sign-16b288c.stdout
+++ b/tests/reference/pass_flip_sign-flip_sign-16b288c.stdout
@@ -33,7 +33,7 @@
                                 (ExternalSymbol
                                     2
                                     flipsign@flipsigni32r32
-                                    99 flipsigni32r32
+                                    98 flipsigni32r32
                                     lfortran_intrinsic_optimization
                                     []
                                     flipsigni32r32
@@ -202,7 +202,7 @@
                 (ExternalSymbol
                     1
                     flipsign
-                    99 flipsign
+                    98 flipsign
                     lfortran_intrinsic_optimization
                     []
                     flipsign

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2890,6 +2890,10 @@ filename = "fixed_form/contains1.f"
 ast = true
 
 [[test]]
+filename = "fixed_form/intrinsic_implicit.f"
+asr_implicit_interface_and_typing = true
+
+[[test]]
 filename = "parameter1.f90"
 ast = true
 asr = true


### PR DESCRIPTION
This is simple working fix for the min0 and max0 intrinsic functions.
The following now works and produces the correct ASR.
```fortran
program intrinsics_52
integer :: a, b, c, d, e, f
a = 2
b = -3
c = 5
d = 10
e = 20
f = -30

if (max0(10,20) /= 20) error stop
if (max0(3,5,4) /= 5) error stop
if (max0(a,b) /= a) error stop
if (max0(a,b,c) /= c) error stop
if (max0(d,e,f,a,b,c) /= e) error stop

if (min0(10,20) /= 10) error stop
if (min0(3,5,4) /= 3) error stop
if (min0(a,b) /= b) error stop
if (min0(c,b,a) /= b) error stop
if (min0(d,e,f,a,b,c) /= f) error stop

end
```