### PR TITLE
Handle template binary operations with different types 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -958,6 +958,7 @@ RUN(NAME conv_complex2real LABELS gfortran llvm wasm)
 
 RUN(NAME template_01 LABELS llvm wasm)
 RUN(NAME template_02 LABELS llvm)
+RUN(NAME template_03 LABELS llvm)
 RUN(NAME template_add_01 LABELS llvm wasm)
 RUN(NAME template_add_01b LABELS llvm wasm)
 RUN(NAME template_add_01c LABELS llvm wasm)

--- a/integration_tests/template_03.f90
+++ b/integration_tests/template_03.f90
@@ -35,7 +35,6 @@ module template_03_m
         integer, parameter :: sp = kind(1.0), dp = kind(1.d0)
         instantiate axpy_tmpl(real, integer, real, real, operator(+), operator(*))
         real :: a
-        real(dp) :: b
         integer :: x(3)
         real :: y(3)
         a = 0.5

--- a/integration_tests/template_03.f90
+++ b/integration_tests/template_03.f90
@@ -1,0 +1,53 @@
+module template_03_m
+
+    requirement op(T, U, V, op)
+      type, deferred :: T
+      type, deferred :: U
+      type, deferred :: V
+      interface
+        elemental function op(a, b)
+          type(T), intent(in) :: a
+          type(U), intent(in) :: b
+          type(V) :: op
+        end function
+      end interface
+    end requirement
+    
+    template axpy_tmpl(T, U, V, W, plus, times)
+      public :: axpy
+      require :: op(V, W, V, plus)
+      require :: op(T, U, W, times)
+    contains
+      subroutine axpy(a, x, y)
+        type(T), intent(in) :: a
+        type(U), intent(in) :: x(:)
+        type(V), intent(inout) :: y(:)
+        integer :: i
+        do i = 1, size(x)
+            y(i) = plus(y(i), times(a, x(i)))
+        end do
+      end subroutine
+    end template
+    
+    contains
+    
+    subroutine f()
+        integer, parameter :: sp = kind(1.0), dp = kind(1.d0)
+        instantiate axpy_tmpl(real, integer, real, real, operator(+), operator(*))
+        real :: a
+        real(dp) :: b
+        integer :: x(3)
+        real :: y(3)
+        a = 0.5
+        x = 2
+        y = 0
+        call axpy(a, x, y)
+        print *, y
+    end subroutine
+    
+end module
+    
+program template_03
+use template_03_m, only: f
+call f()
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2716,16 +2716,6 @@ public:
                     + "' was not declared", x.base.base.loc);
             }
 
-            /*
-            ASR::symbol_t *requires_arg_sym = current_scope->resolve_symbol(requires_arg);
-            context_map[requirement_arg] = requires_arg;
-            if (!requires_arg_sym) {
-                ASR::symbol_t *requirement_arg_sym = (req->m_symtab)->get_symbol(requirement_arg);
-                requires_arg_sym = replace_symbol(requirement_arg_sym, requires_arg);
-                current_scope->add_symbol(requires_arg, requires_arg_sym);
-            }
-            */
-
             ASR::symbol_t *param_sym = (req->m_symtab)->get_symbol(req_param);
 
             if (std::find(primitives.begin(),
@@ -2994,20 +2984,10 @@ public:
                         throw SemanticError("The restriction " + f_name
                             + " does not have 2 parameters", x.base.base.loc);
                     }
-                    ASR::ttype_t *ltype = ASRUtils::subs_expr_type(type_subs, f->m_args[0]);
-                    ASR::ttype_t *rtype = ASRUtils::subs_expr_type(type_subs, f->m_args[1]);
+
+                    ASR::ttype_t *left_type = ASRUtils::subs_expr_type(type_subs, f->m_args[0]);
+                    ASR::ttype_t *right_type = ASRUtils::subs_expr_type(type_subs, f->m_args[1]);
                     ASR::ttype_t *ftype = ASRUtils::subs_expr_type(type_subs, f->m_return_var);
-                    if (is_binop) {
-                        if (!ASRUtils::check_equal_type(ltype, rtype) || !ASRUtils::check_equal_type(rtype, ftype)) {
-                            throw SemanticError("Intrinsic operator "+ op_name + " does not apply to "
-                                "arguments of different types", x.base.base.loc);
-                        }
-                    } else if (is_cmpop) {
-                        if (!ASRUtils::check_equal_type(ltype, rtype) || !ASRUtils::is_logical(*ftype)) {
-                            throw SemanticError("Intrinsic operator " + op_name +
-                                " requires same-typed arguments and a logical return type", x.base.base.loc);
-                        }
-                    }
 
                     SymbolTable *parent_scope = current_scope;
                     current_scope = al.make_new<SymbolTable>(parent_scope);
@@ -3016,30 +2996,44 @@ public:
                     for (size_t i=0; i<2; i++) {
                         std::string var_name = "arg" + std::to_string(i);
                         ASR::asr_t *v = ASR::make_Variable_t(al, x.base.base.loc, current_scope,
-                            s2c(al, var_name), nullptr, 0, ASR::intentType::In, nullptr, nullptr,
-                            ASR::storage_typeType::Default, ASRUtils::duplicate_type(al, ltype),
-                            nullptr,
-                            ASR::abiType::Source, ASR::accessType::Private,
+                            s2c(al, var_name), nullptr, 0, ASR::intentType::In, nullptr,
+                            nullptr, ASR::storage_typeType::Default,
+                            (i == 0 ? ASRUtils::duplicate_type(al, left_type)
+                                : ASRUtils::duplicate_type(al, right_type)),
+                            nullptr, ASR:: abiType::Source, ASR::accessType::Private,
                             ASR::presenceType::Required, false);
                         current_scope->add_symbol(var_name, ASR::down_cast<ASR::symbol_t>(v));
                         ASR::symbol_t *var = current_scope->get_symbol(var_name);
                         args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, var)));
                     }
 
-                    std::string func_name = op_name + "_intrinsic_" + ASRUtils::type_to_str(ltype);
+                    std::string func_name = op_name + "_intrinsic_" + ASRUtils::type_to_str(left_type);
                     ASR::ttype_t *return_type = nullptr;
                     ASR::expr_t *value = nullptr;
-                    ASR::expr_t *lexpr = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
+                    ASR::expr_t *left = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                         current_scope->get_symbol("arg0")));
-                    ASR::expr_t *rexpr = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
+                    ASR::expr_t *right = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                         current_scope->get_symbol("arg1")));
 
+                    ASR::expr_t **conversion_cand = &left;
+                    ASR::ttype_t *source_type = left_type;
+                    ASR::ttype_t *dest_type = right_type;
+
                     if (is_binop) {
-                        value = ASRUtils::EXPR(ASRUtils::make_Binop_util(al, x.base.base.loc, binop, lexpr, rexpr, ltype));
-                        return_type = ASRUtils::duplicate_type(al, ltype);
+                        ImplicitCastRules::find_conversion_candidate(&left, &right, left_type,
+                                                                     right_type, conversion_cand,
+                                                                     &source_type, &dest_type);
+                        ImplicitCastRules::set_converted_value(al, x.base.base.loc, conversion_cand,
+                                                               source_type, dest_type);
+                        return_type = ASRUtils::duplicate_type(al, ftype);
+                        value = ASRUtils::EXPR(ASRUtils::make_Binop_util(al, x.base.base.loc, binop, left, right, dest_type));
+                        if (!ASRUtils::check_equal_type(dest_type, return_type)) {
+                            throw SemanticError("Unapplicable types for intrinsic operator " + op_name,
+                                x.base.base.loc);
+                        }
                     } else {
-                        value = ASRUtils::EXPR(ASRUtils::make_Cmpop_util(al, x.base.base.loc, cmpop, lexpr, rexpr, ltype));
                         return_type = ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, 4));
+                        value = ASRUtils::EXPR(ASRUtils::make_Cmpop_util(al, x.base.base.loc, cmpop, left, right, left_type));
                     }
 
                     ASR::asr_t *return_v = ASR::make_Variable_t(al, x.base.base.loc,

--- a/tests/reference/asr-template_03-6afb845.json
+++ b/tests/reference/asr-template_03-6afb845.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-template_03-6afb845",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/template_03.f90",
+    "infile_hash": "0b7e013156154f496bd2be289d3816bafbf95c75d2bd614322242fb4",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-template_03-6afb845.stdout",
+    "stdout_hash": "2f5e0256e0af254cbbbf2b4b399ee4e6bf66091a1336b273da9a1813",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-template_03-6afb845.json
+++ b/tests/reference/asr-template_03-6afb845.json
@@ -2,11 +2,11 @@
     "basename": "asr-template_03-6afb845",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/template_03.f90",
-    "infile_hash": "0b7e013156154f496bd2be289d3816bafbf95c75d2bd614322242fb4",
+    "infile_hash": "58b6ec4d6cf448b1aabceb4447e834d0d2e8f5a98058e37b48e86976",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_03-6afb845.stdout",
-    "stdout_hash": "2f5e0256e0af254cbbbf2b4b399ee4e6bf66091a1336b273da9a1813",
+    "stdout_hash": "8cf7c8ab567baf67c09ccf0edbcc9aa2bc025fcf2bad90952b9e310b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_03-6afb845.stdout
+++ b/tests/reference/asr-template_03-6afb845.stdout
@@ -710,22 +710,6 @@
                                                     .false.
                                                     ()
                                                 ),
-                                            b:
-                                                (Variable
-                                                    9
-                                                    b
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 8)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
                                             dp:
                                                 (Variable
                                                     9

--- a/tests/reference/asr-template_03-6afb845.stdout
+++ b/tests/reference/asr-template_03-6afb845.stdout
@@ -1,0 +1,1355 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            lfortran_intrinsic_kind:
+                (IntrinsicModule lfortran_intrinsic_kind),
+            template_03:
+                (Program
+                    (SymbolTable
+                        22
+                        {
+                            f:
+                                (ExternalSymbol
+                                    22
+                                    f
+                                    2 f
+                                    template_03_m
+                                    []
+                                    f
+                                    Public
+                                )
+                        })
+                    template_03
+                    [template_03_m]
+                    [(SubroutineCall
+                        22 f
+                        ()
+                        []
+                        ()
+                    )]
+                ),
+            template_03_m:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            axpy_tmpl:
+                                (Template
+                                    (SymbolTable
+                                        5
+                                        {
+                                            axpy:
+                                                (Function
+                                                    (SymbolTable
+                                                        8
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    8
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            i:
+                                                                (Variable
+                                                                    8
+                                                                    i
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            x:
+                                                                (Variable
+                                                                    8
+                                                                    x
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            u
+                                                                        )
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            y:
+                                                                (Variable
+                                                                    8
+                                                                    y
+                                                                    []
+                                                                    InOut
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            v
+                                                                        )
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    axpy
+                                                    (FunctionType
+                                                        [(TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                u
+                                                            )
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                v
+                                                            )
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        ()
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [times
+                                                    plus]
+                                                    [(Var 8 a)
+                                                    (Var 8 x)
+                                                    (Var 8 y)]
+                                                    [(DoLoop
+                                                        ()
+                                                        ((Var 8 i)
+                                                        (IntegerConstant 1 (Integer 4))
+                                                        (ArraySize
+                                                            (Var 8 x)
+                                                            ()
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ())
+                                                        [(=
+                                                            (ArrayItem
+                                                                (Var 8 y)
+                                                                [(()
+                                                                (Var 8 i)
+                                                                ())]
+                                                                (TypeParameter
+                                                                    v
+                                                                )
+                                                                ColMajor
+                                                                ()
+                                                            )
+                                                            (FunctionCall
+                                                                5 plus
+                                                                ()
+                                                                [((ArrayItem
+                                                                    (Var 8 y)
+                                                                    [(()
+                                                                    (Var 8 i)
+                                                                    ())]
+                                                                    (TypeParameter
+                                                                        v
+                                                                    )
+                                                                    ColMajor
+                                                                    ()
+                                                                ))
+                                                                ((FunctionCall
+                                                                    5 times
+                                                                    ()
+                                                                    [((Var 8 a))
+                                                                    ((ArrayItem
+                                                                        (Var 8 x)
+                                                                        [(()
+                                                                        (Var 8 i)
+                                                                        ())]
+                                                                        (TypeParameter
+                                                                            u
+                                                                        )
+                                                                        ColMajor
+                                                                        ()
+                                                                    ))]
+                                                                    (TypeParameter
+                                                                        w
+                                                                    )
+                                                                    ()
+                                                                    ()
+                                                                ))]
+                                                                (TypeParameter
+                                                                    v
+                                                                )
+                                                                ()
+                                                                ()
+                                                            )
+                                                            ()
+                                                        )]
+                                                    )]
+                                                    ()
+                                                    Public
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            plus:
+                                                (Function
+                                                    (SymbolTable
+                                                        6
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    6
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        v
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    6
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        w
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            op:
+                                                                (Variable
+                                                                    6
+                                                                    op
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        v
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    plus
+                                                    (FunctionType
+                                                        [(TypeParameter
+                                                            v
+                                                        )
+                                                        (TypeParameter
+                                                            w
+                                                        )]
+                                                        (TypeParameter
+                                                            v
+                                                        )
+                                                        Source
+                                                        Interface
+                                                        ()
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 6 a)
+                                                    (Var 6 b)]
+                                                    []
+                                                    (Var 6 op)
+                                                    Public
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            t:
+                                                (Variable
+                                                    5
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        t
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            times:
+                                                (Function
+                                                    (SymbolTable
+                                                        7
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    7
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    7
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        u
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            op:
+                                                                (Variable
+                                                                    7
+                                                                    op
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        w
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    times
+                                                    (FunctionType
+                                                        [(TypeParameter
+                                                            t
+                                                        )
+                                                        (TypeParameter
+                                                            u
+                                                        )]
+                                                        (TypeParameter
+                                                            w
+                                                        )
+                                                        Source
+                                                        Interface
+                                                        ()
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 7 a)
+                                                    (Var 7 b)]
+                                                    []
+                                                    (Var 7 op)
+                                                    Public
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            u:
+                                                (Variable
+                                                    5
+                                                    u
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        u
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            v:
+                                                (Variable
+                                                    5
+                                                    v
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        v
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            w:
+                                                (Variable
+                                                    5
+                                                    w
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        w
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    axpy_tmpl
+                                    [t
+                                    u
+                                    v
+                                    w
+                                    plus
+                                    times]
+                                    [(Require
+                                        op
+                                        [v
+                                        w
+                                        plus]
+                                    )
+                                    (Require
+                                        op
+                                        [t
+                                        u
+                                        w
+                                        times]
+                                    )]
+                                ),
+                            f:
+                                (Function
+                                    (SymbolTable
+                                        9
+                                        {
+                                            a:
+                                                (Variable
+                                                    9
+                                                    a
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            axpy:
+                                                (Function
+                                                    (SymbolTable
+                                                        21
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    21
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            i:
+                                                                (Variable
+                                                                    21
+                                                                    i
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            x:
+                                                                (Variable
+                                                                    21
+                                                                    x
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Integer 4)
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            y:
+                                                                (Variable
+                                                                    21
+                                                                    y
+                                                                    []
+                                                                    InOut
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    axpy
+                                                    (FunctionType
+                                                        [(Real 4)
+                                                        (Array
+                                                            (Integer 4)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (Real 4)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        ()
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [~mul_intrinsic_real
+                                                    ~add_intrinsic_real]
+                                                    [(Var 21 a)
+                                                    (Var 21 x)
+                                                    (Var 21 y)]
+                                                    [(DoLoop
+                                                        ()
+                                                        ((Var 21 i)
+                                                        (IntegerConstant 1 (Integer 4))
+                                                        (ArraySize
+                                                            (Var 21 x)
+                                                            ()
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ())
+                                                        [(=
+                                                            (ArrayItem
+                                                                (Var 21 y)
+                                                                [(()
+                                                                (Var 21 i)
+                                                                ())]
+                                                                (Real 4)
+                                                                ColMajor
+                                                                ()
+                                                            )
+                                                            (FunctionCall
+                                                                9 ~add_intrinsic_real
+                                                                ()
+                                                                [((ArrayItem
+                                                                    (Var 21 y)
+                                                                    [(()
+                                                                    (Var 21 i)
+                                                                    ())]
+                                                                    (Real 4)
+                                                                    ColMajor
+                                                                    ()
+                                                                ))
+                                                                ((FunctionCall
+                                                                    9 ~mul_intrinsic_real
+                                                                    ()
+                                                                    [((Var 21 a))
+                                                                    ((ArrayItem
+                                                                        (Var 21 x)
+                                                                        [(()
+                                                                        (Var 21 i)
+                                                                        ())]
+                                                                        (Integer 4)
+                                                                        ColMajor
+                                                                        ()
+                                                                    ))]
+                                                                    (Real 4)
+                                                                    ()
+                                                                    ()
+                                                                ))]
+                                                                (Real 4)
+                                                                ()
+                                                                ()
+                                                            )
+                                                            ()
+                                                        )]
+                                                    )]
+                                                    ()
+                                                    Public
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            b:
+                                                (Variable
+                                                    9
+                                                    b
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            dp:
+                                                (Variable
+                                                    9
+                                                    dp
+                                                    []
+                                                    Local
+                                                    (FunctionCall
+                                                        9 kind
+                                                        ()
+                                                        [((RealConstant
+                                                            1.000000
+                                                            (Real 8)
+                                                        ))]
+                                                        (Integer 4)
+                                                        (IntegerConstant 8 (Integer 4))
+                                                        ()
+                                                    )
+                                                    (IntegerConstant 8 (Integer 4))
+                                                    Parameter
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            kind:
+                                                (ExternalSymbol
+                                                    9
+                                                    kind
+                                                    11 kind
+                                                    lfortran_intrinsic_kind
+                                                    []
+                                                    kind
+                                                    Private
+                                                ),
+                                            sp:
+                                                (Variable
+                                                    9
+                                                    sp
+                                                    []
+                                                    Local
+                                                    (FunctionCall
+                                                        9 kind
+                                                        ()
+                                                        [((RealConstant
+                                                            1.000000
+                                                            (Real 4)
+                                                        ))]
+                                                        (Integer 4)
+                                                        (IntegerConstant 4 (Integer 4))
+                                                        ()
+                                                    )
+                                                    (IntegerConstant 4 (Integer 4))
+                                                    Parameter
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            x:
+                                                (Variable
+                                                    9
+                                                    x
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Integer 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 3 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            y:
+                                                (Variable
+                                                    9
+                                                    y
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 3 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            ~add_intrinsic_real:
+                                                (Function
+                                                    (SymbolTable
+                                                        19
+                                                        {
+                                                            arg0:
+                                                                (Variable
+                                                                    19
+                                                                    arg0
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            arg1:
+                                                                (Variable
+                                                                    19
+                                                                    arg1
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ret:
+                                                                (Variable
+                                                                    19
+                                                                    ret
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    ~add_intrinsic_real
+                                                    (FunctionType
+                                                        [(Real 4)
+                                                        (Real 4)]
+                                                        (Real 4)
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    []
+                                                    [(Var 19 arg0)
+                                                    (Var 19 arg1)]
+                                                    [(=
+                                                        (Var 19 ret)
+                                                        (RealBinOp
+                                                            (Var 19 arg0)
+                                                            Add
+                                                            (Var 19 arg1)
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )]
+                                                    (Var 19 ret)
+                                                    Public
+                                                    .false.
+                                                    .true.
+                                                    ()
+                                                ),
+                                            ~mul_intrinsic_real:
+                                                (Function
+                                                    (SymbolTable
+                                                        20
+                                                        {
+                                                            arg0:
+                                                                (Variable
+                                                                    20
+                                                                    arg0
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            arg1:
+                                                                (Variable
+                                                                    20
+                                                                    arg1
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ret:
+                                                                (Variable
+                                                                    20
+                                                                    ret
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    ~mul_intrinsic_real
+                                                    (FunctionType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        (Real 4)
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    []
+                                                    [(Var 20 arg0)
+                                                    (Var 20 arg1)]
+                                                    [(=
+                                                        (Var 20 ret)
+                                                        (RealBinOp
+                                                            (Var 20 arg0)
+                                                            Mul
+                                                            (Cast
+                                                                (Var 20 arg1)
+                                                                IntegerToReal
+                                                                (Real 4)
+                                                                ()
+                                                            )
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )]
+                                                    (Var 20 ret)
+                                                    Public
+                                                    .false.
+                                                    .true.
+                                                    ()
+                                                )
+                                        })
+                                    f
+                                    (FunctionType
+                                        []
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    []
+                                    [(=
+                                        (Var 9 a)
+                                        (RealConstant
+                                            0.500000
+                                            (Real 4)
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 9 x)
+                                        (ArrayBroadcast
+                                            (IntegerConstant 2 (Integer 4))
+                                            (ArrayConstant
+                                                [(IntegerConstant 3 (Integer 4))]
+                                                (Array
+                                                    (Integer 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 1 (Integer 4)))]
+                                                    FixedSizeArray
+                                                )
+                                                ColMajor
+                                            )
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 3 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            (ArrayConstant
+                                                [(IntegerConstant 2 (Integer 4))
+                                                (IntegerConstant 2 (Integer 4))
+                                                (IntegerConstant 2 (Integer 4))]
+                                                (Array
+                                                    (Integer 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 3 (Integer 4)))]
+                                                    FixedSizeArray
+                                                )
+                                                ColMajor
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 9 y)
+                                        (ArrayBroadcast
+                                            (Cast
+                                                (IntegerConstant 0 (Integer 4))
+                                                IntegerToReal
+                                                (Real 4)
+                                                (RealConstant
+                                                    0.000000
+                                                    (Real 4)
+                                                )
+                                            )
+                                            (ArrayConstant
+                                                [(IntegerConstant 3 (Integer 4))]
+                                                (Array
+                                                    (Integer 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 1 (Integer 4)))]
+                                                    FixedSizeArray
+                                                )
+                                                ColMajor
+                                            )
+                                            (Array
+                                                (Real 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 3 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            (ArrayConstant
+                                                [(Cast
+                                                    (IntegerConstant 0 (Integer 4))
+                                                    IntegerToReal
+                                                    (Real 4)
+                                                    (RealConstant
+                                                        0.000000
+                                                        (Real 4)
+                                                    )
+                                                )
+                                                (Cast
+                                                    (IntegerConstant 0 (Integer 4))
+                                                    IntegerToReal
+                                                    (Real 4)
+                                                    (RealConstant
+                                                        0.000000
+                                                        (Real 4)
+                                                    )
+                                                )
+                                                (Cast
+                                                    (IntegerConstant 0 (Integer 4))
+                                                    IntegerToReal
+                                                    (Real 4)
+                                                    (RealConstant
+                                                        0.000000
+                                                        (Real 4)
+                                                    )
+                                                )]
+                                                (Array
+                                                    (Real 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 3 (Integer 4)))]
+                                                    FixedSizeArray
+                                                )
+                                                ColMajor
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (SubroutineCall
+                                        9 axpy
+                                        ()
+                                        [((Var 9 a))
+                                        ((ArrayPhysicalCast
+                                            (Var 9 x)
+                                            FixedSizeArray
+                                            DescriptorArray
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 3 (Integer 4)))]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))
+                                        ((ArrayPhysicalCast
+                                            (Var 9 y)
+                                            FixedSizeArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 3 (Integer 4)))]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))]
+                                        ()
+                                    )
+                                    (Print
+                                        [(Var 9 y)]
+                                        ()
+                                        ()
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            op:
+                                (Requirement
+                                    (SymbolTable
+                                        3
+                                        {
+                                            op:
+                                                (Function
+                                                    (SymbolTable
+                                                        4
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    4
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    4
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        u
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            op:
+                                                                (Variable
+                                                                    4
+                                                                    op
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        v
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Public
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    op
+                                                    (FunctionType
+                                                        [(TypeParameter
+                                                            t
+                                                        )
+                                                        (TypeParameter
+                                                            u
+                                                        )]
+                                                        (TypeParameter
+                                                            v
+                                                        )
+                                                        Source
+                                                        Interface
+                                                        ()
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 4 a)
+                                                    (Var 4 b)]
+                                                    []
+                                                    (Var 4 op)
+                                                    Public
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            t:
+                                                (Variable
+                                                    3
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        t
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            u:
+                                                (Variable
+                                                    3
+                                                    u
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        u
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            v:
+                                                (Variable
+                                                    3
+                                                    v
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        v
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    op
+                                    [t
+                                    u
+                                    v
+                                    op]
+                                    []
+                                )
+                        })
+                    template_03_m
+                    [lfortran_intrinsic_kind
+                    template_03_m]
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -97,6 +97,10 @@ asr = true
 ast = true
 
 [[test]]
+filename = "../integration_tests/template_03.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/template_struct_01.f90"
 asr = true
 ast = true


### PR DESCRIPTION
I got the program mentioned in https://github.com/lfortran/lfortran/issues/2771 to work with different types real and integer.
```
subroutine f()
  ...
  instantiate axpy_tmpl(real, integer, real, real, operator(+), operator(*))
  ...
end subroutine
```