### PR TITLE
CI: test `scipy/special/cdflib`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -170,8 +170,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/merge_specfun_minpack_fitpack_amos_mach_03
-            git checkout f7cbdacbd5c5cf807579729d59d3830f2aa9c4a2
+            git checkout -t ondrej/merge_special_minpack_fitpack_01
+            git checkout d4aac2b8415ff47e4a00120536fcd62efe224a69
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init


### PR DESCRIPTION
With this we have 6 / 18 packages ( 1/3rd of SciPy ) compiled and being tested at our CI. More specifically, entire `scipy.special.*` that includes `amos`, `cdflib`, `specfun`, `mach`, also, `minpack`, `fitpack` works with LFortran with no modification.