### PR TITLE
Fix value of iterator after do loop completion

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -262,6 +262,7 @@ RUN(NAME doloop_07 LABELS gfortran llvm c cpp wasm)
 RUN(NAME doloop_08 LABELS gfortran llvm c cpp wasm)
 RUN(NAME doloop_09 LABELS gfortran llvm) # nested subroutine
 RUN(NAME doloop_10 LABELS gfortran llvm wasm) # implicit cast loop variable
+RUN(NAME doloop_11 LABELS gfortran llvm wasm EXTRA_ARGS --use-loop-variable-after-loop)
 
 RUN(NAME cycle_and_exit1 LABELS gfortran llvm fortran)
 RUN(NAME cycle_and_exit2 LABELS gfortran llvm fortran)

--- a/integration_tests/doloop_11.f90
+++ b/integration_tests/doloop_11.f90
@@ -1,0 +1,15 @@
+program doloop11
+    implicit none
+
+    integer :: i
+    integer :: s
+    s = 0
+    do i = 1, 2
+        s = i
+    end do
+
+    print *, s, i
+
+    if (i /= 3) error stop
+    if (s /= 2) error stop
+end program doloop11

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -3209,6 +3209,7 @@ Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr,
     pass_options.always_run = true;
     pass_options.verbose = co.verbose;
     pass_options.dump_all_passes = co.dump_all_passes;
+    pass_options.use_loop_variable_after_loop = co.use_loop_variable_after_loop;
     std::vector<std::string> passes = {"pass_array_by_data", "array_op",
                 "implied_do_loops", "print_arr", "do_loops", "select_case",
                 "intrinsic_function", "nested_vars", "unused_functions"};

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -967,7 +967,7 @@ namespace LCompilers {
                             ASR::binopType::Sub, c, type, nullptr)), nullptr));
                 if (use_loop_variable_after_loop) {
                     stmt_add_c_after_loop = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
-                        ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, a,
+                        ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, target,
                                 ASR::binopType::Add, c, type, nullptr)), nullptr));
                 }
 

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -870,8 +870,8 @@ namespace LCompilers {
             ASR::expr_t *c=loop.m_head.m_increment;
             ASR::expr_t *cond = nullptr;
             ASR::stmt_t *inc_stmt = nullptr;
-            ASR::stmt_t *stmt1 = nullptr;
-            ASR::stmt_t *stmt_add_c = nullptr;
+            ASR::stmt_t *loop_init_stmt = nullptr;
+            ASR::stmt_t *stmt_add_c_after_loop = nullptr;
             if( !a && !b && !c ) {
                 int a_kind = 4;
                 if( loop.m_head.m_v ) {
@@ -962,11 +962,11 @@ namespace LCompilers {
                 int a_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(target));
                 ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, a_kind));
 
-                stmt1 = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
+                loop_init_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
                     ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, a,
                             ASR::binopType::Sub, c, type, nullptr)), nullptr));
                 if (use_loop_variable_after_loop) {
-                    stmt_add_c = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
+                    stmt_add_c_after_loop = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
                         ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, a,
                                 ASR::binopType::Add, c, type, nullptr)), nullptr));
                 }
@@ -989,16 +989,16 @@ namespace LCompilers {
             for (size_t i=0; i<loop.n_body; i++) {
                 body.push_back(al, loop.m_body[i]);
             }
-            ASR::stmt_t *stmt2 = ASRUtils::STMT(ASR::make_WhileLoop_t(al, loc,
+            ASR::stmt_t *while_loop_stmt = ASRUtils::STMT(ASR::make_WhileLoop_t(al, loc,
                 loop.m_name, cond, body.p, body.size()));
             Vec<ASR::stmt_t*> result;
             result.reserve(al, 2);
-            if( stmt1 ) {
-                result.push_back(al, stmt1);
+            if( loop_init_stmt ) {
+                result.push_back(al, loop_init_stmt);
             }
-            result.push_back(al, stmt2);
-            if (stmt_add_c && use_loop_variable_after_loop) {
-                result.push_back(al, stmt_add_c);
+            result.push_back(al, while_loop_stmt);
+            if (stmt_add_c_after_loop && use_loop_variable_after_loop) {
+                result.push_back(al, stmt_add_c_after_loop);
             }
 
             return result;


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/2699

The test at https://github.com/lfortran/lfortran/issues/2699#issue-1957268190 now works:
```console
$ cat examples/expr2.f90 
program cycle_and_exit5
    implicit none

    integer :: i, j
    integer(8) :: s
    s = 0
    do i = 1, 10
        if( 3*(i/3) == i ) exit
        do j = 1, 20
            s = s + i + j
        end do
        print *, i, j
        if( 2*(i/2) == i ) cycle
        s = 2*s
    end do

    print *, s
    if( s/= 710 ) error stop

end program cycle_and_exit5
$ gfortran examples/expr2.f90 
$ ./a.out 
           1          21
           2          21
                  710
$ lfortran_in_main examples/expr2.f90 
1 20
2 20
710
$ lfortran_in_main examples/expr2.f90 --use-loop-variable-after-loop
1 2
2 2
710
$ lfortran examples/expr2.f90                               
1 20
2 20
710
$ lfortran examples/expr2.f90 --use-loop-variable-after-loop 
1 21
2 21
710
```