### PR TITLE
Fix m_sep and m_end for FileWrite in print_arr.cpp

### DIFF
--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -126,7 +126,8 @@ public:
         }
     }
 
-    ASR::stmt_t* create_formatstmt(std::vector<ASR::expr_t*> &print_body, ASR::StringFormat_t* format, const Location &loc, ASR::stmtType _type) {
+    ASR::stmt_t* create_formatstmt(std::vector<ASR::expr_t*> &print_body, ASR::StringFormat_t* format, const Location &loc, ASR::stmtType _type,
+        ASR::expr_t* separator = nullptr, ASR::expr_t* end = nullptr) {
         Vec<ASR::expr_t*> body;
         body.reserve(al, print_body.size());
         for (size_t j=0; j<print_body.size(); j++) {
@@ -144,7 +145,7 @@ public:
             print_args.p, print_args.size(), nullptr, nullptr));
         } else if (_type == ASR::stmtType::FileWrite) {
             statement = ASRUtils::STMT(ASR::make_FileWrite_t(al, loc, 0, nullptr,
-                nullptr, nullptr, nullptr, print_args.p, print_args.size(), nullptr, nullptr));
+                nullptr, nullptr, nullptr, print_args.p, print_args.size(), separator, end));
         }
         print_body.clear();
         return statement;
@@ -326,7 +327,7 @@ public:
                         print_fixed_sized_array(format->m_args[i], write_body, x.base.base.loc);
                     } else {
                         if (write_body.size() > 0) {
-                            write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite);
+                            write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite, x.m_separator, x.m_end);
                             pass_result.push_back(al, write_stmt);
                         }
                         write_stmt = write_array_using_doloop(format->m_args[i],format, x.base.base.loc);
@@ -338,7 +339,7 @@ public:
                 }
             }
             if (write_body.size() > 0) {
-                write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite);
+                write_stmt = create_formatstmt(write_body, format, x.base.base.loc, ASR::stmtType::FileWrite, x.m_separator, x.m_end);
                 pass_result.push_back(al, write_stmt);
             }
             return;

--- a/tests/reference/run-write4-329d906.json
+++ b/tests/reference/run-write4-329d906.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run-write4-329d906.stdout",
-    "stdout_hash": "35b66a98ef22ffcced895e555c3a2a29e11bfdd9d4e091a5b83fb8d7",
+    "stdout_hash": "53a3d179203f266f36431d4b08c3759a60fd29395f9c14e7097066d7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/run-write4-329d906.stdout
+++ b/tests/reference/run-write4-329d906.stdout
@@ -1,6 +1,4 @@
-hi, 
-how are you?
+hi, how are you?
 I 
 am
-doing 
-good
+doing good

--- a/tests/reference/run-write5-4a89b6b.json
+++ b/tests/reference/run-write5-4a89b6b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run-write5-4a89b6b.stdout",
-    "stdout_hash": "f199c73cbfb9af4762f111ddd42db56f47507d629a9130af1ac4a084",
+    "stdout_hash": "0ce186d32817412ff6a24ee5b7c187ab1220c3146ff0a97d640846e5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/run-write5-4a89b6b.stdout
+++ b/tests/reference/run-write5-4a89b6b.stdout
@@ -1,6 +1,3 @@
-hi
-bye
-first, 
-last
-
+hibye
+first, last
 Hello world!


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/2651

```fortran
program expr2
implicit none

write(*,"(a)",advance="no") "hi:"
write(*,"(a)",advance="no") "bye"

end program
```
```console
(lf) ➜  lfortran git:(adv2) ✗ lfortran examples/temp.f90
hi:bye%
(lf) ➜  lfortran git:(adv2) ✗ gfortran examples/temp.f90 && ./a.out
hi:bye%                                                       
```