### PR TITLE
FIX: optional argument handling for elemental funtion

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1340,3 +1340,4 @@ RUN(NAME binop_01 LABELS gfortran llvm)
 RUN(NAME dfloat_01 LABELS gfortran llvm)
 
 RUN(NAME elemental_01 LABELS gfortran llvm)
+RUN(NAME elemental_02 LABELS gfortran llvm)

--- a/integration_tests/elemental_02.f90
+++ b/integration_tests/elemental_02.f90
@@ -1,0 +1,17 @@
+program elemental_02
+
+real :: x(2) = [1, 2], y(2) = [1.0, 2.1]
+logical :: close(2)
+close = is_close(x, y)
+print *, close
+if (.not. close(1)) error stop
+if (close(2)) error stop
+
+contains
+elemental logical function is_close(a, b, rel_tol) result(close)
+real, intent(in) :: a, b
+real, intent(in), optional :: rel_tol
+close = abs(a - b) <= 1e-9
+end function is_close
+
+end program elemental_02

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1379,6 +1379,10 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 int common_rank = 0;
                 bool are_all_rank_same = true;
                 for( size_t iarg = 0; iarg < x->n_args; iarg++ ) {
+                    if (x->m_args[iarg].m_value == nullptr) {
+                        operands.push_back(nullptr);
+                        continue;
+                    }
                     ASR::expr_t** current_expr_copy_9 = current_expr;
                     current_expr = &(x->m_args[iarg].m_value);
                     self().replace_expr(x->m_args[iarg].m_value);
@@ -1451,7 +1455,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                             ref = PassUtils::create_array_ref(operands[iarg], idx_vars_value, al, current_scope);
                         }
                         ASR::call_arg_t ref_arg;
-                        ref_arg.loc = ref->base.loc;
+                        ref_arg.loc = x->m_args[iarg].loc;
                         ref_arg.m_value = ref;
                         ref_args.push_back(al, ref_arg);
                     }


### PR DESCRIPTION
Fixes #3180, towards #3046.

With this PR we get `example_math_is_close` working with LFortran.