### PR TITLE
updated fix: throw error while assigning to a subroutine 

### DIFF
--- a/tests/errors/subroutine1.f90
+++ b/tests/errors/subroutine1.f90
@@ -1,10 +1,7 @@
 program subroutine1
-integer :: i
-call bpe()
-
-contains
-
-subroutine bpe()
-bpe = 1
-end subroutine
+    call bpe()
+    contains
+    subroutine bpe()
+        bpe = 1
+    end subroutine
 end program

--- a/tests/reference/asr-subroutine1-b6656b7.json
+++ b/tests/reference/asr-subroutine1-b6656b7.json
@@ -2,12 +2,12 @@
     "basename": "asr-subroutine1-b6656b7",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/subroutine1.f90",
-    "infile_hash": "3b845963b5516f7053d0066363b3af788746f861a7130c3e9cd11b94",
+    "infile_hash": "0c76f3b9c93978c48be3b338215eb0380706f094f8d28edce0da034e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-subroutine1-b6656b7.stderr",
-    "stderr_hash": "3a02ff891984efd9e1165f874de881642a8e1b93182a31a2a3f5256b",
+    "stderr_hash": "6023ad3e9dde6734e3fcc03d3dc361690e636daec657440736485019",
     "returncode": 2
 }

--- a/tests/reference/asr-subroutine1-b6656b7.stderr
+++ b/tests/reference/asr-subroutine1-b6656b7.stderr
@@ -1,5 +1,5 @@
 semantic error: Assignment to subroutine is not allowed
- --> tests/errors/subroutine1.f90:8:1
+ --> tests/errors/subroutine1.f90:5:9
   |
-8 | bpe = 1
-  | ^^^ 
+5 |         bpe = 1
+  |         ^^^ 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/pull/1882