### PR TITLE
CI: Remove another workaround in dftatom

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -470,8 +470,8 @@ jobs:
         run: |
             git clone https://github.com/czgdp1807/dftatom.git
             cd dftatom
-            git checkout -t origin/lf29
-            git checkout da7d8f8d29ecb930f54e6f9c0cad33b5c75e47c6
+            git checkout -t origin/lf30
+            git checkout fd6ec5fb876d0330b828f817816e9220ea5c4314
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
             make -f Makefile.manual test


### PR DESCRIPTION
I just noticed that this workaround was also fixed by https://github.com/lfortran/lfortran/pull/2624.