### PR TITLE
Dftatom: Fix reference to derived_type when duplicating symbol

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -635,6 +635,7 @@ RUN(NAME interface_10 LABELS gfortran llvm)
 RUN(NAME interface_12a LABELS gfortran llvm EXTRAFILES interface_12b.f90)
 RUN(NAME interface_13 LABELS gfortran llvm)
 RUN(NAME interface_14 LABELS gfortran llvm)
+RUN(NAME interface_15 LABELS gfortran llvm)
 
 RUN(NAME implicit_interface_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/interface_15.f90
+++ b/integration_tests/interface_15.f90
@@ -1,0 +1,36 @@
+module interface_15_mod
+    implicit none
+    type t
+        integer :: x
+    end type t
+end module interface_15_mod
+
+program interface_15
+    use interface_15_mod
+    implicit none
+
+    integer :: x(2)
+    x = [5, 4]
+    print *, func(x)
+
+    if (func(x) /= 9) error stop
+
+    contains
+        function func(i) result(output)
+        integer, intent(in) :: i(:)
+        real :: output
+        type(t) :: type
+
+        interface
+            function R(j, s)
+            use interface_15_mod
+            implicit none
+            integer, intent(in) :: j(:)
+            type(t), intent(inout) :: s
+            real :: R
+            end function
+        end interface
+
+        output = i(1) + i(2)
+        end function func
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3467,6 +3467,15 @@ class SymbolDuplicator {
         if( !node_duplicator.success ) {
             return nullptr;
         }
+        if (ASR::is_a<ASR::Struct_t>(*m_type)) {
+            ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(m_type);
+            std::string derived_type_name = ASRUtils::symbol_name(st->m_derived_type);
+            ASR::symbol_t* derived_type_sym = destination_symtab->resolve_symbol(derived_type_name);
+            LCOMPILERS_ASSERT_MSG( derived_type_sym != nullptr, "derived_type_sym cannot be nullptr");
+            if (derived_type_sym != st->m_derived_type) {
+                st->m_derived_type = derived_type_sym;
+            }
+        }
         return ASR::down_cast<ASR::symbol_t>(
             ASR::make_Variable_t(al, variable->base.base.loc, destination_symtab,
                 variable->m_name, variable->m_dependencies, variable->n_dependencies,

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -93,10 +93,19 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
             node_duplicator.allow_procedure_calls = true;
             SymbolTable* new_symtab = al.make_new<SymbolTable>(current_scope);
             ASRUtils::SymbolDuplicator symbol_duplicator(al);
+            // first duplicate the external symbols
+            // so they can be referenced by derived_type
             for( auto& item: x->m_symtab->get_scope() ) {
-                symbol_duplicator.duplicate_symbol(item.second, new_symtab);
+                if (ASR::is_a<ASR::ExternalSymbol_t>(*item.second)) {
+                    symbol_duplicator.duplicate_symbol(item.second, new_symtab);
+                }
             }
-            Vec<ASR::expr_t*> new_args;
+            for( auto& item: x->m_symtab->get_scope() ) {
+                if (!ASR::is_a<ASR::ExternalSymbol_t>(*item.second)) {
+                    symbol_duplicator.duplicate_symbol(item.second, new_symtab);
+                }
+            }
+          Vec<ASR::expr_t*> new_args;
             std::string suffix = "";
             new_args.reserve(al, x->n_args);
             ASR::expr_t* return_var = nullptr;


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/2435