### PR TITLE
CI dftatom: merge lf38 with master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -470,8 +470,8 @@ jobs:
         run: |
             git clone https://github.com/czgdp1807/dftatom.git
             cd dftatom
-            git checkout -t origin/lf37
-            git checkout c962df0a4bc5f7b21849b72038df412a7352c2d6
+            git checkout -t origin/lf38
+            git checkout 046ae9b06dda7664ab1c71b6aecde48a03952f2d
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
             make -f Makefile.manual test


### PR DESCRIPTION
This makes the diff against the latest master in dftatom simpler.

The diff is here: https://github.com/certik/dftatom/compare/master...czgdp1807:dftatom:lf38