### PR TITLE
lfortran: automatically enable cpp for F files

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2199,6 +2199,10 @@ int main_app(int argc, char *argv[]) {
         compiler_options.fixed_form = true;
     }
 
+    if (endswith(arg_file, ".F90") || endswith(arg_file, ".F")) {
+        compiler_options.c_preprocessor = true;
+    }
+
     std::string outfile;
     std::filesystem::path basename = std::filesystem::path(arg_file).filename();
     if (compiler_options.arg_o.size() > 0) {

--- a/tests/preprocessor16.F90
+++ b/tests/preprocessor16.F90
@@ -1,0 +1,7 @@
+program preprocessor1
+implicit none
+#define X123 12345678
+integer :: x, y
+x = (2+3)*5
+print *, x, X123
+end program

--- a/tests/reference/asr-preprocessor16-3962c71.json
+++ b/tests/reference/asr-preprocessor16-3962c71.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-preprocessor16-3962c71",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/preprocessor16.F90",
+    "infile_hash": "a07132d08deb1a0de21dd365371df337fe07652c9d42aa4c0a7e19ab",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-preprocessor16-3962c71.stdout",
+    "stdout_hash": "891dd4075a4c0181e5835ae5aa1e96c20d591e23e160513994420378",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-preprocessor16-3962c71.stdout
+++ b/tests/reference/asr-preprocessor16-3962c71.stdout
@@ -1,0 +1,71 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            preprocessor1:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    preprocessor1
+                    []
+                    [(Assignment
+                        (Var 2 x)
+                        (IntegerBinOp
+                            (IntegerBinOp
+                                (IntegerConstant 2 (Integer 4))
+                                Add
+                                (IntegerConstant 3 (Integer 4))
+                                (Integer 4)
+                                (IntegerConstant 5 (Integer 4))
+                            )
+                            Mul
+                            (IntegerConstant 5 (Integer 4))
+                            (Integer 4)
+                            (IntegerConstant 25 (Integer 4))
+                        )
+                        ()
+                    )
+                    (Print
+                        [(Var 2 x)
+                        (IntegerConstant 12345678 (Integer 4))]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -477,6 +477,10 @@ filename = "preprocessor15.f90"
 asr_preprocess = true
 
 [[test]]
+filename = "preprocessor16.F90"
+asr = true
+
+[[test]]
 filename = "expr1.f90"
 interactive = true
 ast = true


### PR DESCRIPTION
https://github.com/lfortran/lfortran/pull/3192#issuecomment-1911429389

I feel like automatically pre-processing F and F90 files is the standard for other compilers.