### PR TITLE
Lapack example with generics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1016,6 +1016,7 @@ RUN(NAME template_simple_03 LABELS llvm wasm)
 RUN(NAME template_simple_04 LABELS llvm wasm)
 RUN(NAME template_sort_01 LABELS llvm wasm)
 RUN(NAME template_sort_02 LABELS llvm wasm)
+RUN(NAME template_lapack_01 LABELS llvm wasm)
 
 RUN(NAME statement1 LABELS gfortran llvm)
 

--- a/integration_tests/template_lapack_01.f90
+++ b/integration_tests/template_lapack_01.f90
@@ -22,32 +22,86 @@ module template_lapack_01_m
         end function
     end requirement
 
-    template external_matmul_t(U, gemm, cast_to_T)
-        require :: gemm_r(U, gemm)
-        !require :: cast_r(real, T, cast_to_T)
+    template external_matmul_t(T, gemm, cast_to_T)
+        require :: gemm_r(T, gemm)
+        require :: cast_r(real, T, cast_to_T)
         private
+    contains
+        function nonsimple_external_matmul(a,b) result(c)
+            type(T), intent(in) :: a(:,:), b(:,:)
+            type(T) :: c(size(a,1), size(b,2))
+            integer :: m, n, k
+            m = size(a, dim=1)
+            n = size(b, dim=2)
+            k = size(a, dim=1)
+            call gemm('n', 'n', m, n, k, cast_to_T(1.0), a, m, b, k, cast_to_T(0.0), c, m)
+        end function
     end template
 
 contains
 
-    ! for reference
-    subroutine my_gemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    subroutine my_gemm_real(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
         character, intent(in) :: transa, transb
         integer, intent(in) :: m, n, k, lda, ldb, ldc
         real, intent(in) :: alpha, a(lda, *), b(ldb, *), beta
         real, intent(out) :: c(ldc, *)
     end subroutine
 
-    !function external_matmul {T, gemm, cast_to_T} (a, b) result(c)
-    !    require :: gemm_r(T, gemm)
-    !    require :: cast_r(real, T, cast_to_T)
-    !    type(T), intent(in) :: a(:,:), b(:,:)
-    !    type(T) :: c(size(a,1), size(b,2))
-    !    integer :: m, n, k
-    !end function
+    subroutine my_gemm_double(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+        integer, parameter :: dp = kind(1.d0)
+        character, intent(in) :: transa, transb
+        integer, intent(in) :: m, n, k, lda, ldb, ldc
+        real(dp), intent(in) :: alpha, a(lda, *), b(ldb, *), beta
+        real(dp), intent(out) :: c(ldc, *)
+    end subroutine
+
+    pure elemental function my_cast_to_real(a) result(b)
+        real, intent(in) :: a
+        real :: b
+        b = a
+    end function
+
+    pure elemental function my_cast_to_double(a) result(b)
+        integer, parameter :: dp = kind(1.d0)
+        real, intent(in) :: a
+        real(dp) :: b
+        b = a
+    end function
+
+    function my_external_matmul(a, b) result(c)
+        real, intent(in) :: a(:,:), b(:,:)
+        real :: c(size(a,1), size(b,2))
+        integer :: m, n, k
+        m = size(a, dim=1)
+        n = size(b, dim=2)
+        k = size(a, dim=1)
+        call my_gemm_real('n', 'n', m, n, k, my_cast_to_real(1.0), a, m, b, k, my_cast_to_real(0.0), c, m)
+    end function
+
+    function simple_external_matmul {T, gemm, cast_to_T} (a, b) result(c)
+        require :: gemm_r(T, gemm)
+        require :: cast_r(real, T, cast_to_T)
+        type(T), intent(in) :: a(:,:), b(:,:)
+        type(T) :: c(size(a,1), size(b,2))
+        integer :: m, n, k
+        m = size(a, dim=1)
+        n = size(b, dim=2)
+        k = size(a, dim=1)
+        call gemm('n', 'n', m, n, k, cast_to_T(1.0), a, m, b, k, cast_to_T(0.0), c, m)
+    end function
 
     subroutine test_template()
+        integer, parameter :: dp = kind(1.d0)
+        instantiate external_matmul_t(real, my_gemm_real, my_cast_to_real), &
+            only: nonsimple_external_matmul_real => nonsimple_external_matmul
+        instantiate external_matmul_t(real(dp), my_gemm_double, my_cast_to_double), &
+            only: nonsimple_external_matmul_double => nonsimple_external_matmul
+        
+        real :: asp(2,2), bsp(2,2), csp(2,2)
+        real(dp) :: adp(2,2), bdp(2,2), cdp(2,2)
 
+        csp = simple_external_matmul {real, my_gemm_real, my_cast_to_real} (asp, bsp)
+        cdp = simple_external_matmul {real(dp), my_gemm_double, my_cast_to_double} (adp, bdp)
     end subroutine
 
 end module

--- a/integration_tests/template_lapack_01.f90
+++ b/integration_tests/template_lapack_01.f90
@@ -1,0 +1,61 @@
+module template_lapack_01_m
+    implicit none
+    private
+    public :: test_template
+
+    requirement gemm_r(T, gemm)
+        type, deferred :: T
+        subroutine gemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+            character, intent(in) :: transa, transb
+            integer, intent(in) :: m, n, k, lda, ldb, ldc
+            type(T), intent(in) :: alpha, a(lda, *), b(ldb, *), beta
+            type(T), intent(out) :: c(ldc, *)
+        end subroutine
+    end requirement
+
+    requirement cast_r(T, U, cast)
+        type, deferred :: T
+        type, deferred :: U
+        pure elemental function cast(arg) result(res)
+            type(T), intent(in) :: arg
+            type(U) :: res
+        end function
+    end requirement
+
+    template external_matmul_t(U, gemm, cast_to_T)
+        require :: gemm_r(U, gemm)
+        !require :: cast_r(real, T, cast_to_T)
+        private
+    end template
+
+contains
+
+    ! for reference
+    subroutine my_gemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+        character, intent(in) :: transa, transb
+        integer, intent(in) :: m, n, k, lda, ldb, ldc
+        real, intent(in) :: alpha, a(lda, *), b(ldb, *), beta
+        real, intent(out) :: c(ldc, *)
+    end subroutine
+
+    !function external_matmul {T, gemm, cast_to_T} (a, b) result(c)
+    !    require :: gemm_r(T, gemm)
+    !    require :: cast_r(real, T, cast_to_T)
+    !    type(T), intent(in) :: a(:,:), b(:,:)
+    !    type(T) :: c(size(a,1), size(b,2))
+    !    integer :: m, n, k
+    !end function
+
+    subroutine test_template()
+
+    end subroutine
+
+end module
+
+program template_lapack_01
+use template_lapack_01_m
+implicit none
+
+call test_template()
+
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2912,7 +2912,6 @@ public:
         for (size_t i=0; i<x.n_args; i++) {
             std::string param = temp->m_args[i];
             ASR::symbol_t *param_sym = temp->m_symtab->get_symbol(param);
-            ASR::ttype_t *param_type = ASRUtils::symbol_type(param_sym);
             if (AST::is_a<AST::AttrType_t>(*x.m_args[i])) {
                 // Handling types as instantiate's arguments
                 Vec<ASR::dimension_t> dims;
@@ -2920,6 +2919,7 @@ public:
                 ASR::symbol_t *type_declaration;
                 ASR::ttype_t *arg_type = determine_type(x.m_args[i]->base.loc, param,
                     x.m_args[i], false, false, dims, type_declaration, current_procedure_abi_type);
+                ASR::ttype_t *param_type = ASRUtils::symbol_type(param_sym);
                 if (!ASRUtils::is_type_parameter(*param_type)) {
                     throw SemanticError("The type " + ASRUtils::type_to_str(arg_type) +
                         " cannot be applied to non-type parameter " + param, x.base.base.loc);
@@ -2943,28 +2943,30 @@ public:
                             x.m_args[i]->base.loc);
                     }
                     report_check_restriction(type_subs, symbol_subs, f, f_arg0, x.base.base.loc, diag);
-                } else if (ASRUtils::is_type_parameter(*param_type)) {
-                    // Handling type parameters passed as instantiate's arguments
-                    ASR::symbol_t *arg_sym = current_scope->resolve_symbol(arg);
-                    ASR::ttype_t *arg_type = ASRUtils::symbol_type(arg_sym);
-                    if (ASRUtils::is_type_parameter(*arg_type)) {
-                        type_subs[param] = ASRUtils::TYPE(ASR::make_TypeParameter_t(al,
-                            x.base.base.loc, ASR::down_cast<ASR::TypeParameter_t>(arg_type)->m_param));
-                    } else {
-                        throw SemanticError("The type " + arg + " is not yet handled for "
-                            + "template instantiation", x.base.base.loc);
-                    }
                 } else {
-                    // Handling local variables passed as instantiate's arguments
-                    ASR::symbol_t *arg_sym = current_scope->resolve_symbol(arg);
-                    ASR::ttype_t *arg_type = ASRUtils::symbol_type(arg_sym);
-                    if (!ASRUtils::check_equal_type(arg_type, param_type)) {
-                        throw SemanticError("The type of " + arg + " does not match the type of " + param,
-                            x.base.base.loc);
+                    ASR::ttype_t *param_type = ASRUtils::symbol_type(param_sym);
+                    if (ASRUtils::is_type_parameter(*param_type)) {
+                        // Handling type parameters passed as instantiate's arguments
+                        ASR::symbol_t *arg_sym = current_scope->resolve_symbol(arg);
+                        ASR::ttype_t *arg_type = ASRUtils::symbol_type(arg_sym);
+                        if (ASRUtils::is_type_parameter(*arg_type)) {
+                            type_subs[param] = ASRUtils::TYPE(ASR::make_TypeParameter_t(al,
+                                x.base.base.loc, ASR::down_cast<ASR::TypeParameter_t>(arg_type)->m_param));
+                        } else {
+                            throw SemanticError("The type " + arg + " is not yet handled for "
+                                + "template instantiation", x.base.base.loc);
+                        }
+                    } else {
+                        // Handling local variables passed as instantiate's arguments
+                        ASR::symbol_t *arg_sym = current_scope->resolve_symbol(arg);
+                        ASR::ttype_t *arg_type = ASRUtils::symbol_type(arg_sym);
+                        if (!ASRUtils::check_equal_type(arg_type, param_type)) {
+                            throw SemanticError("The type of " + arg + " does not match the type of " + param,
+                                x.base.base.loc);
+                        }
+                        symbol_subs[param] = arg_sym;
                     }
-                    symbol_subs[param] = arg_sym;
                 }
-
             } else if (AST::is_a<AST::AttrIntrinsicOperator_t>(*x.m_args[i])) {
                 AST::AttrIntrinsicOperator_t *intrinsic_op
                     = AST::down_cast<AST::AttrIntrinsicOperator_t>(x.m_args[i]);

--- a/tests/reference/asr-template_lapack_01-0d30f43.json
+++ b/tests/reference/asr-template_lapack_01-0d30f43.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-template_lapack_01-0d30f43",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/template_lapack_01.f90",
+    "infile_hash": "d79e24fee2aba2e6b98fffd327df1e6a264fdf9cc3e5ebc77b5822d0",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-template_lapack_01-0d30f43.stdout",
+    "stdout_hash": "ac6e5ba9df83dea2285e81bb401936518300894c363e89341b4c1338",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-template_lapack_01-0d30f43.stdout
+++ b/tests/reference/asr-template_lapack_01-0d30f43.stdout
@@ -1,0 +1,5039 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            template_lapack_01:
+                (Program
+                    (SymbolTable
+                        23
+                        {
+                            cast_r:
+                                (ExternalSymbol
+                                    23
+                                    cast_r
+                                    2 cast_r
+                                    template_lapack_01_m
+                                    []
+                                    cast_r
+                                    Public
+                                ),
+                            external_matmul_t:
+                                (ExternalSymbol
+                                    23
+                                    external_matmul_t
+                                    2 external_matmul_t
+                                    template_lapack_01_m
+                                    []
+                                    external_matmul_t
+                                    Public
+                                ),
+                            gemm_r:
+                                (ExternalSymbol
+                                    23
+                                    gemm_r
+                                    2 gemm_r
+                                    template_lapack_01_m
+                                    []
+                                    gemm_r
+                                    Public
+                                ),
+                            my_cast_to_double:
+                                (ExternalSymbol
+                                    23
+                                    my_cast_to_double
+                                    2 my_cast_to_double
+                                    template_lapack_01_m
+                                    []
+                                    my_cast_to_double
+                                    Public
+                                ),
+                            my_cast_to_real:
+                                (ExternalSymbol
+                                    23
+                                    my_cast_to_real
+                                    2 my_cast_to_real
+                                    template_lapack_01_m
+                                    []
+                                    my_cast_to_real
+                                    Public
+                                ),
+                            my_external_matmul:
+                                (ExternalSymbol
+                                    23
+                                    my_external_matmul
+                                    2 my_external_matmul
+                                    template_lapack_01_m
+                                    []
+                                    my_external_matmul
+                                    Public
+                                ),
+                            my_gemm_double:
+                                (ExternalSymbol
+                                    23
+                                    my_gemm_double
+                                    2 my_gemm_double
+                                    template_lapack_01_m
+                                    []
+                                    my_gemm_double
+                                    Public
+                                ),
+                            my_gemm_real:
+                                (ExternalSymbol
+                                    23
+                                    my_gemm_real
+                                    2 my_gemm_real
+                                    template_lapack_01_m
+                                    []
+                                    my_gemm_real
+                                    Public
+                                ),
+                            simple_external_matmul:
+                                (ExternalSymbol
+                                    23
+                                    simple_external_matmul
+                                    2 simple_external_matmul
+                                    template_lapack_01_m
+                                    []
+                                    simple_external_matmul
+                                    Public
+                                ),
+                            test_template:
+                                (ExternalSymbol
+                                    23
+                                    test_template
+                                    2 test_template
+                                    template_lapack_01_m
+                                    []
+                                    test_template
+                                    Public
+                                )
+                        })
+                    template_lapack_01
+                    [template_lapack_01_m]
+                    [(SubroutineCall
+                        23 test_template
+                        ()
+                        []
+                        ()
+                    )]
+                ),
+            template_lapack_01_m:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            cast_r:
+                                (Requirement
+                                    (SymbolTable
+                                        5
+                                        {
+                                            cast:
+                                                (Function
+                                                    (SymbolTable
+                                                        6
+                                                        {
+                                                            arg:
+                                                                (Variable
+                                                                    6
+                                                                    arg
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            res:
+                                                                (Variable
+                                                                    6
+                                                                    res
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        u
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    cast
+                                                    (FunctionType
+                                                        [(TypeParameter
+                                                            t
+                                                        )]
+                                                        (TypeParameter
+                                                            u
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .true.
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 6 arg)]
+                                                    []
+                                                    (Var 6 res)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            t:
+                                                (Variable
+                                                    5
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        t
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            u:
+                                                (Variable
+                                                    5
+                                                    u
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        u
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    cast_r
+                                    [t
+                                    u
+                                    cast]
+                                    []
+                                ),
+                            external_matmul_t:
+                                (Template
+                                    (SymbolTable
+                                        7
+                                        {
+                                            cast_to_t:
+                                                (Function
+                                                    (SymbolTable
+                                                        9
+                                                        {
+                                                            arg:
+                                                                (Variable
+                                                                    9
+                                                                    arg
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            res:
+                                                                (Variable
+                                                                    9
+                                                                    res
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    cast_to_t
+                                                    (FunctionType
+                                                        [(Real 4)]
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .true.
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 9 arg)]
+                                                    []
+                                                    (Var 9 res)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            gemm:
+                                                (Function
+                                                    (SymbolTable
+                                                        8
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    8
+                                                                    a
+                                                                    [lda]
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 8 lda))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            alpha:
+                                                                (Variable
+                                                                    8
+                                                                    alpha
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    8
+                                                                    b
+                                                                    [ldb]
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 8 ldb))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            beta:
+                                                                (Variable
+                                                                    8
+                                                                    beta
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    8
+                                                                    c
+                                                                    [ldc]
+                                                                    Out
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 8 ldc))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    8
+                                                                    k
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            lda:
+                                                                (Variable
+                                                                    8
+                                                                    lda
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ldb:
+                                                                (Variable
+                                                                    8
+                                                                    ldb
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ldc:
+                                                                (Variable
+                                                                    8
+                                                                    ldc
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    8
+                                                                    m
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    8
+                                                                    n
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            transa:
+                                                                (Variable
+                                                                    8
+                                                                    transa
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Character 1 1 ())
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            transb:
+                                                                (Variable
+                                                                    8
+                                                                    transb
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Character 1 1 ())
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    gemm
+                                                    (FunctionType
+                                                        [(Character 1 1 ())
+                                                        (Character 1 1 ())
+                                                        (Integer 4)
+                                                        (Integer 4)
+                                                        (Integer 4)
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                7
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                9
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                12
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)]
+                                                        ()
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 8 transa)
+                                                    (Var 8 transb)
+                                                    (Var 8 m)
+                                                    (Var 8 n)
+                                                    (Var 8 k)
+                                                    (Var 8 alpha)
+                                                    (Var 8 a)
+                                                    (Var 8 lda)
+                                                    (Var 8 b)
+                                                    (Var 8 ldb)
+                                                    (Var 8 beta)
+                                                    (Var 8 c)
+                                                    (Var 8 ldc)]
+                                                    []
+                                                    ()
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            nonsimple_external_matmul:
+                                                (Function
+                                                    (SymbolTable
+                                                        10
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    10
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    10
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    10
+                                                                    c
+                                                                    [a
+                                                                    b]
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 10 a)
+                                                                            (IntegerConstant 1 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))
+                                                                        ((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 10 b)
+                                                                            (IntegerConstant 2 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))]
+                                                                        PointerToDataArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    10
+                                                                    k
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    10
+                                                                    m
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    10
+                                                                    n
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    nonsimple_external_matmul
+                                                    (FunctionType
+                                                        [(Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    0
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 1 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    1
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 2 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            PointerToDataArray
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [cast_to_t
+                                                    gemm]
+                                                    [(Var 10 a)
+                                                    (Var 10 b)]
+                                                    [(=
+                                                        (Var 10 m)
+                                                        (ArraySize
+                                                            (Var 10 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 10 n)
+                                                        (ArraySize
+                                                            (Var 10 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 10 k)
+                                                        (ArraySize
+                                                            (Var 10 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (SubroutineCall
+                                                        7 gemm
+                                                        ()
+                                                        [((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((Var 10 m))
+                                                        ((Var 10 n))
+                                                        ((Var 10 k))
+                                                        ((FunctionCall
+                                                            7 cast_to_t
+                                                            ()
+                                                            [((RealConstant
+                                                                1.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 10 a)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 10 m))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 10 b)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 10 k))
+                                                        ((FunctionCall
+                                                            7 cast_to_t
+                                                            ()
+                                                            [((RealConstant
+                                                                0.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 10 c)
+                                                            PointerToDataArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 10 a)
+                                                                    (IntegerConstant 1 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))
+                                                                ((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 10 b)
+                                                                    (IntegerConstant 2 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 10 m))]
+                                                        ()
+                                                    )]
+                                                    (Var 10 c)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            real:
+                                                (Variable
+                                                    7
+                                                    real
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            t:
+                                                (Variable
+                                                    7
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        t
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    external_matmul_t
+                                    [t
+                                    gemm
+                                    cast_to_t]
+                                    [(Require
+                                        gemm_r
+                                        [t
+                                        gemm]
+                                    )
+                                    (Require
+                                        cast_r
+                                        [real
+                                        t
+                                        cast_to_t]
+                                    )]
+                                ),
+                            gemm_r:
+                                (Requirement
+                                    (SymbolTable
+                                        3
+                                        {
+                                            gemm:
+                                                (Function
+                                                    (SymbolTable
+                                                        4
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    4
+                                                                    a
+                                                                    [lda]
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 4 lda))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            alpha:
+                                                                (Variable
+                                                                    4
+                                                                    alpha
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    4
+                                                                    b
+                                                                    [ldb]
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 4 ldb))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            beta:
+                                                                (Variable
+                                                                    4
+                                                                    beta
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    4
+                                                                    c
+                                                                    [ldc]
+                                                                    Out
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 4 ldc))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    4
+                                                                    k
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            lda:
+                                                                (Variable
+                                                                    4
+                                                                    lda
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ldb:
+                                                                (Variable
+                                                                    4
+                                                                    ldb
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ldc:
+                                                                (Variable
+                                                                    4
+                                                                    ldc
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    4
+                                                                    m
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    4
+                                                                    n
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            transa:
+                                                                (Variable
+                                                                    4
+                                                                    transa
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Character 1 1 ())
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            transb:
+                                                                (Variable
+                                                                    4
+                                                                    transb
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Character 1 1 ())
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    gemm
+                                                    (FunctionType
+                                                        [(Character 1 1 ())
+                                                        (Character 1 1 ())
+                                                        (Integer 4)
+                                                        (Integer 4)
+                                                        (Integer 4)
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                7
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                9
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                12
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)]
+                                                        ()
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 4 transa)
+                                                    (Var 4 transb)
+                                                    (Var 4 m)
+                                                    (Var 4 n)
+                                                    (Var 4 k)
+                                                    (Var 4 alpha)
+                                                    (Var 4 a)
+                                                    (Var 4 lda)
+                                                    (Var 4 b)
+                                                    (Var 4 ldb)
+                                                    (Var 4 beta)
+                                                    (Var 4 c)
+                                                    (Var 4 ldc)]
+                                                    []
+                                                    ()
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            t:
+                                                (Variable
+                                                    3
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        t
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    gemm_r
+                                    [t
+                                    gemm]
+                                    []
+                                ),
+                            my_cast_to_double:
+                                (Function
+                                    (SymbolTable
+                                        14
+                                        {
+                                            a:
+                                                (Variable
+                                                    14
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    14
+                                                    b
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            dp:
+                                                (Variable
+                                                    14
+                                                    dp
+                                                    []
+                                                    Local
+                                                    (IntrinsicScalarFunction
+                                                        Kind
+                                                        [(RealConstant
+                                                            1.000000
+                                                            (Real 8)
+                                                        )]
+                                                        0
+                                                        (Integer 4)
+                                                        (IntegerConstant 8 (Integer 4))
+                                                    )
+                                                    (IntegerConstant 8 (Integer 4))
+                                                    Parameter
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    my_cast_to_double
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 8)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .true.
+                                        .true.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 14 a)]
+                                    [(=
+                                        (Var 14 b)
+                                        (Cast
+                                            (Var 14 a)
+                                            RealToReal
+                                            (Real 8)
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 14 b)
+                                    Private
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            my_cast_to_real:
+                                (Function
+                                    (SymbolTable
+                                        13
+                                        {
+                                            a:
+                                                (Variable
+                                                    13
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    13
+                                                    b
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    my_cast_to_real
+                                    (FunctionType
+                                        [(Real 4)]
+                                        (Real 4)
+                                        Source
+                                        Implementation
+                                        ()
+                                        .true.
+                                        .true.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 13 a)]
+                                    [(=
+                                        (Var 13 b)
+                                        (Var 13 a)
+                                        ()
+                                    )]
+                                    (Var 13 b)
+                                    Private
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            my_external_matmul:
+                                (Function
+                                    (SymbolTable
+                                        15
+                                        {
+                                            a:
+                                                (Variable
+                                                    15
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    15
+                                                    b
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            c:
+                                                (Variable
+                                                    15
+                                                    c
+                                                    [a
+                                                    b]
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (ArraySize
+                                                            (Var 15 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        ))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (ArraySize
+                                                            (Var 15 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        ))]
+                                                        PointerToDataArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            k:
+                                                (Variable
+                                                    15
+                                                    k
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            m:
+                                                (Variable
+                                                    15
+                                                    m
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            n:
+                                                (Variable
+                                                    15
+                                                    n
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    my_external_matmul
+                                    (FunctionType
+                                        [(Array
+                                            (Real 4)
+                                            [(()
+                                            ())
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Array
+                                            (Real 4)
+                                            [(()
+                                            ())
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )]
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (ArraySize
+                                                (FunctionParam
+                                                    0
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                )
+                                                (IntegerConstant 1 (Integer 4))
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            ((IntegerConstant 1 (Integer 4))
+                                            (ArraySize
+                                                (FunctionParam
+                                                    1
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                )
+                                                (IntegerConstant 2 (Integer 4))
+                                                (Integer 4)
+                                                ()
+                                            ))]
+                                            PointerToDataArray
+                                        )
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    [my_cast_to_real
+                                    my_gemm_real]
+                                    [(Var 15 a)
+                                    (Var 15 b)]
+                                    [(=
+                                        (Var 15 m)
+                                        (ArraySize
+                                            (Var 15 a)
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 15 n)
+                                        (ArraySize
+                                            (Var 15 b)
+                                            (IntegerConstant 2 (Integer 4))
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 15 k)
+                                        (ArraySize
+                                            (Var 15 a)
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (SubroutineCall
+                                        2 my_gemm_real
+                                        ()
+                                        [((StringConstant
+                                            "n"
+                                            (Character 1 1 ())
+                                        ))
+                                        ((StringConstant
+                                            "n"
+                                            (Character 1 1 ())
+                                        ))
+                                        ((Var 15 m))
+                                        ((Var 15 n))
+                                        ((Var 15 k))
+                                        ((FunctionCall
+                                            2 my_cast_to_real
+                                            ()
+                                            [((RealConstant
+                                                1.000000
+                                                (Real 4)
+                                            ))]
+                                            (Real 4)
+                                            ()
+                                            ()
+                                        ))
+                                        ((ArrayPhysicalCast
+                                            (Var 15 a)
+                                            DescriptorArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 4)
+                                                [(()
+                                                ())
+                                                (()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))
+                                        ((Var 15 m))
+                                        ((ArrayPhysicalCast
+                                            (Var 15 b)
+                                            DescriptorArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 4)
+                                                [(()
+                                                ())
+                                                (()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))
+                                        ((Var 15 k))
+                                        ((FunctionCall
+                                            2 my_cast_to_real
+                                            ()
+                                            [((RealConstant
+                                                0.000000
+                                                (Real 4)
+                                            ))]
+                                            (Real 4)
+                                            ()
+                                            ()
+                                        ))
+                                        ((ArrayPhysicalCast
+                                            (Var 15 c)
+                                            PointerToDataArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (ArraySize
+                                                    (Var 15 a)
+                                                    (IntegerConstant 1 (Integer 4))
+                                                    (Integer 4)
+                                                    ()
+                                                ))
+                                                ((IntegerConstant 1 (Integer 4))
+                                                (ArraySize
+                                                    (Var 15 b)
+                                                    (IntegerConstant 2 (Integer 4))
+                                                    (Integer 4)
+                                                    ()
+                                                ))]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))
+                                        ((Var 15 m))]
+                                        ()
+                                    )]
+                                    (Var 15 c)
+                                    Private
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            my_gemm_double:
+                                (Function
+                                    (SymbolTable
+                                        12
+                                        {
+                                            a:
+                                                (Variable
+                                                    12
+                                                    a
+                                                    [lda]
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (Var 12 lda))
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            alpha:
+                                                (Variable
+                                                    12
+                                                    alpha
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    12
+                                                    b
+                                                    [ldb]
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (Var 12 ldb))
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            beta:
+                                                (Variable
+                                                    12
+                                                    beta
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 8)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            c:
+                                                (Variable
+                                                    12
+                                                    c
+                                                    [ldc]
+                                                    Out
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (Var 12 ldc))
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            dp:
+                                                (Variable
+                                                    12
+                                                    dp
+                                                    []
+                                                    Local
+                                                    (IntrinsicScalarFunction
+                                                        Kind
+                                                        [(RealConstant
+                                                            1.000000
+                                                            (Real 8)
+                                                        )]
+                                                        0
+                                                        (Integer 4)
+                                                        (IntegerConstant 8 (Integer 4))
+                                                    )
+                                                    (IntegerConstant 8 (Integer 4))
+                                                    Parameter
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            k:
+                                                (Variable
+                                                    12
+                                                    k
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            lda:
+                                                (Variable
+                                                    12
+                                                    lda
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            ldb:
+                                                (Variable
+                                                    12
+                                                    ldb
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            ldc:
+                                                (Variable
+                                                    12
+                                                    ldc
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            m:
+                                                (Variable
+                                                    12
+                                                    m
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            n:
+                                                (Variable
+                                                    12
+                                                    n
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            transa:
+                                                (Variable
+                                                    12
+                                                    transa
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Character 1 1 ())
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            transb:
+                                                (Variable
+                                                    12
+                                                    transb
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Character 1 1 ())
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    my_gemm_double
+                                    (FunctionType
+                                        [(Character 1 1 ())
+                                        (Character 1 1 ())
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Real 8)
+                                        (Array
+                                            (Real 8)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (FunctionParam
+                                                7
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Integer 4)
+                                        (Array
+                                            (Real 8)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (FunctionParam
+                                                9
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Integer 4)
+                                        (Real 8)
+                                        (Array
+                                            (Real 8)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (FunctionParam
+                                                12
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Integer 4)]
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 12 transa)
+                                    (Var 12 transb)
+                                    (Var 12 m)
+                                    (Var 12 n)
+                                    (Var 12 k)
+                                    (Var 12 alpha)
+                                    (Var 12 a)
+                                    (Var 12 lda)
+                                    (Var 12 b)
+                                    (Var 12 ldb)
+                                    (Var 12 beta)
+                                    (Var 12 c)
+                                    (Var 12 ldc)]
+                                    []
+                                    ()
+                                    Private
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            my_gemm_real:
+                                (Function
+                                    (SymbolTable
+                                        11
+                                        {
+                                            a:
+                                                (Variable
+                                                    11
+                                                    a
+                                                    [lda]
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (Var 11 lda))
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            alpha:
+                                                (Variable
+                                                    11
+                                                    alpha
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    11
+                                                    b
+                                                    [ldb]
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (Var 11 ldb))
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            beta:
+                                                (Variable
+                                                    11
+                                                    beta
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            c:
+                                                (Variable
+                                                    11
+                                                    c
+                                                    [ldc]
+                                                    Out
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (Var 11 ldc))
+                                                        (()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            k:
+                                                (Variable
+                                                    11
+                                                    k
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            lda:
+                                                (Variable
+                                                    11
+                                                    lda
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            ldb:
+                                                (Variable
+                                                    11
+                                                    ldb
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            ldc:
+                                                (Variable
+                                                    11
+                                                    ldc
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            m:
+                                                (Variable
+                                                    11
+                                                    m
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            n:
+                                                (Variable
+                                                    11
+                                                    n
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            transa:
+                                                (Variable
+                                                    11
+                                                    transa
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Character 1 1 ())
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            transb:
+                                                (Variable
+                                                    11
+                                                    transb
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Character 1 1 ())
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    my_gemm_real
+                                    (FunctionType
+                                        [(Character 1 1 ())
+                                        (Character 1 1 ())
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Real 4)
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (FunctionParam
+                                                7
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Integer 4)
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (FunctionParam
+                                                9
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Integer 4)
+                                        (Real 4)
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (FunctionParam
+                                                12
+                                                (Integer 4)
+                                                ()
+                                            ))
+                                            (()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                        (Integer 4)]
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 11 transa)
+                                    (Var 11 transb)
+                                    (Var 11 m)
+                                    (Var 11 n)
+                                    (Var 11 k)
+                                    (Var 11 alpha)
+                                    (Var 11 a)
+                                    (Var 11 lda)
+                                    (Var 11 b)
+                                    (Var 11 ldb)
+                                    (Var 11 beta)
+                                    (Var 11 c)
+                                    (Var 11 ldc)]
+                                    []
+                                    ()
+                                    Private
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            simple_external_matmul:
+                                (Template
+                                    (SymbolTable
+                                        16
+                                        {
+                                            cast_to_t:
+                                                (Function
+                                                    (SymbolTable
+                                                        18
+                                                        {
+                                                            arg:
+                                                                (Variable
+                                                                    18
+                                                                    arg
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Real 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            res:
+                                                                (Variable
+                                                                    18
+                                                                    res
+                                                                    []
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    cast_to_t
+                                                    (FunctionType
+                                                        [(Real 4)]
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .true.
+                                                        .true.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 18 arg)]
+                                                    []
+                                                    (Var 18 res)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            gemm:
+                                                (Function
+                                                    (SymbolTable
+                                                        17
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    17
+                                                                    a
+                                                                    [lda]
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 17 lda))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            alpha:
+                                                                (Variable
+                                                                    17
+                                                                    alpha
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    17
+                                                                    b
+                                                                    [ldb]
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 17 ldb))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            beta:
+                                                                (Variable
+                                                                    17
+                                                                    beta
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (TypeParameter
+                                                                        t
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    17
+                                                                    c
+                                                                    [ldc]
+                                                                    Out
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (Var 17 ldc))
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    17
+                                                                    k
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            lda:
+                                                                (Variable
+                                                                    17
+                                                                    lda
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ldb:
+                                                                (Variable
+                                                                    17
+                                                                    ldb
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            ldc:
+                                                                (Variable
+                                                                    17
+                                                                    ldc
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    17
+                                                                    m
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    17
+                                                                    n
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            transa:
+                                                                (Variable
+                                                                    17
+                                                                    transa
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Character 1 1 ())
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            transb:
+                                                                (Variable
+                                                                    17
+                                                                    transb
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Character 1 1 ())
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    gemm
+                                                    (FunctionType
+                                                        [(Character 1 1 ())
+                                                        (Character 1 1 ())
+                                                        (Integer 4)
+                                                        (Integer 4)
+                                                        (Integer 4)
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                7
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                9
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)
+                                                        (TypeParameter
+                                                            t
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (FunctionParam
+                                                                12
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Integer 4)]
+                                                        ()
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .true.
+                                                    )
+                                                    []
+                                                    [(Var 17 transa)
+                                                    (Var 17 transb)
+                                                    (Var 17 m)
+                                                    (Var 17 n)
+                                                    (Var 17 k)
+                                                    (Var 17 alpha)
+                                                    (Var 17 a)
+                                                    (Var 17 lda)
+                                                    (Var 17 b)
+                                                    (Var 17 ldb)
+                                                    (Var 17 beta)
+                                                    (Var 17 c)
+                                                    (Var 17 ldc)]
+                                                    []
+                                                    ()
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            real:
+                                                (Variable
+                                                    16
+                                                    real
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            simple_external_matmul:
+                                                (Function
+                                                    (SymbolTable
+                                                        19
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    19
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    19
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    19
+                                                                    c
+                                                                    [a
+                                                                    b]
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 19 a)
+                                                                            (IntegerConstant 1 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))
+                                                                        ((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 19 b)
+                                                                            (IntegerConstant 2 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))]
+                                                                        PointerToDataArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    19
+                                                                    k
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    19
+                                                                    m
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    19
+                                                                    n
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    simple_external_matmul
+                                                    (FunctionType
+                                                        [(Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        (Array
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    0
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 1 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    1
+                                                                    (Array
+                                                                        (TypeParameter
+                                                                            t
+                                                                        )
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 2 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            PointerToDataArray
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [cast_to_t
+                                                    gemm]
+                                                    [(Var 19 a)
+                                                    (Var 19 b)]
+                                                    [(=
+                                                        (Var 19 m)
+                                                        (ArraySize
+                                                            (Var 19 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 19 n)
+                                                        (ArraySize
+                                                            (Var 19 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 19 k)
+                                                        (ArraySize
+                                                            (Var 19 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (SubroutineCall
+                                                        16 gemm
+                                                        ()
+                                                        [((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((Var 19 m))
+                                                        ((Var 19 n))
+                                                        ((Var 19 k))
+                                                        ((FunctionCall
+                                                            16 cast_to_t
+                                                            ()
+                                                            [((RealConstant
+                                                                1.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 19 a)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 19 m))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 19 b)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 19 k))
+                                                        ((FunctionCall
+                                                            16 cast_to_t
+                                                            ()
+                                                            [((RealConstant
+                                                                0.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (TypeParameter
+                                                                t
+                                                            )
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 19 c)
+                                                            PointerToDataArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 19 a)
+                                                                    (IntegerConstant 1 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))
+                                                                ((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 19 b)
+                                                                    (IntegerConstant 2 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 19 m))]
+                                                        ()
+                                                    )]
+                                                    (Var 19 c)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            t:
+                                                (Variable
+                                                    16
+                                                    t
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (TypeParameter
+                                                        t
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    simple_external_matmul
+                                    [t
+                                    gemm
+                                    cast_to_t]
+                                    [(Require
+                                        gemm_r
+                                        [t
+                                        gemm]
+                                    )
+                                    (Require
+                                        cast_r
+                                        [real
+                                        t
+                                        cast_to_t]
+                                    )]
+                                ),
+                            test_template:
+                                (Function
+                                    (SymbolTable
+                                        20
+                                        {
+                                            __instantiated_simple_external_matmul:
+                                                (Function
+                                                    (SymbolTable
+                                                        24
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    24
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    24
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    24
+                                                                    c
+                                                                    [a
+                                                                    b]
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 24 a)
+                                                                            (IntegerConstant 1 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))
+                                                                        ((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 24 b)
+                                                                            (IntegerConstant 2 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))]
+                                                                        PointerToDataArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    24
+                                                                    k
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    24
+                                                                    m
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    24
+                                                                    n
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    __instantiated_simple_external_matmul
+                                                    (FunctionType
+                                                        [(Array
+                                                            (Real 4)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (Real 4)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        (Array
+                                                            (Real 4)
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    0
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 1 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    1
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 2 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            PointerToDataArray
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [my_cast_to_real
+                                                    my_gemm_real]
+                                                    [(Var 24 a)
+                                                    (Var 24 b)]
+                                                    [(=
+                                                        (Var 24 m)
+                                                        (ArraySize
+                                                            (Var 24 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 24 n)
+                                                        (ArraySize
+                                                            (Var 24 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 24 k)
+                                                        (ArraySize
+                                                            (Var 24 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (SubroutineCall
+                                                        2 my_gemm_real
+                                                        ()
+                                                        [((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((Var 24 m))
+                                                        ((Var 24 n))
+                                                        ((Var 24 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_real
+                                                            ()
+                                                            [((RealConstant
+                                                                1.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 4)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 24 a)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 4)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 24 m))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 24 b)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 4)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 24 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_real
+                                                            ()
+                                                            [((RealConstant
+                                                                0.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 4)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 24 c)
+                                                            PointerToDataArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 4)
+                                                                [((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 24 a)
+                                                                    (IntegerConstant 1 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))
+                                                                ((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 24 b)
+                                                                    (IntegerConstant 2 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 24 m))]
+                                                        ()
+                                                    )]
+                                                    (Var 24 c)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            __instantiated_simple_external_matmul1:
+                                                (Function
+                                                    (SymbolTable
+                                                        25
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    25
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    25
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    25
+                                                                    c
+                                                                    [a
+                                                                    b]
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 25 a)
+                                                                            (IntegerConstant 1 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))
+                                                                        ((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 25 b)
+                                                                            (IntegerConstant 2 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))]
+                                                                        PointerToDataArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    25
+                                                                    k
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    25
+                                                                    m
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    25
+                                                                    n
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    __instantiated_simple_external_matmul1
+                                                    (FunctionType
+                                                        [(Array
+                                                            (Real 8)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (Real 8)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        (Array
+                                                            (Real 8)
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    0
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 1 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    1
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 2 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            PointerToDataArray
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [my_cast_to_double
+                                                    my_gemm_double]
+                                                    [(Var 25 a)
+                                                    (Var 25 b)]
+                                                    [(=
+                                                        (Var 25 m)
+                                                        (ArraySize
+                                                            (Var 25 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 25 n)
+                                                        (ArraySize
+                                                            (Var 25 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 25 k)
+                                                        (ArraySize
+                                                            (Var 25 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (SubroutineCall
+                                                        2 my_gemm_double
+                                                        ()
+                                                        [((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((Var 25 m))
+                                                        ((Var 25 n))
+                                                        ((Var 25 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_double
+                                                            ()
+                                                            [((RealConstant
+                                                                1.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 8)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 25 a)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 8)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 25 m))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 25 b)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 8)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 25 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_double
+                                                            ()
+                                                            [((RealConstant
+                                                                0.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 8)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 25 c)
+                                                            PointerToDataArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 8)
+                                                                [((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 25 a)
+                                                                    (IntegerConstant 1 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))
+                                                                ((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 25 b)
+                                                                    (IntegerConstant 2 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 25 m))]
+                                                        ()
+                                                    )]
+                                                    (Var 25 c)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            adp:
+                                                (Variable
+                                                    20
+                                                    adp
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            asp:
+                                                (Variable
+                                                    20
+                                                    asp
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            bdp:
+                                                (Variable
+                                                    20
+                                                    bdp
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            bsp:
+                                                (Variable
+                                                    20
+                                                    bsp
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            cdp:
+                                                (Variable
+                                                    20
+                                                    cdp
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            csp:
+                                                (Variable
+                                                    20
+                                                    csp
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))
+                                                        ((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 2 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            dp:
+                                                (Variable
+                                                    20
+                                                    dp
+                                                    []
+                                                    Local
+                                                    (IntrinsicScalarFunction
+                                                        Kind
+                                                        [(RealConstant
+                                                            1.000000
+                                                            (Real 8)
+                                                        )]
+                                                        0
+                                                        (Integer 4)
+                                                        (IntegerConstant 8 (Integer 4))
+                                                    )
+                                                    (IntegerConstant 8 (Integer 4))
+                                                    Parameter
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            nonsimple_external_matmul_double:
+                                                (Function
+                                                    (SymbolTable
+                                                        22
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    22
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    22
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    22
+                                                                    c
+                                                                    [a
+                                                                    b]
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 22 a)
+                                                                            (IntegerConstant 1 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))
+                                                                        ((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 22 b)
+                                                                            (IntegerConstant 2 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))]
+                                                                        PointerToDataArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    22
+                                                                    k
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    22
+                                                                    m
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    22
+                                                                    n
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    nonsimple_external_matmul_double
+                                                    (FunctionType
+                                                        [(Array
+                                                            (Real 8)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (Real 8)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        (Array
+                                                            (Real 8)
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    0
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 1 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    1
+                                                                    (Array
+                                                                        (Real 8)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 2 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            PointerToDataArray
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [my_cast_to_double
+                                                    my_gemm_double]
+                                                    [(Var 22 a)
+                                                    (Var 22 b)]
+                                                    [(=
+                                                        (Var 22 m)
+                                                        (ArraySize
+                                                            (Var 22 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 22 n)
+                                                        (ArraySize
+                                                            (Var 22 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 22 k)
+                                                        (ArraySize
+                                                            (Var 22 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (SubroutineCall
+                                                        2 my_gemm_double
+                                                        ()
+                                                        [((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((Var 22 m))
+                                                        ((Var 22 n))
+                                                        ((Var 22 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_double
+                                                            ()
+                                                            [((RealConstant
+                                                                1.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 8)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 22 a)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 8)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 22 m))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 22 b)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 8)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 22 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_double
+                                                            ()
+                                                            [((RealConstant
+                                                                0.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 8)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 22 c)
+                                                            PointerToDataArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 8)
+                                                                [((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 22 a)
+                                                                    (IntegerConstant 1 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))
+                                                                ((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 22 b)
+                                                                    (IntegerConstant 2 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 22 m))]
+                                                        ()
+                                                    )]
+                                                    (Var 22 c)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                ),
+                                            nonsimple_external_matmul_real:
+                                                (Function
+                                                    (SymbolTable
+                                                        21
+                                                        {
+                                                            a:
+                                                                (Variable
+                                                                    21
+                                                                    a
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            b:
+                                                                (Variable
+                                                                    21
+                                                                    b
+                                                                    []
+                                                                    In
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            c:
+                                                                (Variable
+                                                                    21
+                                                                    c
+                                                                    [a
+                                                                    b]
+                                                                    ReturnVar
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 21 a)
+                                                                            (IntegerConstant 1 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))
+                                                                        ((IntegerConstant 1 (Integer 4))
+                                                                        (ArraySize
+                                                                            (Var 21 b)
+                                                                            (IntegerConstant 2 (Integer 4))
+                                                                            (Integer 4)
+                                                                            ()
+                                                                        ))]
+                                                                        PointerToDataArray
+                                                                    )
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            k:
+                                                                (Variable
+                                                                    21
+                                                                    k
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            m:
+                                                                (Variable
+                                                                    21
+                                                                    m
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                ),
+                                                            n:
+                                                                (Variable
+                                                                    21
+                                                                    n
+                                                                    []
+                                                                    Local
+                                                                    ()
+                                                                    ()
+                                                                    Default
+                                                                    (Integer 4)
+                                                                    ()
+                                                                    Source
+                                                                    Private
+                                                                    Required
+                                                                    .false.
+                                                                )
+                                                        })
+                                                    nonsimple_external_matmul_real
+                                                    (FunctionType
+                                                        [(Array
+                                                            (Real 4)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                        (Array
+                                                            (Real 4)
+                                                            [(()
+                                                            ())
+                                                            (()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )]
+                                                        (Array
+                                                            (Real 4)
+                                                            [((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    0
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 1 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))
+                                                            ((IntegerConstant 1 (Integer 4))
+                                                            (ArraySize
+                                                                (FunctionParam
+                                                                    1
+                                                                    (Array
+                                                                        (Real 4)
+                                                                        [(()
+                                                                        ())
+                                                                        (()
+                                                                        ())]
+                                                                        DescriptorArray
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                (IntegerConstant 2 (Integer 4))
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            PointerToDataArray
+                                                        )
+                                                        Source
+                                                        Implementation
+                                                        ()
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        .false.
+                                                        []
+                                                        .false.
+                                                    )
+                                                    [my_cast_to_real
+                                                    my_gemm_real]
+                                                    [(Var 21 a)
+                                                    (Var 21 b)]
+                                                    [(=
+                                                        (Var 21 m)
+                                                        (ArraySize
+                                                            (Var 21 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 21 n)
+                                                        (ArraySize
+                                                            (Var 21 b)
+                                                            (IntegerConstant 2 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (=
+                                                        (Var 21 k)
+                                                        (ArraySize
+                                                            (Var 21 a)
+                                                            (IntegerConstant 1 (Integer 4))
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        ()
+                                                    )
+                                                    (SubroutineCall
+                                                        2 my_gemm_real
+                                                        ()
+                                                        [((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((StringConstant
+                                                            "n"
+                                                            (Character 1 1 ())
+                                                        ))
+                                                        ((Var 21 m))
+                                                        ((Var 21 n))
+                                                        ((Var 21 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_real
+                                                            ()
+                                                            [((RealConstant
+                                                                1.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 4)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 21 a)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 4)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 21 m))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 21 b)
+                                                            DescriptorArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 4)
+                                                                [(()
+                                                                ())
+                                                                (()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 21 k))
+                                                        ((FunctionCall
+                                                            2 my_cast_to_real
+                                                            ()
+                                                            [((RealConstant
+                                                                0.000000
+                                                                (Real 4)
+                                                            ))]
+                                                            (Real 4)
+                                                            ()
+                                                            ()
+                                                        ))
+                                                        ((ArrayPhysicalCast
+                                                            (Var 21 c)
+                                                            PointerToDataArray
+                                                            DescriptorArray
+                                                            (Array
+                                                                (Real 4)
+                                                                [((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 21 a)
+                                                                    (IntegerConstant 1 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))
+                                                                ((IntegerConstant 1 (Integer 4))
+                                                                (ArraySize
+                                                                    (Var 21 b)
+                                                                    (IntegerConstant 2 (Integer 4))
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ))]
+                                                                DescriptorArray
+                                                            )
+                                                            ()
+                                                        ))
+                                                        ((Var 21 m))]
+                                                        ()
+                                                    )]
+                                                    (Var 21 c)
+                                                    Private
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                )
+                                        })
+                                    test_template
+                                    (FunctionType
+                                        []
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    []
+                                    [(=
+                                        (Var 20 csp)
+                                        (FunctionCall
+                                            20 __instantiated_simple_external_matmul
+                                            ()
+                                            [((ArrayPhysicalCast
+                                                (Var 20 asp)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Real 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))
+                                                    ((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            ))
+                                            ((ArrayPhysicalCast
+                                                (Var 20 bsp)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Real 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))
+                                                    ((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            ))]
+                                            (Array
+                                                (Real 4)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 2 (Integer 4)))
+                                                ((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 2 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 20 cdp)
+                                        (FunctionCall
+                                            20 __instantiated_simple_external_matmul1
+                                            ()
+                                            [((ArrayPhysicalCast
+                                                (Var 20 adp)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Real 8)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))
+                                                    ((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            ))
+                                            ((ArrayPhysicalCast
+                                                (Var 20 bdp)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Real 8)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))
+                                                    ((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            ))]
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 2 (Integer 4)))
+                                                ((IntegerConstant 1 (Integer 4))
+                                                (IntegerConstant 2 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    template_lapack_01_m
+                    [template_lapack_01_m]
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -150,6 +150,10 @@ filename = "../integration_tests/template_sort_02.f90"
 asr = true
 
 [[test]]
+filename = "../integration_tests/template_lapack_01.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/test_backspace_01.f90"
 asr = true
 


### PR DESCRIPTION
Addressing #2267. However, the example described in the issue didn't implement the specific subroutines `sgemm`, etc.