### PR TITLE
chore: add `inst/` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ src/runtime/tests/test_tan
 integration_tests/test-*
 input.txt
 input
+inst/
 src/libasr/libasr.a.*
 *.html
 *.o.tmp.c


### PR DESCRIPTION
Fixes the problem of 

```console
% git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	inst/

nothing added to commit but untracked files present (use "git add" to track)
```