### PR TITLE
Refactor: Remove old `abs` runtime implementations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -528,7 +528,7 @@ jobs:
             git checkout 409ba02a107f47ee835f3976952bbc64dd46de8a
             mkdir lf
             cd lf
-            FC=$(pwd)/../../src/bin/lfortran cmake ..
+            FC="$(pwd)/../../src/bin/lfortran --intrinsic-mangling" cmake ..
             make
             examples/example_hybrd
             examples/example_hybrd1

--- a/integration_tests/intrinsics_03.f90
+++ b/integration_tests/intrinsics_03.f90
@@ -1,6 +1,7 @@
 program intrinsics_03
 use iso_fortran_env, only: dp => real64
 real :: x
+integer :: i = -12
 real(dp) :: a, r1, r2
 a = 4.2_dp
 
@@ -12,5 +13,7 @@ if (abs(cos(cos(1.5) + cos(a+cos(a))) - 0.71640354) > 1e-7) error stop
 r1 = dcos(a)
 r2 = -0.4902608213406995_dp
 if (dabs(r1-r2) > 1e-15_dp) error stop
+print *, iabs(i)
+if (iabs(i) /= 12) error stop
 
 end program intrinsics_03

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -722,6 +722,7 @@ public:
     };
 
     std::map<std::string, std::string> intrinsic_mapping = {
+        {"iabs", "abs"},
         {"dabs", "abs"},
 
         {"dsinh", "sinh"},

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -721,7 +721,7 @@ public:
         {"ishft", {IntrinsicSignature({"i", "shift"}, 2, 2)}},
     };
 
-    std::map<std::string, std::string> double_precision_intrinsics = {
+    std::map<std::string, std::string> intrinsic_mapping = {
         {"dabs", "abs"},
 
         {"dsinh", "sinh"},
@@ -4686,7 +4686,7 @@ public:
     }
 
     bool is_intrinsic_registry_function(std::string var_name) {
-        bool is_double_precision_intrinsic = double_precision_intrinsics.count(var_name);
+        bool is_double_precision_intrinsic = intrinsic_mapping.count(var_name);
         if (intrinsic_procedures_as_asr_nodes.is_intrinsic_present_in_ASR(var_name) ||
             intrinsic_procedures_as_asr_nodes.is_kind_based_selection_required(var_name) ||
             ASRUtils::IntrinsicScalarFunctionRegistry::is_intrinsic_function(var_name) ||
@@ -4701,11 +4701,11 @@ public:
     ASR::symbol_t* intrinsic_as_node(const AST::FuncCallOrArray_t &x,
                                      bool& is_function) {
         std::string var_name = to_lower(x.m_func);
-        bool is_double_precision_intrinsic = double_precision_intrinsics.count(var_name);
+        bool is_double_precision_intrinsic = intrinsic_mapping.count(var_name);
         if( is_intrinsic_registry_function(var_name)) {
             is_function = false;
             if (is_double_precision_intrinsic) {
-                var_name = double_precision_intrinsics[var_name];
+                var_name = intrinsic_mapping[var_name];
             }
             if( ASRUtils::IntrinsicScalarFunctionRegistry::is_intrinsic_function(var_name) ||
                     ASRUtils::IntrinsicArrayFunctionRegistry::is_intrinsic_function(var_name) ) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -722,6 +722,8 @@ public:
     };
 
     std::map<std::string, std::string> double_precision_intrinsics = {
+        {"dabs", "abs"},
+
         {"dsinh", "sinh"},
         {"dcosh", "cosh"},
         {"dtanh", "tanh"},

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -118,9 +118,7 @@ struct IntrinsicProcedures {
             {"zlog", {m_math, &eval_zlog, true}},
             {"erf", {m_math, &eval_erf, true}},
             {"erfc", {m_math, &eval_erfc, true}},
-            {"iabs", {m_math, &not_implemented, true}},
             {"datan", {m_math, &eval_datan, true}},
-            {"dabs", {m_math2, &eval_dabs, true}},
             {"dcos", {m_math, &eval_dcos, true}},
             {"dsin", {m_math, &eval_dsin, true}},
             {"log10", {m_math, &eval_log10, true}},
@@ -565,24 +563,6 @@ TRIG2(atan, datan)
         return eval_2args_ri(al, loc, args, compiler_options,
             &IntrinsicProcedures::lfortran_max,
             &IntrinsicProcedures::lfortran_max_i);
-    }
-
-    static ASR::expr_t *eval_dabs(Allocator &al, const Location &loc,
-            Vec<ASR::expr_t*> &args, const CompilerOptions &
-            ) {
-        LCOMPILERS_ASSERT(ASRUtils::all_args_evaluated(args));
-        if (args.size() != 1) {
-            throw SemanticError("Intrinsic abs function accepts exactly 1 argument", loc);
-        }
-        ASR::expr_t* trig_arg = args[0];
-        ASR::ttype_t* t = ASRUtils::expr_type(args[0]);
-        if (ASR::is_a<ASR::Real_t>(*t)) {
-            double rv = ASR::down_cast<ASR::RealConstant_t>(trig_arg)->m_r;
-            double val = std::abs(rv);
-            return ASR::down_cast<ASR::expr_t>(ASR::make_RealConstant_t(al, loc, val, t));
-        } else {
-            throw SemanticError("Argument of the dabs function must be Real", loc);
-        }
     }
 
     static ASR::expr_t *eval_range(Allocator &al, const Location &loc,

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -149,6 +149,10 @@ class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
                 }
             }
         }
+        if (intrinsic_symbols_mangling && startswith(x.m_name, "_lcompilers_")) {
+            ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
+            sym_to_renamed[sym] = update_name(x.m_name);
+        }
         for (auto &a : x.m_symtab->get_scope()) {
             bool nested_function = is_nested_function(a.second);
             if (nested_function) {

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -102,7 +102,7 @@ class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
         if (all_symbols_mangling || module_name_mangling || should_mangle) {
             sym_to_renamed[sym] = update_name(x.m_name);
         }
-        if ((x.m_intrinsic && intrinsic_symbols_mangling) ||
+        if (
                 (global_symbols_mangling && startswith(x.m_name, "_global_symbols"))) {
             should_mangle = true;
         }

--- a/src/runtime/impure/lfortran_intrinsic_math.f90
+++ b/src/runtime/impure/lfortran_intrinsic_math.f90
@@ -3,10 +3,6 @@ use, intrinsic :: iso_fortran_env, only: i8 => int8, i16 => int16, i32 => int32,
 use, intrinsic :: iso_c_binding, only: c_float, c_double
 implicit none
 
-interface abs
-    module procedure i8abs, i16abs, iabs, i64abs, sabs, dabs, cabs, zabs
-end interface
-
 interface aimag
     module procedure caimag, zaimag
 end interface
@@ -134,72 +130,6 @@ interface dot_product
 end interface
 
 contains
-
-! abs --------------------------------------------------------------------------
-
-elemental integer(i16) function i16abs(x) result(r)
-integer(i16), intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental integer(i8) function i8abs(x) result(r)
-integer(i8), intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental integer function iabs(x) result(r)
-integer, intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental integer(i64) function i64abs(x) result(r)
-integer(i64), intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental real(sp) function sabs(x) result(r)
-real(sp), intent(in) :: x
-if (x > 0) then
-    r = x
-else
-    r = 0-x
-end if
-end function
-
-elemental real(dp) function dabs(x) result(r)
-real(dp), intent(in) :: x
-if (x > 0) then
-    r = x
-else
-    r = 0-x
-end if
-end function
-
-elemental real(sp) function cabs(x) result(r)
-complex(sp), intent(in) :: x
-r = sqrt(real(x,sp)**2 + aimag(x)**2)
-end function
-
-elemental real(dp) function zabs(x) result(r)
-complex(dp), intent(in) :: x
-r = sqrt(real(x,dp)**2 + aimag(x)**2)
-end function
 
 ! aimag ------------------------------------------------------------------------
 

--- a/src/runtime/pure/lfortran_intrinsic_math2.f90
+++ b/src/runtime/pure/lfortran_intrinsic_math2.f90
@@ -4,10 +4,6 @@ use, intrinsic :: iso_fortran_env, only: i8 => int8, i16 => int16, i32 => int32,
 use lfortran_intrinsic_math3, only: floor
 implicit none
 
-interface abs
-    module procedure i8abs, i16abs, iabs, i64abs, sabs, dabs, cabs, zabs
-end interface
-
 interface sqrt
     module procedure ssqrt, dsqrt
 end interface
@@ -53,72 +49,6 @@ interface huge
 end interface
 
 contains
-
-! abs --------------------------------------------------------------------------
-
-elemental integer(i16) function i16abs(x) result(r)
-integer(i16), intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental integer(i8) function i8abs(x) result(r)
-integer(i8), intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental integer function iabs(x) result(r)
-integer, intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental integer(i64) function i64abs(x) result(r)
-integer(i64), intent(in) :: x
-if (x >= 0) then
-    r = x
-else
-    r = -x
-end if
-end function
-
-elemental real(sp) function sabs(x) result(r)
-real(sp), intent(in) :: x
-if (x > 0) then
-    r = x
-else
-    r = 0-x
-end if
-end function
-
-elemental real(dp) function dabs(x) result(r)
-real(dp), intent(in) :: x
-if (x > 0) then
-    r = x
-else
-    r = 0-x
-end if
-end function
-
-elemental real(sp) function cabs(x) result(r)
-complex(sp), intent(in) :: x
-r = 1.0
-end function
-
-elemental real(dp) function zabs(x) result(r)
-complex(dp), intent(in) :: x
-r = 1.0
-end function
 
 ! sqrt -------------------------------------------------------------------------
 

--- a/tests/reference/asr-intrinsics_03-ef06d46.json
+++ b/tests/reference/asr-intrinsics_03-ef06d46.json
@@ -2,11 +2,11 @@
     "basename": "asr-intrinsics_03-ef06d46",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_03.f90",
-    "infile_hash": "48a324df4f168342971e9fca436f92c3f5b31428d4903e5ad60732ad",
+    "infile_hash": "e7fb61db3237594018e226a4236884f778bd41ae0848c5667da97462",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_03-ef06d46.stdout",
-    "stdout_hash": "1c3ca2a2b104a3a336f9ce270b14e69ac27e0ad8b663054f0e0ebf38",
+    "stdout_hash": "89bf37cee4ea1291a9abdb1488342448282567125f117b2c1ec3dc71",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_03-ef06d46.json
+++ b/tests/reference/asr-intrinsics_03-ef06d46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_03-ef06d46.stdout",
-    "stdout_hash": "c43d4aa9ffb42f8a61fe20af438fa5fa737fa7b4d444d47720c56abd",
+    "stdout_hash": "1c3ca2a2b104a3a336f9ce270b14e69ac27e0ad8b663054f0e0ebf38",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_03-ef06d46.stdout
+++ b/tests/reference/asr-intrinsics_03-ef06d46.stdout
@@ -33,6 +33,26 @@
                                     real64
                                     Public
                                 ),
+                            i:
+                                (Variable
+                                    2
+                                    i
+                                    []
+                                    Local
+                                    (IntegerUnaryMinus
+                                        (IntegerConstant 12 (Integer 4))
+                                        (Integer 4)
+                                        (IntegerConstant -12 (Integer 4))
+                                    )
+                                    (IntegerConstant -12 (Integer 4))
+                                    Save
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             r1:
                                 (Variable
                                     2
@@ -336,6 +356,36 @@
                                 0.000000
                                 (Real 8)
                             )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        [(IntrinsicScalarFunction
+                            Abs
+                            [(Var 2 i)]
+                            0
+                            (Integer 4)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )
+                    (If
+                        (IntegerCompare
+                            (IntrinsicScalarFunction
+                                Abs
+                                [(Var 2 i)]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            NotEq
+                            (IntegerConstant 12 (Integer 4))
                             (Logical 4)
                             ()
                         )

--- a/tests/reference/asr-intrinsics_03-ef06d46.stdout
+++ b/tests/reference/asr-intrinsics_03-ef06d46.stdout
@@ -23,16 +23,6 @@
                                     Required
                                     .false.
                                 ),
-                            dabs:
-                                (ExternalSymbol
-                                    2
-                                    dabs
-                                    6 dabs
-                                    lfortran_intrinsic_math2
-                                    []
-                                    dabs
-                                    Private
-                                ),
                             dp:
                                 (ExternalSymbol
                                     2
@@ -328,18 +318,17 @@
                     )
                     (If
                         (RealCompare
-                            (FunctionCall
-                                2 dabs
-                                ()
-                                [((RealBinOp
+                            (IntrinsicScalarFunction
+                                Abs
+                                [(RealBinOp
                                     (Var 2 r1)
                                     Sub
                                     (Var 2 r2)
                                     (Real 8)
                                     ()
-                                ))]
+                                )]
+                                0
                                 (Real 8)
-                                ()
                                 ()
                             )
                             Gt
@@ -357,13 +346,7 @@
                     )]
                 ),
             iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math2:
-                (IntrinsicModule lfortran_intrinsic_math2),
-            lfortran_intrinsic_math3:
-                (IntrinsicModule lfortran_intrinsic_math3)
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env)
         })
     []
 )

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -2,11 +2,11 @@
     "basename": "llvm-intrinsics_03-0771f1b",
     "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_03.f90",
-    "infile_hash": "48a324df4f168342971e9fca436f92c3f5b31428d4903e5ad60732ad",
+    "infile_hash": "e7fb61db3237594018e226a4236884f778bd41ae0848c5667da97462",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "1653b7c046483548b92dde4b86d6b692a1bea460fc4389522bd6b742",
+    "stdout_hash": "187b580e3df94619be71ad1da69c2ad803a152ef4a18452ef669bacb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "77493aae2142f2381ddfdbc0588300b31aa81785996da50ffccaf3f3",
+    "stdout_hash": "1653b7c046483548b92dde4b86d6b692a1bea460fc4389522bd6b742",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -81,32 +81,6 @@ return:                                           ; preds = %.entry
 
 declare double @_lfortran_dcos(double)
 
-define double @__module_lfortran_intrinsic_math2_dabs(double* %x) {
-.entry:
-  %r = alloca double, align 8
-  %0 = load double, double* %x, align 8
-  %1 = fcmp ogt double %0, 0.000000e+00
-  br i1 %1, label %then, label %else
-
-then:                                             ; preds = %.entry
-  %2 = load double, double* %x, align 8
-  store double %2, double* %r, align 8
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  %3 = load double, double* %x, align 8
-  %4 = fsub double 0.000000e+00, %3
-  store double %4, double* %r, align 8
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  br label %return
-
-return:                                           ; preds = %ifcont
-  %5 = load double, double* %r, align 8
-  ret double %5
-}
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value11 = alloca double, align 8
@@ -184,7 +158,7 @@ ifcont10:                                         ; preds = %else9, %then8
   %21 = load double, double* %r2, align 8
   %22 = fsub double %20, %21
   store double %22, double* %call_arg_value11, align 8
-  %23 = call double @__module_lfortran_intrinsic_math2_dabs(double* %call_arg_value11)
+  %23 = call double @_lcompilers_abs_f64(double* %call_arg_value11)
   %24 = fcmp ogt double %23, 1.000000e-15
   br i1 %24, label %then12, label %else13
 

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+@intrinsics_03.i = internal global i32 0
 @0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -13,6 +14,12 @@ source_filename = "LFortran"
 @9 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@12 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@13 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@14 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
+@15 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
+@16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define float @_lcompilers_abs_f32(float* %x) {
 .entry:
@@ -66,6 +73,32 @@ return:                                           ; preds = %ifcont
   ret double %5
 }
 
+define i32 @_lcompilers_abs_i32(i32* %x) {
+.entry:
+  %_lcompilers_abs_i32 = alloca i32, align 4
+  %0 = load i32, i32* %x, align 4
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %then, label %else
+
+then:                                             ; preds = %.entry
+  %2 = load i32, i32* %x, align 4
+  store i32 %2, i32* %_lcompilers_abs_i32, align 4
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  %3 = load i32, i32* %x, align 4
+  %4 = sub i32 0, %3
+  store i32 %4, i32* %_lcompilers_abs_i32, align 4
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
+  %5 = load i32, i32* %_lcompilers_abs_i32, align 4
+  ret i32 %5
+}
+
 define double @_lcompilers_cos_f64(double* %x) {
 .entry:
   %_lcompilers_cos_f64 = alloca double, align 8
@@ -91,6 +124,7 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value = alloca float, align 4
   call void @_lpython_set_argv(i32 %0, i8** %1)
   %a = alloca double, align 8
+  store i32 -12, i32* @intrinsics_03.i, align 4
   %r1 = alloca double, align 8
   %r2 = alloca double, align 8
   %x = alloca float, align 4
@@ -171,6 +205,21 @@ else13:                                           ; preds = %ifcont10
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
+  %25 = call i32 @_lcompilers_abs_i32(i32* @intrinsics_03.i)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  %26 = call i32 @_lcompilers_abs_i32(i32* @intrinsics_03.i)
+  %27 = icmp ne i32 %26, 12
+  br i1 %27, label %then15, label %else16
+
+then15:                                           ; preds = %ifcont14
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont17
+
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
+
+ifcont17:                                         ; preds = %else16, %then15
   ret i32 0
 }
 
@@ -179,3 +228,5 @@ declare void @_lpython_set_argv(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lfortran_printf(i8*, ...)

--- a/tests/reference/pass_flip_sign-expr_13-e24d940.json
+++ b/tests/reference/pass_flip_sign-expr_13-e24d940.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_flip_sign-expr_13-e24d940.stdout",
-    "stdout_hash": "cda5652ef46582363ae2a6429fd1ba7347aa54f66c9e30569a6c7062",
+    "stdout_hash": "fb2c797216e008ed9377c1d85dbafd8a1ea5d62fd002a4b9188fd0ee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_flip_sign-expr_13-e24d940.stdout
+++ b/tests/reference/pass_flip_sign-expr_13-e24d940.stdout
@@ -5,11 +5,11 @@
             _lcompilers_optimization_flipsign_f32:
                 (Function
                     (SymbolTable
-                        86
+                        78
                         {
                             _lcompilers_optimization_flipsign_f32:
                                 (Variable
-                                    86
+                                    78
                                     _lcompilers_optimization_flipsign_f32
                                     []
                                     ReturnVar
@@ -25,7 +25,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    86
+                                    78
                                     signal
                                     []
                                     In
@@ -41,7 +41,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    86
+                                    78
                                     variable
                                     []
                                     In
@@ -73,12 +73,12 @@
                         .false.
                     )
                     []
-                    [(Var 86 signal)
-                    (Var 86 variable)]
+                    [(Var 78 signal)
+                    (Var 78 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 86 signal)
+                                (Var 78 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -86,7 +86,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 86 signal)
+                                                (Var 78 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -117,21 +117,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 86 _lcompilers_optimization_flipsign_f32)
+                            (Var 78 _lcompilers_optimization_flipsign_f32)
                             (RealUnaryMinus
-                                (Var 86 variable)
+                                (Var 78 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 86 _lcompilers_optimization_flipsign_f32)
-                            (Var 86 variable)
+                            (Var 78 _lcompilers_optimization_flipsign_f32)
+                            (Var 78 variable)
                             ()
                         )]
                     )]
-                    (Var 86 _lcompilers_optimization_flipsign_f32)
+                    (Var 78 _lcompilers_optimization_flipsign_f32)
                     Public
                     .false.
                     .false.
@@ -140,11 +140,11 @@
             _lcompilers_optimization_flipsign_f321:
                 (Function
                     (SymbolTable
-                        87
+                        79
                         {
                             _lcompilers_optimization_flipsign_f321:
                                 (Variable
-                                    87
+                                    79
                                     _lcompilers_optimization_flipsign_f321
                                     []
                                     ReturnVar
@@ -160,7 +160,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    87
+                                    79
                                     signal
                                     []
                                     In
@@ -176,7 +176,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    87
+                                    79
                                     variable
                                     []
                                     In
@@ -208,12 +208,12 @@
                         .false.
                     )
                     []
-                    [(Var 87 signal)
-                    (Var 87 variable)]
+                    [(Var 79 signal)
+                    (Var 79 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 87 signal)
+                                (Var 79 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -221,7 +221,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 87 signal)
+                                                (Var 79 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -252,21 +252,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 87 _lcompilers_optimization_flipsign_f321)
+                            (Var 79 _lcompilers_optimization_flipsign_f321)
                             (RealUnaryMinus
-                                (Var 87 variable)
+                                (Var 79 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 87 _lcompilers_optimization_flipsign_f321)
-                            (Var 87 variable)
+                            (Var 79 _lcompilers_optimization_flipsign_f321)
+                            (Var 79 variable)
                             ()
                         )]
                     )]
-                    (Var 87 _lcompilers_optimization_flipsign_f321)
+                    (Var 79 _lcompilers_optimization_flipsign_f321)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_flip_sign-flip_sign-16b288c.json
+++ b/tests/reference/pass_flip_sign-flip_sign-16b288c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_flip_sign-flip_sign-16b288c.stdout",
-    "stdout_hash": "c43db938c4b6cd6c6207d030e1921d65bc295964503667fd45b57a1d",
+    "stdout_hash": "22bf65801d065b43e5b13bcad03885d951627aa7a012babe15bbe0f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_flip_sign-flip_sign-16b288c.stdout
+++ b/tests/reference/pass_flip_sign-flip_sign-16b288c.stdout
@@ -5,11 +5,11 @@
             _lcompilers_optimization_flipsign_f32:
                 (Function
                     (SymbolTable
-                        86
+                        78
                         {
                             _lcompilers_optimization_flipsign_f32:
                                 (Variable
-                                    86
+                                    78
                                     _lcompilers_optimization_flipsign_f32
                                     []
                                     ReturnVar
@@ -25,7 +25,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    86
+                                    78
                                     signal
                                     []
                                     In
@@ -41,7 +41,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    86
+                                    78
                                     variable
                                     []
                                     In
@@ -73,12 +73,12 @@
                         .false.
                     )
                     []
-                    [(Var 86 signal)
-                    (Var 86 variable)]
+                    [(Var 78 signal)
+                    (Var 78 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 86 signal)
+                                (Var 78 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -86,7 +86,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 86 signal)
+                                                (Var 78 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -117,21 +117,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 86 _lcompilers_optimization_flipsign_f32)
+                            (Var 78 _lcompilers_optimization_flipsign_f32)
                             (RealUnaryMinus
-                                (Var 86 variable)
+                                (Var 78 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 86 _lcompilers_optimization_flipsign_f32)
-                            (Var 86 variable)
+                            (Var 78 _lcompilers_optimization_flipsign_f32)
+                            (Var 78 variable)
                             ()
                         )]
                     )]
-                    (Var 86 _lcompilers_optimization_flipsign_f32)
+                    (Var 78 _lcompilers_optimization_flipsign_f32)
                     Public
                     .false.
                     .false.
@@ -140,11 +140,11 @@
             _lcompilers_optimization_flipsign_f321:
                 (Function
                     (SymbolTable
-                        87
+                        79
                         {
                             _lcompilers_optimization_flipsign_f321:
                                 (Variable
-                                    87
+                                    79
                                     _lcompilers_optimization_flipsign_f321
                                     []
                                     ReturnVar
@@ -160,7 +160,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    87
+                                    79
                                     signal
                                     []
                                     In
@@ -176,7 +176,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    87
+                                    79
                                     variable
                                     []
                                     In
@@ -208,12 +208,12 @@
                         .false.
                     )
                     []
-                    [(Var 87 signal)
-                    (Var 87 variable)]
+                    [(Var 79 signal)
+                    (Var 79 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 87 signal)
+                                (Var 79 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -221,7 +221,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 87 signal)
+                                                (Var 79 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -252,21 +252,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 87 _lcompilers_optimization_flipsign_f321)
+                            (Var 79 _lcompilers_optimization_flipsign_f321)
                             (RealUnaryMinus
-                                (Var 87 variable)
+                                (Var 79 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 87 _lcompilers_optimization_flipsign_f321)
-                            (Var 87 variable)
+                            (Var 79 _lcompilers_optimization_flipsign_f321)
+                            (Var 79 variable)
                             ()
                         )]
                     )]
-                    (Var 87 _lcompilers_optimization_flipsign_f321)
+                    (Var 79 _lcompilers_optimization_flipsign_f321)
                     Public
                     .false.
                     .false.


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/3034