### PR TITLE
CI: test `scipy/integrate/mach`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -170,8 +170,8 @@ jobs:
             cd scipy
             git remote add ondrej https://github.com/certik/scipy
             git fetch ondrej
-            git checkout -t ondrej/merge_special_minpack_minpack2_fitpack_01
-            git checkout aafa865a87404792c80e6e60d7a64923b0519215
+            git checkout -t ondrej/merge_special_minpack_minpack2_fitpack_mach_01
+            git checkout 53109f0f0d9cf0110c314c993063ae3b4121ffbe
             micromamba env create -f environment.yml
             micromamba activate scipy-dev
             git submodule update --init
@@ -207,6 +207,13 @@ jobs:
             cd scipy/
             micromamba activate scipy-dev
             python dev.py test -t scipy.interpolate -v
+
+      - name: Test SciPy Mach (Integrate)
+        shell: bash -e -x -l {0}
+        run: |
+            cd scipy/
+            micromamba activate scipy-dev
+            python dev.py test -t scipy.integrate -v
 
   build_to_wasm_and_upload:
     name: Build LFortran to WASM and Upload


### PR DESCRIPTION
Ah, I am not sure how much is this needed but if we are compiling it and tests pass why not test it at CI. Subroutines defined in `d1mach.f` and `xerror.f` are highly likely to be used in `odepack`, `quadpack`. 