### PR TITLE
Handle arrays for StringFormat correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -412,6 +412,7 @@ RUN(NAME format_05 LABELS gfortran)
 RUN(NAME format_06 LABELS gfortran llvm)
 RUN(NAME format_07 LABELS gfortran llvm)
 RUN(NAME format_08 LABELS gfortran llvm)
+RUN(NAME format_09 LABELS gfortran llvm)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran)

--- a/integration_tests/format_09.f90
+++ b/integration_tests/format_09.f90
@@ -1,0 +1,18 @@
+program format_09
+    implicit none
+    integer :: a(5),b(5),c(10)
+    integer, parameter :: dp=kind(0d0)
+    real(dp) :: d(3)
+    a = [117,123,124,126,129]
+    b = [1,2,3,4,5]
+    c = 1
+    d = [1._dp,1._dp,1._dp]
+    print '(6(i6))', c
+    print 10, "hello", a ,"world", b
+  10  format(a,i10,i4,i5,i6,i7)
+    print 20, 'String:', 3.1415926d0, &
+    'Integer:', 42, &
+    'Array:', d
+  20 format(5x,a,d15.7//,5x,a,16x,i10//,5x,a//1(5x,3d15.7))
+  end program
+  

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8891,17 +8891,45 @@ public:
         //ASR::expr_t* fmt_value = ASRUtils::expr_value(x.m_fmt);
         // if (fmt_value) ...
         if (x.m_kind == ASR::string_format_kindType::FormatFortran) {
-            std::vector<llvm::Value *> args;
+            std::vector<llvm::Value *> args,values;
             int size = x.n_args;
+
+            for (size_t i=0; i<x.n_args; i++) {
+                std::vector<std::string>fmt;
+                if (PassUtils::is_array(x.m_args[i])) {
+                    ASR::expr_t *arr_expr = x.m_args[i];
+                    ASR::dimension_t* m_dims;
+                    int n_dims = ASRUtils::extract_dimensions_from_ttype(ASRUtils::expr_type(arr_expr), m_dims);
+                    int m_dim_length = ASR::down_cast<ASR::IntegerConstant_t>(m_dims->m_length)->m_n;
+                    size = size + n_dims*m_dim_length - 1;
+                    Vec<ASR::expr_t*> idx_vars;
+                    PassUtils::create_idx_vars(idx_vars, n_dims, x.base.base.loc, al, current_scope,"_v");
+                    ASR::ttype_t *int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
+                    ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1, int32_type));
+                    for (int n = 0; n < n_dims; n++) {
+                        ASR::stmt_t* assign = ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, idx_vars[n], one, nullptr));
+                        this->visit_stmt(*assign);
+                        for (int m = 0; m < m_dim_length; m++) {
+                            ASR::expr_t* ref = PassUtils::create_array_ref(arr_expr, idx_vars, al, current_scope);
+                            compute_fmt_specifier_and_arg(fmt, values, ref, x.base.base.loc);
+                            this->visit_expr_wrapper(ref);
+                            ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc, idx_vars[n],
+                                ASR::binopType::Add, one, int32_type, nullptr));
+                            ASR::stmt_t* assign_inc = ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, idx_vars[n], increment, nullptr));
+                            this->visit_stmt(*assign_inc);
+                        }
+                    }
+                } else {
+                    //  Use the function to compute the args, but ignore the format
+                    compute_fmt_specifier_and_arg(fmt, values, x.m_args[i], x.base.base.loc);
+                }
+            }
             llvm::Value *count = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), size);
             args.push_back(count);
             visit_expr(*x.m_fmt);
             args.push_back(tmp);
-
-            for (size_t i=0; i<x.n_args; i++) {
-                std::vector<std::string>fmt;
-                //  Use the function to compute the args, but ignore the format
-                compute_fmt_specifier_and_arg(fmt, args, x.m_args[i], x.base.base.loc);
+            for (size_t i=0; i<values.size(); i++) {
+                args.push_back(values[i]);
             }
             tmp = string_format_fortran(context, *module, *builder, args);
         } else {

--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -139,7 +139,7 @@ public:
                                                 nullptr, nullptr, 0, nullptr, nullptr));
             ASR::StringFormat_t* format = ASR::down_cast<ASR::StringFormat_t>(x.m_values[0]);
             for (size_t i=0; i<format->n_args; i++) {
-                if (PassUtils::is_array(format->m_args[i])) {
+                if (PassUtils::is_array(format->m_args[i]) && !ASRUtils::is_fixed_size_array(ASRUtils::expr_type(format->m_args[i]))) {
                     if (print_body.size() > 0) {
                         print_stmt = create_formatstmt(print_body, format, x.base.base.loc, ASR::stmtType::Print);
                         pass_result.push_back(al, print_stmt);
@@ -293,7 +293,7 @@ public:
         if(x.m_values && x.m_values[0] != nullptr && ASR::is_a<ASR::StringFormat_t>(*x.m_values[0])){
             ASR::StringFormat_t* format = ASR::down_cast<ASR::StringFormat_t>(x.m_values[0]);
             for (size_t i=0; i<format->n_args; i++) {
-                if (PassUtils::is_array(format->m_args[i])) {
+                if (PassUtils::is_array(format->m_args[i]) && !ASRUtils::is_fixed_size_array(ASRUtils::expr_type(format->m_args[i]))) {
                     if (write_body.size() > 0) {
                         write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite);
                         pass_result.push_back(al, write_stmt);


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2344
This PR allows us to use arrays in between arguments of print statements and print them with the correct formatting.
Before, we made a new print statement for every element for the array.
Now we have all of them, along with the other arguments, in a single ```StringFormat``` expr in their correct places.
The following produces the same output for lfortran and gfortran:
```fortran
program format_09
    implicit none
    integer :: a(5),b(5),c(10)
    integer, parameter :: dp=kind(0d0)
    real(dp) :: d(3)
    a = [117,123,124,126,129]
    b = [1,2,3,4,5]
    c = 1
    d = [1._dp,1._dp,1._dp]
    print '(6(i6))', c
    print 10, "hello", a ,"world", b
  10  format(a,i10,i4,i5,i6,i7)
    print 20, 'String:', 3.1415926d0, &
    'Integer:', 42, &
    'Array:', d
  20 format(5x,a,d15.7//,5x,a,16x,i10//,5x,a//1(5x,3d15.7))
  end program
  ```
```console
     1     1     1     1     1     1
     1     1     1     1
hello       117 123  124   126    129
world         1   2    3     4      5
     String:  0.3141593D+01

     Integer:                        42

     Array:

       0.1000000D+01  0.1000000D+01  0.1000000D+01
```
Please test this properly and check if the output differs between lfortran and gfortran.