### PR TITLE
Use `unique_symbols` pass from lpython

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1051,3 +1051,5 @@ RUN(NAME optional_01 LABELS gfortran llvm)
 RUN(NAME optional_02 LABELS gfortran llvm)
 
 RUN(NAME end_name_match LABELS gfortran llvm)
+
+RUN(NAME mangle_underscore_01 LABELS gfortran llvm EXTRA_ARGS --mangle-underscore --all-mangling)

--- a/integration_tests/mangle_underscore_01.f90
+++ b/integration_tests/mangle_underscore_01.f90
@@ -1,0 +1,17 @@
+subroutine add(x, y)
+    real :: x, y
+    print *, x + y
+    if (abs(x + y - 0.7) > 1e-7) error stop
+end subroutine
+
+subroutine sub(x,y)
+    real :: x, y
+    print *, x - y
+    if (abs(x - y - (-4.5)) > 1e-7) error stop
+
+end subroutine
+
+program mangle_underscore_01
+    call add(-1.9, 2.6)
+    call sub(-1.9, 2.6)
+end program

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -38,6 +38,7 @@
 #include <libasr/pass/inline_function_calls.h>
 #include <libasr/pass/dead_code_removal.h>
 #include <libasr/pass/replace_sign_from_value.h>
+#include <libasr/pass/unique_symbols.h>
 #include <libasr/asr_utils.h>
 #include <libasr/asr_verify.h>
 #include <libasr/modfile.h>
@@ -669,6 +670,11 @@ int emit_asr(const std::string &infile,
     pass_options.verbose = compiler_options.verbose;
     pass_options.pass_cumulative = compiler_options.pass_cumulative;
     pass_options.realloc_lhs = compiler_options.realloc_lhs;
+    pass_options.all_symbols_mangling = compiler_options.all_symbols_mangling;
+    pass_options.module_name_mangling = compiler_options.module_name_mangling;
+    pass_options.global_symbols_mangling = compiler_options.global_symbols_mangling;
+    pass_options.intrinsic_symbols_mangling = compiler_options.intrinsic_symbols_mangling;
+    pass_options.mangle_underscore = compiler_options.mangle_underscore;
 
     pass_manager.apply_passes(al, asr, pass_options, diagnostics);
     if (compiler_options.tree) {
@@ -1927,6 +1933,11 @@ int main(int argc, char *argv[])
         app.add_flag("--verbose", compiler_options.verbose, "Print debugging statements");
         app.add_flag("--cumulative", compiler_options.pass_cumulative, "Apply all the passes cumulatively till the given pass");
         app.add_flag("--realloc-lhs", compiler_options.realloc_lhs, "Reallocate left hand side automatically");
+        app.add_flag("--module-mangling", compiler_options.module_name_mangling, "Mangles the module name");
+        app.add_flag("--global-mangling", compiler_options.global_symbols_mangling, "Mangles all the global symbols");
+        app.add_flag("--intrinsic-mangling", compiler_options.intrinsic_symbols_mangling, "Mangles all the intrinsic symbols");
+        app.add_flag("--all-mangling", compiler_options.all_symbols_mangling, "Mangles all possible symbols");
+        app.add_flag("--mangle-underscore", compiler_options.mangle_underscore, "Mangles with underscore");
 
         /*
         * Subcommands:

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -482,6 +482,11 @@ Result<std::string> FortranEvaluator::get_c3(ASR::TranslationUnit_t &asr,
     pass_options.verbose = compiler_options.verbose;
     pass_options.pass_cumulative = compiler_options.pass_cumulative;
     pass_options.realloc_lhs = compiler_options.realloc_lhs;
+    pass_options.all_symbols_mangling = compiler_options.all_symbols_mangling;
+    pass_options.module_name_mangling = compiler_options.module_name_mangling;
+    pass_options.global_symbols_mangling = compiler_options.global_symbols_mangling;
+    pass_options.intrinsic_symbols_mangling = compiler_options.intrinsic_symbols_mangling;
+    pass_options.mangle_underscore = compiler_options.mangle_underscore;
     pass_manager.skip_c_passes();
     pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
     // ASR pass -> C

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SRC
     pass/pass_array_by_data.cpp
     pass/pass_list_expr.cpp
     pass/pass_compare.cpp
+    pass/unique_symbols.cpp
 
     asr_verify.cpp
     asr_utils.cpp

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8393,6 +8393,11 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     pass_options.use_loop_variable_after_loop = co.use_loop_variable_after_loop;
     pass_options.realloc_lhs = co.realloc_lhs;
     pass_manager.rtlib = co.rtlib;
+    pass_options.all_symbols_mangling = co.all_symbols_mangling;
+    pass_options.module_name_mangling = co.module_name_mangling;
+    pass_options.global_symbols_mangling = co.global_symbols_mangling;
+    pass_options.intrinsic_symbols_mangling = co.intrinsic_symbols_mangling;
+    pass_options.mangle_underscore = co.mangle_underscore;
     pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
 
     // Uncomment for debugging the ASR after the transformation

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -46,6 +46,7 @@
 #include <libasr/pass/create_subroutine_from_function.h>
 #include <libasr/pass/transform_optional_argument_functions.h>
 #include <libasr/pass/nested_vars.h>
+#include <libasr/pass/unique_symbols.h>
 #include <libasr/pass/replace_print_struct_type.h>
 #include <libasr/asr_verify.h>
 
@@ -94,7 +95,8 @@ namespace LCompilers {
             {"init_expr", &pass_replace_init_expr},
             {"nested_vars", &pass_nested_vars},
             {"where", &pass_replace_where},
-            {"print_struct_type", &pass_replace_print_struct_type}
+            {"print_struct_type", &pass_replace_print_struct_type},
+            {"unique_symbols", &pass_unique_symbols}
         };
 
         bool is_fast;
@@ -213,7 +215,8 @@ namespace LCompilers {
                 "select_case",
                 "inline_function_calls",
                 "unused_functions",
-                "transform_optional_argument_functions"
+                "transform_optional_argument_functions",
+                "unique_symbols"
             };
 
             _with_optimization_passes = {
@@ -244,7 +247,8 @@ namespace LCompilers {
                 "div_to_mul",
                 "fma",
                 "transform_optional_argument_functions",
-                "inline_function_calls"
+                "inline_function_calls",
+                "unique_symbols"
             };
 
             // These are re-write passes which are already handled

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -1,0 +1,453 @@
+#include <libasr/asr.h>
+#include <libasr/containers.h>
+#include <libasr/exception.h>
+#include <libasr/asr_utils.h>
+#include <libasr/asr_verify.h>
+#include <libasr/pass/unique_symbols.h>
+#include <libasr/pass/pass_utils.h>
+#include <unordered_map>
+#include <set>
+
+
+extern std::string lcompilers_unique_ID;
+
+/*
+ASR pass for replacing symbol names with some new name, mostly because
+we want to generate unique symbols for each generated ASR output
+so that it doesn't give linking errors for the generated backend code like C.
+
+This is done using two classes:
+1. SymbolRenameVisitor - This captures symbols to be renamed based on the options
+   provided:
+   1.1: module_name_mangling - Mangles the module name.
+   1.2: global_symbols_mangling - Mangles all the global symbols.
+   1.3: intrinsic_symbols_mangling - Mangles all the intrinsic symbols.
+   1.4: all_symbols_mangling - Mangles all possible symbols.
+
+   Note: this skips BindC functions and symbols starting with `_lpython` or `_lfortran`
+
+2. UniqueSymbolVisitor: Renames all the captured symbols from SymbolRenameVisitor.
+*/
+namespace LCompilers {
+
+using ASR::down_cast;
+
+class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
+    public:
+    std::unordered_map<ASR::symbol_t*, std::string> sym_to_renamed;
+    bool module_name_mangling;
+    bool global_symbols_mangling;
+    bool intrinsic_symbols_mangling;
+    bool all_symbols_mangling;
+    bool should_mangle = false;
+    std::string module_name = "";
+
+    SymbolRenameVisitor(
+    bool mm, bool gm, bool im, bool am) : module_name_mangling(mm),
+    global_symbols_mangling(gm), intrinsic_symbols_mangling(im),
+    all_symbols_mangling(am){}
+
+
+    std::string update_name(std::string curr_name) {
+        if (startswith(curr_name, "_lpython") || startswith(curr_name, "_lfortran") ) {
+            return curr_name;
+        }
+        return module_name + curr_name + "_" + lcompilers_unique_ID;
+    }
+
+    void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+        ASR::TranslationUnit_t& xx = const_cast<ASR::TranslationUnit_t&>(x);
+        std::unordered_map<ASR::symbol_t*, std::string> tmp_scope;
+        for (auto &a : xx.m_global_scope->get_scope()) {
+            visit_symbol(*a.second);
+        }
+    }
+
+    void visit_Program(const ASR::Program_t &x) {
+        for (auto &a : x.m_symtab->get_scope()) {
+            visit_symbol(*a.second);
+        }
+    }
+
+    void visit_Module(const ASR::Module_t &x) {
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        bool should_mangle_copy = should_mangle;
+        std::string mod_name_copy = module_name;
+        module_name = std::string(x.m_name) + "_";
+        if (all_symbols_mangling || module_name_mangling || should_mangle) {
+            sym_to_renamed[sym] = update_name(x.m_name);
+        }
+        if ((x.m_intrinsic && intrinsic_symbols_mangling) ||
+                (global_symbols_mangling && startswith(x.m_name, "_global_symbols"))) {
+            should_mangle = true;
+        }
+        for (auto &a : x.m_symtab->get_scope()) {
+            visit_symbol(*a.second);
+        }
+        should_mangle = should_mangle_copy;
+        module_name = mod_name_copy;
+    }
+
+    void visit_Function(const ASR::Function_t &x) {
+        ASR::FunctionType_t *f_type = ASRUtils::get_FunctionType(x);
+        if (f_type->m_abi != ASR::abiType::BindC) {
+            ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+            if (all_symbols_mangling || should_mangle) {
+                sym_to_renamed[sym] = update_name(x.m_name);
+            }
+        }
+        for (auto &a : x.m_symtab->get_scope()) {
+            visit_symbol(*a.second);
+        }
+    }
+
+    template <typename T>
+    void visit_symbols_1(T &x) {
+        if (all_symbols_mangling || should_mangle) {
+            ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+            sym_to_renamed[sym] = update_name(x.m_name);
+        }
+    }
+
+    void visit_GenericProcedure(const ASR::GenericProcedure_t &x) {
+        visit_symbols_1(x);
+    }
+
+    void visit_CustomOperator(const ASR::CustomOperator_t &x) {
+        visit_symbols_1(x);
+    }
+
+    void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
+        visit_symbols_1(x);
+    }
+
+    void visit_Variable(const ASR::Variable_t &x) {
+        visit_symbols_1(x);
+    }
+
+    template <typename T>
+    void visit_symbols_2(T &x) {
+        if (x.m_abi != ASR::abiType::BindC) {
+            if (all_symbols_mangling || should_mangle) {
+                ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+                sym_to_renamed[sym] = update_name(x.m_name);
+            }
+        }
+        for (auto &a : x.m_symtab->get_scope()) {
+            this->visit_symbol(*a.second);
+        }
+    }
+
+    void visit_StructType(const ASR::StructType_t &x) {
+        visit_symbols_2(x);
+    }
+
+    void visit_EnumType(const ASR::EnumType_t &x) {
+        visit_symbols_2(x);
+    }
+
+    void visit_UnionType(const ASR::UnionType_t &x) {
+        visit_symbols_2(x);
+    }
+
+    void visit_ClassType(const ASR::ClassType_t &x) {
+        visit_symbols_2(x);
+    }
+
+    void visit_ClassProcedure(const ASR::ClassProcedure_t &x) {
+        if (x.m_abi != ASR::abiType::BindC) {
+            if (all_symbols_mangling || should_mangle) {
+                ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+                sym_to_renamed[sym] = update_name(x.m_name);
+            }
+        }
+    }
+
+    template <typename T>
+    void visit_symbols_3(T &x) {
+        if (all_symbols_mangling || should_mangle) {
+            ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+            sym_to_renamed[sym] = update_name(x.m_name);
+        }
+        for (auto &a : x.m_symtab->get_scope()) {
+            this->visit_symbol(*a.second);
+        }
+    }
+
+    void visit_AssociateBlock(const ASR::AssociateBlock_t &x) {
+        visit_symbols_3(x);
+    }
+
+    void visit_Block(const ASR::Block_t &x) {
+        visit_symbols_3(x);
+    }
+
+    void visit_Requirement(const ASR::Requirement_t &x) {
+        visit_symbols_3(x);
+    }
+
+    void visit_Template(const ASR::Template_t &x) {
+        visit_symbols_3(x);
+    }
+
+};
+
+
+class UniqueSymbolVisitor: public ASR::BaseWalkVisitor<UniqueSymbolVisitor> {
+    private:
+
+    Allocator& al;
+
+    public:
+    std::unordered_map<ASR::symbol_t*, std::string>& sym_to_new_name;
+    std::map<std::string, ASR::symbol_t*> current_scope;
+
+    UniqueSymbolVisitor(Allocator& al_,
+    std::unordered_map<ASR::symbol_t*, std::string> &sn) : al(al_), sym_to_new_name(sn){}
+
+
+    void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+        ASR::TranslationUnit_t& xx = const_cast<ASR::TranslationUnit_t&>(x);
+        std::map<std::string, ASR::symbol_t*> current_scope_copy = current_scope;
+        current_scope = x.m_global_scope->get_scope();
+        for (auto &a : xx.m_global_scope->get_scope()) {
+            visit_symbol(*a.second);
+        }
+        for (auto &a: current_scope) {
+            if (sym_to_new_name.find(a.second) != sym_to_new_name.end()) {
+                xx.m_global_scope->erase_symbol(a.first);
+                xx.m_global_scope->add_symbol(sym_to_new_name[a.second], a.second);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
+    template <typename T>
+    void update_symbols_1(const T &x) {
+        T& xx = const_cast<T&>(x);
+        std::map<std::string, ASR::symbol_t*> current_scope_copy = current_scope;
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+        for (size_t i=0; i<xx.n_dependencies; i++) {
+            if (current_scope.find(xx.m_dependencies[i]) != current_scope.end()) {
+                sym = current_scope[xx.m_dependencies[i]];
+                if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+                    xx.m_dependencies[i] = s2c(al, sym_to_new_name[sym]);
+                }
+            }
+        }
+        current_scope = x.m_symtab->get_scope();
+        for (auto &a : x.m_symtab->get_scope()) {
+                visit_symbol(*a.second);
+        }
+        for (auto &a: current_scope) {
+            if (sym_to_new_name.find(a.second) != sym_to_new_name.end()) {
+                xx.m_symtab->erase_symbol(a.first);
+                xx.m_symtab->add_symbol(sym_to_new_name[a.second], a.second);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
+    void visit_Program(const ASR::Program_t &x) {
+        update_symbols_1(x);
+    }
+
+    void visit_Module(const ASR::Module_t &x) {
+        update_symbols_1(x);
+    }
+
+    void visit_Function(const ASR::Function_t &x) {
+        update_symbols_1(x);
+    }
+
+    void visit_GenericProcedure(const ASR::GenericProcedure_t &x) {
+        ASR::GenericProcedure_t& xx = const_cast<ASR::GenericProcedure_t&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+    }
+
+    void visit_CustomOperator(const ASR::CustomOperator_t &x) {
+        ASR::CustomOperator_t& xx = const_cast<ASR::CustomOperator_t&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+    }
+
+    void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
+        ASR::ExternalSymbol_t& xx = const_cast<ASR::ExternalSymbol_t&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+        SymbolTable* s = ASRUtils::symbol_parent_symtab(x.m_external);
+        ASR::symbol_t *asr_owner = ASR::down_cast<ASR::symbol_t>(s->asr_owner);
+        if (sym_to_new_name.find(x.m_external) != sym_to_new_name.end()) {
+            xx.m_original_name = s2c(al, sym_to_new_name[x.m_external]);
+        }
+        if (sym_to_new_name.find(asr_owner) != sym_to_new_name.end()) {
+            xx.m_module_name = s2c(al, sym_to_new_name[asr_owner]);
+        }
+    }
+
+    template <typename T>
+    void update_symbols_2(const T &x) {
+        T& xx = const_cast<T&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+        std::map<std::string, ASR::symbol_t*> current_scope_copy = current_scope;
+        for (size_t i=0; i<xx.n_dependencies; i++) {
+            if (current_scope.find(xx.m_dependencies[i]) != current_scope.end()) {
+                sym = current_scope[xx.m_dependencies[i]];
+                if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+                    xx.m_dependencies[i] = s2c(al, sym_to_new_name[sym]);
+                }
+            }
+        }
+        current_scope = x.m_symtab->get_scope();
+        for (size_t i=0; i<xx.n_members; i++) {
+            if (current_scope.find(xx.m_members[i]) != current_scope.end()) {
+                sym = current_scope[xx.m_members[i]];
+                if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+                    xx.m_members[i] = s2c(al, sym_to_new_name[sym]);
+                }
+            }
+        }
+        for (auto &a : x.m_symtab->get_scope()) {
+            visit_symbol(*a.second);
+        }
+        for (auto &a: current_scope) {
+            if (sym_to_new_name.find(a.second) != sym_to_new_name.end()) {
+                xx.m_symtab->erase_symbol(a.first);
+                xx.m_symtab->add_symbol(sym_to_new_name[a.second], a.second);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
+    void visit_StructType(const ASR::StructType_t &x) {
+        update_symbols_2(x);
+    }
+
+    void visit_EnumType(const ASR::EnumType_t &x) {
+        update_symbols_2(x);
+    }
+
+    void visit_UnionType(const ASR::UnionType_t &x) {
+        update_symbols_2(x);
+    }
+
+    void visit_Variable(const ASR::Variable_t &x) {
+        ASR::Variable_t& xx = const_cast<ASR::Variable_t&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+        for (size_t i=0; i<xx.n_dependencies; i++) {
+            if (current_scope.find(xx.m_dependencies[i]) != current_scope.end()) {
+                sym = current_scope[xx.m_dependencies[i]];
+                if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+                    xx.m_dependencies[i] = s2c(al, sym_to_new_name[sym]);
+                }
+            }
+        }
+    }
+
+    void visit_ClassType(const ASR::ClassType_t &x) {
+        ASR::ClassType_t& xx = const_cast<ASR::ClassType_t&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+        std::map<std::string, ASR::symbol_t*> current_scope_copy = current_scope;
+        current_scope = x.m_symtab->get_scope();
+        for (auto &a : x.m_symtab->get_scope()) {
+            visit_symbol(*a.second);
+        }
+        for (auto &a: current_scope) {
+            if (sym_to_new_name.find(a.second) != sym_to_new_name.end()) {
+                xx.m_symtab->erase_symbol(a.first);
+                xx.m_symtab->add_symbol(sym_to_new_name[a.second], a.second);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
+    void visit_ClassProcedure(const ASR::ClassProcedure_t &x) {
+        ASR::ClassProcedure_t& xx = const_cast<ASR::ClassProcedure_t&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+    }
+
+    template <typename T>
+    void update_symbols_3(const T &x) {
+        T& xx = const_cast<T&>(x);
+        ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+        if (sym_to_new_name.find(sym) != sym_to_new_name.end()) {
+            xx.m_name = s2c(al, sym_to_new_name[sym]);
+        }
+        std::map<std::string, ASR::symbol_t*> current_scope_copy = current_scope;
+        current_scope = x.m_symtab->get_scope();
+        for (auto &a : x.m_symtab->get_scope()) {
+            visit_symbol(*a.second);
+        }
+        for (auto &a: current_scope) {
+            if (sym_to_new_name.find(a.second) != sym_to_new_name.end()) {
+                xx.m_symtab->erase_symbol(a.first);
+                xx.m_symtab->add_symbol(sym_to_new_name[a.second], a.second);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
+    void visit_AssociateBlock(const ASR::AssociateBlock_t &x) {
+        update_symbols_3(x);
+    }
+
+    void visit_Block(const ASR::Block_t &x) {
+        update_symbols_3(x);
+    }
+
+    void visit_Requirement(const ASR::Requirement_t &x) {
+        update_symbols_3(x);
+    }
+
+    void visit_Template(const ASR::Template_t &x) {
+       update_symbols_3(x);
+    }
+
+};
+
+
+void pass_unique_symbols(Allocator &al, ASR::TranslationUnit_t &unit,
+    const LCompilers::PassOptions& pass_options) {
+    bool any_present = (pass_options.module_name_mangling || pass_options.global_symbols_mangling ||
+                    pass_options.intrinsic_symbols_mangling || pass_options.all_symbols_mangling);
+    if (pass_options.mangle_underscore) {
+        lcompilers_unique_ID = "";
+    }
+    if (!any_present || ( !pass_options.mangle_underscore && lcompilers_unique_ID.empty() )) {
+        return;
+    }
+    SymbolRenameVisitor v(pass_options.module_name_mangling,
+                pass_options.global_symbols_mangling,
+                pass_options.intrinsic_symbols_mangling,
+                pass_options.all_symbols_mangling);
+    v.visit_TranslationUnit(unit);
+    UniqueSymbolVisitor u(al, v.sym_to_renamed);
+    u.visit_TranslationUnit(unit);
+    PassUtils::UpdateDependenciesVisitor x(al);
+    x.visit_TranslationUnit(unit);
+}
+
+
+} // namespace LCompilers

--- a/src/libasr/pass/unique_symbols.h
+++ b/src/libasr/pass/unique_symbols.h
@@ -1,0 +1,14 @@
+#ifndef LIBASR_PASS_UNIQUE_SYMBOLS_H
+#define LIBASR_PASS_UNIQUE_SYMBOLS_H
+
+#include <libasr/asr.h>
+#include <libasr/utils.h>
+
+namespace LCompilers {
+
+    void pass_unique_symbols(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const PassOptions &pass_options);
+
+} // namespace LCompilers
+
+#endif // LIBASR_PASS_UNIQUE_SYMBOLS_H

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -67,6 +67,11 @@ struct CompilerOptions {
     bool enable_symengine = false;
     bool link_numpy = false;
     bool realloc_lhs = false;
+    bool module_name_mangling = false;
+    bool global_symbols_mangling = false;
+    bool intrinsic_symbols_mangling = false;
+    bool all_symbols_mangling = false;
+    bool mangle_underscore = false;
     std::vector<std::string> import_paths;
     Platform platform;
 
@@ -98,6 +103,11 @@ namespace LCompilers {
         bool disable_main = false;
         bool use_loop_variable_after_loop = false;
         bool realloc_lhs = false;
+        bool module_name_mangling = false;
+        bool global_symbols_mangling = false;
+        bool intrinsic_symbols_mangling = false;
+        bool all_symbols_mangling = false;
+        bool mangle_underscore = false;
     };
 
 }


### PR DESCRIPTION
Thanks @Smit-create for implementation! When I use `--all-mangling --mangle-underscore` flags to compile the file, I now don't need `_` fixes.
PS: I just copied entire pass from `lpython` and added `--mangle-underscore` flag to explicitly specify `_` mangling.