### PR TITLE
Handle a 1D array from 2D array in legacy-array-sections

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1112,5 +1112,5 @@ RUN(NAME array_unbounded_02 LABELS gfortran llvm)
 
 RUN(NAME matmul_01 LABELS gfortran)
 RUN(NAME legacy_array_sections_01 LABELS gfortran llvm EXTRA_ARGS --legacy-array-sections)
-
+RUN(NAME legacy_array_sections_02 LABELS gfortran llvm EXTRA_ARGS --legacy-array-sections)
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm)

--- a/integration_tests/legacy_array_sections_02.f90
+++ b/integration_tests/legacy_array_sections_02.f90
@@ -1,0 +1,17 @@
+subroutine sub(a)
+double precision :: a
+dimension :: a(16)
+print *, a
+if (abs(a(1) - 1) > 1d-15) error stop
+if (abs(a(2) - 2) > 1d-15) error stop
+if (.not. all(abs(a(3:) - 1) < 1d-15)) error stop
+end subroutine
+
+program main
+double precision :: a(16,3)
+integer :: j
+j = 3
+a = 1
+a(2,3) = 2
+call sub(a(1,j))
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2528,8 +2528,10 @@ public:
                                 dims.push_back(al, dim);
                                 ASR::asr_t* descriptor_array = ASR::make_Array_t(al, x.base.base.loc, ASRUtils::type_get_past_array(expected_arg_type),
                                                                 dims.p, dims.size(), ASR::array_physical_typeType::DescriptorArray);
+
+                                ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(expected_arg_type);
                                 ASR::asr_t* expected_array = ASR::make_Array_t(al, x.base.base.loc, ASRUtils::type_get_past_array(expected_arg_type),
-                                                                dims.p, dims.size(), ASRUtils::extract_physical_type(expected_arg_type));
+                                                                array_t->m_dims, array_t->n_dims, ASRUtils::extract_physical_type(expected_arg_type));
 
                                 // make ArraySection
                                 Vec<ASR::array_index_t> array_indices;


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/2481