### PR TITLE
Support runtime stacktrace to work in arbitrary directories

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1616,9 +1616,10 @@ int link_executable(const std::vector<std::string> &infiles,
 #else
                 cmd += "llvm-dwarfdump --debug-line " + file_name + ".out > ";
 #endif
-                cmd += file_name + "_ldd.txt && (cd src/libasr; ./dwarf_convert.py ../../"
-                    + file_name + "_ldd.txt ../../" + file_name + "_lines.txt ../../"
-                    + file_name + "_lines.dat && ./dat_convert.py ../../"
+                std::string libasr_path = LCompilers::LFortran::get_runtime_library_c_header_dir() + "/../";
+                cmd += file_name + "_ldd.txt && (" + libasr_path + "dwarf_convert.py "
+                    + file_name + "_ldd.txt " + file_name + "_lines.txt "
+                    + file_name + "_lines.dat && " + libasr_path + "dat_convert.py "
                     + file_name + "_lines.dat)";
                 int status = system(cmd.c_str());
                 if ( status != 0 ) {

--- a/src/libasr/dwarf_convert.py
+++ b/src/libasr/dwarf_convert.py
@@ -64,15 +64,21 @@ class Parser:
 
     def parse_debug_line(self):
         self.line = self.file.readline()
+        include_dirs_found = True
         while not self.line.startswith("include_directories"):
-            self.line = self.file.readline()
+            if self.line.startswith("file_names"):
+                include_dirs_found = False
+                break
+            else:
+                self.line = self.file.readline()
 
         include_directories = []
-        while self.line.startswith("include_directories"):
-            n, path = re.compile(r"include_directories\[[ ]*(\d+)\] = \"([^\"]+)\"").findall(self.line)[0]
-            n = int(n)
-            include_directories.append(IncludeDirectory(n, path))
-            self.line = self.file.readline()
+        if include_dirs_found:
+            while self.line.startswith("include_directories"):
+                n, path = re.compile(r"include_directories\[[ ]*(\d+)\] = \"([^\"]+)\"").findall(self.line)[0]
+                n = int(n)
+                include_directories.append(IncludeDirectory(n, path))
+                self.line = self.file.readline()
 
         file_names = []
         while self.line.startswith("file_names"):

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2399,8 +2399,14 @@ struct Stacktrace get_stacktrace_addresses() {
 }
 
 char *get_base_name(char *filename) {
-    size_t start = strrchr(filename, '/')-filename+1;
+    // Assuming filename always has an extensions
     size_t end = strrchr(filename, '.')-filename-1;
+    // Check for directories else start at 0th index
+    char *slash_idx_ptr = strrchr(filename, '/');
+    size_t start = 0;
+    if (slash_idx_ptr) {
+        start = slash_idx_ptr - filename+1;
+    }
     int nos_of_chars = end - start + 1;
     char *base_name;
     if (nos_of_chars < 0) {


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/2535