### PR TITLE
Compute args for StringFormat and fix format segfault

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -408,6 +408,7 @@ RUN(NAME format_04 LABELS gfortran llvm)
 RUN(NAME format_05 LABELS gfortran)
 RUN(NAME format_06 LABELS gfortran llvm)
 RUN(NAME format_07 LABELS gfortran llvm)
+RUN(NAME format_08 LABELS gfortran llvm)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran)

--- a/integration_tests/format_08.f90
+++ b/integration_tests/format_08.f90
@@ -1,0 +1,9 @@
+program format_08
+    implicit none
+    character(:), allocatable :: a
+    integer :: b(10)
+    a = "xx"
+    b = 1
+    print "(a)", a
+    print "(1000(i6))", b
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8570,37 +8570,9 @@ public:
             args.push_back(tmp);
 
             for (size_t i=0; i<x.n_args; i++) {
-                visit_expr_wrapper(x.m_args[i], true);
-                ASR::expr_t *v = x.m_args[i];
-                ASR::ttype_t *t = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(v));
-                t = ASRUtils::type_get_past_allocatable(t);
-                int a_kind = ASRUtils::extract_kind_from_ttype_t(t);
-                if (ASRUtils::is_real(*t)) {
-                    llvm::Value *d;
-                    switch( a_kind ) {
-                        case 4 : {
-                            // Cast float to double as a workaround for the fact that
-                            // vprintf() seems to cast to double even for %f, which
-                            // causes it to print 0.000000.
-                            d = builder->CreateFPExt(tmp,
-                            llvm::Type::getDoubleTy(context));
-                            break;
-                        }
-                        case 8 : {
-                            d = builder->CreateFPExt(tmp,
-                            llvm::Type::getDoubleTy(context));
-                            break;
-                        }
-                        default: {
-                        throw CodeGenError(R"""(Printing support is available only
-                                            for 32, and 64 bit real kinds.)""",
-                                            x.base.base.loc);
-                        }
-                    }
-                    args.push_back(d);
-                } else {
-                    args.push_back(tmp);
-                }
+                std::vector<std::string>fmt;
+                //  Use the function to compute the args, but ignore the format
+                compute_fmt_specifier_and_arg(fmt, args, x.m_args[i], x.base.base.loc);
             }
             tmp = string_format_fortran(context, *module, *builder, args);
         } else {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -377,7 +377,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                 int repeat = atoi(substring(value, 0, j));
                 if (value[j] == '(') {
                     value = substring(value, j, strlen(value));
-                    format_values[i] = substring(format_values[i], 1, strlen(format_values[i]));
+                    format_values[i] = substring(format_values[i], j, strlen(format_values[i]));
                     char* new_input_string = (char*)malloc(sizeof(char));
                     new_input_string[0] = '\0';
                     for (int k = i; k < format_values_count; k++) {
@@ -475,7 +475,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
             }
 
             while (newline != 0) {
-                result = append_to_string(result, " ");
+                result = append_to_string(result, "\n");
                 newline--;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2320 and https://github.com/lfortran/lfortran/issues/2321
```fortran
program test_print
implicit none
character(:), allocatable :: a
a = "xx"
print "(a)", a
end program
```
```console
xx
```
```fortran
program test_print
implicit none
integer :: a(10)
a = 1
print "(1000(i6))", a
end program
```
```console
     1     1     1     1     1     1     1     1     1     1
```