### PR TITLE
Fix intrinsic function dependency on external symbol in dims

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -499,8 +499,8 @@ RUN(NAME intrinsics_66 LABELS gfortran llvm) # sign
 RUN(NAME intrinsics_67 LABELS gfortran llvm) # dcosh, dsinh, dtanh, dtan
 RUN(NAME intrinsics_68 LABELS gfortran llvm) # dsign
 RUN(NAME intrinsics_69 LABELS gfortran llvm) # radix
-
 RUN(NAME intrinsics_70 LABELS gfortran llvm) # aint
+RUN(NAME intrinsics_71 LABELS gfortran llvm) # matmul
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_71.f90
+++ b/integration_tests/intrinsics_71.f90
@@ -1,0 +1,29 @@
+program intrinsics_71
+    implicit none
+    integer :: result_value
+    result_value = routine(3)
+
+    print *, result_value
+    if (result_value /= 600) error stop
+
+contains
+
+    function routine(p) result(r)
+        integer, intent(in) :: p
+        integer :: a(1, p)
+        integer :: b(p, 1)
+        integer :: c(1, 1)
+        integer :: r
+
+        a(1, 1) = 10
+        a(1, 2) = 10
+        a(1, 3) = 10
+
+        b(1, 1) = 20
+        b(2, 1) = 20
+        b(3, 1) = 20
+
+        c = matmul(a, b)
+        r = c(1, 1)
+    end function routine
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1602,8 +1602,8 @@ namespace MatMul {
          *                 [ 3, 4 ] ▼
          */
         declare_basic_variables("_lcompilers_matmul");
-        fill_func_arg("matrix_a", arg_types[0]);
-        fill_func_arg("matrix_b", arg_types[1]);
+        fill_func_arg("matrix_a", duplicate_type_with_empty_dims(al, arg_types[0]));
+        fill_func_arg("matrix_b", duplicate_type_with_empty_dims(al, arg_types[1]));
         ASR::expr_t *result = declare("result", return_type, Out);
         args.push_back(al, result);
         ASR::expr_t *i = declare("i", int32, Local);


### PR DESCRIPTION
This PR fixes the following issue:

```bash
$ cat integration_tests/intrinsics_71.f90      
program intrinsics_71
    implicit none
    integer :: result_value
    result_value = routine(3)

    print *, result_value
    if (result_value /= 600) error stop

contains

    function routine(p) result(r)
        integer, intent(in) :: p
        integer :: a(1, p)
        integer :: b(p, 1)
        integer :: c(1, 1)
        integer :: r

        a(1, 1) = 10
        a(1, 2) = 10
        a(1, 3) = 10

        b(1, 1) = 20
        b(2, 1) = 20
        b(3, 1) = 20

        c = matmul(a, b)
        r = c(1, 1)
    end function routine
end program
$ gfortran integration_tests/intrinsics_71.f90
$ ./a.out 
         600
$ lfortran_in_main integration_tests/intrinsics_71.f90 
ASR verify pass error: ASR verify: The symbol table was not found in the scope of `symtab`.

ASR verify pass error: ASR verify: Var::m_v `p` cannot point outside of its symbol table
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/ubaid/Desktop/OpenSource/orig_lfortran/src/bin/lfortran.cpp", line 2206
    err = compile_to_object_file(arg_file, tmp_o, false,
  File "/Users/ubaid/Desktop/OpenSource/orig_lfortran/src/bin/lfortran.cpp", line 939
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
  File "/Users/ubaid/Desktop/OpenSource/orig_lfortran/src/lfortran/fortran_evaluator.cpp", line 346
    compiler_options, run_fn, infile);
  File "/Users/ubaid/Desktop/OpenSource/orig_lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 8725
    pass_manager.apply_passes(al, &asr, pass_options, diagnostics);
  File "/Users/ubaid/Desktop/OpenSource/orig_lfortran/src/libasr/pass/pass_manager.h", line 293
    apply_passes(al, asr, _passes, pass_options, diagnostics);
  File "/Users/ubaid/Desktop/OpenSource/orig_lfortran/src/libasr/pass/pass_manager.h", line 166
    throw LCompilersException("Verify failed in the pass: "
LCompilersException: Verify failed in the pass: intrinsic_function
$ lfortran integration_tests/intrinsics_71.f90 
600
```