### PR TITLE
Use std::stoll instead of std::stoi

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1136,3 +1136,4 @@ RUN(NAME equivalence_05 LABELS gfortran)
 RUN(NAME equivalence_06 LABELS gfortran llvm)
 RUN(NAME equivalence_07 LABELS gfortran llvm)
 
+RUN(NAME fortran_primes_01 LABELS gfortran llvm)

--- a/integration_tests/fortran_primes_01.f90
+++ b/integration_tests/fortran_primes_01.f90
@@ -1,0 +1,41 @@
+module fortran_primes_01_module
+   use iso_fortran_env
+
+   implicit none
+
+   integer, parameter :: IP = int32  ! Integer kind parameter for 32-bit integers
+   integer, parameter :: WP = int64  ! Integer kind parameter for 64-bit integers
+end module fortran_primes_01_module
+
+elemental function witnesses_for_64(n) result(i)
+   use fortran_primes_01_module
+   implicit none
+   integer(WP), intent(in) :: n  ! Input integer with kind parameter WP
+   integer(WP) :: i             ! Output integer with kind parameter WP
+
+   ! Compute the number of Miller-Rabin witnesses for n using bitwise XOR, left shift, and multiplication
+   i = ieor(shifta(n, 32_WP), n) * int(z'45d9f3b3335b369', WP)
+
+end function witnesses_for_64
+
+program fortran_primes_01
+   use fortran_primes_01_module
+   implicit none
+   integer(WP) :: n, i
+   
+   interface
+      function witnesses_for_64(n) result(i)
+         use fortran_primes_01_module
+         implicit none
+         integer(WP), intent(in) :: n
+         integer(WP) :: i
+      end function witnesses_for_64
+   end interface
+
+   n = 2_WP  ! Set n to 2 (with kind parameter WP)
+
+   i = witnesses_for_64(n)
+   print *, i
+   if (i /= 629165251193693906_WP) error stop
+
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5947,7 +5947,7 @@ public:
                                 x.base.base.loc);
         }
         std::string boz_str = s.substr(2, s.size() - 2);
-        int boz_int = std::stoi(boz_str, nullptr, base);
+        int64_t boz_int = std::stoll(boz_str, nullptr, base);
         tmp = ASR::make_IntegerBOZ_t(al, x.base.base.loc, boz_int,
                                 boz_type, nullptr);
     }


### PR DESCRIPTION
Towards #2545.

A test needs to be added.