### PR TITLE
SIMD: C: Fix memory issue and enable matmul_01

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1174,7 +1174,7 @@ RUN(NAME precision_02 LABELS gfortran) # TODO fix this test
 RUN(NAME array_unbounded_01 LABELS gfortran llvm llvmStackArray)
 RUN(NAME array_unbounded_02 LABELS gfortran llvm llvmStackArray)
 
-RUN(NAME matmul_01 LABELS gfortran llvm EXTRA_ARGS --ignore-pragma)
+RUN(NAME matmul_01 LABELS gfortran llvm c EXTRA_ARGS --ignore-pragma)
 RUN(NAME matmul_02 LABELS gfortran)
 RUN(NAME simd_01 LABELS gfortran c NOFAST)
 RUN(NAME simd_02 LABELS gfortran c NOFAST)

--- a/integration_tests/matmul_01.f90
+++ b/integration_tests/matmul_01.f90
@@ -139,6 +139,7 @@ integer, parameter :: dp = kind(0.d0)
 integer :: n, iter, i
 real(dp) :: t1, t2, t, GHz, fma_clock, freq, measured, percent_peak
 real, allocatable :: A(:,:), B(:,:), C(:,:), C2(:,:)
+real :: err
 
 ! Use n = 960 for a good benchmark
 n = 96
@@ -179,7 +180,8 @@ do i = 1, iter
     call matmul2(A, B, C2)
 end do
 call cpu_time(t2)
-print *, "Error:", maxval(abs(C-C2))
+err = maxval(abs(C-C2))
+print *, "Error:", err
 t = (t2-t1)/iter
 GHz = 1e9_dp
 fma_clock = 0.0625_dp
@@ -191,6 +193,7 @@ print *, "Clock cycles per element:"
 print *, "Theoretical performance peak:", fma_clock, "cycles"
 print *, "Measured:                    ", measured, "cycles"
 print *, "Percent peak:                ", percent_peak, "%"
+if (err > 1e-4) error stop
 
 print *
 print *, "matmul1:"
@@ -199,7 +202,8 @@ do i = 1, iter
     call matmul1(A, B, C2)
 end do
 call cpu_time(t2)
-print *, "Error:", maxval(abs(C-C2))
+err = maxval(abs(C-C2))
+print *, "Error:", err
 t = (t2-t1)/iter
 GHz = 1e9_dp
 fma_clock = 0.0625_dp
@@ -211,5 +215,6 @@ print *, "Clock cycles per element:"
 print *, "Theoretical performance peak:", fma_clock, "cycles"
 print *, "Measured:                    ", measured, "cycles"
 print *, "Percent peak:                ", percent_peak, "%"
+if (err > 1e-4) error stop
 
 end program

--- a/integration_tests/matmul_02.f90
+++ b/integration_tests/matmul_02.f90
@@ -177,6 +177,7 @@ integer, parameter :: dp = kind(0.d0)
 integer :: n, iter, i
 real(dp) :: t1, t2, t, GHz, fma_clock, freq, measured, percent_peak
 real, allocatable :: A(:,:), B(:,:), C(:,:), C2(:,:)
+real :: err
 
 ! Use n=960 for a good benchmark
 n = 96
@@ -215,7 +216,8 @@ do i = 1, iter
     call matmul7(A, B, C2)
 end do
 call cpu_time(t2)
-print *, "Error:", maxval(abs(C-C2))
+err = maxval(abs(C-C2))
+print *, "Error:", err
 t = (t2-t1)/iter
 GHz = 1e9_dp
 fma_clock = 0.0625_dp
@@ -227,6 +229,7 @@ print *, "Clock cycles per element:"
 print *, "Theoretical performance peak:", fma_clock, "cycles"
 print *, "Measured:                    ", measured, "cycles"
 print *, "Percent peak:                ", percent_peak, "%"
+if (err > 1e-4) error stop
 
 print *
 print *, "matmul1:"
@@ -235,7 +238,8 @@ do i = 1, iter
     call matmul1(A, B, C2)
 end do
 call cpu_time(t2)
-print *, "Error:", maxval(abs(C-C2))
+err = maxval(abs(C-C2))
+print *, "Error:", err
 t = (t2-t1)/iter
 GHz = 1e9_dp
 fma_clock = 0.0625_dp
@@ -247,5 +251,6 @@ print *, "Clock cycles per element:"
 print *, "Theoretical performance peak:", fma_clock, "cycles"
 print *, "Measured:                    ", measured, "cycles"
 print *, "Percent peak:                ", percent_peak, "%"
+if (err > 1e-4) error stop
 
 end program

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -2615,7 +2615,7 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
                     } else {
                         l = "1";
                     }
-                    size_str += "*" + l;
+                    size_str += "*" + sym + "->dims[" + std::to_string(j) + "].length";
                     out += indent + sym + "->dims[" + std::to_string(j) + "].lower_bound = ";
                     out += st + ";\n";
                     out += indent + sym + "->dims[" + std::to_string(j) + "].length = ";

--- a/tests/reference/asr-matmul_01-7b0b0c2.json
+++ b/tests/reference/asr-matmul_01-7b0b0c2.json
@@ -2,11 +2,11 @@
     "basename": "asr-matmul_01-7b0b0c2",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/matmul_01.f90",
-    "infile_hash": "1b7adac0d66138d6eed440c0ab5aaad8cbb9f3119a3759df3ed4fa4b",
+    "infile_hash": "24655aaf38792131e6094029a5b6e4beabb1b00c5481954501573308",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matmul_01-7b0b0c2.stdout",
-    "stdout_hash": "be5d7151533febfcee3723fec2e485197f2ad73ca45114ba54a04d78",
+    "stdout_hash": "0d9e59e9e8e3cf19f004ef2b815819e6fca6c11fe8bb1cb0d825fe17",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matmul_01-7b0b0c2.stdout
+++ b/tests/reference/asr-matmul_01-7b0b0c2.stdout
@@ -153,6 +153,22 @@
                                     Required
                                     .false.
                                 ),
+                            err:
+                                (Variable
+                                    6
+                                    err
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             fma_clock:
                                 (Variable
                                     6
@@ -759,11 +775,8 @@
                         [((Var 6 t2))]
                         ()
                     )
-                    (Print
-                        [(StringConstant
-                            "Error:"
-                            (Character 1 6 ())
-                        )
+                    (=
+                        (Var 6 err)
                         (IntrinsicArrayFunction
                             MaxVal
                             [(IntrinsicScalarFunction
@@ -796,7 +809,15 @@
                             0
                             (Real 4)
                             ()
-                        )]
+                        )
+                        ()
+                    )
+                    (Print
+                        [(StringConstant
+                            "Error:"
+                            (Character 1 6 ())
+                        )
+                        (Var 6 err)]
                         ()
                         ()
                     )
@@ -960,6 +981,22 @@
                         )]
                         ()
                         ()
+                    )
+                    (If
+                        (RealCompare
+                            (Var 6 err)
+                            Gt
+                            (RealConstant
+                                0.000100
+                                (Real 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
                     )
                     (Print
                         []
@@ -1001,11 +1038,8 @@
                         [((Var 6 t2))]
                         ()
                     )
-                    (Print
-                        [(StringConstant
-                            "Error:"
-                            (Character 1 6 ())
-                        )
+                    (=
+                        (Var 6 err)
                         (IntrinsicArrayFunction
                             MaxVal
                             [(IntrinsicScalarFunction
@@ -1038,7 +1072,15 @@
                             0
                             (Real 4)
                             ()
-                        )]
+                        )
+                        ()
+                    )
+                    (Print
+                        [(StringConstant
+                            "Error:"
+                            (Character 1 6 ())
+                        )
+                        (Var 6 err)]
                         ()
                         ()
                     )
@@ -1202,6 +1244,22 @@
                         )]
                         ()
                         ()
+                    )
+                    (If
+                        (RealCompare
+                            (Var 6 err)
+                            Gt
+                            (RealConstant
+                                0.000100
+                                (Real 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
                     )
                     (ImplicitDeallocate
                         [(Var 6 a)


### PR DESCRIPTION
The memory fix is taken from https://github.com/lfortran/lfortran/pull/2865.