### PR TITLE
Handle nested optional arguments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1097,6 +1097,7 @@ RUN(NAME minpack_03 LABELS gfortran llvm NOFAST)
 RUN(NAME optional_01 LABELS gfortran llvm)
 RUN(NAME optional_02 LABELS gfortran llvm)
 RUN(NAME optional_03 LABELS gfortran llvm)
+RUN(NAME optional_04 LABELS gfortran llvm)
 
 RUN(NAME end_name_match LABELS gfortran llvm)
 

--- a/integration_tests/optional_04.f90
+++ b/integration_tests/optional_04.f90
@@ -1,0 +1,16 @@
+module module_optional_04
+contains
+   subroutine sub( a )
+      integer, intent(in), optional :: a(10)
+      call sub2( a(5) )
+   end subroutine
+   subroutine sub2( a )
+      integer, intent(in), optional :: a
+      if ( .not. present(a) ) error stop
+   end subroutine
+end module
+
+program optional_04
+   use module_optional_04
+   call sub()
+end

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -333,7 +333,7 @@ bool fill_new_args(Vec<ASR::call_arg_t>& new_args, Allocator& al,
                     size_t k;
                     bool k_found = false;
                     for( k = 0; k < owning_function->n_args; k++ ) {
-                        if( ASR::down_cast<ASR::Var_t>(owning_function->m_args[k])->m_v ==
+                        if( ASR::is_a<ASR::Var_t>(*x.m_args[i].m_value) && ASR::down_cast<ASR::Var_t>(owning_function->m_args[k])->m_v ==
                             ASR::down_cast<ASR::Var_t>(x.m_args[i].m_value)->m_v ) {
                             k_found = true;
                             break ;


### PR DESCRIPTION
Fixes #2463.

Code gets compiled and give a junk value in return, that is why I have not added any test yet

```fortran
module m
contains
   subroutine sub( a )
      integer, intent(in), optional :: a(10)
      call sub2( a(5) )
   end subroutine
   subroutine sub2( a )
      integer, intent(in), optional :: a
      if ( present(a) ) print *, a
   end subroutine
end module
   use m
   call sub()
end
```

> LFortran

```console
% lfortran a.f90              
-1470529752
```

> GFortran

```console
% gfortran a.f90&& ./a.out

Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

Backtrace for this error:
#0  0x1028e5b07
#1  0x1028e4b53
#2  0x1a891ea23
#3  0x1029d8597
zsh: segmentation fault  ./a.out
```