### PR TITLE
LLVM: Add an assert statement

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6996,6 +6996,7 @@ public:
                     } else {
                         // Must be an argument/chained procedure pass
                         tmp = llvm_symtab_fn_arg[h];
+                        LCOMPILERS_ASSERT(tmp != nullptr)
                     }
                 }
             } else if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*x.m_args[i].m_value)) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6995,6 +6995,7 @@ public:
                         tmp = llvm_symtab_fn[h];
                     } else {
                         // Must be an argument/chained procedure pass
+                        LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());
                         tmp = llvm_symtab_fn_arg[h];
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     }


### PR DESCRIPTION
To catch errors earlier.

Towards #1977.