### PR TITLE
Add flag --fixed-form-infer

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1871,7 +1871,7 @@ int main(int argc, char *argv[])
         // LFortran specific options
         app.add_flag("--cpp", compiler_options.c_preprocessor, "Enable C preprocessing");
         app.add_flag("--fixed-form", compiler_options.fixed_form, "Use fixed form Fortran source parsing");
-	app.add_flag("--fixed-form-infer", fixed_form_infer, "Use heuristics to infer if a file is in fixed form");
+        app.add_flag("--fixed-form-infer", fixed_form_infer, "Use heuristics to infer if a file is in fixed form");
         app.add_flag("--no-prescan", arg_no_prescan, "Turn off prescan");
         app.add_flag("--show-prescan", show_prescan, "Show tokens for the given file and exit");
         app.add_flag("--show-tokens", show_tokens, "Show tokens for the given file and exit");
@@ -2053,12 +2053,12 @@ int main(int argc, char *argv[])
         if (CLI::NonexistentPath(arg_file).empty())
             throw LCompilers::LCompilersException("File does not exist: " + arg_file);
 
-	// Decide if a file is fixed format based on the extension
-	// Gfortran does the same thing
-	if (fixed_form_infer && endswith(arg_file, ".f")) {
-	    compiler_options.fixed_form = true;
-	}
-	
+        // Decide if a file is fixed format based on the extension
+        // Gfortran does the same thing
+        if (fixed_form_infer && endswith(arg_file, ".f")) {
+            compiler_options.fixed_form = true;
+        }
+        
         std::string outfile;
         std::filesystem::path basename = std::filesystem::path(arg_file).filename();
         if (compiler_options.arg_o.size() > 0) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2053,7 +2053,7 @@ int main(int argc, char *argv[])
 
         // Decide if a file is fixed format based on the extension
         // Gfortran does the same thing
-        if (arg_file.size() >= 2 && arg_file.substr(arg_file.size() - 2) == ".f") {
+        if (endswith(arg_file, ".f")) {
             compiler_options.fixed_form = true;
         }
 

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2051,6 +2051,12 @@ int main(int argc, char *argv[])
         if (CLI::NonexistentPath(arg_file).empty())
             throw LCompilers::LCompilersException("File does not exist: " + arg_file);
 
+        // Decide if a file is fixed format based on the extension
+        // Gfortran does the same thing
+        if (arg_file.size() >= 2 && arg_file.substr(arg_file.size() - 2) == ".f") {
+            compiler_options.fixed_form = true;
+        }
+
         std::string outfile;
         std::filesystem::path basename = std::filesystem::path(arg_file).filename();
         if (compiler_options.arg_o.size() > 0) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1828,6 +1828,7 @@ int main(int argc, char *argv[])
         std::string arg_kernel_f;
         bool print_targets = false;
         bool link_with_gcc = false;
+	bool fixed_form_infer = false;
 
         std::string arg_fmt_file;
         int arg_fmt_indent = 4;
@@ -1870,6 +1871,7 @@ int main(int argc, char *argv[])
         // LFortran specific options
         app.add_flag("--cpp", compiler_options.c_preprocessor, "Enable C preprocessing");
         app.add_flag("--fixed-form", compiler_options.fixed_form, "Use fixed form Fortran source parsing");
+	app.add_flag("--fixed-form-infer", fixed_form_infer, "Use heuristics to infer if a file is in fixed form");
         app.add_flag("--no-prescan", arg_no_prescan, "Turn off prescan");
         app.add_flag("--show-prescan", show_prescan, "Show tokens for the given file and exit");
         app.add_flag("--show-tokens", show_tokens, "Show tokens for the given file and exit");
@@ -2051,12 +2053,12 @@ int main(int argc, char *argv[])
         if (CLI::NonexistentPath(arg_file).empty())
             throw LCompilers::LCompilersException("File does not exist: " + arg_file);
 
-        // Decide if a file is fixed format based on the extension
-        // Gfortran does the same thing
-        if (endswith(arg_file, ".f")) {
-            compiler_options.fixed_form = true;
-        }
-
+	// Decide if a file is fixed format based on the extension
+	// Gfortran does the same thing
+	if (fixed_form_infer && endswith(arg_file, ".f")) {
+	    compiler_options.fixed_form = true;
+	}
+	
         std::string outfile;
         std::filesystem::path basename = std::filesystem::path(arg_file).filename();
         if (compiler_options.arg_o.size() > 0) {


### PR DESCRIPTION
At the moment we only use the file extension .f, in the future as problems arise we can add more heuristics like what values appear on the first 5 columns.

~~Is there any reason this has not been done yet?~~

~~Ok, six tests fail, if those are the only reasons I'm wiling to work on them.~~