### PR TITLE
ENH: support `IntegerBinOp` in pass `function_call_in_declaration`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -346,6 +346,7 @@ RUN(NAME functions_16 LABELS gfortran)
 RUN(NAME functions_17 LABELS gfortran llvm)
 RUN(NAME functions_18 LABELS gfortran llvm)
 RUN(NAME functions_19 LABELS gfortran llvm)
+RUN(NAME functions_20 LABELS gfortran llvm)
 
 RUN(NAME common_01 LABELS gfortran)
 

--- a/integration_tests/functions_20.f90
+++ b/integration_tests/functions_20.f90
@@ -1,0 +1,26 @@
+pure function diag_rsp_mat(A, k) result(res)
+real, intent(in) :: A(:,:)
+integer, intent(in) :: k
+real :: res(minval(shape(A)) - abs(k))
+
+res = 123.71_4
+end function diag_rsp_mat
+
+program functions_20
+real, dimension(3,3) :: A
+real :: B(2)
+integer :: k
+
+interface
+    function diag_rsp_mat(A, k) result(res)
+        real, intent(in) :: A(:,:)
+        integer, intent(in) :: k
+        real :: res(minval(shape(A)) - abs(k))
+    end function diag_rsp_mat
+end interface
+
+k = 1
+B = diag_rsp_mat(A, k)
+print *, B
+if (any(abs(B - 123.71_4) > 1e-6)) error stop
+end program functions_20

--- a/src/libasr/gen_pass.py
+++ b/src/libasr/gen_pass.py
@@ -1,5 +1,6 @@
 passes = [
         "replace_arr_slice",
+        "replace_function_call_in_declaration",
         "replace_array_op",
         "replace_class_constructor",
         "dead_code_removal",


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/pull/3407#issuecomment-1945387833, towards #3323.

With this PR we can remove https://github.com/Pranavchiku/stdlib-fortran-lang/commit/c9b4090da37dd3aae824d433aa5fc6e689207f0b