### PR TITLE
Fix intrinsic All

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -459,6 +459,7 @@ RUN(NAME intrinsics_55 LABELS gfortran llvm NOFAST) #min
 RUN(NAME intrinsics_56 LABELS gfortran llvm)
 RUN(NAME intrinsics_57 LABELS gfortran llvm)
 RUN(NAME intrinsics_58 LABELS gfortran llvm) # sign
+RUN(NAME intrinsics_59 LABELS gfortran llvm) # all
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_59.f90
+++ b/integration_tests/intrinsics_59.f90
@@ -1,0 +1,21 @@
+program intrinsics_59
+    implicit none
+
+    logical :: a(3) = [.true., .true., .false.]
+    logical :: x(2, 2)
+
+    print *, all(a)
+    if (all(a)) error stop
+
+    a = [.true., .true., .true.]
+    print *, all(a)
+    if (.not. all(a)) error stop
+
+    x(1, 1) = .true.
+    x(1, 2) = .true.
+    x(2, 1) = .true.
+    x(2, 2) = .false.
+
+    print *, all(x)
+    if (all(x)) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4256,40 +4256,6 @@ public:
             func_args.size(), type, nullptr, nullptr);
     }
 
-    ASR::asr_t* create_ArrayAll(const AST::FuncCallOrArray_t& x) {
-        Vec<ASR::expr_t*> args;
-        std::vector<std::string> kwarg_names = {"dim"};
-        handle_intrinsic_node_args(x, args, kwarg_names, 1, 2, "all");
-        ASR::expr_t *mask = args[0], *dim = args[1];
-        ASR::expr_t* value = nullptr;
-        // TODO: Use dim to compute the `value`
-        ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, 4));
-        if (ASR::is_a<ASR::ArrayConstant_t>(*mask)) {
-            ASR::ArrayConstant_t *array = ASR::down_cast<ASR::ArrayConstant_t>(mask);
-            bool result = true;
-            value = ASRUtils::EXPR(ASR::make_LogicalConstant_t(al,
-                array->base.base.loc, result, type));
-            for (size_t i = 0; i < array->n_args; i++) {
-                ASR::expr_t *args_value = ASRUtils::expr_value(array->m_args[i]);
-                if (args_value && ASR::is_a<ASR::LogicalConstant_t>(*args_value)) {
-                    if (result) {
-                        result = ASR::down_cast<ASR::LogicalConstant_t>(
-                            args_value)->m_value;
-                    }
-                } else {
-                    // TODO: Handle other expressions
-                    result = true; value = nullptr;
-                    break;
-                }
-            }
-            if (!result) {
-                value = ASRUtils::EXPR(ASR::make_LogicalConstant_t(al,
-                    array->base.base.loc, false, type));
-            }
-        }
-        return ASR::make_ArrayAll_t(al, x.base.base.loc, mask, dim, type, value);
-    }
-
     std::vector<IntrinsicSignature> get_intrinsic_signature(std::string& var_name) {
         if( name2signature.find(var_name) == name2signature.end() ) {
             return {IntrinsicSignature({}, 1, 1)};
@@ -4381,8 +4347,6 @@ public:
                 tmp = create_Associated(x);
             } else if( var_name == "_lfortran_sqrt" ) {
                 tmp = create_IntrinsicFunctionSqrt(x);
-            } else if( var_name == "all" ) {
-                tmp = create_ArrayAll(x);
             } else {
                 throw LCompilersException("create_" + var_name + " not implemented yet.");
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -712,6 +712,7 @@ public:
 
     std::map<std::string, std::vector<IntrinsicSignature>> name2signature = {
         {"any", {IntrinsicSignature({"dim"}, 1, 2)}},
+        {"all", {IntrinsicSignature({"dim"}, 1, 2)}},
         {"sum", {IntrinsicSignature({"dim", "mask"}, 1, 3),
                  IntrinsicSignature({"mask"}, 1, 2)}},
         {"product", {IntrinsicSignature({"dim", "mask"}, 1, 3),

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -2034,7 +2034,7 @@ static inline void verify_args(const ASR::IntrinsicFunction_t& x, diag::Diagnost
                     "mask argument cannot be nullptr", x.base.base.loc, diagnostics);
             }
             ASRUtils::require_impl(x.n_args >= 2 && x.m_args[1] != nullptr,
-                "dim argument to any intrinsic cannot be nullptr",
+                "dim argument to " + intrinsic_func_name + " intrinsic cannot be nullptr",
                 x.base.base.loc, diagnostics);
             verify_array_dim(x.m_args[0], x.m_args[1], x.m_type, x.base.base.loc, diagnostics, intrinsic_func_id);
             break;

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -432,17 +432,10 @@ class ASRBuilder {
     }
 
     ASR::expr_t* ElementalOr(ASR::expr_t* left, ASR::expr_t* right,
-        const Location& loc) {
+        const Location& loc, ASR::expr_t* value=nullptr) {
         return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,
             left, ASR::Or, right,
-            ASRUtils::TYPE(ASR::make_Logical_t( al, loc, 4)), nullptr));
-    }
-
-    ASR::expr_t* Or(ASR::expr_t* left, ASR::expr_t* right,
-        const Location& loc) {
-        return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,
-            left, ASR::Or, right, ASRUtils::expr_type(left),
-            nullptr));
+            ASRUtils::TYPE(ASR::make_Logical_t( al, loc, 4)), value));
     }
 
     ASR::expr_t* Call(ASR::symbol_t* s, Vec<ASR::call_arg_t>& args,
@@ -1525,7 +1518,7 @@ static inline void generate_body_for_scalar_output(Allocator& al, const Location
         },
         [=, &al, &idx_vars, &doloop_body, &builder] () {
             ASR::expr_t* array_ref = PassUtils::create_array_ref(array, idx_vars, al);
-            ASR::expr_t* logical_or = builder.Or(return_var, array_ref, loc);
+            ASR::expr_t* logical_or = builder.ElementalOr(return_var, array_ref, loc);
             ASR::stmt_t* loop_invariant = Assignment(return_var, logical_or);
             doloop_body.push_back(al, loop_invariant);
         }

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1673,6 +1673,34 @@ static inline ASR::expr_t* instantiate_ArrIntrinAnyAll(Allocator &al, const Loca
 
 } // namespace ArrIntrinAnyAll
 
+namespace Any {
+
+static inline void verify_args(const ASR::IntrinsicFunction_t& x, diag::Diagnostics& diagnostics) {
+    ArrIntrinAnyAll::verify_args(x, diagnostics, ASRUtils::IntrinsicFunctions::Any);
+}
+
+static inline ASR::expr_t *eval_Any(Allocator & /*al*/,
+    const Location & /*loc*/, Vec<ASR::expr_t*>& /*args*/) {
+    return nullptr;
+}
+
+static inline ASR::asr_t* create_Any(
+    Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args,
+    const std::function<void (const std::string &, const Location &)> err) {
+    return ArrIntrinAnyAll::create_ArrIntrinAnyAll(al, loc, args, err, ASRUtils::IntrinsicFunctions::Any);
+}
+
+static inline ASR::expr_t* instantiate_Any(Allocator &al, const Location &loc,
+    SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types,
+    Vec<ASR::call_arg_t>& new_args, int64_t overload_id,
+    ASR::expr_t* compile_time_value) {
+    return ArrIntrinAnyAll::instantiate_ArrIntrinAnyAll(al, loc, scope, arg_types, new_args,
+        overload_id, compile_time_value, ASRUtils::IntrinsicFunctions::Any,
+        make_ConstantWithKind(make_LogicalConstant_t, make_Logical_t, false, 4, loc), &ASRUtils::ASRBuilder::ElementalOr);
+}
+
+} // namespace Any
+
 namespace Max {
     static inline void verify_args(const ASR::IntrinsicFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args > 1, "ASR Verify: Call to max0 must have at least two arguments",

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1758,15 +1758,6 @@ LFORTRAN_API int32_t _lfortran_iachar(char *c) {
     return (int32_t) c[0];
 }
 
-LFORTRAN_API int32_t _lfortran_all(bool *mask, int32_t n) {
-    for (size_t i = 0; i < n; i++) {
-        if (!mask[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
 // Command line arguments
 int32_t _argc;
 char **_argv;

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -257,7 +257,6 @@ LFORTRAN_API void _lpython_close(int64_t fd);
 LFORTRAN_API void _lfortran_close(int32_t unit_num);
 LFORTRAN_API int32_t _lfortran_ichar(char *c);
 LFORTRAN_API int32_t _lfortran_iachar(char *c);
-LFORTRAN_API int32_t _lfortran_all(bool *mask, int32_t n);
 LFORTRAN_API void _lpython_set_argv(int32_t argc_1, char *argv_1[]);
 LFORTRAN_API int32_t _lpython_get_argc();
 LFORTRAN_API char *_lpython_get_argv(int32_t index);

--- a/tests/reference/asr-intrinsics_35-10733ec.json
+++ b/tests/reference/asr-intrinsics_35-10733ec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_35-10733ec.stdout",
-    "stdout_hash": "e5022dd861ea443b2476234945be82adaf6e2d96569f074bcc069184",
+    "stdout_hash": "06eacb7ff5e31aef7f6f09a2ff47ed00c57ecbd10f1997fcc2521359",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_35-10733ec.stdout
+++ b/tests/reference/asr-intrinsics_35-10733ec.stdout
@@ -254,7 +254,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )

--- a/tests/reference/asr-intrinsics_47-bdbe527.json
+++ b/tests/reference/asr-intrinsics_47-bdbe527.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_47-bdbe527.stdout",
-    "stdout_hash": "f1809524bf0241f8fb54dc882bbada57baeec3db1f0151f02411b6ce",
+    "stdout_hash": "290ec1a299515e54624f2fc22a7a53ea45381e5217e4991bdcbf9680",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_47-bdbe527.stdout
+++ b/tests/reference/asr-intrinsics_47-bdbe527.stdout
@@ -74,25 +74,37 @@
                                     l
                                     []
                                     Local
-                                    (ArrayAll
-                                        (ArrayConstant
-                                            [(LogicalConstant
-                                                .true.
-                                                (Logical 4)
+                                    (IntrinsicFunction
+                                        All
+                                        [(ArrayPhysicalCast
+                                            (ArrayConstant
+                                                [(LogicalConstant
+                                                    .true.
+                                                    (Logical 4)
+                                                )
+                                                (LogicalConstant
+                                                    .true.
+                                                    (Logical 4)
+                                                )]
+                                                (Array
+                                                    (Logical 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    FixedSizeArray
+                                                )
+                                                ColMajor
                                             )
-                                            (LogicalConstant
-                                                .true.
-                                                (Logical 4)
-                                            )]
+                                            FixedSizeArray
+                                            DescriptorArray
                                             (Array
                                                 (Logical 4)
                                                 [((IntegerConstant 1 (Integer 4))
                                                 (IntegerConstant 2 (Integer 4)))]
-                                                FixedSizeArray
+                                                DescriptorArray
                                             )
-                                            ColMajor
-                                        )
-                                        ()
+                                            ()
+                                        )]
+                                        0
                                         (Logical 4)
                                         (LogicalConstant
                                             .true.
@@ -116,25 +128,37 @@
                     []
                     [(=
                         (Var 2 l)
-                        (ArrayAll
-                            (ArrayConstant
-                                [(LogicalConstant
-                                    .true.
-                                    (Logical 4)
+                        (IntrinsicFunction
+                            All
+                            [(ArrayPhysicalCast
+                                (ArrayConstant
+                                    [(LogicalConstant
+                                        .true.
+                                        (Logical 4)
+                                    )
+                                    (LogicalConstant
+                                        .false.
+                                        (Logical 4)
+                                    )]
+                                    (Array
+                                        (Logical 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 2 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ColMajor
                                 )
-                                (LogicalConstant
-                                    .false.
-                                    (Logical 4)
-                                )]
+                                FixedSizeArray
+                                DescriptorArray
                                 (Array
                                     (Logical 4)
                                     [((IntegerConstant 1 (Integer 4))
                                     (IntegerConstant 2 (Integer 4)))]
-                                    FixedSizeArray
+                                    DescriptorArray
                                 )
-                                ColMajor
-                            )
-                            ()
+                                ()
+                            )]
+                            0
                             (Logical 4)
                             (LogicalConstant
                                 .false.
@@ -145,21 +169,33 @@
                     )
                     (=
                         (Var 2 l)
-                        (ArrayAll
-                            (ArrayConstant
-                                [(LogicalConstant
-                                    .false.
-                                    (Logical 4)
-                                )]
+                        (IntrinsicFunction
+                            All
+                            [(ArrayPhysicalCast
+                                (ArrayConstant
+                                    [(LogicalConstant
+                                        .false.
+                                        (Logical 4)
+                                    )]
+                                    (Array
+                                        (Logical 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 1 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ColMajor
+                                )
+                                FixedSizeArray
+                                DescriptorArray
                                 (Array
                                     (Logical 4)
                                     [((IntegerConstant 1 (Integer 4))
                                     (IntegerConstant 1 (Integer 4)))]
-                                    FixedSizeArray
+                                    DescriptorArray
                                 )
-                                ColMajor
-                            )
-                            ()
+                                ()
+                            )]
+                            0
                             (Logical 4)
                             (LogicalConstant
                                 .false.
@@ -170,21 +206,33 @@
                     )
                     (=
                         (Var 2 l)
-                        (ArrayAll
-                            (ArrayConstant
-                                [(LogicalConstant
-                                    .true.
-                                    (Logical 4)
-                                )]
+                        (IntrinsicFunction
+                            All
+                            [(ArrayPhysicalCast
+                                (ArrayConstant
+                                    [(LogicalConstant
+                                        .true.
+                                        (Logical 4)
+                                    )]
+                                    (Array
+                                        (Logical 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 1 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ColMajor
+                                )
+                                FixedSizeArray
+                                DescriptorArray
                                 (Array
                                     (Logical 4)
                                     [((IntegerConstant 1 (Integer 4))
                                     (IntegerConstant 1 (Integer 4)))]
-                                    FixedSizeArray
+                                    DescriptorArray
                                 )
-                                ColMajor
-                            )
-                            ()
+                                ()
+                            )]
+                            0
                             (Logical 4)
                             (LogicalConstant
                                 .true.
@@ -195,9 +243,21 @@
                     )
                     (=
                         (Var 2 l)
-                        (ArrayAll
-                            (Var 2 a)
-                            ()
+                        (IntrinsicFunction
+                            All
+                            [(ArrayPhysicalCast
+                                (Var 2 a)
+                                FixedSizeArray
+                                DescriptorArray
+                                (Array
+                                    (Logical 4)
+                                    [((IntegerConstant 1 (Integer 4))
+                                    (IntegerConstant 3 (Integer 4)))]
+                                    DescriptorArray
+                                )
+                                ()
+                            )]
+                            0
                             (Logical 4)
                             ()
                         )
@@ -205,37 +265,49 @@
                     )
                     (=
                         (Var 2 l)
-                        (ArrayAll
-                            (ArrayConstant
-                                [(IntegerCompare
-                                    (IntegerConstant 1 (Integer 4))
-                                    Eq
-                                    (IntegerConstant 2 (Integer 4))
-                                    (Logical 4)
-                                    (LogicalConstant
-                                        .false.
+                        (IntrinsicFunction
+                            All
+                            [(ArrayPhysicalCast
+                                (ArrayConstant
+                                    [(IntegerCompare
+                                        (IntegerConstant 1 (Integer 4))
+                                        Eq
+                                        (IntegerConstant 2 (Integer 4))
                                         (Logical 4)
+                                        (LogicalConstant
+                                            .false.
+                                            (Logical 4)
+                                        )
                                     )
+                                    (IntegerCompare
+                                        (IntegerConstant 0 (Integer 4))
+                                        Eq
+                                        (IntegerConstant 0 (Integer 4))
+                                        (Logical 4)
+                                        (LogicalConstant
+                                            .true.
+                                            (Logical 4)
+                                        )
+                                    )]
+                                    (Array
+                                        (Logical 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 2 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ColMajor
                                 )
-                                (IntegerCompare
-                                    (IntegerConstant 0 (Integer 4))
-                                    Eq
-                                    (IntegerConstant 0 (Integer 4))
-                                    (Logical 4)
-                                    (LogicalConstant
-                                        .true.
-                                        (Logical 4)
-                                    )
-                                )]
+                                FixedSizeArray
+                                DescriptorArray
                                 (Array
                                     (Logical 4)
                                     [((IntegerConstant 1 (Integer 4))
                                     (IntegerConstant 2 (Integer 4)))]
-                                    FixedSizeArray
+                                    DescriptorArray
                                 )
-                                ColMajor
-                            )
-                            ()
+                                ()
+                            )]
+                            0
                             (Logical 4)
                             (LogicalConstant
                                 .false.

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "d1d2553c5bbeaace7a5800f4c8356599fb573682c685b4fb76daed22",
+    "stdout_hash": "54af10513e22ae4071f42f46060a40c543bc343d5ded1b3d6fc1af1b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -10,11 +10,11 @@ source_filename = "LFortran"
 
 @0 = private unnamed_addr constant [1 x i8] zeroinitializer, align 1
 
-define i1 @any_4_1_0(%array* %mask) {
+define i1 @Any_4_1_0(%array* %mask) {
 .entry:
+  %Any_4_1_0 = alloca i1, align 1
   %__1_i = alloca i32, align 4
-  %any_4_1_0 = alloca i1, align 1
-  store i1 false, i1* %any_4_1_0, align 1
+  store i1 false, i1* %Any_4_1_0, align 1
   %0 = getelementptr %array, %array* %mask, i32 0, i32 2
   %1 = load %dimension_descriptor*, %dimension_descriptor** %0, align 8
   %2 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1, i32 0
@@ -43,7 +43,7 @@ loop.body:                                        ; preds = %loop.head
   %18 = load i32, i32* %__1_i, align 4
   %19 = add i32 %18, 1
   store i32 %19, i32* %__1_i, align 4
-  %20 = load i1, i1* %any_4_1_0, align 1
+  %20 = load i1, i1* %Any_4_1_0, align 1
   %21 = load i32, i32* %__1_i, align 4
   %22 = getelementptr %array, %array* %mask, i32 0, i32 2
   %23 = load %dimension_descriptor*, %dimension_descriptor** %22, align 8
@@ -76,14 +76,14 @@ else:                                             ; preds = %loop.body
 
 ifcont:                                           ; preds = %else, %then
   %41 = load i1, i1* %40, align 1
-  store i1 %41, i1* %any_4_1_0, align 1
+  store i1 %41, i1* %Any_4_1_0, align 1
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br label %return
 
 return:                                           ; preds = %loop.end
-  %42 = load i1, i1* %any_4_1_0, align 1
+  %42 = load i1, i1* %Any_4_1_0, align 1
   ret i1 %42
 }
 
@@ -172,7 +172,7 @@ loop.end:                                         ; preds = %ifcont4
   store i32 1, i32* %32, align 4
   store i32 1, i32* %33, align 4
   store i32 2, i32* %34, align 4
-  %35 = call i1 @any_4_1_0(%array* %array_descriptor)
+  %35 = call i1 @Any_4_1_0(%array* %array_descriptor)
   %36 = load i1, i1* %toomany, align 1
   %37 = load i1, i1* %test, align 1
   %38 = xor i1 %37, true


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/1970

On branch:
```bash
$ cat examples/expr3.f90                
program expr3
implicit none

logical :: x(3) = [.true., .true., .false.]
print *, all(x)

end program
$ gfortran examples/expr3.f90 && ./a.out
 F
$ lfortran examples/expr3.f90       
False
$ cat examples/expr2.f90         
program expr2
    implicit none

    logical :: x(2, 2)
    x(1, 1) = .true.
    x(1, 2) = .true.
    x(2, 1) = .true.
    x(2, 2) = .false.

    print *, all(x)
    if (all(x)) error stop
end program
$ gfortran examples/expr2.f90 && ./a.out
 F
$ lfortran examples/expr2.f90           
False
```