### PR TITLE
CI fastGPT: turn gpt2 into a function

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -425,8 +425,8 @@ jobs:
             ldd ./test_more_inputs
 
             git clean -dfx
-            git checkout -t origin/lf20run
-            git checkout bb16b1806e3f4a3e47b91b553d1febbf915748da
+            git checkout -t origin/lf21run
+            git checkout 71fc5a89233873e5606fff8d6e16d3905f36ee42
             FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS .
             make
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat


### PR DESCRIPTION
This converts the `gpt2` subroutine to a function, but it modifies the output array so that it works with LFortran:

* https://github.com/certik/fastGPT/commit/71fc5a89233873e5606fff8d6e16d3905f36ee42

It is not clear to me yet what exactly the bug is, but the above commit works, which brings `fastGPT` closer to `main`, so it's a step in the right direction.