### PR TITLE
Add provision to handle `ArrayItem` while populating `COMMON` block variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -921,6 +921,8 @@ RUN(NAME common_07 LABELS gfortran llvmImplicit)
 RUN(NAME common_08 LABELS gfortran llvmImplicit)
 RUN(NAME common_09 LABELS gfortran llvm)
 RUN(NAME common_10 LABELS gfortran llvm)
+RUN(NAME common_11 LABELS gfortran llvm)
+
 
 RUN(NAME statement_01 LABELS gfortran llvmImplicit)
 RUN(NAME statement_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/common_11.f90
+++ b/integration_tests/common_11.f90
@@ -1,0 +1,14 @@
+subroutine sub1()
+   double precision el
+   common /dvod01/ el(13)
+end
+
+subroutine sub2()
+   double precision el
+   common /dvod01/ el(13)
+end
+
+program common_11
+   call sub1()
+   call sub2()
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1467,11 +1467,25 @@ public:
                         x.base.base.loc);
                 } else {
                     for (auto &expr: common_block_dictionary[common_block_name].second) {
-                        ASR::Variable_t* var_ = ASRUtils::EXPR2VAR(expr);
+                        ASR::Variable_t* var_ = nullptr;
+                        if (ASR::is_a<ASR::ArrayItem_t>(*expr)) {
+                            ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(expr);
+                            ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(array_item->m_v);
+                            var_ = ASR::down_cast<ASR::Variable_t>(var->m_v);
+                        } else {
+                            var_ = ASRUtils::EXPR2VAR(expr);
+                        }
                         s = x.m_syms[i];
                         AST::expr_t* expr_ = s.m_initializer;
                         this->visit_expr(*expr_);
-                        ASR::Variable_t* var__ = ASRUtils::EXPR2VAR(ASRUtils::EXPR(tmp));
+                        ASR::Variable_t* var__ = nullptr;
+                        if (ASR::is_a<ASR::ArrayItem_t>(*ASRUtils::EXPR(tmp))) {
+                            ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(ASRUtils::EXPR(tmp));
+                            ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(array_item->m_v);
+                            var__ = ASR::down_cast<ASR::Variable_t>(var->m_v);
+                        } else {
+                            var__ = ASRUtils::EXPR2VAR(ASRUtils::EXPR(tmp));
+                        }
                         if (!ASRUtils::check_equal_type(var_->m_type, var__->m_type)) {
                             throw SemanticError("The order of variables in common block must be same in all programs",
                                 x.base.base.loc);


### PR DESCRIPTION
Fixes #1914.