### PR TITLE
Find the zstd library properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ set(WITH_TARGET_AARCH64 no CACHE BOOL "Enable target AARCH64")
 set(WITH_TARGET_X86 no CACHE BOOL "Enable target X86")
 set(WITH_TARGET_WASM no CACHE BOOL "Enable target WebAssembly")
 if (WITH_LLVM)
+    find_package(StaticZSTD REQUIRED)
+
     set(LFORTRAN_LLVM_COMPONENTS core support mcjit orcjit native asmparser asmprinter)
     find_package(LLVM REQUIRED)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -19,5 +19,6 @@ dependencies:
   - ninja
   - zlib
   - rapidjson
+  - zstd-static=1.5.5
 #  - bison=3.4  [not win]
 #  - m2-bison=3.4  [win]

--- a/cmake/FindStaticZSTD.cmake
+++ b/cmake/FindStaticZSTD.cmake
@@ -1,0 +1,29 @@
+# Backup the original value of the requested library suffixes
+set(_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+# Static libraries end with .a on Unix and .lib on Windows
+set(CMAKE_FIND_LIBRARY_SUFFIXES .a .lib)
+
+find_path(zstd_INCLUDE_DIR zstd.h)
+find_library(zstd_LIBRARY zstd)
+
+# Reset the library suffixes to the original value
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES})
+# Unset the temporary to not pollute the global namespace
+unset(_CMAKE_FIND_LIBRARY_SUFFIXES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(StaticZSTD DEFAULT_MSG zstd_LIBRARY
+    zstd_INCLUDE_DIR)
+
+
+# We found the static ZSTD library and then we set this target which
+# LLVM CMake uses to find the "shared" library. Then ZSTD gets linked
+# statically with LFortran and everything works. This is dependent
+# on LLVM's CMake. If it changes, we also have to change the handling
+# here.
+
+add_library(zstd::libzstd_shared INTERFACE IMPORTED)
+set_property(TARGET zstd::libzstd_shared PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    ${zstd_INCLUDE_DIR})
+set_property(TARGET zstd::libzstd_shared PROPERTY INTERFACE_LINK_LIBRARIES
+    ${zstd_LIBRARY})


### PR DESCRIPTION
Fixes #2575.

TODO:
* [x] Install `zstd-static` into the appropriate conda environments
* [x] This is only needed from certain LLVM versions up -- find out which ones and allow to turn this off for older ones, or maybe we can just require it all the time, since newer LLVM requires it. Fix: it turns out all CI tests pass, because the runners already have this library preinstalled; and it's ok to just require it whenever LLVM is used, since modern LLVM requires it, and for older versions one just installs this library via conda; If this becomes a problem, we can later add some more options to disable this.