### PR TITLE
Fixes reference to derived_type_symbol in Function that has interface as argument

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -633,6 +633,7 @@ RUN(NAME interface_09 LABELS gfortran)
 RUN(NAME interface_10 LABELS gfortran llvm)
 RUN(NAME interface_12a LABELS gfortran llvm EXTRAFILES interface_12b.f90)
 RUN(NAME interface_13 LABELS gfortran llvm)
+RUN(NAME interface_14 LABELS gfortran llvm)
 
 RUN(NAME implicit_interface_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/interface_14.f90
+++ b/integration_tests/interface_14.f90
@@ -1,0 +1,42 @@
+module interface_14_data
+    implicit none
+    public data_t
+
+    type data_t
+        integer :: x
+    end type
+end module
+
+program interface_14
+    use interface_14_data, only: data_t
+    implicit none
+
+    integer :: x
+    x = get_x_from_data(return_x_from_data)
+    print *, x
+    if (x /= 100) error stop
+
+    contains
+
+    function return_x_from_data(d)
+        type(data_t), intent(inout) :: d
+        integer :: return_x_from_data
+        return_x_from_data = d%x
+    end function
+
+    function get_x_from_data(R)
+    interface
+        function R(d)
+        use interface_14_data
+        implicit none
+        type(data_t), intent(inout) :: d
+        integer :: R
+        end function
+    end interface
+    integer :: get_x_from_data
+    type(data_t) :: d
+    d%x = 100
+    get_x_from_data = R(d)
+    end function
+
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -186,7 +186,7 @@ public:
                                 ASR::FunctionType_t* func_type = ASRUtils::get_FunctionType(*func);
                                 if( func_type->m_return_var_type ) {
                                     ASRUtils::ReplaceWithFunctionParamVisitor replacer(al, func->m_args, func->n_args);
-                                    func_type->m_return_var_type = replacer.replace_args_with_FunctionParam(data->type);
+                                    func_type->m_return_var_type = replacer.replace_args_with_FunctionParam(data->type, data->scope);
                                 }
                             }
                         }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2149,7 +2149,7 @@ public:
             this->visit_unit_decl2(*x.m_decl[i]);
             if (tmp && ASR::is_a<ASR::require_instantiation_t>(*tmp)) {
                 reqs.push_back(al, ASR::down_cast<ASR::require_instantiation_t>(tmp));
-                tmp = nullptr;    
+                tmp = nullptr;
             }
         }
         for (size_t i=0; i<x.n_funcs; i++) {
@@ -2229,7 +2229,7 @@ public:
                 throw SemanticError("Parameter '" + std::string(x.m_namelist[i])
                     + "' was not declared", x.base.base.loc);
             }
-            
+
             ASR::symbol_t *requires_arg_sym = current_scope->resolve_symbol(requires_arg);
             context_map[requirement_arg] = requires_arg;
             if (!requires_arg_sym) {
@@ -2244,7 +2244,7 @@ public:
         for (auto &item: req->m_symtab->get_scope()) {
             if (ASR::is_a<ASR::CustomOperator_t>(*item.second)) {
                 ASR::CustomOperator_t *c_op = ASR::down_cast<ASR::CustomOperator_t>(item.second);
-                
+
                 // may not need to add new custom operators if another requires already got an interface
                 Vec<ASR::symbol_t*> symbols;
                 symbols.reserve(al, c_op->n_procs);
@@ -2492,7 +2492,7 @@ public:
                         }
                     } else if (is_cmpop) {
                         if (!ASRUtils::check_equal_type(ltype, rtype) || !ASRUtils::is_logical(*ftype)) {
-                            throw SemanticError("Intrinsic operator " + op_name + 
+                            throw SemanticError("Intrinsic operator " + op_name +
                                 " requires same-typed arguments and a logical return type", x.base.base.loc);
                         }
                     }
@@ -2521,7 +2521,7 @@ public:
                         current_scope->get_symbol("arg0")));
                     ASR::expr_t *rexpr = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                         current_scope->get_symbol("arg1")));
-                        
+
                     if (is_binop) {
                         value = ASRUtils::EXPR(ASRUtils::make_Binop_util(al, x.base.base.loc, binop, lexpr, rexpr, ltype));
                         return_type = ASRUtils::duplicate_type(al, ltype);

--- a/src/libasr/asdl_cpp.py
+++ b/src/libasr/asdl_cpp.py
@@ -1303,6 +1303,8 @@ class ExprBaseReplacerVisitor(ASDLVisitor):
                     self.emit("    self().replace_expr(x->m_%s[i]);"%(field.name), level)
                     self.emit("    current_expr = current_expr_copy_%d;" % (self.current_expr_copy_variable_count), level)
                     self.current_expr_copy_variable_count += 1
+                elif field.type == "ttype":
+                    self.emit("    self().replace_%s(x->m_%s[i]);" % (field.type, field.name), level)
                 self.emit("}", level)
             else:
                 if field.type != "symbol":

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3277,6 +3277,16 @@ class ReplaceWithFunctionParamVisitor: public ASR::BaseExprReplacer<ReplaceWithF
         }
     }
 
+    void replace_Struct(ASR::Struct_t *x) {
+        std::string derived_type_name = ASRUtils::symbol_name(x->m_derived_type);
+        ASR::symbol_t* derived_type_sym = current_scope->resolve_symbol(derived_type_name);
+        LCOMPILERS_ASSERT_MSG( derived_type_sym != nullptr,
+                    "derived_type_sym cannot be nullptr");
+        if (derived_type_sym != x->m_derived_type) {
+            x->m_derived_type = derived_type_sym;
+        }
+    }
+
     ASR::ttype_t* replace_args_with_FunctionParam(ASR::ttype_t* t, SymbolTable* current_scope) {
         this->current_scope = current_scope;
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3247,10 +3247,12 @@ class ReplaceWithFunctionParamVisitor: public ASR::BaseExprReplacer<ReplaceWithF
 
     size_t n_args;
 
+    SymbolTable* current_scope;
+
     public:
 
     ReplaceWithFunctionParamVisitor(Allocator& al_, ASR::expr_t** m_args_, size_t n_args_) :
-        al(al_), m_args(m_args_), n_args(n_args_) {}
+        al(al_), m_args(m_args_), n_args(n_args_), current_scope(nullptr) {}
 
     void replace_Var(ASR::Var_t* x) {
         size_t arg_idx = 0;
@@ -3268,14 +3270,16 @@ class ReplaceWithFunctionParamVisitor: public ASR::BaseExprReplacer<ReplaceWithF
         if( idx_found ) {
             LCOMPILERS_ASSERT(current_expr);
             ASR::ttype_t* t_ = replace_args_with_FunctionParam(
-                                ASRUtils::symbol_type(x->m_v));
+                                ASRUtils::symbol_type(x->m_v), current_scope);
             *current_expr = ASRUtils::EXPR(ASR::make_FunctionParam_t(
                                 al, m_args[arg_idx]->base.loc, arg_idx,
                                 t_, nullptr));
         }
     }
 
-    ASR::ttype_t* replace_args_with_FunctionParam(ASR::ttype_t* t) {
+    ASR::ttype_t* replace_args_with_FunctionParam(ASR::ttype_t* t, SymbolTable* current_scope) {
+        this->current_scope = current_scope;
+
         ASRUtils::ExprStmtDuplicator duplicator(al);
         duplicator.allow_procedure_calls = true;
 
@@ -3312,7 +3316,7 @@ inline ASR::asr_t* make_FunctionType_t_util(Allocator &al,
     ASR::expr_t* a_return_var, ASR::abiType a_abi, ASR::deftypeType a_deftype,
     char* a_bindc_name, bool a_elemental, bool a_pure, bool a_module, bool a_inline,
     bool a_static,
-    ASR::symbol_t** a_restrictions, size_t n_restrictions, bool a_is_restriction) {
+    ASR::symbol_t** a_restrictions, size_t n_restrictions, bool a_is_restriction, SymbolTable* current_scope) {
     Vec<ASR::ttype_t*> arg_types;
     arg_types.reserve(al, n_args);
     ReplaceWithFunctionParamVisitor replacer(al, a_args, n_args);
@@ -3320,13 +3324,13 @@ inline ASR::asr_t* make_FunctionType_t_util(Allocator &al,
         // We need to substitute all direct argument variable references with
         // FunctionParam.
         ASR::ttype_t *t = replacer.replace_args_with_FunctionParam(
-                            expr_type(a_args[i]));
+                            expr_type(a_args[i]), current_scope);
         arg_types.push_back(al, t);
     }
     ASR::ttype_t* return_var_type = nullptr;
     if( a_return_var ) {
         return_var_type = replacer.replace_args_with_FunctionParam(
-                            ASRUtils::expr_type(a_return_var));
+                            ASRUtils::expr_type(a_return_var), current_scope);
     }
 
     LCOMPILERS_ASSERT(arg_types.size() == n_args);
@@ -3338,12 +3342,12 @@ inline ASR::asr_t* make_FunctionType_t_util(Allocator &al,
 }
 
 inline ASR::asr_t* make_FunctionType_t_util(Allocator &al, const Location &a_loc,
-    ASR::expr_t** a_args, size_t n_args, ASR::expr_t* a_return_var, ASR::FunctionType_t* ft) {
+    ASR::expr_t** a_args, size_t n_args, ASR::expr_t* a_return_var, ASR::FunctionType_t* ft, SymbolTable* current_scope) {
     return ASRUtils::make_FunctionType_t_util(al, a_loc, a_args, n_args, a_return_var,
         ft->m_abi, ft->m_deftype, ft->m_bindc_name, ft->m_elemental,
         ft->m_pure, ft->m_module, ft->m_inline, ft->m_static,
         ft->m_restrictions,
-        ft->n_restrictions, ft->m_is_restriction);
+        ft->n_restrictions, ft->m_is_restriction, current_scope);
 }
 
 inline ASR::asr_t* make_Function_t_util(Allocator& al, const Location& loc,
@@ -3357,7 +3361,7 @@ inline ASR::asr_t* make_Function_t_util(Allocator& al, const Location& loc,
     ASR::ttype_t* func_type = ASRUtils::TYPE(ASRUtils::make_FunctionType_t_util(
         al, loc, a_args, n_args, m_return_var, m_abi, m_deftype, m_bindc_name,
         m_elemental, m_pure, m_module, m_inline, m_static,
-        m_restrictions, n_restrictions, m_is_restriction));
+        m_restrictions, n_restrictions, m_is_restriction, m_symtab));
     return ASR::make_Function_t(
         al, loc, m_symtab, m_name, func_type, m_dependencies, n_dependencies,
         a_args, n_args, m_body, n_body, m_return_var, m_access, m_deterministic,

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -199,7 +199,7 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
 
             ASR::FunctionType_t* func_type = ASRUtils::get_FunctionType(*x);
             x->m_function_signature = ASRUtils::TYPE(ASRUtils::make_FunctionType_t_util(
-                al, func_type->base.base.loc, new_args.p, new_args.size(), x->m_return_var, func_type));
+                al, func_type->base.base.loc, new_args.p, new_args.size(), x->m_return_var, func_type, current_scope));
             x->m_args = new_args.p;
             x->n_args = new_args.size();
         }

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -744,7 +744,7 @@ namespace LCompilers {
                 for(auto &e: a_args) {
                     ASRUtils::ReplaceWithFunctionParamVisitor replacer(al, x->m_args, x->n_args);
                     arg_types.push_back(al, replacer.replace_args_with_FunctionParam(
-                                                ASRUtils::expr_type(e)));
+                                                ASRUtils::expr_type(e), x->m_symtab));
                 }
                 s_func_type->m_arg_types = arg_types.p;
                 s_func_type->n_arg_types = arg_types.n;


### PR DESCRIPTION
Fixes the issue https://github.com/lfortran/lfortran/issues/2386#issuecomment-1720501673.

Related https://github.com/lcompilers/lpython/pull/2326.