### PR TITLE
CI fastGPT: remove several workarounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -458,8 +458,8 @@ jobs:
             ldd ./test_more_inputs
 
             git clean -dfx
-            git checkout -t origin/lf23run
-            git checkout 2ba1e83a1901503f6bb671a791005839985c0750
+            git checkout -t origin/lf24run
+            git checkout 596600f789cf1e3101664a617f1ad55be96e1853
             FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS .
             make
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -459,7 +459,7 @@ jobs:
 
             git clean -dfx
             git checkout -t origin/lf24run
-            git checkout 596600f789cf1e3101664a617f1ad55be96e1853
+            git checkout 5346a2ebeae381250c1e4721ca2d4bd1ce028e4a
             FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS .
             make
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat


### PR DESCRIPTION
These are the only workarounds left in [gpt2.f90](https://github.com/certik/fastGPT/blob/63d279d800ab316f4143a681d4cd46486e4d7f26/gpt2.f90):
```diff
diff --git a/gpt2.f90 b/gpt2.f90
index 28406a5..a57876e 100644
--- a/gpt2.f90
+++ b/gpt2.f90
@@ -21,7 +21,7 @@ type :: model_t
         ln2_b(:,:), ln2_g(:,:), &
         lnf_b(:), lnf_g(:)
     integer, allocatable :: decoder_idx(:), vocab_idx(:), byte_encoder(:)
-    integer(1), allocatable :: decoder_txt(:), vocab_txt(:)
+    character, allocatable :: decoder_txt(:), vocab_txt(:)
     integer :: model_file_version
 end type
 
@@ -93,13 +93,9 @@ end function
 function ffn(x, fc_w, fc_b, proj_w, proj_b) result(y)
 real(sp), intent(in) :: x(:,:), fc_w(:,:), fc_b(:), proj_w(:,:), proj_b(:)
 real(sp) :: y(size(x,1),size(x,2))
-real(sp) :: yy(size(x,1),size(x,2))
-real(sp) :: a(4*size(x,1),size(x,2))
-real(sp) :: aa(4*size(x,1),size(x,2))
-aa = linear(x, fc_w, fc_b)
-a = gelu(aa)
-yy = linear(a, proj_w, proj_b)
-y = yy
+!real(sp) :: a(4*size(x,1),size(x,2))
+!a = gelu(linear(x, fc_w, fc_b))
+y = linear(gelu(linear(x, fc_w, fc_b)), proj_w, proj_b)
 end function
 
 function attention(n_embd_head,n_seq,n_seq_x, q, k, v, mask) result(y)
@@ -110,8 +106,7 @@ real(sp) :: tmp(n_seq,n_seq_x)
 !tmp = matmul(transpose(k), q)
 !call matmul_2d(transpose(k), q, tmp)
 call matmul_2d_t(k, q, tmp)
-tmp = tmp / sqrt(real(n_embd_head,sp)) + mask
-call matmul_2d(v, softmax(tmp), y)
+call matmul_2d(v, softmax(tmp / sqrt(real(n_embd_head,sp)) + mask), y)
 end function
 
 function mha(n_seq, n_seq_x, n_embd, x, attn_w, attn_b, proj_w, proj_b, n_head, &
```