### PR TITLE
Print arrays with StringFormat

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -401,7 +401,7 @@ RUN(NAME format_02 LABELS gfortran)
 RUN(NAME format_04 LABELS gfortran llvm)
 RUN(NAME format_05 LABELS gfortran)
 RUN(NAME format_06 LABELS gfortran llvm)
-RUN(NAME format_07 LABELS gfortran)
+RUN(NAME format_07 LABELS gfortran llvm)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -401,6 +401,7 @@ RUN(NAME format_02 LABELS gfortran)
 RUN(NAME format_04 LABELS gfortran llvm)
 RUN(NAME format_05 LABELS gfortran)
 RUN(NAME format_06 LABELS gfortran llvm)
+RUN(NAME format_07 LABELS gfortran)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran)

--- a/integration_tests/format_07.f90
+++ b/integration_tests/format_07.f90
@@ -1,0 +1,16 @@
+program format_07
+    implicit none
+    integer, parameter :: dp=kind(0d0)
+    real(dp) :: x(3)
+    real :: z(3)
+    integer :: y(4)
+    x = [1._dp,1._dp,1._dp]
+    y = [117,123,124,126]
+    z = [1.0,2.0,3.0]
+  10 format(3d12.5)
+  20 format(4i10)
+  30 format(3d12.5)
+    print 10, x
+    print 20, y
+    print 30, z
+end program


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/pull/2193#issuecomment-1694506731

This PR allows to print arrays while using format statements.
The following gives same output for GFortran and LFortran
```fortran
program format_07
    implicit none
    integer, parameter :: dp=kind(0d0)
    real(dp) :: x(3)
    real :: z(3)
    integer :: y(4)
    x = [1._dp,1._dp,1._dp]
    y = [117,123,124,126]
    z = [1.0,2.0,3.0]
  10 format(3d12.5)
  20 format(4i10)
  30 format(3d12.5)
    print 10, x
    print 20, y
    print 30, z
end program
```
```console
 0.10000D+01 0.10000D+01 0.10000D+01
       117       123       124       126
 0.10000D+01 0.20000D+01 0.30000D+01
```