### PR TITLE
CI: fastGPT: Test the chat with no workarounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -498,8 +498,8 @@ jobs:
             ldd ./test_more_inputs
 
             git clean -dfx
-            git checkout -t origin/lf35run
-            git checkout 9de55b77576ea57c70c0651f233971d1e2bd0cae
+            git checkout -t origin/lf36run
+            git checkout c915a244354df2e23b0dc613e302893b496549e2
             curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 
             mkdir lf


### PR DESCRIPTION
towards https://github.com/lfortran/lfortran/issues/1953

The `test_chat` works for all the `14` items available, but we test only the first `3` because
- they were the ones that were initially tested (before the workaround)
- the CI completes quickly