### PR TITLE
Implement intrinsic `mod`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -513,6 +513,8 @@ RUN(NAME intrinsics_74 LABELS gfortran llvm c) # random_number
 RUN(NAME intrinsics_75 LABELS gfortran llvm)
 RUN(NAME intrinsics_76 LABELS gfortran llvm)
 RUN(NAME intrinsics_77 LABELS gfortran llvm)
+RUN(NAME intrinsics_78 LABELS gfortran llvm) # mod
+
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -513,7 +513,7 @@ RUN(NAME intrinsics_74 LABELS gfortran llvm c) # random_number
 RUN(NAME intrinsics_75 LABELS gfortran llvm)
 RUN(NAME intrinsics_76 LABELS gfortran llvm)
 RUN(NAME intrinsics_77 LABELS gfortran llvm)
-RUN(NAME intrinsics_78 LABELS gfortran llvm) # mod
+RUN(NAME intrinsics_78 LABELS gfortran llvm wasm) # mod
 
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/intrinsics_78.f90
+++ b/integration_tests/intrinsics_78.f90
@@ -1,0 +1,87 @@
+program intrinsics_78
+    implicit none
+    integer :: ix, iy, iresult
+    real :: rx, ry, rresult
+    double precision :: dx, dy, dresult
+
+    ! Test integer values
+    ix = 10
+    iy = 3
+    iresult = mod(ix, iy)
+    print *, "Test 1: mod(", ix, ",", iy, ") = ", iresult
+    if (iresult /= 1) error stop "Test 1 failed"
+
+    ix = 10
+    iy = 5
+    iresult = mod(ix, iy)
+    print *, "Test 2: mod(", ix, ",", iy, ") = ", iresult
+    if (iresult /= 0) error stop "Test 2 failed"
+
+    ix = -10
+    iy = 3
+    iresult = mod(ix, iy)
+    print *, "Test 3: mod(", ix, ",", iy, ") = ", iresult
+    if (iresult /= -1) error stop "Test 3 failed"
+
+    ! Test real values
+    rx = 10.0
+    ry = 3.0
+    rresult = mod(rx, ry)
+    print *, "Test 4: mod(", rx, ",", ry, ") = ", rresult
+    if (abs(rresult - 1.0) > 1e-9) error stop "Test 4 failed"
+
+    rx = 10.0
+    ry = 5.0
+    rresult = mod(rx, ry)
+    print *, "Test 5: mod(", rx, ",", ry, ") = ", rresult
+    if (abs(rresult - 0.0) > 1e-9) error stop "Test 5 failed"
+
+    rx = -10.0
+    ry = 3.0
+    rresult = mod(rx, ry)
+    print *, "Test 6: mod(", rx, ",", ry, ") = ", rresult
+    if (abs(rresult - (-1.0)) > 1e-9) error stop "Test 6 failed"
+
+    rx = 12.98
+    ry = 3.0
+    rresult = mod(rx, ry)
+    print *, "Test 7: mod(", rx, ",", ry, ") = ", rresult
+    if (abs(rresult - 0.98) > 1e-6) error stop "Test 7 failed"
+
+    rx = 12.98
+    ry = 13.0
+    rresult = mod(rx, ry)
+    print *, "Test 8: mod(", rx, ",", ry, ") = ", rresult
+    if (abs(rresult - 12.98) > 1e-9) error stop "Test 8 failed"
+
+    ! Test double precision values
+    dx = 10.0D0
+    dy = 3.0D0
+    dresult = mod(dx, dy)
+    print *, "Test 9: mod(", dx, ",", dy, ") = ", dresult
+    if (abs(dresult - 1.0D0) > 1d-9) error stop "Test 9 failed"
+
+    dx = 12.98D0
+    dy = 3.0D0
+    dresult = mod(dx, dy)
+    print *, "Test 10: mod(", dx, ",", dy, ") = ", dresult
+    if (abs(dresult - 0.98D0) > 1d-9) error stop "Test 10 failed"
+
+    dx = 12.98D0
+    dy = 13.0D0
+    dresult = mod(dx, dy)
+    print *, "Test 11: mod(", dx, ",", dy, ") = ", dresult
+    if (abs(dresult - 12.98D0) > 1d-9) error stop "Test 11 failed"
+
+    dx = -12.98D0
+    dy = 13.0D0
+    dresult = mod(dx, dy)
+    print *, "Test 12: mod(", dx, ",", dy, ") = ", dresult
+    if (abs(dresult - (-12.98D0)) > 1d-9) error stop "Test 12 failed"
+
+    dx = -3.14D0
+    dy = -2.0D0
+    dresult = mod(dx, dy)
+    print *, "Test 13: mod(", dx, ",", dy, ") = ", dresult
+    if (abs(dresult - (-1.14D0)) > 1d-9) error stop "Test 13 failed"
+end program intrinsics_78

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -736,6 +736,7 @@ public:
         {"aint", {IntrinsicSignature({}, 1, 2)}},
         {"atan2", {IntrinsicSignature({}, 2, 2)}},
         {"shape", {IntrinsicSignature({"kind"}, 1, 2)}},
+        {"mod", {IntrinsicSignature({"mod"}, 1, 2)}},
     };
 
 

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -96,7 +96,6 @@ struct IntrinsicProcedures {
             {"floor", {m_math3, &eval_floor, true}},
             {"ceiling", {m_math2, &eval_ceiling, true}},
             {"nint", {m_math2, &eval_nint, true}},
-            {"mod", {m_math2, &eval_mod, true}},
             {"modulo", {m_math2, &eval_modulo, true}},
             {"min", {m_math2, &eval_min, true}},
             {"max", {m_math2, &eval_max, true}},
@@ -624,12 +623,6 @@ TRIG2(sqrt, dsqrt)
         return eval_2args_ri(al, loc, args,
             &IntrinsicProcedures::lfortran_modulo,
             &IntrinsicProcedures::lfortran_modulo_i);
-    }
-
-    static ASR::expr_t *eval_mod(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args) {
-        return eval_2args_ri(al, loc, args,
-            &IntrinsicProcedures::lfortran_mod,
-            &IntrinsicProcedures::lfortran_mod_i);
     }
 
     static double lfortran_min(double x, double y) {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -314,10 +314,10 @@ class ASRBuilder {
             ASR::binopType::Sub, right, int32, nullptr))
     #define iDiv(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
                 i2r32(left), ASR::binopType::Div, i2r32(right), real32, nullptr)))
-    #define iDivr32(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
-                left, ASR::binopType::Div, right, real32, nullptr)))
-    #define iDivr64(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
-                left, ASR::binopType::Div, right, real64, nullptr))) \
+    #define r32Div(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, \
+                left, ASR::binopType::Div, right, real32, nullptr))
+    #define r64Div(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, \
+                left, ASR::binopType::Div, right, real64, nullptr))
 
     #define r32Sub(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, left,      \
             ASR::binopType::Sub, right, real32, nullptr))
@@ -2044,11 +2044,11 @@ namespace Mod {
         if (is_real(*arg_types[1])) {
             int kind = ASRUtils::extract_kind_from_ttype_t(arg_types[1]);
             if (kind == 4) {
-                q = iDivr32(args[0], args[1]);
+                q = r2i32(r32Div(args[0], args[1]));
                 op1 = r32Mul(args[1], i2r32(q));
                 op2 = r32Sub(args[0], op1);
             } else {
-                q = iDivr64(args[0], args[1]);
+                q = r2i64(r64Div(args[0], args[1]));
                 op1 = r64Mul(args[1], i2r64(q));
                 op2 = r64Sub(args[0], op1);
             }

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -44,6 +44,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     Expm1,
     FMA,
     FlipSign,
+    Mod,
     ListIndex,
     Partition,
     ListReverse,
@@ -103,6 +104,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Expm1)
         INTRINSIC_NAME_CASE(FMA)
         INTRINSIC_NAME_CASE(FlipSign)
+        INTRINSIC_NAME_CASE(Mod)
         INTRINSIC_NAME_CASE(ListIndex)
         INTRINSIC_NAME_CASE(Partition)
         INTRINSIC_NAME_CASE(ListReverse)
@@ -311,8 +313,20 @@ class ASRBuilder {
     #define iSub(left, right) EXPR(ASR::make_IntegerBinOp_t(al, loc, left,      \
             ASR::binopType::Sub, right, int32, nullptr))
     #define iDiv(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
-                i2r32(left), ASR::binopType::Div, i2r32(right), real32, nullptr))) \
+                i2r32(left), ASR::binopType::Div, i2r32(right), real32, nullptr)))
+    #define iDivr32(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
+                i2r32(left), ASR::binopType::Div, i2r32(right), real32, nullptr)))
+    #define iDivr64(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
+                i2r64(left), ASR::binopType::Div, i2r64(right), real64, nullptr))) \
 
+    #define r32Sub(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, left,      \
+            ASR::binopType::Sub, right, real32, nullptr))
+    #define r64Sub(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, left,      \
+            ASR::binopType::Sub, right, real64, nullptr))
+    #define r32Mul(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, left,      \
+            ASR::binopType::Mul, right, real32, nullptr))
+    #define r64Mul(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, left,      \
+            ASR::binopType::Mul, right, real64, nullptr))
     #define rDiv(left, right) ASRUtils::make_ArrayBroadcast_t_util(al, loc, left, right); \
         EXPR(ASR::make_RealBinOp_t(al, loc, left, \
             ASR::binopType::Div, right, real32, nullptr)) \
@@ -1952,6 +1966,107 @@ namespace FlipSign {
 
 } // namespace FlipSign
 
+namespace Mod {
+
+     static inline void verify_args(const ASR::IntrinsicScalarFunction_t& x, diag::Diagnostics& diagnostics) {
+        ASRUtils::require_impl(x.n_args == 2,
+            "ASR Verify: Call to Mod must have exactly 2 arguments",
+            x.base.base.loc, diagnostics);
+        ASR::ttype_t *type1 = ASRUtils::expr_type(x.m_args[0]);
+        ASR::ttype_t *type2 = ASRUtils::expr_type(x.m_args[1]);
+        ASRUtils::require_impl((is_integer(*type1) && is_integer(*type2)) ||
+                                (is_real(*type1) && is_real(*type2)),
+            "ASR Verify: Arguments to Mod must be of real or integer type",
+            x.base.base.loc, diagnostics);
+    }
+
+    static ASR::expr_t *eval_Mod(Allocator &al, const Location &loc,
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args) {
+        bool is_real1 = is_real(*ASRUtils::expr_type(args[0]));
+        bool is_real2 = is_real(*ASRUtils::expr_type(args[1]));
+        bool is_int1 = is_integer(*ASRUtils::expr_type(args[0]));
+        bool is_int2 = is_integer(*ASRUtils::expr_type(args[1]));
+
+        if (is_int1 && is_int2) {
+            int64_t a = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
+            int64_t b = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+            return make_ConstantWithType(make_IntegerConstant_t, a % b, t1, loc);
+        } else if (is_real1 && is_real2) {
+            double a = ASR::down_cast<ASR::RealConstant_t>(args[0])->m_r;
+            double b = ASR::down_cast<ASR::RealConstant_t>(args[1])->m_r;
+            return make_ConstantWithType(make_RealConstant_t, std::fmod(a, b), t1, loc);
+        }
+        return nullptr;
+    }
+
+    static inline ASR::asr_t* create_Mod(Allocator& al, const Location& loc,
+            Vec<ASR::expr_t*>& args,
+            const std::function<void (const std::string &, const Location &)> err) {
+        if (args.size() != 2) {
+            err("Intrinsic Mod function accepts exactly 2 arguments", loc);
+        }
+        ASR::ttype_t *type1 = ASRUtils::expr_type(args[0]);
+        ASR::ttype_t *type2 = ASRUtils::expr_type(args[1]);
+        if (!((ASRUtils::is_integer(*type1) && ASRUtils::is_integer(*type2)) ||
+            (ASRUtils::is_real(*type1) && ASRUtils::is_real(*type2)))) {
+            err("Argument of the Mod function must be either Real or Integer",
+                args[0]->base.loc);
+        }
+        ASR::expr_t *m_value = nullptr;
+        if (all_args_evaluated(args)) {
+            Vec<ASR::expr_t*> arg_values; arg_values.reserve(al, 2);
+            arg_values.push_back(al, expr_value(args[0]));
+            arg_values.push_back(al, expr_value(args[1]));
+            m_value = eval_Mod(al, loc, expr_type(args[1]), arg_values);
+        }
+        return ASR::make_IntrinsicScalarFunction_t(al, loc,
+            static_cast<int64_t>(IntrinsicScalarFunctions::Mod),
+            args.p, args.n, 0, ASRUtils::expr_type(args[0]), m_value);
+    }
+
+    static inline ASR::expr_t* instantiate_Mod(Allocator &al, const Location &loc,
+            SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
+            Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
+        declare_basic_variables("_lcompilers_optimization_mod_" + type_to_str_python(arg_types[1]));
+        fill_func_arg("a", arg_types[0]);
+        fill_func_arg("p", arg_types[1]);
+        auto result = declare(fn_name, return_type, ReturnVar);
+        /*
+        function modi32i32(a, p) result(d)
+            integer(int32), intent(in) :: a, p
+            integer(int32) :: q
+            q = a/p
+            d = a - p*q
+        end function
+        */
+
+        ASR::expr_t *q = nullptr, *op1 = nullptr, *op2 = nullptr;
+        if (is_real(*arg_types[1])) {
+            int kind = ASRUtils::extract_kind_from_ttype_t(arg_types[1]);
+            if (kind == 4) {
+                q = iDivr32(args[0], args[1]);
+                op1 = r32Mul(args[1], i2r32(q));
+                op2 = r32Sub(args[0], op1);
+            } else {
+                q = iDivr64(args[0], args[1]);
+                op1 = r64Mul(args[1], i2r64(q));
+                op2 = r64Sub(args[0], op1);
+            }
+        } else {
+            q = iDiv(args[0], args[1]);
+            op1 = iMul(args[1], q);
+            op2 = iSub(args[0], op1);
+        }
+        body.push_back(al, b.Assignment(result, op2));
+
+        ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
+            body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+        scope->add_symbol(fn_name, f_sym);
+        return b.Call(f_sym, new_args, return_type, nullptr);
+    }
+
+} // namespace Mod
+
 #define create_exp_macro(X, stdeval)                                                      \
 namespace X {                                                                             \
     static inline ASR::expr_t* eval_##X(Allocator &al, const Location &loc,               \
@@ -2981,6 +3096,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {&FMA::instantiate_FMA, &FMA::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::FlipSign),
             {&FlipSign::instantiate_FlipSign, &FlipSign::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::Mod),
+            {&Mod::instantiate_Mod, &Mod::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Abs),
             {&Abs::instantiate_Abs, &Abs::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Partition),
@@ -3081,6 +3198,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "fma"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::FlipSign),
             "flipsign"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::Mod),
+            "mod"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::Expm1),
             "expm1"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::ListIndex),
@@ -3165,6 +3284,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"exp2", {&Exp2::create_Exp2, &Exp2::eval_Exp2}},
                 {"expm1", {&Expm1::create_Expm1, &Expm1::eval_Expm1}},
                 {"fma", {&FMA::create_FMA, &FMA::eval_FMA}},
+                {"mod", {&Mod::create_Mod, &Mod::eval_Mod}},
                 {"list.index", {&ListIndex::create_ListIndex, &ListIndex::eval_list_index}},
                 {"list.reverse", {&ListReverse::create_ListReverse, &ListReverse::eval_list_reverse}},
                 {"list.pop", {&ListPop::create_ListPop, &ListPop::eval_list_pop}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -315,9 +315,9 @@ class ASRBuilder {
     #define iDiv(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
                 i2r32(left), ASR::binopType::Div, i2r32(right), real32, nullptr)))
     #define iDivr32(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
-                i2r32(left), ASR::binopType::Div, i2r32(right), real32, nullptr)))
+                left, ASR::binopType::Div, right, real32, nullptr)))
     #define iDivr64(left, right) r2i32(EXPR(ASR::make_RealBinOp_t(al, loc, \
-                i2r64(left), ASR::binopType::Div, i2r64(right), real64, nullptr))) \
+                left, ASR::binopType::Div, right, real64, nullptr))) \
 
     #define r32Sub(left, right) EXPR(ASR::make_RealBinOp_t(al, loc, left,      \
             ASR::binopType::Sub, right, real32, nullptr))


### PR DESCRIPTION
I was trying to see how far we are to compile https://github.com/perazz/fortran-primes/tree/main which requires intrinsic `mod`.