### PR TITLE
Set `-DCMAKE_Fortran_FLAGS` to use `-g` option for Fortran backend

### DIFF
--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -30,6 +30,10 @@ def run_test(backend):
     elif backend == "cpp":
         run_cmd(f"FC=lfortran FFLAGS=\"--openmp\" cmake -DLFORTRAN_BACKEND={backend} -DFAST={fast_tests}" + common,
                 cwd=cwd)
+    elif backend == "fortran":
+        run_cmd(f"FC=lfortran cmake -DLFORTRAN_BACKEND={backend} "
+            "-DFAST={fast_tests} -DCMAKE_Fortran_FLAGS=\"-g\"" + common,
+                cwd=cwd)
     else:
         run_cmd(f"FC=lfortran cmake -DLFORTRAN_BACKEND={backend} -DFAST={fast_tests}" + common,
                 cwd=cwd)


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/2482