### PR TITLE
Implement 'F' formatting for float values

### DIFF
--- a/integration_tests/format_04.f90
+++ b/integration_tests/format_04.f90
@@ -1,12 +1,16 @@
 program format_04
 
 real :: a,b,c,d
+double precision :: r,s,t
 integer :: f
 a = 123.456
 b = 123.45678
 c = 12.34
 d = 123.45
 f = 12345
+r = 12345678
+s = 23.5678
+t = 0.345678
 
 print *, "ok", "b"
 print '(a,a)', "ok", "b"
@@ -23,4 +27,6 @@ print '(i0)', f, -f
 print '(d0.0,1x,d0.1,1x,d0.2)',a,b,c
 print '(d0.0,1x,d0.1,1x,d0.2)',-a,-b,-c
 print '("Hello")'
+print '( F13.3,1X,F9.6,1X, F0.2 )', r, s, t
+print '( F13.3,1X,F9.6,1X, F0.2 )', -r, -s, -t
 end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -185,6 +185,68 @@ void handle_integer(char* format, int val, char** result) {
     }
 }
 
+void handle_float(char* format, double val, char** result) {
+    int width = 0, decimal_digits = 0;
+    int64_t integer_part = (int64_t)fabs(val);
+    double decimal_part = fabs(val) - labs(integer_part);
+
+    int sign_width = (val < 0) ? 1 : 0;
+    int integer_length = (integer_part == 0) ? 1 : (int)log10(llabs(integer_part)) + 1;
+    char int_str[64];
+    sprintf(int_str, "%ld", integer_part);
+    char dec_str[64];
+    sprintf(dec_str, "%f", decimal_part);
+    strcpy(dec_str,dec_str+2);
+
+    char* dot_pos = strchr(format, '.');
+    width = atoi(format + 1);
+    if (dot_pos != NULL) {
+        dot_pos++;
+        decimal_digits = atoi(dot_pos);
+        if (width == 0) {
+            if (decimal_digits == 0) {
+                width = integer_length + sign_width + 1;
+            } else {
+                width = integer_length + sign_width + decimal_digits + 1;
+            }
+        }
+    }
+    char formatted_value[64] = "";
+    int spaces = width - decimal_digits - sign_width - integer_length - 1;
+    for (int i = 0; i < spaces; i++) {
+        strcat(formatted_value, " ");
+    }
+    if (val < 0) {
+        strcat(formatted_value,"-");
+    }
+    if ((integer_part != 0 || (atoi(format + 1) != 0 || atoi(dot_pos) == 0))) {
+        strcat(formatted_value,int_str);
+    }
+    strcat(formatted_value,".");
+    if (decimal_part == 0) {
+        for(int i=0;i<decimal_digits;i++){
+            strcat(formatted_value, "0");
+        }
+    } else if (decimal_digits < strlen(dec_str)) {
+        long long t = (long long)round((double)atoll(dec_str) / (long long)pow(10, (strlen(dec_str) - decimal_digits)));
+        sprintf(dec_str, "%lld", t);
+        strncat(formatted_value, dec_str, decimal_digits);
+    } else {
+        strncat(formatted_value, dec_str, strlen(dec_str));
+        for(int i=0;i<decimal_digits - strlen(dec_str);i++){
+            strcat(formatted_value, "0");
+        }
+    }
+
+    if (strlen(formatted_value) > width) {
+        for(int i=0; i<width; i++){
+            *result = append_to_string(*result,"*");
+        }
+    } else {
+        *result = append_to_string(*result, formatted_value);
+    }
+}
+
 void handle_decimal(char* format, double val, int scale, char** result, char* c) {
     int width = 0, decimal_digits = 0;
     int64_t integer_part = (int64_t)val;
@@ -469,7 +531,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                 if ( count == 0 ) break;
                 count--;
                 double val = va_arg(args, double);
-                handle_decimal(value, val, scale, &result, "E");
+                handle_float(value, val, &result);
             } else if (strlen(value) != 0) {
                 printf("Printing support is not available for %s format.\n",value);
             }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -187,7 +187,7 @@ void handle_integer(char* format, int val, char** result) {
 
 void handle_float(char* format, double val, char** result) {
     int width = 0, decimal_digits = 0;
-    int64_t integer_part = (int64_t)fabs(val);
+    long integer_part = (long)fabs(val);
     double decimal_part = fabs(val) - labs(integer_part);
 
     int sign_width = (val < 0) ? 1 : 0;

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -196,7 +196,7 @@ void handle_float(char* format, double val, char** result) {
     sprintf(int_str, "%ld", integer_part);
     char dec_str[64];
     sprintf(dec_str, "%f", decimal_part);
-    strcpy(dec_str,dec_str+2);
+    memmove(dec_str,dec_str+2,strlen(dec_str));
 
     char* dot_pos = strchr(format, '.');
     width = atoi(format + 1);


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2325
```fortran
PROGRAM TEST
    DOUBLE PRECISION :: R,S,T
    R = 12345678
    S = 23.5678
    T = 0.345678
    PRINT '( F13.3,1X,F9.6,1X, F0.2 )', R, S, T
    PRINT '( F13.3,1X,F9.6,1X, F0.2 )', -R, -S, -T
END 
```
```console
 12345678.000 23.567800 .35
-12345678.000 ********* -.35
```
I might have missed some corner cases, let me know if this is working as expected with fastGPT