### PR TITLE
Initial Implementation of String Formatting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -363,6 +363,8 @@ RUN(NAME namelist_01 LABELS gfortran)
 RUN(NAME format_01 LABELS gfortran)
 RUN(NAME format_02 LABELS gfortran)
 
+RUN(NAME string_formatting_01 LABELS gfortran llvm)
+
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran)
 RUN(NAME submodule_03 LABELS gfortran)

--- a/integration_tests/string_formatting_01.f90
+++ b/integration_tests/string_formatting_01.f90
@@ -1,0 +1,12 @@
+program string_formatting_01
+implicit none
+
+WRITE( *, '(5X,A8)') 'Success!'
+WRITE( *, '(10X,"abcd ",A5)') 'Success!'
+WRITE( *, '(" abcd ",5X,A10," abcd ")') 'Success!'
+
+PRINT '(I10)' , 123
+PRINT '(I10.5)' , 123
+PRINT '(I6.6)' , 12345
+
+end program

--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -162,7 +162,7 @@ public:
                 body.push_back(al, print_body[j]);
             }
             print_stmt = ASRUtils::STMT(ASR::make_Print_t(
-                al, x.base.base.loc, nullptr, body.p, body.size(),
+                al, x.base.base.loc, x.m_fmt, body.p, body.size(),
                 x.m_separator, x.m_end));
             pass_result.push_back(al, print_stmt);
             print_body.clear();
@@ -243,7 +243,7 @@ public:
                 body.push_back(al, write_body[j]);
             }
             write_stmt = ASRUtils::STMT(ASR::make_FileWrite_t(
-                al, x.base.base.loc, x.m_label, nullptr, nullptr, nullptr, nullptr, nullptr, body.p, body.size(), nullptr, nullptr));
+                al, x.base.base.loc, x.m_label, nullptr, x.m_fmt, nullptr, nullptr, nullptr, body.p, body.size(), nullptr, nullptr));
             pass_result.push_back(al, write_stmt);
             write_body.clear();
         }

--- a/src/libasr/pass/print_list_tuple.cpp
+++ b/src/libasr/pass/print_list_tuple.cpp
@@ -353,7 +353,7 @@ class PrintListTupleVisitor
                 tmp_vec.push_back(al, e);
             }
             ASR::stmt_t *print_stmt = ASRUtils::STMT(
-                ASR::make_Print_t(al, x.base.base.loc, nullptr, tmp_vec.p, tmp_vec.size(),
+                ASR::make_Print_t(al, x.base.base.loc, x.m_fmt, tmp_vec.p, tmp_vec.size(),
                             x.m_separator, x.m_end));
             print_tmp.clear();
             pass_result.push_back(al, print_stmt);


### PR DESCRIPTION
This is a draft PR to show my attempt on string formatting so far.
- I would like to know if this is the correct approach, and if I am going in the right direction.
- This PR implements Integer , Newlines, Strings and Positional editing.
- As I implement more features and things get complex, I will split them into different functions so the code does not look so cluttered.
- I will first try to make the string formatting in ```WRITE``` and ```PRINT``` statements completely working since they are easier for early testing and implementation, then move forward to the ```FORMAT``` statement itself. It will use the same functions/api.
- Support for variables has not been implemented.
- There are many other features left to implement. I have collected the different types of formats used in ```scipy``` and consider them in higher priority.

With this PR, LFortran and GFortran produce the same output for the following code:
```fortran
program format
implicit none

WRITE( *, '(5X,A8)') 'Success!'
WRITE( *, '(10X,"abcd ",A5)') 'Success!'
WRITE( *, '(" abcd ",5X,A10," abcd ")') 'Success!'

PRINT '(I10)' , 123
PRINT '(I10.5)' , 123
PRINT '(I6.6)' , 12345

end program
```
Output:
```console
     Success!
          abcd Succe
 abcd        Success! abcd 
       123
     00123
012345
```