### PR TITLE
[tests] enable some expr & data tests

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -210,22 +210,22 @@ RUN(NAME expr_01 FAIL LABELS gfortran llvm cpp x86 wasm c fortran)
 RUN(NAME expr_02 LABELS gfortran llvm cpp x86 wasm c fortran)
 RUN(NAME expr_03 LABELS gfortran llvm cpp x86 wasm c fortran)
 RUN(NAME expr_04 LABELS gfortran llvm cpp wasm c fortran)
-RUN(NAME expr_05 LABELS gfortran llvm cpp c) # it contains pow, wasm supports only x**2
-RUN(NAME expr_06 LABELS gfortran llvm wasm c)
-RUN(NAME expr_07 LABELS gfortran llvm wasm c)
-RUN(NAME expr_08 LABELS gfortran llvm wasm c)
-RUN(NAME expr_09 LABELS gfortran llvm wasm c)
-RUN(NAME expr_10 LABELS gfortran llvm wasm c)
-RUN(NAME expr_12 LABELS gfortran llvm c) # it uses string compare
+RUN(NAME expr_05 LABELS gfortran llvm cpp c fortran) # it contains pow, wasm supports only x**2
+RUN(NAME expr_06 LABELS gfortran llvm wasm c fortran)
+RUN(NAME expr_07 LABELS gfortran llvm wasm c fortran)
+RUN(NAME expr_08 LABELS gfortran llvm wasm c fortran)
+RUN(NAME expr_09 LABELS gfortran llvm wasm c fortran)
+RUN(NAME expr_10 LABELS gfortran llvm wasm c fortran)
+RUN(NAME expr_12 LABELS gfortran llvm c fortran) # it uses string compare
 RUN(NAME expr_13 LABELS gfortran llvm wasm c)
 RUN(NAME expr_14 LABELS gfortran llvm wasm c)
-RUN(NAME expr_15 LABELS gfortran llvm wasm c)
+RUN(NAME expr_15 LABELS gfortran llvm wasm c fortran)
 RUN(NAME expr_16 LABELS gfortran llvm wasm c)
 RUN(NAME expr_17 LABELS gfortran llvm)
 
-RUN(NAME data_01 LABELS gfortran llvm c)
+RUN(NAME data_01 LABELS gfortran llvm c fortran)
 RUN(NAME data_02 LABELS gfortran)
-RUN(NAME data_03 LABELS gfortran llvm c)
+RUN(NAME data_03 LABELS gfortran llvm c fortran)
 RUN(NAME data_04 LABELS gfortran llvm c)
 RUN(NAME data_05 LABELS gfortran) # llvmImplicit removed
 RUN(NAME data_06 LABELS gfortran llvm c)


### PR DESCRIPTION
confirmed both the generated code and test codes are the same for each case.