### PR TITLE
Handle external interface in `convert_call_args`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1002,7 +1002,8 @@ RUN(NAME external_03 LABELS gfortran llvmImplicit)
 RUN(NAME external_04 LABELS gfortran llvmImplicit)
 RUN(NAME external_05 LABELS gfortran llvmImplicit)
 RUN(NAME external_06 LABELS gfortran llvmImplicit)
-
+RUN(NAME external_07 LABELS gfortran llvmImplicit)
+RUN(NAME external_08 LABELS gfortran llvmImplicit)
 
 
 RUN(NAME interface_12 LABELS gfortran llvm)

--- a/integration_tests/external_07.f90
+++ b/integration_tests/external_07.f90
@@ -1,0 +1,22 @@
+double precision function f(x)
+  double precision x
+  f = x**2
+  return
+end function f
+
+subroutine sub(f)
+  external f
+  double precision f
+  print *, f(2.0d0)
+  if (abs(f(2.0d0) - 4.0d0) > 1.0d-10) error stop
+  return
+end subroutine sub
+
+recursive subroutine a()
+external f 
+call sub(f)
+end
+
+program external_07
+  call a()
+end

--- a/integration_tests/external_08.f90
+++ b/integration_tests/external_08.f90
@@ -1,0 +1,33 @@
+subroutine b(f,g)
+    ! f, g are functions
+    call f(1.39)
+    call g(-9.16)
+end subroutine
+
+subroutine f(x)
+    real :: x
+    print *, x
+    if (abs(x - 1.39) > 1e-8) error stop
+end subroutine
+
+subroutine g(x)
+    real :: x
+    print *, x
+    if (abs(x - (-9.16)) > 1e-8) error stop
+end subroutine
+
+subroutine a()
+interface
+    subroutine f(x)
+        real :: x
+    end subroutine
+    subroutine g(x)
+        real :: x
+    end subroutine
+end interface
+call b(f,g)
+end subroutine
+
+program external_08
+call a()
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7868,6 +7868,12 @@ public:
                     if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Implementation) {
                         LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
                         tmp = llvm_symtab_fn[h];
+                    } else if (llvm_symtab_fn_arg.find(h) == llvm_symtab_fn_arg.end() &&
+                                ASR::is_a<ASR::Function_t>(*var_sym) &&
+                                ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface ) {
+                        LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
+                        tmp = llvm_symtab_fn[h];
+                        LCOMPILERS_ASSERT(tmp != nullptr)
                     } else {
                         // Must be an argument/chained procedure pass
                         LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());

--- a/tests/external_04.f90
+++ b/tests/external_04.f90
@@ -1,0 +1,5 @@
+subroutine a()
+external f, g
+
+call b(f, g)
+end

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-external_03-c3442bb",
+    "cmd": "lfortran --show-llvm --implicit-typing --implicit-interface {infile} -o {outfile}",
+    "infile": "tests/external_03.f90",
+    "infile_hash": "82ee198be6d031398277671c0c2f48a832124a1458e94c3317d080ba",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-external_03-c3442bb.stdout",
+    "stdout_hash": "60379731371935c4f30469f1b287b1929fc8d1423e036c5141d77bc9",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -1,0 +1,46 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@2 = private unnamed_addr constant [9 x i8] c"%13.8e%s\00", align 1
+
+define void @a(float (float*)* %f) {
+.entry:
+  %call_arg_value = alloca float, align 4
+  %r = alloca float, align 4
+  store float 2.000000e+00, float* %call_arg_value, align 4
+  %0 = call float %f(float* %call_arg_value)
+  store float %0, float* %r, align 4
+  %1 = load float, float* %r, align 4
+  %2 = fpext float %1 to double
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), double %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+declare float @f(float*)
+
+define void @b() {
+.entry:
+  call void @a(float (float*)* @f.1)
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+declare float @f.1(float*)
+
+declare void @_lfortran_printf(i8*, ...)
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  call void @_lpython_set_argv(i32 %0, i8** %1)
+  call void @b()
+  ret i32 0
+}
+
+declare void @_lpython_set_argv(i32, i8**)

--- a/tests/reference/llvm-external_04-30bc1c7.json
+++ b/tests/reference/llvm-external_04-30bc1c7.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-external_04-30bc1c7",
+    "cmd": "lfortran --show-llvm --implicit-typing --implicit-interface {infile} -o {outfile}",
+    "infile": "tests/external_04.f90",
+    "infile_hash": "a5c33c0669ed285af4ed4856e01d35a773adcd4be529adc807f976c5",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-external_04-30bc1c7.stdout",
+    "stdout_hash": "e765e3f184d0c44ea7a6ee624caa70ab2d916ffbf2dbce0589648787",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-external_04-30bc1c7.stdout
+++ b/tests/reference/llvm-external_04-30bc1c7.stdout
@@ -1,0 +1,17 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+define void @a() {
+.entry:
+  call void @b(float ()* @f, float ()* @g)
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+declare void @b(float ()*, float ()*)
+
+declare float @f()
+
+declare float @g()

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2920,6 +2920,11 @@ asr_implicit_interface_and_typing_with_llvm = true
 [[test]]
 filename = "external_03.f90"
 asr_implicit_interface_and_typing = true
+asr_implicit_interface_and_typing_with_llvm = true
+
+[[test]]
+filename = "external_04.f90"
+asr_implicit_interface_and_typing_with_llvm = true
 
 [[test]]
 filename = "dimension_attr2.f90"


### PR DESCRIPTION
Fixes #1977. Fixes #2748. Fixes #2427