### PR TITLE
Improvements to integer and decimal formatting

### DIFF
--- a/integration_tests/format_04.f90
+++ b/integration_tests/format_04.f90
@@ -1,6 +1,7 @@
 program format_04
 
 real :: a,b,c,d
+integer :: f
 a = 123.456
 b = 123.45678
 c = 12.34
@@ -17,4 +18,8 @@ print '(1pd10.2,2pd15.6,1pd010.2,2x,1pd9.2)', -a, b, -c, d
 print '(-1pe10.2,-2pe15.6,1pe010.2,2x,1pe9.2)', -a, b, -c, d
 print "(12(i3))", 1,2,3,4,5,6,7,8,9,10,11,12
 print "(4(i3),' hello')", 1,2,3,4,5,6,7,8,9,10,11,12,13,14
+print '(i0)', f, -f
+print '(d0.0,1x,d0.1,1x,d0.2)',a,b,c
+print '(d0.0,1x,d0.1,1x,d0.2)',-a,-b,-c
+print '("Hello")'
 end program


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2274
This now gives the same output as ```gfortran```:
```fortran
program format_04

    real :: a,b,c
    integer :: f
    a = 123.456
    b = 123.45678
    c = 12.34
    f = 12345
    
    print '(i0)', f, -f
    print '(d0.0,1x,d0.1,1x,d0.2)',a,b,c
    print '(d0.0,1x,d0.1,1x,d0.2)',-a,-b,-c
    print '("Hello")'

end program
```
```console
12345
-12345
0.123456001D+3 0.1D+3 0.12D+2
-0.123456001D+3 -0.1D+3 -0.12D+2
Hello
```