### PR TITLE
CI: test full fastGPT run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -368,8 +368,8 @@ jobs:
             ldd ./test_more_inputs
 
             git clean -dfx
-            git checkout -t origin/lf8run
-            git checkout 19685587df0424e28d18a041321d717cee2b76bd
+            git checkout -t origin/lf10run
+            git checkout 09c2027d724a9985a8b7eea5a814358c65ea2200
             FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS .
             make
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat


### PR DESCRIPTION
The results agree with GFortran. There is just one change with regards to correct results:

    diff --git a/gpt2.f90 b/gpt2.f90
    index e04fec5..b3dbdd3 100644
    --- a/gpt2.f90
    +++ b/gpt2.f90
    @@ -274,7 +274,7 @@ end if
     !print *, "It fails below:"
     do j = 1, n_layer
         i = j
    -    !i = 1
    +    i = 1
     !    print *, i ! Never gets printed
         call transformer_block(n_seq, n_seq_x, n_embd, x, &
             mlp_fc_w(:,:,i), mlp_fc_b(:,i), &

Without it LFortran has a bug while passing `A(:,i)` as an argument, only `i=1` works, higher `i` fail.