### PR TITLE
Implement a fix for "der_type_name.size() != 0"

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2485,40 +2485,57 @@ public:
         }
         ASR::Variable_t* member = down_cast<ASR::Variable_t>(symbol_get_past_external(x.m_m));
         std::string member_name = std::string(member->m_name);
-        LCOMPILERS_ASSERT(der_type_name.size() != 0);
-        while( name2memidx[der_type_name].find(member_name) == name2memidx[der_type_name].end() ) {
-            if( dertype2parent.find(der_type_name) == dertype2parent.end() ) {
-                throw CodeGenError(der_type_name + " doesn't have any member named " + member_name,
-                                    x.base.base.loc);
+        if (der_type_name.size() != 0) {
+            while( name2memidx[der_type_name].find(member_name) == name2memidx[der_type_name].end() ) {
+                if( dertype2parent.find(der_type_name) == dertype2parent.end() ) {
+                    throw CodeGenError(der_type_name + " doesn't have any member named " + member_name,
+                                        x.base.base.loc);
+                }
+                tmp = llvm_utils->create_gep(tmp, 0);
+                der_type_name = dertype2parent[der_type_name];
             }
-            tmp = llvm_utils->create_gep(tmp, 0);
-            der_type_name = dertype2parent[der_type_name];
-        }
-        int member_idx = name2memidx[der_type_name][member_name];
-        std::vector<llvm::Value*> idx_vec = {
-            llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
-            llvm::ConstantInt::get(context, llvm::APInt(32, member_idx))};
-        // if( (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_v) ||
-        //      ASR::is_a<ASR::UnionInstanceMember_t>(*x.m_v)) &&
-        //     is_nested_pointer(tmp) ) {
-        //     tmp = CreateLoad(tmp);
-        // }
-        llvm::Value* tmp1 = CreateGEP(tmp, idx_vec);
-        ASR::ttype_t* member_type = member->m_type;
-        if( LLVM::is_llvm_pointer(*member_type) ) {
-            member_type = ASRUtils::type_get_past_pointer(
-                ASRUtils::type_get_past_allocatable(member_type));
-        }
-        if( member_type->type == ASR::ttypeType::Struct ) {
-            ASR::Struct_t* der = (ASR::Struct_t*)(&(member_type->base));
-            ASR::StructType_t* der_type = (ASR::StructType_t*)(&(der->m_derived_type->base));
-            der_type_name = std::string(der_type->m_name);
-            uint32_t h = get_hash((ASR::asr_t*)member);
-            if( llvm_symtab.find(h) != llvm_symtab.end() ) {
-                tmp = llvm_symtab[h];
+            int member_idx = name2memidx[der_type_name][member_name];
+            std::vector<llvm::Value*> idx_vec = {
+                llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+                llvm::ConstantInt::get(context, llvm::APInt(32, member_idx))};
+
+            llvm::Value* tmp1 = CreateGEP(tmp, idx_vec);
+            ASR::ttype_t* member_type = member->m_type;
+            if( LLVM::is_llvm_pointer(*member_type) ) {
+                member_type = ASRUtils::type_get_past_pointer(
+                    ASRUtils::type_get_past_allocatable(member_type));
+            }
+            if( member_type->type == ASR::ttypeType::Struct ) {
+                ASR::Struct_t* der = (ASR::Struct_t*)(&(member_type->base));
+                ASR::StructType_t* der_type = (ASR::StructType_t*)(&(der->m_derived_type->base));
+                der_type_name = std::string(der_type->m_name);
+                uint32_t h = get_hash((ASR::asr_t*)member);
+                if( llvm_symtab.find(h) != llvm_symtab.end() ) {
+                    tmp = llvm_symtab[h];
+                }
+            }
+            tmp = tmp1;
+        } else {
+            // if( (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_v) ||
+            //      ASR::is_a<ASR::UnionInstanceMember_t>(*x.m_v)) &&
+            //     is_nested_pointer(tmp) ) {
+            //     tmp = CreateLoad(tmp);
+            // }
+            ASR::ttype_t* member_type = member->m_type;
+            if( LLVM::is_llvm_pointer(*member_type) ) {
+                member_type = ASRUtils::type_get_past_pointer(
+                    ASRUtils::type_get_past_allocatable(member_type));
+            }
+            if( member_type->type == ASR::ttypeType::Struct ) {
+                ASR::Struct_t* der = (ASR::Struct_t*)(&(member_type->base));
+                ASR::StructType_t* der_type = (ASR::StructType_t*)(&(der->m_derived_type->base));
+                der_type_name = std::string(der_type->m_name);
+                uint32_t h = get_hash((ASR::asr_t*)member);
+                if( llvm_symtab.find(h) != llvm_symtab.end() ) {
+                    tmp = llvm_symtab[h];
+                }
             }
         }
-        tmp = tmp1;
     }
 
     void visit_Variable(const ASR::Variable_t &x) {


### PR DESCRIPTION
This PR fixes in fastGPT:
```console
$ lfortran --show-llvm main.f90
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 2018
    return emit_llvm(arg_file, lfortran_pass_manager,
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 806
    = fe.get_llvm(input, lm, pass_manager, diagnostics);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/fortran_evaluator.cpp", line 290
    Result<std::unique_ptr<LLVMModule>> res = get_llvm2(code, lm, pass_manager, diagnostics);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/fortran_evaluator.cpp", line 312
    diagnostics, lm.files.back().in_filename);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/fortran_evaluator.cpp", line 345
    compiler_options, run_fn, infile);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 8595
    pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
  File "../libasr/asr.h", line 4890
  File "../libasr/asr.h", line 4866
  File "../libasr/asr.h", line 4891
  File "../libasr/asr.h", line 4605
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 1368
    ASR::symbol_t *mod = x.m_global_scope->get_symbol(item);
  File "../libasr/asr.h", line 4893
  File "../libasr/asr.h", line 4614
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 2870
    finish_module_init_function_prototype(x);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4291
    ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 3898
    visit_procedures(x);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4244
    this->visit_stmt(*x.m_body[i]);
  File "../libasr/asr.h", line 4910
  File "../libasr/asr.h", line 4666
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 5599
    }, [=]() {
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 324
    start_new_block(loopbody); {
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 5601
    this->visit_stmt(*x.m_body[i]);
  File "../libasr/asr.h", line 4910
  File "../libasr/asr.h", line 4638
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4865
    is_assignment_target = true;
  File "../libasr/asr.h", line 4956
  File "../libasr/asr.h", line 4757
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 2488
    LCOMPILERS_ASSERT(der_type_name.size() != 0);
AssertFailed: der_type_name.size() != 0
```

We should write a test, but that would require to bisect fastGPT to find a minimal reproducible example.