### PR TITLE
FIX: selection of wrong interface in case of argument with matching type and mismatched dimensions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -772,6 +772,7 @@ RUN(NAME interface_12a LABELS gfortran llvm EXTRAFILES interface_12b.f90)
 RUN(NAME interface_13 LABELS gfortran llvm)
 RUN(NAME interface_14 LABELS gfortran llvm)
 RUN(NAME interface_15 LABELS gfortran llvm fortran)
+RUN(NAME interface_16 LABELS gfortran llvm)
 
 RUN(NAME implicit_interface_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/interface_16.f90
+++ b/integration_tests/interface_16.f90
@@ -1,0 +1,31 @@
+module interface_16_module
+
+interface all_close
+
+procedure :: all_close_1_csp
+procedure :: all_close_2_csp
+end interface all_close
+contains
+
+logical pure function all_close_1_csp(a, b) result(close)
+
+    complex, intent(in) :: a(:), b(:)
+end function all_close_1_csp
+logical pure function all_close_2_csp(a, b) result(close)
+
+    complex, intent(in) :: a(:,:), b(:,:)
+    close = .false.
+end function all_close_2_csp
+
+end module
+
+program interface_16
+use interface_16_module, only: all_close
+
+complex :: z(4, 4)
+
+print *, all_close(z + cmplx(1.0e-11, 1.0e-11), z)
+if (all_close(z + cmplx(1.0e-11, 1.0e-11), z)) error stop
+
+end program interface_16
+  

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3386,28 +3386,47 @@ bool select_func_subrout(const ASR::symbol_t* proc, const Vec<ASR::call_arg_t>& 
     Location& loc, const std::function<void (const std::string &, const Location &)> err);
 
 template <typename T>
+bool argument_types_and_dimensions_match(const Vec<ASR::call_arg_t>& args,
+        const T &sub);
+
+template <typename T>
 int select_generic_procedure(const Vec<ASR::call_arg_t> &args,
     const T &p, Location loc,
     const std::function<void (const std::string &, const Location &)> err,
     bool raise_error=true) {
+    std::vector<std::pair<int, ASR::symbol_t*>> candidates;
     for (size_t i=0; i < p.n_procs; i++) {
         if( ASR::is_a<ASR::ClassProcedure_t>(*p.m_procs[i]) ) {
             ASR::ClassProcedure_t *clss_fn
                 = ASR::down_cast<ASR::ClassProcedure_t>(p.m_procs[i]);
-            const ASR::symbol_t *proc = ASRUtils::symbol_get_past_external(clss_fn->m_proc);
+            ASR::symbol_t *proc = ASRUtils::symbol_get_past_external(clss_fn->m_proc);
             if( select_func_subrout(proc, args, loc, err) ) {
-                return i;
+                candidates.push_back(std::make_pair(i, proc));
             }
         } else {
             if( select_func_subrout(p.m_procs[i], args, loc, err) ) {
-                return i;
+                candidates.push_back(std::make_pair(i, p.m_procs[i]));
             }
         }
     }
-    if( raise_error ) {
+    if( raise_error && candidates.size() == 0 ) {
         err("Arguments do not match for any generic procedure, " + std::string(p.m_name), loc);
     }
-    return -1;
+    for (size_t i=0; i < candidates.size(); i++) {
+        ASR::symbol_t* proc = candidates[i].second;
+        int idx = candidates[i].first;
+
+        proc = ASRUtils::symbol_get_past_external(proc);
+
+        if (ASR::is_a<ASR::Function_t>(*proc)) {
+            ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(proc);
+            if (argument_types_and_dimensions_match(args, *fn)) {
+                return idx;
+            }
+        }
+    }
+
+    return candidates.size() > 0 ? candidates[0].first : -1;
 }
 
 ASR::asr_t* symbol_resolve_external_generic_procedure_without_eval(


### PR DESCRIPTION
Fixes #3244, towards #3046.

With this PR and https://github.com/Pranavchiku/stdlib-fortran-lang/commit/578ec4253e6f4dc0fb6618939a32c8053de753c8 we get `example_math_all_close` working.