### PR TITLE
Implement `--implicit-argument-casting`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -101,6 +101,10 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             execute_process(COMMAND lfortran ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.f90
 				${extra_args} --implicit-typing --implicit-interface -o ${name})
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
+        elseif (LFORTRAN_BACKEND STREQUAL "llvmImplicitArgument")
+            execute_process(COMMAND lfortran ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.f90
+				${extra_args} --implicit-argument-casting -o ${name})
+            add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         elseif (LFORTRAN_BACKEND STREQUAL "llvm")
             add_executable(${name} ${file_name}.f90 ${extra_files})
             target_compile_options(${name} PUBLIC ${extra_args})
@@ -954,3 +958,5 @@ RUN(NAME entry_03 LABELS gfortran llvm)
 RUN(NAME character_01 LABELS gfortran llvm)
 
 RUN(NAME c_ptr_01 LABELS gfortran llvm NOFAST)
+
+RUN(NAME implicit_argument_casting_01 LABELS llvmImplicitArgument)

--- a/integration_tests/implicit_argument_casting_01.f90
+++ b/integration_tests/implicit_argument_casting_01.f90
@@ -1,33 +1,28 @@
-subroutine idz_realcomp(n,a)
-   integer n
-   real*8 a(n)
-   a = 12.5d0
-   return
-end
+subroutine idz_realcomp(n, a)
+implicit none
+integer, parameter :: dp = kind(0.d0)
+integer n
+real(dp) a(n)
+a = 12.5d0
+end subroutine
 
-subroutine idzp_svd(ls, w)
-   use iso_c_binding, only: c_f_pointer, c_loc
-   real*8 eps
-   complex*16, target :: w(*)
-   integer :: ls, isi, i
-   isi = 1
-   ls = 5
-   call idz_realcomp(ls,w(isi))
-   print *, w(isi)
-   if (abs(real(w(isi)) - 12.5d0) > 1e-12) error stop
-   return
-end
 
 program main
-   complex*16, target :: w(5)
-   interface
-      subroutine idzp_svd(ls, w)
-         use iso_c_binding, only: c_f_pointer, c_loc
-         complex*16, target :: w(*)
-         integer :: ls
-      end subroutine
-   end interface
-   call idzp_svd(5, w)
+implicit none
+integer, parameter :: dp = kind(0.d0)
+complex(dp) :: w(5)
+call idzp_svd(5, w)
+
+contains
+
+    subroutine idzp_svd(ls, w)
+    implicit none
+    complex(dp) :: w(*)
+    integer :: ls, isi
+    isi = 1
+    call idz_realcomp(ls*2, w(isi))
+    print *, w(isi)
+    if (abs(real(w(isi), dp) - 12.5d0) > 1e-12) error stop
+    end
+
 end program
-
-

--- a/integration_tests/implicit_argument_casting_01.f90
+++ b/integration_tests/implicit_argument_casting_01.f90
@@ -1,0 +1,33 @@
+subroutine idz_realcomp(n,a)
+   integer n
+   real*8 a(n)
+   a = 12.5d0
+   return
+end
+
+subroutine idzp_svd(ls, w)
+   use iso_c_binding, only: c_f_pointer, c_loc
+   real*8 eps
+   complex*16, target :: w(*)
+   integer :: ls, isi, i
+   isi = 1
+   ls = 5
+   call idz_realcomp(ls,w(isi))
+   print *, w(isi)
+   if (abs(real(w(isi)) - 12.5d0) > 1e-12) error stop
+   return
+end
+
+program main
+   complex*16, target :: w(5)
+   interface
+      subroutine idzp_svd(ls, w)
+         use iso_c_binding, only: c_f_pointer, c_loc
+         complex*16, target :: w(*)
+         integer :: ls
+      end subroutine
+   end interface
+   call idzp_svd(5, w)
+end program
+
+

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -7,7 +7,7 @@ import os
 # Initialization
 NO_OF_THREADS = 8 # default no of threads is 8
 SUPPORTED_BACKENDS = ['llvm', 'llvm2', 'llvm_rtlib', 'c',
-                      'cpp', 'x86', 'wasm', 'gfortran', 'llvmImplicit']
+                      'cpp', 'x86', 'wasm', 'gfortran', 'llvmImplicit', 'llvmImplicitArgument']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LFORTRAN_PATH = f"{BASE_DIR}/../src/bin:$PATH"
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -40,6 +40,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     asr_implicit_typing = is_included("asr_implicit_typing")
     asr_implicit_interface = is_included("asr_implicit_interface")
     asr_implicit_interface_and_typing = is_included("asr_implicit_interface_and_typing")
+    asr_implicit_argument_casting = is_included("asr_implicit_argument_casting")
     asr_implicit_interface_and_typing_with_llvm = is_included("asr_implicit_interface_and_typing_with_llvm")
     asr_preprocess = is_included("asr_preprocess")
     asr_indent = is_included("asr_indent")
@@ -214,6 +215,15 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
             filename,
             "asr",
             "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+            filename,
+            update_reference,
+            extra_args)
+
+    if asr_implicit_argument_casting:
+        run_test(
+            filename,
+            "asr",
+            "lfortran --show-asr --implicit-argument-casting --no-color {infile} -o {outfile}",
             filename,
             update_reference,
             extra_args)

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2309,8 +2309,13 @@ public:
         if( f ) {
             ASRUtils::set_absent_optional_arguments_to_null(args, f, al, v_expr);
         }
+        ASR::stmt_t* cast_stmt = nullptr;
         tmp = ASRUtils::make_SubroutineCall_t_util(al, x.base.base.loc,
-                final_sym, original_sym, args.p, args.size(), v_expr);
+                final_sym, original_sym, args.p, args.size(), v_expr, &cast_stmt, compiler_options.implicit_argument_casting);
+
+        if (cast_stmt != nullptr) {
+            current_body->push_back(al, cast_stmt);
+        }
     }
 
     // Changes argument `sub_name` to the new symbol from the current symbol

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -873,7 +873,7 @@ void process_overloaded_assignment_function(ASR::symbol_t* proc, ASR::expr_t* ta
             ASRUtils::insert_module_dependency(a_name, al, current_module_dependencies);
             ASRUtils::set_absent_optional_arguments_to_null(a_args, subrout, al);
             asr = ASRUtils::make_SubroutineCall_t_util(al, loc, a_name, sym,
-                                            a_args.p, 2, nullptr);
+                                            a_args.p, 2, nullptr, nullptr, false);
         }
     }
 }
@@ -1213,7 +1213,7 @@ ASR::asr_t* symbol_resolve_external_generic_procedure_without_eval(
         }
         return ASRUtils::make_SubroutineCall_t_util(al, loc, final_sym,
                                         v, args.p, args.size(),
-                                        nullptr);
+                                        nullptr, nullptr, false);
     } else {
         if( func ) {
             ASRUtils::set_absent_optional_arguments_to_null(args, func, al);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3984,7 +3984,10 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                     }
                 }
             } else {
-                /*TODO: Remove this if check one intrinsic procedures are implemented correctly*/
+                // TODO: Make this a regular error. The current asr_utils.h is
+                // not setup to return errors, so we need to refactor things.
+                // For now we just do an assert.
+                /*TODO: Remove this if check once intrinsic procedures are implemented correctly*/
                 LCOMPILERS_ASSERT_MSG( ASRUtils::check_equal_type(arg_type, orig_arg_type),
                     "ASRUtils::check_equal_type(" + ASRUtils::get_type_code(arg_type) + ", " +
                         ASRUtils::get_type_code(orig_arg_type) + ")");

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4034,7 +4034,7 @@ static inline ASR::asr_t* make_FunctionCall_t_util(
 static inline ASR::asr_t* make_SubroutineCall_t_util(
     Allocator &al, const Location &a_loc, ASR::symbol_t* a_name,
     ASR::symbol_t* a_original_name, ASR::call_arg_t* a_args, size_t n_args,
-    ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt = nullptr, bool implicit_argument_casting = false) {
+    ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt, bool implicit_argument_casting) {
 
     Call_t_body(al, a_name, a_args, n_args, a_dt, cast_stmt, implicit_argument_casting);
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3915,6 +3915,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                             ASR::dimension_t dim_;
                             dim_.m_start = nullptr;
                             dim_.m_length = nullptr;
+                            dim_.loc = arg->base.loc;
                             dim.push_back(al, dim_);
                             arg_array_t = (ASR::Array_t*) ASR::make_Array_t(al, arg->base.loc, orig_arg_array_t->m_type,
                             dim.p, dim.size(), ASR::array_physical_typeType::DescriptorArray);
@@ -3957,6 +3958,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                         ASR::dimension_t dim_;
                         dim_.m_start = one;
                         dim_.m_length = one;
+                        dim_.loc = arg->base.loc;
                         dim.push_back(al, dim_);
 
                         ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, arg->base.loc, int32_type, dim.p, dim.size(), ASR::array_physical_typeType::FixedSizeArray));
@@ -3972,6 +3974,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                         ASR::dimension_t dims_;
                         dims_.m_start = nullptr;
                         dims_.m_length = nullptr;
+                        dim_.loc = arg->base.loc;
                         dims.push_back(al, dims_);
 
                         array_t = ASR::make_Array_t(al, arg->base.loc, orig_arg_array_t->m_type,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3887,7 +3887,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
             !(ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(arg_type)) ||
               ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(orig_arg_type))) &&
             a_dt == nullptr ) {
-            if (!ASRUtils::check_equal_type(arg_type, orig_arg_type) && implicit_argument_casting) {
+            if (implicit_argument_casting && !ASRUtils::check_equal_type(arg_type, orig_arg_type)) {
                 if (ASR::is_a<ASR::Function_t>(*a_name_)) {
                     // get current_scope
                     SymbolTable* current_scope = nullptr;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3852,7 +3852,7 @@ static inline ASR::asr_t* make_ArrayPhysicalCast_t_util(Allocator &al, const Loc
 }
 
 static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
-    ASR::call_arg_t* a_args, size_t n_args, ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt = nullptr, bool implicit_argument_casting = false) {
+    ASR::call_arg_t* a_args, size_t n_args, ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt, bool implicit_argument_casting) {
     bool is_method = a_dt != nullptr;
     ASR::symbol_t* a_name_ = ASRUtils::symbol_get_past_external(a_name);
     ASR::FunctionType_t* func_type = nullptr;
@@ -4025,7 +4025,7 @@ static inline ASR::asr_t* make_FunctionCall_t_util(
     ASR::symbol_t* a_original_name, ASR::call_arg_t* a_args, size_t n_args,
     ASR::ttype_t* a_type, ASR::expr_t* a_value, ASR::expr_t* a_dt) {
 
-    Call_t_body(al, a_name, a_args, n_args, a_dt);
+    Call_t_body(al, a_name, a_args, n_args, a_dt, nullptr, false);
 
     return ASR::make_FunctionCall_t(al, a_loc, a_name, a_original_name,
             a_args, n_args, a_type, a_value, a_dt);

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1096,7 +1096,8 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
             result_arg.m_value = *current_expr;
             s_args.push_back(al, result_arg);
             ASR::stmt_t* subrout_call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, loc,
-                                            x->m_name, nullptr, s_args.p, s_args.size(), nullptr));
+                                            x->m_name, nullptr, s_args.p, s_args.size(), nullptr,
+                                            nullptr, false));
             pass_result.push_back(al, subrout_call);
 
             if (is_allocatable && result_var != *current_expr &&

--- a/src/libasr/pass/global_stmts_program.cpp
+++ b/src/libasr/pass/global_stmts_program.cpp
@@ -50,7 +50,8 @@ void pass_wrap_global_stmts_program(Allocator &al,
                 al, unit.base.base.loc,
                 fn_s, nullptr,
                 nullptr, 0,
-                nullptr);
+                nullptr,
+                nullptr, false);
         prog_body.push_back(al, ASR::down_cast<ASR::stmt_t>(stmt));
         prog_dep.push_back(al, s2c(al, "_global_symbols"));
     }

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -367,7 +367,7 @@ public:
         }
         dependencies.push_back(al, ASRUtils::symbol_name(name));
         return ASRUtils::make_SubroutineCall_t_util(al, x->base.base.loc, name /* change this */,
-            x->m_original_name, args.p, args.size(), dt);
+            x->m_original_name, args.p, args.size(), dt, nullptr, false);
     }
 
 

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -263,7 +263,7 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
         new_args.push_back(al, new_arg);
         pass_result.push_back(al, ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(
             al, x->base.base.loc, x->m_name, x->m_original_name, new_args.p,
-            new_args.size(), x->m_dt)));
+            new_args.size(), x->m_dt, nullptr, false)));
 
         *current_expr = new_args.p[new_args.size() - 1].m_value;
     }

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -403,7 +403,8 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
             visit_expr(*x.m_dt);
         }
         ASR::FunctionCall_t& xx = const_cast<ASR::FunctionCall_t&>(x);
-        ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt);
+        ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt,
+            nullptr, false);
     }
 
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {
@@ -423,7 +424,8 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
         }
 
         ASR::SubroutineCall_t& xx = const_cast<ASR::SubroutineCall_t&>(x);
-        ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt);
+        ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt,
+            nullptr, false);
     }
 
 };

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -778,7 +778,7 @@ namespace LCompilers {
             args.push_back(al, arg5_);
             return ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, loc, v,
                                                              nullptr, args.p, args.size(),
-                                                             nullptr));
+                                                             nullptr, nullptr, false));
         }
 
         ASR::expr_t* get_sign_from_value(ASR::expr_t* arg0, ASR::expr_t* arg1,

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -158,7 +158,8 @@ class ReplaceFunctionCallWithSubroutineCall:
             result_arg.m_value = result_var;
             s_args.push_back(al, result_arg);
             ASR::stmt_t* subrout_call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(
-                al, x->base.base.loc, x->m_name, nullptr, s_args.p, s_args.size(), nullptr));
+                al, x->base.base.loc, x->m_name, nullptr, s_args.p, s_args.size(), nullptr,
+                nullptr, false));
             pass_result.push_back(al, subrout_call);
             result_var = nullptr;
         }

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -386,7 +386,8 @@ class ReplaceSubroutineCallsWithOptionalArgumentsVisitor : public PassUtils::Pas
             }
             pass_result.push_back(al, ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al,
                                     x.base.base.loc, x.m_name, x.m_original_name,
-                                    new_args.p, new_args.size(), x.m_dt)));
+                                    new_args.p, new_args.size(), x.m_dt,
+                                    nullptr, false)));
         }
 };
 

--- a/tests/reference/asr-implicit_argument_casting_01-2274b4b.json
+++ b/tests/reference/asr-implicit_argument_casting_01-2274b4b.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-implicit_argument_casting_01-2274b4b",
+    "cmd": "lfortran --show-asr --implicit-argument-casting --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/implicit_argument_casting_01.f90",
+    "infile_hash": "7592210ad6046c12c005301338a547d35c4c130ce9d5dd46c8afe8f6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-implicit_argument_casting_01-2274b4b.stdout",
+    "stdout_hash": "b5db79ddb1e3f565f748b8ea7d297dec5eecc5ac022bf930973387cc",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-implicit_argument_casting_01-2274b4b.json
+++ b/tests/reference/asr-implicit_argument_casting_01-2274b4b.json
@@ -2,11 +2,11 @@
     "basename": "asr-implicit_argument_casting_01-2274b4b",
     "cmd": "lfortran --show-asr --implicit-argument-casting --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/implicit_argument_casting_01.f90",
-    "infile_hash": "7592210ad6046c12c005301338a547d35c4c130ce9d5dd46c8afe8f6",
+    "infile_hash": "3ed389916666e17233ec1aa288c9e7cfee00c97aacc83db1aeec5c7b",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_argument_casting_01-2274b4b.stdout",
-    "stdout_hash": "b5db79ddb1e3f565f748b8ea7d297dec5eecc5ac022bf930973387cc",
+    "stdout_hash": "eeeaa64e599a92b5e6d4f8aa3d9c4935f0b998a1add9eb9b5845ac57",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_argument_casting_01-2274b4b.stdout
+++ b/tests/reference/asr-implicit_argument_casting_01-2274b4b.stdout
@@ -1,0 +1,540 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            idz_realcomp:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            a:
+                                (Variable
+                                    2
+                                    a
+                                    [n]
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Real 8)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (Var 2 n))]
+                                        PointerToDataArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            n:
+                                (Variable
+                                    2
+                                    n
+                                    []
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    idz_realcomp
+                    (FunctionType
+                        [(Integer 4)
+                        (Array
+                            (Real 8)
+                            [((IntegerConstant 1 (Integer 4))
+                            (FunctionParam
+                                0
+                                (Integer 4)
+                                ()
+                            ))]
+                            PointerToDataArray
+                        )]
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    []
+                    [(Var 2 n)
+                    (Var 2 a)]
+                    [(=
+                        (Var 2 a)
+                        (RealConstant
+                            12.500000
+                            (Real 8)
+                        )
+                        ()
+                    )
+                    (Return)]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            idzp_svd:
+                (Function
+                    (SymbolTable
+                        3
+                        {
+                            c_f_pointer:
+                                (ExternalSymbol
+                                    3
+                                    c_f_pointer
+                                    5 c_f_pointer
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_f_pointer
+                                    Public
+                                ),
+                            c_loc:
+                                (ExternalSymbol
+                                    3
+                                    c_loc
+                                    5 c_loc
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_loc
+                                    Public
+                                ),
+                            eps:
+                                (Variable
+                                    3
+                                    eps
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            i:
+                                (Variable
+                                    3
+                                    i
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            isi:
+                                (Variable
+                                    3
+                                    isi
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ls:
+                                (Variable
+                                    3
+                                    ls
+                                    []
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            real:
+                                (ExternalSymbol
+                                    3
+                                    real
+                                    13 real
+                                    lfortran_intrinsic_builtin
+                                    []
+                                    real
+                                    Private
+                                ),
+                            w:
+                                (Variable
+                                    3
+                                    w
+                                    []
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Complex 8)
+                                        [(()
+                                        ())]
+                                        DescriptorArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            w_cast:
+                                (Variable
+                                    3
+                                    w_cast
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Pointer
+                                        (Array
+                                            (Real 8)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    idzp_svd
+                    (FunctionType
+                        [(Integer 4)
+                        (Array
+                            (Complex 8)
+                            [(()
+                            ())]
+                            DescriptorArray
+                        )]
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    [idz_realcomp]
+                    [(Var 3 ls)
+                    (Var 3 w)]
+                    [(=
+                        (Var 3 isi)
+                        (IntegerConstant 1 (Integer 4))
+                        ()
+                    )
+                    (=
+                        (Var 3 ls)
+                        (IntegerConstant 5 (Integer 4))
+                        ()
+                    )
+                    (CPtrToPointer
+                        (PointerToCPtr
+                            (GetPointer
+                                (ArrayItem
+                                    (Var 3 w)
+                                    [(()
+                                    (Var 3 isi)
+                                    ())]
+                                    (Complex 8)
+                                    ColMajor
+                                    ()
+                                )
+                                (Pointer
+                                    (Complex 8)
+                                )
+                                ()
+                            )
+                            (CPtr)
+                            ()
+                        )
+                        (Var 3 w_cast)
+                        (ArrayConstant
+                            [(IntegerConstant 1000 (Integer 4))]
+                            (Array
+                                (Integer 4)
+                                [((IntegerConstant 1 (Integer 4))
+                                (IntegerConstant 1 (Integer 4)))]
+                                FixedSizeArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (SubroutineCall
+                        1 idz_realcomp
+                        ()
+                        [((Var 3 ls))
+                        ((ArrayPhysicalCast
+                            (Var 3 w_cast)
+                            DescriptorArray
+                            PointerToDataArray
+                            (Pointer
+                                (Array
+                                    (Real 8)
+                                    [(()
+                                    ())]
+                                    PointerToDataArray
+                                )
+                            )
+                            ()
+                        ))]
+                        ()
+                    )
+                    (Print
+                        ()
+                        [(ArrayItem
+                            (Var 3 w)
+                            [(()
+                            (Var 3 isi)
+                            ())]
+                            (Complex 8)
+                            ColMajor
+                            ()
+                        )]
+                        ()
+                        ()
+                    )
+                    (If
+                        (RealCompare
+                            (IntrinsicFunction
+                                Abs
+                                [(RealBinOp
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 3 w)
+                                            [(()
+                                            (Var 3 isi)
+                                            ())]
+                                            (Complex 8)
+                                            ColMajor
+                                            ()
+                                        )
+                                        ComplexToReal
+                                        (Real 4)
+                                        ()
+                                    )
+                                    Sub
+                                    (Cast
+                                        (RealConstant
+                                            12.500000
+                                            (Real 8)
+                                        )
+                                        RealToReal
+                                        (Real 4)
+                                        (RealConstant
+                                            12.500000
+                                            (Real 4)
+                                        )
+                                    )
+                                    (Real 4)
+                                    ()
+                                )]
+                                0
+                                (Real 4)
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000000
+                                (Real 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Return)]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            iso_c_binding:
+                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
+            lfortran_intrinsic_builtin:
+                (IntrinsicModule lfortran_intrinsic_builtin),
+            main:
+                (Program
+                    (SymbolTable
+                        10
+                        {
+                            idzp_svd:
+                                (Function
+                                    (SymbolTable
+                                        11
+                                        {
+                                            c_f_pointer:
+                                                (ExternalSymbol
+                                                    11
+                                                    c_f_pointer
+                                                    5 c_f_pointer
+                                                    lfortran_intrinsic_iso_c_binding
+                                                    []
+                                                    c_f_pointer
+                                                    Public
+                                                ),
+                                            c_loc:
+                                                (ExternalSymbol
+                                                    11
+                                                    c_loc
+                                                    5 c_loc
+                                                    lfortran_intrinsic_iso_c_binding
+                                                    []
+                                                    c_loc
+                                                    Public
+                                                ),
+                                            ls:
+                                                (Variable
+                                                    11
+                                                    ls
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            w:
+                                                (Variable
+                                                    11
+                                                    w
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Complex 8)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    idzp_svd
+                                    (FunctionType
+                                        [(Integer 4)
+                                        (Array
+                                            (Complex 8)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )]
+                                        ()
+                                        Source
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 11 ls)
+                                    (Var 11 w)]
+                                    []
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            w:
+                                (Variable
+                                    10
+                                    w
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Complex 8)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 5 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    main
+                    [iso_c_binding]
+                    [(SubroutineCall
+                        10 idzp_svd
+                        ()
+                        [((IntegerConstant 5 (Integer 4)))
+                        ((ArrayPhysicalCast
+                            (Var 10 w)
+                            FixedSizeArray
+                            DescriptorArray
+                            (Array
+                                (Complex 8)
+                                [((IntegerConstant 1 (Integer 4))
+                                (IntegerConstant 5 (Integer 4)))]
+                                DescriptorArray
+                            )
+                            ()
+                        ))]
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/asr-implicit_argument_casting_01-2274b4b.stdout
+++ b/tests/reference/asr-implicit_argument_casting_01-2274b4b.stdout
@@ -28,6 +28,42 @@
                                     Required
                                     .false.
                                 ),
+                            dp:
+                                (Variable
+                                    2
+                                    dp
+                                    []
+                                    Local
+                                    (FunctionCall
+                                        2 kind
+                                        ()
+                                        [((RealConstant
+                                            0.000000
+                                            (Real 8)
+                                        ))]
+                                        (Integer 4)
+                                        (IntegerConstant 8 (Integer 4))
+                                        ()
+                                    )
+                                    (IntegerConstant 8 (Integer 4))
+                                    Parameter
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            kind:
+                                (ExternalSymbol
+                                    2
+                                    kind
+                                    4 kind
+                                    lfortran_intrinsic_kind
+                                    []
+                                    kind
+                                    Private
+                                ),
                             n:
                                 (Variable
                                     2
@@ -69,7 +105,7 @@
                         .false.
                         .false.
                     )
-                    []
+                    [kind]
                     [(Var 2 n)
                     (Var 2 a)]
                     [(=
@@ -79,354 +115,72 @@
                             (Real 8)
                         )
                         ()
-                    )
-                    (Return)]
+                    )]
                     ()
                     Public
                     .false.
                     .false.
                     ()
                 ),
-            idzp_svd:
-                (Function
-                    (SymbolTable
-                        3
-                        {
-                            c_f_pointer:
-                                (ExternalSymbol
-                                    3
-                                    c_f_pointer
-                                    5 c_f_pointer
-                                    lfortran_intrinsic_iso_c_binding
-                                    []
-                                    c_f_pointer
-                                    Public
-                                ),
-                            c_loc:
-                                (ExternalSymbol
-                                    3
-                                    c_loc
-                                    5 c_loc
-                                    lfortran_intrinsic_iso_c_binding
-                                    []
-                                    c_loc
-                                    Public
-                                ),
-                            eps:
-                                (Variable
-                                    3
-                                    eps
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 8)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                ),
-                            i:
-                                (Variable
-                                    3
-                                    i
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                ),
-                            isi:
-                                (Variable
-                                    3
-                                    isi
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                ),
-                            ls:
-                                (Variable
-                                    3
-                                    ls
-                                    []
-                                    Unspecified
-                                    ()
-                                    ()
-                                    Default
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                ),
-                            real:
-                                (ExternalSymbol
-                                    3
-                                    real
-                                    13 real
-                                    lfortran_intrinsic_builtin
-                                    []
-                                    real
-                                    Private
-                                ),
-                            w:
-                                (Variable
-                                    3
-                                    w
-                                    []
-                                    Unspecified
-                                    ()
-                                    ()
-                                    Default
-                                    (Array
-                                        (Complex 8)
-                                        [(()
-                                        ())]
-                                        DescriptorArray
-                                    )
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                ),
-                            w_cast:
-                                (Variable
-                                    3
-                                    w_cast
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Pointer
-                                        (Array
-                                            (Real 8)
-                                            [(()
-                                            ())]
-                                            DescriptorArray
-                                        )
-                                    )
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                )
-                        })
-                    idzp_svd
-                    (FunctionType
-                        [(Integer 4)
-                        (Array
-                            (Complex 8)
-                            [(()
-                            ())]
-                            DescriptorArray
-                        )]
-                        ()
-                        Source
-                        Implementation
-                        ()
-                        .false.
-                        .false.
-                        .false.
-                        .false.
-                        .false.
-                        .false.
-                    )
-                    [idz_realcomp]
-                    [(Var 3 ls)
-                    (Var 3 w)]
-                    [(=
-                        (Var 3 isi)
-                        (IntegerConstant 1 (Integer 4))
-                        ()
-                    )
-                    (=
-                        (Var 3 ls)
-                        (IntegerConstant 5 (Integer 4))
-                        ()
-                    )
-                    (CPtrToPointer
-                        (PointerToCPtr
-                            (GetPointer
-                                (ArrayItem
-                                    (Var 3 w)
-                                    [(()
-                                    (Var 3 isi)
-                                    ())]
-                                    (Complex 8)
-                                    ColMajor
-                                    ()
-                                )
-                                (Pointer
-                                    (Complex 8)
-                                )
-                                ()
-                            )
-                            (CPtr)
-                            ()
-                        )
-                        (Var 3 w_cast)
-                        (ArrayConstant
-                            [(IntegerConstant 1000 (Integer 4))]
-                            (Array
-                                (Integer 4)
-                                [((IntegerConstant 1 (Integer 4))
-                                (IntegerConstant 1 (Integer 4)))]
-                                FixedSizeArray
-                            )
-                            ColMajor
-                        )
-                        ()
-                    )
-                    (SubroutineCall
-                        1 idz_realcomp
-                        ()
-                        [((Var 3 ls))
-                        ((ArrayPhysicalCast
-                            (Var 3 w_cast)
-                            DescriptorArray
-                            PointerToDataArray
-                            (Pointer
-                                (Array
-                                    (Real 8)
-                                    [(()
-                                    ())]
-                                    PointerToDataArray
-                                )
-                            )
-                            ()
-                        ))]
-                        ()
-                    )
-                    (Print
-                        ()
-                        [(ArrayItem
-                            (Var 3 w)
-                            [(()
-                            (Var 3 isi)
-                            ())]
-                            (Complex 8)
-                            ColMajor
-                            ()
-                        )]
-                        ()
-                        ()
-                    )
-                    (If
-                        (RealCompare
-                            (IntrinsicFunction
-                                Abs
-                                [(RealBinOp
-                                    (Cast
-                                        (ArrayItem
-                                            (Var 3 w)
-                                            [(()
-                                            (Var 3 isi)
-                                            ())]
-                                            (Complex 8)
-                                            ColMajor
-                                            ()
-                                        )
-                                        ComplexToReal
-                                        (Real 4)
-                                        ()
-                                    )
-                                    Sub
-                                    (Cast
-                                        (RealConstant
-                                            12.500000
-                                            (Real 8)
-                                        )
-                                        RealToReal
-                                        (Real 4)
-                                        (RealConstant
-                                            12.500000
-                                            (Real 4)
-                                        )
-                                    )
-                                    (Real 4)
-                                    ()
-                                )]
-                                0
-                                (Real 4)
-                                ()
-                            )
-                            Gt
-                            (RealConstant
-                                0.000000
-                                (Real 4)
-                            )
-                            (Logical 4)
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (Return)]
-                    ()
-                    Public
-                    .false.
-                    .false.
-                    ()
-                ),
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
             lfortran_intrinsic_builtin:
                 (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_kind:
+                (IntrinsicModule lfortran_intrinsic_kind),
             main:
                 (Program
                     (SymbolTable
-                        10
+                        12
                         {
+                            dp:
+                                (Variable
+                                    12
+                                    dp
+                                    []
+                                    Local
+                                    (FunctionCall
+                                        12 kind
+                                        ()
+                                        [((RealConstant
+                                            0.000000
+                                            (Real 8)
+                                        ))]
+                                        (Integer 4)
+                                        (IntegerConstant 8 (Integer 4))
+                                        ()
+                                    )
+                                    (IntegerConstant 8 (Integer 4))
+                                    Parameter
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             idzp_svd:
                                 (Function
                                     (SymbolTable
-                                        11
+                                        13
                                         {
-                                            c_f_pointer:
-                                                (ExternalSymbol
-                                                    11
-                                                    c_f_pointer
-                                                    5 c_f_pointer
-                                                    lfortran_intrinsic_iso_c_binding
+                                            isi:
+                                                (Variable
+                                                    13
+                                                    isi
                                                     []
-                                                    c_f_pointer
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
                                                     Public
-                                                ),
-                                            c_loc:
-                                                (ExternalSymbol
-                                                    11
-                                                    c_loc
-                                                    5 c_loc
-                                                    lfortran_intrinsic_iso_c_binding
-                                                    []
-                                                    c_loc
-                                                    Public
+                                                    Required
+                                                    .false.
                                                 ),
                                             ls:
                                                 (Variable
-                                                    11
+                                                    13
                                                     ls
                                                     []
                                                     Unspecified
@@ -440,9 +194,19 @@
                                                     Required
                                                     .false.
                                                 ),
+                                            real:
+                                                (ExternalSymbol
+                                                    13
+                                                    real
+                                                    15 real
+                                                    lfortran_intrinsic_builtin
+                                                    []
+                                                    real
+                                                    Private
+                                                ),
                                             w:
                                                 (Variable
-                                                    11
+                                                    13
                                                     w
                                                     []
                                                     Unspecified
@@ -454,6 +218,29 @@
                                                         [(()
                                                         ())]
                                                         DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            w_cast:
+                                                (Variable
+                                                    13
+                                                    w_cast
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Pointer
+                                                        (Array
+                                                            (Real 8)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
                                                     )
                                                     ()
                                                     Source
@@ -473,7 +260,7 @@
                                         )]
                                         ()
                                         Source
-                                        Interface
+                                        Implementation
                                         ()
                                         .false.
                                         .false.
@@ -482,19 +269,158 @@
                                         .false.
                                         .false.
                                     )
-                                    []
-                                    [(Var 11 ls)
-                                    (Var 11 w)]
-                                    []
+                                    [idz_realcomp]
+                                    [(Var 13 ls)
+                                    (Var 13 w)]
+                                    [(=
+                                        (Var 13 isi)
+                                        (IntegerConstant 1 (Integer 4))
+                                        ()
+                                    )
+                                    (CPtrToPointer
+                                        (PointerToCPtr
+                                            (GetPointer
+                                                (ArrayItem
+                                                    (Var 13 w)
+                                                    [(()
+                                                    (Var 13 isi)
+                                                    ())]
+                                                    (Complex 8)
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (Pointer
+                                                    (Complex 8)
+                                                )
+                                                ()
+                                            )
+                                            (CPtr)
+                                            ()
+                                        )
+                                        (Var 13 w_cast)
+                                        (ArrayConstant
+                                            [(IntegerConstant 1000 (Integer 4))]
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 1 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        )
+                                        ()
+                                    )
+                                    (SubroutineCall
+                                        1 idz_realcomp
+                                        ()
+                                        [((IntegerBinOp
+                                            (Var 13 ls)
+                                            Mul
+                                            (IntegerConstant 2 (Integer 4))
+                                            (Integer 4)
+                                            ()
+                                        ))
+                                        ((ArrayPhysicalCast
+                                            (Var 13 w_cast)
+                                            DescriptorArray
+                                            PointerToDataArray
+                                            (Pointer
+                                                (Array
+                                                    (Real 8)
+                                                    [(()
+                                                    ())]
+                                                    PointerToDataArray
+                                                )
+                                            )
+                                            ()
+                                        ))]
+                                        ()
+                                    )
+                                    (Print
+                                        ()
+                                        [(ArrayItem
+                                            (Var 13 w)
+                                            [(()
+                                            (Var 13 isi)
+                                            ())]
+                                            (Complex 8)
+                                            ColMajor
+                                            ()
+                                        )]
+                                        ()
+                                        ()
+                                    )
+                                    (If
+                                        (RealCompare
+                                            (IntrinsicFunction
+                                                Abs
+                                                [(RealBinOp
+                                                    (Cast
+                                                        (ArrayItem
+                                                            (Var 13 w)
+                                                            [(()
+                                                            (Var 13 isi)
+                                                            ())]
+                                                            (Complex 8)
+                                                            ColMajor
+                                                            ()
+                                                        )
+                                                        ComplexToReal
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    Sub
+                                                    (RealConstant
+                                                        12.500000
+                                                        (Real 8)
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )]
+                                                0
+                                                (Real 8)
+                                                ()
+                                            )
+                                            Gt
+                                            (Cast
+                                                (RealConstant
+                                                    0.000000
+                                                    (Real 4)
+                                                )
+                                                RealToReal
+                                                (Real 8)
+                                                (RealConstant
+                                                    0.000000
+                                                    (Real 8)
+                                                )
+                                            )
+                                            (Logical 4)
+                                            ()
+                                        )
+                                        [(ErrorStop
+                                            ()
+                                        )]
+                                        []
+                                    )]
                                     ()
                                     Public
                                     .false.
                                     .false.
                                     ()
                                 ),
+                            kind:
+                                (ExternalSymbol
+                                    12
+                                    kind
+                                    4 kind
+                                    lfortran_intrinsic_kind
+                                    []
+                                    kind
+                                    Private
+                                ),
                             w:
                                 (Variable
-                                    10
+                                    12
                                     w
                                     []
                                     Local
@@ -515,13 +441,13 @@
                                 )
                         })
                     main
-                    [iso_c_binding]
+                    [lfortran_intrinsic_kind]
                     [(SubroutineCall
-                        10 idzp_svd
+                        12 idzp_svd
                         ()
                         [((IntegerConstant 5 (Integer 4)))
                         ((ArrayPhysicalCast
-                            (Var 10 w)
+                            (Var 12 w)
                             FixedSizeArray
                             DescriptorArray
                             (Array

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3358,3 +3358,7 @@ asr = true
 [[test]]
 filename = "errors/subroutine3.f90"
 asr = true
+
+[[test]]
+filename = "../integration_tests/implicit_argument_casting_01.f90"
+asr_implicit_argument_casting = true


### PR DESCRIPTION
Fixes #1926.
With this, we get `scipy/linalg` compile to ASR once again.