### PR TITLE
Fix `abs` for complex arrays

### DIFF
--- a/a.f90
+++ b/a.f90
@@ -1,0 +1,8 @@
+program main
+    complex(4) :: x, y(4)
+    x = (1.0, 2.0)
+    y = (3.0, 4.0)
+    ! print*, abs([(1, 2), (3 ,4)])
+    print*, abs(y)
+    ! print*, sin([(1, 2), (3 ,4)])
+end

--- a/b.f90
+++ b/b.f90
@@ -1,0 +1,4 @@
+program main
+    integer(4) :: i(5) = [1, 2, -3, 4, -5]
+    print*, abs(i)   
+end

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -673,6 +673,7 @@ TRIG2(atan, datan)
     static ASR::expr_t *eval_dabs(Allocator &al, const Location &loc,
             Vec<ASR::expr_t*> &args
             ) {
+                std::cout<<"eval_dabs"<<'\n';
         LCOMPILERS_ASSERT(ASRUtils::all_args_evaluated(args));
         if (args.size() != 1) {
             throw SemanticError("Intrinsic abs function accepts exactly 1 argument", loc);

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1270,8 +1270,29 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
         result_var = result_var_copy;
         bool result_var_created = false;
         if( result_var == nullptr ) {
-            result_var = PassUtils::create_var(result_counter, res_prefix,
-                            loc, *current_expr, al, current_scope);
+            std::cout<<"hk1"<<'\n';
+            // ASR::Function_t *func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x->m_type));
+            ASR::Function_t *func = ASR::down_cast<ASR::Function_t>(x->m_type);
+
+            std::cout<<"hk2"<<'\n';
+            if(func->m_return_var != nullptr) {
+                std::cout<<"yaha1"<<'\n';
+            }
+            
+            if (func->m_return_var != nullptr && !ASRUtils::is_array(ASRUtils::expr_type(func->m_return_var))) {
+                std::cout<<"hk3"<<'\n';
+                ASR::ttype_t* sibling_type = ASRUtils::expr_type(*current_expr);
+                ASR::dimension_t* m_dims; int ndims;
+                PassUtils::get_dim_rank(sibling_type, m_dims, ndims);
+                ASR::ttype_t* arr_type = ASRUtils::TYPE(ASR::make_Array_t(al, loc, ASRUtils::expr_type(func->m_return_var),
+                                        m_dims, ndims, ASR::array_physical_typeType::FixedSizeArray));
+                result_var = PassUtils::create_var(result_counter, res_prefix,
+                                loc, arr_type, al, current_scope);
+            } else {
+                std::cout<<"hk4"<<'\n';
+                result_var = PassUtils::create_var(result_counter, res_prefix,
+                                loc, *current_expr, al, current_scope);
+            }
             result_counter += 1;
             operand = first_array_operand;
             ASR::dimension_t* m_dims;
@@ -1409,7 +1430,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 result_var = result_var_copy;
                 bool result_var_created = false;
                 if( result_var == nullptr ) {
-                    ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x->m_name));
+                     ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x->m_name));
                     if (func->m_return_var != nullptr && !ASRUtils::is_array(ASRUtils::expr_type(func->m_return_var))) {
                         ASR::ttype_t* sibling_type = ASRUtils::expr_type(operand);
                         ASR::dimension_t* m_dims; int ndims;


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/3160