### PR TITLE
[asr->fortran] implement visit_Cast

### DIFF
--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1054,8 +1054,145 @@ public:
     // void visit_OverloadedUnaryMinus(const ASR::OverloadedUnaryMinus_t &x) {}
 
     void visit_Cast(const ASR::Cast_t &x) {
-        // TODO
+        std::string r;
         visit_expr(*x.m_arg);
+        switch (x.m_kind) {
+            case (ASR::cast_kindType::IntegerToReal) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "real(" + s + ", " + std::to_string(dest_kind) + ")"; break;
+                    case 8: r = "real(" + s + ", " + std::to_string(dest_kind) + ")"; break;
+                    default: throw CodeGenError("Cast IntegerToReal: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::RealToInteger) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "int(" + s + ", " + std::to_string(dest_kind) + ")"; break;
+                    case 8: r = "int(" + s + ", " + std::to_string(dest_kind) + ")"; break;
+                    default: throw CodeGenError("Cast RealToInteger: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::RealToReal) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "real(" + s + ", " + std::to_string(dest_kind * 2) + ")"; break;
+                    case 8: r = "real(" + s + ", " + std::to_string(dest_kind / 2) + ")"; break;
+                    default: throw CodeGenError("Cast RealToReal: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::IntegerToInteger) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "int(" + s + ", " + std::to_string(dest_kind * 2) + ")"; break;
+                    case 8: r = "int(" + s + ", " + std::to_string(dest_kind / 2) + ")"; break;
+                    default: throw CodeGenError("Cast IntegerToInteger: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::UnsignedIntegerToUnsignedInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::IntegerToUnsignedInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::RealToUnsignedInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::UnsignedIntegerToInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::UnsignedIntegerToReal) : {
+                break;
+            }
+            case (ASR::cast_kindType::ComplexToComplex) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "cmplx(" + s + ", " + std::to_string(dest_kind * 2) + ")"; break;
+                    case 8: r = "cmplx(" + s + ", " + std::to_string(dest_kind / 2) + ")"; break;
+                    default: throw CodeGenError("Cast ComplexToComplex: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::IntegerToComplex) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "cmplx(" + s + ", " + "0.0" + ", " + std::to_string(dest_kind) + ")"; break;
+                    case 8: r = "cmplx(" + s + ", " + "0.0" + ", " + std::to_string(dest_kind) + ")"; break;
+                    default: throw CodeGenError("Cast IntegerToComplex: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::ComplexToReal) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "real(" + s + ", " + std::to_string(dest_kind) + ")"; break;
+                    case 8: r = "real(" + s + ", " + std::to_string(dest_kind) + ")"; break;
+                    default: throw CodeGenError("Cast ComplexToReal: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::RealToComplex) : {
+                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                switch (dest_kind) {
+                    case 4: r = "cmplx(" + s + ", " + "0.0" + ", " + std::to_string(dest_kind) + ")"; break;
+                    case 8: r = "cmplx(" + s + ", " + "0.0" + ", " + std::to_string(dest_kind) + ")"; break;
+                    default: throw CodeGenError("Cast IntegerToComplex: Unsupported Kind " + std::to_string(dest_kind));
+                }
+                last_expr_precedence = 2;
+                break;
+            }
+            case (ASR::cast_kindType::LogicalToInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::LogicalToCharacter) : {
+                break;
+            }
+            case (ASR::cast_kindType::IntegerToLogical) : {
+                break;
+            }
+            case (ASR::cast_kindType::LogicalToReal) : {
+                break;
+            }
+            case (ASR::cast_kindType::RealToLogical) : {
+                break;
+            }
+            case (ASR::cast_kindType::CharacterToLogical) : {
+                break;
+            }
+            case (ASR::cast_kindType::ComplexToLogical) : {
+                break;
+            }
+            case (ASR::cast_kindType::IntegerToCharacter) : {
+                break;
+            }
+            case (ASR::cast_kindType::CharacterToInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::RealToCharacter) : {
+                break;
+            }
+            case (ASR::cast_kindType::CPtrToUnsignedInteger) : {
+                break;
+            }
+            case (ASR::cast_kindType::UnsignedIntegerToCPtr) : {
+                break;
+            }
+            default : {
+                throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",
+                    x.base.base.loc);
+            }
+        }
     }
 
     void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t &x) {


### PR DESCRIPTION
*Currently WIP*
#### Casting Rules
- **IntegerToReal**: real4 -> int4; real8 -> int8
- **RealToInteger**: int4 -> real4; int8 -> real8
- **RealToReal**: real8 -> real4; real4 -> real8 *(data loss)*
    - ***Note***: fortran does not implicitly convert these dtypes; therefore, we need an explicit conversion
- **IntegerToInteger**: int8 -> int4; int4 -> int8 *(data loss)*
    - ***Note***: same as above
- Fortran does not have Unsigned integers; so we don't need type conversion as of now
- **ComplexToComplex**: cmplx8 -> cmplx4; cmplx4 -> cmplx8 *(data loss)*
- **IntegerToComplex**:
    - integer part: cmplx4 -> int4; cmplx8 -> int8
    - imaginary part: 0.0
- **ComplexToReal**: extracted real part of the complex number
    - real4 -> cmplx4; real8 -> cmplx8
- **RealToComplex**:
    - real part: cmplx4 -> real4; cmplx8 -> real8
    - imaginary part: 0.0

#### TODO
- [ ] add remaining type conversions