### PR TITLE
ci: update stdlib branch to remove workaround for gamma

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -503,8 +503,8 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/stdlib-fortran-lang.git
             cd stdlib-fortran-lang
-            git checkout -t origin/lf-special-function-gamma
-            git checkout 1a048c08aa140937a8011bcafb9069155299945b
+            git checkout -t origin/lf-special-function-gamma-2
+            git checkout 6b1c348d02576739df10c755cdcee2520ec18fe6
             micromamba activate lf
             micromamba install -c conda-forge fypp
             FC=$(pwd)/../src/bin/lfortran cmake .


### PR DESCRIPTION
Towards #3000

Branch: https://github.com/Pranavchiku/stdlib-fortran-lang/commits/lf-special-function-gamma-2/
Commit: https://github.com/Pranavchiku/stdlib-fortran-lang/commit/6b1c348d02576739df10c755cdcee2520ec18fe6