### PR TITLE
Remove extra supports for --dump-all-passes-fortran

### DIFF
--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -513,8 +513,7 @@ Result<std::string> FortranEvaluator::get_julia(const std::string &code,
 }
 
 Result<std::string> FortranEvaluator::get_fortran(const std::string &code,
-    LocationManager &lm, LCompilers::PassManager &pass_manager,
-    diag::Diagnostics &diagnostics)
+    LocationManager &lm, diag::Diagnostics &diagnostics)
 {
     // SRC -> AST -> ASR -> Fortran
     SymbolTable *old_symbol_table = symbol_table;
@@ -522,14 +521,6 @@ Result<std::string> FortranEvaluator::get_fortran(const std::string &code,
     Result<ASR::TranslationUnit_t*> asr = get_asr2(code, lm, diagnostics);
     symbol_table = old_symbol_table;
     if (asr.ok) {
-        Allocator al(64*1024*1024);
-        if (compiler_options.po.dump_fortran) {
-            compiler_options.po.always_run = true;
-            compiler_options.po.run_fun = "f";
-
-            pass_manager.use_default_passes();
-            pass_manager.apply_passes(al, asr.result, compiler_options.po, diagnostics, lm);
-        }
         return asr_to_fortran(*asr.result, diagnostics, false, 4);
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -106,8 +106,7 @@ public:
     Result<std::string> get_julia(const std::string &code,
         LocationManager &lm, diag::Diagnostics &diagnostics);
     Result<std::string> get_fortran(const std::string &code,
-        LocationManager &lm,  LCompilers::PassManager &pass_manager,
-        diag::Diagnostics &diagnostics);
+        LocationManager &lm, diag::Diagnostics &diagnostics);
     Result<std::string> get_fmt(const std::string &code, LocationManager &lm,
         diag::Diagnostics &diagnostics);
 


### PR DESCRIPTION
towards https://github.com/lfortran/lfortran/issues/2744.

Now it can only be used as `lfortran main.f90 --dump-all-passes-fortran` which is the same as how `--dump-all-passes` used to work previously before PR https://github.com/lfortran/lfortran/pull/2733 was merged.