### PR TITLE
Implement formatting for Write statement and fix "advance" bug

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -976,6 +976,7 @@ RUN(NAME implicit_deallocate_01 LABELS gfortran llvm)
 RUN(NAME write_01 LABELS gfortran llvm)
 RUN(NAME write_02 LABELS gfortran llvm)
 RUN(NAME write_03 LABELS gfortran llvmImplicit NOFAST)
+RUN(NAME write_04 LABELS gfortran llvm)
 
 RUN(NAME do_loop_01 LABELS gfortran llvm)
 

--- a/integration_tests/format_09.f90
+++ b/integration_tests/format_09.f90
@@ -2,17 +2,17 @@ program format_09
     implicit none
     integer :: a(5),b(5),c(10)
     integer, parameter :: dp=kind(0d0)
-    real(dp) :: d(3)
+    real(dp) :: d(5)
     a = [117,123,124,126,129]
     b = [1,2,3,4,5]
     c = 1
-    d = [1._dp,1._dp,1._dp]
+    d = [1._dp,1._dp,1._dp,1._dp,1._dp]
     print '(6(i6))', c
     print 10, "hello", a ,"world", b
   10  format(a,i10,i4,i5,i6,i7)
     print 20, 'String:', 3.1415926d0, &
     'Integer:', 42, &
     'Array:', d
-  20 format(5x,a,d15.7//,5x,a,16x,i10//,5x,a//1(5x,3d15.7))
+  20 format(5x,a,d15.7//,5x,a,16x,i10//,5x,a//(5x,3d15.7))
   end program
   

--- a/integration_tests/write_04.f90
+++ b/integration_tests/write_04.f90
@@ -1,0 +1,7 @@
+program write_04
+    implicit none
+    
+    write(*,'("Hello ")',advance='NO')
+    write(*,'("world!")')
+
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -537,7 +537,9 @@ public:
                 *args[i] = ASRUtils::EXPR(tmp);
             }
         }
-        a_fmt_constant = a_fmt;
+        if (_type == AST::stmtType::Write){
+            a_fmt_constant = a_fmt;
+        }
         for( std::uint32_t i = 0; i < n_kwargs; i++ ) {
             AST::kw_argstar_t kwarg = m_kwargs[i];
             std::string m_arg_str(kwarg.m_arg);

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -537,6 +537,7 @@ public:
                 *args[i] = ASRUtils::EXPR(tmp);
             }
         }
+        a_fmt_constant = a_fmt;
         for( std::uint32_t i = 0; i < n_kwargs; i++ ) {
             AST::kw_argstar_t kwarg = m_kwargs[i];
             std::string m_arg_str(kwarg.m_arg);
@@ -621,7 +622,7 @@ public:
                 ASR::expr_t *newline = ASRUtils::EXPR(ASR::make_StringConstant_t(
                     al, loc, s2c(al, "\n"), str_type_len_1));
                 if (ASR::is_a<ASR::StringConstant_t>(*adv_val_expr)) {
-                    std::string adv_val = ASR::down_cast<ASR::StringConstant_t>(adv_val_expr)->m_s;
+                    std::string adv_val = to_lower(ASR::down_cast<ASR::StringConstant_t>(adv_val_expr)->m_s);
                     if (adv_val == "yes") {
                         a_end = newline;
                     } else if (adv_val == "no") {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7152,10 +7152,6 @@ public:
     }
 
     void visit_FileWrite(const ASR::FileWrite_t &x) {
-        if (x.m_fmt != nullptr) {
-            diag.codegen_warning_label("format string in write() is not implemented yet and it is currently treated as '*'",
-                {x.m_fmt->base.loc}, "treated as '*'");
-        }
         if (x.m_unit != nullptr) {
             diag.codegen_warning_label("unit in write() is not implemented yet and it is currently treated as '*'",
                 {x.m_unit->base.loc}, "treated as '*'");

--- a/tests/reference/asr-arrays_23-a731033.json
+++ b/tests/reference/asr-arrays_23-a731033.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_23-a731033.stdout",
-    "stdout_hash": "44c60654926cded9ebfd8c2cb1bacfbd79a08fd54fad554360ff04ae",
+    "stdout_hash": "0f2899fbabd0bc1c505a5f94ca57bd490df7809e544a343c08538f1c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_23-a731033.stdout
+++ b/tests/reference/asr-arrays_23-a731033.stdout
@@ -157,10 +157,19 @@
                                             ()
                                             ()
                                             ()
-                                            [(StructInstanceMember
-                                                (Var 4 context)
-                                                4 1_toml_context_num
-                                                (Integer 4)
+                                            [(StringFormat
+                                                (StringConstant
+                                                    "(\"line\",1x,i0,\":\")"
+                                                    (Character 1 18 ())
+                                                )
+                                                [(StructInstanceMember
+                                                    (Var 4 context)
+                                                    4 1_toml_context_num
+                                                    (Integer 4)
+                                                    ()
+                                                )]
+                                                FormatFortran
+                                                (Character -1 0 ())
                                                 ()
                                             )]
                                             ()

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "76d9dec0ee4152a34b753b88faf788b73f1171d2a274bb0511a567e0",
+    "stdout_hash": "1afcbfa2627a04d8493c1750d5a40b9c4cb62ae93e5c241d5e04e2d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -127,22 +127,31 @@
                                         ()
                                         ()
                                         ()
-                                        [(StructInstanceMember
-                                            (Var 6 rhs)
-                                            6 1_toml_date_year
-                                            (Integer 4)
-                                            ()
-                                        )
-                                        (StructInstanceMember
-                                            (Var 6 rhs)
-                                            6 1_toml_date_month
-                                            (Integer 4)
-                                            ()
-                                        )
-                                        (StructInstanceMember
-                                            (Var 6 rhs)
-                                            6 1_toml_date_day
-                                            (Integer 4)
+                                        [(StringFormat
+                                            (StringConstant
+                                                "(i4.4,\"-\",i2.2,\"-\",i2.2)"
+                                                (Character 1 24 ())
+                                            )
+                                            [(StructInstanceMember
+                                                (Var 6 rhs)
+                                                6 1_toml_date_year
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            (StructInstanceMember
+                                                (Var 6 rhs)
+                                                6 1_toml_date_month
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            (StructInstanceMember
+                                                (Var 6 rhs)
+                                                6 1_toml_date_day
+                                                (Integer 4)
+                                                ()
+                                            )]
+                                            FormatFortran
+                                            (Character -1 0 ())
                                             ()
                                         )]
                                         ()
@@ -904,30 +913,39 @@
                                             ()
                                             ()
                                             ()
-                                            [(StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_hour
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_minute
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_second
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_millisec
-                                                (Allocatable
-                                                    (Integer 4)
+                                            [(StringFormat
+                                                (StringConstant
+                                                    "(i2.2,\":\",i2.2,\":\",i2.2,\".\",i3.3)"
+                                                    (Character 1 33 ())
                                                 )
+                                                [(StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_hour
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_minute
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_second
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_millisec
+                                                    (Allocatable
+                                                        (Integer 4)
+                                                    )
+                                                    ()
+                                                )]
+                                                FormatFortran
+                                                (Character -1 0 ())
                                                 ()
                                             )]
                                             ()
@@ -952,22 +970,31 @@
                                             ()
                                             ()
                                             ()
-                                            [(StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_hour
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_minute
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 7 rhs)
-                                                7 1_toml_time_second
-                                                (Integer 4)
+                                            [(StringFormat
+                                                (StringConstant
+                                                    "(i2.2,\":\",i2.2,\":\",i2.2)"
+                                                    (Character 1 24 ())
+                                                )
+                                                [(StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_hour
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_minute
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 7 rhs)
+                                                    7 1_toml_time_second
+                                                    (Integer 4)
+                                                    ()
+                                                )]
+                                                FormatFortran
+                                                (Character -1 0 ())
                                                 ()
                                             )]
                                             ()

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "880e6a86e09fa8a44709c73a453c52d7791bad1a4cfb0c9371f3be35",
+    "stdout_hash": "6d6e256112b92866ba0fd6828e288ebe93700bfead12ee154d78518d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -127,22 +127,31 @@
                                         ()
                                         ()
                                         ()
-                                        [(StructInstanceMember
-                                            (Var 11 rhs)
-                                            11 1_toml_date_year
-                                            (Integer 4)
-                                            ()
-                                        )
-                                        (StructInstanceMember
-                                            (Var 11 rhs)
-                                            11 1_toml_date_month
-                                            (Integer 4)
-                                            ()
-                                        )
-                                        (StructInstanceMember
-                                            (Var 11 rhs)
-                                            11 1_toml_date_day
-                                            (Integer 4)
+                                        [(StringFormat
+                                            (StringConstant
+                                                "(i4.4,\"-\",i2.2,\"-\",i2.2)"
+                                                (Character 1 24 ())
+                                            )
+                                            [(StructInstanceMember
+                                                (Var 11 rhs)
+                                                11 1_toml_date_year
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            (StructInstanceMember
+                                                (Var 11 rhs)
+                                                11 1_toml_date_month
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            (StructInstanceMember
+                                                (Var 11 rhs)
+                                                11 1_toml_date_day
+                                                (Integer 4)
+                                                ()
+                                            )]
+                                            FormatFortran
+                                            (Character -1 0 ())
                                             ()
                                         )]
                                         ()
@@ -904,30 +913,39 @@
                                             ()
                                             ()
                                             ()
-                                            [(StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_hour
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_minute
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_second
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_millisec
-                                                (Allocatable
-                                                    (Integer 4)
+                                            [(StringFormat
+                                                (StringConstant
+                                                    "(i2.2,\":\",i2.2,\":\",i2.2,\".\",i3.3)"
+                                                    (Character 1 33 ())
                                                 )
+                                                [(StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_hour
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_minute
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_second
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_millisec
+                                                    (Allocatable
+                                                        (Integer 4)
+                                                    )
+                                                    ()
+                                                )]
+                                                FormatFortran
+                                                (Character -1 0 ())
                                                 ()
                                             )]
                                             ()
@@ -952,22 +970,31 @@
                                             ()
                                             ()
                                             ()
-                                            [(StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_hour
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_minute
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            (StructInstanceMember
-                                                (Var 14 rhs)
-                                                14 1_toml_time_second
-                                                (Integer 4)
+                                            [(StringFormat
+                                                (StringConstant
+                                                    "(i2.2,\":\",i2.2,\":\",i2.2)"
+                                                    (Character 1 24 ())
+                                                )
+                                                [(StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_hour
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_minute
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (StructInstanceMember
+                                                    (Var 14 rhs)
+                                                    14 1_toml_time_second
+                                                    (Integer 4)
+                                                    ()
+                                                )]
+                                                FormatFortran
+                                                (Character -1 0 ())
                                                 ()
                                             )]
                                             ()

--- a/tests/reference/asr-fn5-3d75eb7.json
+++ b/tests/reference/asr-fn5-3d75eb7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn5-3d75eb7.stdout",
-    "stdout_hash": "c1bfd1c3a1c4934c1be05a2601848b20336c23c0051ac943892b5192",
+    "stdout_hash": "082e5328cd18988e06fb8e4ee69d25c57cd6ce40f12b0dab43440eb7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn5-3d75eb7.stdout
+++ b/tests/reference/asr-fn5-3d75eb7.stdout
@@ -563,140 +563,17 @@
                                         ()
                                         ()
                                         ()
-                                        [(FunctionCall
-                                            2 atleast
-                                            ()
-                                            [((StringConstant
-                                                "KEYWORD"
-                                                (Character 1 7 ())
-                                            ))
-                                            ((FunctionCall
-                                                4 max@imax
-                                                4 max
-                                                [((StringLen
-                                                    (ArrayItem
-                                                        (Var 4 keywords)
-                                                        [(()
-                                                        (ArrayBound
-                                                            (Var 4 keywords)
-                                                            (IntegerConstant 1 (Integer 4))
-                                                            (Integer 4)
-                                                            LBound
-                                                            ()
-                                                        )
-                                                        ())]
-                                                        (Character 1 -2 ())
-                                                        ColMajor
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                ))
-                                                ((IntegerConstant 8 (Integer 4)))]
-                                                (Integer 4)
-                                                ()
-                                                ()
-                                            ))
-                                            (())]
-                                            (Character 1 -3 (FunctionCall
-                                                4 imax
-                                                3 max
-                                                [((FunctionCall
-                                                    4 max@imax
-                                                    4 max
-                                                    [((StringLen
-                                                        (ArrayItem
-                                                            (Var 4 keywords)
-                                                            [(()
-                                                            (ArrayBound
-                                                                (Var 4 keywords)
-                                                                (IntegerConstant 1 (Integer 4))
-                                                                (Integer 4)
-                                                                LBound
-                                                                ()
-                                                            )
-                                                            ())]
-                                                            (Character 1 -2 ())
-                                                            ColMajor
-                                                            ()
-                                                        )
-                                                        (Integer 4)
-                                                        ()
-                                                    ))
-                                                    ((IntegerConstant 8 (Integer 4)))]
-                                                    (Integer 4)
-                                                    ()
-                                                    ()
-                                                ))
-                                                ((StringLen
-                                                    (FunctionCall
-                                                        4 trim
-                                                        ()
-                                                        [((StringConstant
-                                                            "KEYWORD"
-                                                            (Character 1 7 ())
-                                                        ))]
-                                                        (Character 1 -3 (FunctionCall
-                                                            4 len_trim
-                                                            ()
-                                                            [((StringConstant
-                                                                "KEYWORD"
-                                                                (Character 1 7 ())
-                                                            ))]
-                                                            (Integer 4)
-                                                            ()
-                                                            ()
-                                                        ))
-                                                        ()
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                ))]
-                                                (Integer 4)
-                                                ()
-                                                ()
-                                            ))
-                                            ()
-                                            ()
-                                        )
-                                        (StringConstant
-                                            "SHORT"
-                                            (Character 1 5 ())
-                                        )
-                                        (StringConstant
-                                            "PRESENT"
-                                            (Character 1 7 ())
-                                        )
-                                        (StringConstant
-                                            "VALUE"
-                                            (Character 1 5 ())
-                                        )]
-                                        ()
-                                        ()
-                                    )
-                                    (FileWrite
-                                        0
-                                        ()
-                                        (StringConstant
-                                            "(*(a,1x,a5,1x,l1,8x,\"[\",a,\"]\",/))"
-                                            (Character 1 33 ())
-                                        )
-                                        ()
-                                        ()
-                                        ()
-                                        [(ImpliedDoLoop
+                                        [(StringFormat
+                                            (StringConstant
+                                                "(a,1x,a,1x,a,1x,a)"
+                                                (Character 1 18 ())
+                                            )
                                             [(FunctionCall
                                                 2 atleast
                                                 ()
-                                                [((ArrayItem
-                                                    (Var 4 keywords)
-                                                    [(()
-                                                    (Var 4 i)
-                                                    ())]
-                                                    (Character 1 -2 ())
-                                                    ColMajor
-                                                    ()
+                                                [((StringConstant
+                                                    "KEYWORD"
+                                                    (Character 1 7 ())
                                                 ))
                                                 ((FunctionCall
                                                     4 max@imax
@@ -760,26 +637,16 @@
                                                         (FunctionCall
                                                             4 trim
                                                             ()
-                                                            [((ArrayItem
-                                                                (Var 4 keywords)
-                                                                [(()
-                                                                (Var 4 i)
-                                                                ())]
-                                                                (Character 1 -2 ())
-                                                                ColMajor
-                                                                ()
+                                                            [((StringConstant
+                                                                "KEYWORD"
+                                                                (Character 1 7 ())
                                                             ))]
                                                             (Character 1 -3 (FunctionCall
                                                                 4 len_trim
                                                                 ()
-                                                                [((ArrayItem
-                                                                    (Var 4 keywords)
-                                                                    [(()
-                                                                    (Var 4 i)
-                                                                    ())]
-                                                                    (Character 1 -2 ())
-                                                                    ColMajor
-                                                                    ()
+                                                                [((StringConstant
+                                                                    "KEYWORD"
+                                                                    (Character 1 7 ())
                                                                 ))]
                                                                 (Integer 4)
                                                                 ()
@@ -798,47 +665,54 @@
                                                 ()
                                                 ()
                                             )
-                                            (ArrayItem
-                                                (Var 4 shorts)
-                                                [(()
-                                                (Var 4 i)
-                                                ())]
-                                                (Character 1 -2 ())
-                                                ColMajor
-                                                ()
+                                            (StringConstant
+                                                "SHORT"
+                                                (Character 1 5 ())
                                             )
-                                            (ArrayItem
-                                                (Var 4 present_in)
-                                                [(()
-                                                (Var 4 i)
-                                                ())]
-                                                (Logical 4)
-                                                ColMajor
-                                                ()
+                                            (StringConstant
+                                                "PRESENT"
+                                                (Character 1 7 ())
                                             )
-                                            (ArrayItem
-                                                (Var 4 values)
-                                                [(()
-                                                (Var 4 i)
-                                                ())]
-                                                (Character 1 -2 ())
-                                                ColMajor
-                                                ()
+                                            (StringConstant
+                                                "VALUE"
+                                                (Character 1 5 ())
                                             )]
-                                            (Var 4 i)
-                                            (IntegerConstant 1 (Integer 4))
-                                            (ArraySize
-                                                (Var 4 keywords)
-                                                ()
-                                                (Integer 4)
-                                                ()
-                                            )
+                                            FormatFortran
+                                            (Character -1 0 ())
                                             ()
-                                            (Tuple
-                                                [(Character 1 -3 (FunctionCall
-                                                    4 imax
-                                                    3 max
-                                                    [((FunctionCall
+                                        )]
+                                        ()
+                                        ()
+                                    )
+                                    (FileWrite
+                                        0
+                                        ()
+                                        (StringConstant
+                                            "(*(a,1x,a5,1x,l1,8x,\"[\",a,\"]\",/))"
+                                            (Character 1 33 ())
+                                        )
+                                        ()
+                                        ()
+                                        ()
+                                        [(StringFormat
+                                            (StringConstant
+                                                "(*(a,1x,a5,1x,l1,8x,\"[\",a,\"]\",/))"
+                                                (Character 1 33 ())
+                                            )
+                                            [(ImpliedDoLoop
+                                                [(FunctionCall
+                                                    2 atleast
+                                                    ()
+                                                    [((ArrayItem
+                                                        (Var 4 keywords)
+                                                        [(()
+                                                        (Var 4 i)
+                                                        ())]
+                                                        (Character 1 -2 ())
+                                                        ColMajor
+                                                        ()
+                                                    ))
+                                                    ((FunctionCall
                                                         4 max@imax
                                                         4 max
                                                         [((StringLen
@@ -865,21 +739,40 @@
                                                         ()
                                                         ()
                                                     ))
-                                                    ((StringLen
-                                                        (FunctionCall
-                                                            4 trim
-                                                            ()
-                                                            [((ArrayItem
-                                                                (Var 4 keywords)
-                                                                [(()
-                                                                (Var 4 i)
-                                                                ())]
-                                                                (Character 1 -2 ())
-                                                                ColMajor
+                                                    (())]
+                                                    (Character 1 -3 (FunctionCall
+                                                        4 imax
+                                                        3 max
+                                                        [((FunctionCall
+                                                            4 max@imax
+                                                            4 max
+                                                            [((StringLen
+                                                                (ArrayItem
+                                                                    (Var 4 keywords)
+                                                                    [(()
+                                                                    (ArrayBound
+                                                                        (Var 4 keywords)
+                                                                        (IntegerConstant 1 (Integer 4))
+                                                                        (Integer 4)
+                                                                        LBound
+                                                                        ()
+                                                                    )
+                                                                    ())]
+                                                                    (Character 1 -2 ())
+                                                                    ColMajor
+                                                                    ()
+                                                                )
+                                                                (Integer 4)
                                                                 ()
-                                                            ))]
-                                                            (Character 1 -3 (FunctionCall
-                                                                4 len_trim
+                                                            ))
+                                                            ((IntegerConstant 8 (Integer 4)))]
+                                                            (Integer 4)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((StringLen
+                                                            (FunctionCall
+                                                                4 trim
                                                                 ()
                                                                 [((ArrayItem
                                                                     (Var 4 keywords)
@@ -890,24 +783,149 @@
                                                                     ColMajor
                                                                     ()
                                                                 ))]
-                                                                (Integer 4)
+                                                                (Character 1 -3 (FunctionCall
+                                                                    4 len_trim
+                                                                    ()
+                                                                    [((ArrayItem
+                                                                        (Var 4 keywords)
+                                                                        [(()
+                                                                        (Var 4 i)
+                                                                        ())]
+                                                                        (Character 1 -2 ())
+                                                                        ColMajor
+                                                                        ()
+                                                                    ))]
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    ()
+                                                                ))
                                                                 ()
                                                                 ()
-                                                            ))
+                                                            )
+                                                            (Integer 4)
                                                             ()
-                                                            ()
-                                                        )
+                                                        ))]
                                                         (Integer 4)
                                                         ()
-                                                    ))]
+                                                        ()
+                                                    ))
+                                                    ()
+                                                    ()
+                                                )
+                                                (ArrayItem
+                                                    (Var 4 shorts)
+                                                    [(()
+                                                    (Var 4 i)
+                                                    ())]
+                                                    (Character 1 -2 ())
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (ArrayItem
+                                                    (Var 4 present_in)
+                                                    [(()
+                                                    (Var 4 i)
+                                                    ())]
+                                                    (Logical 4)
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (ArrayItem
+                                                    (Var 4 values)
+                                                    [(()
+                                                    (Var 4 i)
+                                                    ())]
+                                                    (Character 1 -2 ())
+                                                    ColMajor
+                                                    ()
+                                                )]
+                                                (Var 4 i)
+                                                (IntegerConstant 1 (Integer 4))
+                                                (ArraySize
+                                                    (Var 4 keywords)
+                                                    ()
                                                     (Integer 4)
                                                     ()
-                                                    ()
-                                                ))
-                                                (Character 1 -2 ())
-                                                (Logical 4)
-                                                (Character 1 -2 ())]
-                                            )
+                                                )
+                                                ()
+                                                (Tuple
+                                                    [(Character 1 -3 (FunctionCall
+                                                        4 imax
+                                                        3 max
+                                                        [((FunctionCall
+                                                            4 max@imax
+                                                            4 max
+                                                            [((StringLen
+                                                                (ArrayItem
+                                                                    (Var 4 keywords)
+                                                                    [(()
+                                                                    (ArrayBound
+                                                                        (Var 4 keywords)
+                                                                        (IntegerConstant 1 (Integer 4))
+                                                                        (Integer 4)
+                                                                        LBound
+                                                                        ()
+                                                                    )
+                                                                    ())]
+                                                                    (Character 1 -2 ())
+                                                                    ColMajor
+                                                                    ()
+                                                                )
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 8 (Integer 4)))]
+                                                            (Integer 4)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((StringLen
+                                                            (FunctionCall
+                                                                4 trim
+                                                                ()
+                                                                [((ArrayItem
+                                                                    (Var 4 keywords)
+                                                                    [(()
+                                                                    (Var 4 i)
+                                                                    ())]
+                                                                    (Character 1 -2 ())
+                                                                    ColMajor
+                                                                    ()
+                                                                ))]
+                                                                (Character 1 -3 (FunctionCall
+                                                                    4 len_trim
+                                                                    ()
+                                                                    [((ArrayItem
+                                                                        (Var 4 keywords)
+                                                                        [(()
+                                                                        (Var 4 i)
+                                                                        ())]
+                                                                        (Character 1 -2 ())
+                                                                        ColMajor
+                                                                        ()
+                                                                    ))]
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    ()
+                                                                ))
+                                                                ()
+                                                                ()
+                                                            )
+                                                            (Integer 4)
+                                                            ()
+                                                        ))]
+                                                        (Integer 4)
+                                                        ()
+                                                        ()
+                                                    ))
+                                                    (Character 1 -2 ())
+                                                    (Logical 4)
+                                                    (Character 1 -2 ())]
+                                                )
+                                                ()
+                                            )]
+                                            FormatFortran
+                                            (Character -1 0 ())
                                             ()
                                         )]
                                         ()

--- a/tests/reference/asr-fn6-a24010a.json
+++ b/tests/reference/asr-fn6-a24010a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn6-a24010a.stdout",
-    "stdout_hash": "d56a9cf5e2873266e50943e9dd3e8d13a09386629733ce466e0460c7",
+    "stdout_hash": "e2f5b5041ab62099ce0c2d5faf1d57131a10278472f0494010cee411",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn6-a24010a.stdout
+++ b/tests/reference/asr-fn6-a24010a.stdout
@@ -268,22 +268,31 @@
                                         ()
                                         ()
                                         ()
-                                        [(FunctionCall
-                                            2 msg_scalar
-                                            2 str
-                                            [((Var 6 g0))
-                                            ((Var 6 g1))
-                                            ((Var 6 g2))
-                                            ((Var 6 g3))
-                                            ((Var 6 ga))
-                                            ((Var 6 gb))
-                                            ((Var 6 gc))
-                                            ((Var 6 gd))
-                                            ((Var 6 sep))]
-                                            (Allocatable
-                                                (Character 1 -2 ())
+                                        [(StringFormat
+                                            (StringConstant
+                                                "(a)"
+                                                (Character 1 3 ())
                                             )
-                                            ()
+                                            [(FunctionCall
+                                                2 msg_scalar
+                                                2 str
+                                                [((Var 6 g0))
+                                                ((Var 6 g1))
+                                                ((Var 6 g2))
+                                                ((Var 6 g3))
+                                                ((Var 6 ga))
+                                                ((Var 6 gb))
+                                                ((Var 6 gc))
+                                                ((Var 6 gd))
+                                                ((Var 6 sep))]
+                                                (Allocatable
+                                                    (Character 1 -2 ())
+                                                )
+                                                ()
+                                                ()
+                                            )]
+                                            FormatFortran
+                                            (Character -1 0 ())
                                             ()
                                         )]
                                         ()
@@ -594,7 +603,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(i0)"
+                                                                                (Character 1 4 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -630,7 +648,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(i0)"
+                                                                                (Character 1 4 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -666,7 +693,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(i0)"
+                                                                                (Character 1 4 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -702,7 +738,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(i0)"
+                                                                                (Character 1 4 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -738,7 +783,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(1pg0)"
+                                                                                (Character 1 6 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -774,7 +828,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(1pg0)"
+                                                                                (Character 1 6 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -810,7 +873,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(l1)"
+                                                                                (Character 1 4 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]
@@ -855,19 +927,28 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(FunctionCall
-                                                                            3 trim
-                                                                            ()
-                                                                            [((Var 5 generic))]
-                                                                            (Character 1 -3 (FunctionCall
-                                                                                64 len_trim
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(a)"
+                                                                                (Character 1 3 ())
+                                                                            )
+                                                                            [(FunctionCall
+                                                                                3 trim
                                                                                 ()
                                                                                 [((Var 5 generic))]
-                                                                                (Integer 4)
+                                                                                (Character 1 -3 (FunctionCall
+                                                                                    64 len_trim
+                                                                                    ()
+                                                                                    [((Var 5 generic))]
+                                                                                    (Integer 4)
+                                                                                    ()
+                                                                                    ()
+                                                                                ))
                                                                                 ()
                                                                                 ()
-                                                                            ))
-                                                                            ()
+                                                                            )]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
                                                                             ()
                                                                         )]
                                                                         ()
@@ -905,7 +986,16 @@
                                                                         ()
                                                                         ()
                                                                         ()
-                                                                        [(Var 5 generic)]
+                                                                        [(StringFormat
+                                                                            (StringConstant
+                                                                                "(\"(\",1pg0,\",\",1pg0,\")\")"
+                                                                                (Character 1 23 ())
+                                                                            )
+                                                                            [(Var 5 generic)]
+                                                                            FormatFortran
+                                                                            (Character -1 0 ())
+                                                                            ()
+                                                                        )]
                                                                         ()
                                                                         ()
                                                                     )]

--- a/tests/reference/asr-intrinsics_open_close_read_write-a696eca.json
+++ b/tests/reference/asr-intrinsics_open_close_read_write-a696eca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_open_close_read_write-a696eca.stdout",
-    "stdout_hash": "d7482ced3a68d6390aace20345d914e779d8fadec153e08f6e658c48",
+    "stdout_hash": "c75a0cbc8f5eb26e2df0450dc772e7931b575ecc7ff3aabd877367f3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_open_close_read_write-a696eca.stdout
+++ b/tests/reference/asr-intrinsics_open_close_read_write-a696eca.stdout
@@ -303,22 +303,31 @@
                             ()
                             ()
                             ()
-                            [(ArrayItem
-                                (Var 2 x)
-                                [(()
-                                (Var 2 i)
-                                ())]
-                                (Real 4)
-                                ColMajor
-                                ()
-                            )
-                            (ArrayItem
-                                (Var 2 y)
-                                [(()
-                                (Var 2 i)
-                                ())]
-                                (Real 4)
-                                ColMajor
+                            [(StringFormat
+                                (StringConstant
+                                    "(10F8.2)"
+                                    (Character 1 8 ())
+                                )
+                                [(ArrayItem
+                                    (Var 2 x)
+                                    [(()
+                                    (Var 2 i)
+                                    ())]
+                                    (Real 4)
+                                    ColMajor
+                                    ()
+                                )
+                                (ArrayItem
+                                    (Var 2 y)
+                                    [(()
+                                    (Var 2 i)
+                                    ())]
+                                    (Real 4)
+                                    ColMajor
+                                    ()
+                                )]
+                                FormatFortran
+                                (Character -1 0 ())
                                 ()
                             )]
                             ()

--- a/tests/reference/run-write4-329d906.json
+++ b/tests/reference/run-write4-329d906.json
@@ -6,8 +6,8 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run-write4-329d906.stdout",
-    "stdout_hash": "53a3d179203f266f36431d4b08c3759a60fd29395f9c14e7097066d7",
-    "stderr": "run-write4-329d906.stderr",
-    "stderr_hash": "72787637b37840055523f9c3c84bcc6ff93e9249d111c21306dc455f",
+    "stdout_hash": "35b66a98ef22ffcced895e555c3a2a29e11bfdd9d4e091a5b83fb8d7",
+    "stderr": null,
+    "stderr_hash": null,
     "returncode": 0
 }

--- a/tests/reference/run-write4-329d906.stdout
+++ b/tests/reference/run-write4-329d906.stdout
@@ -1,4 +1,6 @@
-hi, how are you?
+hi, 
+how are you?
 I 
 am
-doing good
+doing 
+good

--- a/tests/reference/run-write5-4a89b6b.json
+++ b/tests/reference/run-write5-4a89b6b.json
@@ -2,12 +2,12 @@
     "basename": "run-write5-4a89b6b",
     "cmd": "lfortran --no-color --run {infile} -o write5.f90.out",
     "infile": "tests/write5.f90",
-    "infile_hash": "78a58078463c4bac62b10d2223a2b33f3ce25a44a9ed664cf4d0813a",
+    "infile_hash": "5d5d604b32e128f6ff9c94fd138118f49b7df62bfb1350c28972bdf2",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run-write5-4a89b6b.stdout",
-    "stdout_hash": "39f81598f2a98f1bb2d641477c471fd1a614f5e2dfca152ad3856b61",
-    "stderr": "run-write5-4a89b6b.stderr",
-    "stderr_hash": "bcb0fa2d870d9b070c2ee7c573e3c721f87a86647f2671976a81e555",
+    "stdout_hash": "f199c73cbfb9af4762f111ddd42db56f47507d629a9130af1ac4a084",
+    "stderr": null,
+    "stderr_hash": null,
     "returncode": 0
 }

--- a/tests/reference/run-write5-4a89b6b.stdout
+++ b/tests/reference/run-write5-4a89b6b.stdout
@@ -1,2 +1,6 @@
-hibye
-first, last
+hi
+bye
+first, 
+last
+
+Hello world!

--- a/tests/write5.f90
+++ b/tests/write5.f90
@@ -11,4 +11,7 @@ program write5
 
     write (*, "(a)", advance="n"//"o") first_name//", "
     write (*, "(a)", advance="y"//"e"//"s") last_name
+
+    write(*,'("Hello ")',advance='NO')
+    write(*,'("world!")')
 end program


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2413
```fortran
program test
    implicit none
    
    write(*,'("Hello ")',advance='NO')
    write(*,'("world!")')

end program
```
```console
(lf) ➜  lfortran git:(advance) ✗ lfortran examples/temp.f90 
Hello world!
```