### PR TITLE
[stdlib] Use source directory as module path directory

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -711,7 +711,7 @@ jobs:
             lfortran subprojects/test-drive/src/testdrive.F90 --show-llvm
 
             git checkout lf19
-            git checkout b7533a11a770225dd995e81c34c552fa089cfc01
+            git checkout 8f3bdd13bbbe7b9ba9a9b04201f1ee4ae3cc424c
             micromamba install -c conda-forge fypp
             ./build_test_array_lf.sh
             ./build_test_array_gf.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -711,7 +711,7 @@ jobs:
             lfortran subprojects/test-drive/src/testdrive.F90 --show-llvm
 
             git checkout lf19
-            git checkout 8f3bdd13bbbe7b9ba9a9b04201f1ee4ae3cc424c
+            git checkout 2cb8a1dfb12de756c56a0832affac5727e923906
             micromamba install -c conda-forge fypp
             ./build_test_array_lf.sh
             ./build_test_array_gf.sh


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3357