### PR TITLE
ENH: Implement quadruple precision

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2655,7 +2655,7 @@ public:
                 this->visit_expr(*sym_type->m_kind->m_value);
                 ASR::expr_t* kind_expr = ASRUtils::EXPR(tmp);
                 int kind_value = ASRUtils::extract_kind<SemanticError>(kind_expr, loc);
-                if (kind_value != 4 && kind_value != 8) {
+                if (kind_value != 4 && kind_value != 8 && kind_value != 16) {
                     throw SemanticError("Kind " + std::to_string(kind_value) + " is not supported for Real",
                                     loc);
                 }

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -424,6 +424,9 @@ namespace LCompilers {
                 case 8:
                     type_ptr =  llvm::Type::getDoublePtrTy(context);
                     break;
+                case 16:
+                    type_ptr = llvm::Type::getFP128PtrTy(context);
+                    break;
                 default:
                     throw CodeGenError("Only 32 and 64 bits real kinds are supported.");
             }
@@ -435,6 +438,9 @@ namespace LCompilers {
                     break;
                 case 8:
                     type_ptr = llvm::Type::getDoubleTy(context);
+                    break;
+                case 16:
+                    type_ptr = llvm::Type::getFP128Ty(context);
                     break;
                 default:
                     throw CodeGenError("Only 32 and 64 bits real kinds are supported.");

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -7,14 +7,14 @@ integer, parameter :: int32 = 4
 integer, parameter :: int64 = 8
 integer, parameter :: real32 = 4
 integer, parameter :: real64 = 8
-integer, parameter :: real128 = -1
+integer, parameter :: real128 = 16
 
 integer, parameter :: input_unit = 5
 integer, parameter :: output_unit = 6
 integer, parameter :: error_unit = 0
 
 integer, parameter :: integer_kinds(2) = [4, 8]
-integer, parameter :: real_kinds(2) = [4, 8]
+integer, parameter :: real_kinds(3) = [4, 8, 16]
 integer, parameter :: character_kinds(1) = [1]
 integer, parameter :: logical_kinds(1) = [4]
 


### PR DESCRIPTION
Fixes #2999.

```fortran
program main
    use iso_fortran_env, only : qp => real128
    implicit none
    real(qp) :: y
    y = 1.0_qp
    print *, y
end program
```

> LFortran

```console
% lfortran a.f90 
Traceback (most recent call last):
  Binary file "/usr/lib/system/libsystem_platform.dylib", local address: 0x18046da23
Segfault: Signal SIGSEGV (segmentation fault) received
```

This happens at https://github.com/lfortran/lfortran/blob/main/src/libasr/codegen/asr_to_llvm.cpp#L4954 because of memory alignment, I am unable to proceed from here.