### PR TITLE
LLVM Save: Prepend parent function name in global variable name

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3419,8 +3419,8 @@ public:
                         ptr = builder->CreateBitCast(ptr_i8, type->getPointerTo());
                     } else {
                         if (v->m_storage == ASR::storage_typeType::Save) {
-                            // TODO: prepend the function name to this variable
-                            std::string global_name = std::string("f.") + v->m_name;
+                            std::string parent_function_name = std::string(x.m_name);
+                            std::string global_name = parent_function_name+ "." + v->m_name;
                             ptr = module->getOrInsertGlobal(global_name, type);
                             llvm::GlobalVariable *gptr = module->getNamedGlobal(global_name);
                             gptr->setLinkage(llvm::GlobalValue::InternalLinkage);

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "74ede760544b403b503152070f69f52ca9e8bcf5416db9dabfcce089",
+    "stdout_hash": "9e92164992ad7f64fdac2628bca86433700e61681e494664d4ae8bf7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -8,9 +8,9 @@ source_filename = "LFortran"
 @1 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
 @2 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
 @3 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
-@f.dim1 = internal global i32 0
-@f.dim2 = internal global i32 0
-@f.dim3 = internal global i32 0
+@array_op_3.dim1 = internal global i32 0
+@array_op_3.dim2 = internal global i32 0
+@array_op_3.dim3 = internal global i32 0
 
 define i1 @modulo2(i32* %x) {
 .entry:
@@ -487,15 +487,15 @@ define i32 @main(i32 %0, i8** %1) {
   %19 = getelementptr %array, %array* %arr_desc2, i32 0, i32 0
   store i1* null, i1** %19, align 8
   store %array* %arr_desc2, %array** %c, align 8
-  store i32 10, i32* @f.dim1, align 4
-  store i32 100, i32* @f.dim2, align 4
-  store i32 1, i32* @f.dim3, align 4
+  store i32 10, i32* @array_op_3.dim1, align 4
+  store i32 100, i32* @array_op_3.dim2, align 4
+  store i32 1, i32* @array_op_3.dim3, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   %k = alloca i32, align 4
-  %20 = load i32, i32* @f.dim1, align 4
-  %21 = load i32, i32* @f.dim2, align 4
-  %22 = load i32, i32* @f.dim3, align 4
+  %20 = load i32, i32* @array_op_3.dim1, align 4
+  %21 = load i32, i32* @array_op_3.dim2, align 4
+  %22 = load i32, i32* @array_op_3.dim3, align 4
   %23 = load %array*, %array** %a, align 8
   %24 = getelementptr %array, %array* %23, i32 0, i32 1
   store i32 0, i32* %24, align 4
@@ -533,9 +533,9 @@ define i32 @main(i32 %0, i8** %1) {
   %46 = call i8* (i32, ...) @_lfortran_malloc(i32 %45)
   %47 = bitcast i8* %46 to i1*
   store i1* %47, i1** %42, align 8
-  %48 = load i32, i32* @f.dim1, align 4
-  %49 = load i32, i32* @f.dim2, align 4
-  %50 = load i32, i32* @f.dim3, align 4
+  %48 = load i32, i32* @array_op_3.dim1, align 4
+  %49 = load i32, i32* @array_op_3.dim2, align 4
+  %50 = load i32, i32* @array_op_3.dim3, align 4
   %51 = load %array*, %array** %b, align 8
   %52 = getelementptr %array, %array* %51, i32 0, i32 1
   store i32 0, i32* %52, align 4
@@ -573,9 +573,9 @@ define i32 @main(i32 %0, i8** %1) {
   %74 = call i8* (i32, ...) @_lfortran_malloc(i32 %73)
   %75 = bitcast i8* %74 to i1*
   store i1* %75, i1** %70, align 8
-  %76 = load i32, i32* @f.dim1, align 4
-  %77 = load i32, i32* @f.dim2, align 4
-  %78 = load i32, i32* @f.dim3, align 4
+  %76 = load i32, i32* @array_op_3.dim1, align 4
+  %77 = load i32, i32* @array_op_3.dim2, align 4
+  %78 = load i32, i32* @array_op_3.dim3, align 4
   %79 = load %array*, %array** %c, align 8
   %80 = getelementptr %array, %array* %79, i32 0, i32 1
   store i32 0, i32* %80, align 4
@@ -619,7 +619,7 @@ define i32 @main(i32 %0, i8** %1) {
 loop.head:                                        ; preds = %loop.end8, %.entry
   %104 = load i32, i32* %i, align 4
   %105 = add i32 %104, 1
-  %106 = load i32, i32* @f.dim1, align 4
+  %106 = load i32, i32* @array_op_3.dim1, align 4
   %107 = icmp sle i32 %105, %106
   br i1 %107, label %loop.body, label %loop.end9
 
@@ -633,7 +633,7 @@ loop.body:                                        ; preds = %loop.head
 loop.head3:                                       ; preds = %loop.end, %loop.body
   %110 = load i32, i32* %j, align 4
   %111 = add i32 %110, 1
-  %112 = load i32, i32* @f.dim2, align 4
+  %112 = load i32, i32* @array_op_3.dim2, align 4
   %113 = icmp sle i32 %111, %112
   br i1 %113, label %loop.body4, label %loop.end8
 
@@ -647,7 +647,7 @@ loop.body4:                                       ; preds = %loop.head3
 loop.head5:                                       ; preds = %loop.body6, %loop.body4
   %116 = load i32, i32* %k, align 4
   %117 = add i32 %116, 1
-  %118 = load i32, i32* @f.dim3, align 4
+  %118 = load i32, i32* @array_op_3.dim3, align 4
   %119 = icmp sle i32 %117, %118
   br i1 %119, label %loop.body6, label %loop.end
 

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "74d2c2a246a708a45c4b62ad8db6f7c54709459c5fd975ce3d298772",
+    "stdout_hash": "e3837d2970d58a252039003c0d14d51ea5a60ebb1c8488ee58601c85",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -3,9 +3,9 @@ source_filename = "LFortran"
 
 %complex_4 = type { float, float }
 
-@f.t1 = internal global i32 0
-@f.t2 = internal global double 0.000000e+00
-@f.t3 = internal global %complex_4 zeroinitializer
+@associate_02.t1 = internal global i32 0
+@associate_02.t2 = internal global double 0.000000e+00
+@associate_02.t3 = internal global %complex_4 zeroinitializer
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
@@ -40,18 +40,18 @@ define i32 @main(i32 %0, i8** %1) {
   store double* null, double** %p2, align 8
   %p3 = alloca %complex_4*, align 8
   store %complex_4* null, %complex_4** %p3, align 8
-  store i32 2, i32* @f.t1, align 4
-  store double 2.000000e+00, double* @f.t2, align 8
+  store i32 2, i32* @associate_02.t1, align 4
+  store double 2.000000e+00, double* @associate_02.t2, align 8
   %2 = alloca %complex_4, align 8
   %3 = getelementptr %complex_4, %complex_4* %2, i32 0, i32 0
   %4 = getelementptr %complex_4, %complex_4* %2, i32 0, i32 1
   store float 2.000000e+00, float* %3, align 4
   store float 3.000000e+00, float* %4, align 4
   %5 = load %complex_4, %complex_4* %2, align 4
-  store %complex_4 %5, %complex_4* @f.t3, align 4
-  store i32* @f.t1, i32** %p1, align 8
-  store double* @f.t2, double** %p2, align 8
-  store %complex_4* @f.t3, %complex_4** %p3, align 8
+  store %complex_4 %5, %complex_4* @associate_02.t3, align 4
+  store i32* @associate_02.t1, i32** %p1, align 8
+  store double* @associate_02.t2, double** %p2, align 8
+  store %complex_4* @associate_02.t3, %complex_4** %p3, align 8
   %6 = load i32*, i32** %p1, align 8
   store i32 1, i32* %6, align 4
   %7 = load double*, double** %p2, align 8
@@ -59,7 +59,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = load i32*, i32** %p1, align 8
   %9 = load i32, i32* %8, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %10 = load i32, i32* @f.t1, align 4
+  %10 = load i32, i32* @associate_02.t1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   %11 = load double*, double** %p2, align 8
   %12 = load double, double* %11, align 8
@@ -68,17 +68,17 @@ define i32 @main(i32 %0, i8** %1) {
   %15 = sitofp i32 %14 to double
   %16 = fadd double %12, %15
   %17 = fptosi double %16 to i32
-  store i32 %17, i32* @f.t1, align 4
+  store i32 %17, i32* @associate_02.t1, align 4
   %18 = load i32*, i32** %p1, align 8
   %19 = load i32, i32* %18, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  %20 = load i32, i32* @f.t1, align 4
+  %20 = load i32, i32* @associate_02.t1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  store i32 8, i32* @f.t1, align 4
+  store i32 8, i32* @associate_02.t1, align 4
   %21 = load i32*, i32** %p1, align 8
   %22 = load i32, i32* %21, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
-  %23 = load i32, i32* @f.t1, align 4
+  %23 = load i32, i32* @associate_02.t1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   %24 = load %complex_4*, %complex_4** %p3, align 8
   %25 = alloca %complex_4, align 8
@@ -110,7 +110,7 @@ define i32 @main(i32 %0, i8** %1) {
   %43 = load float, float* %42, align 4
   %44 = fpext float %43 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @20, i32 0, i32 0), double %40, double %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
-  %45 = load %complex_4, %complex_4* @f.t3, align 4
+  %45 = load %complex_4, %complex_4* @associate_02.t3, align 4
   %46 = alloca %complex_4, align 8
   store %complex_4 %45, %complex_4* %46, align 4
   %47 = getelementptr %complex_4, %complex_4* %46, i32 0, i32 0

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "c8bd100dc14c570aa5b33d747669c59d1d2a2a7034f9ffb868f6add1",
+    "stdout_hash": "f2876d4bc412c2285ca8f43c92bcbc727467928d1aec0de5375453a4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.t1 = internal global i32 0
-@f.t2 = internal global i32 0
+@associate_03.t1 = internal global i32 0
+@associate_03.t2 = internal global i32 0
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [9 x i8] c"%d%s%d%s\00", align 1
@@ -17,22 +17,22 @@ define i32 @main(i32 %0, i8** %1) {
   %i = alloca i32, align 4
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
-  store i32 2, i32* @f.t1, align 4
-  store i32 1, i32* @f.t2, align 4
-  %2 = load i32, i32* @f.t1, align 4
-  %3 = load i32, i32* @f.t2, align 4
+  store i32 2, i32* @associate_03.t1, align 4
+  store i32 1, i32* @associate_03.t2, align 4
+  %2 = load i32, i32* @associate_03.t1, align 4
+  %3 = load i32, i32* @associate_03.t2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %4 = load i32, i32* @f.t1, align 4
-  %5 = load i32, i32* @f.t2, align 4
+  %4 = load i32, i32* @associate_03.t1, align 4
+  %5 = load i32, i32* @associate_03.t2, align 4
   %6 = icmp sgt i32 %4, %5
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32* @f.t1, i32** %p1, align 8
+  store i32* @associate_03.t1, i32** %p1, align 8
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  store i32* @f.t2, i32** %p1, align 8
+  store i32* @associate_03.t2, i32** %p1, align 8
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -43,7 +43,7 @@ ifcont:                                           ; preds = %else, %then
   %10 = load i32, i32* %9, align 4
   store i32 %10, i32* %i, align 4
   %11 = load i32, i32* %i, align 4
-  %12 = load i32, i32* @f.t2, align 4
+  %12 = load i32, i32* @associate_03.t2, align 4
   %13 = icmp eq i32 %11, %12
   br i1 %13, label %then1, label %else2
 

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "721a9f1fd47ee46ca3fed9ce4af6242186927111535735d1bec1597b",
+    "stdout_hash": "20685540e1ee95cc58f6ecd682b993b9558682f526accd29ced4b78b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.idx = internal global i32 0
+@bindc3.idx = internal global i32 0
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [13 x i8] c"%lld%s%lld%s\00", align 1
@@ -12,7 +12,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  store i32 1, i32* @f.idx, align 4
+  store i32 1, i32* @bindc3.idx, align 4
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
   store i16* null, i16** %x, align 8

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "f56209cda1752c528868ba47f44ee844cb08ec20cd55b7b85898ee06",
+    "stdout_hash": "ca79007f8521661affe362d3f5045728f518bfd3f64ad0de0a976390",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -10,7 +10,7 @@ source_filename = "LFortran"
 @6 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @7 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @8 = private unnamed_addr constant [9 x i8] c"%13.8e%s\00", align 1
-@f.res = internal global float 0.000000e+00
+@main.res = internal global float 0.000000e+00
 
 define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (float*, float*)* %f) {
 .entry:
@@ -70,11 +70,11 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  store float 0.000000e+00, float* @f.res, align 4
+  store float 0.000000e+00, float* @main.res, align 4
   store float 1.500000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
-  %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @f.res)
-  store float %2, float* @f.res, align 4
+  %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @main.res)
+  store float %2, float* @main.res, align 4
   ret i32 0
 }
 

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "7ba426ad1bd993972667710548824d16ff38636c2b7f6af6f5d85c50",
+    "stdout_hash": "b79346cac6aeb7c442e20b19397935f66529fed1d7457586843ec181",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -4,7 +4,7 @@ source_filename = "LFortran"
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
-@f.x = internal global i32 0
+@main.x = internal global i32 0
 
 define void @__module_callback_05_px_call1(i32* %x) {
 .entry:
@@ -52,8 +52,8 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  store i32 5, i32* @f.x, align 4
-  call void @__module_callback_05_px_call1(i32* @f.x)
+  store i32 5, i32* @main.x, align 4
+  call void @__module_callback_05_px_call1(i32* @main.x)
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "dcec333c82b167600e44c06c0706b74bbba02d8a1f1ac8f960cd6973",
+    "stdout_hash": "2e0cd39b3c83d7e754feda26f498d04f88000fb0b4d4bb77d4c0a4da",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -4,9 +4,9 @@ source_filename = "LFortran"
 %complex_4 = type { float, float }
 %complex_8 = type { double, double }
 
-@f.u = internal global %complex_4 zeroinitializer
-@f.v = internal global %complex_8 zeroinitializer
-@f.zero = internal global %complex_8 zeroinitializer
+@complex_dp_param.u = internal global %complex_4 zeroinitializer
+@complex_dp_param.v = internal global %complex_8 zeroinitializer
+@complex_dp_param.zero = internal global %complex_8 zeroinitializer
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [32 x i8] c"(%f,%f)%s(%lf,%lf)%s(%lf,%lf)%s\00", align 1
@@ -24,22 +24,22 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0x3FF0CCCCC0000000, float* %3, align 4
   store float 0x3FF0CCCCC0000000, float* %4, align 4
   %5 = load %complex_4, %complex_4* %2, align 4
-  store %complex_4 %5, %complex_4* @f.u, align 4
+  store %complex_4 %5, %complex_4* @complex_dp_param.u, align 4
   %6 = alloca %complex_8, align 8
   %7 = getelementptr %complex_8, %complex_8* %6, i32 0, i32 0
   %8 = getelementptr %complex_8, %complex_8* %6, i32 0, i32 1
   store double 1.050000e+00, double* %7, align 8
   store double 1.050000e+00, double* %8, align 8
   %9 = load %complex_8, %complex_8* %6, align 8
-  store %complex_8 %9, %complex_8* @f.v, align 8
+  store %complex_8 %9, %complex_8* @complex_dp_param.v, align 8
   %10 = alloca %complex_8, align 8
   %11 = getelementptr %complex_8, %complex_8* %10, i32 0, i32 0
   %12 = getelementptr %complex_8, %complex_8* %10, i32 0, i32 1
   store double 0.000000e+00, double* %11, align 8
   store double 0.000000e+00, double* %12, align 8
   %13 = load %complex_8, %complex_8* %10, align 8
-  store %complex_8 %13, %complex_8* @f.zero, align 8
-  %14 = load %complex_4, %complex_4* @f.u, align 4
+  store %complex_8 %13, %complex_8* @complex_dp_param.zero, align 8
+  %14 = load %complex_4, %complex_4* @complex_dp_param.u, align 4
   %15 = alloca %complex_4, align 8
   store %complex_4 %14, %complex_4* %15, align 4
   %16 = getelementptr %complex_4, %complex_4* %15, i32 0, i32 0
@@ -50,7 +50,7 @@ define i32 @main(i32 %0, i8** %1) {
   %20 = getelementptr %complex_4, %complex_4* %19, i32 0, i32 1
   %21 = load float, float* %20, align 4
   %22 = fpext float %21 to double
-  %23 = load %complex_8, %complex_8* @f.v, align 8
+  %23 = load %complex_8, %complex_8* @complex_dp_param.v, align 8
   %24 = alloca %complex_8, align 8
   store %complex_8 %23, %complex_8* %24, align 8
   %25 = getelementptr %complex_8, %complex_8* %24, i32 0, i32 0
@@ -59,7 +59,7 @@ define i32 @main(i32 %0, i8** %1) {
   store %complex_8 %23, %complex_8* %27, align 8
   %28 = getelementptr %complex_8, %complex_8* %27, i32 0, i32 1
   %29 = load double, double* %28, align 8
-  %30 = load %complex_8, %complex_8* @f.zero, align 8
+  %30 = load %complex_8, %complex_8* @complex_dp_param.zero, align 8
   %31 = alloca %complex_8, align 8
   store %complex_8 %30, %complex_8* %31, align 8
   %32 = getelementptr %complex_8, %complex_8* %31, i32 0, i32 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "83c3b9f61e618fda7ba29a53876bc6120416d0f2d269765ce0402137",
+    "stdout_hash": "a2c0f73f29c783d9b6045d30511316296dc29e5830028a0fd812c782",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -9,8 +9,8 @@ source_filename = "LFortran"
 @5 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
 @6 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
 @7 = private unnamed_addr constant [12 x i8] c"ERROR STOP\0A\00", align 1
-@f.b = internal global [3 x i32] zeroinitializer
-@f.n = internal global i32 0
+@main.b = internal global [3 x i32] zeroinitializer
+@main.n = internal global i32 0
 
 define void @driver(void (i32*, i32*, i32*)* %fnc, i32* %arr, i32* %m) {
 .entry:
@@ -120,7 +120,7 @@ define i32 @main(i32 %0, i8** %1) {
   %array_bound = alloca i32, align 4
   call void @_lpython_set_argv(i32 %0, i8** %1)
   %__1_k = alloca i32, align 4
-  store i32 3, i32* @f.n, align 4
+  store i32 3, i32* @main.n, align 4
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry
@@ -137,7 +137,7 @@ ifcont:                                           ; preds = %else, %then
   %4 = sub i32 %3, 1
   %5 = mul i32 1, %4
   %6 = add i32 0, %5
-  %7 = getelementptr [3 x i32], [3 x i32]* @f.b, i32 0, i32 %6
+  %7 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %6
   store i32 10, i32* %7, align 4
   %8 = load i32, i32* %__1_k, align 4
   %9 = add i32 %8, 1
@@ -146,7 +146,7 @@ ifcont:                                           ; preds = %else, %then
   %11 = sub i32 %10, 1
   %12 = mul i32 1, %11
   %13 = add i32 0, %12
-  %14 = getelementptr [3 x i32], [3 x i32]* @f.b, i32 0, i32 %13
+  %14 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %13
   store i32 20, i32* %14, align 4
   %15 = load i32, i32* %__1_k, align 4
   %16 = add i32 %15, 1
@@ -155,12 +155,12 @@ ifcont:                                           ; preds = %else, %then
   %18 = sub i32 %17, 1
   %19 = mul i32 1, %18
   %20 = add i32 0, %19
-  %21 = getelementptr [3 x i32], [3 x i32]* @f.b, i32 0, i32 %20
+  %21 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %20
   store i32 30, i32* %21, align 4
   %22 = load i32, i32* %__1_k, align 4
   %23 = add i32 %22, 1
   store i32 %23, i32* %__1_k, align 4
-  call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @f.b, i32 0, i32 0), i32* @f.n)
+  call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
   ret i32 0
 }
 

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "25fe25e3065333d1a27c1d97d43ca5b7f2de0855875d306140840079",
+    "stdout_hash": "88e2d0d1f11b63a583d9ed6815c9c1e94ba9f03a4b2d5a0480310c63",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.u = internal global i32 0
-@f.v = internal global i64 0
+@int_dp.u = internal global i32 0
+@int_dp.v = internal global i64 0
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [11 x i8] c"%d%s%lld%s\00", align 1
@@ -10,10 +10,10 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  store i32 2147483647, i32* @f.u, align 4
-  store i64 2147483647, i64* @f.v, align 4
-  %2 = load i32, i32* @f.u, align 4
-  %3 = load i64, i64* @f.v, align 4
+  store i32 2147483647, i32* @int_dp.u, align 4
+  store i64 2147483647, i64* @int_dp.v, align 4
+  %2 = load i32, i32* @int_dp.u, align 4
+  %3 = load i64, i64* @int_dp.v, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   ret i32 0
 }

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "0502d0ad658a9a7a86bb0bb732ee4ddbf9e76586e4b407e634a332d6",
+    "stdout_hash": "ecfe6e219479b257fdffc355c1a673c8ab40da3fc2408e7858b01ec9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.u = internal global i32 0
-@f.v = internal global i64 0
+@int_dp_param.u = internal global i32 0
+@int_dp_param.v = internal global i64 0
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [11 x i8] c"%d%s%lld%s\00", align 1
@@ -14,10 +14,10 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  store i32 2147483647, i32* @f.u, align 4
-  store i64 2147483647, i64* @f.v, align 4
-  %2 = load i32, i32* @f.u, align 4
-  %3 = load i64, i64* @f.v, align 4
+  store i32 2147483647, i32* @int_dp_param.u, align 4
+  store i64 2147483647, i64* @int_dp_param.v, align 4
+  %2 = load i32, i32* @int_dp_param.u, align 4
+  %3 = load i64, i64* @int_dp_param.v, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   ret i32 0
 }

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "2393672d81880b88820882570d1bfe51fbefb568b108ba7509ca0aa1",
+    "stdout_hash": "acd79b3742c81b2399d0eb60aa6f2b275d5453807656317243da235b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.x = internal global float 0.000000e+00
+@intrinsics_02.x = internal global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [18 x i8] c"%13.8e%s%23.17e%s\00", align 1
@@ -102,14 +102,14 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  store float 0x3FEFEB7AA0000000, float* @f.x, align 4
+  store float 0x3FEFEB7AA0000000, float* @intrinsics_02.x, align 4
   %y = alloca double, align 8
   store double 0x3FEFEB7A9B2C6D8B, double* %y, align 8
-  %2 = load float, float* @f.x, align 4
+  %2 = load float, float* @intrinsics_02.x, align 4
   %3 = fpext float %2 to double
   %4 = load double, double* %y, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %5 = load float, float* @f.x, align 4
+  %5 = load float, float* @intrinsics_02.x, align 4
   %6 = fsub float %5, 0x3FEFEB7AA0000000
   store float %6, float* %call_arg_value, align 4
   %7 = call float @_lcompilers_abs_f32(float* %call_arg_value)
@@ -125,7 +125,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %9 = call float @_lcompilers_sin_f32(float* @f.x)
+  %9 = call float @_lcompilers_sin_f32(float* @intrinsics_02.x)
   %10 = fsub float %9, 0x3FEAE238A0000000
   store float %10, float* %call_arg_value1, align 4
   %11 = call float @_lcompilers_abs_f32(float* %call_arg_value1)
@@ -169,8 +169,8 @@ else10:                                           ; preds = %ifcont8
 
 ifcont11:                                         ; preds = %else10, %then9
   %17 = call double @_lcompilers_sin_f64(double* %y)
-  %18 = load float, float* @f.x, align 4
-  %19 = call float @_lcompilers_sin_f32(float* @f.x)
+  %18 = load float, float* @intrinsics_02.x, align 4
+  %19 = call float @_lcompilers_sin_f32(float* @intrinsics_02.x)
   %20 = fadd float %18, %19
   store float %20, float* %call_arg_value12, align 4
   %21 = call float @_lcompilers_sin_f32(float* %call_arg_value12)

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "39df0a5a143984a7db4a8e5b71c29f323cbe12a25a9ee386bffc08de",
+    "stdout_hash": "ae853f54ca59294d9d912fc5826f53e431f547bc454b26f32e96dbfd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -1,9 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.u = internal global float 0.000000e+00
-@f.v = internal global double 0.000000e+00
-@f.zero = internal global double 0.000000e+00
+@real_dp_param.u = internal global float 0.000000e+00
+@real_dp_param.v = internal global double 0.000000e+00
+@real_dp_param.zero = internal global double 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [27 x i8] c"%13.8e%s%23.17e%s%23.17e%s\00", align 1
@@ -15,13 +15,13 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  store float 0x3FF0CCCCC0000000, float* @f.u, align 4
-  store double 1.050000e+00, double* @f.v, align 8
-  store double 0.000000e+00, double* @f.zero, align 8
-  %2 = load float, float* @f.u, align 4
+  store float 0x3FF0CCCCC0000000, float* @real_dp_param.u, align 4
+  store double 1.050000e+00, double* @real_dp_param.v, align 8
+  store double 0.000000e+00, double* @real_dp_param.zero, align 8
+  %2 = load float, float* @real_dp_param.u, align 4
   %3 = fpext float %2 to double
-  %4 = load double, double* @f.v, align 8
-  %5 = load double, double* @f.zero, align 8
+  %4 = load double, double* @real_dp_param.v, align 8
+  %5 = load double, double* @real_dp_param.zero, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([27 x i8], [27 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   ret i32 0
 }

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "538f4e580dbedd526b1d26f72099d7a865826e600b66d465aff3932e",
+    "stdout_hash": "0ce4329aa854b3fae5ef328f22db56e5222d1ff4d0f04770fe08cae8",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -9,7 +9,7 @@ source_filename = "LFortran"
 @5 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @6 = private unnamed_addr constant [14 x i8] c"normal return\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
-@f.main_out = internal global i32 0
+@main.main_out = internal global i32 0
 @8 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @9 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @10 = private unnamed_addr constant [13 x i8] c"main1 called\00", align 1
@@ -50,8 +50,8 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  store i32 999, i32* @f.main_out, align 4
-  call void @main1(i32* @f.main_out)
+  store i32 999, i32* @main.main_out, align 4
+  call void @main1(i32* @main.main_out)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
   ret i32 0
 }

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "dbac90b979ac1fe3bde999f067388ccb95b42d2343a832765757af84",
+    "stdout_hash": "194a4d86ed676011a860503c075472753ef7b0aedc893642da73004c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.my_name = internal global i8* null
+@print_01.my_name = internal global i8* null
 @0 = private unnamed_addr constant [8 x i8] c"Dominic\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -13,10 +13,10 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_set_argv(i32 %0, i8** %1)
   %2 = call i8* (i32, ...) @_lfortran_malloc(i32 8)
   call void (i32, i8*, ...) @_lfortran_string_init(i32 8, i8* %2)
-  store i8* %2, i8** @f.my_name, align 8
-  call void @_lfortran_strcpy(i8** @f.my_name, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @0, i32 0, i32 0), i8 0)
-  %3 = load i8*, i8** @f.my_name, align 8
-  %4 = load i8*, i8** @f.my_name, align 8
+  store i8* %2, i8** @print_01.my_name, align 8
+  call void @_lfortran_strcpy(i8** @print_01.my_name, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @0, i32 0, i32 0), i8 0)
+  %3 = load i8*, i8** @print_01.my_name, align 8
+  %4 = load i8*, i8** @print_01.my_name, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @4, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_free(i8* %3)
   ret i32 0

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "65e687d2a0cff01d09e99e6f00b2b5e7e4a12eea9997e4b4480077d6",
+    "stdout_hash": "51917793b0b866bf425742450b19092bcc2065cbdad2f8311f3912a7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@f.c = internal global i8* null
+@string_10.c = internal global i8* null
 @0 = private unnamed_addr constant [3 x i8] c"BC\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"Z\00", align 1
@@ -41,22 +41,22 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_set_argv(i32 %0, i8** %1)
   %2 = call i8* (i32, ...) @_lfortran_malloc(i32 3)
   call void (i32, i8*, ...) @_lfortran_string_init(i32 3, i8* %2)
-  store i8* %2, i8** @f.c, align 8
-  call void @_lfortran_strcpy(i8** @f.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @0, i32 0, i32 0), i8 0)
-  %3 = load i8*, i8** @f.c, align 8
+  store i8* %2, i8** @string_10.c, align 8
+  call void @_lfortran_strcpy(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @0, i32 0, i32 0), i8 0)
+  %3 = load i8*, i8** @string_10.c, align 8
   %is_alpha = alloca i1, align 1
   %num = alloca i8*, align 8
   %4 = call i8* (i32, ...) @_lfortran_malloc(i32 4)
   call void (i32, i8*, ...) @_lfortran_string_init(i32 4, i8* %4)
   store i8* %4, i8** %num, align 8
   %5 = load i8*, i8** %num, align 8
-  %6 = load i8*, i8** @f.c, align 8
+  %6 = load i8*, i8** @string_10.c, align 8
   %7 = alloca i8*, align 8
   store i8* %6, i8** %7, align 8
   %8 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0), i8** %8, align 8
   %9 = call i1 @_lpython_str_compare_gte(i8** %7, i8** %8)
-  %10 = load i8*, i8** @f.c, align 8
+  %10 = load i8*, i8** @string_10.c, align 8
   %11 = alloca i8*, align 8
   store i8* %10, i8** %11, align 8
   %12 = alloca i8*, align 8
@@ -64,13 +64,13 @@ define i32 @main(i32 %0, i8** %1) {
   %13 = call i1 @_lpython_str_compare_lte(i8** %11, i8** %12)
   %14 = icmp eq i1 %9, false
   %15 = select i1 %14, i1 %9, i1 %13
-  %16 = load i8*, i8** @f.c, align 8
+  %16 = load i8*, i8** @string_10.c, align 8
   %17 = alloca i8*, align 8
   store i8* %16, i8** %17, align 8
   %18 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i8** %18, align 8
   %19 = call i1 @_lpython_str_compare_gte(i8** %17, i8** %18)
-  %20 = load i8*, i8** @f.c, align 8
+  %20 = load i8*, i8** @string_10.c, align 8
   %21 = alloca i8*, align 8
   store i8* %20, i8** %21, align 8
   %22 = alloca i8*, align 8
@@ -85,14 +85,14 @@ define i32 @main(i32 %0, i8** %1) {
   %29 = icmp eq i1 %28, false
   %30 = select i1 %29, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lfortran_strcpy(i8** @f.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @10, i32 0, i32 0), i8 0)
-  %31 = load i8*, i8** @f.c, align 8
+  call void @_lfortran_strcpy(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @10, i32 0, i32 0), i8 0)
+  %31 = load i8*, i8** @string_10.c, align 8
   %32 = alloca i8*, align 8
   store i8* %31, i8** %32, align 8
   %33 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0), i8** %33, align 8
   %34 = call i1 @_lpython_str_compare_gte(i8** %32, i8** %33)
-  %35 = load i8*, i8** @f.c, align 8
+  %35 = load i8*, i8** @string_10.c, align 8
   %36 = alloca i8*, align 8
   store i8* %35, i8** %36, align 8
   %37 = alloca i8*, align 8
@@ -100,13 +100,13 @@ define i32 @main(i32 %0, i8** %1) {
   %38 = call i1 @_lpython_str_compare_lte(i8** %36, i8** %37)
   %39 = icmp eq i1 %34, false
   %40 = select i1 %39, i1 %34, i1 %38
-  %41 = load i8*, i8** @f.c, align 8
+  %41 = load i8*, i8** @string_10.c, align 8
   %42 = alloca i8*, align 8
   store i8* %41, i8** %42, align 8
   %43 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0), i8** %43, align 8
   %44 = call i1 @_lpython_str_compare_gte(i8** %42, i8** %43)
-  %45 = load i8*, i8** @f.c, align 8
+  %45 = load i8*, i8** @string_10.c, align 8
   %46 = alloca i8*, align 8
   store i8* %45, i8** %46, align 8
   %47 = alloca i8*, align 8
@@ -121,14 +121,14 @@ define i32 @main(i32 %0, i8** %1) {
   %54 = icmp eq i1 %53, false
   %55 = select i1 %54, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lfortran_strcpy(i8** @f.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @20, i32 0, i32 0), i8 0)
-  %56 = load i8*, i8** @f.c, align 8
+  call void @_lfortran_strcpy(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @20, i32 0, i32 0), i8 0)
+  %56 = load i8*, i8** @string_10.c, align 8
   %57 = alloca i8*, align 8
   store i8* %56, i8** %57, align 8
   %58 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0), i8** %58, align 8
   %59 = call i1 @_lpython_str_compare_gte(i8** %57, i8** %58)
-  %60 = load i8*, i8** @f.c, align 8
+  %60 = load i8*, i8** @string_10.c, align 8
   %61 = alloca i8*, align 8
   store i8* %60, i8** %61, align 8
   %62 = alloca i8*, align 8
@@ -136,13 +136,13 @@ define i32 @main(i32 %0, i8** %1) {
   %63 = call i1 @_lpython_str_compare_lte(i8** %61, i8** %62)
   %64 = icmp eq i1 %59, false
   %65 = select i1 %64, i1 %59, i1 %63
-  %66 = load i8*, i8** @f.c, align 8
+  %66 = load i8*, i8** @string_10.c, align 8
   %67 = alloca i8*, align 8
   store i8* %66, i8** %67, align 8
   %68 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0), i8** %68, align 8
   %69 = call i1 @_lpython_str_compare_gte(i8** %67, i8** %68)
-  %70 = load i8*, i8** @f.c, align 8
+  %70 = load i8*, i8** @string_10.c, align 8
   %71 = alloca i8*, align 8
   store i8* %70, i8** %71, align 8
   %72 = alloca i8*, align 8


### PR DESCRIPTION
Fixes #2677.