### PR TITLE
Remove another workaround for array

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -470,8 +470,8 @@ jobs:
         run: |
             git clone https://github.com/czgdp1807/dftatom.git
             cd dftatom
-            git checkout -t origin/lf30_convrlda
-            git checkout a73ca412dce71542542b3c1ec3c128e44490e422
+            git checkout -t origin/lf31
+            git checkout a64ed6b231136bb6b42a8aa873a1363907b013af
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
             make -f Makefile.manual test


### PR DESCRIPTION
The branch `lf31` is based out of the latest `lf30_convrlda` at https://github.com/czgdp1807/dftatom.