### PR TITLE
Allow to cast if target is `StructInstanceMember`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -918,6 +918,7 @@ RUN(NAME common_06 LABELS gfortran llvm llvmImplicit)
 RUN(NAME common_07 LABELS gfortran llvmImplicit)
 RUN(NAME common_08 LABELS gfortran llvmImplicit)
 RUN(NAME common_09 LABELS gfortran llvm)
+RUN(NAME common_10 LABELS gfortran llvm)
 
 RUN(NAME statement_01 LABELS gfortran llvmImplicit)
 RUN(NAME statement_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/common_10.f90
+++ b/integration_tests/common_10.f90
@@ -1,0 +1,6 @@
+program common_10
+   real :: x
+   common /timing/ x
+   x = 0.0D0
+end program
+

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2137,7 +2137,8 @@ public:
         if( overloaded_stmt == nullptr ) {
             if ((target->type == ASR::exprType::Var ||
                 target->type == ASR::exprType::ArrayItem ||
-                target->type == ASR::exprType::ArraySection) &&
+                target->type == ASR::exprType::ArraySection ||
+                target->type == ASR::exprType::StructInstanceMember) &&
                 !ASRUtils::check_equal_type(target_type, value_type)) {
                 if (value->type == ASR::exprType::ArrayConstant) {
                     ASR::ArrayConstant_t *ac = ASR::down_cast<ASR::ArrayConstant_t>(value);


### PR DESCRIPTION
Fixes #1910.
With this and #1909 we get `scipy/sparse/linalg/_eigen/arpack` compiled to ASR.