### PR TITLE
Implement datan2()

### DIFF
--- a/integration_tests/intrinsics_17.f90
+++ b/integration_tests/intrinsics_17.f90
@@ -22,5 +22,7 @@ x = atan2(1.5_sp, 2.5_sp)
 print *, x
 y = atan2(1.5_dp, 2.5_dp)
 print *, y
+y = datan2(1.5_dp, 2.5_dp)
+print *, y
 
 end

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -732,6 +732,7 @@ public:
         {"merge", {IntrinsicSignature({}, 3, 3)}},
         {"sign", {IntrinsicSignature({}, 2, 2)}},
         {"aint", {IntrinsicSignature({}, 1, 2)}},
+        {"atan2", {IntrinsicSignature({}, 2, 2)}},
         {"shape", {IntrinsicSignature({"kind"}, 1, 2)}},
     };
 
@@ -4367,6 +4368,7 @@ public:
         double_precision_intrinsics["dsin"] = "sin";
         double_precision_intrinsics["dcos"] = "cos";
         double_precision_intrinsics["dtan"] = "tan";
+        double_precision_intrinsics["datan2"] = "atan2";
 
         double_precision_intrinsics["dsign"] = "sign";
     }


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2378
```datan2()``` is an archaic form of ```atan2``` that works only on ```real(8)``` kind.
```fortran
program main
real*8 :: x
x = datan2(0d0,-1.d0)
print*, "x = ", x
end program
```
```console
x =  3.14159265358979312e+00
```
Implemented as an intrinsic function. Implemented a namespace ```BinarayInstrinsicFunction```  (taken from ```UnaryInstinsicFunction```) as well, since I thought it would be useful in the future.