### PR TITLE
Redesign the `epsilon` and `tiny` intrinsics implementations

### DIFF
--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -99,8 +99,6 @@ struct IntrinsicProcedures {
             {"selected_int_kind", {m_kind, &eval_selected_int_kind, true}},
             {"selected_real_kind", {m_kind, &eval_selected_real_kind, true}},
             {"selected_char_kind", {m_kind, &eval_selected_char_kind, true}},
-            {"epsilon", {m_math, &eval_epsilon, false}},
-            {"tiny", {m_math, &eval_tiny, false}},
 
             {"dot_product", {m_math, &not_implemented, false}},
             {"conjg", {m_math, &not_implemented, false}},
@@ -246,39 +244,6 @@ struct IntrinsicProcedures {
         int64_t not_arg = ~(arg_int->m_n);
         ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, arg_int_type->m_kind));
         return ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, not_arg, int_type));
-    }
-
-    static ASR::expr_t *eval_tiny(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, const CompilerOptions &) {
-        // We assume the input is valid
-        // ASR::expr_t* tiny_expr = args[0];
-        ASR::ttype_t* tiny_type = ASRUtils::expr_type(args[0]);
-        // TODO: Arrays of reals are a valid argument for tiny
-        if (ASRUtils::is_array(tiny_type)){
-            throw SemanticError("Array values not implemented yet",
-                                loc);
-        }
-        // TODO: Figure out how to deal with higher precision later
-        if (ASR::is_a<ASR::Real_t>(*tiny_type)) {
-            // We don't actually need the value yet, it is enough to know it is a double
-            // but it might provide further information later (precision)
-            // double tiny_val = ASR::down_cast<ASR::RealConstant_t>(ASRUtils::expr_value(tiny_expr))->m_r;
-            int tiny_kind = ASRUtils::extract_kind_from_ttype_t(tiny_type);
-            if (tiny_kind == 4){
-                float low_val = std::numeric_limits<float>::min();
-                return ASR::down_cast<ASR::expr_t>(ASR::make_RealConstant_t(al, loc,
-                                                                                low_val, // value
-                                                                                tiny_type));
-            } else {
-                double low_val = std::numeric_limits<double>::min();
-                return ASR::down_cast<ASR::expr_t>(ASR::make_RealConstant_t(al, loc,
-                                                                                low_val, // value
-                                                                                tiny_type));
-                    }
-        }
-        else {
-            throw SemanticError("Argument for tiny must be Real",
-                                loc);
-        }
     }
 
     static ASR::expr_t *eval_floor(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, const CompilerOptions &compiler_options) {
@@ -547,27 +512,6 @@ struct IntrinsicProcedures {
         } else {
             throw SemanticError("achar() must have one integer argument", loc);
         }
-    }
-
-    static ASR::expr_t *eval_epsilon(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, const CompilerOptions &) {
-        LCOMPILERS_ASSERT(args.size() == 1);
-        ASR::ttype_t* t = ASRUtils::expr_type(args[0]);
-        if (!ASR::is_a<ASR::Real_t>(*t)) {
-            throw SemanticError("Only inputs of real type are accepted in epsilon intrinsic.", loc);
-        }
-        ASR::Real_t* t_real = ASR::down_cast<ASR::Real_t>(t);
-        if( t_real->m_kind == 4 ) {
-            float epsilon_val = std::numeric_limits<float>::epsilon();
-            return ASR::down_cast<ASR::expr_t>(
-                    ASR::make_RealConstant_t(al, loc, epsilon_val, t));
-        } else if( t_real->m_kind == 8 ) {
-            double epsilon_val = std::numeric_limits<double>::epsilon();
-            return ASR::down_cast<ASR::expr_t>(
-                    ASR::make_RealConstant_t(al, loc, epsilon_val, t));
-        } else {
-            throw SemanticError("Only 32 and 64 bit kinds are supported in epsilon intrinsic.", loc);
-        }
-        return nullptr;
     }
 
     static ASR::expr_t *eval_adjustl(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, const CompilerOptions &) {

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -205,11 +205,22 @@ intrinsic_funcs_args = {
             "return": "int32"
         },
     ],
-
+    "Epsilon": [
+        {
+            "args": [("real",)],
+            "ret_type_arg_idx": 0
+        }
+    ],
+    "Tiny": [
+        {
+            "args": [("real",)],
+            "ret_type_arg_idx": 0
+        }
+    ],
 }
 
 skip_create_func = ["Partition"]
-skip_fn_instantiation = ["Radix", "Range"]
+skip_fn_instantiation = ["Radix", "Range", "Epsilon", "Tiny"]
 
 type_to_asr_type_check = {
     "any": "!ASR::is_a<ASR::TypeParameter_t>",

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -83,6 +83,8 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Idint)
         INTRINSIC_NAME_CASE(Floor)
         INTRINSIC_NAME_CASE(Ceiling)
+        INTRINSIC_NAME_CASE(Epsilon)
+        INTRINSIC_NAME_CASE(Tiny)
         INTRINSIC_NAME_CASE(SymbolicSymbol)
         INTRINSIC_NAME_CASE(SymbolicAdd)
         INTRINSIC_NAME_CASE(SymbolicSub)
@@ -249,6 +251,10 @@ namespace IntrinsicScalarFunctionRegistry {
             {&Idint::instantiate_Idint, &Idint::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SignFromValue),
             {&SignFromValue::instantiate_SignFromValue, &SignFromValue::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::Epsilon),
+            {nullptr, &UnaryIntrinsicFunction::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::Tiny),
+            {nullptr, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicSymbol),
             {nullptr, &SymbolicSymbol::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicAdd),
@@ -428,6 +434,10 @@ namespace IntrinsicScalarFunctionRegistry {
             "ifix"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SignFromValue),
             "signfromvalue"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::Epsilon),
+            "epsilon"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::Tiny),
+            "tiny"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicSymbol),
             "Symbol"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicAdd),
@@ -546,6 +556,8 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"sngl", {&Sngl::create_Sngl, &Sngl::eval_Sngl}},
                 {"ifix", {&Ifix::create_Ifix, &Ifix::eval_Ifix}},
                 {"idint", {&Idint::create_Idint, &Idint::eval_Idint}},
+                {"epsilon", {&Epsilon::create_Epsilon, &Epsilon::eval_Epsilon}},
+                {"tiny", {&Tiny::create_Tiny, &Tiny::eval_Tiny}},
                 {"Symbol", {&SymbolicSymbol::create_SymbolicSymbol, &SymbolicSymbol::eval_SymbolicSymbol}},
                 {"SymbolicAdd", {&SymbolicAdd::create_SymbolicAdd, &SymbolicAdd::eval_SymbolicAdd}},
                 {"SymbolicSub", {&SymbolicSub::create_SymbolicSub, &SymbolicSub::eval_SymbolicSub}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -85,6 +85,8 @@ enum class IntrinsicScalarFunctions : int64_t {
     Idint,
     Floor,
     Ceiling,
+    Epsilon,
+    Tiny,
     SymbolicSymbol,
     SymbolicAdd,
     SymbolicSub,
@@ -3010,6 +3012,46 @@ namespace Partition {
     }
 
 } // namespace Partition
+
+namespace Epsilon {
+
+    static ASR::expr_t *eval_Epsilon(Allocator &al, const Location &loc,
+            ASR::ttype_t* arg_type, Vec<ASR::expr_t*> &/*args*/) {
+        double epsilon_val = -1;
+        int32_t kind = extract_kind_from_ttype_t(arg_type);
+        switch ( kind ) {
+            case 4: {
+                epsilon_val = std::numeric_limits<float>::epsilon(); break;
+            } case 8: {
+                epsilon_val = std::numeric_limits<double>::epsilon(); break;
+            } default: {
+                break;
+            }
+        }
+        return f(epsilon_val, arg_type);
+    }
+
+}  // namespace Epsilon
+
+namespace Tiny {
+
+    static ASR::expr_t *eval_Tiny(Allocator &al, const Location &loc,
+            ASR::ttype_t* arg_type, Vec<ASR::expr_t*> &/*args*/) {
+        double tiny_value = -1;
+        int32_t kind = extract_kind_from_ttype_t(arg_type);
+        switch ( kind ) {
+            case 4: {
+                tiny_value = std::numeric_limits<float>::min(); break;
+            } case 8: {
+                tiny_value = std::numeric_limits<double>::min(); break;
+            } default: {
+                break;
+            }
+        }
+        return f(tiny_value, arg_type);
+    }
+
+}  // namespace Tiny
 
 namespace SymbolicSymbol {
 

--- a/src/runtime/impure/lfortran_intrinsic_math.f90
+++ b/src/runtime/impure/lfortran_intrinsic_math.f90
@@ -3,14 +3,6 @@ use, intrinsic :: iso_fortran_env, only: i8 => int8, i16 => int16, i32 => int32,
 use, intrinsic :: iso_c_binding, only: c_float, c_double
 implicit none
 
-interface epsilon
-    module procedure sepsilon, depsilon
-end interface
-
-interface tiny
-    module procedure stiny, dtiny
-end interface
-
 interface system_clock
     module procedure i32sys_clock, i64sys_clock
 end interface
@@ -36,30 +28,6 @@ interface dot_product
 end interface
 
 contains
-
-! epsilon ---------------------------------------------------------------------
-
-elemental real(sp) function sepsilon(x) result(r)
-real(sp), intent(in) :: x
-r = 1.19209290E-07
-end function
-
-elemental real(dp) function depsilon(x) result(r)
-real(dp), intent(in) :: x
-r = 2.2204460492503131E-016
-end function
-
-! tiny ---------------------------------------------------------------------
-
-elemental real(sp) function stiny(x) result(r)
-real(sp), intent(in) :: x
-r = 1.17549435E-38
-end function
-
-elemental real(dp) function dtiny(x) result(r)
-real(dp), intent(in) :: x
-r = 2.2250738585072014E-308
-end function
 
 ! cpu_time ---------------------------------------------------------------------
 

--- a/tests/reference/asr-intrinsics_08-9988b1f.json
+++ b/tests/reference/asr-intrinsics_08-9988b1f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_08-9988b1f.stdout",
-    "stdout_hash": "9ada8c14bd77b4e5f16511191c5aa031cae5f1dc67791699703200eb",
+    "stdout_hash": "2cbbca53df7c8079a4b74e8ff028efffff889102de3f4d8d8e70680d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_08-9988b1f.stdout
+++ b/tests/reference/asr-intrinsics_08-9988b1f.stdout
@@ -23,55 +23,24 @@
                                     Required
                                     .false.
                                 ),
-                            tiny:
-                                (ExternalSymbol
-                                    2
-                                    tiny
-                                    4 tiny
-                                    lfortran_intrinsic_math
-                                    []
-                                    tiny
-                                    Private
-                                ),
-                            tiny@dtiny:
-                                (ExternalSymbol
-                                    2
-                                    tiny@dtiny
-                                    4 dtiny
-                                    lfortran_intrinsic_math
-                                    []
-                                    dtiny
-                                    Private
-                                ),
-                            tiny@stiny:
-                                (ExternalSymbol
-                                    2
-                                    tiny@stiny
-                                    4 stiny
-                                    lfortran_intrinsic_math
-                                    []
-                                    stiny
-                                    Private
-                                ),
                             x:
                                 (Variable
                                     2
                                     x
                                     []
                                     Local
-                                    (FunctionCall
-                                        2 tiny@stiny
-                                        2 tiny
-                                        [((RealConstant
+                                    (IntrinsicScalarFunction
+                                        Tiny
+                                        [(RealConstant
                                             1.000000
                                             (Real 4)
-                                        ))]
+                                        )]
+                                        0
                                         (Real 4)
                                         (RealConstant
                                             0.000000
                                             (Real 4)
                                         )
-                                        ()
                                     )
                                     (RealConstant
                                         0.000000
@@ -91,16 +60,15 @@
                                     y
                                     [b]
                                     Local
-                                    (FunctionCall
-                                        2 tiny@dtiny
-                                        2 tiny
-                                        [((Var 2 b))]
+                                    (IntrinsicScalarFunction
+                                        Tiny
+                                        [(Var 2 b)]
+                                        0
                                         (Real 8)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
                                         )
-                                        ()
                                     )
                                     (RealConstant
                                         0.000000
@@ -116,7 +84,7 @@
                                 )
                         })
                     intrinsics_08
-                    [lfortran_intrinsic_math]
+                    []
                     [(Print
                         [(Var 2 x)]
                         ()
@@ -127,15 +95,7 @@
                         ()
                         ()
                     )]
-                ),
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math:
-                (IntrinsicModule lfortran_intrinsic_math)
+                )
         })
     []
 )

--- a/tests/reference/asr-intrinsics_09-2af35ec.json
+++ b/tests/reference/asr-intrinsics_09-2af35ec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_09-2af35ec.stdout",
-    "stdout_hash": "c9ce0992a4e30afe98581ae3c696165ecedc613948de9e41b819e422",
+    "stdout_hash": "13cd7b1a50319566e192ae98794fbfcade895fc70c3467577d488c57",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_09-2af35ec.stdout
+++ b/tests/reference/asr-intrinsics_09-2af35ec.stdout
@@ -7,26 +7,6 @@
                     (SymbolTable
                         2
                         {
-                            tiny:
-                                (ExternalSymbol
-                                    2
-                                    tiny
-                                    4 tiny
-                                    lfortran_intrinsic_math
-                                    []
-                                    tiny
-                                    Private
-                                ),
-                            tiny@stiny:
-                                (ExternalSymbol
-                                    2
-                                    tiny@stiny
-                                    4 stiny
-                                    lfortran_intrinsic_math
-                                    []
-                                    stiny
-                                    Private
-                                ),
                             z:
                                 (Variable
                                     2
@@ -56,19 +36,18 @@
                         (RealCompare
                             (Var 2 z)
                             Lt
-                            (FunctionCall
-                                2 tiny@stiny
-                                2 tiny
-                                [((RealConstant
+                            (IntrinsicScalarFunction
+                                Tiny
+                                [(RealConstant
                                     1.000000
                                     (Real 4)
-                                ))]
+                                )]
+                                0
                                 (Real 4)
                                 (RealConstant
                                     0.000000
                                     (Real 4)
                                 )
-                                ()
                             )
                             (Logical 4)
                             ()
@@ -80,15 +59,7 @@
                         )]
                         []
                     )]
-                ),
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math:
-                (IntrinsicModule lfortran_intrinsic_math)
+                )
         })
     []
 )

--- a/tests/reference/asr-intrinsics_34-c5cfc20.json
+++ b/tests/reference/asr-intrinsics_34-c5cfc20.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_34-c5cfc20.stdout",
-    "stdout_hash": "90e979becf58c5e4b16eb52eb2bee99149c362d6e4bab08a724b049a",
+    "stdout_hash": "c062779b0ebc8e62eb86b2766d8974659a6ec17eac9d170622c829df",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_34-c5cfc20.stdout
+++ b/tests/reference/asr-intrinsics_34-c5cfc20.stdout
@@ -32,36 +32,6 @@
                                     Required
                                     .false.
                                 ),
-                            epsilon:
-                                (ExternalSymbol
-                                    2
-                                    epsilon
-                                    4 epsilon
-                                    lfortran_intrinsic_math
-                                    []
-                                    epsilon
-                                    Private
-                                ),
-                            epsilon@depsilon:
-                                (ExternalSymbol
-                                    2
-                                    epsilon@depsilon
-                                    4 depsilon
-                                    lfortran_intrinsic_math
-                                    []
-                                    depsilon
-                                    Private
-                                ),
-                            epsilon@sepsilon:
-                                (ExternalSymbol
-                                    2
-                                    epsilon@sepsilon
-                                    4 sepsilon
-                                    lfortran_intrinsic_math
-                                    []
-                                    sepsilon
-                                    Private
-                                ),
                             x:
                                 (Variable
                                     2
@@ -118,50 +88,47 @@
                     intrinsics_34
                     []
                     [(Print
-                        [(FunctionCall
-                            2 epsilon@sepsilon
-                            2 epsilon
-                            [((Var 2 x))]
+                        [(IntrinsicScalarFunction
+                            Epsilon
+                            [(Var 2 x)]
+                            0
                             (Real 4)
                             (RealConstant
                                 0.000000
                                 (Real 4)
                             )
-                            ()
                         )]
                         ()
                         ()
                     )
                     (Print
-                        [(FunctionCall
-                            2 epsilon@depsilon
-                            2 epsilon
-                            [((Var 2 y))]
+                        [(IntrinsicScalarFunction
+                            Epsilon
+                            [(Var 2 y)]
+                            0
                             (Real 8)
                             (RealConstant
                                 0.000000
                                 (Real 8)
                             )
-                            ()
                         )]
                         ()
                         ()
                     )
                     (Print
                         [(RealBinOp
-                            (FunctionCall
-                                2 epsilon@depsilon
-                                2 epsilon
-                                [((RealConstant
+                            (IntrinsicScalarFunction
+                                Epsilon
+                                [(RealConstant
                                     1.000000
                                     (Real 8)
-                                ))]
+                                )]
+                                0
                                 (Real 8)
                                 (RealConstant
                                     0.000000
                                     (Real 8)
                                 )
-                                ()
                             )
                             Pow
                             (Cast
@@ -190,16 +157,15 @@
                             (IntrinsicScalarFunction
                                 Abs
                                 [(RealBinOp
-                                    (FunctionCall
-                                        2 epsilon@sepsilon
-                                        2 epsilon
-                                        [((Var 2 x))]
+                                    (IntrinsicScalarFunction
+                                        Epsilon
+                                        [(Var 2 x)]
+                                        0
                                         (Real 4)
                                         (RealConstant
                                             0.000000
                                             (Real 4)
                                         )
-                                        ()
                                     )
                                     Sub
                                     (RealConstant
@@ -240,16 +206,15 @@
                             (IntrinsicScalarFunction
                                 Abs
                                 [(RealBinOp
-                                    (FunctionCall
-                                        2 epsilon@depsilon
-                                        2 epsilon
-                                        [((Var 2 y))]
+                                    (IntrinsicScalarFunction
+                                        Epsilon
+                                        [(Var 2 y)]
+                                        0
                                         (Real 8)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
                                         )
-                                        ()
                                     )
                                     Sub
                                     (RealConstant
@@ -291,19 +256,18 @@
                                 Abs
                                 [(RealBinOp
                                     (RealBinOp
-                                        (FunctionCall
-                                            2 epsilon@depsilon
-                                            2 epsilon
-                                            [((RealConstant
+                                        (IntrinsicScalarFunction
+                                            Epsilon
+                                            [(RealConstant
                                                 1.000000
                                                 (Real 8)
-                                            ))]
+                                            )]
+                                            0
                                             (Real 8)
                                             (RealConstant
                                                 0.000000
                                                 (Real 8)
                                             )
-                                            ()
                                         )
                                         Pow
                                         (RealConstant
@@ -350,15 +314,7 @@
                         )]
                         []
                     )]
-                ),
-            iso_c_binding:
-                (IntrinsicModule lfortran_intrinsic_iso_c_binding),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_builtin:
-                (IntrinsicModule lfortran_intrinsic_builtin),
-            lfortran_intrinsic_math:
-                (IntrinsicModule lfortran_intrinsic_math)
+                )
         })
     []
 )


### PR DESCRIPTION
Towards: #3034 