### PR TITLE
lfortran: add option to infer cpp for F files

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -51,6 +51,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     mod_to_asr = is_included("mod_to_asr")
     llvm = is_included("llvm")
     cpp = is_included("cpp")
+    cpp_infer = is_included("cpp_infer")
     c = is_included("c")
     is_cumulative_pass = is_included("cumulative")
     julia = is_included("julia")
@@ -94,6 +95,8 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
         extra_args += " --print-leading-space"
     if interactive:
         extra_args += " --interactive-parse"
+    if cpp_infer:
+        extra_args += " --cpp-infer"
 
     if tokens:
         run_test(

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1940,6 +1940,7 @@ int main_app(int argc, char *argv[]) {
     bool print_targets = false;
     bool link_with_gcc = false;
     bool fixed_form_infer = false;
+    bool cpp_infer = false;
 
     std::string arg_fmt_file;
     int arg_fmt_indent = 4;
@@ -1987,6 +1988,7 @@ int main_app(int argc, char *argv[]) {
 
     // LFortran specific options
     app.add_flag("--cpp", compiler_options.c_preprocessor, "Enable C preprocessing");
+    app.add_flag("--cpp-infer", cpp_infer, "Use heuristics to infer if a file needs preprocessing");
     app.add_flag("--fixed-form", compiler_options.fixed_form, "Use fixed form Fortran source parsing");
     app.add_flag("--fixed-form-infer", fixed_form_infer, "Use heuristics to infer if a file is in fixed form");
     app.add_flag("--no-prescan", arg_no_prescan, "Turn off prescan");
@@ -2197,6 +2199,12 @@ int main_app(int argc, char *argv[]) {
     // Gfortran does the same thing
     if (fixed_form_infer && endswith(arg_file, ".f")) {
         compiler_options.fixed_form = true;
+    }
+
+    // Decide if a file gets preprocessing based on the extension
+    // Gfortran does the same thing
+    if (cpp_infer && (endswith(arg_file, ".F90") || endswith(arg_file, ".F"))) {
+        compiler_options.c_preprocessor = true;
     }
 
     std::string outfile;

--- a/tests/preprocessor17.F90
+++ b/tests/preprocessor17.F90
@@ -1,0 +1,7 @@
+program preprocessor1
+implicit none
+#define X123 12345678
+integer :: x, y
+x = (2+3)*5
+print *, x, X123
+end program

--- a/tests/reference/asr-preprocessor17-f2d76bb.json
+++ b/tests/reference/asr-preprocessor17-f2d76bb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-preprocessor17-f2d76bb",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/preprocessor17.F90",
+    "infile_hash": "a07132d08deb1a0de21dd365371df337fe07652c9d42aa4c0a7e19ab",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-preprocessor17-f2d76bb.stdout",
+    "stdout_hash": "891dd4075a4c0181e5835ae5aa1e96c20d591e23e160513994420378",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-preprocessor17-f2d76bb.stdout
+++ b/tests/reference/asr-preprocessor17-f2d76bb.stdout
@@ -1,0 +1,71 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            preprocessor1:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    preprocessor1
+                    []
+                    [(Assignment
+                        (Var 2 x)
+                        (IntegerBinOp
+                            (IntegerBinOp
+                                (IntegerConstant 2 (Integer 4))
+                                Add
+                                (IntegerConstant 3 (Integer 4))
+                                (Integer 4)
+                                (IntegerConstant 5 (Integer 4))
+                            )
+                            Mul
+                            (IntegerConstant 5 (Integer 4))
+                            (Integer 4)
+                            (IntegerConstant 25 (Integer 4))
+                        )
+                        ()
+                    )
+                    (Print
+                        [(Var 2 x)
+                        (IntegerConstant 12345678 (Integer 4))]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -485,6 +485,11 @@ filename = "preprocessor16.f90"
 asr_preprocess = true
 
 [[test]]
+filename = "preprocessor17.F90"
+cpp_infer = true
+asr = true
+
+[[test]]
 filename = "expr1.f90"
 interactive = true
 ast = true


### PR DESCRIPTION
Fix #3349
Closes #3228 
Related #3208 