### PR TITLE
Test added for Type *getType() const { return VTy; }

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1029,3 +1029,5 @@ RUN(NAME specfun_01 LABELS gfortran llvmUseLoopVariableAfterLoop NOFAST)
 
 RUN(NAME cpp_pre_01 LABELS gfortran llvm c CPP_PRE)
 RUN(NAME cpp_pre_02 LABELS gfortran llvm c wasm CPP_PRE)
+
+RUN(NAME minpack_03 LABELS gfortran llvm NOFAST)

--- a/integration_tests/minpack_03.f90
+++ b/integration_tests/minpack_03.f90
@@ -1,0 +1,25 @@
+program minpack_03
+
+    implicit none
+    integer,dimension(2),parameter :: info_original = [1,1]
+    integer :: ic
+    ic = 1
+
+    call compare_solutions(ic)
+
+    contains
+
+    subroutine compare_solutions(ic)
+
+    implicit none
+
+    integer :: ic
+    
+    if ( info_original(1) /= 1 ) error stop
+    if ( info_original(2) /= 1 ) error stop
+    if ( size(info_original) /= 2 ) error stop
+
+    print *, info_original(ic)
+    end subroutine compare_solutions
+
+end program minpack_03


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/1563