### PR TITLE
Fix for allocatable array in ``ArrayAll``

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1258,12 +1258,11 @@ public:
         }
         ASR::ttype_t *type_ = ASRUtils::expr_type(x.m_mask);
         int64_t ptr_loads_copy = ptr_loads;
-        ptr_loads = 2 - !LLVM::is_llvm_pointer(*type_);
+        ptr_loads = 1 - !LLVM::is_llvm_pointer(*type_);
         this->visit_expr(*x.m_mask);
         ptr_loads = ptr_loads_copy;
         llvm::Value *mask = tmp;
-        LCOMPILERS_ASSERT(ASR::is_a<ASR::Logical_t>(
-            *ASRUtils::type_get_past_array(type_))) // TODO
+        LCOMPILERS_ASSERT(ASRUtils::is_logical(*type_));
         int32_t n = ASRUtils::extract_n_dims_from_ttype(type_);
         llvm::Value *size = llvm::ConstantInt::get(context, llvm::APInt(32, n));
         switch( ASRUtils::extract_physical_type(type_) ) {


### PR DESCRIPTION
```zsh
(fastgpt) 21:10:02:~/lfortran_project/fastGPT % FC=lfortran cmake -DFASTGPT_BLAS=OpenBLAS .
-- The C compiler identification is AppleClang 14.0.3.14030022
-- The CXX compiler identification is AppleClang 14.0.3.14030022
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The Fortran compiler identification is unknown
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - failed
-- Check for working Fortran compiler: /Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran
-- Check for working Fortran compiler: /Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran - works
-- Checking whether /Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran supports Fortran 90
-- Checking whether /Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran supports Fortran 90 - no
-- Found OPENBLAS: /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/System/Library/Frameworks/vecLib.framework/Headers  
-- Found OMP: /Users/czgdp1807/mambaforge/envs/fastgpt/include  


Configuration results
---------------------
Fortran compiler: /Users/czgdp1807/lfortran_project/lfortran/src/bin/lfortran
Build type: Release
Fortran compiler flags: 
Installation prefix: /usr/local
FASTGPT_BLAS: OpenBLAS
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/czgdp1807/lfortran_project/fastGPT
(fastgpt) 21:10:28:~/lfortran_project/fastGPT % make gpt2
[ 11%] Building Fortran object CMakeFiles/fastgpt.dir/linalg_c.f90.o
[ 22%] Building Fortran object CMakeFiles/fastgpt.dir/tokenizer.f90.o
[ 33%] Building Fortran object CMakeFiles/fastgpt.dir/gpt2.f90.o
[ 44%] Building Fortran object CMakeFiles/fastgpt.dir/omp.f90.o
[ 55%] Building Fortran object CMakeFiles/fastgpt.dir/driver.f90.o
[ 66%] Building C object CMakeFiles/fastgpt.dir/linalg_openblas.c.o
[ 77%] Linking Fortran static library libfastgpt.a
[ 77%] Built target fastgpt
[ 88%] Building Fortran object CMakeFiles/gpt2.dir/main.f90.o
warning: format string in read() is not implemented yet and it is currently treated as '*'
 --> /Users/czgdp1807/lfortran_project/fastGPT/main.f90:1:1
  |
1 | program gpt2
  | ^ treated as '*'


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
[100%] Linking Fortran executable gpt2
[100%] Built target gpt2
(fastgpt) 21:10:32:~/lfortran_project/fastGPT % make test_basic_input
[ 77%] Built target fastgpt
[ 88%] Building Fortran object CMakeFiles/test_basic_input.dir/tests/test_basic_input.f90.o
warning: format string in read() is not implemented yet and it is currently treated as '*'
 --> /Users/czgdp1807/lfortran_project/fastGPT/tests/test_basic_input.f90:1:1
  |
1 | program test_basic_input
  | ^ treated as '*'


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
[100%] Linking Fortran executable test_basic_input
[100%] Built target test_basic_input
(fastgpt) 21:10:38:~/lfortran_project/fastGPT % ./test_basic_input
zsh: segmentation fault  ./test_basic_input
```

Closes https://github.com/lfortran/lfortran/issues/2011