### PR TITLE
Refactor replace_symbol used in require statements

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -707,7 +707,7 @@ public:
                 if (ASR::is_a<ASR::Function_t>(*s) && !ASRUtils::is_template_arg(sym, s_name)) {
                     ASR::Function_t *new_f = ASR::down_cast<ASR::Function_t>(
                         current_scope->resolve_symbol(s_name));
-                    pass_instantiate_function_body(al, context_map, type_subs, symbol_subs,
+                    instantiate_function_body(al, context_map, type_subs, symbol_subs,
                         current_scope, temp->m_symtab, new_f, ASR::down_cast<ASR::Function_t>(s));
                 }
             }
@@ -721,7 +721,7 @@ public:
                 if (ASR::is_a<ASR::Function_t>(*s)) {
                     ASR::Function_t *new_f = ASR::down_cast<ASR::Function_t>(
                         current_scope->resolve_symbol(new_s_name));
-                    pass_instantiate_function_body(al, context_map, type_subs, symbol_subs, current_scope,
+                    instantiate_function_body(al, context_map, type_subs, symbol_subs, current_scope,
                         temp->m_symtab, new_f, ASR::down_cast<ASR::Function_t>(s));
                 } else if (ASR::is_a<ASR::StructType_t>(*s)) {
                     ASR::StructType_t *new_st = ASR::down_cast<ASR::StructType_t>(
@@ -733,7 +733,7 @@ public:
                             ASR::Function_t *temp_f = ASR::down_cast<ASR::Function_t>(
                                 temp->m_symtab->resolve_symbol(proc->m_name));
                             ASR::Function_t *new_f = ASR::down_cast<ASR::Function_t>(proc->m_proc);
-                            pass_instantiate_function_body(al, context_map, type_subs, symbol_subs, current_scope,
+                            instantiate_function_body(al, context_map, type_subs, symbol_subs, current_scope,
                                 temp_f->m_symtab, new_f, temp_f);
                         }
                     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5889,12 +5889,12 @@ public:
             target_scope = current_scope->parent;
         }
 
-        pass_instantiate_symbol(al, context_map, type_subs, symbol_subs,
+        instantiate_symbol(al, context_map, type_subs, symbol_subs,
             target_scope, temp->m_symtab, new_func_name, s);
 
         ASR::symbol_t *new_s = target_scope->get_symbol(new_func_name);
         ASR::Function_t *new_f = ASR::down_cast<ASR::Function_t>(new_s);
-        pass_instantiate_function_body(al, context_map, type_subs, symbol_subs,
+        instantiate_function_body(al, context_map, type_subs, symbol_subs,
             target_scope, temp->m_symtab, new_f, ASR::down_cast<ASR::Function_t>(s));
 
         // Build generic procedure if has not existed yet

--- a/src/libasr/pass/instantiate_template.h
+++ b/src/libasr/pass/instantiate_template.h
@@ -11,23 +11,28 @@ namespace LCompilers {
      *        contain any type parameters and restrictions. No type checking
      *        is executed here
      */
-    ASR::symbol_t* pass_instantiate_symbol(Allocator &al,
-        std::map<std::string, std::string>& context_map,
+    ASR::symbol_t* instantiate_symbol(Allocator &al,
+        std::map<std::string, std::string> &context_map,
         std::map<std::string, ASR::ttype_t*> type_subs,
         std::map<std::string, ASR::symbol_t*> symbol_subs,
         SymbolTable *current_scope, SymbolTable *template_scope,
        std::string new_sym_name, ASR::symbol_t *sym);
 
-    ASR::symbol_t* pass_instantiate_function_body(Allocator &al,
-        std::map<std::string, std::string>& context_map,
+    ASR::symbol_t* instantiate_function_body(Allocator &al,
+        std::map<std::string, std::string> &context_map,
         std::map<std::string, ASR::ttype_t*> type_subs,
         std::map<std::string, ASR::symbol_t*> symbol_subs,
         SymbolTable *current_scope, SymbolTable *template_scope,
         ASR::Function_t *new_f, ASR::Function_t *f);
 
+    ASR::symbol_t* rename_symbol(Allocator &al,
+        std::map<std::string, ASR::ttype_t*> &type_subs,
+        SymbolTable *current_scope,
+        std::string new_sym_name, ASR::symbol_t *sym);
+
     void check_restriction(std::map<std::string, ASR::ttype_t*> type_subs,
         std::map<std::string, ASR::symbol_t*> &symbol_subs,
-        ASR::Function_t *f, ASR::symbol_t *sym_arg, const Location& loc,
+        ASR::Function_t *f, ASR::symbol_t *sym_arg, const Location &loc,
         diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers


### PR DESCRIPTION
I reverted the AST changes I made in #2721 and kept the replace_symbol refactor.