### PR TITLE
Initial support for f8.3 format

### DIFF
--- a/integration_tests/format_05.f90
+++ b/integration_tests/format_05.f90
@@ -7,7 +7,7 @@ b = 123.45678
 c = 12.34
 d = 123.45
 
-print '(-1pe10.2,-2pe15.6,1pe010.2,2x,1pe9.2)', -a, b, -c, d
+print '(-1pe10.2,-2pe15.6,1pe010.2,2x,1pe9.2,f10.3)', -a, b, -c, d, d
 write (s, '(-1pe10.2,-2pe15.6,1pe010.2,2x,1pe9.2)') -a, b, -c, d
 if (trim(s) /= " -0.01E+04   0.001235E+05 -1.23E+01   1.23E+02") error stop
 end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -411,6 +411,10 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(const char* format, ...)
             double val = va_arg(args, double);
             handle_decimal(value, val, scale, &result, "E");
             arguments++;
+        } else if (tolower(value[0]) == 'f') {
+            double val = va_arg(args, double);
+            handle_decimal(value, val, scale, &result, "E");
+            arguments++;
         } else if (strlen(value) != 0) {
             printf("Printing support is not available for %s format.\n",value);
         }


### PR DESCRIPTION
The formatting of f8.3 is not correct, but at least it prints the right number now.