### PR TITLE
FIX: inconsistent kind handling for array item indices

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -429,6 +429,8 @@ RUN(NAME arrays_32 LABELS gfortran llvm llvmStackArray)
 RUN(NAME arrays_33 LABELS gfortran llvm llvmStackArray)
 RUN(NAME arrays_34 LABELS gfortran llvm llvmStackArray)
 RUN(NAME arrays_35 LABELS gfortran llvm)
+RUN(NAME arrays_36 LABELS gfortran llvm)
+RUN(NAME arrays_37 LABELS gfortran llvm)
 
 
 # GFortran

--- a/integration_tests/arrays_36.f90
+++ b/integration_tests/arrays_36.f90
@@ -1,0 +1,21 @@
+program arrays_36
+use iso_fortran_env, only: int16
+integer(int16), allocatable :: result(:)
+
+integer(int16) :: start_, end_, step_
+integer(int16) :: i
+
+allocate(result(10))
+start_ = 1_int16
+end_ = 10_int16
+
+result = [(i, i=start_, end_)]
+
+print *, result
+i = 1_int16
+do while (i <= 10_int16)
+    if (result(i) /= i) error stop
+    i = i + 1_int16
+end do
+
+end program

--- a/integration_tests/arrays_37.f90
+++ b/integration_tests/arrays_37.f90
@@ -1,0 +1,20 @@
+program arrays_37
+use iso_fortran_env, only: dp => real64
+real(dp), allocatable :: result(:)
+
+real(dp) :: start_, end_, step_
+integer :: i
+
+allocate(result(10))
+start_ = 1.0_dp
+end_ = 10.0_dp
+step_ = 1.0_dp
+
+result = [(start_ + (i - 1)*step_, i=1, size(result), 1)]
+print *, result
+i = 1
+do while (i <= size(result))
+    if (abs(result(i) - (start_ + (i - 1)*step_)) > 1.0e-15_dp) error stop
+    i = i + 1
+end do
+end program

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -346,9 +346,10 @@ namespace LCompilers {
                 llvm::Value* s_val = llvm_utils->create_gep(dim_val, 0);
                 llvm::Value* l_val = llvm_utils->create_gep(dim_val, 1);
                 llvm::Value* dim_size_ptr = llvm_utils->create_gep(dim_val, 2);
+                llvm::Value* first = builder->CreateSExtOrTrunc(llvm_dims[r].first, llvm::Type::getInt32Ty(context));
+                llvm::Value* dim_size = builder->CreateSExtOrTrunc(llvm_dims[r].second, llvm::Type::getInt32Ty(context));
                 builder->CreateStore(prod, s_val);
-                builder->CreateStore(llvm_dims[r].first, l_val);
-                llvm::Value* dim_size = llvm_dims[r].second;
+                builder->CreateStore(first, l_val);
                 builder->CreateStore(dim_size, dim_size_ptr);
                 prod = builder->CreateMul(prod, dim_size);
             }
@@ -579,6 +580,8 @@ namespace LCompilers {
                 llvm::Value* curr_llvm_idx = m_args[r];
                 llvm::Value* dim_des_ptr = llvm_utils->create_ptr_gep(dim_des_arr_ptr, r);
                 llvm::Value* lval = LLVM::CreateLoad(*builder, llvm_utils->create_gep(dim_des_ptr, 1));
+                // first cast curr_llvm_idx to 32 bit
+                curr_llvm_idx = builder->CreateSExt(curr_llvm_idx, llvm::Type::getInt32Ty(context));
                 curr_llvm_idx = builder->CreateSub(curr_llvm_idx, lval);
                 if( check_for_bounds ) {
                     // check_single_element(curr_llvm_idx, arr); TODO: To be implemented

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -46,14 +46,15 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
         ASR::expr_t* end = implied_doloop->m_end;
         ASR::expr_t* d = implied_doloop->m_increment;
         ASR::expr_t* implied_doloop_size = nullptr;
+        int kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(end));
         if( d == nullptr ) {
             implied_doloop_size = builder.ElementalAdd(
                 builder.ElementalSub(end, start, loc),
-                make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, 4, loc), loc);
+                make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, kind, loc), loc);
         } else {
             implied_doloop_size = builder.ElementalAdd(builder.ElementalDiv(
                 builder.ElementalSub(end, start, loc), d, loc),
-                make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, 4, loc), loc);
+                make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, kind, loc), loc);
         }
         int const_elements = 0;
         ASR::expr_t* implied_doloop_size_ = nullptr;
@@ -74,11 +75,11 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
         if( const_elements > 1 ) {
             if( implied_doloop_size_ == nullptr ) {
                 implied_doloop_size_ = make_ConstantWithKind(make_IntegerConstant_t,
-                    make_Integer_t, const_elements, 4, loc);
+                    make_Integer_t, const_elements, kind, loc);
             } else {
                 implied_doloop_size_ = builder.ElementalAdd(
                     make_ConstantWithKind(make_IntegerConstant_t,
-                        make_Integer_t, const_elements, 4, loc),
+                        make_Integer_t, const_elements, kind, loc),
                     implied_doloop_size_, loc);
             }
         }

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -216,7 +216,7 @@ class ASRBuilder {
 
     #define make_ConstantWithKind(Constructor, TypeConstructor, value, kind, loc) ASRUtils::EXPR( \
         ASR::Constructor( al, loc, value, \
-            ASRUtils::TYPE(ASR::TypeConstructor(al, loc, 4)))) \
+            ASRUtils::TYPE(ASR::TypeConstructor(al, loc, kind)))) \
 
     #define make_ConstantWithType(Constructor, value, type, loc) ASRUtils::EXPR( \
         ASR::Constructor(al, loc, value, type)) \

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -587,8 +587,9 @@ namespace LCompilers {
                                                     array_ref, idoloop->m_values[i], nullptr));
                     doloop_body.push_back(al, doloop_stmt);
                     if( arr_idx != nullptr ) {
+                        ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_var->base.loc, 1, ASRUtils::TYPE(ASR::make_Integer_t(al, arr_var->base.loc, 4))));
                         ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.loc,
-                                                    arr_idx, ASR::binopType::Add, const_1, ASRUtils::expr_type(arr_idx), nullptr));
+                                                    arr_idx, ASR::binopType::Add, one, ASRUtils::expr_type(arr_idx), nullptr));
                         ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.loc,
                                                     arr_idx, increment, nullptr));
                         doloop_body.push_back(al, assign_stmt);


### PR DESCRIPTION
Continuation of #3073, towards #3046.

With this PR we get `src/stdlib_math_arange.f90` compiled to LLVM.