### PR TITLE
Fix all memory leaks in string formatting and print

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7511,6 +7511,10 @@ public:
         printf_args.push_back(fmt_ptr);
         printf_args.insert(printf_args.end(), args.begin(), args.end());
         printf(context, *module, *builder, printf_args);
+        for (size_t i=0; i<x.n_values; i++) {
+            if (ASR::is_a<ASR::StringFormat_t>(*x.m_values[i]))
+                LLVM::lfortran_free(context, *module, *builder, args[i]);
+        }
     }
 
     void visit_Stop(const ASR::Stop_t &x) {


### PR DESCRIPTION
Fixes #2621 
Fixed all memory leaks in all format related integration tests, and ensured that the output is correct by comparing with gfortran.
```console
(lf) ➜  lfortran git:(memleak) ✗ valgrind --leak-check=yes ./format_04.out          
==334439== Memcheck, a memory error detector
==334439== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==334439== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==334439== Command: ./format_04.out
==334439== 
ok b
okb
Success!
          Hello World!
danc  in themoon
ab  cdef  ghi  jkl  qwerty 12
123     00456
012345  ***
  0.12D+03  -0.123457D+03  0.12D+02  *******
 -1.23D+02   12.34568D+01 -1.23D+01   1.23D+02
 -0.01E+04   0.001235E+05 -1.23E+01   1.23E+02
  1  2  3  4  5  6  7  8  9 10 11 12
  1  2  3  4 hello
  5  6  7  8 hello
  9 10 11 12 hello
 13 14
12345
-12345
0.123456001D+3 0.1D+3 0.12D+2
-0.123456001D+3 -0.1D+3 -0.12D+2
Hello
 12345678.000 23.567800 .35
-12345678.000 ********* -.35
 2.000000E+00
 0.000000E+00
   0.0000000000000000000012345
x:1.12 y:4.5E+00
==334439== 
==334439== HEAP SUMMARY:
==334439==     in use at exit: 24 bytes in 2 blocks
==334439==   total heap usage: 685 allocs, 683 frees, 15,746 bytes allocated
==334439== 
==334439== LEAK SUMMARY:
==334439==    definitely lost: 0 bytes in 0 blocks
==334439==    indirectly lost: 0 bytes in 0 blocks
==334439==      possibly lost: 0 bytes in 0 blocks
==334439==    still reachable: 24 bytes in 2 blocks
==334439==         suppressed: 0 bytes in 0 blocks
==334439== Reachable blocks (those to which a pointer was found) are not shown.
==334439== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==334439== 
==334439== For lists of detected and suppressed errors, rerun with: -s
==334439== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
```console
(lf) ➜  lfortran git:(memleak) ✗ valgrind --leak-check=yes ./format_06.out
==334737== Memcheck, a memory error detector
==334737== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==334737== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==334737== Command: ./format_06.out
==334737== 
a b
cd
Success!
          Hello World!
danc  in themoon
ab  cdef  ghi  jkl  qwerty 12
123     00456
012345  ***
  0.12D+03  -0.123457D+03  0.12D+02  *******
 -1.23D+02   12.34568D+01 -1.23D+01   1.23D+02
 -0.01E+04   0.001235E+05 -1.23E+01   1.23E+02
Hello 
World!
==334737== 
==334737== HEAP SUMMARY:
==334737==     in use at exit: 24 bytes in 2 blocks
==334737==   total heap usage: 325 allocs, 323 frees, 7,209 bytes allocated
==334737== 
==334737== LEAK SUMMARY:
==334737==    definitely lost: 0 bytes in 0 blocks
==334737==    indirectly lost: 0 bytes in 0 blocks
==334737==      possibly lost: 0 bytes in 0 blocks
==334737==    still reachable: 24 bytes in 2 blocks
==334737==         suppressed: 0 bytes in 0 blocks
==334737== Reachable blocks (those to which a pointer was found) are not shown.
==334737== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==334737== 
==334737== For lists of detected and suppressed errors, rerun with: -s
==334737== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```