### PR TITLE
Avoid verifying ``IntrinsicFunction`` if ``check_external`` is ``False``

### DIFF
--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -974,6 +974,10 @@ public:
     }
 
     void visit_IntrinsicFunction(const ASR::IntrinsicFunction_t& x) {
+        if( !check_external ) {
+            BaseWalkVisitor<VerifyVisitor>::visit_IntrinsicFunction(x);
+            return ;
+        }
         ASRUtils::verify_function verify_ = ASRUtils::IntrinsicFunctionRegistry
             ::get_verify_function(x.m_intrinsic_id);
         LCOMPILERS_ASSERT(verify_ != nullptr);

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -399,6 +399,14 @@ ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
     ASR::FixParentSymtabVisitor p;
     p.visit_TranslationUnit(*tu);
 
+#if defined(WITH_LFORTRAN_ASSERT)
+    diag::Diagnostics diagnostics;
+    if (!asr_verify(*tu, false, diagnostics)) {
+        std::cerr << diagnostics.render2();
+        throw LCompilersException("Verify failed");
+    };
+ #endif
+
     return node;
 }
 


### PR DESCRIPTION
Corresponding LPython PR - https://github.com/lcompilers/lpython/pull/2155