### PR TITLE
ENH: handling of `char(xx)` as a variable symbolic value

### DIFF
--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -645,7 +645,11 @@ public:
         }
         r += " :: ";
         r.append(x.m_name);
-        if (x.m_value) {
+        if (x.m_symbolic_value && x.m_value && ASR::is_a<ASR::StringChr_t>(*x.m_symbolic_value) && ASR::is_a<ASR::StringConstant_t>(*x.m_value)) {
+            r += " = ";
+            visit_expr(*x.m_symbolic_value);
+            r += s;
+        } else if (x.m_value) {
             r += " = ";
             visit_expr(*x.m_value);
             r += s;

--- a/tests/char1.f90
+++ b/tests/char1.f90
@@ -1,0 +1,3 @@
+program char1
+character(len=1, kind=1), parameter :: c_null_char = char(0)
+end program

--- a/tests/reference/fortran-char1-046b501.json
+++ b/tests/reference/fortran-char1-046b501.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-char1-046b501",
+    "cmd": "lfortran --show-fortran --no-color {infile} -o {outfile}",
+    "infile": "tests/char1.f90",
+    "infile_hash": "78e727aecb70503bac5e780ad046d418a533f576cf7b276702bb6be1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-char1-046b501.stdout",
+    "stdout_hash": "70340b6836155a639a14ae6fefdf51a25c5bdf6a0119823a34cf722a",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-char1-046b501.stdout
+++ b/tests/reference/fortran-char1-046b501.stdout
@@ -1,0 +1,4 @@
+program char1
+implicit none
+character(len=1, kind=1), parameter :: c_null_char = char(0)
+end program char1

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3594,3 +3594,7 @@ llvm = true
 [[test]]
 filename = "errors/type_conflict1.f90"
 asr = true
+
+[[test]]
+filename = "char1.f90"
+fortran = true


### PR DESCRIPTION
Fixes #2819