### PR TITLE
Fix `shape` intrinsic for scalar arg

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -604,6 +604,7 @@ RUN(NAME intrinsics_101 LABELS gfortran llvm)#repeat
 RUN(NAME intrinsics_102 LABELS gfortran llvm)
 RUN(NAME intrinsics_103 LABELS gfortran llvm)
 RUN(NAME intrinsics_104 LABELS gfortran llvm c wasm)
+RUN(NAME intrinsics_105 LABELS gfortran llvm)#shape
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_105.f90
+++ b/integration_tests/intrinsics_105.f90
@@ -5,9 +5,9 @@ PROGRAM intrinsics_105
   result = shape(A)
   print*, shape(A)
   
-  if ( result(1) - 3 /= 0 ) error stop
-  if ( result(2) - 4 /= 0 ) error stop
-  if ( result(3) - 12 /= 0 ) error stop
-  if ( size(shape(42)) - 0 /= 0 ) error stop
+  if ( result(1) /= 3 ) error stop
+  if ( result(2) /= 4 ) error stop
+  if ( result(3) /= 12 ) error stop
+  if ( size(shape(42)) /= 0 ) error stop
 
 END PROGRAM

--- a/integration_tests/intrinsics_105.f90
+++ b/integration_tests/intrinsics_105.f90
@@ -1,0 +1,13 @@
+PROGRAM intrinsics_105
+  INTEGER, DIMENSION(-1:1, -1:2, -1:10) :: A
+  INTEGER :: result(3)
+
+  result = shape(A)
+  print*, shape(A)
+  
+  if ( result(1) - 3 /= 0 ) error stop
+  if ( result(2) - 4 /= 0 ) error stop
+  if ( result(3) - 12 /= 0 ) error stop
+  if ( size(shape(42)) - 0 /= 0 ) error stop
+
+END PROGRAM

--- a/integration_tests/intrinsics_62.f90
+++ b/integration_tests/intrinsics_62.f90
@@ -35,5 +35,5 @@ program intrinsics_62
     ! if (res_01(1) /= 4) error stop
 
     ! TODO: Support size(x), where x is rank 0
-    ! if (size(shape(z)) /= 0) error stop
+    if (size(shape(z)) /= 0) error stop
 end program intrinsics_62

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -765,7 +765,8 @@ namespace Shape {
         size_t n_dims = extract_dimensions_from_ttype(expr_type(args[0]), m_dims);
         Vec<ASR::expr_t *> m_shapes; m_shapes.reserve(al, n_dims);
         if( n_dims == 0 ){
-            m_shapes.push_back(al, i32(0));
+            return EXPR(ASR::make_ArrayConstant_t(al, loc, m_shapes.p, 0,
+                type, ASR::arraystorageType::ColMajor));
         } else {
             for (size_t i = 0; i < n_dims; i++) {
                 if (m_dims[i].m_length) {
@@ -807,7 +808,7 @@ namespace Shape {
         ASR::ttype_t *return_type = b.Array({n_dims},
             TYPE(ASR::make_Integer_t(al, loc, kind)));
         ASR::expr_t *m_value = eval_Shape(al, loc, return_type, args);
-        
+
         return ASRUtils::make_IntrinsicArrayFunction_t_util(al, loc,
             static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Shape),
             m_args.p, m_args.n, 0, return_type, m_value);

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -764,15 +764,19 @@ namespace Shape {
         ASR::dimension_t *m_dims;
         size_t n_dims = extract_dimensions_from_ttype(expr_type(args[0]), m_dims);
         Vec<ASR::expr_t *> m_shapes; m_shapes.reserve(al, n_dims);
-        for (size_t i = 0; i < n_dims; i++) {
-            if (m_dims[i].m_length) {
-                ASR::expr_t *e = nullptr;
-                if (extract_kind_from_ttype_t(type) != 4) {
-                    e = i2i(m_dims[i].m_length, extract_type(type));
-                } else {
-                    e = m_dims[i].m_length;
+        if( n_dims == 0 ){
+            m_shapes.push_back(al, i32(0));
+        } else {
+            for (size_t i = 0; i < n_dims; i++) {
+                if (m_dims[i].m_length) {
+                    ASR::expr_t *e = nullptr;
+                    if (extract_kind_from_ttype_t(type) != 4) {
+                        e = i2i(m_dims[i].m_length, extract_type(type));
+                    } else {
+                        e = m_dims[i].m_length;
+                    }
+                    m_shapes.push_back(al, e);
                 }
-                m_shapes.push_back(al, e);
             }
         }
         ASR::expr_t *value = nullptr;
@@ -803,7 +807,7 @@ namespace Shape {
         ASR::ttype_t *return_type = b.Array({n_dims},
             TYPE(ASR::make_Integer_t(al, loc, kind)));
         ASR::expr_t *m_value = eval_Shape(al, loc, return_type, args);
-
+        
         return ASRUtils::make_IntrinsicArrayFunction_t_util(al, loc,
             static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Shape),
             m_args.p, m_args.n, 0, return_type, m_value);
@@ -825,7 +829,6 @@ namespace Shape {
             b.Assignment(i, iAdd(i, i32(1)))
         }));
         body.push_back(al, Return());
-
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);

--- a/tests/reference/asr-intrinsics_27-11ba39d.json
+++ b/tests/reference/asr-intrinsics_27-11ba39d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_27-11ba39d.stdout",
-    "stdout_hash": "ddea02e0722437dbbac4a7a4f38e347ea560aad6d2dec392b9bf6199",
+    "stdout_hash": "3cedf3eae4cd302fbbc2f057d15cd716569040fc5ee3c1a7c70c47ad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_27-11ba39d.json
+++ b/tests/reference/asr-intrinsics_27-11ba39d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_27-11ba39d.stdout",
-    "stdout_hash": "cc39fa985dd3a4006f3060d227e187bfbebc1f78a1ae139b48e6642a",
+    "stdout_hash": "ddea02e0722437dbbac4a7a4f38e347ea560aad6d2dec392b9bf6199",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_27-11ba39d.stdout
+++ b/tests/reference/asr-intrinsics_27-11ba39d.stdout
@@ -100,7 +100,16 @@
                                     (IntegerConstant 0 (Integer 4)))]
                                     FixedSizeArray
                                 )
-                                ()
+                                (ArrayConstant
+                                    [(IntegerConstant 0 (Integer 4))]
+                                    (Array
+                                        (Integer 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 0 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
+                                    ColMajor
+                                )
                             )
                             ()
                             (Integer 4)

--- a/tests/reference/asr-intrinsics_27-11ba39d.stdout
+++ b/tests/reference/asr-intrinsics_27-11ba39d.stdout
@@ -101,7 +101,7 @@
                                     FixedSizeArray
                                 )
                                 (ArrayConstant
-                                    [(IntegerConstant 0 (Integer 4))]
+                                    []
                                     (Array
                                         (Integer 4)
                                         [((IntegerConstant 1 (Integer 4))


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3081