### PR TITLE
Better error message when derived type is used before it is defined

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -41,9 +41,11 @@ public:
             std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
             std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
             std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-            std::vector<ASR::stmt_t*> &data_structure)
+            std::vector<ASR::stmt_t*> &data_structure,
+            std::vector<std::string> &derived_type_names, 
+            std::vector<std::pair<std::string, Location>> &undefined_derived_type_names)
         : CommonVisitor(al, nullptr, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure),
+                        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, derived_type_names, undefined_derived_type_names),
         asr{unit}, from_block{false} {}
 
     void visit_Declaration(const AST::Declaration_t& x) {
@@ -3326,10 +3328,12 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-        std::vector<ASR::stmt_t*> &data_structure)
+        std::vector<ASR::stmt_t*> &data_structure,
+        std::vector<std::string> &derived_type_names,
+        std::vector<std::pair<std::string, Location>> &undefined_derived_type_names)
 {
     BodyVisitor b(al, unit, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                  instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
+                  instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, derived_type_names, undefined_derived_type_names);
     try {
         b.is_body_visitor = true;
         b.visit_TranslationUnit(ast);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -829,6 +829,8 @@ public:
     std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types;
     std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols;
     std::vector<ASR::stmt_t*> &data_structure;
+    std::vector<std::string> &derived_type_names;
+    std::vector<std::pair<std::string, Location>> &undefined_derived_type_names;
 
     CommonVisitor(Allocator &al, SymbolTable *symbol_table,
             diag::Diagnostics &diagnostics, CompilerOptions &compiler_options,
@@ -839,13 +841,15 @@ public:
             std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
             std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
             std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-            std::vector<ASR::stmt_t*> &data_structure)
+            std::vector<ASR::stmt_t*> &data_structure,
+            std::vector<std::string> &derived_type_names,
+            std::vector<std::pair<std::string, Location>> &undefined_derived_type_names)
         : diag{diagnostics}, al{al}, compiler_options{compiler_options},
           current_scope{symbol_table}, implicit_mapping{implicit_mapping},
           common_variables_hash{common_variables_hash}, external_procedures_mapping{external_procedures_mapping},
           entry_functions{entry_functions},entry_function_arguments_mapping{entry_function_arguments_mapping},
           current_variable_type_{nullptr}, instantiate_types{instantiate_types},
-          instantiate_symbols{instantiate_symbols}, data_structure{data_structure} {
+          instantiate_symbols{instantiate_symbols}, data_structure{data_structure}, derived_type_names{derived_type_names}, undefined_derived_type_names{undefined_derived_type_names} {
         current_module_dependencies.reserve(al, 4);
         enum_init_val = 0;
     }
@@ -1736,6 +1740,13 @@ public:
             std::remove(external_procedures_mapping[hash].begin(),
             external_procedures_mapping[hash].end(), sym),
             external_procedures_mapping[hash].end());
+    }
+
+    void check_undefined_derived_types() {
+        if (undefined_derived_type_names.size() > 0) {
+            throw SemanticError("Derived type `" + undefined_derived_type_names[0].first + "` is used before it is defined!",
+                undefined_derived_type_names[0].second);
+        }
     }
 
     void visit_DeclarationUtil(const AST::Declaration_t &x) {
@@ -2862,12 +2873,15 @@ public:
                                           "in any requirements", loc);
                     }
                     // Placeholder symbol for Struct type
-                    // Derived type can be used before its actually defined
+                    if (std::find(derived_type_names.begin(), derived_type_names.end(), derived_type_name) == derived_type_names.end()) {
+                        undefined_derived_type_names.push_back({derived_type_name, loc});
+                    }
+                    // Derived type can be used before it's actually defined
                     v = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(
                             al, loc, current_scope, s2c(al, derived_type_name),
                             nullptr, nullptr, nullptr, 0, s2c(al, derived_type_name),
                             ASR::accessType::Private));
-                }
+                }  
                 type = ASRUtils::TYPE(ASR::make_Struct_t(al, loc, v));
                 type = ASRUtils::make_Array_t_util(
                     al, loc, type, dims.p, dims.size(), abi, is_argument);
@@ -2920,12 +2934,10 @@ public:
             throw SemanticError("Type not implemented yet.",
                     loc);
         }
-
         if( is_allocatable ) {
             type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
                 ASRUtils::type_get_past_allocatable(type)));
         }
-
         return type;
     }
 

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -109,9 +109,11 @@ public:
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-        std::vector<ASR::stmt_t*> &data_structure)
+        std::vector<ASR::stmt_t*> &data_structure,
+        std::vector<std::string> &derived_type_names,
+        std::vector<std::pair<std::string, Location>> &undefined_derived_type_names)
       : CommonVisitor(al, symbol_table, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                      instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure) {}
+                      instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, derived_type_names, undefined_derived_type_names) {}
 
     void visit_TranslationUnit(const AST::TranslationUnit_t &x) {
         if (!current_scope) {
@@ -569,6 +571,7 @@ public:
 
         fix_type_info(ASR::down_cast2<ASR::Program_t>(tmp));
         mark_common_blocks_as_declared();
+        check_undefined_derived_types();
     }
 
     bool subroutine_contains_entry_function(std::string subroutine_name, AST::stmt_t** body, size_t n_body) {
@@ -1575,6 +1578,10 @@ public:
 
     void visit_DerivedType(const AST::DerivedType_t &x) {
         dt_name = to_lower(x.m_name);
+        std::string derived_type_name = std::string(dt_name);
+        derived_type_names.push_back(dt_name);
+        undefined_derived_type_names.erase(std::remove_if(undefined_derived_type_names.begin(), undefined_derived_type_names.end(),
+        [&derived_type_name](const auto& pair) { return pair.first == derived_type_name; }), undefined_derived_type_names.end());
         bool is_abstract = false;
         bool is_deferred = false;
         AST::AttrExtends_t *attr_extend = nullptr;
@@ -3419,10 +3426,12 @@ Result<ASR::asr_t*> symbol_table_visitor(Allocator &al, AST::TranslationUnit_t &
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-        std::vector<ASR::stmt_t*> &data_structure)
+        std::vector<ASR::stmt_t*> &data_structure,
+        std::vector<std::string> &derived_type_names,
+        std::vector<std::pair<std::string, Location>> &undefined_derived_type_names)
 {
     SymbolTableVisitor v(al, symbol_table, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                         instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
+                         instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, derived_type_names, undefined_derived_type_names);
     try {
         v.visit_TranslationUnit(ast);
     } catch (const SemanticError &e) {

--- a/src/lfortran/semantics/ast_to_asr.cpp
+++ b/src/lfortran/semantics/ast_to_asr.cpp
@@ -33,7 +33,9 @@ Result<ASR::asr_t*> symbol_table_visitor(Allocator &al, AST::TranslationUnit_t &
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-        std::vector<ASR::stmt_t*> &data_structure);
+        std::vector<ASR::stmt_t*> &data_structure,
+        std::vector<std::string> &derived_type_names,
+        std::vector<std::pair<std::string, Location>> &undefined_derived_type_names);
 
 Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         AST::TranslationUnit_t &ast,
@@ -47,7 +49,9 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-        std::vector<ASR::stmt_t*> &data_structure);
+        std::vector<ASR::stmt_t*> &data_structure,
+        std::vector<std::string> &derived_type_names,
+        std::vector<std::pair<std::string, Location>> &undefined_derived_type_names);
 
 void load_rtlib(Allocator &al, ASR::TranslationUnit_t &tu, CompilerOptions &compiler_options) {
     SymbolTable *tu_symtab = tu.m_symtab;
@@ -91,10 +95,12 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> entry_functions;
     std::map<std::string, std::vector<int>> entry_function_arguments_mapping;
     std::vector<ASR::stmt_t*> data_structure;
+    std::vector<std::string> derived_type_names;
+    std::vector<std::pair<std::string, Location>> undefined_derived_type_names;
     ASR::asr_t *unit;
     auto res = symbol_table_visitor(al, ast, diagnostics, symbol_table,
         compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
+        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, derived_type_names, undefined_derived_type_names);
     if (res.ok) {
         unit = res.result;
     } else {
@@ -124,7 +130,7 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     if (!symtab_only) {
         auto res = body_visitor(al, ast, diagnostics, unit, compiler_options,
             implicit_mapping, common_variables_hash, external_procedures_mapping,
-            instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure);
+            instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, derived_type_names, undefined_derived_type_names);
         if (res.ok) {
             tu = res.result;
         } else {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4318,7 +4318,7 @@ class VerifyAbort {};
 static inline void require_impl(bool cond, const std::string &error_msg,
     const Location &loc, diag::Diagnostics &diagnostics) {
     if (!cond) {
-        diagnostics.message_label("ASR verify: " + error_msg,
+        diagnostics.message_label(error_msg,
             {loc}, "failed here",
             diag::Level::Error, diag::Stage::ASRVerify);
         throw VerifyAbort();

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -76,19 +76,19 @@ public:
                         // The symbol table was found and the symbol `sym` is in it
                         return true;
                     } else {
-                        diagnostics.message_label("ASR verify: The symbol table was found and the symbol in it shares the name, but is not equal to `sym`",
+                        diagnostics.message_label("The symbol table was found and the symbol in it shares the name, but is not equal to `sym`",
                         {sym->base.loc}, "failed here", diag::Level::Error, diag::Stage::ASRVerify);
                         return false;
                     }
                 } else {
-                    diagnostics.message_label("ASR verify: The symbol table was found, but the symbol `sym` is not in it",
+                    diagnostics.message_label("The symbol table was found, but the symbol `sym` is not in it",
                         {sym->base.loc}, "failed here", diag::Level::Error, diag::Stage::ASRVerify);
                     return false;
                 }
             }
             s = s->parent;
         }
-        diagnostics.message_label("ASR verify: The symbol table was not found in the scope of `symtab`.",
+        diagnostics.message_label("The symbol table was not found in the scope of `symtab`.",
                         {sym->base.loc}, "failed here", diag::Level::Error, diag::Stage::ASRVerify);
         return false;
     }

--- a/tests/errors/derived_type_06.f90
+++ b/tests/errors/derived_type_06.f90
@@ -1,0 +1,5 @@
+program test
+    implicit none
+    type(foo) :: c
+end program
+    

--- a/tests/reference/asr-derived_type_06-f08a2b6.json
+++ b/tests/reference/asr-derived_type_06-f08a2b6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-derived_type_06-f08a2b6",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/derived_type_06.f90",
+    "infile_hash": "e385ffc48263039ce33d35205060cc92e93766274c92f9f807adc05d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-derived_type_06-f08a2b6.stderr",
+    "stderr_hash": "124bd4a984e2d90a33ede44403e4227017e5b7457257232b51db4b32",
+    "returncode": 2
+}

--- a/tests/reference/asr-derived_type_06-f08a2b6.stderr
+++ b/tests/reference/asr-derived_type_06-f08a2b6.stderr
@@ -1,0 +1,5 @@
+semantic error: Derived type `foo` is used before it is defined!
+ --> tests/errors/derived_type_06.f90:3:5
+  |
+3 |     type(foo) :: c
+  |     ^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3610,3 +3610,7 @@ asr = true
 [[test]]
 filename = "errors/parameter_01.f90"
 asr = true
+
+[[test]]
+filename = "errors/derived_type_06.f90"
+asr = true


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/2944