### PR TITLE
assign "value" for IntegerBinOp node in StringSection when adjusting for 0-based indexing

### DIFF
--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -314,17 +314,17 @@ class ASRBuilder {
     }
 
     // Expressions -------------------------------------------------------------
-    #define i(x, t)   EXPR(ASR::make_IntegerConstant_t(al, loc, x, t))
-    #define i32(x)   EXPR(ASR::make_IntegerConstant_t(al, loc, x, int32))
-    #define i32_n(x) EXPR(ASR::make_IntegerUnaryMinus_t(al, loc, i32(abs(x)),   \
+    #define i(x, t)   ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, x, t))
+    #define i32(x)   ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, x, int32))
+    #define i32_n(x) ASRUtils::EXPR(ASR::make_IntegerUnaryMinus_t(al, loc, i32(abs(x)),   \
         int32, i32(x)))
-    #define i32_neg(x, t) EXPR(ASR::make_IntegerUnaryMinus_t(al, loc, x, t, nullptr))
+    #define i32_neg(x, t) ASRUtils::EXPR(ASR::make_IntegerUnaryMinus_t(al, loc, x, t, nullptr))
 
-    #define f(x, t)   EXPR(ASR::make_RealConstant_t(al, loc, x, t))
-    #define f32(x) EXPR(ASR::make_RealConstant_t(al, loc, x, real32))
-    #define f32_neg(x, t) EXPR(ASR::make_RealUnaryMinus_t(al, loc, x, t, nullptr))
+    #define f(x, t)   ASRUtils::EXPR(ASR::make_RealConstant_t(al, loc, x, t))
+    #define f32(x) ASRUtils::EXPR(ASR::make_RealConstant_t(al, loc, x, real32))
+    #define f32_neg(x, t) ASRUtils::EXPR(ASR::make_RealUnaryMinus_t(al, loc, x, t, nullptr))
 
-    #define bool32(x)  EXPR(ASR::make_LogicalConstant_t(al, loc, x, logical))
+    #define bool32(x)  ASRUtils::EXPR(ASR::make_LogicalConstant_t(al, loc, x, logical))
 
     #define ListItem(x, pos, type) EXPR(ASR::make_ListItem_t(al, loc, x, pos,   \
         type, nullptr))
@@ -381,8 +381,10 @@ class ASRBuilder {
             ASR::binopType::Add, right, t, nullptr))
 
     #define iSub(left, right) EXPR(ASR::make_IntegerBinOp_t(al, loc, left,      \
-            ASR::binopType::Sub, right, int32, nullptr))
-    #define i8Sub(left, right) EXPR(ASR::make_IntegerBinOp_t(al, loc, left,     \
+            ASR::binopType::Sub, right, ASRUtils::int32, nullptr))
+    #define i_vSub(left, right, value) ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, left,      \
+            ASR::binopType::Sub, right, ASRUtils::int32, value))
+    #define i8Sub(left, right) ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, left,     \
         ASR::binopType::Sub, right, int8, nullptr))
     #define i16Sub(left, right) EXPR(ASR::make_IntegerBinOp_t(al, loc, left,    \
         ASR::binopType::Sub, right, int16, nullptr))

--- a/tests/errors/substring_endidx.f90
+++ b/tests/errors/substring_endidx.f90
@@ -1,0 +1,5 @@
+program substring_noninteger_endidx
+    implicit none
+    character(len=8) :: s = "lfortran"
+    print*, s(1:5.2)
+end program substring_noninteger_endidx

--- a/tests/errors/substring_startidx.f90
+++ b/tests/errors/substring_startidx.f90
@@ -1,0 +1,5 @@
+program substring_noninteger_startidx
+    implicit none
+    character(len=8) :: s = "lfortran"
+    print*, s(1.1:5)
+end program substring_noninteger_startidx

--- a/tests/errors/substring_stride.f90
+++ b/tests/errors/substring_stride.f90
@@ -1,0 +1,5 @@
+program substring_noninteger_stride
+    implicit none
+    character(len=8) :: s = "lfortran"
+    print*, s(1:5:2.2)
+end program substring_noninteger_stride

--- a/tests/reference/asr-allocate_04-68facec.json
+++ b/tests/reference/asr-allocate_04-68facec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_04-68facec.stdout",
-    "stdout_hash": "2dc672674755450e9f43ef501b6ce104a0faceb9e7e2710e0b3a5c23",
+    "stdout_hash": "42ecbc435f6aad459cc9a7e1e150939d1fe2f0c92167d3bc6e481bf6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_04-68facec.stdout
+++ b/tests/reference/asr-allocate_04-68facec.stdout
@@ -201,7 +201,7 @@
                                 Sub
                                 (IntegerConstant 1 (Integer 4))
                                 (Integer 4)
-                                ()
+                                (IntegerConstant 0 (Integer 4))
                             )
                             (IntegerBinOp
                                 (FunctionCall

--- a/tests/reference/asr-arrays_23-a731033.json
+++ b/tests/reference/asr-arrays_23-a731033.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_23-a731033.stdout",
-    "stdout_hash": "ddffe4eef3b34c6e1d658a15ec77471de3c54370e7856a1311d7a582",
+    "stdout_hash": "c0cb4d298e26e591ab6fb99caabfd0e8ce7e7e306848412c35efb116",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_23-a731033.stdout
+++ b/tests/reference/asr-arrays_23-a731033.stdout
@@ -181,7 +181,7 @@
                                                         Sub
                                                         (IntegerConstant 1 (Integer 4))
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant 0 (Integer 4))
                                                     )
                                                     (IntegerBinOp
                                                         (FunctionCall

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "910dce1d75f8c30f5b1c42cb477589bc7018fcbc9953bb0d69077ad3",
+    "stdout_hash": "4b4513f0caf10222d25aa81f2e144dc17c610bf349e593b034d13875",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -1265,7 +1265,7 @@
                                                                         Sub
                                                                         (IntegerConstant 1 (Integer 4))
                                                                         (Integer 4)
-                                                                        ()
+                                                                        (IntegerConstant 0 (Integer 4))
                                                                     )
                                                                     (IntegerConstant 1 (Integer 4))
                                                                     (IntegerConstant 1 (Integer 4))

--- a/tests/reference/asr-string_04-2ebc0e6.json
+++ b/tests/reference/asr-string_04-2ebc0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_04-2ebc0e6.stdout",
-    "stdout_hash": "b8ffe6415cf2c0706648c0ba0960dd43e43a32d0cb5b1e69c50e90ec",
+    "stdout_hash": "453acd5fb4ecd34aafe1c6c68149a1f164f85809781389ccc21be94c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_04-2ebc0e6.stdout
+++ b/tests/reference/asr-string_04-2ebc0e6.stdout
@@ -289,7 +289,7 @@
                                         Sub
                                         (IntegerConstant 1 (Integer 4))
                                         (Integer 4)
-                                        ()
+                                        (IntegerConstant 1 (Integer 4))
                                     )
                                     ()
                                     (IntegerConstant 1 (Integer 4))

--- a/tests/reference/asr-string_10-eb8bca7.json
+++ b/tests/reference/asr-string_10-eb8bca7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_10-eb8bca7.stdout",
-    "stdout_hash": "65e71f77964cdb0adb9070bfc7817e84cee001ce528bf0f78d715f2f",
+    "stdout_hash": "7520669809230e263cd201b14df977634b3695276614f9d4e06fb979",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_10-eb8bca7.stdout
+++ b/tests/reference/asr-string_10-eb8bca7.stdout
@@ -280,7 +280,7 @@
                                 Sub
                                 (IntegerConstant 1 (Integer 4))
                                 (Integer 4)
-                                ()
+                                (IntegerConstant 0 (Integer 4))
                             )
                             (IntegerConstant 3 (Integer 4))
                             (IntegerConstant 1 (Integer 4))

--- a/tests/reference/asr-string_12-e72e066.json
+++ b/tests/reference/asr-string_12-e72e066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_12-e72e066.stdout",
-    "stdout_hash": "86e800d554b702d9bd05579b97fdbda0168ac30fcbb7e71d0d0e457e",
+    "stdout_hash": "e73b1b4fedf4a04e968318e79c1989fa8f442d04086c90a8ef6f1d07",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_12-e72e066.stdout
+++ b/tests/reference/asr-string_12-e72e066.stdout
@@ -20,7 +20,7 @@
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant 0 (Integer 4))
                                         )
                                         (IntegerConstant 10 (Integer 4))
                                         (IntegerConstant 1 (Integer 4))
@@ -77,7 +77,7 @@
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant 0 (Integer 4))
                                         )
                                         (IntegerConstant 16 (Integer 4))
                                         (IntegerConstant 1 (Integer 4))
@@ -134,7 +134,7 @@
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant 26 (Integer 4))
                                         )
                                         ()
                                         (IntegerConstant 1 (Integer 4))
@@ -191,7 +191,7 @@
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant 0 (Integer 4))
                                         )
                                         (IntegerConstant 8 (Integer 4))
                                         (IntegerConstant 1 (Integer 4))
@@ -226,7 +226,7 @@
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant 0 (Integer 4))
                                         )
                                         (IntegerConstant 26 (Integer 4))
                                         (IntegerConstant 1 (Integer 4))

--- a/tests/reference/asr-substring_endidx-0f7e2c9.json
+++ b/tests/reference/asr-substring_endidx-0f7e2c9.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-substring_endidx-0f7e2c9",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/substring_endidx.f90",
+    "infile_hash": "822fddebe2c138bf6639648f87d91376999e080c3364c20e939b4b35",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-substring_endidx-0f7e2c9.stderr",
+    "stderr_hash": "0364385c1f5a421621582c1588a156629243fa24183e1913f217c691",
+    "returncode": 2
+}

--- a/tests/reference/asr-substring_endidx-0f7e2c9.stderr
+++ b/tests/reference/asr-substring_endidx-0f7e2c9.stderr
@@ -1,0 +1,5 @@
+semantic error: Substring end index at must be of type integer
+ --> tests/errors/substring_endidx.f90:4:17
+  |
+4 |     print*, s(1:5.2)
+  |                 ^^^

--- a/tests/reference/asr-substring_startidx-5fb6d57.json
+++ b/tests/reference/asr-substring_startidx-5fb6d57.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-substring_startidx-5fb6d57",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/substring_startidx.f90",
+    "infile_hash": "fcff3742bb69cbe950f45a39c1dca614325666b260ee503f8862cfdf",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-substring_startidx-5fb6d57.stderr",
+    "stderr_hash": "564b4a23bb9dc1c50abb4282ce068b3666966efc9fd6fa9de268b987",
+    "returncode": 2
+}

--- a/tests/reference/asr-substring_startidx-5fb6d57.stderr
+++ b/tests/reference/asr-substring_startidx-5fb6d57.stderr
@@ -1,0 +1,5 @@
+semantic error: Substring start index at must be of type integer
+ --> tests/errors/substring_startidx.f90:4:15
+  |
+4 |     print*, s(1.1:5)
+  |               ^^^

--- a/tests/reference/asr-substring_stride-27c1b9d.json
+++ b/tests/reference/asr-substring_stride-27c1b9d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-substring_stride-27c1b9d",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/substring_stride.f90",
+    "infile_hash": "6a9643c1bd0727933536c1be695d01d8caf526e230d57f98040d83fa",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-substring_stride-27c1b9d.stderr",
+    "stderr_hash": "e07c19b5d759c9008954fa634e6b1bc48b258d40b917a75276e8d84f",
+    "returncode": 2
+}

--- a/tests/reference/asr-substring_stride-27c1b9d.stderr
+++ b/tests/reference/asr-substring_stride-27c1b9d.stderr
@@ -1,0 +1,5 @@
+semantic error: Substring stride must be of type integer
+ --> tests/errors/substring_stride.f90:4:19
+  |
+4 |     print*, s(1:5:2.2)
+  |                   ^^^

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3691,3 +3691,15 @@ asr = true
 [[test]]
 filename = "errors/min_02.f90"
 asr = true
+
+[[test]]
+filename = "errors/substring_startidx.f90"
+asr = true
+
+[[test]]
+filename = "errors/substring_endidx.f90"
+asr = true
+
+[[test]]
+filename = "errors/substring_stride.f90"
+asr = true


### PR DESCRIPTION
Fixes #3273