### PR TITLE
Rename the module in tests

### DIFF
--- a/tests/errors/template_error_08.f90
+++ b/tests/errors/template_error_08.f90
@@ -1,4 +1,4 @@
-module template_add_01b_m
+module template_add_01b_m_e
     implicit none
     private
     public :: add_t
@@ -42,7 +42,7 @@ contains
 end module
 
 program template_add_01b
-use template_add_01b_m
+use template_add_01b_m_e
 implicit none
 
 call test_template()

--- a/tests/reference/asr-template_error_08-b380a57.json
+++ b/tests/reference/asr-template_error_08-b380a57.json
@@ -2,7 +2,7 @@
     "basename": "asr-template_error_08-b380a57",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/template_error_08.f90",
-    "infile_hash": "62712b2a727c52ea5367fb0c18310cfacb99b91ef177eacbb0acaf19",
+    "infile_hash": "5d3d6c8f03fb6c2313dbfeb16021c563f6773a29b22c094eee856765",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,


### PR DESCRIPTION
There was a duplicate module name, now it should be fixed.

Towards #2606.