### PR TITLE
Handle exceptions in ASR->Fortran properly

### DIFF
--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -535,7 +535,7 @@ Result<std::string> FortranEvaluator::get_fortran(const std::string &code,
     Result<ASR::TranslationUnit_t*> asr = get_asr2(code, lm, diagnostics);
     symbol_table = old_symbol_table;
     if (asr.ok) {
-        return asr_to_fortran(*asr.result);
+        return asr_to_fortran(*asr.result, diagnostics, false, 4);
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return asr.error;

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1157,10 +1157,15 @@ public:
 
 };
 
-std::string asr_to_fortran(ASR::TranslationUnit_t &asr,
-        bool color, int indent) {
+Result<std::string> asr_to_fortran(ASR::TranslationUnit_t &asr,
+        diag::Diagnostics &diagnostics, bool color, int indent) {
     ASRToFortranVisitor v(color, indent);
-    v.visit_TranslationUnit(asr);
+    try {
+        v.visit_TranslationUnit(asr);
+    } catch (const CodeGenError &e) {
+        diagnostics.diagnostics.push_back(e.d);
+        return Error();
+    }
     return v.s;
 }
 

--- a/src/libasr/codegen/asr_to_fortran.h
+++ b/src/libasr/codegen/asr_to_fortran.h
@@ -7,8 +7,8 @@
 namespace LCompilers {
 
     // Converts ASR to Fortran source code
-    std::string asr_to_fortran(ASR::TranslationUnit_t &asr,
-        bool color=false, int indent=4);
+    Result<std::string> asr_to_fortran(ASR::TranslationUnit_t &asr,
+            diag::Diagnostics &diagnostics, bool color, int indent);
 
 } // namespace LCompilers
 


### PR DESCRIPTION
With this PR in, the failure in https://github.com/lfortran/lfortran/pull/2663 can be debugged as follows:
```console
$ lfortran --show-fortran intrinsics_61.f90 
code generation error: Cast IntegerToInteger: Unsupported Kind 1


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
```
and the full stacktrace can be seen by:
```console
$ lfortran --show-fortran intrinsics_61.f90 --show-stacktrace
Traceback (most recent call last):
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 2289
    return emit_fortran(arg_file, compiler_options);
  File "/Users/ondrej/repos/lfortran/lfortran/src/bin/lfortran.cpp", line 794
    LCompilers::Result<std::string> src = fe.get_fortran(input, lm, diagnostics);
  File "/Users/ondrej/repos/lfortran/lfortran/src/lfortran/fortran_evaluator.cpp", line 538
    return asr_to_fortran(*asr.result, diagnostics, false, 4);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_fortran.cpp", line 1315
    v.visit_TranslationUnit(asr);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_fortran.cpp", line 179
    visit_symbol(*item.second);
  File "../libasr/asr.h", line 5060
  File "../libasr/asr.h", line 4774
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_fortran.cpp", line 202
    visit_body(x, r, false);
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_fortran.cpp", line 112
    visit_stmt(*x.m_body[i]);
  File "../libasr/asr.h", line 5077
  File "../libasr/asr.h", line 4799
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_fortran.cpp", line 410
    visit_expr(*x.m_value);
  File "../libasr/asr.h", line 5124
  File "../libasr/asr.h", line 4931
  File "/Users/ondrej/repos/lfortran/lfortran/src/libasr/codegen/asr_to_fortran.cpp", line 1118
    default: throw CodeGenError("Cast IntegerToInteger: Unsupported Kind " + std::to_string(dest_kind));
  File "../libasr/codegen/c_utils.h", line 33
  File "../libasr/codegen/c_utils.h", line 32
code generation error: Cast IntegerToInteger: Unsupported Kind 1


Note: Please report unclear or confusing messages as bugs at
https://github.com/lfortran/lfortran/issues.
```