### PR TITLE
[LLVM] Initial implementation for BitCast

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1217,3 +1217,6 @@ RUN(NAME selected_int_kind_01 LABELS gfortran llvm)
 RUN(NAME capital_01 LABELS gfortran llvmImplicit)
 
 RUN(NAME do_concurrent_01 LABELS gfortran llvm)
+
+RUN(NAME transfer_01 LABELS gfortran llvm)
+RUN(NAME transfer_02 LABELS gfortran)

--- a/integration_tests/transfer_01.f90
+++ b/integration_tests/transfer_01.f90
@@ -1,0 +1,25 @@
+program transfer_01
+    implicit none
+    integer :: i, integer_result, y(3, 2)
+    real :: r, result, x(5, 4)
+    r = 2.987654
+    i = 123456
+    x = 3.19
+    y = 4
+
+    result = transfer(i, r)
+    print *, result
+    if (abs(result - 1.72998703e-40) > 1e-6) error stop
+
+    integer_result = transfer(r, i)
+    print *, integer_result
+    if (integer_result /= 1077884345) error stop
+
+    integer_result = transfer(x(5,2), i)
+    print *, integer_result
+    if (integer_result /= 1078733046) error stop
+
+    result = transfer(y(1,1), x(5,2))
+    print *, result
+    if (abs(result - 5.60519386E-45) > 1e-6) error stop
+end program transfer_01

--- a/integration_tests/transfer_02.f90
+++ b/integration_tests/transfer_02.f90
@@ -1,0 +1,16 @@
+program transfer_02
+    integer :: result
+    double precision :: d
+    complex :: result1
+    real :: r
+
+    d = 3.14D0
+    result = transfer(d, result)
+    print *, result
+    if (result /= 1374389535) error stop
+
+    r = 1.0
+    result1 = transfer(r, result1)
+    print *, result1
+    if( real(result1) /= 1.0 ) error stop
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6659,6 +6659,21 @@ public:
         tmp = CreateLoad(result);
     }
 
+    void visit_BitCast(const ASR::BitCast_t& x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+
+        this->visit_expr_wrapper(x.m_source, true);
+        llvm::Value* source = tmp;
+        llvm::Type* source_type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::expr_type(x.m_source), module.get());
+        llvm::Value* source_ptr = CreateAlloca(source_type, nullptr, "bitcast_source");
+        builder->CreateStore(source, source_ptr);
+        llvm::Type* target_llvm_type = llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get())->getPointerTo();
+        tmp = LLVM::CreateLoad(*builder, builder->CreateBitCast(source_ptr, target_llvm_type));
+    }
+
     void visit_Cast(const ASR::Cast_t &x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);


### PR DESCRIPTION
Fixes #2875. I am not sure if this is correct approach. For 
```fortran
program main
    implicit none
    integer :: i = 123456
    real :: r
    real :: result

    result = transfer(i, r)
    print *, result
end program main
```

> LFortran

```console
% lfortran a.f90 
1.23456000e+05
```

> GFortran

```console
% gfortran a.f90 && ./a.out
   1.72998703E-40
```

I feel output of GFortran is incorrect. 