### PR TITLE
Support iostat in read()

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -488,8 +488,8 @@ jobs:
             ldd ./test_more_inputs
 
             git clean -dfx
-            git checkout -t origin/lf32run
-            git checkout dbf8349dd71103381ce295b04d39c40b7d59e5dd
+            git checkout -t origin/lf33run
+            git checkout eefc5c91918a99c5253a7324b817f4e6110f9ac7
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 
             mkdir lf

--- a/integration_tests/file_10.f90
+++ b/integration_tests/file_10.f90
@@ -31,7 +31,7 @@ program file_10
         integer, intent(in) :: fp
         character(:), allocatable :: input
         character(1024) :: tmp
-        integer ::ios = 0
+        integer ::ios
         read(fp, "(a)", iostat=ios) tmp
         if (ios == 0) then
             input = trim(tmp)

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6660,7 +6660,7 @@ public:
     }
 
     void visit_FileRead(const ASR::FileRead_t &x) {
-        llvm::Value *unit_val;
+        llvm::Value *unit_val, *iostat;
         if (x.m_unit == nullptr) {
             // Read from stdin
             unit_val = llvm::ConstantInt::get(
@@ -6670,9 +6670,21 @@ public:
             unit_val = tmp;
         }
 
+        if (x.m_iostat) {
+            int ptr_copy = ptr_loads;
+            ptr_loads = 0;
+            this->visit_expr_wrapper(x.m_iostat, false);
+            ptr_loads = ptr_copy;
+            iostat = tmp;
+        } else {
+            iostat = builder->CreateAlloca(
+                        llvm::Type::getInt32Ty(context), nullptr);
+        }
+
         if (x.m_fmt) {
             std::vector<llvm::Value*> args;
             args.push_back(unit_val);
+            args.push_back(iostat);
             this->visit_expr_wrapper(x.m_fmt, true);
             args.push_back(tmp);
             args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, x.n_values)));
@@ -6689,6 +6701,7 @@ public:
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
                         llvm::Type::getVoidTy(context), {
                             llvm::Type::getInt32Ty(context),
+                            llvm::Type::getInt32Ty(context)->getPointerTo(),
                             character_type,
                             llvm::Type::getInt32Ty(context)
                         }, true);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2164,7 +2164,7 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num)
     }
 }
 
-LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, char* fmt, int32_t no_of_args, ...)
+LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, int32_t* iostat, char* fmt, int32_t no_of_args, ...)
 {
     if (!streql(fmt, "(a)")) {
         printf("Only (a) supported as fmt currently");
@@ -2183,7 +2183,7 @@ LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, char* fmt, int32_t 
 
     if (unit_num == -1) {
         // Read from stdin
-        fgets(*arg, n, stdin);
+        *iostat = !(fgets(*arg, n, stdin) == *arg);
         (*arg)[strcspn(*arg, "\n")] = 0;
         va_end(args);
         return;
@@ -2196,7 +2196,7 @@ LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, char* fmt, int32_t 
         exit(1);
     }
 
-    fgets(*arg, n, filep);
+    *iostat = !(fgets(*arg, n, filep) == *arg);
     (*arg)[strcspn(*arg, "\n")] = 0;
     va_end(args);
 }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -250,7 +250,7 @@ LFORTRAN_API int64_t _lpython_open(char *path, char *flags);
 LFORTRAN_API int64_t _lfortran_open(int32_t unit_num, char *f_name, char *status, char* form);
 LFORTRAN_API void _lfortran_flush(int32_t unit_num);
 LFORTRAN_API void _lfortran_inquire(char *f_name, bool *exists, int32_t unit_num, bool *opened);
-LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, char* fmt, int32_t no_of_args, ...);
+LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, int32_t* iostat, char* fmt, int32_t no_of_args, ...);
 LFORTRAN_API char* _lpython_read(int64_t fd, int64_t n);
 LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num);
 LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num);


### PR DESCRIPTION
This PR gets the chat program in the lf33run branch at fastgpt (https://github.com/certik/fastGPT/tree/lf33run) to run. It currently works for first 2 prompts but segfaults on the exact third run. Also, note that in the lf33run branch, to make it work with LFortran, we replaced a local array allocated on stack with an allocatable array allocated on heap.