### PR TITLE
CI: bump specfun, minpack, fitpack to latest commit of scipy, remove all patches

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,8 +169,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/merge_specfun_minpack_fitpack2
-            git checkout b996d330471a36fc0ed592dbaee1ede02b8e4bd4
+            git checkout -t ondrej/merge_specfun_minpack_fitpack3
+            git checkout 5ed604385ff0912dccf958a6ae48a76e3d9571b8
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init


### PR DESCRIPTION
Once https://github.com/lfortran/lfortran/pull/2395 gets merged, we can merge this too.

With this we get scipy/interpolate/fitpack tested without any patch. We are using https://github.com/certik/scipy/commits/merge_specfun_minpack_fitpack3, it has only 4 commits, and those are "exact version in environment file", "Specfun: use our own library", "Minpack: use our own library" and "Fitpack: use our own library" and no extra patches.