### PR TITLE
CI: bump specfun, minpack to latest commit of scipy, remove all patches

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,8 +169,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/merge_special_minpack
-            git checkout 2b0e8f6adaffb454040d2f03af9f327c86deb91f
+            git checkout -t ondrej/merge_special_minpack3
+            git checkout fc1e68cdf5fe75f45db5e2628e7cf6cdfc8781e6
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init


### PR DESCRIPTION
With this we get `scipy/special/specfun` tested without any patch. We are using https://github.com/certik/scipy/commits/merge_special_minpack3, it has only 3 commits those are `exact version in environment file`, `Specfun: use our own library`, `Minpack: use our own library`, no extra patches. 