### PR TITLE
CI: change branch to test amos, mach without any patch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -170,8 +170,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/merge_specfun_minpack_fitpack_amos_mach_02
-            git checkout 5cc5edb03d0ae5b1a54639cece63d6263a111f5f
+            git checkout -t ondrej/merge_specfun_minpack_fitpack_amos_mach_03
+            git checkout f7cbdacbd5c5cf807579729d59d3830f2aa9c4a2
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init


### PR DESCRIPTION
Refer: https://github.com/lfortran/lfortran/pull/2673#issuecomment-1780556534

This PR tests https://github.com/certik/scipy/commits/merge_specfun_minpack_fitpack_amos_mach_03, commit: https://github.com/certik/scipy/commit/f7cbdacbd5c5cf807579729d59d3830f2aa9c4a2

TODO:
* [ ] Get this PR merged
* [ ] Send a test PR to ensure that CI works for `amos`, `mach`. This can be done by simply reverting #2716 .