### PR TITLE
Fix: using lfortran intrinsic module inside module

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -720,7 +720,7 @@ RUN(NAME modules_51 LABELS gfortran llvmImplicit)
 RUN(NAME modules_53 LABELS gfortran llvm)
 RUN(NAME modules_54 LABELS gfortran llvm)
 RUN(NAME modules_55 LABELS gfortran llvm)
-RUN(NAME modules_56 LABELS gfortran llvm)
+RUN(NAME modules_56 LABELS gfortran llvm NOFAST)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -720,6 +720,7 @@ RUN(NAME modules_51 LABELS gfortran llvmImplicit)
 RUN(NAME modules_53 LABELS gfortran llvm)
 RUN(NAME modules_54 LABELS gfortran llvm)
 RUN(NAME modules_55 LABELS gfortran llvm)
+RUN(NAME modules_56 LABELS gfortran llvm)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES

--- a/integration_tests/modules_56.f90
+++ b/integration_tests/modules_56.f90
@@ -13,8 +13,10 @@ end module
 program main
     use modules_56_module
     implicit none
-    real :: a = 0.0
+    real :: a
+    logical :: res
 
-    print *, is_close_rsp(a)
-    if (is_close_rsp(a)) error stop
+    res = is_close_rsp(a)
+    print *, res
+    if (res) error stop
 end program main

--- a/integration_tests/modules_56.f90
+++ b/integration_tests/modules_56.f90
@@ -1,0 +1,20 @@
+module modules_56_module
+
+contains
+logical function is_close_rsp(a) result(res)
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_nan
+
+    real, intent(in) :: a
+
+    res = ieee_is_nan(a)
+end function is_close_rsp
+end module
+
+program main
+    use modules_56_module
+    implicit none
+    real :: a = 0.0
+
+    print *, is_close_rsp(a)
+    if (is_close_rsp(a)) error stop
+end program main

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2570,6 +2570,9 @@ public:
 
     void visit_Use(const AST::Use_t &x) {
         std::string msym = to_lower(x.m_module);
+        if (msym == "ieee_arithmetic") {
+            msym = "lfortran_intrinsic_" + msym;
+        }
         Str msym_c; msym_c.from_str_view(msym);
         char *msym_cc = msym_c.c_str(al);
         current_module_dependencies.push_back(al, msym_cc);


### PR DESCRIPTION
Fixes #3054, towards #3046.

Continuation of #3056.

After this PR, most of examples align with GFortran, I will setup checks like `if (xx) error stop` and then set it up at CI.