### PR TITLE
Add an example how to implement the equivalence

### DIFF
--- a/a.f90
+++ b/a.f90
@@ -1,0 +1,22 @@
+program test_equivalence
+    implicit none
+    DOUBLE PRECISION DMACH(5)
+    INTEGER*4 SMALL(2)
+    INTEGER*4 LARGE(2)
+    INTEGER*4 RIGHT(2)
+    INTEGER*4 DIVER(2)
+    INTEGER*4 LOG10(2)
+    EQUIVALENCE (DMACH(1),SMALL(1))
+    EQUIVALENCE (DMACH(2),LARGE(1))
+    EQUIVALENCE (DMACH(3),RIGHT(1))
+    EQUIVALENCE (DMACH(4),DIVER(1))
+    EQUIVALENCE (DMACH(5),LOG10(1))
+    dmach(2) = 5.6_8
+    print *, large
+    dmach(2) = 5.7_8
+    print *, large
+end
+
+
+! when body visitor visits  EQUIVALENCE (DMACH(1),SMALL(1)), 
+! - Step 1 - make dmach(1) equivalent to pointer of small(1) -> dmach(1) -> small(1). We don't have small pointer yet, hence INTEGER*4, pointer :: SMALL(:)

--- a/b.f90
+++ b/b.f90
@@ -1,0 +1,19 @@
+program test_equivalence
+    use iso_c_binding, only: c_loc, c_f_pointer
+    implicit none
+    DOUBLE PRECISION, target :: DMACH(5)
+    INTEGER*4, pointer :: SMALL(:)
+    INTEGER*4, pointer :: LARGE(:)
+    INTEGER*4, pointer :: RIGHT(:)
+    INTEGER*4, pointer :: DIVER(:)
+    INTEGER*4, pointer :: LOG10(:)
+    call c_f_pointer(c_loc(dmach(1)), small, [2])
+    call c_f_pointer(c_loc(dmach(2)), large, [2])
+    call c_f_pointer(c_loc(dmach(3)), right, [2])
+    call c_f_pointer(c_loc(dmach(4)), diver, [2])
+    call c_f_pointer(c_loc(dmach(5)), log10, [2])
+    dmach(2) = 5.6_8
+    print *, large
+    dmach(2) = 5.7_8
+    print *, large
+    end

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -40,9 +40,10 @@ public:
             std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
             std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
             std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-            std::map<std::string, std::vector<int>> &entry_function_arguments_mapping)
+            std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+            std::vector<ASR::stmt_t*> &data_structure)
         : CommonVisitor(al, nullptr, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping),
+                        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure),
         asr{unit}, from_block{false} {}
 
     void visit_Declaration(const AST::Declaration_t& x) {
@@ -1486,6 +1487,13 @@ public:
 
         Vec<ASR::stmt_t*> body;
         body.reserve(al, x.n_body);
+        if(data_structure.size()>0){
+            // throw SemanticError("Data structure not supported in program", x.base.base.loc);
+            for(auto it: data_structure){
+                body.push_back(al, it);
+            }
+        }
+        
         transform_stmts(body, x.n_body, x.m_body);
         handle_format();
         ASR::stmt_t* impl_del = create_implicit_deallocate(x.base.base.loc);
@@ -3284,10 +3292,11 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping)
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+        std::vector<ASR::stmt_t*> &data_structure)
 {
     BodyVisitor b(al, unit, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                  instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping);
+                  instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
     try {
         b.is_body_visitor = true;
         b.visit_TranslationUnit(ast);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2046,7 +2046,6 @@ public:
                 } else if (AST::is_a<AST::AttrEquivalence_t>(*x.m_attributes[i])) {
                     AST::AttrEquivalence_t *eq = AST::down_cast<AST::AttrEquivalence_t>(x.m_attributes[i]);
                     if (eq->n_args == 1) {
-                        std::cout<<"Equivalence: "<<'\n';
                         if (eq->m_args[0].n_set_list == 2) {
                             AST::expr_t *eq1 = eq->m_args[0].m_set_list[0];
                             AST::expr_t *eq2 = eq->m_args[0].m_set_list[1];
@@ -2067,6 +2066,8 @@ public:
                                 //TODO: wrap this with "c_loc":
                                 ASR::ttype_t* arg_type = ASRUtils::type_get_past_allocatable(
                                             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(asr_eq1)));
+                                // ASR::ttype_t* arg_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc,
+                                // ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(ASRUtils::expr_type(asr_eq2)))));
                                 ASR::ttype_t* pointer_type_ = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, ASRUtils::type_get_past_array(arg_type)));
                                 ASR::asr_t* get_pointer = ASR::make_GetPointer_t(al, asr_eq1->base.loc, asr_eq1, pointer_type_, nullptr);
                                 ASR::ttype_t *cptr = ASRUtils::TYPE(ASR::make_CPtr_t(al, asr_eq1->base.loc));
@@ -2088,10 +2089,19 @@ public:
                                 args.reserve(al, 1);
                                 args.push_back(al, two);
 
+                                ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(asr_eq2);
+                                ASR::expr_t* array = array_item->m_v;
+                                // std::cout<<array->base<<'\n';
+                                
+                                // ASR::ttype_t* m_type = ASRUtils::make_Array_t_util(al, asr_eq2->base.loc, m_type, dims.p, dims.size(), ASR::array_physical_typeType::DescriptorArray);
+                                // ASR::asr_t* ptr = make_Pointer_t(al, asr_eq2->base.loc, m_type);
+                                // current_scope->add_or_overwrite_symbol("small", ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, asr_eq2->base.loc, current_scope, s2c(al, "small"), nullptr, 0, ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default, m_type, nullptr, ASR::abiType::BindC, ASR::accessType::Public, ASR::presenceType::Required, false)));
+
                                 ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, asr_eq1->base.loc, int32_type, dim.p, dim.size(), ASR::array_physical_typeType::PointerToDataArray));
+                                
                                 ASR::asr_t* array_constant = ASRUtils::make_ArrayConstant_t_util(al, asr_eq1->base.loc, args.p, args.size(), array_type, ASR::arraystorageType::ColMajor);
                               
-                                ASR::asr_t* c_f_pointer =ASR::make_CPtrToPointer_t(al, asr_eq1->base.loc, ASRUtils::EXPR(pointer_to_cptr), asr_eq2, ASRUtils::EXPR(array_constant), nullptr);
+                                ASR::asr_t* c_f_pointer =ASR::make_CPtrToPointer_t(al, asr_eq1->base.loc, ASRUtils::EXPR(pointer_to_cptr), ASR::down_cast<ASR::ArrayItem_t>(asr_eq2)->m_v, ASRUtils::EXPR(array_constant), nullptr);
 
                                 ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
                                 data_structure.push_back(stmt);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -795,8 +795,7 @@ public:
 
     std::map<std::string, ASR::ttype_t*> implicit_dictionary;
     std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping;
-    std::vector<ASR::stmt_t*> &data_structure;
-
+    
     std::map<std::string, std::pair<bool,std::vector<ASR::expr_t*>>> common_block_dictionary;
     std::map<uint64_t, ASR::symbol_t*> &common_variables_hash;
 
@@ -825,6 +824,7 @@ public:
     std::map<std::string, std::string> context_map;     // TODO: refactor treatment of context map
     std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types;
     std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols;
+    std::vector<ASR::stmt_t*> &data_structure;
 
     CommonVisitor(Allocator &al, SymbolTable *symbol_table,
             diag::Diagnostics &diagnostics, CompilerOptions &compiler_options,
@@ -841,12 +841,7 @@ public:
           common_variables_hash{common_variables_hash}, external_procedures_mapping{external_procedures_mapping},
           entry_functions{entry_functions},entry_function_arguments_mapping{entry_function_arguments_mapping},
           current_variable_type_{nullptr}, instantiate_types{instantiate_types},
-          instantiate_symbols{instantiate_symbols} {
-        : diag{diagnostics}, al{al}, compiler_options{compiler_options},
-          current_scope{symbol_table}, implicit_mapping{implicit_mapping},
-          common_variables_hash{common_variables_hash}, external_procedures_mapping{external_procedures_mapping},
-          current_variable_type_{nullptr},
-          instantiate_types{instantiate_types}, instantiate_symbols{instantiate_symbols}, data_structure{data_structure} {
+          instantiate_symbols{instantiate_symbols}, data_structure{data_structure}{
         current_module_dependencies.reserve(al, 4);
         enum_init_val = 0;
     }
@@ -2091,11 +2086,12 @@ public:
 
                                 ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(asr_eq2);
                                 ASR::expr_t* array = array_item->m_v;
-                                // std::cout<<array->base<<'\n';
-                                
-                                // ASR::ttype_t* m_type = ASRUtils::make_Array_t_util(al, asr_eq2->base.loc, m_type, dims.p, dims.size(), ASR::array_physical_typeType::DescriptorArray);
-                                // ASR::asr_t* ptr = make_Pointer_t(al, asr_eq2->base.loc, m_type);
-                                // current_scope->add_or_overwrite_symbol("small", ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, asr_eq2->base.loc, current_scope, s2c(al, "small"), nullptr, 0, ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default, m_type, nullptr, ASR::abiType::BindC, ASR::accessType::Public, ASR::presenceType::Required, false)));
+                                ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(array);
+                                ASR::Variable_t *var__ = ASR::down_cast<ASR::Variable_t>(var->m_v);
+                                std::string name = var__->m_name;
+                                ASR::ttype_t* type = ASRUtils::make_Array_t_util(al, asr_eq2->base.loc, type, dim.p, dim.size(), ASR::abiType::BindC, false, ASR::array_physical_typeType::DescriptorArray, false, false);
+                                ASR::asr_t* ptr = make_Pointer_t(al, asr_eq2->base.loc, type);
+                                current_scope->add_or_overwrite_symbol(name, ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, asr_eq2->base.loc, current_scope, s2c(al, name), nullptr, 0, ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr, ASR::abiType::BindC, ASR::accessType::Public, ASR::presenceType::Required, false)));
 
                                 ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, asr_eq1->base.loc, int32_type, dim.p, dim.size(), ASR::array_physical_typeType::PointerToDataArray));
                                 

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -106,9 +106,10 @@ public:
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping)
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+        std::vector<ASR::stmt_t*> &data_structure)
       : CommonVisitor(al, symbol_table, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                      instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping) {}
+                      instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure) {}
 
     void visit_TranslationUnit(const AST::TranslationUnit_t &x) {
         if (!current_scope) {
@@ -3266,10 +3267,11 @@ Result<ASR::asr_t*> symbol_table_visitor(Allocator &al, AST::TranslationUnit_t &
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping)
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+        std::vector<ASR::stmt_t*> &data_structure)
 {
     SymbolTableVisitor v(al, symbol_table, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                         instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping);
+                         instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
     try {
         v.visit_TranslationUnit(ast);
     } catch (const SemanticError &e) {

--- a/src/lfortran/semantics/ast_to_asr.cpp
+++ b/src/lfortran/semantics/ast_to_asr.cpp
@@ -31,7 +31,8 @@ Result<ASR::asr_t*> symbol_table_visitor(Allocator &al, AST::TranslationUnit_t &
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping);
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping, 
+        std::vector<ASR::stmt_t*> &data_structure);
 
 Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         AST::TranslationUnit_t &ast,
@@ -44,7 +45,8 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping);
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+        std::vector<ASR::stmt_t*> &data_structure);
 
 void load_rtlib(Allocator &al, ASR::TranslationUnit_t &tu, CompilerOptions &compiler_options) {
     SymbolTable *tu_symtab = tu.m_symtab;
@@ -91,10 +93,11 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> instantiate_symbols;
     std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> entry_functions;
     std::map<std::string, std::vector<int>> entry_function_arguments_mapping;
+    std::vector<ASR::stmt_t*> data_structure;
     ASR::asr_t *unit;
     auto res = symbol_table_visitor(al, ast, diagnostics, symbol_table,
         compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping);
+        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
     if (res.ok) {
         unit = res.result;
     } else {
@@ -114,7 +117,7 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     if (!symtab_only) {
         auto res = body_visitor(al, ast, diagnostics, unit, compiler_options,
             implicit_mapping, common_variables_hash, external_procedures_mapping,
-            instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping);
+            instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
         if (res.ok) {
             tu = res.result;
         } else {

--- a/x.f90
+++ b/x.f90
@@ -1,4 +1,6 @@
 program main
     ! integer*4 small(2)
-    print *, [2]
+    ! integer:: a = 3
+    INTEGER*4 :: small
+    print *, small
 end

--- a/x.f90
+++ b/x.f90
@@ -1,0 +1,4 @@
+program main
+    ! integer*4 small(2)
+    print *, [2]
+end


### PR DESCRIPTION
Test this with:
```console
$ lfortran --show-asr a.f90 --show-stacktrace
[...]
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/semantics/ast_symboltable_visitor.cpp", line 1137
    visit_DeclarationUtil(x);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 2095
    x.base.base.loc);
  File "../libasr/semantic_exception.h", line 20
  File "../libasr/semantic_exception.h", line 17
semantic error: XX
 --> a.f90:9:1
  |
9 | EQUIVALENCE (DMACH(1),SMALL(1))
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
```
where `a.f90` is:
```fortran
program test_equivalence
implicit none
DOUBLE PRECISION DMACH(5)
INTEGER*4 SMALL(2)
INTEGER*4 LARGE(2)
INTEGER*4 RIGHT(2)
INTEGER*4 DIVER(2)
INTEGER*4 LOG10(2)
EQUIVALENCE (DMACH(1),SMALL(1))
EQUIVALENCE (DMACH(2),LARGE(1))
EQUIVALENCE (DMACH(3),RIGHT(1))
EQUIVALENCE (DMACH(4),DIVER(1))
EQUIVALENCE (DMACH(5),LOG10(1))
dmach(2) = 5.6_8
print *, large
dmach(2) = 5.7_8
print *, large
end
```