### PR TITLE
Emit warning for CPP defines if `--cpp` is not present

### DIFF
--- a/tests/reference/asr-preprocess_01-20f7efb.json
+++ b/tests/reference/asr-preprocess_01-20f7efb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-preprocess_01-20f7efb",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/warnings/preprocess_01.f90",
+    "infile_hash": "8b0a43c23607be7c2557620c9ad10af23a6bcf0430bf1d5170b65303",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-preprocess_01-20f7efb.stdout",
+    "stdout_hash": "3ff0534ff3a68c1d3035adf373b2d447474db34dea891e8d3f5658e5",
+    "stderr": "asr-preprocess_01-20f7efb.stderr",
+    "stderr_hash": "add78f2a68b8c40d46c23122eeab18b258daae408143d3fb854b005d",
+    "returncode": 0
+}

--- a/tests/reference/asr-preprocess_01-20f7efb.stderr
+++ b/tests/reference/asr-preprocess_01-20f7efb.stderr
@@ -1,0 +1,35 @@
+warning: #ifdef ignored
+ --> tests/warnings/preprocess_01.f90:6:1
+  |
+6 | #ifdef pqr
+  | ^^^^^^^^^^^ help: use the '--cpp' command line option to preprocess it
+
+warning: #elif ignored
+ --> tests/warnings/preprocess_01.f90:8:1
+  |
+8 | #elif mno == 18
+  | ^^^^^^^^^^^^^^^^ help: use the '--cpp' command line option to preprocess it
+
+warning: #else ignored
+  --> tests/warnings/preprocess_01.f90:10:1
+   |
+10 | #else
+   | ^^^^^^ help: use the '--cpp' command line option to preprocess it
+
+warning: #endif ignored
+  --> tests/warnings/preprocess_01.f90:13:1
+   |
+13 | #endif
+   | ^^^^^^^ help: use the '--cpp' command line option to preprocess it
+
+warning: #define ignored
+  --> tests/warnings/preprocess_01.f90:16:1
+   |
+16 | #define abc(m, n) m + n
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the '--cpp' command line option to preprocess it
+
+warning: Unsupported macro
+  --> tests/warnings/preprocess_01.f90:18:1
+   |
+18 | #abcd
+   | ^^^^^^ Ignored

--- a/tests/reference/asr-preprocess_01-20f7efb.stdout
+++ b/tests/reference/asr-preprocess_01-20f7efb.stdout
@@ -1,0 +1,77 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            preprocess_01:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    preprocess_01
+                    []
+                    [(Assignment
+                        (Var 2 x)
+                        (IntegerBinOp
+                            (IntegerBinOp
+                                (IntegerConstant 2 (Integer 4))
+                                Add
+                                (IntegerConstant 3 (Integer 4))
+                                (Integer 4)
+                                (IntegerConstant 5 (Integer 4))
+                            )
+                            Mul
+                            (IntegerConstant 5 (Integer 4))
+                            (Integer 4)
+                            (IntegerConstant 25 (Integer 4))
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 x)
+                        (IntegerConstant 18 (Integer 4))
+                        ()
+                    )
+                    (Print
+                        [(StringConstant
+                            "Else condition"
+                            (Character 1 14 ())
+                        )]
+                        ()
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 x)
+                        (IntegerConstant 30 (Integer 4))
+                        ()
+                    )
+                    (Print
+                        [(Var 2 x)]
+                        ()
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 x)
+                        (IntegerConstant 10000 (Integer 4))
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -417,6 +417,10 @@ filename = "warnings/character_01.f90"
 asr = true
 
 [[test]]
+filename = "warnings/preprocess_01.f90"
+asr = true
+
+[[test]]
 filename = "preprocessor1.f90"
 asr_preprocess = true
 

--- a/tests/warnings/preprocess_01.f90
+++ b/tests/warnings/preprocess_01.f90
@@ -1,0 +1,20 @@
+program preprocess_01
+    implicit none
+#line 10
+
+    integer :: x
+#ifdef pqr
+x = (2+3)*5
+#elif mno == 18
+x = 18
+#else
+    print *, "Else condition"
+    x = 30
+#endif
+print *, x
+x = 10000
+#define abc(m, n) m + n
+
+#abcd
+
+end program


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/3259