### PR TITLE
Support --no-loc to skip location info in Json

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -687,7 +687,7 @@ int emit_asr(const std::string &infile,
     } else if (compiler_options.json) {
         std::cout << LCompilers::pickle_json(*asr, lm, compiler_options.no_loc, with_intrinsic_modules) << std::endl;
     } else if (compiler_options.visualize) {
-        std::string astr_data_json = LCompilers::pickle_json(*asr, lm, with_intrinsic_modules);
+        std::string astr_data_json = LCompilers::pickle_json(*asr, lm, compiler_options.no_loc, with_intrinsic_modules);
         return visualize_json(astr_data_json, compiler_options.platform);
     } else {
         std::cout << LCompilers::pickle(*asr, compiler_options.use_colors, compiler_options.indent,

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -685,7 +685,7 @@ int emit_asr(const std::string &infile,
         std::cout << LCompilers::pickle_tree(*asr,
             compiler_options.use_colors) << std::endl;
     } else if (compiler_options.json) {
-        std::cout << LCompilers::pickle_json(*asr, lm, with_intrinsic_modules) << std::endl;
+        std::cout << LCompilers::pickle_json(*asr, lm, compiler_options.no_loc, with_intrinsic_modules) << std::endl;
     } else if (compiler_options.visualize) {
         std::string astr_data_json = LCompilers::pickle_json(*asr, lm, with_intrinsic_modules);
         return visualize_json(astr_data_json, compiler_options.platform);
@@ -2014,6 +2014,7 @@ int main(int argc, char *argv[])
         app.add_flag("--no-indent", arg_no_indent, "Turn off Indented print ASR/AST");
         app.add_flag("--tree", compiler_options.tree, "Tree structure print ASR/AST");
         app.add_flag("--json", compiler_options.json, "Print ASR/AST Json format");
+        app.add_flag("--no-loc", compiler_options.no_loc, "Skip location information in ASR/AST Json format");
         app.add_flag("--visualize", compiler_options.visualize, "Print ASR/AST Visualization");
         app.add_option("--pass", arg_pass, "Apply the ASR pass and show ASR (implies --show-asr)");
         app.add_option("--skip-pass", skip_pass, "Skip an ASR pass in default pipeline");

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -678,6 +678,7 @@ int emit_asr(const std::string &infile,
     pass_options.intrinsic_symbols_mangling = compiler_options.intrinsic_symbols_mangling;
     pass_options.bindc_mangling = compiler_options.bindc_mangling;
     pass_options.mangle_underscore = compiler_options.mangle_underscore;
+    pass_options.use_loop_variable_after_loop = compiler_options.use_loop_variable_after_loop;
 
     pass_manager.apply_passes(al, asr, pass_options, diagnostics);
     if (compiler_options.tree) {

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -224,7 +224,7 @@ Result<std::string> FortranEvaluator::get_asr(const std::string &code,
         if (compiler_options.tree) {
             return pickle_tree(*asr.result, compiler_options.use_colors);
         } else if (compiler_options.json) {
-            return pickle_json(*asr.result, lm);
+            return pickle_json(*asr.result, lm, compiler_options.no_loc, false);
         }
         return pickle(*asr.result,
             compiler_options.use_colors, compiler_options.indent);

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -174,7 +174,7 @@ Result<std::string> FortranEvaluator::get_ast(const std::string &code,
         if (compiler_options.tree) {
             return LFortran::pickle_tree(*ast.result, compiler_options.use_colors);
         } else if (compiler_options.json || compiler_options.visualize) {
-            return LFortran::pickle_json(*ast.result, lm);
+            return LFortran::pickle_json(*ast.result, lm, compiler_options.no_loc);
         }
         return LFortran::pickle(*ast.result, compiler_options.use_colors,
             compiler_options.indent);

--- a/src/lfortran/pickle.cpp
+++ b/src/lfortran/pickle.cpp
@@ -226,14 +226,15 @@ public:
     }
 };
 
-std::string pickle_json(LFortran::AST::ast_t &ast, LocationManager &lm) {
+std::string pickle_json(LFortran::AST::ast_t &ast, LocationManager &lm, bool no_loc) {
     ASTJsonVisitor v(lm);
+    v.no_loc = no_loc;
     v.visit_ast(ast);
     return v.get_str();
 }
 
-std::string pickle_json(LFortran::AST::TranslationUnit_t &ast, LocationManager &lm) {
-    return pickle_json((LFortran::AST::ast_t &)ast, lm);
+std::string pickle_json(LFortran::AST::TranslationUnit_t &ast, LocationManager &lm, bool no_loc) {
+    return pickle_json((LFortran::AST::ast_t &)ast, lm, no_loc);
 }
 
 } // namespace LCompilers::LFortran

--- a/src/lfortran/pickle.h
+++ b/src/lfortran/pickle.h
@@ -20,8 +20,8 @@ namespace LCompilers::LFortran {
     std::string pickle_tree(AST::TranslationUnit_t &ast, bool colors=true);
 
     // Print Json structure
-    std::string pickle_json(AST::ast_t &ast, LocationManager &lm);
-    std::string pickle_json(AST::TranslationUnit_t &ast, LocationManager &lm);
+    std::string pickle_json(AST::ast_t &ast, LocationManager &lm, bool no_loc=false);
+    std::string pickle_json(AST::TranslationUnit_t &ast, LocationManager &lm, bool no_loc=false);
 
 } // namespace LCompilers::LFortran
 

--- a/src/lfortran/pickle.h
+++ b/src/lfortran/pickle.h
@@ -20,8 +20,8 @@ namespace LCompilers::LFortran {
     std::string pickle_tree(AST::TranslationUnit_t &ast, bool colors=true);
 
     // Print Json structure
-    std::string pickle_json(AST::ast_t &ast, LocationManager &lm, bool no_loc=false);
-    std::string pickle_json(AST::TranslationUnit_t &ast, LocationManager &lm, bool no_loc=false);
+    std::string pickle_json(AST::ast_t &ast, LocationManager &lm, bool no_loc);
+    std::string pickle_json(AST::TranslationUnit_t &ast, LocationManager &lm, bool no_loc);
 
 } // namespace LCompilers::LFortran
 

--- a/src/libasr/asdl_cpp.py
+++ b/src/libasr/asdl_cpp.py
@@ -1718,6 +1718,7 @@ class JsonVisitorVisitor(ASDLVisitor):
         self.emit(  "Struct& self() { return static_cast<Struct&>(*this); }", 1)
         self.emit("public:")
         self.emit(  "std::string s, indtd = \"\";", 1)
+        self.emit(  "bool no_loc = false;", 1)
         self.emit(  "int indent_level = 0, indent_spaces = 4;", 1)
         # Storing a reference to LocationManager like this isn't ideal.
         # One must make sure JsonBaseVisitor isn't reused in a case where AST/ASR has changed
@@ -1739,7 +1740,9 @@ class JsonVisitorVisitor(ASDLVisitor):
         self.emit(      "indtd = std::string(indent_level*indent_spaces, ' ');",2)
         self.emit(  "}",1)
         self.emit(  "void append_location(std::string &s, uint32_t first, uint32_t last) {", 1)
-        self.emit(      's.append("\\"loc\\": {");', 2);
+        self.emit(      'if (no_loc) return;', 2)
+        self.emit(      's.append(",\\n" + indtd);', 2)
+        self.emit(      's.append("\\"loc\\": {");', 2)
         self.emit(      'inc_indent();', 2)
         self.emit(      's.append("\\n" + indtd);', 2)
         self.emit(      's.append("\\"first\\": " + std::to_string(first));', 2)
@@ -1809,7 +1812,6 @@ class JsonVisitorVisitor(ASDLVisitor):
                     self.emit('s.append(",\\n" + indtd);', 2)
             self.emit('dec_indent(); s.append("\\n" + indtd);', 2)
         self.emit(    's.append("}");', 2)
-        self.emit(    's.append(",\\n" + indtd);', 2)
         if name in products:
             self.emit(    'append_location(s, x.loc.first, x.loc.last);', 2)
         else:

--- a/src/libasr/pickle.cpp
+++ b/src/libasr/pickle.cpp
@@ -224,15 +224,16 @@ public:
     }
 };
 
-std::string pickle_json(ASR::asr_t &asr, LocationManager &lm, bool show_intrinsic_modules) {
+std::string pickle_json(ASR::asr_t &asr, LocationManager &lm, bool no_loc, bool show_intrinsic_modules) {
     ASRJsonVisitor v(lm);
     v.show_intrinsic_modules = show_intrinsic_modules;
+    v.no_loc = no_loc;
     v.visit_asr(asr);
     return v.get_str();
 }
 
-std::string pickle_json(ASR::TranslationUnit_t &asr, LocationManager &lm, bool show_intrinsic_modules) {
-    return pickle_json((ASR::asr_t &)asr, lm, show_intrinsic_modules);
+std::string pickle_json(ASR::TranslationUnit_t &asr, LocationManager &lm, bool no_loc, bool show_intrinsic_modules) {
+    return pickle_json((ASR::asr_t &)asr, lm, no_loc, show_intrinsic_modules);
 }
 
 } // namespace LCompilers

--- a/src/libasr/pickle.h
+++ b/src/libasr/pickle.h
@@ -17,8 +17,8 @@ namespace LCompilers {
     std::string pickle_tree(ASR::TranslationUnit_t &asr, bool colors, bool show_intrinsic_modules=false);
 
     // Print Json structure
-    std::string pickle_json(ASR::asr_t &asr, LocationManager &lm, bool no_loc=false, bool show_intrinsic_modules=false);
-    std::string pickle_json(ASR::TranslationUnit_t &asr, LocationManager &lm, bool no_loc=false, bool show_intrinsic_modules=false);
+    std::string pickle_json(ASR::asr_t &asr, LocationManager &lm, bool no_loc, bool show_intrinsic_modules);
+    std::string pickle_json(ASR::TranslationUnit_t &asr, LocationManager &lm, bool no_loc, bool show_intrinsic_modules);
 
 } // namespace LCompilers
 

--- a/src/libasr/pickle.h
+++ b/src/libasr/pickle.h
@@ -17,8 +17,8 @@ namespace LCompilers {
     std::string pickle_tree(ASR::TranslationUnit_t &asr, bool colors, bool show_intrinsic_modules=false);
 
     // Print Json structure
-    std::string pickle_json(ASR::asr_t &asr, LocationManager &lm, bool show_intrinsic_modules=false);
-    std::string pickle_json(ASR::TranslationUnit_t &asr, LocationManager &lm, bool show_intrinsic_modules=false);
+    std::string pickle_json(ASR::asr_t &asr, LocationManager &lm, bool no_loc=false, bool show_intrinsic_modules=false);
+    std::string pickle_json(ASR::TranslationUnit_t &asr, LocationManager &lm, bool no_loc=false, bool show_intrinsic_modules=false);
 
 } // namespace LCompilers
 

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -41,6 +41,7 @@ struct CompilerOptions {
     bool use_colors = true;
     bool indent = true;
     bool json = false;
+    bool no_loc = false;
     bool tree = false;
     bool visualize = false;
     bool fast = false;


### PR DESCRIPTION
This PR supports a `--no-loc` flag which enables the user to skip the location information in the generated AST/R Json format.

```console
$ lfortran examples/expr2.f90 --show-asr --json --no-loc
{
    "node": "TranslationUnit",
    "fields": {
        "symtab": {
            "node": "SymbolTable1",
            "fields": {
                "expr2": {
                    "node": "Program",
                    "fields": {
                        "symtab": {
                            "node": "SymbolTable2",
                            "fields": {
                                "x": {
                                    "node": "Variable",
                                    "fields": {
                                        "parent_symtab": 2,
                                        "name": "x",
                                        "dependencies": [],
                                        "intent": "Local",
                                        "symbolic_value": [],
                                        "value": [],
                                        "storage": "Default",
                                        "type": {
                                            "node": "Integer",
                                            "fields": {
                                                "kind": 4
                                            }
                                        },
                                        "type_declaration": [],
                                        "abi": "Source",
                                        "access": "Public",
                                        "presence": "Required",
                                        "value_attr": false
                                    }
                                }
                            }
                        },
                        "name": "expr2",
                        "dependencies": [],
                        "body": [
                            {
                                "node": "Assignment",
                                "fields": {
                                    "target": {
                                        "node": "Var",
                                        "fields": {
                                            "v": "x (SymbolTable2)"
                                        }
                                    },
                                    "value": {
                                        "node": "IntegerBinOp",
                                        "fields": {
                                            "left": {
                                                "node": "IntegerBinOp",
                                                "fields": {
                                                    "left": {
                                                        "node": "IntegerConstant",
                                                        "fields": {
                                                            "n": 2,
                                                            "type": {
                                                                "node": "Integer",
                                                                "fields": {
                                                                    "kind": 4
                                                                }
                                                            }
                                                        }
                                                    },
                                                    "op": "Add",
                                                    "right": {
                                                        "node": "IntegerConstant",
                                                        "fields": {
                                                            "n": 3,
                                                            "type": {
                                                                "node": "Integer",
                                                                "fields": {
                                                                    "kind": 4
                                                                }
                                                            }
                                                        }
                                                    },
                                                    "type": {
                                                        "node": "Integer",
                                                        "fields": {
                                                            "kind": 4
                                                        }
                                                    },
                                                    "value": {
                                                        "node": "IntegerConstant",
                                                        "fields": {
                                                            "n": 5,
                                                            "type": {
                                                                "node": "Integer",
                                                                "fields": {
                                                                    "kind": 4
                                                                }
                                                            }
                                                        }
                                                    }
                                                }
                                            },
                                            "op": "Mul",
                                            "right": {
                                                "node": "IntegerConstant",
                                                "fields": {
                                                    "n": 5,
                                                    "type": {
                                                        "node": "Integer",
                                                        "fields": {
                                                            "kind": 4
                                                        }
                                                    }
                                                }
                                            },
                                            "type": {
                                                "node": "Integer",
                                                "fields": {
                                                    "kind": 4
                                                }
                                            },
                                            "value": {
                                                "node": "IntegerConstant",
                                                "fields": {
                                                    "n": 25,
                                                    "type": {
                                                        "node": "Integer",
                                                        "fields": {
                                                            "kind": 4
                                                        }
                                                    }
                                                }
                                            }
                                        }
                                    },
                                    "overloaded": []
                                }
                            },
                            {
                                "node": "Print",
                                "fields": {
                                    "values": [
                                        {
                                            "node": "Var",
                                            "fields": {
                                                "v": "x (SymbolTable2)"
                                            }
                                        }
                                    ],
                                    "separator": [],
                                    "end": []
                                }
                            }
                        ]
                    }
                }
            }
        },
        "items": []
    }
}
```