### PR TITLE
CI: bump to latest commit of scipy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,8 +169,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/special8
-            git checkout b8ee2a865500263d17d366d7b286ee3a60abe6ec
+            git checkout -t ondrej/special9
+            git checkout 5244ee49fd36b7c29e13079d69ecdd7561787de8
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init
@@ -180,8 +180,8 @@ jobs:
             cp scipy/special/specfun.so $CONDA_PREFIX/lib/scipy/special/
             cp ../src/runtime/liblfortran_runtime.so $CONDA_PREFIX/lib/
             python dev.py build
-            mkdir -p ./build-install/lib/python3.10/scipy/special/
-            cp scipy/special/specfun.so ./build-install/lib/python3.10/scipy/special/
+            mkdir -p ./build-install/lib/python3.11/scipy/special/
+            cp scipy/special/specfun.so ./build-install/lib/python3.11/scipy/special/
             python dev.py test -t scipy.special -v
 
   build_to_wasm_and_upload:


### PR DESCRIPTION
The only patch left is:
```diff
% git diff origin/main scipy/special/specfun/specfun.f
diff --git a/scipy/special/specfun/specfun.f b/scipy/special/specfun/specfun.f
index b30997331..5025de738 100644
--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -4382,7 +4382,7 @@ C             (2) DVLA for computing Dv(x) for large |x|
 C       ====================================================
 C
         IMPLICIT DOUBLE PRECISION (A-H,O-Z)
-        DIMENSION DV(0:*),DP(0:*)
+        DIMENSION DV(0:100),DP(0:100)
         XA=DABS(X)
         VH=V
         V=V+DSIGN(1.0D0,V)
@@ -7978,7 +7978,7 @@ C       ==================================================
 C
         IMPLICIT DOUBLE PRECISION (A-B,D-H,O-Y)
         IMPLICIT COMPLEX*16 (C,Z)
-        DIMENSION CPB(0:*),CPD(0:*)
+        DIMENSION CPB(0:100),CPD(0:100)
         PI=3.141592653589793D0
         X=DBLE(Z)
         A0=ABS(Z)
@@ -11431,7 +11431,7 @@ C             (2) VVLA for computing Vv(x) for large |x|
 C       ===================================================
 C
         IMPLICIT DOUBLE PRECISION (A-H,O-Z)
-        DIMENSION VV(0:*),VP(0:*)
+        DIMENSION VV(0:100),VP(0:100)
         PI=3.141592653589793D0
         XA=DABS(X)
         VH=V
```