### PR TITLE
CI: Use fixed node v18.13.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -739,7 +739,7 @@ jobs:
           environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
-            nodejs
+            nodejs=18.13.0
 
       - uses: hendrikmuhs/ccache-action@main
         with:


### PR DESCRIPTION
It seems a few hours back `conda` used to install node `v18`. It currently installs node `v20`. It seems there are some changes to WASI API interface in node `v20`. For the moment, in this PR, we are using a fixed node `v18` at the CI. For the longer term, I think we can try supporting all major node versions for the generated `wasm` binary and related `js` script.