### PR TITLE
Fix: Throw an error for numeric binop on strings

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5332,6 +5332,13 @@ public:
 
             asr = ASR::make_ComplexBinOp_t(al, x.base.base.loc, left, op, right, dest_type, value);
 
+        } else if (ASRUtils::is_character(*dest_type)) {
+            diag.semantic_error_label(
+                            "Binary numeric operators cannot be used on strings",
+                            {x.base.base.loc},
+                            "help: use '//' for string concatenation"
+                        );
+            throw SemanticAbort();
         } else if (ASRUtils::is_type_parameter(*left_type) || ASRUtils::is_type_parameter(*right_type)) {
             // if overloaded is not found, then reject
             if (overloaded == nullptr) {

--- a/tests/errors/string_binop.f90
+++ b/tests/errors/string_binop.f90
@@ -1,0 +1,2 @@
+print *, "a" + "b"
+end

--- a/tests/reference/asr-string_binop-415f1fa.json
+++ b/tests/reference/asr-string_binop-415f1fa.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-string_binop-415f1fa",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/string_binop.f90",
+    "infile_hash": "4e6301859ddd78b04a2a25c7024ec1a91d427fe1e12477c3d337dc6f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-string_binop-415f1fa.stderr",
+    "stderr_hash": "b5d483b65a65764781e8af477c3eecc912b46d8ad9eb26cdb8d29319",
+    "returncode": 2
+}

--- a/tests/reference/asr-string_binop-415f1fa.stderr
+++ b/tests/reference/asr-string_binop-415f1fa.stderr
@@ -1,0 +1,5 @@
+semantic error: Binary numeric operators cannot be used on strings
+ --> tests/errors/string_binop.f90:1:10
+  |
+1 | print *, "a" + "b"
+  |          ^^^^^^^^^ help: use '//' for string concatenation

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2123,6 +2123,10 @@ filename = "../integration_tests/string_12.f90"
 asr = true
 
 [[test]]
+filename = "errors/string_binop.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/parsing_01.f90"
 ast = true
 


### PR DESCRIPTION
Fixes #2303 
```fortran
print *, "a" + "b"
end
```
```console
(lf) sarthak@pop-os:~/lfortran$ lfortran tests/errors/string_binop.f90 
semantic error: Binary numeric operators cannot be used on strings
 --> tests/errors/string_binop.f90:1:10
  |
1 | print *, "a" + "b"
  |          ^^^^^^^^^ help: use '//' for string concatenation


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
```