### PR TITLE
Add provision to check `array->m_type` in data stmt

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -206,7 +206,7 @@ RUN(NAME data_04 LABELS gfortran llvm NOFAST)
 RUN(NAME data_05 LABELS gfortran) # llvmImplicit removed
 RUN(NAME data_06 LABELS gfortran llvm NOFAST)
 RUN(NAME data_07 LABELS gfortran) # TODO: Fix this test
-RUN(NAME data_08 LABELS gfortran llvmImplicit)
+RUN(NAME data_08 LABELS gfortran llvmImplicit NOFAST)
 RUN(NAME minmax_01 LABELS gfortran llvm wasm)
 RUN(NAME arithmetic_if_01 LABELS gfortran llvm) # arithmetic tests use goto
 RUN(NAME arithmetic_if_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -206,6 +206,7 @@ RUN(NAME data_04 LABELS gfortran llvm NOFAST)
 RUN(NAME data_05 LABELS gfortran) # llvmImplicit removed
 RUN(NAME data_06 LABELS gfortran llvm NOFAST)
 RUN(NAME data_07 LABELS gfortran) # TODO: Fix this test
+RUN(NAME data_08 LABELS gfortran llvmImplicit)
 RUN(NAME minmax_01 LABELS gfortran llvm wasm)
 RUN(NAME arithmetic_if_01 LABELS gfortran llvm) # arithmetic tests use goto
 RUN(NAME arithmetic_if_02 LABELS gfortran llvm)

--- a/integration_tests/data_08.f90
+++ b/integration_tests/data_08.f90
@@ -1,0 +1,13 @@
+subroutine gamo()
+   implicit double precision (A-H,O-Z)
+   dimension g(2)
+   data g/1.5D0,2.5D0/
+   if (abs(g(1)-1.5D0) > 1e-12) error stop
+   if (abs(g(2)-2.5D0) > 1e-12) error stop
+   print *, g
+end subroutine
+
+program main
+   call gamo()
+end program
+

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1103,12 +1103,13 @@ public:
                     ASR::expr_t* object = ASRUtils::EXPR(tmp);
                     ASR::ttype_t* obj_type = ASRUtils::expr_type(object);
                     if (ASRUtils::is_array(obj_type)) { // it is an array
+                        ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(obj_type);
                         Vec<ASR::expr_t*> body;
                         body.reserve(al, a->n_value);
                         for (size_t j=0; j < a->n_value; j++) {
                             this->visit_expr(*a->m_value[j]);
                             ASR::expr_t* value = ASRUtils::EXPR(tmp);
-                            if (!ASRUtils::types_equal(ASRUtils::expr_type(value), obj_type)) {
+                            if (!ASRUtils::types_equal(ASRUtils::expr_type(value), array_type->m_type)) {
                                 throw SemanticError("Type mismatch during data initialization",
                                     x.base.base.loc);
                             }
@@ -1773,7 +1774,7 @@ public:
                                 } else {
                                     intent = ASRUtils::intent_local;
                                 }
-                                get_sym = declare_implicit_variable(s.loc, sym, intent);
+                                get_sym = declare_implicit_variable2(s.loc, sym, intent, implicit_dictionary[std::string(1,sym[0])]);
                             } else {
                                 throw SemanticError("Cannot set dimension for undeclared variable", x.base.base.loc);
                             }

--- a/tests/reference/asr-implicit4-704272e.json
+++ b/tests/reference/asr-implicit4-704272e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit4-704272e.stdout",
-    "stdout_hash": "2655fe136a913d05abab7a20cabb157067d8bbd770c7196a95951231",
+    "stdout_hash": "1278b76a918e58a8e511aaaa3ec88b58f1de36d71a2252fff37f69c5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit4-704272e.stdout
+++ b/tests/reference/asr-implicit4-704272e.stdout
@@ -113,7 +113,7 @@
                                     ()
                                     Default
                                     (Array
-                                        (Real 4)
+                                        (Real 8)
                                         [(()
                                         ())]
                                     )
@@ -133,7 +133,7 @@
                                     ()
                                     Default
                                     (Array
-                                        (Real 4)
+                                        (Real 8)
                                         [(()
                                         ())]
                                     )
@@ -153,7 +153,7 @@
                                     ()
                                     Default
                                     (Array
-                                        (Real 4)
+                                        (Real 8)
                                         [(()
                                         ())]
                                     )
@@ -167,17 +167,17 @@
                     idd_random_transf
                     (FunctionType
                         [(Array
-                            (Real 4)
+                            (Real 8)
                             [(()
                             ())]
                         )
                         (Array
-                            (Real 4)
+                            (Real 8)
                             [(()
                             ())]
                         )
                         (Array
-                            (Real 4)
+                            (Real 8)
                             [(()
                             ())]
                         )]
@@ -204,7 +204,7 @@
                                 [(()
                                 (IntegerConstant 1 (Integer 4))
                                 ())]
-                                (Real 4)
+                                (Real 8)
                                 ColMajor
                                 ()
                             )
@@ -222,7 +222,7 @@
                                 [(()
                                 (IntegerConstant 2 (Integer 4))
                                 ())]
-                                (Real 4)
+                                (Real 8)
                                 ColMajor
                                 ()
                             )
@@ -240,7 +240,7 @@
                                 [(()
                                 (IntegerConstant 3 (Integer 4))
                                 ())]
-                                (Real 4)
+                                (Real 8)
                                 ColMajor
                                 ()
                             )
@@ -258,7 +258,7 @@
                                 [(()
                                 (IntegerConstant 4 (Integer 4))
                                 ())]
-                                (Real 4)
+                                (Real 8)
                                 ColMajor
                                 ()
                             )
@@ -276,7 +276,7 @@
                                 [(()
                                 (IntegerConstant 5 (Integer 4))
                                 ())]
-                                (Real 4)
+                                (Real 8)
                                 ColMajor
                                 ()
                             )


### PR DESCRIPTION
Fixes #1891.