### PR TITLE
Hack to get I/O operations via implied do loops working

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -932,9 +932,11 @@ RUN(NAME template_vector LABELS llvm)
 
 RUN(NAME statement1 LABELS gfortran llvm)
 
-RUN(NAME implied_do_loops1 LABELS gfortran)
+RUN(NAME implied_do_loops1 LABELS gfortran llvm NOFAST)
 RUN(NAME implied_do_loops2 LABELS gfortran)
 RUN(NAME implied_do_loops3 LABELS gfortran)
+RUN(NAME implied_do_loops4 LABELS gfortran llvm)
+
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90 NOFAST)

--- a/integration_tests/implied_do_loops4.f90
+++ b/integration_tests/implied_do_loops4.f90
@@ -1,0 +1,9 @@
+program implied_do_loops4
+integer :: i, j
+real :: x(5)
+j = 12
+x = (/ (real(i),i=1,5) /)
+print *, (i,i=1,3), (i,i=4,6), j
+write (*,*) (i,i=1,3), (i,i=4,6), j
+print *, (x(i) + 1.0, i=1,5)
+end program


### PR DESCRIPTION
With this we get `scipy/optimize/lbfgsb_src` compiled to LLVM.

We currently have support for implied do loops represented as `[(i, i=1,3)]`, so to get `print *, (i,i=1,3)` working I replaced it as `print *, [(i, i=1,3)]`.