### PR TITLE
Introduce and implement `UnboundedPointerToData`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1085,3 +1085,4 @@ RUN(NAME precision_01 LABELS gfortran llvm)
 RUN(NAME precision_02 LABELS gfortran) # TODO fix this test
 
 RUN(NAME array_unbounded_01 LABELS gfortran llvm)
+RUN(NAME array_unbounded_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1083,3 +1083,5 @@ RUN(NAME nan_handling_01 LABELS gfortran llvm)
 
 RUN(NAME precision_01 LABELS gfortran llvm)
 RUN(NAME precision_02 LABELS gfortran) # TODO fix this test
+
+RUN(NAME array_unbounded_01 LABELS gfortran llvm)

--- a/integration_tests/array_unbounded_01.f90
+++ b/integration_tests/array_unbounded_01.f90
@@ -4,7 +4,7 @@ subroutine sub(x, z)
     print *, x(1)
 end subroutine
     
-program main
+program array_unbounded_01
     real :: y(10), w(10)
     call sub(y, w)
     print *, y(1)

--- a/integration_tests/array_unbounded_01.f90
+++ b/integration_tests/array_unbounded_01.f90
@@ -1,0 +1,12 @@
+subroutine sub(x, z)
+    real :: x(1:*), z(10)
+    x(1) = 4.29
+    print *, x(1)
+end subroutine
+    
+program main
+    real :: y(10), w(10)
+    call sub(y, w)
+    print *, y(1)
+    if (abs(y(1) - 4.29) > 1e-10) error stop
+end program

--- a/integration_tests/array_unbounded_02.f90
+++ b/integration_tests/array_unbounded_02.f90
@@ -1,0 +1,13 @@
+subroutine sub(x)
+    real :: x
+    dimension :: x(1:*)
+    x(1) = 4.39
+end subroutine
+    
+program array_unbounded_02
+    real :: y(10), w(10)
+    call sub(y)
+    print *, y(1)
+    if (abs(y(1) - 4.39) > 1e-10) error stop
+end program
+    

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2497,7 +2497,7 @@ public:
         } else if (sym_type->m_type == AST::decl_typeType::TypeDoublePrecision) {
             a_kind = 8;
             type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, a_kind));
-            type = ASRUtils::make_Array_t_util(al, loc, type, dims.p, dims.size(), abi, is_argument);
+            type = ASRUtils::make_Array_t_util(al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                     ASRUtils::type_get_past_allocatable(type)));
@@ -2505,7 +2505,7 @@ public:
         } else if (sym_type->m_type == AST::decl_typeType::TypeInteger) {
             type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, a_kind));
             type = ASRUtils::make_Array_t_util(
-                al, loc, type, dims.p, dims.size(), abi, is_argument);
+                al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                     ASRUtils::type_get_past_allocatable(type)));
@@ -2513,7 +2513,7 @@ public:
         } else if (sym_type->m_type == AST::decl_typeType::TypeLogical) {
             type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4));
             type = ASRUtils::make_Array_t_util(
-                al, loc, type, dims.p, dims.size(), abi, is_argument);
+                al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                     ASRUtils::type_get_past_allocatable(type)));
@@ -2521,7 +2521,7 @@ public:
         } else if (sym_type->m_type == AST::decl_typeType::TypeComplex) {
             type = ASRUtils::TYPE(ASR::make_Complex_t(al, loc, a_kind));
             type = ASRUtils::make_Array_t_util(
-                al, loc, type, dims.p, dims.size(), abi, is_argument);
+                al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                     ASRUtils::type_get_past_allocatable(type)));
@@ -2530,7 +2530,7 @@ public:
             a_kind = 8;
             type = ASRUtils::TYPE(ASR::make_Complex_t(al, loc, a_kind));
             type = ASRUtils::make_Array_t_util(
-                al, loc, type, dims.p, dims.size(), abi, is_argument);
+                al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                     ASRUtils::type_get_past_allocatable(type)));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1995,7 +1995,13 @@ public:
                             bool is_char_type = ASR::is_a<ASR::Character_t>(*v->m_type);
                             process_dims(al, dims, x.m_syms[i].m_dim, x.m_syms[i].n_dim, is_compile_time, is_char_type);
 
-                            if (!ASRUtils::ttype_set_dimensions(&(v->m_type), dims.data(), dims.size(), al)) {
+                            bool is_star_dimension = false;
+
+                            if (x.m_syms[i].n_dim > 0) {
+                                is_star_dimension = (x.m_syms[i].m_dim[0].m_end_star == AST::dimension_typeType::DimensionStar);
+                            }
+
+                            if (!ASRUtils::ttype_set_dimensions(&(v->m_type), dims.data(), dims.size(), al, ASR::abiType::Source, false, is_star_dimension)) {
                                 throw SemanticError("Cannot set dimension for variable of non-numerical type", x.base.base.loc);
                             }
                             SetChar variable_dependencies_vec;

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -419,6 +419,7 @@ ttype
 array_physical_type
     = DescriptorArray
     | PointerToDataArray
+    | UnboundedPointerToDataArray
     | FixedSizeArray
     | NumPyArray
     | ISODescriptorArray

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1973,7 +1973,7 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
     ASR::ttype_t* type, ASR::dimension_t* m_dims, size_t n_dims,
     ASR::abiType abi=ASR::abiType::Source, bool is_argument=false,
     ASR::array_physical_typeType physical_type=ASR::array_physical_typeType::DescriptorArray,
-    bool override_physical_type=false) {
+    bool override_physical_type=false, bool is_dimension_star=false) {
     if( n_dims == 0 ) {
         return type;
     }
@@ -1990,7 +1990,7 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
                 }
             } else if( !ASRUtils::is_dimension_empty(m_dims, n_dims) ) {
                 physical_type = ASR::array_physical_typeType::PointerToDataArray;
-            } else if ( ASRUtils::is_only_upper_bound_empty(m_dims[n_dims-1]) ) {
+            } else if ( is_dimension_star && ASRUtils::is_only_upper_bound_empty(m_dims[n_dims-1]) ) {
                 physical_type = ASR::array_physical_typeType::UnboundedPointerToDataArray;
             }
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2004,7 +2004,7 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
 inline bool ttype_set_dimensions(ASR::ttype_t** x,
             ASR::dimension_t *m_dims, int64_t n_dims,
             Allocator& al, ASR::abiType abi=ASR::abiType::Source,
-            bool is_argument=false) {
+            bool is_argument=false, bool is_dimension_star=false) {
     switch ((*x)->type) {
         case ASR::ttypeType::Array: {
             ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(*x);
@@ -2031,7 +2031,7 @@ inline bool ttype_set_dimensions(ASR::ttype_t** x,
         case ASR::ttypeType::Union:
         case ASR::ttypeType::TypeParameter: {
             *x = ASRUtils::make_Array_t_util(al,
-                (*x)->base.loc, *x, m_dims, n_dims, abi, is_argument);
+                (*x)->base.loc, *x, m_dims, n_dims, abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
             return true;
         }
         default:

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1965,6 +1965,10 @@ static inline bool is_dimension_empty(ASR::dimension_t* dims, size_t n) {
     return false;
 }
 
+static inline bool is_only_upper_bound_empty(ASR::dimension_t& dim) {
+    return (dim.m_start != nullptr && dim.m_length == nullptr);
+}
+
 inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
     ASR::ttype_t* type, ASR::dimension_t* m_dims, size_t n_dims,
     ASR::abiType abi=ASR::abiType::Source, bool is_argument=false,
@@ -1986,6 +1990,8 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
                 }
             } else if( !ASRUtils::is_dimension_empty(m_dims, n_dims) ) {
                 physical_type = ASR::array_physical_typeType::PointerToDataArray;
+            } else if ( ASRUtils::is_only_upper_bound_empty(m_dims[n_dims-1]) ) {
+                physical_type = ASR::array_physical_typeType::UnboundedPointerToDataArray;
             }
         }
     }

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -266,7 +266,7 @@ namespace LCompilers {
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
-                    bool polymorphic=false, llvm::Type* polymorphic_type=nullptr) = 0;
+                    bool polymorphic=false, llvm::Type* polymorphic_type=nullptr, bool is_unbounded_pointer_to_data = false) = 0;
 
                 virtual
                 llvm::Value* get_is_allocated_flag(llvm::Value* array, llvm::Type* llvm_data_type) = 0;
@@ -314,7 +314,7 @@ namespace LCompilers {
 
                 llvm::Value* cmo_convertor_single_element_data_only(
                     llvm::Value** llvm_diminfo, std::vector<llvm::Value*>& m_args,
-                    int n_args, bool check_for_bounds);
+                    int n_args, bool check_for_bounds, bool is_unbounded_pointer_to_data = false);
 
             public:
 
@@ -430,7 +430,7 @@ namespace LCompilers {
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
-                    bool polymorphic=false, llvm::Type* polymorphic_type=nullptr);
+                    bool polymorphic=false, llvm::Type* polymorphic_type=nullptr, bool is_unbounded_pointer_to_data = false);
 
                 virtual
                 llvm::Value* get_is_allocated_flag(llvm::Value* array, llvm::Type* llvm_data_type);

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -589,6 +589,19 @@ namespace LCompilers {
                         }
                         break;
                     }
+                    case ASR::array_physical_typeType::UnboundedPointerToDataArray: {
+                        type = nullptr;
+                        if( ASR::is_a<ASR::Complex_t>(*v_type->m_type) ) {
+                            ASR::Complex_t* complex_t = ASR::down_cast<ASR::Complex_t>(v_type->m_type);
+                            type = getComplexType(complex_t->m_kind, true);
+                        }
+
+
+                        if( type == nullptr ) {
+                            type = get_type_from_ttype_t_util(v_type->m_type, module, arg_m_abi)->getPointerTo();
+                        }
+                        break;
+                    }
                     case ASR::array_physical_typeType::FixedSizeArray: {
                         type = llvm::ArrayType::get(get_el_type(v_type->m_type, module),
                                         ASRUtils::get_fixed_size_of_array(


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2198. I manually checked scipy build for specfun, now we can remove the one last patch that we had :). With this PR, we get specfun working perfectly without any patches.