### PR TITLE
CI: cancel duplicated runs in PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
 env:
   MACOSX_DEPLOYMENT_TARGET: 12.0
 


### PR DESCRIPTION
This will basically cancel the CI when one pushes to a PR twice.