### PR TITLE
CI: update test stdlib special function 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -505,8 +505,8 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/stdlib-fortran-lang.git
             cd stdlib-fortran-lang
-            git checkout -t origin/lf-special-function-gamma-2
-            git checkout 6b1c348d02576739df10c755cdcee2520ec18fe6
+            git checkout -t origin/lf-special-function-gamma-3
+            git checkout f15a3a107f399b2e00b46ad5ee805d94aca2b404
             micromamba activate lf
             micromamba install -c conda-forge fypp
             FC=$(pwd)/../src/bin/lfortran cmake .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -506,7 +506,7 @@ jobs:
             git clone https://github.com/Pranavchiku/stdlib-fortran-lang.git
             cd stdlib-fortran-lang
             git checkout -t origin/lf-special-function-gamma-3
-            git checkout f15a3a107f399b2e00b46ad5ee805d94aca2b404
+            git checkout 95d77d69335d2086034b3509a8d072e918c1809d
             micromamba activate lf
             micromamba install -c conda-forge fypp
             FC=$(pwd)/../src/bin/lfortran cmake .


### PR DESCRIPTION
This PR updates branch and commit of `stdlb-special-function-gamma` that has `error stop` conditions on examples to ensure alignment with GFortran. All examples align correctly.

Towards #3000.

Branch: https://github.com/pranavchiku/stdlib-fortran-lang/tree/lf-special-function-gamma-3
Commit: https://github.com/Pranavchiku/stdlib-fortran-lang/commit/f15a3a107f399b2e00b46ad5ee805d94aca2b404