### PR TITLE
Use kind as tiebreaker when two types have same priority 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1057,3 +1057,6 @@ RUN(NAME end_name_match LABELS gfortran llvm)
 RUN(NAME mangle_underscore_01 LABELS gfortran llvm EXTRA_ARGS --mangle-underscore --all-mangling)
 
 RUN(NAME nan_handling_01 LABELS gfortran llvm)
+
+RUN(NAME precision_01 LABELS gfortran llvm)
+RUN(NAME precision_02 LABELS gfortran) # TODO fix this test

--- a/integration_tests/precision_01.f90
+++ b/integration_tests/precision_01.f90
@@ -1,0 +1,8 @@
+program precision_01
+    double precision :: x,x1, x2
+    x1 = 1.234D0
+    x2 = 4.567D0
+    x = 1.0 - x1 / x2
+    print *, x
+    if (abs(x - 0.72980074447120646D0) > 1d-10) error stop
+end program

--- a/integration_tests/precision_02.f90
+++ b/integration_tests/precision_02.f90
@@ -1,0 +1,9 @@
+program precision_02
+    integer, parameter :: dp = kind(0.d0)
+    real(dp) :: x, x1
+    x1 = 1.1_dp
+    x = 1.1 - x1
+    print *, x
+    if (abs(x - 2.3841857821338408E-008) > 1D-10) error stop
+end program
+    

--- a/src/lfortran/semantics/asr_implicit_cast_rules.h
+++ b/src/lfortran/semantics/asr_implicit_cast_rules.h
@@ -290,11 +290,25 @@ public:
     LCOMPILERS_ASSERT(right_type2->type < num_types);
     int left_type_p = type_priority[left_type2->type];
     int right_type_p = type_priority[right_type2->type];
+    int left_kind = 0, right_kind = 1;
+    left_kind = ASRUtils::extract_kind_from_ttype_t(left_type2);
+    right_kind = ASRUtils::extract_kind_from_ttype_t(right_type2);
 
-    if (left_type_p >= right_type_p) {
+    if (left_type_p > right_type_p) {
       conversion_cand = right;
       *source_type = right_type;
       *dest_type = left_type;
+    } else if (left_type_p == right_type_p) {
+      // both are of same priority, then the one with lower kind is chosen
+      if (left_kind >= right_kind) {
+        conversion_cand = right;
+        *source_type = right_type;
+        *dest_type = left_type;
+      } else if (left_kind < right_kind) {
+        conversion_cand = left;
+        *source_type = left_type;
+        *dest_type = right_type;
+      }
     } else {
       conversion_cand = left;
       *source_type = left_type;

--- a/src/lfortran/semantics/asr_implicit_cast_rules.h
+++ b/src/lfortran/semantics/asr_implicit_cast_rules.h
@@ -299,7 +299,7 @@ public:
       *source_type = right_type;
       *dest_type = left_type;
     } else if (left_type_p == right_type_p) {
-      // both are of same priority, then the one with lower kind is chosen
+      // both are of same priority, then the one with lower kind is chosen to be cast to the higher kind
       if (left_kind >= right_kind) {
         conversion_cand = right;
         *source_type = right_type;

--- a/tests/reference/asr-div_to_mul-3aaf3c0.json
+++ b/tests/reference/asr-div_to_mul-3aaf3c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-div_to_mul-3aaf3c0.stdout",
-    "stdout_hash": "727d10b3f05c9bb800a43731eedfa017f81a6ec556311f852318a54c",
+    "stdout_hash": "5b2c9af027be255774b1414990ca34904c89af2cb64bd5fd6e8e8bcf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-div_to_mul-3aaf3c0.stdout
+++ b/tests/reference/asr-div_to_mul-3aaf3c0.stdout
@@ -169,37 +169,47 @@
                                 Abs
                                 [(RealBinOp
                                     (RealBinOp
-                                        (Var 2 x)
-                                        Div
                                         (Cast
-                                            (RealConstant
-                                                2.000000
-                                                (Real 8)
-                                            )
+                                            (Var 2 x)
                                             RealToReal
-                                            (Real 4)
-                                            (RealConstant
-                                                2.000000
-                                                (Real 4)
-                                            )
+                                            (Real 8)
+                                            ()
                                         )
-                                        (Real 4)
+                                        Div
+                                        (RealConstant
+                                            2.000000
+                                            (Real 8)
+                                        )
+                                        (Real 8)
                                         ()
                                     )
                                     Sub
-                                    (RealConstant
-                                        1.570000
-                                        (Real 4)
+                                    (Cast
+                                        (RealConstant
+                                            1.570000
+                                            (Real 4)
+                                        )
+                                        RealToReal
+                                        (Real 8)
+                                        (RealConstant
+                                            1.570000
+                                            (Real 8)
+                                        )
                                     )
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )]
                                 0
-                                (Real 4)
+                                (Real 8)
                                 ()
                             )
                             Gt
-                            (Var 2 eps)
+                            (Cast
+                                (Var 2 eps)
+                                RealToReal
+                                (Real 8)
+                                ()
+                            )
                             (Logical 4)
                             ()
                         )

--- a/tests/reference/asr-intrinsics_03-ef06d46.json
+++ b/tests/reference/asr-intrinsics_03-ef06d46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_03-ef06d46.stdout",
-    "stdout_hash": "18be2da680907760a3181a535209f54603ac72201f8997ce24c3f87d",
+    "stdout_hash": "f39afca6d8a5880b0d3fed005ac8ff6b684bcc974194faa9061a27bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_03-ef06d46.stdout
+++ b/tests/reference/asr-intrinsics_03-ef06d46.stdout
@@ -211,67 +211,86 @@
                                     (IntrinsicScalarFunction
                                         Cos
                                         [(RealBinOp
-                                            (IntrinsicScalarFunction
-                                                Cos
-                                                [(RealConstant
-                                                    1.500000
-                                                    (Real 4)
-                                                )]
-                                                0
-                                                (Real 4)
-                                                (RealConstant
-                                                    0.070737
-                                                    (Real 4)
-                                                )
-                                            )
-                                            Add
                                             (Cast
                                                 (IntrinsicScalarFunction
                                                     Cos
-                                                    [(RealBinOp
-                                                        (Var 2 a)
-                                                        Add
-                                                        (IntrinsicScalarFunction
-                                                            Cos
-                                                            [(Var 2 a)]
-                                                            0
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        (Real 8)
-                                                        ()
+                                                    [(RealConstant
+                                                        1.500000
+                                                        (Real 4)
                                                     )]
                                                     0
-                                                    (Real 8)
-                                                    ()
+                                                    (Real 4)
+                                                    (RealConstant
+                                                        0.070737
+                                                        (Real 4)
+                                                    )
                                                 )
                                                 RealToReal
-                                                (Real 4)
+                                                (Real 8)
+                                                (RealConstant
+                                                    0.070737
+                                                    (Real 8)
+                                                )
+                                            )
+                                            Add
+                                            (IntrinsicScalarFunction
+                                                Cos
+                                                [(RealBinOp
+                                                    (Var 2 a)
+                                                    Add
+                                                    (IntrinsicScalarFunction
+                                                        Cos
+                                                        [(Var 2 a)]
+                                                        0
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )]
+                                                0
+                                                (Real 8)
                                                 ()
                                             )
-                                            (Real 4)
+                                            (Real 8)
                                             ()
                                         )]
                                         0
-                                        (Real 4)
+                                        (Real 8)
                                         ()
                                     )
                                     Sub
-                                    (RealConstant
-                                        0.716404
-                                        (Real 4)
+                                    (Cast
+                                        (RealConstant
+                                            0.716404
+                                            (Real 4)
+                                        )
+                                        RealToReal
+                                        (Real 8)
+                                        (RealConstant
+                                            0.716404
+                                            (Real 8)
+                                        )
                                     )
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )]
                                 0
-                                (Real 4)
+                                (Real 8)
                                 ()
                             )
                             Gt
-                            (RealConstant
-                                0.000000
-                                (Real 4)
+                            (Cast
+                                (RealConstant
+                                    0.000000
+                                    (Real 4)
+                                )
+                                RealToReal
+                                (Real 8)
+                                (RealConstant
+                                    0.000000
+                                    (Real 8)
+                                )
                             )
                             (Logical 4)
                             ()

--- a/tests/reference/asr-intrinsics_04-524ec3a.json
+++ b/tests/reference/asr-intrinsics_04-524ec3a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_04-524ec3a.stdout",
-    "stdout_hash": "d1fcc1fd1f52dfa2fc67714966e5433356df491f29bdd33ccefa4c6b",
+    "stdout_hash": "3a8617e70814e69b5033865a744c7181997d26e660ff7cd08b3bc6d0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_04-524ec3a.stdout
+++ b/tests/reference/asr-intrinsics_04-524ec3a.stdout
@@ -188,67 +188,86 @@
                                     (IntrinsicScalarFunction
                                         Tan
                                         [(RealBinOp
-                                            (IntrinsicScalarFunction
-                                                Tan
-                                                [(RealConstant
-                                                    1.500000
-                                                    (Real 4)
-                                                )]
-                                                0
-                                                (Real 4)
-                                                (RealConstant
-                                                    14.101420
-                                                    (Real 4)
-                                                )
-                                            )
-                                            Add
                                             (Cast
                                                 (IntrinsicScalarFunction
                                                     Tan
-                                                    [(RealBinOp
-                                                        (Var 2 x)
-                                                        Add
-                                                        (IntrinsicScalarFunction
-                                                            Tan
-                                                            [(Var 2 x)]
-                                                            0
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        (Real 8)
-                                                        ()
+                                                    [(RealConstant
+                                                        1.500000
+                                                        (Real 4)
                                                     )]
                                                     0
-                                                    (Real 8)
-                                                    ()
+                                                    (Real 4)
+                                                    (RealConstant
+                                                        14.101420
+                                                        (Real 4)
+                                                    )
                                                 )
                                                 RealToReal
-                                                (Real 4)
+                                                (Real 8)
+                                                (RealConstant
+                                                    14.101420
+                                                    (Real 8)
+                                                )
+                                            )
+                                            Add
+                                            (IntrinsicScalarFunction
+                                                Tan
+                                                [(RealBinOp
+                                                    (Var 2 x)
+                                                    Add
+                                                    (IntrinsicScalarFunction
+                                                        Tan
+                                                        [(Var 2 x)]
+                                                        0
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )]
+                                                0
+                                                (Real 8)
                                                 ()
                                             )
-                                            (Real 4)
+                                            (Real 8)
                                             ()
                                         )]
                                         0
-                                        (Real 4)
+                                        (Real 8)
                                         ()
                                     )
                                     Sub
-                                    (RealConstant
-                                        2.254825
-                                        (Real 4)
+                                    (Cast
+                                        (RealConstant
+                                            2.254825
+                                            (Real 4)
+                                        )
+                                        RealToReal
+                                        (Real 8)
+                                        (RealConstant
+                                            2.254825
+                                            (Real 8)
+                                        )
                                     )
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )]
                                 0
-                                (Real 4)
+                                (Real 8)
                                 ()
                             )
                             Gt
-                            (RealConstant
-                                0.000010
-                                (Real 4)
+                            (Cast
+                                (RealConstant
+                                    0.000010
+                                    (Real 4)
+                                )
+                                RealToReal
+                                (Real 8)
+                                (RealConstant
+                                    0.000010
+                                    (Real 8)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -333,73 +352,73 @@
                     )
                     (If
                         (RealCompare
-                            (IntrinsicScalarFunction
-                                Abs
-                                [(RealBinOp
-                                    (Cast
-                                        (IntrinsicScalarFunction
-                                            Tan
-                                            [(ComplexConstructor
-                                                (RealConstant
-                                                    1.500000
-                                                    (Real 4)
-                                                )
-                                                (RealConstant
-                                                    3.500000
-                                                    (Real 4)
-                                                )
+                            (Cast
+                                (IntrinsicScalarFunction
+                                    Abs
+                                    [(RealBinOp
+                                        (Cast
+                                            (IntrinsicScalarFunction
+                                                Tan
+                                                [(ComplexConstructor
+                                                    (RealConstant
+                                                        1.500000
+                                                        (Real 4)
+                                                    )
+                                                    (RealConstant
+                                                        3.500000
+                                                        (Real 4)
+                                                    )
+                                                    (Complex 4)
+                                                    (ComplexConstant
+                                                        1.500000
+                                                        3.500000
+                                                        (Complex 4)
+                                                    )
+                                                )]
+                                                0
                                                 (Complex 4)
                                                 (ComplexConstant
-                                                    1.500000
-                                                    3.500000
+                                                    0.000258
+                                                    1.001807
                                                     (Complex 4)
                                                 )
-                                            )]
-                                            0
-                                            (Complex 4)
-                                            (ComplexConstant
+                                            )
+                                            ComplexToReal
+                                            (Real 4)
+                                            (RealConstant
                                                 0.000258
-                                                1.001807
-                                                (Complex 4)
+                                                (Real 4)
                                             )
                                         )
-                                        ComplexToReal
-                                        (Real 4)
+                                        Sub
                                         (RealConstant
                                             0.000258
                                             (Real 4)
                                         )
-                                    )
-                                    Sub
-                                    (RealConstant
-                                        0.000258
                                         (Real 4)
-                                    )
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4)
+                                        )
+                                    )]
+                                    0
                                     (Real 4)
                                     (RealConstant
                                         0.000000
                                         (Real 4)
                                     )
-                                )]
-                                0
-                                (Real 4)
-                                (RealConstant
-                                    0.000000
-                                    (Real 4)
                                 )
-                            )
-                            Gt
-                            (Cast
+                                RealToReal
+                                (Real 8)
                                 (RealConstant
                                     0.000000
                                     (Real 8)
                                 )
-                                RealToReal
-                                (Real 4)
-                                (RealConstant
-                                    0.000000
-                                    (Real 4)
-                                )
+                            )
+                            Gt
+                            (RealConstant
+                                0.000000
+                                (Real 8)
                             )
                             (Logical 4)
                             (LogicalConstant

--- a/tests/reference/asr-intrinsics_37-8df004d.json
+++ b/tests/reference/asr-intrinsics_37-8df004d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_37-8df004d.stdout",
-    "stdout_hash": "a9501f5cad91419e8b0e4e384effa0c4e650025d1cc14af21b720085",
+    "stdout_hash": "b6cbd08a9eecb4306c80044817dd20ad8cb548af6f5b41483525f907",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_37-8df004d.stdout
+++ b/tests/reference/asr-intrinsics_37-8df004d.stdout
@@ -709,31 +709,29 @@
                             (RealBinOp
                                 (Var 2 fsource)
                                 Mul
-                                (Cast
-                                    (RealBinOp
+                                (RealBinOp
+                                    (Cast
                                         (RealConstant
                                             1.000000
                                             (Real 4)
                                         )
-                                        Sub
-                                        (Cast
-                                            (Var 2 real_mask)
-                                            RealToReal
-                                            (Array
-                                                (Real 4)
-                                                [((IntegerConstant 1 (Integer 4))
-                                                (IntegerConstant 2 (Integer 4)))
-                                                ((IntegerConstant 1 (Integer 4))
-                                                (IntegerConstant 3 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            ()
+                                        RealToReal
+                                        (Real 8)
+                                        (RealConstant
+                                            1.000000
+                                            (Real 8)
                                         )
-                                        (Real 4)
-                                        ()
                                     )
-                                    RealToReal
-                                    (Real 8)
+                                    Sub
+                                    (Var 2 real_mask)
+                                    (Array
+                                        (Real 8)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 2 (Integer 4)))
+                                        ((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 3 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
                                     ()
                                 )
                                 (Array

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "5f9559fa89a926381a19614b157a4754fac56e94e62c6c763f359dd5",
+    "stdout_hash": "6a505d1148835eaf97c8377d15dff21b5a5d7b0fe111561115d6a8cc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -58,21 +58,6 @@ return:                                           ; preds = %ifcont
   ret double %5
 }
 
-define float @_lcompilers_cos_f32(float* %x) {
-.entry:
-  %_lcompilers_cos_f32 = alloca float, align 4
-  %0 = load float, float* %x, align 4
-  %1 = call float @_lfortran_scos(float %0)
-  store float %1, float* %_lcompilers_cos_f32, align 4
-  br label %return
-
-return:                                           ; preds = %.entry
-  %2 = load float, float* %_lcompilers_cos_f32, align 4
-  ret float %2
-}
-
-declare float @_lfortran_scos(float)
-
 define double @_lcompilers_cos_f64(double* %x) {
 .entry:
   %_lcompilers_cos_f64 = alloca double, align 8
@@ -117,8 +102,8 @@ return:                                           ; preds = %ifcont
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value11 = alloca double, align 8
-  %call_arg_value7 = alloca float, align 4
-  %call_arg_value6 = alloca float, align 4
+  %call_arg_value7 = alloca double, align 8
+  %call_arg_value6 = alloca double, align 8
   %call_arg_value5 = alloca double, align 8
   %call_arg_value1 = alloca double, align 8
   %call_arg_value = alloca float, align 4
@@ -166,15 +151,14 @@ ifcont4:                                          ; preds = %else3, %then2
   %12 = fadd double %10, %11
   store double %12, double* %call_arg_value5, align 8
   %13 = call double @_lcompilers_cos_f64(double* %call_arg_value5)
-  %14 = fptrunc double %13 to float
-  %15 = fadd float 0x3FB21BD540000000, %14
-  store float %15, float* %call_arg_value6, align 4
-  %16 = call float @_lcompilers_cos_f32(float* %call_arg_value6)
-  %17 = fsub float %16, 0x3FE6ECC720000000
-  store float %17, float* %call_arg_value7, align 4
-  %18 = call float @_lcompilers_abs_f32(float* %call_arg_value7)
-  %19 = fcmp ogt float %18, 0x3E7AD7F2A0000000
-  br i1 %19, label %then8, label %else9
+  %14 = fadd double 0x3FB21BD54FC5F9A7, %13
+  store double %14, double* %call_arg_value6, align 8
+  %15 = call double @_lcompilers_cos_f64(double* %call_arg_value6)
+  %16 = fsub double %15, 0x3FE6ECC71DE13C70
+  store double %16, double* %call_arg_value7, align 8
+  %17 = call double @_lcompilers_abs_f64(double* %call_arg_value7)
+  %18 = fcmp ogt double %17, 0x3E7AD7F29ABCAF48
+  br i1 %18, label %then8, label %else9
 
 then8:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0))
@@ -185,16 +169,16 @@ else9:                                            ; preds = %ifcont4
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %20 = call double @_lcompilers_cos_f64(double* %a)
-  store double %20, double* %r1, align 8
+  %19 = call double @_lcompilers_cos_f64(double* %a)
+  store double %19, double* %r1, align 8
   store double 0xBFDF606EEC8AC71E, double* %r2, align 8
-  %21 = load double, double* %r1, align 8
-  %22 = load double, double* %r2, align 8
-  %23 = fsub double %21, %22
-  store double %23, double* %call_arg_value11, align 8
-  %24 = call double @__module_lfortran_intrinsic_math2_dabs(double* %call_arg_value11)
-  %25 = fcmp ogt double %24, 1.000000e-15
-  br i1 %25, label %then12, label %else13
+  %20 = load double, double* %r1, align 8
+  %21 = load double, double* %r2, align 8
+  %22 = fsub double %20, %21
+  store double %22, double* %call_arg_value11, align 8
+  %23 = call double @__module_lfortran_intrinsic_math2_dabs(double* %call_arg_value11)
+  %24 = fcmp ogt double %23, 1.000000e-15
+  br i1 %24, label %then12, label %else13
 
 then12:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([12 x i8], [12 x i8]* @3, i32 0, i32 0))

--- a/tests/reference/pass_div_to_mul-div_to_mul-d0027c6.json
+++ b/tests/reference/pass_div_to_mul-div_to_mul-d0027c6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_div_to_mul-div_to_mul-d0027c6.stdout",
-    "stdout_hash": "ff5319016bb7b02a1c7c33334676960a357c2d261990092e40f6047e",
+    "stdout_hash": "cc3d39058e202572302ba9576838ec8c2433f90b96d48b5c0fad8d4f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_div_to_mul-div_to_mul-d0027c6.stdout
+++ b/tests/reference/pass_div_to_mul-div_to_mul-d0027c6.stdout
@@ -172,29 +172,47 @@
                                 Abs
                                 [(RealBinOp
                                     (RealBinOp
-                                        (Var 2 x)
+                                        (Cast
+                                            (Var 2 x)
+                                            RealToReal
+                                            (Real 8)
+                                            ()
+                                        )
                                         Mul
                                         (RealConstant
                                             0.500000
-                                            (Real 4)
+                                            (Real 8)
                                         )
-                                        (Real 4)
+                                        (Real 8)
                                         ()
                                     )
                                     Sub
-                                    (RealConstant
-                                        1.570000
-                                        (Real 4)
+                                    (Cast
+                                        (RealConstant
+                                            1.570000
+                                            (Real 4)
+                                        )
+                                        RealToReal
+                                        (Real 8)
+                                        (RealConstant
+                                            1.570000
+                                            (Real 8)
+                                        )
                                     )
-                                    (Real 4)
+                                    (Real 8)
                                     ()
                                 )]
                                 0
-                                (Real 4)
+                                (Real 8)
                                 ()
                             )
                             Gt
-                            (Var 2 eps)
+                            (Cast
+                                (Var 2 eps)
+                                RealToReal
+                                (Real 8)
+                                ()
+                            )
                             (Logical 4)
                             ()
                         )


### PR DESCRIPTION
Towards #2246.