### PR TITLE
Update subroutine call and function arguments using `UpdateArgsVisitor`

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4566,6 +4566,7 @@ public:
 
                 // erase from external_procedures_mapping
                 erase_from_external_mapping(var_name);
+                ASRUtils::update_call_args(al, current_scope, compiler_options.implicit_interface);
 
                 // Update arguments if the symbol belonged to a function
                 if (current_scope->asr_owner) {
@@ -4594,6 +4595,7 @@ public:
             if (ASR::is_a<ASR::Function_t>(*v2)) {
                 current_scope->erase_symbol(var_name);
                 erase_from_external_mapping(var_name);
+                ASRUtils::update_call_args(al, current_scope, compiler_options.implicit_interface);
                 v = v2;
             }
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1432,6 +1432,8 @@ void extract_module_python(const ASR::TranslationUnit_t &m,
         std::vector<std::pair<std::string, ASR::Module_t*>>& children_modules,
         std::string module_name);
 
+void update_call_args(Allocator &al, SymbolTable *current_scope, bool implicit_interface);
+
 ASR::Module_t* extract_module(const ASR::TranslationUnit_t &m);
 
 ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,

--- a/tests/external4.f90
+++ b/tests/external4.f90
@@ -1,0 +1,7 @@
+subroutine dqc25s(f)
+    double precision dlog,f
+    external f
+    call dqk15w(f)
+    print *, f(hlgth+centr)
+    print *, dlog(2.0d0)
+end subroutine

--- a/tests/reference/asr-external4-4e8bc7b.json
+++ b/tests/reference/asr-external4-4e8bc7b.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-external4-4e8bc7b",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/external4.f90",
+    "infile_hash": "99ee52cdcb37892af52701838b935fa68c04ab899074299c9ffd47ba",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-external4-4e8bc7b.stdout",
+    "stdout_hash": "dfdc584bbfbd29f7933afd8f060abb36b993ca4942fd24d7d15a55a1",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-external4-4e8bc7b.stdout
+++ b/tests/reference/asr-external4-4e8bc7b.stdout
@@ -1,0 +1,278 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            dqc25s:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            centr:
+                                (Variable
+                                    2
+                                    centr
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            dlog:
+                                (ExternalSymbol
+                                    2
+                                    dlog
+                                    7 dlog
+                                    lfortran_intrinsic_math
+                                    []
+                                    dlog
+                                    Private
+                                ),
+                            dqk15w:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            
+                                        })
+                                    dqk15w
+                                    (FunctionType
+                                        [(FunctionType
+                                            []
+                                            (Real 8)
+                                            BindC
+                                            Interface
+                                            ()
+                                            .false.
+                                            .false.
+                                            .false.
+                                            .false.
+                                            .false.
+                                            .false.
+                                        )]
+                                        ()
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 2 f)]
+                                    []
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            f:
+                                (Function
+                                    (SymbolTable
+                                        5
+                                        {
+                                            centr:
+                                                (Variable
+                                                    5
+                                                    centr
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            f_arg_0:
+                                                (Variable
+                                                    5
+                                                    f_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            f_return_var_name:
+                                                (Variable
+                                                    5
+                                                    f_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            hlgth:
+                                                (Variable
+                                                    5
+                                                    hlgth
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    f
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 8)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 5 f_arg_0)]
+                                    []
+                                    (Var 5 f_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            hlgth:
+                                (Variable
+                                    2
+                                    hlgth
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    dqc25s
+                    (FunctionType
+                        [(FunctionType
+                            []
+                            (Real 8)
+                            BindC
+                            Interface
+                            ()
+                            .false.
+                            .false.
+                            .false.
+                            .false.
+                            .false.
+                            .false.
+                        )]
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    [dqk15w
+                    f
+                    dlog]
+                    [(Var 2 f)]
+                    [(SubroutineCall
+                        2 dqk15w
+                        ()
+                        [((Var 2 f))]
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(FunctionCall
+                            2 f
+                            ()
+                            [((RealBinOp
+                                (Var 2 hlgth)
+                                Add
+                                (Var 2 centr)
+                                (Real 4)
+                                ()
+                            ))]
+                            (Real 8)
+                            ()
+                            ()
+                        )]
+                        ()
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(FunctionCall
+                            2 dlog
+                            ()
+                            [((RealConstant
+                                2.000000
+                                (Real 8)
+                            ))]
+                            (Real 8)
+                            (RealConstant
+                                0.693147
+                                (Real 8)
+                            )
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            iso_c_binding:
+                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
+            iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
+            lfortran_intrinsic_builtin:
+                (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_math:
+                (IntrinsicModule lfortran_intrinsic_math)
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3242,6 +3242,10 @@ filename = "external3.f90"
 asr_implicit_interface_and_typing = true
 
 [[test]]
+filename = "external4.f90"
+asr_implicit_interface_and_typing = true
+
+[[test]]
 filename = "errors/external1.f90"
 asr = true
 


### PR DESCRIPTION
Fixes #1839.
