### PR TITLE
doc: Update Windows build instructions

### DIFF
--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -182,7 +182,7 @@ conda init bash
 conda activate lf
 sudo apt update
 sudo apt-get install build-essential
-sudo apt-get install zlib1g-dev
+sudo apt-get install zlib1g-dev libzstd-dev
 sudo apt install clang
 ```
 * You can change the directory to a Windows location using `cd /mnt/[drive letter]/[windows location]`.

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -135,7 +135,7 @@ build1.bat
 If everything compiled, then you can use LFortran as follows:
 ```
 inst\bin\lfortran examples/expr2.f90
-a.out
+expr2.exe
 inst\bin\lfortran
 ```
 And so on.
@@ -205,7 +205,7 @@ make -j8
 * If everything compiles, you can use LFortran as follows
 ```bash
 ./src/bin/lfortran ./examples/expr2.f90
-./a.out
+./expr2.out
 ```
 
 * Run an interactive prompt


### PR DESCRIPTION
I tried to build `lfortran` in WSL2 and for the most part it went well.
There are a few places in the documentation that need to be updated.

- In addition to zlib, you need zstd, otherwise cmake will complain that it can't find the dependencies.
  Maybe this could be added to conda's environment configuration as well? Just like:
https://github.com/lfortran/lfortran/blob/60dac4092ece5ed0b49d1d8b727a67ce78864352/ci/environment.yml#L22

- `lfortran` now generates an executable with the same name as the source file

- Do we need to add `-DWITH_RUNTIME_STACKTRACE=yes` to the default cmake flags?
  Otherwise `./run_tests.py` will throw an error when executing `runtime_stacktrace_01.f90 * run_dbg`
  Or skip the related tests if the WITH_RUNTIME_STACKTRACE flag is not set
https://github.com/lfortran/lfortran/blob/60dac4092ece5ed0b49d1d8b727a67ce78864352/doc/src/installation.md?plain=1#L201
