### PR TITLE
Add support for modifier constant

### DIFF
--- a/grammar/AST.asdl
+++ b/grammar/AST.asdl
@@ -290,6 +290,7 @@ simple_attribute
     | AttrAllocatable
     | AttrAsynchronous
     | AttrCommon
+    | AttrConstant
     | AttrContiguous
     | AttrDeferred
     | AttrElemental

--- a/integration_tests/template_add_04b.f90
+++ b/integration_tests/template_add_04b.f90
@@ -1,0 +1,60 @@
+module template_add_04_m
+  implicit none
+  private
+  public :: add_t
+
+  requirement R(T, F)
+      type, deferred :: T
+      function F(x, y) result(z)
+          type(T), intent(in) :: x, y
+          type(T) :: z
+      end function
+  end requirement
+
+  template add_t(T, F, mult)
+      requires R(T, F)
+      integer, constant :: mult
+      private
+      public :: add_generic
+  contains
+      function add_generic(x, y) result(z)
+          type(T), intent(in) :: x, y
+          type(T) :: z
+          integer :: i
+          z = F(x, y)
+          do i = 1,mult-1
+              z = F(z, F(x,y))
+          end do
+      end function
+  end template
+
+contains
+
+  real function func_arg_real(x, y) result(z)
+      real, intent(in) :: x, y
+      z = x + y
+  end function
+
+  integer function func_arg_int(x, y) result(z)
+      integer, intent(in) :: x, y
+      z = x + y
+  end function
+
+  subroutine test_template()
+      integer :: n = 5
+      instantiate add_t(real, func_arg_real, n), only: add_real => add_generic
+      real :: x, y
+      integer :: a, b
+      x = 5.1
+      y = 7.2
+      print*, "The result is ", add_real(x, y)
+  end subroutine
+end module
+
+program template_add_04
+use template_add_04_m
+implicit none
+
+call test_template()
+
+end program

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -159,6 +159,7 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %token <string> KW_COMMON
 %token <string> KW_COMPLEX
 %token <string> KW_CONCURRENT
+%token <string> KW_CONSTANT
 %token <string> KW_CONTAINS
 %token <string> KW_CONTIGUOUS
 %token <string> KW_CONTINUE
@@ -1354,6 +1355,7 @@ var_modifier_list
 
 var_modifier
     : KW_PARAMETER { $$ = SIMPLE_ATTR(Parameter, @$); }
+    | KW_CONSTANT { $$ = SIMPLE_ATTR(Constant, @$); }
     | KW_DIMENSION "(" array_comp_decl_list ")" { $$ = DIMENSION($3, @$); }
     | KW_DIMENSION { $$ = DIMENSION0(@$); }
     | KW_CODIMENSION "[" coarray_comp_decl_list "]" { $$ = CODIMENSION($3, @$); }

--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -271,6 +271,7 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
             'common' { KW(COMMON) }
             'complex' { KW(COMPLEX) }
             'concurrent' { KW(CONCURRENT) }
+            'constant' { KW(CONSTANT) }
             'contains' { KW(CONTAINS) }
             'contiguous' { KW(CONTIGUOUS) }
             'continue' { KW(CONTINUE) }


### PR DESCRIPTION
The modifier `constant` is not yet supported. Extended the parser, but the modifier is not yet processed.