### PR TITLE
Fix function reference and create real-time test for `datan2`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -501,6 +501,7 @@ RUN(NAME intrinsics_68 LABELS gfortran llvm) # dsign
 RUN(NAME intrinsics_69 LABELS gfortran llvm) # radix
 RUN(NAME intrinsics_70 LABELS gfortran llvm) # aint
 RUN(NAME intrinsics_71 LABELS gfortran llvm) # matmul
+RUN(NAME intrinsics_72 LABELS gfortran llvmImplicit) # datan2
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_72.f90
+++ b/integration_tests/intrinsics_72.f90
@@ -1,0 +1,8 @@
+program main
+    real(8) :: x, y, datan2
+    x = 2.33D0
+    y = 3.41D0
+    print *, datan2(x,y)
+    if(abs(datan2(x,y) - 0.59941916594660438) > 1d-6) error stop
+    
+end program

--- a/tests/errors/intrinsics_02.f90
+++ b/tests/errors/intrinsics_02.f90
@@ -1,4 +1,4 @@
-program intrinsics_72
+program intrinsics_02
     real(8) :: x, y, datan2
     x = 2.33D0
     y = 3.41D0

--- a/tests/reference/asr-intrinsics_02-eb20326.json
+++ b/tests/reference/asr-intrinsics_02-eb20326.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics_02-eb20326",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics_02.f90",
+    "infile_hash": "5f9e65831d5f5364221b0dcd48a8b2c564706dd06b00318116f21337",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics_02-eb20326.stderr",
+    "stderr_hash": "269e7974bceb6a1c2b1da260030b5b1edb394fd1eda2c1a2c58af0f8",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics_02-eb20326.stderr
+++ b/tests/reference/asr-intrinsics_02-eb20326.stderr
@@ -1,0 +1,5 @@
+semantic error: datan2 was declared as a variable, it can't be called as a function
+ --> tests/errors/intrinsics_02.f90:5:14
+  |
+5 |     print *, datan2(x,y)
+  |              ^^^^^^^^^^^ help: use the compiler option "--implicit-interface" to use intrinsic functions

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3354,6 +3354,10 @@ filename = "errors/intrinsics1.f90"
 asr = true
 
 [[test]]
+filename = "errors/intrinsics_02.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/statement_01.f90"
 asr_implicit_interface_and_typing = true
 


### PR DESCRIPTION
Function reference for ```datan2``` is not working in main because it is not registered in the ```comptime_eval_map```.
That is now fixed with this PR. A real-time test for ```datan2``` has been registered as well.
```fortran
program main
    real(8) :: x, y, datan2
    x = 2.0D0
    y = 3.0D0

    print *, datan2(x,y)

end program
```
```console
(lf) ~$ lfortran --implicit-interface integration_tests/intrinsics_72.f90 
5.88002603547567504e-01
```

>  https://github.com/lfortran/lfortran/issues/2345#issuecomment-1711656575 These get resolved when I comment out real*8 datan2

This will not be required anymore.