### PR TITLE
Added warning for integer division when floating point division was meant

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5075,9 +5075,15 @@ public:
                     case (ASR::Mul):
                         result = left_value * right_value;
                         break;
-                    case (ASR::Div):
+                    case (ASR::Div): {
+                        diag.semantic_warning_label(
+                            "Possible integer division instead of floating point division",
+                            {left->base.loc, right->base.loc},
+                            "help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result"
+                        );
                         result = left_value / right_value;
                         break;
+                    }
                     case (ASR::Pow):
                         result = std::pow(left_value, right_value);
                         break;

--- a/tests/reference/asr-doloop_02-cc78975.json
+++ b/tests/reference/asr-doloop_02-cc78975.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-doloop_02-cc78975.stdout",
     "stdout_hash": "2c19c77e2e3373eeeddfb36edec300c991f41fb9ae13e40d54a3d196",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-doloop_02-cc78975.stderr",
+    "stderr_hash": "3d322af162137fe90270647306d41374678de4780692a6ef628fc024",
     "returncode": 0
 }

--- a/tests/reference/asr-doloop_02-cc78975.stderr
+++ b/tests/reference/asr-doloop_02-cc78975.stderr
@@ -1,0 +1,5 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/doloop_02.f90:19:14
+   |
+19 |     if (a /= 100*101/2) error stop
+   |              ^^^^^^^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/asr-integer_div-9ec9cf4.json
+++ b/tests/reference/asr-integer_div-9ec9cf4.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-integer_div-9ec9cf4",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/warnings/integer_div.f90",
+    "infile_hash": "5edabb35d74c6238322518d32ec21e4e47769dfca313245a7a72ca8c",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-integer_div-9ec9cf4.stdout",
+    "stdout_hash": "b600adf1ec9c381ca528d34f1600d246056a65454439253ff3d390ae",
+    "stderr": "asr-integer_div-9ec9cf4.stderr",
+    "stderr_hash": "5c75e02736c567845c9028f1d91ad881203ff781cdf5d1f6ce63da8f",
+    "returncode": 0
+}

--- a/tests/reference/asr-integer_div-9ec9cf4.stderr
+++ b/tests/reference/asr-integer_div-9ec9cf4.stderr
@@ -1,0 +1,5 @@
+warning: Possible integer division instead of floating point division
+ --> tests/warnings/integer_div.f90:3:9
+  |
+3 |     x = 8/7
+  |         ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/asr-integer_div-9ec9cf4.stdout
+++ b/tests/reference/asr-integer_div-9ec9cf4.stdout
@@ -1,0 +1,49 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            main:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    main
+                    []
+                    [(=
+                        (Var 2 x)
+                        (IntegerBinOp
+                            (IntegerConstant 8 (Integer 4))
+                            Div
+                            (IntegerConstant 7 (Integer 4))
+                            (Integer 4)
+                            (IntegerConstant 1 (Integer 4))
+                        )
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(Var 2 x)]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/asr-intrinsic_implicit-77de888.json
+++ b/tests/reference/asr-intrinsic_implicit-77de888.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-intrinsic_implicit-77de888.stdout",
     "stdout_hash": "ecef2c1b17199737c5982ed7c079161cca556e545322128b3119a011",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-intrinsic_implicit-77de888.stderr",
+    "stderr_hash": "04a86e4e3282a36340a1d16d5ec7a70233e4184480d3cfe003a85142",
     "returncode": 0
 }

--- a/tests/reference/asr-intrinsic_implicit-77de888.stderr
+++ b/tests/reference/asr-intrinsic_implicit-77de888.stderr
@@ -1,0 +1,5 @@
+warning: Possible integer division instead of floating point division
+ --> tests/fixed_form/intrinsic_implicit.f:6:18
+  |
+6 |       b = max0(1,2/2,1)
+  |                  ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/asr-types_05-fa1bde9.json
+++ b/tests/reference/asr-types_05-fa1bde9.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-types_05-fa1bde9.stdout",
     "stdout_hash": "6f33f4cad6e3525e42548fbbb869a987f6a7a788ab7f256d52abd3c5",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-types_05-fa1bde9.stderr",
+    "stderr_hash": "e7312ca808d091bb338ca9b0974b839380f7dc069848aedcbf5fef81",
     "returncode": 0
 }

--- a/tests/reference/asr-types_05-fa1bde9.stderr
+++ b/tests/reference/asr-types_05-fa1bde9.stderr
@@ -1,0 +1,11 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:10:5
+   |
+10 | r = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result
+
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:18:5
+   |
+18 | i = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/cpp-types_05-06dea62.json
+++ b/tests/reference/cpp-types_05-06dea62.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "cpp-types_05-06dea62.stdout",
     "stdout_hash": "dec545721dedb9f1cb6f881988b09d15d17614ca8e3acbcc8864d412",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "cpp-types_05-06dea62.stderr",
+    "stderr_hash": "e7312ca808d091bb338ca9b0974b839380f7dc069848aedcbf5fef81",
     "returncode": 0
 }

--- a/tests/reference/cpp-types_05-06dea62.stderr
+++ b/tests/reference/cpp-types_05-06dea62.stderr
@@ -1,0 +1,11 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:10:5
+   |
+10 | r = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result
+
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:18:5
+   |
+18 | i = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/julia-doloop_02-13efa8f.json
+++ b/tests/reference/julia-doloop_02-13efa8f.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "julia-doloop_02-13efa8f.stdout",
     "stdout_hash": "5b604b185db4645137879631e1fee5d8c404f0a2182d0f8a7e0e0df8",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "julia-doloop_02-13efa8f.stderr",
+    "stderr_hash": "3d322af162137fe90270647306d41374678de4780692a6ef628fc024",
     "returncode": 0
 }

--- a/tests/reference/julia-doloop_02-13efa8f.stderr
+++ b/tests/reference/julia-doloop_02-13efa8f.stderr
@@ -1,0 +1,5 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/doloop_02.f90:19:14
+   |
+19 |     if (a /= 100*101/2) error stop
+   |              ^^^^^^^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
     "stdout_hash": "f55327e5c67646bfce174e8811ba74af2c48cd5378084a0cc2b3e739",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "llvm-doloop_02-9fcb598.stderr",
+    "stderr_hash": "3d322af162137fe90270647306d41374678de4780692a6ef628fc024",
     "returncode": 0
 }

--- a/tests/reference/llvm-doloop_02-9fcb598.stderr
+++ b/tests/reference/llvm-doloop_02-9fcb598.stderr
@@ -1,0 +1,5 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/doloop_02.f90:19:14
+   |
+19 |     if (a /= 100*101/2) error stop
+   |              ^^^^^^^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
     "stdout_hash": "70c98024205ceb3e904542c8388d7270928d9a9f41e521ee0f0f55fd",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "llvm-types_05-aa71aa9.stderr",
+    "stderr_hash": "e7312ca808d091bb338ca9b0974b839380f7dc069848aedcbf5fef81",
     "returncode": 0
 }

--- a/tests/reference/llvm-types_05-aa71aa9.stderr
+++ b/tests/reference/llvm-types_05-aa71aa9.stderr
@@ -1,0 +1,11 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:10:5
+   |
+10 | r = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result
+
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:18:5
+   |
+18 | i = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/wat-doloop_02-1ee6409.json
+++ b/tests/reference/wat-doloop_02-1ee6409.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "wat-doloop_02-1ee6409.stdout",
     "stdout_hash": "5b2908283ea4894c3408154947ae1e46e7a7c96dc505100064cf83c1",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "wat-doloop_02-1ee6409.stderr",
+    "stderr_hash": "3d322af162137fe90270647306d41374678de4780692a6ef628fc024",
     "returncode": 0
 }

--- a/tests/reference/wat-doloop_02-1ee6409.stderr
+++ b/tests/reference/wat-doloop_02-1ee6409.stderr
@@ -1,0 +1,5 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/doloop_02.f90:19:14
+   |
+19 |     if (a /= 100*101/2) error stop
+   |              ^^^^^^^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/reference/wat-types_05-884adc8.json
+++ b/tests/reference/wat-types_05-884adc8.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "wat-types_05-884adc8.stdout",
     "stdout_hash": "ecec3e8ba676fa8215c8ac6371ea2ee9d1d9adf1f6d28fb7e0e7b3fa",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "wat-types_05-884adc8.stderr",
+    "stderr_hash": "e7312ca808d091bb338ca9b0974b839380f7dc069848aedcbf5fef81",
     "returncode": 0
 }

--- a/tests/reference/wat-types_05-884adc8.stderr
+++ b/tests/reference/wat-types_05-884adc8.stderr
@@ -1,0 +1,11 @@
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:10:5
+   |
+10 | r = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result
+
+warning: Possible integer division instead of floating point division
+  --> tests/../integration_tests/types_05.f90:18:5
+   |
+18 | i = 1/2
+   |     ^ ^ help: Check the operands and ensure at least one of them is a floating point number to obtain the desired result

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3337,3 +3337,7 @@ asr = true
 [[test]]
 filename = "errors/subroutine3.f90"
 asr = true
+
+[[test]]
+filename = "warnings/integer_div.f90"
+asr = true

--- a/tests/warnings/integer_div.f90
+++ b/tests/warnings/integer_div.f90
@@ -1,0 +1,7 @@
+program main
+    integer:: x
+    x = 8/7
+    print *, x
+end program
+    
+    


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/1904