### PR TITLE
Add provision to `visit_FunctionCall` in `update_call_args`

### DIFF
--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -190,33 +190,39 @@ void update_call_args(Allocator &al, SymbolTable *current_scope, bool implicit_i
             }
             return sym;
         }
-
-        #define visit_Call(call) for (size_t j = 0; j < call->n_args; j++) { \
-                ASR::call_arg_t arg = call->m_args[j]; \
-                ASR::expr_t* arg_expr = arg.m_value; \
-                if (ASR::is_a<ASR::Var_t>(*arg_expr)) { \
-                    ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(arg_expr); \
-                    ASR::symbol_t* arg_sym = arg_var->m_v; \
-                    ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym); \
-                    ASR::symbol_t* sym = fetch_sym(arg_sym_underlying); \
-                    if (sym != arg_sym) { \
-                        ASR::expr_t** current_expr_copy = current_expr; \
-                        current_expr = const_cast<ASR::expr_t**>(&(call->m_args[j].m_value)); \
-                        this->call_replacer_(sym); \
-                        current_expr = current_expr_copy; \
-                    } \
-                } \
-            } \
         
+        void handle_Var(ASR::expr_t* arg_expr, ASR::expr_t** expr_to_replace) {
+            if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
+                ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(arg_expr);
+                ASR::symbol_t* arg_sym = arg_var->m_v;
+                ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym);
+                ASR::symbol_t* sym = fetch_sym(arg_sym_underlying);
+                if (sym != arg_sym) {
+                    ASR::expr_t** current_expr_copy = current_expr;
+                    current_expr = const_cast<ASR::expr_t**>((expr_to_replace));
+                    this->call_replacer_(sym);
+                    current_expr = current_expr_copy;
+                }
+            }
+        }
+
 
         void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
             ASR::SubroutineCall_t* subrout_call = (ASR::SubroutineCall_t*)(&x);
-            visit_Call(subrout_call);
+            for (size_t j = 0; j < subrout_call->n_args; j++) {
+                ASR::call_arg_t arg = subrout_call->m_args[j];
+                ASR::expr_t* arg_expr = arg.m_value;
+                handle_Var(arg_expr, &(subrout_call->m_args[j].m_value));
+            }
         }
 
         void visit_FunctionCall(const ASR::FunctionCall_t& x) {
             ASR::FunctionCall_t* func_call = (ASR::FunctionCall_t*)(&x);
-            visit_Call(func_call);
+            for (size_t j = 0; j < func_call->n_args; j++) {
+                ASR::call_arg_t arg = func_call->m_args[j];
+                ASR::expr_t* arg_expr = arg.m_value;
+                handle_Var(arg_expr, &(func_call->m_args[j].m_value));
+            }
         }
 
         void visit_Function(const ASR::Function_t& x) {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -191,24 +191,32 @@ void update_call_args(Allocator &al, SymbolTable *current_scope, bool implicit_i
             return sym;
         }
 
+        #define visit_Call(call) for (size_t j = 0; j < call->n_args; j++) { \
+                ASR::call_arg_t arg = call->m_args[j]; \
+                ASR::expr_t* arg_expr = arg.m_value; \
+                if (ASR::is_a<ASR::Var_t>(*arg_expr)) { \
+                    ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(arg_expr); \
+                    ASR::symbol_t* arg_sym = arg_var->m_v; \
+                    ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym); \
+                    ASR::symbol_t* sym = fetch_sym(arg_sym_underlying); \
+                    if (sym != arg_sym) { \
+                        ASR::expr_t** current_expr_copy = current_expr; \
+                        current_expr = const_cast<ASR::expr_t**>(&(call->m_args[j].m_value)); \
+                        this->call_replacer_(sym); \
+                        current_expr = current_expr_copy; \
+                    } \
+                } \
+            } \
+        
+
         void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
             ASR::SubroutineCall_t* subrout_call = (ASR::SubroutineCall_t*)(&x);
-            for (size_t j = 0; j < subrout_call->n_args; j++) {
-                ASR::call_arg_t arg = subrout_call->m_args[j];
-                ASR::expr_t* arg_expr = arg.m_value;
-                if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
-                    ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(arg_expr);
-                    ASR::symbol_t* arg_sym = arg_var->m_v;
-                    ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym);
-                    ASR::symbol_t* sym = fetch_sym(arg_sym_underlying);
-                    if (sym != arg_sym) {
-                        ASR::expr_t** current_expr_copy = current_expr;
-                        current_expr = const_cast<ASR::expr_t**>(&(subrout_call->m_args[j].m_value));
-                        this->call_replacer_(sym);
-                        current_expr = current_expr_copy;
-                    }
-                }
-            }
+            visit_Call(subrout_call);
+        }
+
+        void visit_FunctionCall(const ASR::FunctionCall_t& x) {
+            ASR::FunctionCall_t* func_call = (ASR::FunctionCall_t*)(&x);
+            visit_Call(func_call);
         }
 
         void visit_Function(const ASR::Function_t& x) {

--- a/tests/external_03.f90
+++ b/tests/external_03.f90
@@ -1,0 +1,15 @@
+subroutine b()
+   external f
+   call a(f)
+end subroutine
+
+subroutine a(f)
+   real r
+   external f
+   r = f(2.0)
+   print *, r
+end subroutine
+
+program external_03
+   call b()
+end program

--- a/tests/reference/asr-allow_implicit_interface3-7ef92cc.json
+++ b/tests/reference/asr-allow_implicit_interface3-7ef92cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allow_implicit_interface3-7ef92cc.stdout",
-    "stdout_hash": "6f5a3eeb96f496e39fabce6967356a33d72ef17ae9020dcfe8ce327f",
+    "stdout_hash": "c6ecd169a5acbf53ee7f2277899369aadeee015011253844880eb277",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allow_implicit_interface3-7ef92cc.stdout
+++ b/tests/reference/asr-allow_implicit_interface3-7ef92cc.stdout
@@ -26,11 +26,11 @@
                             lsame:
                                 (Function
                                     (SymbolTable
-                                        4
+                                        5
                                         {
                                             lsame_arg_0:
                                                 (Variable
-                                                    4
+                                                    5
                                                     lsame_arg_0
                                                     []
                                                     Unspecified
@@ -46,7 +46,7 @@
                                                 ),
                                             lsame_arg_1:
                                                 (Variable
-                                                    4
+                                                    5
                                                     lsame_arg_1
                                                     []
                                                     Unspecified
@@ -62,7 +62,7 @@
                                                 ),
                                             lsame_return_var_name:
                                                 (Variable
-                                                    4
+                                                    5
                                                     lsame_return_var_name
                                                     []
                                                     ReturnVar
@@ -94,10 +94,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 4 lsame_arg_0)
-                                    (Var 4 lsame_arg_1)]
+                                    [(Var 5 lsame_arg_0)
+                                    (Var 5 lsame_arg_1)]
                                     []
-                                    (Var 4 lsame_return_var_name)
+                                    (Var 5 lsame_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external3-2aafcb3.json
+++ b/tests/reference/asr-external3-2aafcb3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external3-2aafcb3.stdout",
-    "stdout_hash": "d3cf8f6fe96b9b257e798fa143fa0647ca90b4d04fb6f8d9c568cff9",
+    "stdout_hash": "3960fa0f797ad6b47c50f7d474a4d29e4524ccc5ec257c2c5e298ba5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external3-2aafcb3.stdout
+++ b/tests/reference/asr-external3-2aafcb3.stdout
@@ -42,11 +42,11 @@
                             bcorr:
                                 (Function
                                     (SymbolTable
-                                        4
+                                        5
                                         {
                                             a:
                                                 (Variable
-                                                    4
+                                                    5
                                                     a
                                                     []
                                                     Local
@@ -62,7 +62,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    4
+                                                    5
                                                     b
                                                     []
                                                     Local
@@ -78,7 +78,7 @@
                                                 ),
                                             bcorr_arg_0:
                                                 (Variable
-                                                    4
+                                                    5
                                                     bcorr_arg_0
                                                     []
                                                     Unspecified
@@ -94,7 +94,7 @@
                                                 ),
                                             bcorr_arg_1:
                                                 (Variable
-                                                    4
+                                                    5
                                                     bcorr_arg_1
                                                     []
                                                     Unspecified
@@ -110,7 +110,7 @@
                                                 ),
                                             bcorr_return_var_name:
                                                 (Variable
-                                                    4
+                                                    5
                                                     bcorr_return_var_name
                                                     []
                                                     ReturnVar
@@ -142,10 +142,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 4 bcorr_arg_0)
-                                    (Var 4 bcorr_arg_1)]
+                                    [(Var 5 bcorr_arg_0)
+                                    (Var 5 bcorr_arg_1)]
                                     []
-                                    (Var 4 bcorr_return_var_name)
+                                    (Var 5 bcorr_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external4-4e8bc7b.json
+++ b/tests/reference/asr-external4-4e8bc7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external4-4e8bc7b.stdout",
-    "stdout_hash": "80e04a23155ac5beefd5b56112dd16ec66475e4ff7013f77d3cd594a",
+    "stdout_hash": "c6c88bc486ef30fa991109816097da83eb294c698935937e3dc716dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external4-4e8bc7b.stdout
+++ b/tests/reference/asr-external4-4e8bc7b.stdout
@@ -27,7 +27,7 @@
                                 (ExternalSymbol
                                     2
                                     dlog
-                                    7 dlog
+                                    8 dlog
                                     lfortran_intrinsic_math
                                     []
                                     dlog
@@ -80,11 +80,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        5
+                                        6
                                         {
                                             centr:
                                                 (Variable
-                                                    5
+                                                    6
                                                     centr
                                                     []
                                                     Local
@@ -100,7 +100,7 @@
                                                 ),
                                             f_arg_0:
                                                 (Variable
-                                                    5
+                                                    6
                                                     f_arg_0
                                                     []
                                                     Unspecified
@@ -116,7 +116,7 @@
                                                 ),
                                             f_return_var_name:
                                                 (Variable
-                                                    5
+                                                    6
                                                     f_return_var_name
                                                     []
                                                     ReturnVar
@@ -132,7 +132,7 @@
                                                 ),
                                             hlgth:
                                                 (Variable
-                                                    5
+                                                    6
                                                     hlgth
                                                     []
                                                     Local
@@ -163,9 +163,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 5 f_arg_0)]
+                                    [(Var 6 f_arg_0)]
                                     []
-                                    (Var 5 f_return_var_name)
+                                    (Var 6 f_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external_01-6754623.json
+++ b/tests/reference/asr-external_01-6754623.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external_01-6754623.stdout",
-    "stdout_hash": "8dc77dbce4260bbfde2a2a791fb33ee0d79d9cde9323e7ff6982b276",
+    "stdout_hash": "59669cd4879255ecfc6ff23ab7da72acc46b2991bb3bc3e0f2564109",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external_01-6754623.stdout
+++ b/tests/reference/asr-external_01-6754623.stdout
@@ -42,11 +42,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        4
+                                        5
                                         {
                                             f_arg_0:
                                                 (Variable
-                                                    4
+                                                    5
                                                     f_arg_0
                                                     []
                                                     Unspecified
@@ -62,7 +62,7 @@
                                                 ),
                                             f_return_var_name:
                                                 (Variable
-                                                    4
+                                                    5
                                                     f_return_var_name
                                                     []
                                                     ReturnVar
@@ -93,9 +93,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 4 f_arg_0)]
+                                    [(Var 5 f_arg_0)]
                                     []
-                                    (Var 4 f_return_var_name)
+                                    (Var 5 f_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external_03-fe60427.json
+++ b/tests/reference/asr-external_03-fe60427.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-external_03-fe60427",
+    "cmd": "lfortran --show-asr --implicit-typing --implicit-interface --no-color {infile} -o {outfile}",
+    "infile": "tests/external_03.f90",
+    "infile_hash": "82ee198be6d031398277671c0c2f48a832124a1458e94c3317d080ba",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-external_03-fe60427.stdout",
+    "stdout_hash": "d34eb96334d83901fa72b3a6930906040bd7187ce135b6e3f0f4d5d3",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-external_03-fe60427.stdout
+++ b/tests/reference/asr-external_03-fe60427.stdout
@@ -1,0 +1,260 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            a:
+                (Function
+                    (SymbolTable
+                        4
+                        {
+                            f:
+                                (Function
+                                    (SymbolTable
+                                        9
+                                        {
+                                            f_arg_0:
+                                                (Variable
+                                                    9
+                                                    f_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            f_return_var_name:
+                                                (Variable
+                                                    9
+                                                    f_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    f
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 4)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 9 f_arg_0)]
+                                    []
+                                    (Var 9 f_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            r:
+                                (Variable
+                                    4
+                                    r
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    a
+                    (FunctionType
+                        [(FunctionType
+                            []
+                            (Real 4)
+                            BindC
+                            Interface
+                            ()
+                            .false.
+                            .false.
+                            .false.
+                            .false.
+                            .false.
+                            []
+                            .false.
+                        )]
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        []
+                        .false.
+                    )
+                    []
+                    [(Var 4 f)]
+                    [(=
+                        (Var 4 r)
+                        (FunctionCall
+                            4 f
+                            ()
+                            [((RealConstant
+                                2.000000
+                                (Real 4)
+                            ))]
+                            (Real 4)
+                            ()
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        [(Var 4 r)]
+                        ()
+                        ()
+                    )]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            b:
+                (Function
+                    (SymbolTable
+                        2
+                        {
+                            f:
+                                (Function
+                                    (SymbolTable
+                                        8
+                                        {
+                                            f_arg_0:
+                                                (Variable
+                                                    8
+                                                    f_arg_0
+                                                    []
+                                                    Unspecified
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            f_return_var_name:
+                                                (Variable
+                                                    8
+                                                    f_return_var_name
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    f
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 4)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 8 f_arg_0)]
+                                    []
+                                    (Var 8 f_return_var_name)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    b
+                    (FunctionType
+                        []
+                        ()
+                        Source
+                        Implementation
+                        ()
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        .false.
+                        []
+                        .false.
+                    )
+                    [a]
+                    []
+                    [(SubroutineCall
+                        1 a
+                        ()
+                        [((Var 2 f))]
+                        ()
+                    )]
+                    ()
+                    Public
+                    .false.
+                    .false.
+                    ()
+                ),
+            external_03:
+                (Program
+                    (SymbolTable
+                        6
+                        {
+                            
+                        })
+                    external_03
+                    []
+                    [(SubroutineCall
+                        1 b
+                        ()
+                        []
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2910,6 +2910,10 @@ asr_implicit_interface_and_typing = true
 asr_implicit_interface_and_typing_with_llvm = true
 
 [[test]]
+filename = "external_03.f90"
+asr_implicit_interface_and_typing = true
+
+[[test]]
 filename = "dimension_attr2.f90"
 asr_implicit_typing = true
 


### PR DESCRIPTION
With this we get correct ASR for https://github.com/lfortran/lfortran/issues/1977#issuecomment-1791095925, however the error still persists.  On debugging, I found that `llvm_symtab_fn_arg` consists hash corresponding to  `f` present in symbol table of `a`, and then when we encounter `call a(f)` in body of `b`, `f` is part of symbol table belonging to `b` and thus it throws error. 

One way to fix this is, whenever we add hash of an external function into  `llvm_symtab_fn_arg`, lookup all the symtabs where it is present and add their hash as well. Although, we do not have any information to check if `is_external(f)`.

Another way that comes to my mind is to make all external functions part of module `__lcompilers_external_functions_module`, this way we have a global module accessible to every subroutine but, this will have a large blast radius ( handling `ExternalSymbol`, the same we faced in https://github.com/lfortran/lfortran/pull/2396 ).

```fortran
subroutine b()
   external f
   call a(f)
end subroutine

subroutine a(f)
   real r
   external f
   r = f(2.0)
   print *, r
end subroutine

program main
   call b()
end program
```

> LFortran


```console
% lfortran ./tests/external_03.f90 --implicit-typing --implicit-interface 
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/pranavchiku/repos/lfortran/src/bin/lfortran.cpp", line 2307
    err = compile_to_object_file(arg_file, tmp_o, false,
  File "/Users/pranavchiku/repos/lfortran/src/bin/lfortran.cpp", line 930
    res = fe.get_llvm3(*asr, lpm, lm, diagnostics, infile);
  File "/Users/pranavchiku/repos/lfortran/src/lfortran/fortran_evaluator.cpp", line 358
    = asr_to_llvm(asr, diagnostics,
  File "/Users/pranavchiku/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 9220
    v.visit_asr((ASR::asr_t&)asr);
  File "../libasr/asr.h", line 5057
  File "../libasr/asr.h", line 5033
  File "../libasr/asr.h", line 5058
  File "../libasr/asr.h", line 4766
  File "/Users/pranavchiku/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 938
    visit_symbol(*item.second);
  File "../libasr/asr.h", line 5060
  File "../libasr/asr.h", line 4775
  File "/Users/pranavchiku/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 3673
    visit_procedures(x);
  File "/Users/pranavchiku/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 3870
    this->visit_stmt(*x.m_body[i]);
  File "../libasr/asr.h", line 5077
  File "../libasr/asr.h", line 4825
  File "/Users/pranavchiku/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 8388
    std::vector<llvm::Value *> args2 = convert_call_args(x, is_method);
  File "/Users/pranavchiku/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 7870
    LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());
AssertFailed: llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end()
```

