### PR TITLE
ENH: Handle complex constructor over array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1193,6 +1193,7 @@ RUN(NAME complex_13 LABELS gfortran llvm wasm)
 RUN(NAME complex_14 LABELS gfortran llvm wasm)
 RUN(NAME complex_15 LABELS gfortran llvm fortran)
 RUN(NAME complex_16 LABELS gfortran llvm)
+RUN(NAME complex_17 LABELS gfortran llvm)
 
 RUN(NAME array_op_01 LABELS gfortran llvm llvmStackArray wasm)
 RUN(NAME array_op_02 LABELS gfortran llvm llvmStackArray wasm)

--- a/integration_tests/complex_17.f90
+++ b/integration_tests/complex_17.f90
@@ -1,0 +1,35 @@
+pure function linspace_n_1_cdp_cdp(x, y, n) result(res)
+integer, intent(in) :: n
+
+complex :: res(n)
+
+real, intent(in) :: x(n)
+real, intent(in) :: y(n)
+
+res = cmplx(x, y)
+end function linspace_n_1_cdp_cdp
+
+program complex_17
+implicit none
+integer :: i
+real :: x(10), y(10)
+complex :: z(10)
+interface
+    pure function linspace_n_1_cdp_cdp(x, y, n) result(res)
+    integer, intent(in) :: n
+    complex :: res(n)
+    real, intent(in) :: x(n)
+    real, intent(in) :: y(n)
+    end function linspace_n_1_cdp_cdp
+end interface
+
+x = 1.0
+y = 2.0
+
+z = linspace_n_1_cdp_cdp(x, y, 10)
+print *, z
+print *, abs(z)
+do i = 1, 10
+    if (abs(abs(z(i)) - 2.236068) > 1e-8) error stop
+end do
+end program

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -71,6 +71,9 @@ namespace LCompilers {
                 ASR::ttype_t* x_type = ASR::down_cast<ASR::ArrayPhysicalCast_t>(x)->m_type;
                 ASR::dimension_t* m_dims;
                 get_dim_rank(x_type, m_dims, n_dims);
+            } else if (ASR::is_a<ASR::ComplexConstructor_t>(*x)) {
+                ASR::ComplexConstructor_t* cc = ASR::down_cast<ASR::ComplexConstructor_t>(x);
+                return get_rank(cc->m_re);
             }
             return n_dims;
         }


### PR DESCRIPTION
Fixes #3275, towards #3046.

With this we get `example_linspace_complex` working. Also, with https://github.com/pranavchiku/stdlib-fortran-lang/tree/lf-math7 and this PR we get `example_logspace_*` working.