### PR TITLE
CI: use CMake system to build SciPy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,57 +169,21 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/merge_specfun_minpack_fitpack3
-            git checkout 5ed604385ff0912dccf958a6ae48a76e3d9571b8
+            git checkout -t ondrej/merge_specfun_minpack_fitpack4
+            git checkout ad71e61e9ed8ce769c3040e914e145ee60a2be66
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init
-            for src in $(find ./scipy/optimize/minpack/ -name "*.f"); do
-                ../src/bin/lfortran -c $src -o ${src%.f}.o --fixed-form --implicit-typing --implicit-interface --generate-object-code --use-loop-variable-after-loop --all-mangling --bindc-mangling --mangle-underscore --legacy-array-sections
-                cp ${src%.f}.o ./
-            done
-            ../src/bin/lfortran -c ./scipy/optimize/minpack/chkder.f -o chkder.o --fixed-form --implicit-typing --implicit-interface --generate-object-code --use-loop-variable-after-loop --rtlib --all-mangling --bindc-mangling --mangle-underscore --legacy-array-sections
-
-            clang -shared -fPIC -o ./scipy/optimize/minpack.so *.o -L../src/runtime -llfortran_runtime
-
-            rm *.o
-
-            for src in $(find ./scipy/interpolate/fitpack/ -name "*.f"); do
-                echo "Compiling $src"
-                ../src/bin/lfortran -c $src -o ${src%.f}.o --fixed-form --implicit-typing --implicit-interface --generate-object-code --use-loop-variable-after-loop --all-mangling --bindc-mangling --mangle-underscore --legacy-array-sections
-                cp ${src%.f}.o ./
-            done
-            ../src/bin/lfortran -c ./scipy/interpolate/fitpack/evapol.f -o evapol.o --fixed-form --implicit-typing --implicit-interface --generate-object-code --use-loop-variable-after-loop --rtlib --all-mangling --bindc-mangling --mangle-underscore --legacy-array-sections
-
-            clang -shared -fPIC -o ./scipy/interpolate/fitpack.so *.o -L../src/runtime -llfortran_runtime
-
-            rm *.o
-
-            ../src/bin/lfortran -c ./scipy/special/specfun/specfun.f -o scipy/special/specfun.o --fixed-form --implicit-typing --implicit-interface --generate-object-code --use-loop-variable-after-loop --all-mangling --mangle-underscore --legacy-array-sections --bindc-mangling --rtlib
-
-            clang -shared -fPIC -o ./scipy/special/specfun.so scipy/special/specfun.o -L../src/runtime -llfortran_runtime
-
-            mkdir -p $CONDA_PREFIX/lib/scipy/optimize/
-            cp scipy/optimize/minpack.so $CONDA_PREFIX/lib/scipy/optimize/
-
-            mkdir -p $CONDA_PREFIX/lib/scipy/interpolate/
-            cp scipy/interpolate/fitpack.so $CONDA_PREFIX/lib/scipy/interpolate/
-
-            mkdir -p $CONDA_PREFIX/lib/scipy/special/
-            cp scipy/special/specfun.so $CONDA_PREFIX/lib/scipy/special/
-
-            cp ../src/runtime/liblfortran_runtime.so $CONDA_PREFIX/lib/
-
+            mkdir lfortran-build/
+            cd lfortran-build/
+            LIBRARY_PATH=`pwd`/../../src/runtime/liblfortran_runtime.so
+            FC=$(pwd)/../../src/bin/lfortran cmake \
+              -DCMAKE_Fortran_FLAGS=--verbose \
+              -DLFORTRAN_RUNTIME_LIBRARY_PATH=$LIBRARY_PATH \
+              ..
+            make install
+            cd ../
             python dev.py build
-
-            mkdir -p ./build-install/lib/python3.11/scipy/optimize/
-            cp scipy/optimize/minpack.so ./build-install/lib/python3.11/scipy/optimize/
-
-            mkdir -p ./build-install/lib/python3.11/scipy/interpolate/
-            cp scipy/interpolate/fitpack.so ./build-install/lib/python3.11/scipy/interpolate/
-
-            mkdir -p ./build-install/lib/python3.11/scipy/special/
-            cp scipy/special/specfun.so ./build-install/lib/python3.11/scipy/special/
 
       - name: Test SciPy Specfun
         shell: bash -e -x -l {0}


### PR DESCRIPTION
TODO:
* [ ] Get this PR merged
* [ ] Open a test PR that fails scipy build
* [ ] Ensure gfortran is not used at all in our cmake, not for building, not for cmake configure, not for linking. Only lfortran.