### PR TITLE
CI fastGPT: convert some subroutines to functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -425,8 +425,8 @@ jobs:
             ldd ./test_more_inputs
 
             git clean -dfx
-            git checkout -t origin/lf15run
-            git checkout 1b3501f75399f350a2cac51a89d9024493a2c34f
+            git checkout -t origin/lf16run
+            git checkout 5a289cec91938d7754c123797c65457ddc3d571a
             FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS .
             make
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat


### PR DESCRIPTION
This PR converts some subroutines back to functions, but not all yet:

* https://github.com/certik/fastGPT/commit/5a289cec91938d7754c123797c65457ddc3d571a