### PR TITLE
Update asdl.py

### DIFF
--- a/src/libasr/asdl.py
+++ b/src/libasr/asdl.py
@@ -194,7 +194,7 @@ def check(mod):
 
 def parse(filename):
     """Parse ASDL from the given file and return a Module node describing it."""
-    with open(filename) as f:
+    with open(filename, encoding='utf8') as f:
         parser = ASDLParser()
         return parser.parse(f.read())
 


### PR DESCRIPTION
Otherwise
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 621: illegal multibyte se quence
```

TLDR
# 1 What I have done
```
git clone https://github.com/lfortran/lfortran.git
cd lfortran
./build0.sh
```

# 2 What I get
```
+ ci/version.sh
++ git describe --tags --dirty
+ version=v0.20.1-17-g43dfd2bad-dirty
+ version=0.20.1-17-g43dfd2bad-dirty
+ echo 0.20.1-17-g43dfd2bad-dirty
+ python src/libasr/asdl_cpp.py grammar/AST.asdl src/lfortran/ast.h
filename='grammar/AST.asdl'
Traceback (most recent call last):
  File "C:\tmp\candel\lfortran\src\libasr\asdl_cpp.py", line 2785, in <module>
    sys.exit(main(sys.argv))
  File "C:\tmp\candel\lfortran\src\libasr\asdl_cpp.py", line 2730, in main
    mod = asdl.parse(def_file)
  File "C:/tmp\candel\lfortran\src\libasr/asdl.py", line 200, in parse
    return parser.parse(f.read())
UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 621: illegal multibyte se
quence

```