### PR TITLE
FIX: Elemental function with complex array throws error

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1334,3 +1334,5 @@ RUN(NAME print_arr_05 LABELS gfortran llvm)
 RUN(NAME binop_01 LABELS gfortran llvm)
 
 RUN(NAME dfloat_01 LABELS gfortran llvm)
+
+RUN(NAME elemental_01 LABELS gfortran llvm)

--- a/integration_tests/elemental_01.f90
+++ b/integration_tests/elemental_01.f90
@@ -1,0 +1,16 @@
+program elemental_01
+  real :: x(4)
+  print *, arg([(0.0, 1.0), (1.0, 0.0), (0.0, -1.0), (-1.0, 0.0)])
+  x = arg([(0.0, 1.0), (1.0, 0.0), (0.0, -1.0), (-1.0, 0.0)])
+  if (abs(x(1) - 1.57079637) > 1e-6) error stop
+  if (abs(x(2) - 0.0) > 1e-6) error stop
+  if (abs(x(3) + 1.57079637) > 1e-6) error stop
+  if (abs(x(4) - 3.14159274) > 1e-6) error stop
+
+contains
+  elemental function arg(z) result(result) 
+  complex, intent(in) :: z
+  real :: result
+  result = atan2(aimag(z), real(z))
+  end function arg
+end program elemental_01

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1409,8 +1409,19 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 result_var = result_var_copy;
                 bool result_var_created = false;
                 if( result_var == nullptr ) {
-                    result_var = PassUtils::create_var(result_counter, res_prefix,
-                                    loc, operand, al, current_scope);
+                    ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x->m_name));
+                    if (func->m_return_var != nullptr && !ASRUtils::is_array(ASRUtils::expr_type(func->m_return_var))) {
+                        ASR::ttype_t* sibling_type = ASRUtils::expr_type(operand);
+                        ASR::dimension_t* m_dims; int ndims;
+                        PassUtils::get_dim_rank(sibling_type, m_dims, ndims);
+                        ASR::ttype_t* arr_type = ASRUtils::TYPE(ASR::make_Array_t(al, loc, ASRUtils::expr_type(func->m_return_var),
+                                                m_dims, ndims, ASR::array_physical_typeType::FixedSizeArray));
+                        result_var = PassUtils::create_var(result_counter, res_prefix,
+                                        loc, arr_type, al, current_scope);
+                    } else {
+                        result_var = PassUtils::create_var(result_counter, res_prefix,
+                                        loc, operand, al, current_scope);
+                    }
                     result_counter += 1;
                     result_var_created = true;
                 }


### PR DESCRIPTION
Fixes #3171. With this PR, we get `stdlib_math_argxx` examples working.