### PR TITLE
handle `implicit none` in external variable declaration

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -816,6 +816,7 @@ RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
 RUN(NAME minpack_02 LABELS gfortran llvm)
 
 RUN(NAME external_01 LABELS gfortran llvm)
+RUN(NAME external_02 LABELS gfortran llvmImplicit)
 
 RUN(NAME interface_12 LABELS gfortran llvm)
 

--- a/integration_tests/external_02.f90
+++ b/integration_tests/external_02.f90
@@ -1,0 +1,9 @@
+subroutine cdfpoi()
+   implicit none
+   external cumpoi
+   return
+end subroutine
+
+program external_02
+   call cdfpoi()
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1544,6 +1544,11 @@ public:
                                         type = ASRUtils::symbol_type(sym_);
                                     } else if (compiler_options.implicit_typing) {
                                         type = implicit_dictionary[std::string(1,sym[0])];
+                                        if (!type) {
+                                            // There exists an `implicit none` statement, here compiler has 
+                                            // no information about type of symbol hence keeping it real*4.
+                                            type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 4));
+                                        }
                                     } else {
                                         // Here compiler has no information about type of symbol hence keeping it real*4.
                                         type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 4));


### PR DESCRIPTION
Fixes #1801.
With this and #1800 PR LFortran compile 61/64 files of `scipy/special/cdflib` to ASR, the remaining 3 are `save` , `visit_DataImpliedDo`.