### PR TITLE
FIX: missing dependency because of calling function in variable declaration

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -345,6 +345,8 @@ RUN(NAME functions_15 LABELS gfortran llvm)
 RUN(NAME functions_16 LABELS gfortran)
 RUN(NAME functions_17 LABELS gfortran llvm)
 RUN(NAME functions_18 LABELS gfortran llvm)
+RUN(NAME functions_19 LABELS llvm) # TODO: make it work with GFortran
+
 
 RUN(NAME common_01 LABELS gfortran)
 

--- a/integration_tests/functions_19.f90
+++ b/integration_tests/functions_19.f90
@@ -1,0 +1,36 @@
+pure integer function fn1(A) result(r)
+real, intent(in) :: A(:, :)
+r = minval(shape(A))
+end function
+
+subroutine diag_rsp_mat(A, res)
+implicit none
+real, intent(in) :: A(:,:)
+real, intent(out) :: res(fn1(A))
+interface
+pure integer function fn1(A) result(r)
+real, intent(in) :: A(:, :)
+end function
+end interface
+print *, shape(res), fn1(A)
+if (fn1(A) /= 5) error stop
+end subroutine diag_rsp_mat
+
+program functions_19
+implicit none
+real :: A(5, 5)
+real :: res(5)
+integer :: result
+interface
+    subroutine diag_rsp_mat(A, res)
+    real, intent(in) :: A(:,:)
+    real, intent(out) :: res(fn1(A))
+        interface
+        pure integer function fn1(A) result(r)
+        real, intent(in) :: A(:, :)
+        end function
+        end interface
+    end subroutine diag_rsp_mat
+end interface
+call diag_rsp_mat(A, res)
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -790,6 +790,7 @@ public:
     bool is_common_variable = false;
     bool _processing_dimensions = false;
     bool is_implicit_interface = false;
+    bool declaring_variable = false;
     Vec<ASR::stmt_t*> *current_body = nullptr;
 
     std::map<std::string, ASR::ttype_t*> implicit_dictionary;
@@ -1736,6 +1737,7 @@ public:
     }
 
     void visit_DeclarationUtil(const AST::Declaration_t &x) {
+        declaring_variable = true;
         if (x.m_vartype == nullptr &&
                 x.n_attributes == 1 &&
                 AST::is_a<AST::AttrNamelist_t>(*x.m_attributes[0])) {
@@ -2794,6 +2796,7 @@ public:
                 }
             } // for m_syms
         }
+        declaring_variable = false;
     }
 
     void visit_Interface(const AST::Interface_t &/*x*/) {
@@ -5609,6 +5612,9 @@ public:
                 tmp = create_FunctionCallWithASTNode(x, v, args_with_mdt);
             } else {
                 tmp = create_FunctionCallWithASTNode(x, v, args);
+            }
+            if (declaring_variable) {
+                current_function_dependencies.push_back_unique(al, ASRUtils::symbol_name(v));
             }
         } else {
             switch (f2->type) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5614,7 +5614,7 @@ public:
                 tmp = create_FunctionCallWithASTNode(x, v, args);
             }
             if (declaring_variable) {
-                current_function_dependencies.push_back_unique(al, ASRUtils::symbol_name(v));
+                current_function_dependencies.push_back(al, ASRUtils::symbol_name(v));
             }
         } else {
             switch (f2->type) {


### PR DESCRIPTION
Towards #3337.

The test with GFortran gives the following error, I am not sure how to fix it.

```console
% gfortran ./integration_tests/functions_19.f90 && ./a.out
./integration_tests/functions_19.f90:11:25:

   11 | pure integer function fn1(A) result(r)
      |                         1
Error: Return type mismatch of function 'fn1' at (1) (UNKNOWN/INTEGER(4))
./integration_tests/functions_19.f90:29:33:

   29 |         pure integer function fn1(A) result(r)
      |                                 1
Error: Return type mismatch of function 'fn1' at (1) (UNKNOWN/INTEGER(4))
```