### PR TITLE
Apply legacy array sections on arguments of function call

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1200,6 +1200,7 @@ RUN(NAME simd_01 LABELS gfortran c llvm llvm_nopragma c_nopragma)
 RUN(NAME simd_02 LABELS gfortran c llvm llvm_nopragma c_nopragma)
 RUN(NAME legacy_array_sections_01 LABELS gfortran llvm llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_02 LABELS gfortran llvm llvmStackArray EXTRA_ARGS --legacy-array-sections)
+RUN(NAME legacy_array_sections_03 LABELS gfortran llvm EXTRA_ARGS --legacy-array-sections --implicit-interface)
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm)
 
 RUN(NAME ip_01 LABELS gfortran llvm)

--- a/integration_tests/legacy_array_sections_03.f90
+++ b/integration_tests/legacy_array_sections_03.f90
@@ -1,0 +1,24 @@
+DOUBLE PRECISION FUNCTION ddot_sl(dx)
+DOUBLE PRECISION dx(*)
+integer :: i
+do i = 1, 4
+    if (abs(dx(i) - 12.41d0) > 1e-10) error stop
+end do
+ddot_sl = dx(1)
+END
+
+SUBROUTINE slsqpb (n, a)
+INTEGER n
+external ddot_sl
+DOUBLE PRECISION a(n+1), ddot_sl, res
+print *, a
+res = ddot_sl(a(1))
+print *, res
+if (abs(res - 12.41d0) > 1e-10) error stop
+END
+
+program legacy_array_sections_03
+    double precision a(5)
+    a = 12.41d0
+    call slsqpb(4, a)
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2600,89 +2600,9 @@ public:
         bool nopass = false;
         switch (original_sym->type) {
             case (ASR::symbolType::Function) : {
-                f = ASR::down_cast<ASR::Function_t>(original_sym);
-                final_sym=original_sym;
+                final_sym = original_sym;
                 original_sym = nullptr;
-                if (compiler_options.legacy_array_sections) {
-                    // call b(w(icon)) -> call b(w(icon:)) if b is expecting an array
-                    ASR::FunctionType_t* f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
-                    std::map<int, ASR::ttype_t*> array_arg_idx;
-                    for (size_t i = 0; i < f->n_args; i++) {
-                        if (ASRUtils::is_array(ASRUtils::expr_type(f->m_args[i]))) {
-                            array_arg_idx[i] = f_type->m_arg_types[i];
-                        }
-                    }
-                    Vec<ASR::call_arg_t> args_with_array_section;
-                    args_with_array_section.reserve(al, args.size());
-                    for (size_t i = 0; i < args.size(); i++) {
-                        // check if i is in array_arg_idx
-                        if (array_arg_idx.find(i) != array_arg_idx.end()) {
-                            ASR::call_arg_t arg = args[i];
-                            ASR::ttype_t* expected_arg_type = ASRUtils::duplicate_type(al, array_arg_idx[i]);
-                            ASR::expr_t* arg_expr = arg.m_value;
-                            if (ASR::is_a<ASR::ArrayItem_t>(*arg_expr)) {
-                                ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(arg_expr);
-                                ASR::expr_t* array_expr = array_item->m_v;
-                                LCOMPILERS_ASSERT(array_item->n_args > 0);
-                                ASR::array_index_t last_arg = array_item->m_args[array_item->n_args - 1];
-                                ASR::expr_t* idx = last_arg.m_right;
-
-                                Vec<ASR::dimension_t> dims;
-                                dims.reserve(al, 1);
-                                ASR::dimension_t dim;
-                                dim.loc = x.base.base.loc;
-                                dim.m_length = nullptr;
-                                dim.m_start = nullptr;
-                                dims.push_back(al, dim);
-                                ASR::asr_t* descriptor_array = ASR::make_Array_t(al, x.base.base.loc, ASRUtils::type_get_past_array(expected_arg_type),
-                                                                dims.p, dims.size(), ASR::array_physical_typeType::DescriptorArray);
-
-                                ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(expected_arg_type);
-                                ASR::asr_t* expected_array = ASR::make_Array_t(al, x.base.base.loc, ASRUtils::type_get_past_array(expected_arg_type),
-                                                                array_t->m_dims, array_t->n_dims, ASRUtils::extract_physical_type(expected_arg_type));
-
-                                // make ArraySection
-                                Vec<ASR::array_index_t> array_indices;
-                                array_indices.reserve(al, array_item->n_args);
-
-                                for (size_t i = 0; i < array_item->n_args - 1; i++) {
-                                    array_indices.push_back(al, array_item->m_args[i]);
-                                }
-
-                                ASR::ttype_t *int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
-                                ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1, int32_type));
-
-                                ASR::expr_t* array_bound = ASRUtils::get_bound<SemanticError>(array_expr, array_item->n_args, "ubound", al);
-
-                                ASR::array_index_t array_idx;
-                                array_idx.loc = array_item->base.base.loc;
-                                array_idx.m_left = idx;
-                                array_idx.m_right = array_bound;
-                                array_idx.m_step = one;
-
-                                array_indices.push_back(al, array_idx);
-
-                                ASR::expr_t* array_section = ASRUtils::EXPR(ASR::make_ArraySection_t(al, array_item->base.base.loc,
-                                                            array_expr, array_indices.p, array_indices.size(),
-                                                            ASRUtils::TYPE(descriptor_array), nullptr));
-
-                                ASR::asr_t* array_cast = ASRUtils::make_ArrayPhysicalCast_t_util(al, array_item->base.base.loc, array_section,
-                                                        ASRUtils::extract_physical_type(ASRUtils::TYPE(descriptor_array)), ASRUtils::extract_physical_type(expected_arg_type), ASRUtils::TYPE(expected_array), nullptr);
-
-                                ASR::expr_t* array_section_cast = ASRUtils::EXPR(array_cast);
-
-                                arg.m_value = array_section_cast;
-
-                                args_with_array_section.push_back(al, arg);
-                            } else {
-                                args_with_array_section.push_back(al, args[i]);
-                            }
-                        } else {
-                            args_with_array_section.push_back(al, args[i]);
-                        }
-                    }
-                    args = args_with_array_section;
-                }
+                legacy_array_sections_helper(final_sym, args, x.base.base.loc);
                 break;
             }
             case (ASR::symbolType::GenericProcedure) : {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4861,7 +4861,7 @@ public:
                         empty_dim.m_length = nullptr;
                         empty_dims.push_back(al, empty_dim);
                     }
-                    var_type = ASRUtils::duplicate_type(al, var_type, &empty_dims, ASR::array_physical_typeType::PointerToDataArray, true);
+                    var_type = ASRUtils::duplicate_type(al, var_type, &empty_dims, ASR::array_physical_typeType::DescriptorArray, true);
                 }
                 SetChar variable_dependencies_vec;
                 variable_dependencies_vec.reserve(al, 1);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4850,18 +4850,25 @@ public:
                     var_type = ASRUtils::duplicate_type_with_empty_dims(al, var_type,
                         ASR::array_physical_typeType::PointerToDataArray, true);
                 } else if (ASR::is_a<ASR::ArrayItem_t>(*var_expr) && compiler_options.legacy_array_sections) {
-                    ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(var_expr);
-                    size_t n_dims = array_item->n_args;
-                    Vec<ASR::dimension_t> empty_dims;
-                    empty_dims.reserve(al, n_dims);
-                    for( size_t i = 0; i < n_dims; i++ ) {
-                        ASR::dimension_t empty_dim;
-                        empty_dim.loc = var_type->base.loc;
-                        empty_dim.m_start = nullptr;
-                        empty_dim.m_length = nullptr;
-                        empty_dims.push_back(al, empty_dim);
+                    ASR::symbol_t* func_sym = parent_scope->resolve_symbol(func_name);
+                    ASR::Function_t* func = nullptr;
+                    if (func_sym) {
+                        func = ASR::down_cast<ASR::Function_t>(func_sym);
                     }
-                    var_type = ASRUtils::duplicate_type(al, var_type, &empty_dims, ASR::array_physical_typeType::DescriptorArray, true);
+                    if (func && func->n_args > 0 && func->n_args <= x.n_args && ASRUtils::is_array(ASRUtils::expr_type(func->m_args[i]))) {
+                        ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(var_expr);
+                        size_t n_dims = array_item->n_args;
+                        Vec<ASR::dimension_t> empty_dims;
+                        empty_dims.reserve(al, n_dims);
+                        for( size_t i = 0; i < n_dims; i++ ) {
+                            ASR::dimension_t empty_dim;
+                            empty_dim.loc = var_type->base.loc;
+                            empty_dim.m_start = nullptr;
+                            empty_dim.m_length = nullptr;
+                            empty_dims.push_back(al, empty_dim);
+                        }
+                        var_type = ASRUtils::duplicate_type(al, var_type, &empty_dims, ASR::array_physical_typeType::DescriptorArray, true);
+                    }
                 }
                 SetChar variable_dependencies_vec;
                 variable_dependencies_vec.reserve(al, 1);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3617,6 +3617,90 @@ public:
         }
     }
 
+    void legacy_array_sections_helper(ASR::symbol_t *v, Vec<ASR::call_arg_t>& args, const Location &loc) {
+        ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(v));
+        if (compiler_options.legacy_array_sections) {
+            // call b(w(icon)) -> call b(w(icon:)) if b is expecting an array
+            ASR::FunctionType_t* f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+            std::map<int, ASR::ttype_t*> array_arg_idx;
+            for (size_t i = 0; i < f->n_args; i++) {
+                if (ASRUtils::is_array(ASRUtils::expr_type(f->m_args[i]))) {
+                    array_arg_idx[i] = f_type->m_arg_types[i];
+                }
+            }
+            Vec<ASR::call_arg_t> args_with_array_section;
+            args_with_array_section.reserve(al, args.size());
+            for (size_t i = 0; i < args.size(); i++) {
+                // check if i is in array_arg_idx
+                if (array_arg_idx.find(i) != array_arg_idx.end()) {
+                    ASR::call_arg_t arg = args[i];
+                    ASR::ttype_t* expected_arg_type = ASRUtils::duplicate_type(al, array_arg_idx[i]);
+                    ASR::expr_t* arg_expr = arg.m_value;
+                    if (ASR::is_a<ASR::ArrayItem_t>(*arg_expr)) {
+                        ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(arg_expr);
+                        ASR::expr_t* array_expr = array_item->m_v;
+                        LCOMPILERS_ASSERT(array_item->n_args > 0);
+                        ASR::array_index_t last_arg = array_item->m_args[array_item->n_args - 1];
+                        ASR::expr_t* idx = last_arg.m_right;
+
+                        Vec<ASR::dimension_t> dims;
+                        dims.reserve(al, 1);
+                        ASR::dimension_t dim;
+                        dim.loc = loc;
+                        dim.m_length = nullptr;
+                        dim.m_start = nullptr;
+                        dims.push_back(al, dim);
+                        ASR::asr_t* descriptor_array = ASR::make_Array_t(al, loc, ASRUtils::type_get_past_array(expected_arg_type),
+                                                        dims.p, dims.size(), ASR::array_physical_typeType::DescriptorArray);
+
+                        ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(expected_arg_type);
+                        ASR::asr_t* expected_array = ASR::make_Array_t(al, loc, ASRUtils::type_get_past_array(expected_arg_type),
+                                                        array_t->m_dims, array_t->n_dims, ASRUtils::extract_physical_type(expected_arg_type));
+
+                        // make ArraySection
+                        Vec<ASR::array_index_t> array_indices;
+                        array_indices.reserve(al, array_item->n_args);
+
+                        for (size_t i = 0; i < array_item->n_args - 1; i++) {
+                            array_indices.push_back(al, array_item->m_args[i]);
+                        }
+
+                        ASR::ttype_t *int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
+                        ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int32_type));
+
+                        ASR::expr_t* array_bound = ASRUtils::get_bound<SemanticError>(array_expr, array_item->n_args, "ubound", al);
+
+                        ASR::array_index_t array_idx;
+                        array_idx.loc = array_item->base.base.loc;
+                        array_idx.m_left = idx;
+                        array_idx.m_right = array_bound;
+                        array_idx.m_step = one;
+
+                        array_indices.push_back(al, array_idx);
+
+                        ASR::expr_t* array_section = ASRUtils::EXPR(ASR::make_ArraySection_t(al, array_item->base.base.loc,
+                                                    array_expr, array_indices.p, array_indices.size(),
+                                                    ASRUtils::TYPE(descriptor_array), nullptr));
+
+                        ASR::asr_t* array_cast = ASRUtils::make_ArrayPhysicalCast_t_util(al, array_item->base.base.loc, array_section,
+                                                ASRUtils::extract_physical_type(ASRUtils::TYPE(descriptor_array)), ASRUtils::extract_physical_type(expected_arg_type), ASRUtils::TYPE(expected_array), nullptr);
+
+                        ASR::expr_t* array_section_cast = ASRUtils::EXPR(array_cast);
+
+                        arg.m_value = array_section_cast;
+
+                        args_with_array_section.push_back(al, arg);
+                    } else {
+                        args_with_array_section.push_back(al, args[i]);
+                    }
+                } else {
+                    args_with_array_section.push_back(al, args[i]);
+                }
+            }
+            args = args_with_array_section;
+        }
+    }
+
     ASR::asr_t* create_Function(const Location &loc,
                 Vec<ASR::call_arg_t>& args, ASR::symbol_t *v) {
         ASR::symbol_t *f2 = ASRUtils::symbol_get_past_external(v);
@@ -3662,6 +3746,7 @@ public:
         }
         ASRUtils::insert_module_dependency(v, al, current_module_dependencies);
         ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
+        legacy_array_sections_helper(v, args, loc);
         return ASRUtils::make_FunctionCall_t_util(al, loc, v, nullptr,
             args.p, args.size(), return_type, value, nullptr);
     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4764,6 +4764,19 @@ public:
                     // the C ABI is just a pointer
                     var_type = ASRUtils::duplicate_type_with_empty_dims(al, var_type,
                         ASR::array_physical_typeType::PointerToDataArray, true);
+                } else if (ASR::is_a<ASR::ArrayItem_t>(*var_expr) && compiler_options.legacy_array_sections) {
+                    ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(var_expr);
+                    size_t n_dims = array_item->n_args;
+                    Vec<ASR::dimension_t> empty_dims;
+                    empty_dims.reserve(al, n_dims);
+                    for( size_t i = 0; i < n_dims; i++ ) {
+                        ASR::dimension_t empty_dim;
+                        empty_dim.loc = var_type->base.loc;
+                        empty_dim.m_start = nullptr;
+                        empty_dim.m_length = nullptr;
+                        empty_dims.push_back(al, empty_dim);
+                    }
+                    var_type = ASRUtils::duplicate_type(al, var_type, &empty_dims, ASR::array_physical_typeType::PointerToDataArray, true);
                 }
                 SetChar variable_dependencies_vec;
                 variable_dependencies_vec.reserve(al, 1);


### PR DESCRIPTION
Fixes #2753

TODO:

* [x] Fix https://github.com/lfortran/lfortran/issues/2753#issuecomment-1793674856


With this PR, we correctly parse `print *, ddot_sl(a(1,0))` as `print *, ddot_sl(a(1,0:))` with `--legacy-array-sections` but it   throws code generation error while generating llvm. This is because of another issue that needs to be fixed to create a proper test for this PR.

```fortran
DOUBLE PRECISION FUNCTION ddot_sl(dx)
DOUBLE PRECISION dx(*)
END

SUBROUTINE slsqpb (la, n, a)
INTEGER la, n
external ddot_sl
DOUBLE PRECISION a(la,n+1), ddot_sl
print *, ddot_sl(a(1,0)) ! passed an array section
END
```