### PR TITLE
Implement array support and format label for WRITE statements

### DIFF
--- a/integration_tests/format_06.f90
+++ b/integration_tests/format_06.f90
@@ -11,15 +11,15 @@ d = 123.45
 30 format(4a4)
 40 format(A2,4(2X,A),I3)
 
-print *, "ok", "b"
-print 10, "ok", "b"
+print *, "a", "b"
+print 10, "c", "d"
 print 20, "Hello 123"
-print 30, "dancing","in","the","moonlight"
-print 40, "ab", "cdef", "ghi", "jkl","qwerty",12
+write (*,30) "dancing","in","the","moonlight"
+write (*,40) "ab", "cdef", "ghi", "jkl","qwerty",12
 print 50 , 123,456,12345,6789
 print 60, 123.456, -123.45678, 12.34, -123.45
-print 70, -a, b, -c, d
-print 80, -a, b, -c, d
+write (*,70) -a, b, -c, d
+write (*,80) -a, b, -c, d
 
 50 format(i3,i10.5,/i6.6,2x,i3)
 60 format(d10.2,d15.6,d010.2,2x,d7.2)
@@ -30,7 +30,7 @@ print 80, -a, b, -c, d
 if ( a > 0) then
     print 90, "Hello "
     if ( b > 0) then
-      print 100, "World!"
+      write (*,100) "World!"
     end if
   100 format(a)
   end if

--- a/integration_tests/format_07.f90
+++ b/integration_tests/format_07.f90
@@ -13,4 +13,10 @@ program format_07
     print 10, x
     print 20, y
     print 30, z
+    write (*,40) x
+    write (*,50) y
+    write (*,60) z
+  40 format(3d12.5)
+  50 format(4i10)
+  60 format(3d12.5)
 end program

--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -87,11 +87,11 @@ public:
                     ASR::expr_t* string_format = ASRUtils::EXPR(ASR::make_StringFormat_t(al, format->base.base.loc,
                     format->m_fmt, print_args.p, print_args.size(), ASR::string_format_kindType::FormatFortran,
                     format->m_type, format->m_value));
-                    Vec<ASR::expr_t*> print_args;
-                    print_args.reserve(al, 1);
-                    print_args.push_back(al, string_format);
+                    Vec<ASR::expr_t*> format_args;
+                    format_args.reserve(al, 1);
+                    format_args.push_back(al, string_format);
                     print_stmt = ASRUtils::STMT(ASR::make_Print_t(al, loc, nullptr,
-                        print_args.p, print_args.size(), nullptr, empty_space));
+                        format_args.p, format_args.size(), nullptr, empty_space));
                 } else {
                     print_stmt = ASRUtils::STMT(ASR::make_Print_t(al, loc, nullptr,
                                                                 print_args.p, print_args.size(), nullptr, space));
@@ -106,7 +106,7 @@ public:
         return doloop;
     }
 
-    ASR::stmt_t* create_fmtprint(std::vector<ASR::expr_t*> &print_body, ASR::StringFormat_t* format, const Location &loc) {
+    ASR::stmt_t* create_formatstmt(std::vector<ASR::expr_t*> &print_body, ASR::StringFormat_t* format, const Location &loc, ASR::stmtType _type) {
         Vec<ASR::expr_t*> body;
         body.reserve(al, print_body.size());
         for (size_t j=0; j<print_body.size(); j++) {
@@ -118,23 +118,30 @@ public:
         Vec<ASR::expr_t*> print_args;
         print_args.reserve(al, 1);
         print_args.push_back(al, string_format);
-        ASR::stmt_t* print_stmt = ASRUtils::STMT(ASR::make_Print_t(al, loc, nullptr,
+        ASR::stmt_t* statement = nullptr;
+        if (_type == ASR::stmtType::Print) {
+            statement = ASRUtils::STMT(ASR::make_Print_t(al, loc, nullptr,
             print_args.p, print_args.size(), nullptr, nullptr));
+        } else if (_type == ASR::stmtType::FileWrite) {
+            statement = ASRUtils::STMT(ASR::make_FileWrite_t(al, loc, 0, nullptr,
+                nullptr, nullptr, nullptr, nullptr, print_args.p, print_args.size(), nullptr, nullptr));
+        }
         print_body.clear();
-        return print_stmt;
+        return statement;
     }
 
     void visit_Print(const ASR::Print_t& x) {
-        if(x.m_values[0] != nullptr && ASR::is_a<ASR::StringFormat_t>(*x.m_values[0])){
-            std::vector<ASR::expr_t*> print_body;
-            ASR::stmt_t* print_stmt;
-            ASR::stmt_t* empty_print_endl = ASRUtils::STMT(ASR::make_Print_t(al, x.base.base.loc,
+        std::vector<ASR::expr_t*> print_body;
+        ASR::stmt_t* empty_print_endl;
+        ASR::stmt_t* print_stmt;
+        if (x.m_values[0] != nullptr && ASR::is_a<ASR::StringFormat_t>(*x.m_values[0])) {
+            empty_print_endl = ASRUtils::STMT(ASR::make_Print_t(al, x.base.base.loc,
                                                 nullptr, nullptr, 0, nullptr, nullptr));
             ASR::StringFormat_t* format = ASR::down_cast<ASR::StringFormat_t>(x.m_values[0]);
             for (size_t i=0; i<format->n_args; i++) {
                 if (PassUtils::is_array(format->m_args[i])) {
                     if (print_body.size() > 0) {
-                        print_stmt = create_fmtprint(print_body, format, x.base.base.loc);
+                        print_stmt = create_formatstmt(print_body, format, x.base.base.loc, ASR::stmtType::Print);
                         pass_result.push_back(al, print_stmt);
                     }
                     print_stmt = print_array_using_doloop(format->m_args[i],format, x.base.base.loc);
@@ -145,14 +152,11 @@ public:
                 }
             }
             if (print_body.size() > 0) {
-                print_stmt = create_fmtprint(print_body, format, x.base.base.loc);
+                print_stmt = create_formatstmt(print_body, format, x.base.base.loc, ASR::stmtType::Print);
                 pass_result.push_back(al, print_stmt);
             }
             return;
         }
-        std::vector<ASR::expr_t*> print_body;
-        ASR::stmt_t* empty_print_endl;
-        ASR::stmt_t* print_stmt;
         ASR::ttype_t *str_type_len_1 = ASRUtils::TYPE(ASR::make_Character_t(
             al, x.base.base.loc, 1, 1, nullptr));
         ASR::expr_t *space = ASRUtils::EXPR(ASR::make_StringConstant_t(
@@ -223,11 +227,15 @@ public:
         }
     }
 
-    ASR::stmt_t* write_array_using_doloop(ASR::expr_t *arr_expr, const Location &loc) {
+    ASR::stmt_t* write_array_using_doloop(ASR::expr_t *arr_expr, ASR::StringFormat_t* format, const Location &loc) {
         int n_dims = PassUtils::get_rank(arr_expr);
         Vec<ASR::expr_t*> idx_vars;
         PassUtils::create_idx_vars(idx_vars, n_dims, loc, al, current_scope);
         ASR::stmt_t* doloop = nullptr;
+        ASR::ttype_t *str_type_len = ASRUtils::TYPE(ASR::make_Character_t(
+            al, loc, 1, 0, nullptr));
+        ASR::expr_t *empty_space = ASRUtils::EXPR(ASR::make_StringConstant_t(
+            al, loc, s2c(al, ""), str_type_len));
         ASR::stmt_t* empty_file_write_endl = ASRUtils::STMT(ASR::make_FileWrite_t(al, loc,
                                             0, nullptr, nullptr, nullptr, nullptr, nullptr,nullptr, 0, nullptr, nullptr));
         for( int i = n_dims - 1; i >= 0; i-- ) {
@@ -244,8 +252,20 @@ public:
                 Vec<ASR::expr_t*> print_args;
                 print_args.reserve(al, 1);
                 print_args.push_back(al, ref);
-                ASR::stmt_t* write_stmt = ASRUtils::STMT(ASR::make_FileWrite_t(
+                ASR::stmt_t* write_stmt = nullptr;
+                if (format != nullptr) {
+                    ASR::expr_t* string_format = ASRUtils::EXPR(ASR::make_StringFormat_t(al, format->base.base.loc,
+                    format->m_fmt, print_args.p, print_args.size(), ASR::string_format_kindType::FormatFortran,
+                    format->m_type, format->m_value));
+                    Vec<ASR::expr_t*> format_args;
+                    format_args.reserve(al, 1);
+                    format_args.push_back(al, string_format);
+                    write_stmt = ASRUtils::STMT(ASR::make_FileWrite_t(
+                        al, loc, i, nullptr, nullptr, nullptr, nullptr, nullptr, format_args.p, format_args.size(), nullptr, empty_space));
+                } else {
+                    write_stmt = ASRUtils::STMT(ASR::make_FileWrite_t(
                         al, loc, i, nullptr, nullptr, nullptr, nullptr, nullptr, print_args.p, print_args.size(), nullptr, nullptr));
+                }
                 doloop_body.push_back(al, write_stmt);
             } else {
                 doloop_body.push_back(al, doloop);
@@ -258,9 +278,30 @@ public:
 
     void visit_FileWrite(const ASR::FileWrite_t& x) {
         std::vector<ASR::expr_t*> write_body;
+        ASR::stmt_t* write_stmt;
         ASR::stmt_t* empty_file_write_endl = ASRUtils::STMT(ASR::make_FileWrite_t(al, x.base.base.loc,
                                             x.m_label, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr));
-        ASR::stmt_t* write_stmt;
+        if(x.m_values[0] != nullptr && ASR::is_a<ASR::StringFormat_t>(*x.m_values[0])){
+            ASR::StringFormat_t* format = ASR::down_cast<ASR::StringFormat_t>(x.m_values[0]);
+            for (size_t i=0; i<format->n_args; i++) {
+                if (PassUtils::is_array(format->m_args[i])) {
+                    if (write_body.size() > 0) {
+                        write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite);
+                        pass_result.push_back(al, write_stmt);
+                    }
+                    write_stmt = write_array_using_doloop(format->m_args[i],format, x.base.base.loc);
+                    pass_result.push_back(al, write_stmt);
+                    pass_result.push_back(al, empty_file_write_endl);
+                } else {
+                    write_body.push_back(format->m_args[i]);
+                }
+            }
+            if (write_body.size() > 0) {
+                write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite);
+                pass_result.push_back(al, write_stmt);
+            }
+            return;
+        }
         for (size_t i=0; i<x.n_values; i++) {
             // DIVERGENCE between LFortran and LPython
             // If a pointer array variable is provided
@@ -278,7 +319,7 @@ public:
                     pass_result.push_back(al, empty_file_write_endl);
                     write_body.clear();
                 }
-                write_stmt = write_array_using_doloop(x.m_values[i], x.base.base.loc);
+                write_stmt = write_array_using_doloop(x.m_values[i], nullptr, x.base.base.loc);
                 pass_result.push_back(al, write_stmt);
                 pass_result.push_back(al, empty_file_write_endl);
             } else {


### PR DESCRIPTION
```write``` statements will now be able to print arrays correctly and use labels to find ```format``` statements below them.
See the added tests in ```format_06.f90``` and ```format_07.f90``` for example, they now give the same output as ```gfortran```.