### PR TITLE
reserved_02.f90: initialize the variable

### DIFF
--- a/integration_tests/reserved_02.f90
+++ b/integration_tests/reserved_02.f90
@@ -6,6 +6,7 @@ contains
 
 integer function integer()
 integer function
+function = 5
 function = function/function
 integer = function
 end function

--- a/tests/reference/ast_f90-reserved_02-a00a6f2.json
+++ b/tests/reference/ast_f90-reserved_02-a00a6f2.json
@@ -2,11 +2,11 @@
     "basename": "ast_f90-reserved_02-a00a6f2",
     "cmd": "lfortran --show-ast-f90 --no-indent --no-color {infile}",
     "infile": "tests/../integration_tests/reserved_02.f90",
-    "infile_hash": "53fd885967ecf00fd1073cda95a659fa31a4f3d4da78a0fe31cab23b",
+    "infile_hash": "f602644fa98db53850a49c69394e3e9eb664cd1250f81f954484c85e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast_f90-reserved_02-a00a6f2.stdout",
-    "stdout_hash": "c91b24f910d88f415edb8c73d779075be9aaeb27b6d0256dea1da753",
+    "stdout_hash": "2cda8233c77ac420d2688c94e80e9c4fcfe12ab17c884a5d0f189929",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast_f90-reserved_02-a00a6f2.stdout
+++ b/tests/reference/ast_f90-reserved_02-a00a6f2.stdout
@@ -9,6 +9,7 @@ contains
 
 integer function integer()
 integer :: function
+function = 5
 function = function/function
 integer = function
 end function integer


### PR DESCRIPTION
Otherwise it fails in fast mode, probably LLVM optimizes some things out.