### PR TITLE
Refactor: Remove old `aimag` runtime implementations

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2262,24 +2262,27 @@ public:
                 ASR::expr_t* y = value;
                 const Location& loc = x.base.base.loc;
                 ASR::expr_t *val = target;
-                ASR::symbol_t *fn_aimag = resolve_intrinsic_function(loc, "aimag");
-                Vec<ASR::call_arg_t> args; args.reserve(al, 1);
-                ASR::call_arg_t val_arg; val_arg.loc = val->base.loc; val_arg.m_value = val;
-                args.push_back(al, val_arg);
-                ASR::expr_t *im = ASRUtils::EXPR(create_FunctionCall(loc, fn_aimag, args));
+
+                ASRUtils::create_intrinsic_function create_func =
+                    ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("aimag");
+                Vec<ASR::expr_t*> args; args.reserve(al, 1);
+                args.push_back(al, val);
+                ASR::expr_t *im = ASRUtils::EXPR(create_func(al, loc, args,
+                    [&](const std::string &msg, const Location &loc) {
+                        throw SemanticError(msg, loc); }));
+
                 ASR::expr_t* cmplx = ASRUtils::EXPR(ASR::make_ComplexConstructor_t(al, loc, y, im, ASRUtils::expr_type(target), nullptr));
                 value = cmplx;
             }
-        } else if (ASR::is_a<ASR::FunctionCall_t>(*target)) {
-            ASR::FunctionCall_t* fc = ASR::down_cast<ASR::FunctionCall_t>(target);
-            ASR::symbol_t* original_sym = fc->m_original_name;
-            if (std::string(ASRUtils::symbol_name(original_sym)) == "aimag") {
+        } else if (ASR::is_a<ASR::IntrinsicScalarFunction_t>(*target)) {
+            ASR::IntrinsicScalarFunction_t* i = ASR::down_cast<ASR::IntrinsicScalarFunction_t>(target);
+            if (ASRUtils::IntrinsicScalarFunctionRegistry::get_intrinsic_function_name(i->m_intrinsic_id) == "aimag") {
                 /*
                     Case: x % im = y
                     we do: x = cmplx(x%re, y)
                     i.e. target = x, value = cmplx(x%re, y)
                 */
-                target = fc->m_args[0].m_value;
+                target = i->m_args[0];
                 ASR::expr_t* y = value;
                 const Location& loc = x.base.base.loc;
                 ASR::expr_t* re = ASRUtils::EXPR(ASR::make_Cast_t(al, loc, target, ASR::cast_kindType::ComplexToReal, ASRUtils::expr_type(y), nullptr));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3995,16 +3995,13 @@ public:
                     al, loc, &val, v_variable_m_type, dest_type);
                 return (ASR::asr_t*)val;
             } else if (var_name == "im") {
-                ASR::expr_t *val = ASR::down_cast<ASR::expr_t>(ASR::make_Var_t(al, loc, v));
-                ASR::symbol_t *fn_aimag = resolve_intrinsic_function(loc, "aimag");
-                Vec<ASR::call_arg_t> args;
-                args.reserve(al, 1);
-                ASR::call_arg_t val_arg;
-                val_arg.loc = val->base.loc;
-                val_arg.m_value = val;
-                args.push_back(al, val_arg);
-                ASR::asr_t *result = create_FunctionCall(loc, fn_aimag, args);
-                return result;
+                ASRUtils::create_intrinsic_function create_func =
+                    ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("aimag");
+                Vec<ASR::expr_t *> args; args.reserve(al, 1);
+                args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, loc, v)));
+                return create_func(al, loc, args,
+                    [&](const std::string &msg, const Location &loc) {
+                        throw SemanticError(msg, loc); });
             } else {
                 throw SemanticError("Complex variable '" + dt_name + "' only has %re and %im members, not '" + var_name + "'", loc);
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -736,6 +736,9 @@ public:
         {"dtan", "tan"},
         {"datan2", "atan2"},
 
+        {"dimag", "aimag"},
+        {"imag" , "aimag"},
+
         {"dsign", "sign"},
         {"dsqrt", "sqrt"}
     };

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -88,9 +88,6 @@ struct IntrinsicProcedures {
             {"newunit", {m_custom, &not_implemented, false}},
 
             // Require evaluated arguments
-            {"aimag", {m_math, &eval_aimag, true}},
-            {"imag", {m_math, &eval_aimag, true}},
-            {"dimag", {m_math, &eval_aimag, true}},
             {"floor", {m_math3, &eval_floor, true}},
             {"ceiling", {m_math2, &eval_ceiling, true}},
             {"nint", {m_math2, &eval_nint, true}},
@@ -609,26 +606,6 @@ TRIG2(atan, datan)
         }
         ASR::ttype_t* tmp_int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, compiler_options.po.default_integer_kind));
         return ASR::down_cast<ASR::expr_t>(ASR::make_IntegerConstant_t(al, loc, range_val, tmp_int_type));;
-    }
-
-    static ASR::expr_t *eval_aimag(Allocator &al, const Location &loc,
-            Vec<ASR::expr_t*> &args, const CompilerOptions &
-            ) {
-        LCOMPILERS_ASSERT(ASRUtils::all_args_evaluated(args));
-        if (args.size() != 1) {
-            throw SemanticError("Intrinsic trig function accepts exactly 1 argument", loc);
-        }
-        ASR::expr_t* trig_arg = args[0];
-        ASR::ttype_t* t = ASRUtils::expr_type(args[0]);
-        if (ASR::is_a<ASR::Complex_t>(*t)) {
-            double im = ASR::down_cast<ASR::ComplexConstant_t>(trig_arg)->m_im;
-            double result = im;
-            int kind = ASRUtils::extract_kind_from_ttype_t(t);
-            t = ASRUtils::TYPE(ASR::make_Real_t(al, loc, kind));
-            return ASR::down_cast<ASR::expr_t>(ASR::make_RealConstant_t(al, loc, result, t));
-        } else {
-            throw SemanticError("Argument of the aimag() function must be Complex", loc);
-        }
     }
 
     static ASR::expr_t *eval_int(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, const CompilerOptions &compiler_options) {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -2434,12 +2434,12 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         if (m_func_name_idx_map.find(hash) != m_func_name_idx_map.end()) {
             m_wa.emit_call(m_func_name_idx_map[hash].index);
         } else {
-            if (strcmp(fn->m_name, "c_caimag") == 0) {
+            if (strcmp(fn->m_name, "_lfortran_caimag") == 0) {
                 LCOMPILERS_ASSERT(x.n_args == 1);
                 m_wa.emit_global_set(m_compiler_globals[tmp_reg_f32]);
                 m_wa.emit_drop();
                 m_wa.emit_global_get(m_compiler_globals[tmp_reg_f32]);
-            } else if (strcmp(fn->m_name, "c_zaimag") == 0) {
+            } else if (strcmp(fn->m_name, "_lfortran_zaimag") == 0) {
                 m_wa.emit_global_set(m_compiler_globals[tmp_reg_f64]);
                 m_wa.emit_drop();
                 m_wa.emit_global_get(m_compiler_globals[tmp_reg_f64]);

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -116,7 +116,12 @@ intrinsic_funcs_args = {
         {
             "args": [("int", "int")]
         },
-    ]
+    ],
+    "Aimag": [
+        {
+            "args": [("complex",)]
+        },
+    ],
 }
 
 type_to_asr_type_check = {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -998,7 +998,7 @@ static inline ASR::expr_t* instantiate_functions(Allocator &al,
         }
 
         ASR::expr_t *return_var_1 = b.Variable(fn_symtab_1, c_func_name,
-            arg_type, ASRUtils::intent_return_var, ASR::abiType::BindC, false);
+            return_type, ASRUtils::intent_return_var, ASR::abiType::BindC, false);
 
         SetChar dep_1; dep_1.reserve(al, 1);
         Vec<ASR::stmt_t*> body_1; body_1.reserve(al, 1);
@@ -1006,7 +1006,7 @@ static inline ASR::expr_t* instantiate_functions(Allocator &al,
             body_1, return_var_1, ASR::abiType::BindC, ASR::deftypeType::Interface, s2c(al, c_func_name));
         fn_symtab->add_symbol(c_func_name, s);
         dep.push_back(al, s2c(al, c_func_name));
-        body.push_back(al, b.Assignment(result, b.Call(s, args, arg_type)));
+        body.push_back(al, b.Assignment(result, b.Call(s, args, return_type)));
     }
 
     ASR::symbol_t *new_symbol = make_ASR_Function_t(fn_name, fn_symtab, dep, args,

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1378,16 +1378,6 @@ create_trig(Tanh, tanh, tanh)
 
 namespace Aimag {
 
-    static inline void verify_args(const ASR::IntrinsicScalarFunction_t& x,
-            diag::Diagnostics& diagnostics) {
-        ASRUtils::require_impl(x.n_args == 1,
-            "Call to `Aimag` must have exactly one argument",
-            x.base.base.loc, diagnostics);
-        ASRUtils::require_impl(is_complex(*expr_type(x.m_args[0])),
-            "Argument to `Aimag` must be of complex type",
-            x.base.base.loc, diagnostics);
-    }
-
     static inline ASR::expr_t *eval_Aimag(Allocator &al, const Location &loc,
             ASR::ttype_t *t, Vec<ASR::expr_t*>& args) {
         std::complex<double> crv;

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -4146,7 +4146,8 @@ namespace Max {
     static inline ASR::expr_t* instantiate_Max(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
-        std::string func_name = "_lcompilers_max0_" + type_to_str_python(arg_types[0]);
+        std::string func_name = "_lcompilers_max0_" + type_to_str_python(arg_types[0])
+            + "_" + std::to_string(new_args.n);
         std::string fn_name = scope->get_unique_name(func_name);
         SymbolTable *fn_symtab = al.make_new<SymbolTable>(scope);
         Vec<ASR::expr_t*> args;
@@ -4154,8 +4155,8 @@ namespace Max {
         ASRBuilder b(al, loc);
         Vec<ASR::stmt_t*> body; body.reserve(al, args.size());
         SetChar dep; dep.reserve(al, 1);
-        if (scope->get_symbol(fn_name)) {
-            ASR::symbol_t *s = scope->get_symbol(fn_name);
+        if (scope->get_symbol(func_name)) {
+            ASR::symbol_t *s = scope->get_symbol(func_name);
             ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(s);
             return b.Call(s, new_args, expr_type(f->m_return_var), nullptr);
         }

--- a/src/libasr/pass/unused_functions.cpp
+++ b/src/libasr/pass/unused_functions.cpp
@@ -235,7 +235,8 @@ public:
         std::vector<std::string> to_be_erased;
         for (auto it = symtab->get_scope().begin(); it != symtab->get_scope().end(); ++it) {
             uint64_t h = get_hash((ASR::asr_t*)it->second);
-            if (symtab->parent && fn_unused.find(h) != fn_unused.end()) {
+            if ((symtab->parent || (!symtab->parent && startswith(it->first, "_lcompilers_")))
+                    && fn_unused.find(h) != fn_unused.end()) {
                 to_be_erased.push_back(it->first);
             } else {
                 this->visit_symbol(*it->second);

--- a/src/runtime/impure/lfortran_intrinsic_math.f90
+++ b/src/runtime/impure/lfortran_intrinsic_math.f90
@@ -3,18 +3,6 @@ use, intrinsic :: iso_fortran_env, only: i8 => int8, i16 => int16, i32 => int32,
 use, intrinsic :: iso_c_binding, only: c_float, c_double
 implicit none
 
-interface aimag
-    module procedure caimag, zaimag
-end interface
-
-interface imag
-    module procedure caimag
-end interface
-
-interface dimag
-    module procedure zaimag
-end interface
-
 interface exp
     module procedure sexp, dexp, cexp, zexp
 end interface
@@ -131,29 +119,6 @@ end interface
 
 contains
 
-! aimag ------------------------------------------------------------------------
-
-elemental real(sp) function caimag(x) result(r)
-complex(sp), intent(in) :: x
-interface
-    pure real(c_float) function c_caimag(x) bind(c, name="_lfortran_caimag")
-    import :: c_float
-    complex(c_float), intent(in), value :: x
-    end function
-end interface
-r = c_caimag(x)
-end function
-
-elemental real(dp) function zaimag(x) result(r)
-complex(dp), intent(in) :: x
-interface
-    pure real(c_double) function c_zaimag(x) bind(c, name="_lfortran_zaimag")
-    import :: c_double
-    complex(c_double), intent(in), value :: x
-    end function
-end interface
-r = c_zaimag(x)
-end function
 
 ! exp --------------------------------------------------------------------------
 

--- a/src/runtime/pure/lfortran_intrinsic_math2.f90
+++ b/src/runtime/pure/lfortran_intrinsic_math2.f90
@@ -8,10 +8,6 @@ interface sqrt
     module procedure ssqrt, dsqrt
 end interface
 
-interface aimag
-    module procedure saimag, daimag
-end interface
-
 interface ceiling
     module procedure sceiling, dceiling
 end interface
@@ -68,24 +64,6 @@ if (x >= 0) then
 else
     error stop "sqrt(x) for x < 0 is not allowed"
 end if
-end function
-
-! aimag ------------------------------------------------------------------------
-
-elemental real(sp) function saimag(x) result(r)
-complex(sp), intent(in) :: x
-r = 3
-! Uncomment once it is implemented
-!r = x%im
-!error stop "aimag not implemented yet"
-end function
-
-elemental real(dp) function daimag(x) result(r)
-complex(dp), intent(in) :: x
-r = 3
-! Uncomment once it is implemented
-!r = x%im
-!error stop "aimag not implemented yet"
 end function
 
 ! ceiling ------------------------------------------------------------------------

--- a/tests/reference/asr-implicit11-95f56fd.json
+++ b/tests/reference/asr-implicit11-95f56fd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit11-95f56fd.stdout",
-    "stdout_hash": "b78336fa6a9c9d2acf78ea81cc80f088be6dfb64f424a12465d7042b",
+    "stdout_hash": "65f4fef36623031bb320836758f0fd0431009e7b89c3c4e67a450afd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit11-95f56fd.stdout
+++ b/tests/reference/asr-implicit11-95f56fd.stdout
@@ -7,26 +7,6 @@
                     (SymbolTable
                         2
                         {
-                            dimag:
-                                (ExternalSymbol
-                                    2
-                                    dimag
-                                    5 dimag
-                                    lfortran_intrinsic_math
-                                    []
-                                    dimag
-                                    Private
-                                ),
-                            dimag@zaimag:
-                                (ExternalSymbol
-                                    2
-                                    dimag@zaimag
-                                    5 zaimag
-                                    lfortran_intrinsic_math
-                                    []
-                                    zaimag
-                                    Private
-                                ),
                             f1:
                                 (Variable
                                     2
@@ -110,20 +90,18 @@
                         ()
                     )
                     (Print
-                        [(FunctionCall
-                            2 dimag@zaimag
-                            2 dimag
-                            [((Var 2 z))]
+                        [(IntrinsicScalarFunction
+                            Aimag
+                            [(Var 2 z)]
+                            0
                             (Real 8)
-                            ()
                             ()
                         )
-                        (FunctionCall
-                            2 dimag@zaimag
-                            2 dimag
-                            [((Var 2 i))]
+                        (IntrinsicScalarFunction
+                            Aimag
+                            [(Var 2 i)]
+                            0
                             (Real 8)
-                            ()
                             ()
                         )]
                         ()
@@ -211,15 +189,7 @@
                     .false.
                     .false.
                     ()
-                ),
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math:
-                (IntrinsicModule lfortran_intrinsic_math)
+                )
         })
     []
 )

--- a/tests/reference/asr-implicit_typing4-c338b90.json
+++ b/tests/reference/asr-implicit_typing4-c338b90.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_typing4-c338b90.stdout",
-    "stdout_hash": "8a755f08828b8963253195afc775e74a6f8991fbab551b2af9cf3b56",
+    "stdout_hash": "4cf5ccc6c9eb8f406ed368ab1ca16d1b7203efcf2a9d5bc88febd35a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_typing4-c338b90.stdout
+++ b/tests/reference/asr-implicit_typing4-c338b90.stdout
@@ -7,26 +7,6 @@
                     (SymbolTable
                         3
                         {
-                            dimag:
-                                (ExternalSymbol
-                                    3
-                                    dimag
-                                    5 dimag
-                                    lfortran_intrinsic_math
-                                    []
-                                    dimag
-                                    Private
-                                ),
-                            dimag@zaimag:
-                                (ExternalSymbol
-                                    3
-                                    dimag@zaimag
-                                    5 zaimag
-                                    lfortran_intrinsic_math
-                                    []
-                                    zaimag
-                                    Private
-                                ),
                             ls:
                                 (Variable
                                     3
@@ -79,12 +59,11 @@
                     []
                     [(If
                         (RealCompare
-                            (FunctionCall
-                                3 dimag@zaimag
-                                3 dimag
-                                [((Var 3 z))]
+                            (IntrinsicScalarFunction
+                                Aimag
+                                [(Var 3 z)]
+                                0
                                 (Real 8)
-                                ()
                                 ()
                             )
                             Eq
@@ -176,15 +155,7 @@
                     .false.
                     .false.
                     ()
-                ),
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math:
-                (IntrinsicModule lfortran_intrinsic_math)
+                )
         })
     []
 )

--- a/tests/reference/asr-sole_intrinsic-3e826bd.json
+++ b/tests/reference/asr-sole_intrinsic-3e826bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-sole_intrinsic-3e826bd.stdout",
-    "stdout_hash": "2ab344753f4129450a20941194b1bc6279f065b4a3e98926fe926b06",
+    "stdout_hash": "5bd0bec3da23399c86c7e26d1dc6e72a0657aefa54f1fccd77fbf8f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-sole_intrinsic-3e826bd.stdout
+++ b/tests/reference/asr-sole_intrinsic-3e826bd.stdout
@@ -2,39 +2,11 @@
     (SymbolTable
         1
         {
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math:
-                (IntrinsicModule lfortran_intrinsic_math),
             main:
                 (Program
                     (SymbolTable
                         2
                         {
-                            aimag:
-                                (ExternalSymbol
-                                    2
-                                    aimag
-                                    4 aimag
-                                    lfortran_intrinsic_math
-                                    []
-                                    aimag
-                                    Private
-                                ),
-                            aimag@caimag:
-                                (ExternalSymbol
-                                    2
-                                    aimag@caimag
-                                    4 caimag
-                                    lfortran_intrinsic_math
-                                    []
-                                    caimag
-                                    Private
-                                ),
                             f:
                                 (Variable
                                     2
@@ -144,12 +116,11 @@
                     )
                     (Assignment
                         (Var 2 y)
-                        (FunctionCall
-                            2 aimag@caimag
-                            2 aimag
-                            [((Var 2 x))]
+                        (IntrinsicScalarFunction
+                            Aimag
+                            [(Var 2 x)]
+                            0
                             (Real 4)
-                            ()
                             ()
                         )
                         ()

--- a/tests/reference/pass_flip_sign-expr_13-e24d940.json
+++ b/tests/reference/pass_flip_sign-expr_13-e24d940.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_flip_sign-expr_13-e24d940.stdout",
-    "stdout_hash": "fb2c797216e008ed9377c1d85dbafd8a1ea5d62fd002a4b9188fd0ee",
+    "stdout_hash": "5d7fece1e907d0c8089c471b21acc6796add88aa3595b1c2e602e1d2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_flip_sign-expr_13-e24d940.stdout
+++ b/tests/reference/pass_flip_sign-expr_13-e24d940.stdout
@@ -5,11 +5,11 @@
             _lcompilers_optimization_flipsign_f32:
                 (Function
                     (SymbolTable
-                        78
+                        76
                         {
                             _lcompilers_optimization_flipsign_f32:
                                 (Variable
-                                    78
+                                    76
                                     _lcompilers_optimization_flipsign_f32
                                     []
                                     ReturnVar
@@ -25,7 +25,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    78
+                                    76
                                     signal
                                     []
                                     In
@@ -41,7 +41,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    78
+                                    76
                                     variable
                                     []
                                     In
@@ -73,12 +73,12 @@
                         .false.
                     )
                     []
-                    [(Var 78 signal)
-                    (Var 78 variable)]
+                    [(Var 76 signal)
+                    (Var 76 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 78 signal)
+                                (Var 76 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -86,7 +86,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 78 signal)
+                                                (Var 76 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -117,21 +117,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 78 _lcompilers_optimization_flipsign_f32)
+                            (Var 76 _lcompilers_optimization_flipsign_f32)
                             (RealUnaryMinus
-                                (Var 78 variable)
+                                (Var 76 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 78 _lcompilers_optimization_flipsign_f32)
-                            (Var 78 variable)
+                            (Var 76 _lcompilers_optimization_flipsign_f32)
+                            (Var 76 variable)
                             ()
                         )]
                     )]
-                    (Var 78 _lcompilers_optimization_flipsign_f32)
+                    (Var 76 _lcompilers_optimization_flipsign_f32)
                     Public
                     .false.
                     .false.
@@ -140,11 +140,11 @@
             _lcompilers_optimization_flipsign_f321:
                 (Function
                     (SymbolTable
-                        79
+                        77
                         {
                             _lcompilers_optimization_flipsign_f321:
                                 (Variable
-                                    79
+                                    77
                                     _lcompilers_optimization_flipsign_f321
                                     []
                                     ReturnVar
@@ -160,7 +160,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    79
+                                    77
                                     signal
                                     []
                                     In
@@ -176,7 +176,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    79
+                                    77
                                     variable
                                     []
                                     In
@@ -208,12 +208,12 @@
                         .false.
                     )
                     []
-                    [(Var 79 signal)
-                    (Var 79 variable)]
+                    [(Var 77 signal)
+                    (Var 77 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 79 signal)
+                                (Var 77 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -221,7 +221,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 79 signal)
+                                                (Var 77 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -252,21 +252,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 79 _lcompilers_optimization_flipsign_f321)
+                            (Var 77 _lcompilers_optimization_flipsign_f321)
                             (RealUnaryMinus
-                                (Var 79 variable)
+                                (Var 77 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 79 _lcompilers_optimization_flipsign_f321)
-                            (Var 79 variable)
+                            (Var 77 _lcompilers_optimization_flipsign_f321)
+                            (Var 77 variable)
                             ()
                         )]
                     )]
-                    (Var 79 _lcompilers_optimization_flipsign_f321)
+                    (Var 77 _lcompilers_optimization_flipsign_f321)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_flip_sign-flip_sign-16b288c.json
+++ b/tests/reference/pass_flip_sign-flip_sign-16b288c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_flip_sign-flip_sign-16b288c.stdout",
-    "stdout_hash": "22bf65801d065b43e5b13bcad03885d951627aa7a012babe15bbe0f9",
+    "stdout_hash": "e5f0e5d04627e511bcdb36f072b817da3dee74470d3a30299c2f22e8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_flip_sign-flip_sign-16b288c.stdout
+++ b/tests/reference/pass_flip_sign-flip_sign-16b288c.stdout
@@ -5,11 +5,11 @@
             _lcompilers_optimization_flipsign_f32:
                 (Function
                     (SymbolTable
-                        78
+                        76
                         {
                             _lcompilers_optimization_flipsign_f32:
                                 (Variable
-                                    78
+                                    76
                                     _lcompilers_optimization_flipsign_f32
                                     []
                                     ReturnVar
@@ -25,7 +25,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    78
+                                    76
                                     signal
                                     []
                                     In
@@ -41,7 +41,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    78
+                                    76
                                     variable
                                     []
                                     In
@@ -73,12 +73,12 @@
                         .false.
                     )
                     []
-                    [(Var 78 signal)
-                    (Var 78 variable)]
+                    [(Var 76 signal)
+                    (Var 76 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 78 signal)
+                                (Var 76 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -86,7 +86,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 78 signal)
+                                                (Var 76 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -117,21 +117,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 78 _lcompilers_optimization_flipsign_f32)
+                            (Var 76 _lcompilers_optimization_flipsign_f32)
                             (RealUnaryMinus
-                                (Var 78 variable)
+                                (Var 76 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 78 _lcompilers_optimization_flipsign_f32)
-                            (Var 78 variable)
+                            (Var 76 _lcompilers_optimization_flipsign_f32)
+                            (Var 76 variable)
                             ()
                         )]
                     )]
-                    (Var 78 _lcompilers_optimization_flipsign_f32)
+                    (Var 76 _lcompilers_optimization_flipsign_f32)
                     Public
                     .false.
                     .false.
@@ -140,11 +140,11 @@
             _lcompilers_optimization_flipsign_f321:
                 (Function
                     (SymbolTable
-                        79
+                        77
                         {
                             _lcompilers_optimization_flipsign_f321:
                                 (Variable
-                                    79
+                                    77
                                     _lcompilers_optimization_flipsign_f321
                                     []
                                     ReturnVar
@@ -160,7 +160,7 @@
                                 ),
                             signal:
                                 (Variable
-                                    79
+                                    77
                                     signal
                                     []
                                     In
@@ -176,7 +176,7 @@
                                 ),
                             variable:
                                 (Variable
-                                    79
+                                    77
                                     variable
                                     []
                                     In
@@ -208,12 +208,12 @@
                         .false.
                     )
                     []
-                    [(Var 79 signal)
-                    (Var 79 variable)]
+                    [(Var 77 signal)
+                    (Var 77 variable)]
                     [(If
                         (IntegerCompare
                             (IntegerBinOp
-                                (Var 79 signal)
+                                (Var 77 signal)
                                 Sub
                                 (IntegerBinOp
                                     (IntegerConstant 2 (Integer 4))
@@ -221,7 +221,7 @@
                                     (Cast
                                         (RealBinOp
                                             (Cast
-                                                (Var 79 signal)
+                                                (Var 77 signal)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -252,21 +252,21 @@
                             ()
                         )
                         [(Assignment
-                            (Var 79 _lcompilers_optimization_flipsign_f321)
+                            (Var 77 _lcompilers_optimization_flipsign_f321)
                             (RealUnaryMinus
-                                (Var 79 variable)
+                                (Var 77 variable)
                                 (Real 4)
                                 ()
                             )
                             ()
                         )]
                         [(Assignment
-                            (Var 79 _lcompilers_optimization_flipsign_f321)
-                            (Var 79 variable)
+                            (Var 77 _lcompilers_optimization_flipsign_f321)
+                            (Var 77 variable)
                             ()
                         )]
                     )]
-                    (Var 79 _lcompilers_optimization_flipsign_f321)
+                    (Var 77 _lcompilers_optimization_flipsign_f321)
                     Public
                     .false.
                     .false.


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/3034