### PR TITLE
Better error message for nonarray indexing

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1837,7 +1837,8 @@ public:
     */
     bool is_statement_function( const AST::Assignment_t &x ) {
         if (AST::is_a<AST::FuncCallOrArray_t>(*x.m_target)) {
-            // Look for the type of *x.m_target in symbol table, if it is integer or nullptr then it is a statement function
+            // Look for the type of *x.m_target in symbol table, if it is integer, real, logical, or nullptr then it is a statement function
+            // unless it is being indexed as an array
             AST::FuncCallOrArray_t *func_call_or_array = AST::down_cast<AST::FuncCallOrArray_t>(x.m_target);
             if (func_call_or_array->n_member > 0) {
                 // This is part of a derived type, so it is not a statement function
@@ -1859,7 +1860,18 @@ public:
                         if (ASRUtils::is_array(v->m_type)) {
                             return false;
                         } else {
-                            return true;
+                            bool no_array_sections = true;
+                            for (size_t i = 0; i < func_call_or_array->n_args; i++) {
+                                if (func_call_or_array->m_args[i].m_step != nullptr) {
+                                    no_array_sections = false;
+                                    break;
+                                }
+                            }
+                            if (no_array_sections) {
+                                return true;
+                            } else {
+                                return false;
+                            } 
                         }
                     } else {
                         return false;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2734,6 +2734,8 @@ public:
                 this->visit_expr(*(m_args[i].m_start));
                 m_start = ASRUtils::EXPR(tmp);
                 ai.loc = m_start->base.loc;
+            } else {
+                throw SemanticError("Array dimension has no lower bound.", loc);  
             }
             if (m_args[i].m_end != nullptr) {
                 this->visit_expr(*(m_args[i].m_end));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2775,7 +2775,7 @@ public:
                                     nullptr));
                     }
                 } else {
-                    m_end = ASRUtils::get_bound(v_Var, i + 1, "ubound", al);
+                    m_end = ASRUtils::get_bound<SemanticError>(v_Var, i + 1, "ubound", al);
                 }
             }
             if (m_args[i].m_step != nullptr) {
@@ -2937,7 +2937,7 @@ public:
             for( size_t i = 0; i < n_args; i++ ) {
                 if( args.p[i].m_step != nullptr &&
                     args.p[i].m_left == nullptr ) {
-                    args.p[i].m_left = ASRUtils::get_bound(v_Var, i + 1, "lbound", al);
+                    args.p[i].m_left = ASRUtils::get_bound<SemanticError>(v_Var, i + 1, "lbound", al);
                 }
                 if( args.p[i].m_step != nullptr ) {
                     ASR::dimension_t empty_dim;
@@ -3480,13 +3480,13 @@ public:
                         this->visit_expr(*struct_m_args[j].m_start); \
                         index.m_left = ASRUtils::EXPR(tmp); \
                     } else { \
-                        index.m_left = ASRUtils::get_bound(expr, j + 1, "lbound", al); \
+                        index.m_left = ASRUtils::get_bound<SemanticError>(expr, j + 1, "lbound", al); \
                     } \
                     if( struct_m_args[j].m_end ) { \
                         this->visit_expr(*struct_m_args[j].m_end); \
                         index.m_right = ASRUtils::EXPR(tmp); \
                     } else { \
-                        index.m_right = ASRUtils::get_bound(expr, j + 1, "ubound", al); \
+                        index.m_right = ASRUtils::get_bound<SemanticError>(expr, j + 1, "ubound", al); \
                     } \
                     this->visit_expr(*struct_m_args[j].m_step); \
                     index.m_step = ASRUtils::EXPR(tmp); \
@@ -3897,7 +3897,7 @@ public:
                 ASR::array_index_t index;
                 index.loc = x.base.base.loc;
                 index.m_left = nullptr;
-                index.m_right = ASRUtils::get_bound(v_Var, i + 1, "lbound", al);
+                index.m_right = ASRUtils::get_bound<SemanticError>(v_Var, i + 1, "lbound", al);
                 index.m_step = nullptr;
                 lbs.push_back(al, index);
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2734,8 +2734,6 @@ public:
                 this->visit_expr(*(m_args[i].m_start));
                 m_start = ASRUtils::EXPR(tmp);
                 ai.loc = m_start->base.loc;
-            } else { 
-                m_start = ASRUtils::get_bound<SemanticError>(v_Var, i + 1, "lbound", al);
             }
             if (m_args[i].m_end != nullptr) {
                 this->visit_expr(*(m_args[i].m_end));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2734,8 +2734,8 @@ public:
                 this->visit_expr(*(m_args[i].m_start));
                 m_start = ASRUtils::EXPR(tmp);
                 ai.loc = m_start->base.loc;
-            } else {
-                throw SemanticError("Array dimension has no lower bound.", loc);  
+            } else { 
+                m_start = ASRUtils::get_bound<SemanticError>(v_Var, i + 1, "lbound", al);
             }
             if (m_args[i].m_end != nullptr) {
                 this->visit_expr(*(m_args[i].m_end));
@@ -3464,68 +3464,67 @@ public:
         }
     }
 
-    #define make_ArrayItem_from_struct_m_args(struct_m_args, struct_n_args, expr, array_item_node, loc) if( struct_n_args > 0 ) { \
-            ASR::asr_t* tmp_copy = tmp; \
-            Vec<ASR::array_index_t> indices; \
-            indices.reserve(al, struct_n_args); \
-            bool is_array_section = false; \
-            for( size_t j = 0; j < struct_n_args; j++ ) { \
-                is_array_section = is_array_section || (struct_m_args[j].m_step != nullptr); \
-                ASR::array_index_t index; \
-                if( struct_m_args[j].m_step == nullptr ) { \
-                    this->visit_expr(*struct_m_args[j].m_end); \
-                    index.m_right = ASRUtils::EXPR(tmp); \
-                    index.m_left = nullptr; \
-                    index.m_step = nullptr; \
-                } else { \
-                    if( struct_m_args[j].m_start ) { \
-                        this->visit_expr(*struct_m_args[j].m_start); \
-                        index.m_left = ASRUtils::EXPR(tmp); \
-                    } else { \
-                        index.m_left = ASRUtils::get_bound<SemanticError>(expr, j + 1, "lbound", al); \
-                    } \
-                    if( struct_m_args[j].m_end ) { \
-                        this->visit_expr(*struct_m_args[j].m_end); \
-                        index.m_right = ASRUtils::EXPR(tmp); \
-                    } else { \
-                        index.m_right = ASRUtils::get_bound<SemanticError>(expr, j + 1, "ubound", al); \
-                    } \
-                    this->visit_expr(*struct_m_args[j].m_step); \
-                    index.m_step = ASRUtils::EXPR(tmp); \
-                } \
-                index.loc = struct_m_args->loc; \
-                indices.push_back(al, index); \
-            } \
-            tmp = tmp_copy; \
-            if( is_array_section ) { \
-                Vec<ASR::dimension_t> array_section_dims; \
-                array_section_dims.reserve(al, struct_n_args); \
-                for( size_t j = 0; j < struct_n_args; j++ ) { \
-                    if( struct_m_args[j].m_step != nullptr ) { \
-                        ASR::dimension_t empty_dim; \
-                        empty_dim.loc = loc; \
-                        empty_dim.m_start = nullptr; \
-                        empty_dim.m_length = nullptr; \
-                        array_section_dims.push_back(al, empty_dim); \
-                    } \
-                } \
-                ASR::ttype_t *array_section_type = \
-                    ASRUtils::duplicate_type(al, ASRUtils::type_get_past_array( \
-                            ASRUtils::type_get_past_pointer( \
-                                ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(expr)))), \
-                            &array_section_dims); \
-                array_item_node = ASR::make_ArraySection_t(al, loc, expr, indices.p, \
-                    indices.size(), array_section_type, nullptr); \
-            } else { \
-                array_item_node = ASRUtils::make_ArrayItem_t_util(al, loc, expr, indices.p, \
-                    indices.size(), ASRUtils::type_get_past_array( \
-                        ASRUtils::type_get_past_pointer( \
-                            ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(expr)))), \
-                    ASR::arraystorageType::ColMajor, nullptr); \
-            } \
-            array_item_node = (ASR::asr_t*) replace_with_common_block_variables( \
-                ASRUtils::EXPR(array_item_node)); \
-        } \
+    void make_ArrayItem_from_struct_m_args(AST::fnarg_t* struct_m_args, size_t struct_n_args, ASR::expr_t* expr, ASR::asr_t* &array_item_node, const Location &loc) {
+        if (struct_n_args == 0) {
+            return;
+        }
+        ASR::asr_t* tmp_copy = tmp;
+        Vec<ASR::array_index_t> indices;
+        indices.reserve(al, struct_n_args);
+        bool is_array_section = false;
+        for( size_t j = 0; j < struct_n_args; j++ ) {
+            is_array_section = is_array_section || (struct_m_args[j].m_step != nullptr);
+            ASR::array_index_t index;
+            if( struct_m_args[j].m_step == nullptr ) {
+                this->visit_expr(*struct_m_args[j].m_end);
+                index.m_right = ASRUtils::EXPR(tmp);
+                index.m_left = nullptr;
+                index.m_step = nullptr;
+            } else {
+                if( struct_m_args[j].m_start ) {
+                    this->visit_expr(*struct_m_args[j].m_start);
+                    index.m_left = ASRUtils::EXPR(tmp);
+                } else {
+                    index.m_left = ASRUtils::get_bound<SemanticError>(expr, j + 1, "lbound", al);
+                }
+                if( struct_m_args[j].m_end ) {
+                    this->visit_expr(*struct_m_args[j].m_end);
+                    index.m_right = ASRUtils::EXPR(tmp);
+                } else {
+                    index.m_right = ASRUtils::get_bound<SemanticError>(expr, j + 1, "ubound", al);
+                }
+                this->visit_expr(*struct_m_args[j].m_step);
+                index.m_step = ASRUtils::EXPR(tmp);
+            }
+            index.loc = struct_m_args->loc;
+            indices.push_back(al, index);
+        }
+        tmp = tmp_copy;
+        if( is_array_section ) {
+            Vec<ASR::dimension_t> array_section_dims;
+            array_section_dims.reserve(al, struct_n_args);
+            for( size_t j = 0; j < struct_n_args; j++ ) {
+                if( struct_m_args[j].m_step != nullptr ) {
+                    ASR::dimension_t empty_dim;
+                    empty_dim.loc = loc;
+                    empty_dim.m_start = nullptr;
+                    empty_dim.m_length = nullptr;
+                    array_section_dims.push_back(al, empty_dim);
+                }
+            }
+            ASR::ttype_t *array_section_type =
+                ASRUtils::duplicate_type(al, ASRUtils::extract_type(ASRUtils::expr_type(expr)),
+                        &array_section_dims);
+            array_item_node = ASR::make_ArraySection_t(al, loc, expr, indices.p,
+                indices.size(), array_section_type, nullptr);
+        } else {
+            array_item_node = ASRUtils::make_ArrayItem_t_util(al, loc, expr, indices.p,
+                indices.size(), ASRUtils::extract_type(ASRUtils::expr_type(expr)),
+                ASR::arraystorageType::ColMajor, nullptr);
+        }
+        array_item_node = (ASR::asr_t*) replace_with_common_block_variables(
+            ASRUtils::EXPR(array_item_node));
+    }
 
     ASR::asr_t* resolve_variable2(const Location &loc, const std::string &var_name,
             const std::string &dt_name, SymbolTable*& scope,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3711,8 +3711,7 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
             }
             throw SemanticError(msg, arr_expr->base.loc); 
         } else {
-            std::string msg = "Expression cannot be indexed.";
-            throw SemanticError(msg, arr_expr->base.loc);       
+            throw SemanticError("Expression cannot be indexed.", arr_expr->base.loc);       
         }
     }
     dim = dim - 1;
@@ -3741,6 +3740,16 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
             bound_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
                             al, arr_expr->base.loc,
                             const_lbound + const_length - 1, int32_type));
+        }
+    } else {
+        if( arr_dims[dim].m_start == nullptr ) {
+            std::string msg = "Array dimension " + std::to_string(dim+1) + 
+                " has no lower bound.";
+            throw SemanticError(msg, arr_expr->base.loc); 
+        } else {
+            std::string msg = "Array dimension " + std::to_string(dim+1) + 
+                " has no length.";
+            throw SemanticError(msg, arr_expr->base.loc); 
         }
     }
     return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, arr_expr->base.loc, arr_expr, dim_expr,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3741,16 +3741,6 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
                             al, arr_expr->base.loc,
                             const_lbound + const_length - 1, int32_type));
         }
-    } else {
-        if( arr_dims[dim].m_start == nullptr ) {
-            std::string msg = "Array dimension " + std::to_string(dim+1) + 
-                " has no lower bound.";
-            throw SemanticError(msg, arr_expr->base.loc); 
-        } else {
-            std::string msg = "Array dimension " + std::to_string(dim+1) + 
-                " has no length.";
-            throw SemanticError(msg, arr_expr->base.loc); 
-        }
     }
     return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, arr_expr->base.loc, arr_expr, dim_expr,
                 int32_type, bound_type, bound_value));

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -8,6 +8,7 @@
 
 #include <libasr/assert.h>
 #include <libasr/asr.h>
+#include <libasr/semantic_exception.h>
 #include <libasr/string_utils.h>
 #include <libasr/utils.h>
 
@@ -3668,6 +3669,7 @@ static inline bool is_pass_array_by_data_possible(ASR::Function_t* x, std::vecto
     return v.size() > 0;
 }
 
+template <typename SemanticError>
 static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
                                      std::string bound, Allocator& al) {
     ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, 4));
@@ -3682,8 +3684,36 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
     int arr_n_dims = ASRUtils::extract_dimensions_from_ttype(
         ASRUtils::expr_type(arr_expr), arr_dims);
     if( dim > arr_n_dims || dim < 1) {
-        throw LCompilersException("Dimension " + std::to_string(dim) +
-            " is invalid. Rank of the array, " + std::to_string(arr_n_dims));
+        if ( ASR::is_a<ASR::Var_t>(*arr_expr )) {
+            ASR::Var_t* non_array_var = ASR::down_cast<ASR::Var_t>(arr_expr);
+            ASR::Variable_t* non_array_variable = ASR::down_cast<ASR::Variable_t>(
+                symbol_get_past_external(non_array_var->m_v));
+            std::string msg;
+            if (arr_n_dims == 0) {
+                msg = "Variable " + std::string(non_array_variable->m_name) +
+                            " is not an array so it cannot be indexed.";
+            } else {
+                msg = "Variable " + std::string(non_array_variable->m_name) +
+                            " does not have enough dimensions.";  
+            }
+            throw SemanticError(msg, arr_expr->base.loc);
+        } else if ( ASR::is_a<ASR::StructInstanceMember_t>(*arr_expr )) {
+            ASR::StructInstanceMember_t* non_array_struct_inst_mem = ASR::down_cast<ASR::StructInstanceMember_t>(arr_expr);
+            ASR::Variable_t* non_array_variable = ASR::down_cast<ASR::Variable_t>(
+                symbol_get_past_external(non_array_struct_inst_mem->m_m));
+            std::string msg;
+            if (arr_n_dims == 0) {
+                msg = "Type member " + std::string(non_array_variable->m_name) +
+                            " is not an array so it cannot be indexed.";
+            } else {
+                msg = "Type member " + std::string(non_array_variable->m_name) +
+                            " does not have enough dimensions.";  
+            }
+            throw SemanticError(msg, arr_expr->base.loc); 
+        } else {
+            std::string msg = "Expression cannot be indexed.";
+            throw SemanticError(msg, arr_expr->base.loc);       
+        }
     }
     dim = dim - 1;
     if( arr_dims[dim].m_start && arr_dims[dim].m_length ) {
@@ -3748,7 +3778,7 @@ static inline void get_dimensions(ASR::expr_t* array, Vec<ASR::expr_t*>& dims,
     for( int i = 0; i < n_dims; i++ ) {
         ASR::expr_t* start = compile_time_dims[i].m_start;
         if( start == nullptr ) {
-            start = get_bound(array, i + 1, "lbound", al);
+            start = get_bound<SemanticError>(array, i + 1, "lbound", al);
         }
         ASR::expr_t* length = compile_time_dims[i].m_length;
         if( length == nullptr ) {

--- a/tests/errors/array_03.f90
+++ b/tests/errors/array_03.f90
@@ -1,0 +1,7 @@
+program array_03
+implicit none
+
+integer :: a(:)
+a(:,:) = 1
+
+end program

--- a/tests/errors/array_04.f90
+++ b/tests/errors/array_04.f90
@@ -1,0 +1,10 @@
+program array_04
+implicit none
+
+type :: t
+    integer :: a
+end type
+type(t) :: b
+b%a(:) = 1
+
+end program

--- a/tests/reference/asr-array_03-a79d86f.json
+++ b/tests/reference/asr-array_03-a79d86f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-array_03-a79d86f",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/array_03.f90",
+    "infile_hash": "050cfc929eff0de4c108f28e7200df20bd77f9c8f514d67cfadf2d4f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-array_03-a79d86f.stderr",
+    "stderr_hash": "bbb247c30033d48f3eeb15cbbc610013666f571384f908048387aa37",
+    "returncode": 2
+}

--- a/tests/reference/asr-array_03-a79d86f.stderr
+++ b/tests/reference/asr-array_03-a79d86f.stderr
@@ -1,0 +1,5 @@
+semantic error: Variable a does not have enough dimensions.
+ --> tests/errors/array_03.f90:5:1
+  |
+5 | a(:,:) = 1
+  | ^^^^^^ 

--- a/tests/reference/asr-array_04-5864f91.json
+++ b/tests/reference/asr-array_04-5864f91.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-array_04-5864f91",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/array_04.f90",
+    "infile_hash": "49fb2152950af75eb4ccb7c32e09995c2b0a0d7139d2f3d795407d9b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-array_04-5864f91.stderr",
+    "stderr_hash": "0b0d34dadf8e658122e619ddd91c15de32b84d034604dd745defbf69",
+    "returncode": 2
+}

--- a/tests/reference/asr-array_04-5864f91.stderr
+++ b/tests/reference/asr-array_04-5864f91.stderr
@@ -1,0 +1,5 @@
+semantic error: Type member a is not an array so it cannot be indexed.
+ --> tests/errors/array_04.f90:8:1
+  |
+8 | b%a(:) = 1
+  | ^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3262,6 +3262,14 @@ filename = "errors/array_02.f90"
 asr = true
 
 [[test]]
+filename = "errors/array_03.f90"
+asr = true
+
+[[test]]
+filename = "errors/array_04.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/where_02.f90"
 asr = true
 pass = "where"


### PR DESCRIPTION
Closes #2197 

This adds an error message for indexing a non-array variable or type member.