### PR TITLE
CI dftatom: test Debug and Release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -468,12 +468,15 @@ jobs:
       - name: Test dftatom
         shell: bash -e -x -l {0}
         run: |
-            git clone https://github.com/czgdp1807/dftatom.git
+            git clone https://github.com/certik/dftatom.git
             cd dftatom
-            git checkout -t origin/lf32
-            git checkout 58a11c2ce53fe4d2ecd0c71999fc7acff65ff184
+            git checkout -t origin/lf33
+            git checkout b7d6fa705c1c1dd540bb7494c3240c4d29a35caf
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
+            make -f Makefile.manual test
+            git clean -dfx
+            make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
             make -f Makefile.manual test
 
       - name: Test fastGPT


### PR DESCRIPTION
Also only test every 10th atom to make the tests run faster.