### PR TITLE
Stdlib: Fix initialization for complex parameter

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -257,6 +257,7 @@ RUN(NAME expr_14 LABELS gfortran llvm wasm c)
 RUN(NAME expr_15 LABELS gfortran llvm wasm c fortran)
 RUN(NAME expr_16 LABELS gfortran llvm wasm c)
 RUN(NAME expr_17 LABELS gfortran llvm)
+RUN(NAME expr_18 LABELS gfortran llvm wasm c)
 
 RUN(NAME data_01 LABELS gfortran llvm c fortran)
 RUN(NAME data_02 LABELS gfortran)

--- a/integration_tests/expr_18.f90
+++ b/integration_tests/expr_18.f90
@@ -1,0 +1,6 @@
+program main
+    complex, parameter :: x = 123
+
+    print *, x
+    if (abs(x - (123, 0)) > 1e-5) error stop
+end program

--- a/src/lfortran/semantics/asr_implicit_cast_rules.h
+++ b/src/lfortran/semantics/asr_implicit_cast_rules.h
@@ -229,7 +229,18 @@ public:
                         ival, dest_type2);
                 }
             }
-
+        } else if ((ASR::cast_kindType)cast_kind == ASR::cast_kindType::IntegerToComplex) {
+            if (ASRUtils::expr_value(*convert_can)) {
+                LCOMPILERS_ASSERT(ASR::is_a<ASR::Complex_t>(*dest_type2))
+                LCOMPILERS_ASSERT(ASR::is_a<ASR::Integer_t>(*ASRUtils::expr_type(*convert_can)))
+                value = ASRUtils::expr_value(*convert_can);
+                if( ASR::is_a<ASR::IntegerConstant_t>(*value) ) {
+                    ASR::IntegerConstant_t *i = ASR::down_cast<ASR::IntegerConstant_t>(value);
+                    int64_t ival = i->m_n;
+                    value = (ASR::expr_t *)ASR::make_ComplexConstant_t(al, a_loc,
+                      ival, 0, dest_type2);
+                }
+            }
         }
 
       if( !ASRUtils::is_array(source_type) ) {

--- a/tests/reference/asr-allocate_01-f3446f6.json
+++ b/tests/reference/asr-allocate_01-f3446f6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_01-f3446f6.stdout",
-    "stdout_hash": "2914c6d8f5302429a2cf835d0f17bce6e88e57f3b86339ec7ef295ec",
+    "stdout_hash": "fad5d6a42423c013a290f814cda6822d0db53ed9a0795caccaae8cfd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_01-f3446f6.stdout
+++ b/tests/reference/asr-allocate_01-f3446f6.stdout
@@ -305,7 +305,11 @@
                                             (IntegerConstant 0 (Integer 4))
                                             IntegerToComplex
                                             (Complex 4)
-                                            ()
+                                            (ComplexConstant
+                                                0.000000
+                                                0.000000
+                                                (Complex 4)
+                                            )
                                         )
                                         ()
                                     )

--- a/tests/reference/asr-arrays_01_complex-2513a51.json
+++ b/tests/reference/asr-arrays_01_complex-2513a51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_01_complex-2513a51.stdout",
-    "stdout_hash": "77cd78c075e60286600f6f8ee96a6795ca57cceb14b4f8fff0ce89b9",
+    "stdout_hash": "cdd11133753d8b516dcf04a45d437f683fce3a117e26f15e526204ec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_01_complex-2513a51.stdout
+++ b/tests/reference/asr-arrays_01_complex-2513a51.stdout
@@ -154,7 +154,11 @@
                                 (IntegerConstant 11 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    11.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -180,7 +184,11 @@
                                 (IntegerConstant 12 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    12.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -206,7 +214,11 @@
                                 (IntegerConstant 13 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    13.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -263,7 +275,11 @@
                                 (IntegerConstant 11 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    11.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -289,7 +305,11 @@
                                 (IntegerConstant 12 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    12.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -315,7 +335,11 @@
                                 (IntegerConstant 13 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    13.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -341,7 +365,11 @@
                                 (IntegerConstant 14 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    14.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -382,7 +410,11 @@
                                     (IntegerConstant 10 (Integer 4))
                                     IntegerToComplex
                                     (Complex 4)
-                                    ()
+                                    (ComplexConstant
+                                        10.000000
+                                        0.000000
+                                        (Complex 4)
+                                    )
                                 )
                                 (Complex 4)
                                 ()
@@ -406,7 +438,11 @@
                                 (IntegerConstant 1 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    1.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -432,7 +468,11 @@
                                 (IntegerConstant 2 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    2.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -458,7 +498,11 @@
                                 (IntegerConstant 3 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    3.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -547,7 +591,11 @@
                                 (IntegerConstant 17 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    17.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -594,7 +642,11 @@
                                 (IntegerConstant 11 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    11.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -670,7 +722,11 @@
                                 (IntegerConstant 12 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    12.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -699,7 +755,11 @@
                                 (IntegerConstant 13 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    13.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -728,7 +788,11 @@
                                 (IntegerConstant 13 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    13.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()
@@ -757,7 +821,11 @@
                                 (IntegerConstant 14 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    14.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             (Logical 4)
                             ()

--- a/tests/reference/asr-associate_02-ca5c9ec.json
+++ b/tests/reference/asr-associate_02-ca5c9ec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-associate_02-ca5c9ec.stdout",
-    "stdout_hash": "e83fd92a47e12ca529738b63dd882070e93e51ac024978f3ad8923c4",
+    "stdout_hash": "1df701d948bf5bbcf4203de0eef56a33006438da9f2a549fdbf9bb0b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-associate_02-ca5c9ec.stdout
+++ b/tests/reference/asr-associate_02-ca5c9ec.stdout
@@ -235,7 +235,11 @@
                                 (IntegerConstant 2 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    2.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             Mul
                             (Var 2 p3)

--- a/tests/reference/asr-complex_div_test-21dab13.json
+++ b/tests/reference/asr-complex_div_test-21dab13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex_div_test-21dab13.stdout",
-    "stdout_hash": "04850498ef4eba0d7637573107186a352e96f3f457292d975087dc84",
+    "stdout_hash": "22015b469cad00210e6aba986ab0e789d3ac2e0384fb24c089d9fb68",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex_div_test-21dab13.stdout
+++ b/tests/reference/asr-complex_div_test-21dab13.stdout
@@ -81,7 +81,11 @@
                                 (IntegerConstant 2 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    2.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             Div
                             (Var 2 x)
@@ -102,7 +106,11 @@
                                 (IntegerConstant 1 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    1.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             Div
                             (ComplexBinOp

--- a/tests/reference/asr-complex_mul_test-562260f.json
+++ b/tests/reference/asr-complex_mul_test-562260f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex_mul_test-562260f.stdout",
-    "stdout_hash": "805b57c0f8f1adb88ed8b501cdeb63ab77122ee818013a878fc8af95",
+    "stdout_hash": "bcae4c1408a02acdfaca97e6f22cefcb391fa88a8abd731fa8baaf66",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex_mul_test-562260f.stdout
+++ b/tests/reference/asr-complex_mul_test-562260f.stdout
@@ -81,7 +81,11 @@
                                 (IntegerConstant 2 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    2.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             Mul
                             (Var 2 x)

--- a/tests/reference/asr-complex_sub_test-f54ef56.json
+++ b/tests/reference/asr-complex_sub_test-f54ef56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex_sub_test-f54ef56.stdout",
-    "stdout_hash": "b7f9d551c232c50650ded2a6815008a75a8e7c43152fdf3cf1b61807",
+    "stdout_hash": "3761c44ddf4821e70e9310b9f9b89e530ec54567bedf156c2c86eaed",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex_sub_test-f54ef56.stdout
+++ b/tests/reference/asr-complex_sub_test-f54ef56.stdout
@@ -104,7 +104,11 @@
                                 (IntegerConstant 2 (Integer 4))
                                 IntegerToComplex
                                 (Complex 4)
-                                ()
+                                (ComplexConstant
+                                    2.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
                             Sub
                             (Var 2 x)

--- a/tests/reference/asr-implicit10-23a5156.json
+++ b/tests/reference/asr-implicit10-23a5156.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit10-23a5156.stdout",
-    "stdout_hash": "19ae2ae655a3f3b3bb6a60e0a2aadb6280925f4a529e6fd2c83c0024",
+    "stdout_hash": "29f2be002a16a9a4a31e5032881347303df23c91c99a1f2466d99bf3",
     "stderr": "asr-implicit10-23a5156.stderr",
     "stderr_hash": "b084a7018a7ba3ba96747c624fca5307b66d070349563d75f0b7894e",
     "returncode": 0

--- a/tests/reference/asr-implicit10-23a5156.stdout
+++ b/tests/reference/asr-implicit10-23a5156.stdout
@@ -485,7 +485,11 @@
                             (IntegerConstant 7 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                7.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )
@@ -495,7 +499,11 @@
                             (IntegerConstant 8 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                8.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )

--- a/tests/reference/asr-implicit10-f531a25.json
+++ b/tests/reference/asr-implicit10-f531a25.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit10-f531a25.stdout",
-    "stdout_hash": "19ae2ae655a3f3b3bb6a60e0a2aadb6280925f4a529e6fd2c83c0024",
+    "stdout_hash": "29f2be002a16a9a4a31e5032881347303df23c91c99a1f2466d99bf3",
     "stderr": "asr-implicit10-f531a25.stderr",
     "stderr_hash": "b084a7018a7ba3ba96747c624fca5307b66d070349563d75f0b7894e",
     "returncode": 0

--- a/tests/reference/asr-implicit10-f531a25.stdout
+++ b/tests/reference/asr-implicit10-f531a25.stdout
@@ -485,7 +485,11 @@
                             (IntegerConstant 7 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                7.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )
@@ -495,7 +499,11 @@
                             (IntegerConstant 8 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                8.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )

--- a/tests/reference/asr-implicit11-95f56fd.json
+++ b/tests/reference/asr-implicit11-95f56fd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit11-95f56fd.stdout",
-    "stdout_hash": "708241fd34ee73ffd804485dbc5b266436ac910ae4ac62186501a781",
+    "stdout_hash": "b78336fa6a9c9d2acf78ea81cc80f088be6dfb64f424a12465d7042b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit11-95f56fd.stdout
+++ b/tests/reference/asr-implicit11-95f56fd.stdout
@@ -101,7 +101,11 @@
                             (IntegerConstant 5 (Integer 4))
                             IntegerToComplex
                             (Complex 8)
-                            ()
+                            (ComplexConstant
+                                5.000000
+                                0.000000
+                                (Complex 8)
+                            )
                         )
                         ()
                     )
@@ -194,7 +198,11 @@
                             (IntegerConstant 5 (Integer 4))
                             IntegerToComplex
                             (Complex 8)
-                            ()
+                            (ComplexConstant
+                                5.000000
+                                0.000000
+                                (Complex 8)
+                            )
                         )
                         ()
                     )]

--- a/tests/reference/asr-implicit12-1826599.json
+++ b/tests/reference/asr-implicit12-1826599.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit12-1826599.stdout",
-    "stdout_hash": "752f60067f0f2f8e57f3f9cde7217e40aabfa22f1a60a35878154809",
+    "stdout_hash": "8627a98ca30a9d49119e1ab5af63e418387ea2164a36356b8e159f05",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit12-1826599.stdout
+++ b/tests/reference/asr-implicit12-1826599.stdout
@@ -377,7 +377,11 @@
                             (IntegerConstant 8 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                8.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )
@@ -387,7 +391,11 @@
                             (IntegerConstant 9 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                9.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )
@@ -397,7 +405,11 @@
                             (IntegerConstant 10 (Integer 4))
                             IntegerToComplex
                             (Complex 8)
-                            ()
+                            (ComplexConstant
+                                10.000000
+                                0.000000
+                                (Complex 8)
+                            )
                         )
                         ()
                     )

--- a/tests/reference/asr-implicit9-b56b139.json
+++ b/tests/reference/asr-implicit9-b56b139.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit9-b56b139.stdout",
-    "stdout_hash": "bd05470517c31a7385a50e739adb48473b34f94ef46f2a5876a61e69",
+    "stdout_hash": "270e8e1c4efd946e3db528e9c4d6c8c697913529dbea10815f610ad5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit9-b56b139.stdout
+++ b/tests/reference/asr-implicit9-b56b139.stdout
@@ -400,7 +400,11 @@
                             (IntegerConstant 8 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                8.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )
@@ -410,7 +414,11 @@
                             (IntegerConstant 9 (Integer 4))
                             IntegerToComplex
                             (Complex 4)
-                            ()
+                            (ComplexConstant
+                                9.000000
+                                0.000000
+                                (Complex 4)
+                            )
                         )
                         ()
                     )
@@ -420,7 +428,11 @@
                             (IntegerConstant 10 (Integer 4))
                             IntegerToComplex
                             (Complex 8)
-                            ()
+                            (ComplexConstant
+                                10.000000
+                                0.000000
+                                (Complex 8)
+                            )
                         )
                         ()
                     )


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/3096

```bash
(lf2) % cat integration_tests/expr_18.f90 
program main
    complex, parameter :: x = 123

    print *, x
    if (abs(x - (123, 0)) > 1e-5) error stop
end program
(lf2) % gfortran integration_tests/expr_18.f90 
(lf2) % ./a.out 
             (123.000000,0.00000000)
(lf2) % lfortran_in_main integration_tests/expr_18.f90 
Traceback (most recent call last):
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/bin/lfortran.cpp", line 2340
    err = compile_to_object_file(arg_file, tmp_o, false,
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/bin/lfortran.cpp", line 907
    result = fe.get_asr2(input, lm, diagnostics);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/fortran_evaluator.cpp", line 253
    Result<ASR::TranslationUnit_t*> res2 = get_asr3(*ast, diagnostics);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/fortran_evaluator.cpp", line 275
    compiler_options.symtab_only, compiler_options);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/semantics/ast_to_asr.cpp", line 98
    if (res.ok) {
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/semantics/ast_symboltable_visitor.cpp", line 3444
    v.visit_TranslationUnit(ast);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/semantics/ast_symboltable_visitor.cpp", line 120
    visit_ast(*x.m_items[i]);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/ast.h", line 4848
    void visit_ast(const ast_t &b) { visit_ast_t(b, self()); }
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/ast.h", line 4804
    case astType::unit: { v.visit_unit((const unit_t &)x); return; }
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/ast.h", line 4851
    void visit_mod(const mod_t &b) { visit_mod_t(b, self()); }
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/ast.h", line 4438
    case modType::BlockData: { v.visit_BlockData((const BlockData_t &)x); return; }
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/semantics/ast_symboltable_visitor.cpp", line 519
    visit_unit_decl2(*x.m_decl[i]);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/ast.h", line 4862
    void visit_unit_decl2(const unit_decl2_t &b) { visit_unit_decl2_t(b, self()); }
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/ast.h", line 4465
    case unit_decl2Type::Declaration: { v.visit_Declaration((const Declaration_t &)x); return; }
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/semantics/ast_symboltable_visitor.cpp", line 1549
    visit_DeclarationUtil(x);
  File "/Users/ubaid/Desktop/OpenSource/lfortran_in_main/src/lfortran/semantics/ast_common_visitor.h", line 2530
    if (storage_type == ASR::storage_typeType::Parameter) {
  Binary file "/usr/lib/system/libsystem_platform.dylib", local address: 0x18042ea83
Segfault: Signal SIGSEGV (segmentation fault) received
(lf2) % lfortran integration_tests/expr_18.f90 
(123.000000,0.000000)
```