### PR TITLE
FIX: handling of allocatable arrays in intrinsic `abs`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -554,6 +554,7 @@ RUN(NAME intrinsics_83 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_84 LABELS gfortran llvm) # minexponent
 RUN(NAME intrinsics_85 LABELS gfortran llvm) # maxexponent
 RUN(NAME intrinsics_86 LABELS gfortran llvm) # kind
+RUN(NAME intrinsics_87 LABELS gfortran llvm) # abs
 
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/intrinsics_87.f90
+++ b/integration_tests/intrinsics_87.f90
@@ -1,0 +1,10 @@
+program intrinsics_87
+implicit none
+integer, allocatable :: C(:, :)
+allocate(C(5, 10))
+C = -10
+C = abs(C)
+print *, C
+if (any(C /= 10)) error stop
+end program
+

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1451,7 +1451,7 @@ namespace Abs {
                 ASRUtils::extract_kind_from_ttype_t(type)));
         }
         return UnaryIntrinsicFunction::create_UnaryFunction(al, loc, args, eval_Abs,
-            static_cast<int64_t>(IntrinsicScalarFunctions::Abs), 0, type);
+            static_cast<int64_t>(IntrinsicScalarFunctions::Abs), 0, ASRUtils::type_get_past_allocatable(type));
     }
 
     static inline ASR::expr_t* instantiate_Abs(Allocator &al, const Location &loc,


### PR DESCRIPTION
Fixes #2857