### PR TITLE
CI: use latest commit to test Scipy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,8 +136,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/special2
-            git checkout f7e038499ed93216605fe8fff782ccc6a8bac66e
+            git checkout -t ondrej/special3
+            git checkout 31bfe0f4c9721d20304ba80dd28446c1c208d626
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init


### PR DESCRIPTION
Now we only have `nan` handling and segmentation fault left #2198.