### PR TITLE
Generate LLVM from ``fastGPT``

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -357,6 +357,12 @@ jobs:
             FC=$(pwd)/../src/bin/lfortran cmake .
             make fastgpt
             $(pwd)/../src/bin/lfortran --show-asr --no-indent --no-color main.f90
+            git clean -fdx
+            git checkout -t origin/lf3
+            git checkout e5ce0676705d6bd12621f55496d73388a7a3e787
+            FC=$(pwd)/../src/bin/lfortran cmake .
+            make fastgpt
+            $(pwd)/../src/bin/lfortran --show-llvm main.f90
 
 
   fpm:

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3844,6 +3844,9 @@ static inline ASR::asr_t* make_ArrayPhysicalCast_t_util(Allocator &al, const Loc
     }
 
     LCOMPILERS_ASSERT(ASRUtils::extract_physical_type(ASRUtils::expr_type(a_arg)) == a_old);
+    if( a_old == a_new ) {
+        return (ASR::asr_t*) a_arg;
+    }
 
     return ASR::make_ArrayPhysicalCast_t(al, a_loc, a_arg, a_old, a_new, a_type, a_value);
 }

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -836,6 +836,8 @@ public:
 
     void visit_ArrayPhysicalCast(const ASR::ArrayPhysicalCast_t& x) {
         BaseWalkVisitor<VerifyVisitor>::visit_ArrayPhysicalCast(x);
+        require(x.m_new != x.m_old, "ArrayPhysicalCast is redundant, "
+            "the old physical type and new physical type must be different.");
         require(x.m_new == ASRUtils::extract_physical_type(x.m_type),
             "Destination physical type conflicts with the physical type of target");
         require(x.m_old == ASRUtils::extract_physical_type(ASRUtils::expr_type(x.m_arg)),

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1013,6 +1013,16 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
         result_var = nullptr;
     }
 
+    void replace_ArrayPhysicalCast(ASR::ArrayPhysicalCast_t* x) {
+        ASR::BaseExprReplacer<ReplaceArrayOp>::replace_ArrayPhysicalCast(x);
+        if( ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg)) != x->m_old ) {
+            x->m_old = ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg));
+        }
+        if( x->m_old == x->m_new ) {
+            *current_expr = x->m_arg;
+        }
+    }
+
     void replace_FunctionCall(ASR::FunctionCall_t* x) {
         // The following checks if the name of a function actually
         // points to a subroutine. If true this would mean that the

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -2043,7 +2043,8 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al, const Locatio
     int64_t id_array = 0, id_array_dim = 1, id_array_mask = 2;
     int64_t id_array_dim_mask = 3;
 
-    ASR::ttype_t* arg_type = arg_types[0];
+    ASR::ttype_t* arg_type = ASRUtils::type_get_past_allocatable(
+        ASRUtils::type_get_past_pointer(arg_types[0]));
     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
     int rank = ASRUtils::extract_n_dims_from_ttype(arg_type);
     std::string new_name = intrinsic_func_name + "_" + std::to_string(kind) +

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -309,10 +309,6 @@ class EditProcedureReplacer: public ASR::BaseExprReplacer<EditProcedureReplacer>
         }
     }
 
-    void replace_BlockCall(ASR::BlockCall_t* x) {
-        edit_symbol_pointer(m)
-    }
-
     void replace_FunctionCall(ASR::FunctionCall_t* x) {
         edit_symbol_pointer(name)
         ASR::BaseExprReplacer<EditProcedureReplacer>::replace_FunctionCall(x);
@@ -340,6 +336,12 @@ class EditProcedureVisitor: public ASR::CallReplacerOnExpressionsVisitor<EditPro
         ASR::SubroutineCall_t& xx = const_cast<ASR::SubroutineCall_t&>(x);
         edit_symbol_reference(name)
         ASR::CallReplacerOnExpressionsVisitor<EditProcedureVisitor>::visit_SubroutineCall(x);
+    }
+
+    void visit_BlockCall(const ASR::BlockCall_t& x) {
+        ASR::BlockCall_t& xx = const_cast<ASR::BlockCall_t&>(x);
+        edit_symbol_reference(m)
+        ASR::CallReplacerOnExpressionsVisitor<EditProcedureVisitor>::visit_BlockCall(x);
     }
 
 };


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/1932

`main.f90` in `fastGPT` generates LLVM with LFortran. I will add the test for the same in `CI.yml` with `lf3` branch.