### PR TITLE
Avoid visiting statements after return in entry function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -966,6 +966,7 @@ RUN(NAME entry_03 LABELS gfortran llvm)
 RUN(NAME entry_04 LABELS gfortran llvm)
 RUN(NAME entry_05 LABELS gfortran llvm)
 RUN(NAME entry_06 LABELS gfortran)
+RUN(NAME entry_08 LABELS gfortran llvm)
 
 RUN(NAME character_01 LABELS gfortran llvm)
 

--- a/integration_tests/entry_08.f90
+++ b/integration_tests/entry_08.f90
@@ -1,0 +1,14 @@
+subroutine dzror(status)
+   integer status
+ entry dstzr()
+   return
+   status = 8
+end subroutine
+
+program entry_08
+   integer :: status
+   status = 1
+   call dzror(status)
+   if (status /= 1) error stop
+   print *, "status = ", status
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -134,6 +134,10 @@ public:
                             }
                         }
                         stmt_vector.push_back(tmp_stmt);
+
+                        if (tmp_stmt->type == ASR::stmtType::Return) {
+                            break;
+                        }
                     } else if (!tmp_vec.empty()) {
                         for(auto &x: tmp_vec) {
                             stmt_vector.push_back(ASRUtils::STMT(x));


### PR DESCRIPTION
Fixes #1986. 
With this and #1984 we get `scipy/special/cdflib` compile to LLVM