### PR TITLE
Function call with real,dimension(:),allocatable :: xx as return_var works fine

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1027,3 +1027,5 @@ RUN(NAME implicit_argument_casting_01 LABELS gfortran IMPLICIT_ARGS)
 RUN(NAME specfun_01 LABELS gfortran llvmUseLoopVariableAfterLoop NOFAST)
 
 RUN(NAME cpp_pre_01 LABELS gfortran llvm c CPP_PRE)
+
+RUN(NAME return_var_01 LABELS gfortran llvm)

--- a/integration_tests/return_var_01.f90
+++ b/integration_tests/return_var_01.f90
@@ -1,0 +1,27 @@
+program main
+    implicit none
+
+    call compare_solutions()
+
+    contains
+
+    subroutine compare_solutions()
+    implicit none
+    real :: reldiff(2)
+    real :: absdiff
+    real, dimension(:), allocatable :: x
+    
+    x = solution()
+
+    if ( abs(x(1) - 0.10) >= 1e-7 ) error stop
+    if ( abs(x(2) - 0.20) >= 1e-7 ) error stop
+    if (size(x) /= 2) error stop
+
+    end subroutine compare_solutions
+
+    pure function solution() result(x)
+        implicit none
+        real,dimension(:),allocatable :: x
+        x = [0.10,0.20]
+    end function solution
+end program main


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/1631