### PR TITLE
Generate all header files for passes

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -825,7 +825,7 @@ public:
               throw SemanticError("Only functions can be instantiated", x.base.base.loc);
             }
             std::string new_f_name = to_lower(use_symbol->m_local_rename);
-            pass_instantiate_generic_function(al, subs, restriction_subs, current_scope,
+            pass_instantiate_template(al, subs, restriction_subs, current_scope,
                 temp->m_symtab, new_f_name, s);
             current_function_dependencies.erase(ASRUtils::symbol_name(s));
             current_function_dependencies.push_back(al, s2c(al, new_f_name));

--- a/src/libasr/codegen/asr_to_x86.cpp
+++ b/src/libasr/codegen/asr_to_x86.cpp
@@ -577,7 +577,7 @@ Result<int> asr_to_x86(ASR::TranslationUnit_t &asr, Allocator &al,
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        pass_wrap_global_stmts_into_function(al, asr, pass_options);
+        pass_wrap_global_stmts(al, asr, pass_options);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_pass_global = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     }

--- a/src/libasr/gen_pass.py
+++ b/src/libasr/gen_pass.py
@@ -1,0 +1,77 @@
+passes = [
+        # name, optional prefix (pass_PREFIX_name())
+        ("arr_slice", "replace"),
+        ("array_op", "replace"),
+        ("class_constructor", "replace"),
+        ("dead_code_removal", ""),
+        ("div_to_mul", "replace"),
+        ("do_loops", "replace"),
+        ("flip_sign", "replace"),
+        ("fma", "replace"),
+        ("for_all", "replace"),
+        ("global_stmts", "wrap"),
+        ("global_stmts_program", "wrap"),
+        ("global_symbols", "wrap"),
+        ("implied_do_loops", "replace"),
+        ("init_expr", "replace"),
+        ("inline_function_calls", ""),
+        ("instantiate_template", ""),
+        ("intrinsic_function", "replace"),
+        ("loop_unroll", ""),
+        ("loop_vectorise", ""),
+        ("nested_vars", ""),
+        ("param_to_const", "replace"),
+        ("pass_array_by_data", ""),
+        ("pass_compare", ""),
+        ("pass_list_expr", ""),
+        ("print_arr", "replace"),
+        ("print_list_tuple", "replace"),
+        ("print_struct_type", "replace"),
+        ("select_case", "replace"),
+        ("sign_from_value", "replace"),
+        ("subroutine_from_function", "create"),
+        ("transform_optional_argument_functions", ""),
+        ("unused_functions", ""),
+        ("update_array_dim_intrinsic_calls", ""),
+        ("where", "replace"),
+]
+
+
+
+for pass_name, prefix in passes:
+    print(f"Processing: {pass_name}")
+    name = pass_name
+    if name.startswith("pass"):
+        name = name[5:]
+    name_up = name.upper()
+    if prefix != "":
+        prefix += "_"
+    arguments = r"""Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options"""
+    return_type = "void"
+    if pass_name == "instantiate_template":
+        arguments = r"""Allocator &al,
+        std::map<std::string, ASR::ttype_t*> subs, std::map<std::string, ASR::symbol_t*> rt_subs,
+        SymbolTable *current_scope, SymbolTable *template_scope,
+        std::string new_func_name, ASR::symbol_t *sym"""
+        return_type = "ASR::symbol_t*"
+
+
+
+    header = rf"""#ifndef LIBASR_PASS_{name_up}_H
+#define LIBASR_PASS_{name_up}_H
+
+#include <libasr/asr.h>
+#include <libasr/utils.h>
+
+namespace LCompilers {{
+
+    {return_type} pass_{prefix}{name}({arguments});
+
+}} // namespace LCompilers
+
+#endif // LIBASR_PASS_{name_up}_H
+"""
+    header_filename = f"pass/{pass_name}.h"
+    f = open(header_filename, "w")
+    f.write(header)

--- a/src/libasr/pass/arr_slice.h
+++ b/src/libasr/pass/arr_slice.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_ARR_SLICE_H
-#define LFORTRAN_PASS_ARR_SLICE_H
+#ifndef LIBASR_PASS_ARR_SLICE_H
+#define LIBASR_PASS_ARR_SLICE_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_arr_slice(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_ARR_SLICE_H
+#endif // LIBASR_PASS_ARR_SLICE_H

--- a/src/libasr/pass/array_op.h
+++ b/src/libasr/pass/array_op.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_ARRAY_OP_H
-#define LFORTRAN_PASS_ARRAY_OP_H
+#ifndef LIBASR_PASS_ARRAY_OP_H
+#define LIBASR_PASS_ARRAY_OP_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_array_op(Allocator &al, ASR::TranslationUnit_t &unit,
-                               const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_ARRAY_OP_H
+#endif // LIBASR_PASS_ARRAY_OP_H

--- a/src/libasr/pass/class_constructor.h
+++ b/src/libasr/pass/class_constructor.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_CLASS_CONSTRUCTOR_H
-#define LFORTRAN_PASS_CLASS_CONSTRUCTOR_H
+#ifndef LIBASR_PASS_CLASS_CONSTRUCTOR_H
+#define LIBASR_PASS_CLASS_CONSTRUCTOR_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_class_constructor(Allocator &al, ASR::TranslationUnit_t &unit,
-                                        const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_CLASS_CONSTRUCTOR_H
+#endif // LIBASR_PASS_CLASS_CONSTRUCTOR_H

--- a/src/libasr/pass/dead_code_removal.h
+++ b/src/libasr/pass/dead_code_removal.h
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_dead_code_removal(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif
+#endif // LIBASR_PASS_DEAD_CODE_REMOVAL_H

--- a/src/libasr/pass/div_to_mul.h
+++ b/src/libasr/pass/div_to_mul.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_div_to_mul(Allocator &al, ASR::TranslationUnit_t &unit,
-                                 const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/do_loops.h
+++ b/src/libasr/pass/do_loops.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_DO_LOOPS_H
-#define LFORTRAN_PASS_DO_LOOPS_H
+#ifndef LIBASR_PASS_DO_LOOPS_H
+#define LIBASR_PASS_DO_LOOPS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
-                               const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_DO_LOOPS_H
+#endif // LIBASR_PASS_DO_LOOPS_H

--- a/src/libasr/pass/flip_sign.h
+++ b/src/libasr/pass/flip_sign.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_flip_sign(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/fma.h
+++ b/src/libasr/pass/fma.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_fma(Allocator &al, ASR::TranslationUnit_t &unit,
-                          const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/for_all.cpp
+++ b/src/libasr/pass/for_all.cpp
@@ -43,7 +43,7 @@ public:
     }
 };
 
-void pass_replace_forall(Allocator &al, ASR::TranslationUnit_t &unit,
+void pass_replace_for_all(Allocator &al, ASR::TranslationUnit_t &unit,
                          const LCompilers::PassOptions& /*pass_options*/) {
     ForAllVisitor v(al);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/for_all.h
+++ b/src/libasr/pass/for_all.h
@@ -1,14 +1,14 @@
-#ifndef LFORTRAN_PASS_FOR_ALL
-#define LFORTRAN_PASS_FOR_ALL
+#ifndef LIBASR_PASS_FOR_ALL_H
+#define LIBASR_PASS_FOR_ALL_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_replace_forall(Allocator &al, ASR::TranslationUnit_t &unit,
-                             const LCompilers::PassOptions& pass_options);
+    void pass_replace_for_all(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_FOR_ALL
+#endif // LIBASR_PASS_FOR_ALL_H

--- a/src/libasr/pass/global_stmts.cpp
+++ b/src/libasr/pass/global_stmts.cpp
@@ -18,7 +18,7 @@ using ASRUtils::EXPR;
  * statements and expressions into a function.
  *
  */
-void pass_wrap_global_stmts_into_function(Allocator &al,
+void pass_wrap_global_stmts(Allocator &al,
             ASR::TranslationUnit_t &unit, const LCompilers::PassOptions& pass_options) {
     if (unit.n_items == 0) {
         return ;

--- a/src/libasr/pass/global_stmts.h
+++ b/src/libasr/pass/global_stmts.h
@@ -1,14 +1,14 @@
-#ifndef LFORTRAN_PASS_GLOBAL_STMTS_H
-#define LFORTRAN_PASS_GLOBAL_STMTS_H
+#ifndef LIBASR_PASS_GLOBAL_STMTS_H
+#define LIBASR_PASS_GLOBAL_STMTS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_wrap_global_stmts_into_function(Allocator &al, ASR::TranslationUnit_t &unit,
-                                              const LCompilers::PassOptions& pass_options);
+    void pass_wrap_global_stmts(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_GLOBAL_STMTS_H
+#endif // LIBASR_PASS_GLOBAL_STMTS_H

--- a/src/libasr/pass/global_stmts_program.cpp
+++ b/src/libasr/pass/global_stmts_program.cpp
@@ -18,7 +18,7 @@ using ASRUtils::EXPR;
  * statements and expressions into a program.
  *
  */
-void pass_wrap_global_stmts_into_program(Allocator &al,
+void pass_wrap_global_stmts_program(Allocator &al,
             ASR::TranslationUnit_t &unit, const LCompilers::PassOptions& pass_options) {
     std::string program_fn_name = pass_options.run_fun;
     SymbolTable *current_scope = al.make_new<SymbolTable>(unit.m_global_scope);
@@ -28,8 +28,8 @@ void pass_wrap_global_stmts_into_program(Allocator &al,
     SetChar prog_dep;
     prog_dep.reserve(al, 1);
     bool call_main_program = unit.n_items > 0;
-    pass_wrap_global_stmts_into_function(al, unit, pass_options);
-    pass_wrap_global_syms_into_module(al, unit, pass_options);
+    pass_wrap_global_stmts(al, unit, pass_options);
+    pass_wrap_global_symbols(al, unit, pass_options);
     if( call_main_program && !pass_options.disable_main ) {
         // Call `_lpython_main_program` function
         ASR::Module_t *mod = ASR::down_cast<ASR::Module_t>(

--- a/src/libasr/pass/global_stmts_program.h
+++ b/src/libasr/pass/global_stmts_program.h
@@ -6,8 +6,8 @@
 
 namespace LCompilers {
 
-    void pass_wrap_global_stmts_into_program(Allocator &al, ASR::TranslationUnit_t &unit,
-                                             const LCompilers::PassOptions& pass_options);
+    void pass_wrap_global_stmts_program(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/global_symbols.cpp
+++ b/src/libasr/pass/global_symbols.cpp
@@ -14,7 +14,7 @@ namespace LCompilers {
  * and wraps all global symbols into a module
  */
 
-void pass_wrap_global_syms_into_module(Allocator &al,
+void pass_wrap_global_symbols(Allocator &al,
         ASR::TranslationUnit_t &unit,
         const LCompilers::PassOptions &/*pass_options*/) {
     if( unit.m_global_scope->get_scope().size() == 0 ) {

--- a/src/libasr/pass/global_symbols.h
+++ b/src/libasr/pass/global_symbols.h
@@ -1,15 +1,14 @@
-#ifndef LFORTRAN_PASS_GLOBAL_SYMBOLS_H
-#define LFORTRAN_PASS_GLOBAL_SYMBOLS_H
+#ifndef LIBASR_PASS_GLOBAL_SYMBOLS_H
+#define LIBASR_PASS_GLOBAL_SYMBOLS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_wrap_global_syms_into_module(Allocator &al,
-        ASR::TranslationUnit_t &unit,
-        const LCompilers::PassOptions& pass_options);
+    void pass_wrap_global_symbols(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_GLOBAL_SYMBOLS_H
+#endif // LIBASR_PASS_GLOBAL_SYMBOLS_H

--- a/src/libasr/pass/implied_do_loops.h
+++ b/src/libasr/pass/implied_do_loops.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_IMPLIED_DO_LOOPS_H
-#define LFORTRAN_PASS_IMPLIED_DO_LOOPS_H
+#ifndef LIBASR_PASS_IMPLIED_DO_LOOPS_H
+#define LIBASR_PASS_IMPLIED_DO_LOOPS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_implied_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
-                                       const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_IMPLIED_DO_LOOPS_H
+#endif // LIBASR_PASS_IMPLIED_DO_LOOPS_H

--- a/src/libasr/pass/init_expr.h
+++ b/src/libasr/pass/init_expr.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_INIT_EXPR_H
-#define LFORTRAN_PASS_INIT_EXPR_H
+#ifndef LIBASR_PASS_INIT_EXPR_H
+#define LIBASR_PASS_INIT_EXPR_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_init_expr(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_INIT_EXPR_H
+#endif // LIBASR_PASS_INIT_EXPR_H

--- a/src/libasr/pass/inline_function_calls.h
+++ b/src/libasr/pass/inline_function_calls.h
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_inline_function_calls(Allocator &al, ASR::TranslationUnit_t &unit,
-                                    const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LIBASR_PASS_FMA_H
+#endif // LIBASR_PASS_INLINE_FUNCTION_CALLS_H

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -427,7 +427,7 @@ public:
 
 };
 
-ASR::symbol_t* pass_instantiate_generic_function(Allocator &al, std::map<std::string, ASR::ttype_t*> subs,
+ASR::symbol_t* pass_instantiate_template(Allocator &al, std::map<std::string, ASR::ttype_t*> subs,
         std::map<std::string, ASR::symbol_t*> rt_subs, SymbolTable *current_scope,
         SymbolTable* template_scope, std::string new_func_name, ASR::symbol_t *sym) {
     ASR::symbol_t* sym2 = ASRUtils::symbol_get_past_external(sym);

--- a/src/libasr/pass/instantiate_template.h
+++ b/src/libasr/pass/instantiate_template.h
@@ -1,19 +1,16 @@
-#ifndef LFORTRAN_PASS_TEMPLATE_VISITOR_H
-#define LFORTRAN_PASS_TEMPLATE_VISITOR_H
+#ifndef LIBASR_PASS_INSTANTIATE_TEMPLATE_H
+#define LIBASR_PASS_INSTANTIATE_TEMPLATE_H
 
 #include <libasr/asr.h>
+#include <libasr/utils.h>
 
 namespace LCompilers {
 
-    /**
-     * @brief Instantiate a generic function into a function that does not
-     *        contain any type parameters and restrictions. No type checking
-     *        is executed here
-     */
-    ASR::symbol_t* pass_instantiate_generic_function(Allocator &al,
+    ASR::symbol_t* pass_instantiate_template(Allocator &al,
         std::map<std::string, ASR::ttype_t*> subs, std::map<std::string, ASR::symbol_t*> rt_subs,
         SymbolTable *current_scope, SymbolTable *template_scope,
         std::string new_func_name, ASR::symbol_t *sym);
+
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_TEMPLATE_VISITOR_H
+#endif // LIBASR_PASS_INSTANTIATE_TEMPLATE_H

--- a/src/libasr/pass/intrinsic_function.h
+++ b/src/libasr/pass/intrinsic_function.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_intrinsic_function(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/loop_unroll.h
+++ b/src/libasr/pass/loop_unroll.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_loop_unroll(Allocator &al, ASR::TranslationUnit_t &unit,
-                          const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/loop_vectorise.h
+++ b/src/libasr/pass/loop_vectorise.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_loop_vectorise(Allocator &al, ASR::TranslationUnit_t &unit,
-                             const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/nested_vars.h
+++ b/src/libasr/pass/nested_vars.h
@@ -1,13 +1,14 @@
-#ifndef LFORTRAN_PASS_NESTED_VARS_H
-#define LFORTRAN_PASS_NESTED_VARS_H
+#ifndef LIBASR_PASS_NESTED_VARS_H
+#define LIBASR_PASS_NESTED_VARS_H
 
 #include <libasr/asr.h>
+#include <libasr/utils.h>
 
 namespace LCompilers {
 
-     void pass_nested_vars(Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& pass_options);
+    void pass_nested_vars(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_NESTED_VARS_H
+#endif // LIBASR_PASS_NESTED_VARS_H

--- a/src/libasr/pass/param_to_const.h
+++ b/src/libasr/pass/param_to_const.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_PARAM_TO_CONST_H
-#define LFORTRAN_PASS_PARAM_TO_CONST_H
+#ifndef LIBASR_PASS_PARAM_TO_CONST_H
+#define LIBASR_PASS_PARAM_TO_CONST_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,9 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_param_to_const(Allocator &al, ASR::TranslationUnit_t &unit,
-                                     const LCompilers::PassOptions& pass_options
-                                     );
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_PARAM_TO_CONST_H
+#endif // LIBASR_PASS_PARAM_TO_CONST_H

--- a/src/libasr/pass/pass_array_by_data.h
+++ b/src/libasr/pass/pass_array_by_data.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_ARRAY_BY_DATA_H
-#define LFORTRAN_PASS_ARRAY_BY_DATA_H
+#ifndef LIBASR_PASS_ARRAY_BY_DATA_H
+#define LIBASR_PASS_ARRAY_BY_DATA_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_array_by_data(Allocator &al, ASR::TranslationUnit_t &unit,
-                            const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_ARRAY_BY_DATA_H
+#endif // LIBASR_PASS_ARRAY_BY_DATA_H

--- a/src/libasr/pass/pass_compare.h
+++ b/src/libasr/pass/pass_compare.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_compare(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& /*pass_options*/);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/pass_list_expr.h
+++ b/src/libasr/pass/pass_list_expr.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_list_expr(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& /*pass_options*/);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -67,7 +67,7 @@ namespace LCompilers {
         std::vector<std::string> _skip_passes, _c_skip_passes;
         std::map<std::string, pass_function> _passes_db = {
             {"do_loops", &pass_replace_do_loops},
-            {"global_stmts", &pass_wrap_global_stmts_into_function},
+            {"global_stmts", &pass_wrap_global_stmts},
             {"implied_do_loops", &pass_replace_implied_do_loops},
             {"array_op", &pass_replace_array_op},
             {"intrinsic_function", &pass_replace_intrinsic_function},
@@ -83,7 +83,7 @@ namespace LCompilers {
             {"inline_function_calls", &pass_inline_function_calls},
             {"loop_unroll", &pass_loop_unroll},
             {"dead_code_removal", &pass_dead_code_removal},
-            {"forall", &pass_replace_forall},
+            {"forall", &pass_replace_for_all},
             {"select_case", &pass_replace_select_case},
             {"loop_vectorise", &pass_loop_vectorise},
             {"array_dim_intrinsics_update", &pass_update_array_dim_intrinsic_calls},

--- a/src/libasr/pass/print_arr.h
+++ b/src/libasr/pass/print_arr.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_PRINT_ARR_H
-#define LFORTRAN_PASS_PRINT_ARR_H
+#ifndef LIBASR_PASS_PRINT_ARR_H
+#define LIBASR_PASS_PRINT_ARR_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_print_arr(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_PRINT_ARR_H
+#endif // LIBASR_PASS_PRINT_ARR_H

--- a/src/libasr/pass/print_list_tuple.h
+++ b/src/libasr/pass/print_list_tuple.h
@@ -1,15 +1,14 @@
-#ifndef LFORTRAN_PASS_PRINT_LIST_TUPLE_H
-#define LFORTRAN_PASS_PRINT_LIST_TUPLE_H
+#ifndef LIBASR_PASS_PRINT_LIST_TUPLE_H
+#define LIBASR_PASS_PRINT_LIST_TUPLE_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_replace_print_list_tuple(
-    Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions &pass_options);
+    void pass_replace_print_list_tuple(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_PRINT_LIST_TUPLE_H
+#endif // LIBASR_PASS_PRINT_LIST_TUPLE_H

--- a/src/libasr/pass/print_struct_type.h
+++ b/src/libasr/pass/print_struct_type.h
@@ -1,15 +1,14 @@
-#ifndef LFORTRAN_PASS_PRINT_STRUCT_TYPE_H
-#define LFORTRAN_PASS_PRINT_STRUCT_TYPE_H
+#ifndef LIBASR_PASS_PRINT_STRUCT_TYPE_H
+#define LIBASR_PASS_PRINT_STRUCT_TYPE_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_replace_print_struct_type(
-        Allocator &al, ASR::TranslationUnit_t &unit,
-        const LCompilers::PassOptions& pass_options);
+    void pass_replace_print_struct_type(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_PRINT_STRUCT_TYPE_H
+#endif // LIBASR_PASS_PRINT_STRUCT_TYPE_H

--- a/src/libasr/pass/select_case.h
+++ b/src/libasr/pass/select_case.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_SELECT_CASE_H
-#define LFORTRAN_PASS_SELECT_CASE_H
+#ifndef LIBASR_PASS_SELECT_CASE_H
+#define LIBASR_PASS_SELECT_CASE_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_replace_select_case(Allocator &al, ASR::TranslationUnit_t &unit,
-                                  const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_SELECT_CASE_H
+#endif // LIBASR_PASS_SELECT_CASE_H

--- a/src/libasr/pass/sign_from_value.h
+++ b/src/libasr/pass/sign_from_value.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_sign_from_value(Allocator &al, ASR::TranslationUnit_t &unit,
-                                      const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/subroutine_from_function.h
+++ b/src/libasr/pass/subroutine_from_function.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_create_subroutine_from_function(Allocator &al, ASR::TranslationUnit_t &unit,
-                                              const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/transform_optional_argument_functions.h
+++ b/src/libasr/pass/transform_optional_argument_functions.h
@@ -1,16 +1,14 @@
-#ifndef LFORTRAN_PASS_TRANSFORM_OPTIONAL_ARGUMENT_FUNCTIONS
-#define LFORTRAN_PASS_TRANSFORM_OPTIONAL_ARGUMENT_FUNCTIONS
+#ifndef LIBASR_PASS_TRANSFORM_OPTIONAL_ARGUMENT_FUNCTIONS_H
+#define LIBASR_PASS_TRANSFORM_OPTIONAL_ARGUMENT_FUNCTIONS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_transform_optional_argument_functions(
-        Allocator &al, ASR::TranslationUnit_t &unit,
-        const LCompilers::PassOptions& pass_options
-    );
+    void pass_transform_optional_argument_functions(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
-} // namespace LFortran
+} // namespace LCompilers
 
-#endif // LFORTRAN_TRANSFORM_OPTIONAL_ARGUMENT_FUNCTIONS
+#endif // LIBASR_PASS_TRANSFORM_OPTIONAL_ARGUMENT_FUNCTIONS_H

--- a/src/libasr/pass/unused_functions.h
+++ b/src/libasr/pass/unused_functions.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_UNUSED_FUNCTIONS_H
-#define LFORTRAN_PASS_UNUSED_FUNCTIONS_H
+#ifndef LIBASR_PASS_UNUSED_FUNCTIONS_H
+#define LIBASR_PASS_UNUSED_FUNCTIONS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit,
-                               const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_UNUSED_FUNCTIONS_H
+#endif // LIBASR_PASS_UNUSED_FUNCTIONS_H

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.h
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.h
@@ -1,5 +1,5 @@
-#ifndef LFORTRAN_PASS_UPDATE_ARRAY_DIM_H
-#define LFORTRAN_PASS_UPDATE_ARRAY_DIM_H
+#ifndef LIBASR_PASS_UPDATE_ARRAY_DIM_INTRINSIC_CALLS_H
+#define LIBASR_PASS_UPDATE_ARRAY_DIM_INTRINSIC_CALLS_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     void pass_update_array_dim_intrinsic_calls(Allocator &al, ASR::TranslationUnit_t &unit,
-                                               const LCompilers::PassOptions& pass_options);
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_UPDATE_ARRAY_DIM_H
+#endif // LIBASR_PASS_UPDATE_ARRAY_DIM_INTRINSIC_CALLS_H

--- a/src/libasr/pass/where.h
+++ b/src/libasr/pass/where.h
@@ -1,13 +1,14 @@
-#ifndef LFORTRAN_PASS_WHERE_H
-#define LFORTRAN_PASS_WHERE_H
+#ifndef LIBASR_PASS_WHERE_H
+#define LIBASR_PASS_WHERE_H
 
 #include <libasr/asr.h>
 #include <libasr/utils.h>
 
 namespace LCompilers {
 
-    void pass_replace_where(Allocator &al, ASR::TranslationUnit_t &unit, const LCompilers::PassOptions& pass_options);
+    void pass_replace_where(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
 
 } // namespace LCompilers
 
-#endif // LFORTRAN_PASS_WHERE_H
+#endif // LIBASR_PASS_WHERE_H


### PR DESCRIPTION
Make the naming more consistent and the headers more consistent.