### PR TITLE
Add provision to update duplicated nodes of entry function correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -956,6 +956,7 @@ RUN(NAME entry_01 LABELS gfortran llvm)
 RUN(NAME entry_02 LABELS gfortran llvm)
 RUN(NAME entry_03 LABELS gfortran llvm)
 RUN(NAME entry_04 LABELS gfortran llvm)
+RUN(NAME entry_05 LABELS gfortran llvm)
 
 RUN(NAME character_01 LABELS gfortran llvm)
 

--- a/integration_tests/entry_05.f90
+++ b/integration_tests/entry_05.f90
@@ -1,0 +1,22 @@
+subroutine dzror(n, r)
+   implicit none
+   double precision abstol,reltol,zx
+   intrinsic abs,max
+   double precision ftol
+   integer n
+   real r(n)
+   ftol(zx) = 0.5d0*max(abstol,reltol*abs(zx))
+   r = -83.03
+ entry dstzr()
+   return
+end
+
+program entry_05
+   real :: r(10)
+   integer :: i
+   call dzror(10, r)
+   do i = 1, 10
+      if (abs(r(i) - (-83.03)) > 1e-8) error stop
+   end do
+   print *, r
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1512,6 +1512,31 @@ public:
             false, false);
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp_));
 
+        for (auto &item: current_scope->get_scope()) {
+            if (ASR::is_a<ASR::Function_t>(*item.second)) {
+                ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(current_scope->resolve_symbol(item.first));
+                update_duplicated_nodes(al, func->m_symtab);
+            } else if (ASR::is_a<ASR::Variable_t>(*item.second)) {
+                ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(current_scope->resolve_symbol(item.first));
+                ASR::ttype_t* var_type = var->m_type;
+                if (var_type->type == ASR::ttypeType::Array) {
+                    ASR::Array_t* arr_type = ASR::down_cast<ASR::Array_t>(var_type);
+                    for (size_t i = 0; i < arr_type->n_dims; i++) {
+                        ASR::dimension_t dim = arr_type->m_dims[i];
+                        ASR::expr_t* dim_length = dim.m_length;
+                        if (ASR::is_a<ASR::Var_t>(*dim_length)) {
+                            ASR::Var_t* dim_length_var = ASR::down_cast<ASR::Var_t>(dim_length);
+                            ASR::symbol_t* dim_length_sym = dim_length_var->m_v;
+                            std::string dim_length_sym_name = ASRUtils::symbol_name(dim_length_sym);
+                            ASR::symbol_t* dim_length_sym_in_scope = current_scope->resolve_symbol(dim_length_sym_name);
+                            if (dim_length_sym_in_scope) {
+                                dim_length_var->m_v = dim_length_sym_in_scope;
+                            }
+                        }
+                    }
+                }
+            }
+        }
         
         entry_point_mapping[sym_name] = std::vector<AST::stmt_t*>();
         active_entry_points.push_back(sym_name);
@@ -1520,6 +1545,76 @@ public:
         current_function_dependencies = current_function_dependencies_copy;
 
         tmp = nullptr;
+    }
+
+    void update_duplicated_nodes(Allocator &al, SymbolTable *current_scope) {
+        class UpdateDuplicatedNodes : public PassUtils::PassVisitor<UpdateDuplicatedNodes>
+        {
+            public:
+            SymbolTable* scope = current_scope;
+            SymbolTable* correct_scope = nullptr;
+            UpdateDuplicatedNodes(Allocator &al) : PassVisitor(al, nullptr) {}
+
+            void visit_FunctionCall(const ASR::FunctionCall_t& x) {
+                ASR::FunctionCall_t* func_call = (ASR::FunctionCall_t*)(&x);
+                if (scope->counter == correct_scope->counter) {
+                    std::string func_call_name = ASRUtils::symbol_name(func_call->m_name);
+                    ASR::symbol_t* sym = correct_scope->resolve_symbol(func_call_name);
+                    if (sym) {
+                        func_call->m_name = correct_scope->resolve_symbol(func_call_name);
+                    }
+                    std::string func_call_origin_name = ASRUtils::symbol_name(func_call->m_original_name);
+                    sym = correct_scope->resolve_symbol(func_call_origin_name);
+                    if (sym) {
+                        func_call->m_original_name = correct_scope->resolve_symbol(func_call_origin_name);
+                    }
+                }
+                for (size_t i=0; i<x.n_args; i++) {
+                    this->visit_call_arg(x.m_args[i]);
+                }
+                this->visit_ttype(*x.m_type);
+                if (x.m_value) {
+                    this->visit_expr(*x.m_value);
+                }
+                if (x.m_dt) {
+                    this->visit_expr(*x.m_dt);
+                }
+            }
+
+            void visit_Var(const ASR::Var_t& x) {
+                if (scope && scope->counter == correct_scope->counter) {
+                    ASR::Var_t* var = (ASR::Var_t*)(&x);
+                    ASR::symbol_t* sym = var->m_v;
+                    std::string sym_name = ASRUtils::symbol_name(sym);
+
+                    ASR::symbol_t* sym_in_scope = scope->resolve_symbol(sym_name);
+                    var->m_v = sym_in_scope;
+                }
+            }
+
+            void visit_Function(const ASR::Function_t& x) {
+                ASR::Function_t* func = (ASR::Function_t*)(&x);
+                SymbolTable* parent_scope = scope;
+                scope = func->m_symtab;
+                if (func->m_symtab->counter == correct_scope->counter) {
+                    for (size_t i = 0; i < func->n_body; i++) {
+                        this->visit_stmt(*func->m_body[i]);
+                    }
+                    this->visit_expr(*func->m_return_var);
+                }
+                scope = parent_scope;
+                for (auto &item: func->m_symtab->get_scope()) {
+                    this->visit_symbol(*item.second);
+                }
+            }
+        };
+        
+        UpdateDuplicatedNodes v(al);
+        v.correct_scope = current_scope;
+        SymbolTable *tu_symtab = ASRUtils::get_tu_symtab(current_scope);
+        ASR::asr_t* asr_ = tu_symtab->asr_owner;
+        ASR::TranslationUnit_t* tu = ASR::down_cast2<ASR::TranslationUnit_t>(asr_);
+        v.visit_TranslationUnit(*tu);
     }
 
     void visit_Subroutine(const AST::Subroutine_t &x) {

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1600,7 +1600,9 @@ public:
                     for (size_t i = 0; i < func->n_body; i++) {
                         this->visit_stmt(*func->m_body[i]);
                     }
-                    this->visit_expr(*func->m_return_var);
+                    if (func->m_return_var) {
+                        this->visit_expr(*func->m_return_var);
+                    }
                 }
                 scope = parent_scope;
                 for (auto &item: func->m_symtab->get_scope()) {

--- a/tests/reference/asr-entry_05-f368f0e.json
+++ b/tests/reference/asr-entry_05-f368f0e.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-entry_05-f368f0e",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/entry_05.f90",
+    "infile_hash": "6ba013faf5b219ebe9941b538cdb0e7566fcd7389ab49f3e09971eeb",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-entry_05-f368f0e.stdout",
+    "stdout_hash": "cd08f320db5607cb1df88951a59eebef9db33930fff4d7cfee246f9f",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-entry_05-f368f0e.stdout
+++ b/tests/reference/asr-entry_05-f368f0e.stdout
@@ -1,0 +1,620 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            dstzr:
+                (Function
+                    (SymbolTable
+                        89
+                        {
+                            abstol:
+                                (Variable
+                                    89
+                                    abstol
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ftol:
+                                (Function
+                                    (SymbolTable
+                                        90
+                                        {
+                                            ftol_return_var_name:
+                                                (Variable
+                                                    90
+                                                    ftol_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            max:
+                                                (ExternalSymbol
+                                                    90
+                                                    max
+                                                    6 max
+                                                    lfortran_intrinsic_math2
+                                                    []
+                                                    max
+                                                    Private
+                                                ),
+                                            max@dmax:
+                                                (ExternalSymbol
+                                                    90
+                                                    max@dmax
+                                                    6 dmax
+                                                    lfortran_intrinsic_math2
+                                                    []
+                                                    dmax
+                                                    Private
+                                                ),
+                                            zx:
+                                                (Variable
+                                                    90
+                                                    zx
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    ftol
+                                    (FunctionType
+                                        [(Real 8)]
+                                        (Real 8)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [max@dmax]
+                                    [(Var 90 zx)]
+                                    [(=
+                                        (Var 90 ftol_return_var_name)
+                                        (RealBinOp
+                                            (RealConstant
+                                                0.500000
+                                                (Real 8)
+                                            )
+                                            Mul
+                                            (FunctionCall
+                                                90 max@dmax
+                                                90 max
+                                                [((Var 89 abstol))
+                                                ((RealBinOp
+                                                    (Var 89 reltol)
+                                                    Mul
+                                                    (IntrinsicFunction
+                                                        Abs
+                                                        [(Var 90 zx)]
+                                                        0
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                ))]
+                                                (Real 8)
+                                                ()
+                                                ()
+                                            )
+                                            (Real 8)
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 90 ftol_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            n:
+                                (Variable
+                                    89
+                                    n
+                                    []
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            r:
+                                (Variable
+                                    89
+                                    r
+                                    [n]
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (Var 89 n))]
+                                        PointerToDataArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            reltol:
+                                (Variable
+                                    89
+                                    reltol
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            zx:
+                                (Variable
+                                    89
+                                    zx
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    dstzr
+                    (FunctionType
+                        []
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    []
+                    []
+                    [(Return)]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            dzror:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            abstol:
+                                (Variable
+                                    2
+                                    abstol
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ftol:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            ftol_return_var_name:
+                                                (Variable
+                                                    4
+                                                    ftol_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            max:
+                                                (ExternalSymbol
+                                                    4
+                                                    max
+                                                    6 max
+                                                    lfortran_intrinsic_math2
+                                                    []
+                                                    max
+                                                    Private
+                                                ),
+                                            max@dmax:
+                                                (ExternalSymbol
+                                                    4
+                                                    max@dmax
+                                                    6 dmax
+                                                    lfortran_intrinsic_math2
+                                                    []
+                                                    dmax
+                                                    Private
+                                                ),
+                                            zx:
+                                                (Variable
+                                                    4
+                                                    zx
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    ftol
+                                    (FunctionType
+                                        [(Real 8)]
+                                        (Real 8)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                    )
+                                    [max@dmax]
+                                    [(Var 4 zx)]
+                                    [(=
+                                        (Var 4 ftol_return_var_name)
+                                        (RealBinOp
+                                            (RealConstant
+                                                0.500000
+                                                (Real 8)
+                                            )
+                                            Mul
+                                            (FunctionCall
+                                                4 max@dmax
+                                                4 max
+                                                [((Var 2 abstol))
+                                                ((RealBinOp
+                                                    (Var 2 reltol)
+                                                    Mul
+                                                    (IntrinsicFunction
+                                                        Abs
+                                                        [(Var 4 zx)]
+                                                        0
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                ))]
+                                                (Real 8)
+                                                ()
+                                                ()
+                                            )
+                                            (Real 8)
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 4 ftol_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            n:
+                                (Variable
+                                    2
+                                    n
+                                    []
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            r:
+                                (Variable
+                                    2
+                                    r
+                                    [n]
+                                    Unspecified
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (Var 2 n))]
+                                        PointerToDataArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            reltol:
+                                (Variable
+                                    2
+                                    reltol
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            zx:
+                                (Variable
+                                    2
+                                    zx
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    dzror
+                    (FunctionType
+                        [(Integer 4)
+                        (Array
+                            (Real 4)
+                            [((IntegerConstant 1 (Integer 4))
+                            (FunctionParam
+                                0
+                                (Integer 4)
+                                ()
+                            ))]
+                            PointerToDataArray
+                        )]
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                    )
+                    []
+                    [(Var 2 n)
+                    (Var 2 r)]
+                    [(=
+                        (Var 2 r)
+                        (RealUnaryMinus
+                            (RealConstant
+                                83.030000
+                                (Real 4)
+                            )
+                            (Real 4)
+                            (RealConstant
+                                -83.030000
+                                (Real 4)
+                            )
+                        )
+                        ()
+                    )
+                    (Return)]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            entry_05:
+                (Program
+                    (SymbolTable
+                        3
+                        {
+                            i:
+                                (Variable
+                                    3
+                                    i
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            r:
+                                (Variable
+                                    3
+                                    r
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 10 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    entry_05
+                    []
+                    [(SubroutineCall
+                        1 dzror
+                        ()
+                        [((IntegerConstant 10 (Integer 4)))
+                        ((ArrayPhysicalCast
+                            (Var 3 r)
+                            FixedSizeArray
+                            PointerToDataArray
+                            (Array
+                                (Real 4)
+                                [((IntegerConstant 1 (Integer 4))
+                                (IntegerConstant 10 (Integer 4)))]
+                                PointerToDataArray
+                            )
+                            ()
+                        ))]
+                        ()
+                    )
+                    (DoLoop
+                        ()
+                        ((Var 3 i)
+                        (IntegerConstant 1 (Integer 4))
+                        (IntegerConstant 10 (Integer 4))
+                        ())
+                        [(If
+                            (RealCompare
+                                (IntrinsicFunction
+                                    Abs
+                                    [(RealBinOp
+                                        (ArrayItem
+                                            (Var 3 r)
+                                            [(()
+                                            (Var 3 i)
+                                            ())]
+                                            (Real 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        Sub
+                                        (RealUnaryMinus
+                                            (RealConstant
+                                                83.030000
+                                                (Real 4)
+                                            )
+                                            (Real 4)
+                                            (RealConstant
+                                                -83.030000
+                                                (Real 4)
+                                            )
+                                        )
+                                        (Real 4)
+                                        ()
+                                    )]
+                                    0
+                                    (Real 4)
+                                    ()
+                                )
+                                Gt
+                                (RealConstant
+                                    0.000000
+                                    (Real 4)
+                                )
+                                (Logical 4)
+                                ()
+                            )
+                            [(ErrorStop
+                                ()
+                            )]
+                            []
+                        )]
+                    )
+                    (Print
+                        ()
+                        [(Var 3 r)]
+                        ()
+                        ()
+                    )]
+                ),
+            iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
+            lfortran_intrinsic_builtin:
+                (IntrinsicModule lfortran_intrinsic_builtin),
+            lfortran_intrinsic_math2:
+                (IntrinsicModule lfortran_intrinsic_math2),
+            lfortran_intrinsic_math3:
+                (IntrinsicModule lfortran_intrinsic_math3)
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2495,6 +2495,10 @@ filename = "../integration_tests/entry_02.f90"
 asr = true
 
 [[test]]
+filename = "../integration_tests/entry_05.f90"
+asr = true
+
+[[test]]
 filename = "issue532.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
Fixes #1869. Fixes #1913.
This will work for updating nodes of statement functions, but I am not sure about updating the types of variables. The correct fix will be to store AST nodes and redeclare it for entry functions.