### PR TITLE
Fix open keyword args case

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -844,6 +844,7 @@ RUN(NAME file_09       LABELS gfortran llvm COPY_TO_BIN file_01_data.txt)
 RUN(NAME file_10       LABELS gfortran llvm COPY_TO_BIN file_10_data.txt)
 RUN(NAME file_11       LABELS gfortran llvm COPY_TO_BIN file_01_data.txt)
 RUN(NAME file_12       LABELS gfortran llvm COPY_TO_BIN file_12_data.txt)
+RUN(NAME file_13       LABELS gfortran llvm COPY_TO_BIN file_01_data.txt)
 RUN(NAME inquire_01    LABELS gfortran llvm)
 
 RUN(NAME class_01 LABELS gfortran)

--- a/integration_tests/file_13.f90
+++ b/integration_tests/file_13.f90
@@ -1,0 +1,13 @@
+program file_13
+    implicit none
+
+    integer :: num
+
+    open(UNIT=1, file="file_01_data.txt", form="formatted", access="stream", status="old")
+    read(1, *) num
+    close(1)
+
+    print *, num
+    if (num /= 10130) error stop
+
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -282,6 +282,7 @@ public:
         for( std::uint32_t i = 0; i < x.n_kwargs; i++ ) {
             AST::keyword_t kwarg = x.m_kwargs[i];
             std::string m_arg_str(kwarg.m_arg);
+            m_arg_str = to_lower(m_arg_str);
             if( m_arg_str == std::string("newunit") ||
                 m_arg_str == std::string("unit") ) {
                 if( a_newunit != nullptr ) {


### PR DESCRIPTION
This PR solves the following issue:
```
integration_tests % cat file_13.f90     
program file_13
    implicit none

    integer :: num

    open(UNIT=1, file="file_01_data.txt", form="formatted", access="stream", status="old")
    read(1, *) num
    close(1)

    print *, num
    if (num /= 10130) error stop

end program
integration_tests % cat file_01_data.txt
10130
c
4.20
9223372036854775804
integration_tests % gfortran file_13.f90
integration_tests % ./a.out 
       10130
integration_tests % lfortran_in_main file_13.f90
semantic error: `newunit` or `unit` must be specified either in argument or keyword arguments.
 --> file_13.f90:6:5
  |
6 |     open(UNIT=1, file="file_01_data.txt", form="formatted", access="stream", status="old")
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
integration_tests % lfortran file_13.f90 
10130
```