### PR TITLE
ASR Verify: visit function signature

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -437,6 +437,7 @@ RUN(NAME arrays_34 LABELS gfortran llvm llvmStackArray)
 RUN(NAME arrays_35 LABELS gfortran llvm)
 RUN(NAME arrays_36 LABELS gfortran llvm)
 RUN(NAME arrays_37 LABELS gfortran llvm)
+RUN(NAME arrays_38 LABELS gfortran llvm)
 
 
 # GFortran

--- a/integration_tests/arrays_38.f90
+++ b/integration_tests/arrays_38.f90
@@ -9,11 +9,12 @@ program arrays_38
 implicit none
 integer :: n, i
 complex :: res(5)
+complex :: res2(0)
 interface
-pure function linspace_n_1_cdp_cdp(n) result(res)
-integer, intent(in) :: n
-complex :: res(max(n, 0))
-end function linspace_n_1_cdp_cdp
+    pure function linspace_n_1_cdp_cdp(n) result(res)
+    integer, intent(in) :: n
+    complex :: res(max(n, 0))
+    end function linspace_n_1_cdp_cdp
 end interface
 
 res = linspace_n_1_cdp_cdp(5)
@@ -21,4 +22,6 @@ print *, res
 do i = 1, 5
     if (abs(res(i) - (1.0, 3.0)) > 1e-8) error stop
 end do
+res2 = linspace_n_1_cdp_cdp(-3)
+print *, res2
 end program

--- a/integration_tests/arrays_38.f90
+++ b/integration_tests/arrays_38.f90
@@ -1,0 +1,24 @@
+pure function linspace_n_1_cdp_cdp(n) result(res)
+integer, intent(in) :: n
+complex :: res(max(n, 0))
+
+res = (1.0, 3.0)
+end function linspace_n_1_cdp_cdp
+
+program arrays_38
+implicit none
+integer :: n, i
+complex :: res(5)
+interface
+pure function linspace_n_1_cdp_cdp(n) result(res)
+integer, intent(in) :: n
+complex :: res(max(n, 0))
+end function linspace_n_1_cdp_cdp
+end interface
+
+res = linspace_n_1_cdp_cdp(5)
+print *, res
+do i = 1, 5
+    if (abs(res(i) - (1.0, 3.0)) > 1e-8) error stop
+end do
+end program

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -426,6 +426,7 @@ public:
             LCOMPILERS_ASSERT(a.second);
             this->visit_symbol(*a.second);
         }
+        visit_ttype(*x.m_function_signature);
         for (size_t i=0; i<x.n_args; i++) {
             LCOMPILERS_ASSERT(x.m_args[i]);
             visit_expr(*x.m_args[i]);


### PR DESCRIPTION
Fixes #3264, towards #3046.

With this PR we get `example_linspace_int16` working.