### PR TITLE
CI: add lfortran.1 to tarball

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -915,6 +915,7 @@ jobs:
         run: |
           ./build0.sh
           lfortran_version=$(<version)
+          pandoc --standalone --to man doc/man/lfortran.md -o doc/man/lfortran.1
           ci/create_source_tarball.sh $lfortran_version
           ci/upload_tarball.sh
         env:


### PR DESCRIPTION
Fix up for #2934, I think `lfortran.1` should be part of the tarball that gets uploaded.