### PR TITLE
Add a compiler option to enable mangling of bindc abi type functions

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -674,6 +674,7 @@ int emit_asr(const std::string &infile,
     pass_options.module_name_mangling = compiler_options.module_name_mangling;
     pass_options.global_symbols_mangling = compiler_options.global_symbols_mangling;
     pass_options.intrinsic_symbols_mangling = compiler_options.intrinsic_symbols_mangling;
+    pass_options.bindc_mangling = compiler_options.bindc_mangling;
     pass_options.mangle_underscore = compiler_options.mangle_underscore;
 
     pass_manager.apply_passes(al, asr, pass_options, diagnostics);
@@ -1925,6 +1926,7 @@ int main(int argc, char *argv[])
         app.add_flag("--global-mangling", compiler_options.global_symbols_mangling, "Mangles all the global symbols");
         app.add_flag("--intrinsic-mangling", compiler_options.intrinsic_symbols_mangling, "Mangles all the intrinsic symbols");
         app.add_flag("--all-mangling", compiler_options.all_symbols_mangling, "Mangles all possible symbols");
+        app.add_flag("--bindc-mangling", compiler_options.bindc_mangling, "Mangles functions with abi bind(c)");
         app.add_flag("--mangle-underscore", compiler_options.mangle_underscore, "Mangles with underscore");
         app.add_flag("--run", compiler_options.run, "Executes the generated binary");
 

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -486,6 +486,7 @@ Result<std::string> FortranEvaluator::get_c3(ASR::TranslationUnit_t &asr,
     pass_options.module_name_mangling = compiler_options.module_name_mangling;
     pass_options.global_symbols_mangling = compiler_options.global_symbols_mangling;
     pass_options.intrinsic_symbols_mangling = compiler_options.intrinsic_symbols_mangling;
+    pass_options.bindc_mangling = compiler_options.bindc_mangling;
     pass_options.mangle_underscore = compiler_options.mangle_underscore;
     pass_manager.skip_c_passes();
     pass_manager.apply_passes(al, &asr, pass_options, diagnostics);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8630,6 +8630,7 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     pass_options.module_name_mangling = co.module_name_mangling;
     pass_options.global_symbols_mangling = co.global_symbols_mangling;
     pass_options.intrinsic_symbols_mangling = co.intrinsic_symbols_mangling;
+    pass_options.bindc_mangling = co.bindc_mangling;
     pass_options.mangle_underscore = co.mangle_underscore;
     pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
 

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -71,6 +71,7 @@ struct CompilerOptions {
     bool global_symbols_mangling = false;
     bool intrinsic_symbols_mangling = false;
     bool all_symbols_mangling = false;
+    bool bindc_mangling = false;
     bool mangle_underscore = false;
     bool run = false;
     std::vector<std::string> import_paths;
@@ -108,6 +109,7 @@ namespace LCompilers {
         bool global_symbols_mangling = false;
         bool intrinsic_symbols_mangling = false;
         bool all_symbols_mangling = false;
+        bool bindc_mangling = false;
         bool mangle_underscore = false;
     };
 


### PR DESCRIPTION
Refer: https://github.com/lfortran/lfortran/pull/2263#issuecomment-1701441308