### PR TITLE
Do not use clock_gettime for Intel macOS

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1659,6 +1659,8 @@ LFORTRAN_API double _lfortran_time()
     uli.LowPart = ft.dwLowDateTime;
     uli.HighPart = ft.dwHighDateTime;
     return (double)uli.QuadPart / 10000000.0 - 11644473600.0;
+#elif defined(__APPLE__) && !defined(__aarch64__)
+    return 0.0;
 #else
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);


### PR DESCRIPTION
See https://github.com/conda-forge/lfortran-feedstock/pull/41 for the failure.