### PR TITLE
Sprint for fastGPT

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1350,6 +1350,7 @@ static inline Vec<char*> get_scope_names(Allocator &al, const SymbolTable *symta
 }
 
 static inline ASR::expr_t* get_constant_zero_with_given_type(Allocator& al, ASR::ttype_t* asr_type) {
+    asr_type = ASRUtils::type_get_past_pointer(asr_type);
     asr_type = ASRUtils::type_get_past_array(asr_type);
     switch (asr_type->type) {
         case ASR::ttypeType::Integer: {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -224,13 +224,15 @@ class ASRBuilder {
 
     ASR::expr_t* ElementalAdd(ASR::expr_t* left, ASR::expr_t* right,
         const Location& loc, ASR::expr_t* value=nullptr) {
-        switch (ASRUtils::expr_type(left)->type) {
+        ASR::ttype_t *left_type = ASRUtils::expr_type(left);
+        left_type = ASRUtils::type_get_past_pointer(left_type);
+        switch (left_type->type) {
             create_ElementalBinOp(Real, make_RealBinOp_t, Add, value)
             create_ElementalBinOp(Integer, make_IntegerBinOp_t, Add, value)
             create_ElementalBinOp(Complex, make_ComplexBinOp_t, Add, value)
             default: {
                 throw LCompilersException("Expression type, " +
-                                          std::to_string(left->type) +
+                                          std::to_string(left_type->type) +
                                           " not yet supported");
             }
         }


### PR DESCRIPTION
These are quick fixes for fastGPT, it gets it to:
```console
(fastgpt) repos/fastGPT(main) $ FC=lfortran cmake .
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The Fortran compiler identification is unknown
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - failed
-- Check for working Fortran compiler: /Users/ondrej/bin/lfortran
-- Check for working Fortran compiler: /Users/ondrej/bin/lfortran - works
-- Checking whether /Users/ondrej/bin/lfortran supports Fortran 90
-- Checking whether /Users/ondrej/bin/lfortran supports Fortran 90 - no
-- Found OMP: /Users/ondrej/mambaforge/envs/fastgpt/include  


Configuration results
---------------------
Fortran compiler: /Users/ondrej/bin/lfortran
Build type: Release
Fortran compiler flags: 
Installation prefix: /usr/local
FASTGPT_BLAS: Accelerate
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ondrej/repos/fastGPT
(fastgpt) repos/fastGPT(main) $ make
[  5%] Building Fortran object CMakeFiles/fastgpt.dir/linalg_c.f90.o
[ 11%] Building Fortran object CMakeFiles/fastgpt.dir/tokenizer.f90.o
[ 17%] Building Fortran object CMakeFiles/fastgpt.dir/gpt2.f90.o
[ 23%] Building Fortran object CMakeFiles/fastgpt.dir/omp.f90.o
[ 29%] Building Fortran object CMakeFiles/fastgpt.dir/driver.f90.o
[ 35%] Building C object CMakeFiles/fastgpt.dir/linalg_accelerate.c.o
[ 41%] Linking Fortran static library libfastgpt.a
[ 41%] Built target fastgpt
[ 47%] Building Fortran object CMakeFiles/gpt2.dir/main.f90.o
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 2063
    return compile_to_object_file(arg_file, outfile, false,
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 902
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/fortran_evaluator.cpp", line 345
    compiler_options, run_fn, infile);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 8344
    pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
  File "../libasr/asr.h", line 4780
  File "../libasr/asr.h", line 4757
  File "../libasr/asr.h", line 4781
  File "../libasr/asr.h", line 4506
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 1356
    ASR::symbol_t *mod = x.m_global_scope->get_symbol(item);
  File "../libasr/asr.h", line 4783
  File "../libasr/asr.h", line 4515
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 2800
    finish_module_init_function_prototype(x);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4192
    ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 3799
    visit_procedures(x);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4145
    this->visit_stmt(*x.m_body[i]);
  File "../libasr/asr.h", line 4800
  File "../libasr/asr.h", line 4567
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 5486
    }, [=]() {
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 317
    start_new_block(loopbody); {
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 5488
    this->visit_stmt(*x.m_body[i]);
  File "../libasr/asr.h", line 4800
  File "../libasr/asr.h", line 4539
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4742
    asr_target_type, module.get(), name2memidx);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/llvm_utils.cpp", line 365
    module, name2memidx);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/llvm_utils.cpp", line 378
    throw LCompilersException("LLVMUtils::deepcopy isn't implemented for " +
LCompilersException: LLVMUtils::deepcopy isn't implemented for Allocatable[str]
make[2]: *** [CMakeFiles/gpt2.dir/main.f90.o] Error 1
make[1]: *** [CMakeFiles/gpt2.dir/all] Error 2
make: *** [all] Error 2
```


The fastGPT requires the following workarounds:
```diff
diff --git a/driver.f90 b/driver.f90
index 1c9bace..968321b 100644
--- a/driver.f90
+++ b/driver.f90
@@ -17,11 +17,11 @@ character(:), allocatable, intent(out) :: input_txt
 integer, intent(out) :: n_tokens_to_generate
 character(1024) :: input_txt2
 integer :: u, ios
-namelist / input_fastGPT / n_tokens_to_generate
+!namelist / input_fastGPT / n_tokens_to_generate
 allocate(character(0) :: input_txt)
 input_txt = ""
 open(newunit=u, file=filename, status="old")
-read(u, input_fastGPT)
+!read(u, input_fastGPT)
 do
     read(u, "(a)", iostat=ios) input_txt2
     if (ios /= 0) exit
diff --git a/gpt2.f90 b/gpt2.f90
index 6f8651a..e6f730d 100644
--- a/gpt2.f90
+++ b/gpt2.f90
@@ -173,13 +173,13 @@ end function
 function transformer_block(n_seq, n_seq_x, n_embd, x, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b, &
         attn_w, attn_b, attn_proj_w, attn_proj_b, ln1_g, ln1_b, ln2_g, ln2_b, &
         n_head, use_kv_cache, kv_cache) result(y)
+integer, intent(in) :: n_head
+integer, intent(in) :: n_seq, n_seq_x, n_embd
 real(sp), intent(in) :: x(n_embd,n_seq_x), &
     mlp_fc_w(:,:), mlp_fc_b(:), &
     mlp_proj_w(:,:), mlp_proj_b(:), &
     attn_w(:,:), attn_b(:), attn_proj_w(:,:), attn_proj_b(:), &
     ln1_g(:), ln1_b(:), ln2_g(:), ln2_b(:)
-integer, intent(in) :: n_head
-integer, intent(in) :: n_seq, n_seq_x, n_embd
 real(sp) :: y(n_embd,n_seq_x)
 logical, intent(in) :: use_kv_cache
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2)
diff --git a/tokenizer.f90 b/tokenizer.f90
index 952f3f9..888218a 100644
--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -171,7 +171,7 @@ do
         pair_scores(i) = word_idx(tokens(i)%s // " " // tokens(i+1)%s, vocab_idx, vocab_txt)
         if (pair_scores(i) == -1) pair_scores(i) = not_found
     end do
-    merge_pair_idx = minloc(pair_scores, 1)
+!    merge_pair_idx = minloc(pair_scores, 1)
     if (pair_scores(merge_pair_idx) == not_found) then
         ! No token pair can be merged, so we are done:
         exit
```