### PR TITLE
Support calling `get_executable_path()` only once

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1903,6 +1903,7 @@ void _get_rpath_from_linker_flags(std::vector<std::string>& linker_flags, Compil
 int main_app(int argc, char *argv[]) {
     int dirname_length;
     LCompilers::LFortran::get_executable_path(LCompilers::binary_executable_path, dirname_length);
+    LCompilers::LFortran::set_exec_path_and_mode(LCompilers::binary_executable_path, dirname_length);
 
     // TODO: This is now in compiler options and can be removed
     std::string runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -69,22 +69,16 @@ std::string get_runtime_library_dir()
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_DIR");
     if (env_p) return env_p;
 
-    std::string path;
-    int dirname_length;
-    get_executable_path(path, dirname_length);
-    std::string dirname = path.substr(0,dirname_length);
-    if (   endswith(dirname, "src/bin")
-        || endswith(dirname, "src\\bin")
-        || endswith(dirname, "SRC\\BIN")) {
-        // Development version
-        return dirname + "/../runtime";
-    } else if (endswith(dirname, "src/lfortran/tests") ||
-               endswith(to_lower(dirname), "src\\lfortran\\tests")) {
-        // CTest Tests
-        return dirname + "/../../runtime";
-    } else {
-        // Installed version
-        return dirname + "/" + CMAKE_INSTALL_LIBDIR_RELATIVE;
+    switch (execution_mode)
+    {
+        case ExecutionMode::LFortranDevelopment:
+            return lfortran_exec_path_dir + "/../runtime";
+        case ExecutionMode::LFortranCtest:
+            return lfortran_exec_path_dir + "/../../runtime";
+        case ExecutionMode::LFortranInstalled:
+            return lfortran_exec_path_dir + "/" + CMAKE_INSTALL_LIBDIR_RELATIVE;
+        default:
+            return "";
     }
 }
 
@@ -93,11 +87,7 @@ std::string get_runtime_library_header_dir()
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_HEADER_DIR");
     if (env_p) return env_p;
 
-    std::string path;
-    int dirname_length;
-    get_executable_path(path, dirname_length);
-    std::string dirname = path.substr(0,dirname_length);
-    return dirname + "/" + CMAKE_INSTALL_INCLUDEDIR_RELATIVE + "/lfortran/impure";
+    return lfortran_exec_path_dir + "/" + CMAKE_INSTALL_INCLUDEDIR_RELATIVE + "/lfortran/impure";
 }
 
 std::string get_runtime_library_c_header_dir()
@@ -105,27 +95,17 @@ std::string get_runtime_library_c_header_dir()
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_HEADER_DIR");
     if (env_p) return env_p;
 
-    // The header file is in src/libasr/runtime for development, but in impure
-    // in installed version
-    std::string path;
-    int dirname_length;
-    get_executable_path(path, dirname_length);
-    std::string dirname = path.substr(0,dirname_length);
-    if (   endswith(dirname, "src/bin")
-        || endswith(dirname, "src\\bin")
-        || endswith(dirname, "SRC\\BIN")) {
-        // Development version
-        return dirname + "/../libasr/runtime";
-    } else if (endswith(dirname, "src/lpython/tests") ||
-               endswith(to_lower(dirname), "src\\lpython\\tests")) {
-        // CTest Tests
-        return dirname + "/../../libasr/runtime";
-    } else {
-        // Installed version
-        return dirname + "/" + CMAKE_INSTALL_INCLUDEDIR_RELATIVE + "/lfortran/impure";
+    switch (execution_mode)
+    {
+        case ExecutionMode::LFortranDevelopment:
+            return lfortran_exec_path_dir + "/../libasr/runtime";
+        case ExecutionMode::LFortranCtest:
+            return lfortran_exec_path_dir + "/../../libasr/runtime";
+        case ExecutionMode::LFortranInstalled:
+            return lfortran_exec_path_dir + "/" + CMAKE_INSTALL_INCLUDEDIR_RELATIVE + "/lfortran/impure";
+        default:
+            return "";
     }
-
-    return path;
 }
 
 std::string get_dwarf_scripts_dir()
@@ -133,24 +113,17 @@ std::string get_dwarf_scripts_dir()
     char *env_p = std::getenv("LFORTRAN_DWARF_SCRIPTS_DIR");
     if (env_p) return std::string(env_p);
 
-    std::string path;
-    int dirname_length;
-    get_executable_path(path, dirname_length);
-    std::string dirname = path.substr(0,dirname_length);
-    if (   endswith(dirname, "src/bin")
-        || endswith(dirname, "src\\bin")
-        || endswith(dirname, "SRC\\BIN")) {
-        // Development version
-        return dirname + "/../libasr";
-    } else if (endswith(dirname, "src/lpython/tests") ||
-               endswith(to_lower(dirname), "src\\lpython\\tests")) {
-        // CTest Tests
-        return dirname + "/../../libasr";
-    } else {
-        // Installed version
-        return dirname + "/../share/lfortran";
+    switch (execution_mode)
+    {
+        case ExecutionMode::LFortranDevelopment:
+            return lfortran_exec_path_dir + "/../libasr";
+        case ExecutionMode::LFortranCtest:
+            return lfortran_exec_path_dir + "/../../libasr";
+        case ExecutionMode::LFortranInstalled:
+            return lfortran_exec_path_dir + "/../share/lfortran";
+        default:
+            return "";
     }
-    return path;
 }
 
 // Decodes the exit status code of the process (in Unix)

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -18,6 +18,9 @@
 
 namespace LCompilers::LFortran {
 
+ExecutionMode execution_mode;
+std::string lfortran_exec_path_dir;
+
 void get_executable_path(std::string &executable_path, int &dirname_length)
 {
 #ifdef HAVE_WHEREAMI
@@ -38,6 +41,24 @@ void get_executable_path(std::string &executable_path, int &dirname_length)
     executable_path = "src/bin/lfortran.js";
     dirname_length = 7;
 #endif
+}
+
+void set_exec_path_and_mode(std::string &executable_path, int &dirname_length) {
+    lfortran_exec_path_dir = executable_path.substr(0, dirname_length);
+
+    if (   endswith(lfortran_exec_path_dir, "src/bin")
+        || endswith(lfortran_exec_path_dir, "src\\bin")
+        || endswith(lfortran_exec_path_dir, "SRC\\BIN")) {
+        // Development version
+        execution_mode = ExecutionMode::LFortranDevelopment;
+    } else if (endswith(lfortran_exec_path_dir, "src/lfortran/tests") ||
+               endswith(to_lower(lfortran_exec_path_dir), "src\\lfortran\\tests")) {
+        // CTest Tests
+        execution_mode = ExecutionMode::LFortranCtest;
+    } else {
+        // Installed version
+        execution_mode = ExecutionMode::LFortranInstalled;
+    }
 }
 
 std::string get_runtime_library_dir()

--- a/src/lfortran/utils.h
+++ b/src/lfortran/utils.h
@@ -6,7 +6,14 @@
 
 namespace LCompilers::LFortran {
 
+enum class ExecutionMode {
+    LFortranDevelopment,
+    LFortranInstalled,
+    LFortranCtest,
+};
+
 void get_executable_path(std::string &executable_path, int &dirname_length);
+void set_exec_path_and_mode(std::string &executable_path, int &dirname_length);
 std::string get_runtime_library_dir();
 std::string get_runtime_library_header_dir();
 std::string get_runtime_library_c_header_dir();


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/3242.