### PR TITLE
CPP Preprocessor remove cpp comments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -35,7 +35,7 @@ message("LFORTRAN_BACKEND: ${LFORTRAN_BACKEND}")
 message("FAST: ${FAST}")
 
 
-macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
+macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
     set(fail ${${RUN_FAIL}})
     set(name ${${RUN_NAME}})
     set(file_name ${${RUN_FILE_NAME}})
@@ -43,6 +43,7 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
     set(extra_files ${${RUN_EXTRAFILES}})
     set(extra_args ${${RUN_EXTRA_ARGS}})
     set(copy_to_bin ${${RUN_COPY_TO_BIN}})
+    set(gfortran_args ${${RUN_GFORTRAN_ARGS}})
 
     if (NOT name)
         message(FATAL_ERROR "Must specify the NAME argument")
@@ -118,10 +119,10 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         else ()
             if ("gfortranImplicitArgument" IN_LIST labels)
-                set(extra_args ${extra_args} -fallow-argument-mismatch)
+                set(gfortran_args ${extra_args} -fallow-argument-mismatch)
             endif()
             add_executable(${name} ${file_name}.f90 ${extra_files})
-            target_compile_options(${name} PUBLIC ${extra_args})
+            target_compile_options(${name} PUBLIC ${gfortran_args})
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         endif()
 
@@ -140,30 +141,37 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
 endmacro(RUN_UTIL)
 
 macro(RUN)
-    set(options FAIL NOFAST)
-    set(oneValueArgs NAME INCLUDE_PATH COPY_TO_BIN)
+    set(options FAIL NOFAST CPP_PRE)
+    set(oneValueArgs NAME INCLUDE_PATH  COPY_TO_BIN)
     set(multiValueArgs LABELS EXTRAFILES)
     cmake_parse_arguments(RUN "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN} )
 
     set(RUN_EXTRA_ARGS "")
     set(RUN_FILE_NAME ${RUN_NAME})
+    set(RUN_GFORTRAN_ARGS "")
 
     if (RUN_INCLUDE_PATH)
         # Only one include path supported for now
         # Later add support for multiple include paths by looping over and appending to extra args
         set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} -I${CMAKE_CURRENT_SOURCE_DIR}/${RUN_INCLUDE_PATH})
+        set(RUN_GFORTRAN_ARGS ${RUN_GFORTRAN_ARGS} -I${CMAKE_CURRENT_SOURCE_DIR}/${RUN_INCLUDE_PATH})
+    endif()
+
+    if (RUN_CPP_PRE)
+        set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} "--cpp")
+        set(RUN_GFORTRAN_ARGS ${RUN_GFORTRAN_ARGS} "-cpp")
     endif()
 
     if (NOT FAST)
-        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
+        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
     endif()
 
     if ((FAST) AND (NOT RUN_NOFAST))
         set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} --fast)
         set(RUN_NAME "${RUN_NAME}_FAST")
         list(REMOVE_ITEM RUN_LABELS gfortran) # remove gfortran from --fast test
-        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
+        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
     endif()
 endmacro(RUN)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1016,3 +1016,5 @@ RUN(NAME arrayitem_01 LABELS gfortran llvm)
 RUN(NAME implicit_argument_casting_01 LABELS gfortranImplicitArgument llvmImplicitArgument)
 
 RUN(NAME specfun_01 LABELS gfortran llvmUseLoopVariableAfterLoop NOFAST)
+
+RUN(NAME cpp_pre_01 LABELS gfortran llvm c CPP_PRE)

--- a/integration_tests/cpp_pre_01.f90
+++ b/integration_tests/cpp_pre_01.f90
@@ -1,0 +1,19 @@
+! File test.f90
+program test
+#ifdef SOMETHING
+#endif // This should work
+
+# define square(a) /* This should be ignored as well */ a * a
+#define abc "ABC"
+    integer :: a = 10 /*
+    hi*/
+
+    /*
+        This is a multi-line comment
+        line 2*** /**
+        line 3
+    */
+    print *, /*hi, "abc\n"*/ square(a), "hi /* abc*/  //abc"
+    print *, "asdjfal" // "djafl"
+    print *, abc
+end program test

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -192,7 +192,8 @@ Result<LFortran::AST::TranslationUnit_t*> FortranEvaluator::get_ast2(
     if (compiler_options.c_preprocessor) {
         // Preprocessor
         LFortran::CPreprocessor cpp(compiler_options);
-        tmp = cpp.run(code_orig, lm, cpp.macro_definitions);
+        std::string code_without_comments = LFortran::remove_cpp_comments(code_orig);
+        tmp = cpp.run(code_without_comments, lm, cpp.macro_definitions);
         code = &tmp;
     }
     if (compiler_options.prescan || compiler_options.fixed_form) {

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -253,4 +253,57 @@ ReactDOM.render(<MyApp />, document.body);
     return file_name;
 }
 
+std::string remove_cpp_comments(const std::string& code) {
+    std::string cleanedCode;
+    bool inSingleQuote = false;
+    bool inDoubleQuote = false;
+    bool inSingleLineComment = false;
+    bool inPreprocessor = false;
+    bool inMultiLineComment = false;
+    char prevChar = '\0';
+
+    for (auto ch:code) {
+        if (!inSingleLineComment && !inMultiLineComment) {
+            if (inSingleQuote && ch == '\'' && prevChar != '\\')
+                inSingleQuote = false;
+            else if (inDoubleQuote && ch == '\"' && prevChar != '\\')
+                inDoubleQuote = false;
+            else if (!inSingleQuote && !inDoubleQuote) {
+                if (ch == '\'' && prevChar != '\\')
+                    inSingleQuote = true;
+                else if (ch == '\"' && prevChar != '\\')
+                    inDoubleQuote = true;
+                else if (ch == '/' && prevChar == '/' && inPreprocessor)
+                    inSingleLineComment = true;
+                else if (ch == '*' && prevChar == '/')
+                    inMultiLineComment = true;
+                else if (ch == '#')
+                    inPreprocessor = true;
+                else if (ch == '\n')
+                    inPreprocessor = false;
+            }
+
+            if (!inSingleLineComment && !inMultiLineComment)
+                cleanedCode += ch;
+            else if(inSingleLineComment || inMultiLineComment)
+                cleanedCode.pop_back();
+        } else {
+            if (inSingleLineComment) {
+                if (ch == '\n') {
+                    inSingleLineComment = false;
+                    inPreprocessor = false;
+                    cleanedCode += ch;
+                }
+            } else {
+                // inMultiLineComment
+                if (ch == '/' && prevChar == '*')
+                    inMultiLineComment = false;
+            }
+        }
+        prevChar = ch;
+    }
+
+    return cleanedCode;
+}
+
 } // namespace LCompilers::LFortran

--- a/src/lfortran/utils.h
+++ b/src/lfortran/utils.h
@@ -11,6 +11,7 @@ std::string get_runtime_library_dir();
 std::string get_runtime_library_header_dir();
 std::string get_runtime_library_c_header_dir();
 std::string generate_visualize_html(std::string &astr_data_json);
+std::string remove_cpp_comments(const std::string &input);
 
 } // LCompilers::LFortran
 


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/1945

```fortran
$ cat examples/expr2.f90 
! File test.f90
program test
#ifdef SOMETHING
#endif // This should work

#define square(a) /* This should be ignored as well */ a * a
    integer :: a = 10

    print*, square(a)
end program test
```
```
$ gfortran examples/expr2.f90 -cpp 
$ ./a.out 
         100
```
```
$ lfortran examples/expr2.f90 --cpp
100
```