### PR TITLE
Create ArrayBroadcast in BinOp

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5273,6 +5273,15 @@ public:
                                                 source_type, dest_type);
         }
 
+        // Broadcast a scalar to an array if needed
+        if (ASRUtils::is_array(left_type) && !ASRUtils::is_array(right_type)) {
+            ASRUtils::make_ArrayBroadcast_t_util(al, right->base.loc, left, right);
+            right_type = left_type;
+        } else if (!ASRUtils::is_array(left_type) && ASRUtils::is_array(right_type)) {
+            ASRUtils::make_ArrayBroadcast_t_util(al, right->base.loc, right, left);
+            left_type = right_type;
+        }
+
         if( (ASRUtils::is_array(right_type) || ASRUtils::is_array(left_type)) &&
              !ASRUtils::is_array(dest_type) ) {
             ASR::dimension_t* m_dims = nullptr;

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -686,6 +686,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
         op_expr = *current_expr;
         result_var = nullptr;
         this->replace_expr(x->m_left);
+        LCOMPILERS_ASSERT(*current_expr != nullptr)
         ASR::expr_t* left = *current_expr;
         left_dims = op_dims;
         rank_left = op_n_dims;
@@ -698,6 +699,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
         op_expr = *current_expr;
         result_var = nullptr;
         this->replace_expr(x->m_right);
+        LCOMPILERS_ASSERT(*current_expr != nullptr)
         ASR::expr_t* right = *current_expr;
         right_dims = op_dims;
         rank_right = op_n_dims;

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -374,6 +374,11 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
         current_expr = &(x->m_array);
         replace_expr(x->m_array);
         current_expr = current_expr_copy_161;
+        // This line nullifies where `current_expr` points to, and it fails
+        // later in replace_ArrayOpCommon() at the lines:
+        //     this->replace_expr(x->m_left);
+        //     ASR::expr_t* left = *current_expr;
+        // Now `left` is a nullptr, and we fail.
         *current_expr = nullptr;
     }
 


### PR DESCRIPTION
I tested it on:
```fortran
program expr2
integer :: x(3)
x = 2
x = x + 3
print *, x
end program
```
This gives a correct initial ASR with ArrayBroadcast inside BinOp.

It fails in `array_op` in the new asserts that I put in in this PR. The asserts fail because the `current_expr` is nullptr, as indicated by the new comment in `replace_ArrayBroadcast()`.

That line `*current_expr = nullptr;` is however needed, otherwise it seems to produce incorrect ASR that fails in the dependency calculation at the end of `array_op`.

So far I have not figured out a solution how to get `array_op` working.