### PR TITLE
Fix cxxflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,6 @@ message("WITH_ZLIB: ${WITH_ZLIB}")
 message("WITH_TARGET_AARCH64: ${WITH_TARGET_AARCH64}")
 message("WITH_TARGET_X86: ${WITH_TARGET_X86}")
 message("WITH_TARGET_WASM: ${WITH_TARGET_WASM}")
-message("CXXFLAGS: $ENV{CXXFLAGS}")
 
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ message("WITH_ZLIB: ${WITH_ZLIB}")
 message("WITH_TARGET_AARCH64: ${WITH_TARGET_AARCH64}")
 message("WITH_TARGET_X86: ${WITH_TARGET_X86}")
 message("WITH_TARGET_WASM: ${WITH_TARGET_WASM}")
-
+message("CXXFLAGS: ${CMAKE_CXX_FLAGS}")
 
 add_subdirectory(src)
 add_subdirectory(doc/man)

--- a/src/runtime/legacy/CMakeLists.txt
+++ b/src/runtime/legacy/CMakeLists.txt
@@ -3,7 +3,6 @@ set(SRC
 )
 
 add_library(lfortran_runtime SHARED ${SRC})
-target_compile_options(lfortran_runtime PRIVATE $ENV{CXXFLAGS})
 target_include_directories(lfortran_runtime BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(lfortran_runtime BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
 set_target_properties(lfortran_runtime PROPERTIES
@@ -13,7 +12,6 @@ set_target_properties(lfortran_runtime PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ..)
 
 add_library(lfortran_runtime_static STATIC ${SRC})
-target_compile_options(lfortran_runtime_static PRIVATE $ENV{CXXFLAGS})
 target_include_directories(lfortran_runtime_static BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(lfortran_runtime_static BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
 set_target_properties(lfortran_runtime_static PROPERTIES


### PR DESCRIPTION
Fix #2974 

CMake picks up `CXXFLAGS` automatically, so I am not sure what the point of 487ff2ec48 was.