### PR TITLE
Implement `DCOSH`, `DSINH`, `DTANH`, `DTAN` intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -487,6 +487,8 @@ RUN(NAME intrinsics_64 LABELS gfortran llvm wasm) # sign
 
 
 RUN(NAME intrinsics_65 LABELS gfortran llvm) # matmul
+RUN(NAME intrinsics_66 LABELS gfortran llvm) # dcosh, dsinh, dtanh, dtan
+RUN(NAME intrinsics_67 LABELS gfortran llvm) # dsign
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_66.f90
+++ b/integration_tests/intrinsics_66.f90
@@ -1,0 +1,32 @@
+program intrinsics_66
+    double precision :: x
+    x = 1.0D0
+    print *, dcosh(x)
+    print *, dsinh(x)
+    print *, dcosh(1.2D0)
+    print *, dsinh(1.2D0)
+    print *, dtanh(x)
+    print *, dtanh(1.2D0)
+
+    if (abs(dcosh(x) - 1.5430806348152437D0) > 1d-14) error stop
+    if (abs(dsinh(x) - 1.1752011936438014D0) > 1d-14) error stop
+    if (abs(dcosh(1.2D0) - 1.8106555673243747D0) > 1d-14) error stop
+    if (abs(dsinh(1.2D0) - 1.5094613554121725D0) > 1d-12) error stop
+    if (abs(dtanh(x) - 0.76159415595576485D0) > 1d-14) error stop
+    if (abs(dtanh(1.2D0) - 0.83365460701215521D0) > 1d-14) error stop
+
+    x = 4.2D0
+    print *, dcosh(x)
+    print *, dsinh(x)
+    print *, dcosh(4.2D0)
+    print *, dsinh(4.2D0)
+    print *, dtanh(x)
+    print *, dtanh(4.2D0)
+    if (abs(dcosh(x) - 33.350663308872818D0) > 1d-14) error stop
+    if (abs(dsinh(x) - 33.335667732052336D0) > 1d-14) error stop
+    if (abs(dcosh(4.2D0) - 33.350663308872818D0) > 1d-14) error stop
+    if (abs(dsinh(4.2D0) - 33.335667732052336D0) > 1d-14) error stop
+    if (abs(dtanh(x) - 0.99955036645953343D0) > 1d-14) error stop
+    if (abs(dtanh(4.2D0) - 0.99955036645953343D0) > 1d-14) error stop
+end program
+    

--- a/integration_tests/intrinsics_67.f90
+++ b/integration_tests/intrinsics_67.f90
@@ -1,0 +1,34 @@
+program intrinsics_67
+    double precision :: x, y
+
+    x = 1.0D0
+    y = -2.0D0
+
+    print *, dsign(x, y)
+    print *, dsign(x, -y)
+    print *, dsign(-x, y)
+    print *, dsign(-x, -y)
+    if (abs(dsign(x, y) - (-1.0D0)) > 1d-14) error stop
+    if (abs(dsign(x, -y) - (1.0D0)) > 1d-14) error stop
+    if (abs(dsign(-x, y) - (-1.0D0)) > 1d-14) error stop
+    if (abs(dsign(-x, -y) - (1.0D0)) > 1d-14) error stop
+
+    print *, dsign(0.0D0, y)
+    print *, dsign(0.0D0, -y)
+    print *, dsign(x, 0.0D0)
+    print *, dsign(-x, 0.0D0)
+
+    if (abs(dsign(0.0D0, y) - (-0.0D0)) > 1d-14) error stop
+    if (abs(dsign(0.0D0, -y) - (0.0D0)) > 1d-14) error stop
+    if (abs(dsign(x, 0.0D0) - (1.0D0)) > 1d-14) error stop
+    if (abs(dsign(-x, 0.0D0) - (1.0D0)) > 1d-14) error stop
+
+    print *, dsign(0.0D0, 0.0D0)
+    print *, dsign(-0.0D0, 0.0D0)
+    print *, dsign(0.0D0, -0.0D0)
+    print *, dsign(-0.0D0, -0.0D0)
+    if (abs(dsign(0.0D0, 0.0D0) - (0.0D0)) > 1d-14) error stop
+    if (abs(dsign(-0.0D0, 0.0D0) - (0.0D0)) > 1d-14) error stop
+    if (abs(dsign(0.0D0, -0.0D0) - (-0.0D0)) > 1d-14) error stop
+    if (abs(dsign(-0.0D0, -0.0D0) - (-0.0D0)) > 1d-14) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -731,6 +731,7 @@ public:
         {"min", {IntrinsicSignature({}, 2, 100)}},
         {"merge", {IntrinsicSignature({}, 3, 3)}},
         {"sign", {IntrinsicSignature({}, 2, 2)}},
+        {"dsign", {IntrinsicSignature({}, 2, 2)}},
         {"shape", {IntrinsicSignature({"kind"}, 1, 2)}},
     };
 

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -33,6 +33,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     Acos,
     Atan,
     Sinh,
+    DSinh,
     Cosh,
     DCosh,
     Tanh,
@@ -82,6 +83,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Acos)
         INTRINSIC_NAME_CASE(Atan)
         INTRINSIC_NAME_CASE(Sinh)
+        INTRINSIC_NAME_CASE(DSinh)
         INTRINSIC_NAME_CASE(Cosh)
         INTRINSIC_NAME_CASE(DCosh)
         INTRINSIC_NAME_CASE(Tanh)
@@ -1074,6 +1076,7 @@ create_trig(Asin, asin, asin)
 create_trig(Acos, acos, acos)
 create_trig(Atan, atan, atan)
 create_trig(Sinh, sinh, sinh)
+create_trig(DSinh, sinh, sinh)
 create_trig(Cosh, cosh, cosh)
 create_trig(DCosh, cosh, cosh)
 create_trig(Tanh, tanh, tanh)
@@ -2207,6 +2210,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {&Atan::instantiate_Atan, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Sinh),
             {&Sinh::instantiate_Sinh, &UnaryIntrinsicFunction::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DSinh),
+            {&Sinh::instantiate_Sinh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Cosh),
             {&Cosh::instantiate_Cosh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::DCosh),
@@ -2287,6 +2292,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "atan"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Sinh),
             "sinh"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DSinh),
+            "sinh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Cosh),
             "cosh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::DCosh),
@@ -2359,6 +2366,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"acos", {&Acos::create_Acos, &Acos::eval_Acos}},
                 {"atan", {&Atan::create_Atan, &Atan::eval_Atan}},
                 {"sinh", {&Sinh::create_Sinh, &Sinh::eval_Sinh}},
+                {"dsinh", {&Sinh::create_Sinh, &Sinh::eval_Sinh}},
                 {"cosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
                 {"dcosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
                 {"tanh", {&Tanh::create_Tanh, &Tanh::eval_Tanh}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -34,6 +34,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     Atan,
     Sinh,
     Cosh,
+    DCosh,
     Tanh,
     Gamma,
     LogGamma,
@@ -82,6 +83,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Atan)
         INTRINSIC_NAME_CASE(Sinh)
         INTRINSIC_NAME_CASE(Cosh)
+        INTRINSIC_NAME_CASE(DCosh)
         INTRINSIC_NAME_CASE(Tanh)
         INTRINSIC_NAME_CASE(Gamma)
         INTRINSIC_NAME_CASE(LogGamma)
@@ -1073,6 +1075,7 @@ create_trig(Acos, acos, acos)
 create_trig(Atan, atan, atan)
 create_trig(Sinh, sinh, sinh)
 create_trig(Cosh, cosh, cosh)
+create_trig(DCosh, cosh, cosh)
 create_trig(Tanh, tanh, tanh)
 
 namespace Abs {
@@ -2206,6 +2209,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {&Sinh::instantiate_Sinh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Cosh),
             {&Cosh::instantiate_Cosh, &UnaryIntrinsicFunction::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DCosh),
+            {&Cosh::instantiate_Cosh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Tanh),
             {&Tanh::instantiate_Tanh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Exp),
@@ -2284,6 +2289,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "sinh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Cosh),
             "cosh"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DCosh),
+            "dcosh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Tanh),
             "tanh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Abs),
@@ -2353,6 +2360,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"atan", {&Atan::create_Atan, &Atan::eval_Atan}},
                 {"sinh", {&Sinh::create_Sinh, &Sinh::eval_Sinh}},
                 {"cosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
+                {"dcosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
                 {"tanh", {&Tanh::create_Tanh, &Tanh::eval_Tanh}},
                 {"abs", {&Abs::create_Abs, &Abs::eval_Abs}},
                 {"exp", {&Exp::create_Exp, &Exp::eval_Exp}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -37,6 +37,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     Cosh,
     DCosh,
     Tanh,
+    DTanh,
     Gamma,
     LogGamma,
     Abs,
@@ -87,6 +88,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Cosh)
         INTRINSIC_NAME_CASE(DCosh)
         INTRINSIC_NAME_CASE(Tanh)
+        INTRINSIC_NAME_CASE(DTanh)
         INTRINSIC_NAME_CASE(Gamma)
         INTRINSIC_NAME_CASE(LogGamma)
         INTRINSIC_NAME_CASE(Abs)
@@ -1080,6 +1082,7 @@ create_trig(DSinh, sinh, sinh)
 create_trig(Cosh, cosh, cosh)
 create_trig(DCosh, cosh, cosh)
 create_trig(Tanh, tanh, tanh)
+create_trig(DTanh, tanh, tanh)
 
 namespace Abs {
 
@@ -2218,6 +2221,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {&Cosh::instantiate_Cosh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Tanh),
             {&Tanh::instantiate_Tanh, &UnaryIntrinsicFunction::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DTanh),
+            {&Tanh::instantiate_Tanh, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Exp),
             {nullptr, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Exp2),
@@ -2300,6 +2305,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "dcosh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Tanh),
             "tanh"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DTanh),
+            "tanh"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Abs),
             "abs"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Exp),
@@ -2370,6 +2377,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"cosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
                 {"dcosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
                 {"tanh", {&Tanh::create_Tanh, &Tanh::eval_Tanh}},
+                {"dtanh", {&Tanh::create_Tanh, &Tanh::eval_Tanh}},
                 {"abs", {&Abs::create_Abs, &Abs::eval_Abs}},
                 {"exp", {&Exp::create_Exp, &Exp::eval_Exp}},
                 {"exp2", {&Exp2::create_Exp2, &Exp2::eval_Exp2}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -53,6 +53,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     Max,
     Min,
     Sign,
+    DSign,
     SymbolicSymbol,
     SymbolicAdd,
     SymbolicSub,
@@ -105,6 +106,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Max)
         INTRINSIC_NAME_CASE(Min)
         INTRINSIC_NAME_CASE(Sign)
+        INTRINSIC_NAME_CASE(DSign)
         INTRINSIC_NAME_CASE(SymbolicSymbol)
         INTRINSIC_NAME_CASE(SymbolicAdd)
         INTRINSIC_NAME_CASE(SymbolicSub)
@@ -2252,6 +2254,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {&Min::instantiate_Min, &Min::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Sign),
             {&Sign::instantiate_Sign, &Sign::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DSign),
+            {&Sign::instantiate_Sign, &Sign::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicSymbol),
             {nullptr, &SymbolicSymbol::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicAdd),
@@ -2336,6 +2340,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "min"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Sign),
             "sign"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DSign),
+            "sign"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicSymbol),
             "Symbol"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicAdd),
@@ -2398,6 +2404,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"min0", {&Min::create_Min, &Min::eval_Min}},
                 {"min", {&Min::create_Min, &Min::eval_Min}},
                 {"sign", {&Sign::create_Sign, &Sign::eval_Sign}},
+                {"dsign", {&Sign::create_Sign, &Sign::eval_Sign}},
                 {"Symbol", {&SymbolicSymbol::create_SymbolicSymbol, &SymbolicSymbol::eval_SymbolicSymbol}},
                 {"SymbolicAdd", {&SymbolicAdd::create_SymbolicAdd, &SymbolicAdd::eval_SymbolicAdd}},
                 {"SymbolicSub", {&SymbolicSub::create_SymbolicSub, &SymbolicSub::eval_SymbolicSub}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -29,6 +29,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     Sin,
     Cos,
     Tan,
+    DTan,
     Asin,
     Acos,
     Atan,
@@ -80,6 +81,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Sin)
         INTRINSIC_NAME_CASE(Cos)
         INTRINSIC_NAME_CASE(Tan)
+        INTRINSIC_NAME_CASE(DTan)
         INTRINSIC_NAME_CASE(Asin)
         INTRINSIC_NAME_CASE(Acos)
         INTRINSIC_NAME_CASE(Atan)
@@ -1074,6 +1076,7 @@ namespace X {                                                                   
 create_trig(Sin, sin, sin)
 create_trig(Cos, cos, cos)
 create_trig(Tan, tan, tan)
+create_trig(DTan, tan, tan)
 create_trig(Asin, asin, asin)
 create_trig(Acos, acos, acos)
 create_trig(Atan, atan, atan)
@@ -2205,6 +2208,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {&Cos::instantiate_Cos, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Tan),
             {&Tan::instantiate_Tan, &UnaryIntrinsicFunction::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DTan),
+            {&Tan::instantiate_Tan, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Asin),
             {&Asin::instantiate_Asin, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Acos),
@@ -2289,6 +2294,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "cos"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Tan),
             "tan"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::DTan),
+            "tan"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Asin),
             "asin"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Acos),
@@ -2369,6 +2376,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"sin", {&Sin::create_Sin, &Sin::eval_Sin}},
                 {"cos", {&Cos::create_Cos, &Cos::eval_Cos}},
                 {"tan", {&Tan::create_Tan, &Tan::eval_Tan}},
+                {"dtan", {&Tan::create_Tan, &Tan::eval_Tan}},
                 {"asin", {&Asin::create_Asin, &Asin::eval_Asin}},
                 {"acos", {&Acos::create_Acos, &Acos::eval_Acos}},
                 {"atan", {&Atan::create_Atan, &Atan::eval_Atan}},


### PR DESCRIPTION
Fixes #2227. With this PR, we can revert: https://github.com/certik/scipy/commit/305f9fa2d45395e747e6add1592435a487eabeaf