### PR TITLE
Compile ``linalg`` test in ``stdlib``

### DIFF
--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -500,6 +500,13 @@ class ASRBuilder {
             ASRUtils::TYPE(ASR::make_Logical_t( al, loc, 4)), nullptr));
     }
 
+    ASR::expr_t* ElementalAnd(ASR::expr_t* left, ASR::expr_t* right,
+        const Location& loc) {
+        return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,
+            left, ASR::And, right,
+            ASRUtils::TYPE(ASR::make_Logical_t( al, loc, 4)), nullptr));
+    }
+
     ASR::expr_t* Or(ASR::expr_t* left, ASR::expr_t* right,
         const Location& loc) {
         return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5107,9 +5107,15 @@ static inline ASR::asr_t* make_IntrinsicElementalFunction_t_util(
             continue;
         }
         ASR::expr_t* arg = a_args[i];
+        if( ASRUtils::is_array(ASRUtils::expr_type(arg)) &&
+            !ASRUtils::is_array(a_type) ) {
+            ASR::dimension_t* dims;
+            size_t n_dims = ASRUtils::extract_dimensions_from_ttype(ASRUtils::expr_type(arg), dims);
+            a_type = ASRUtils::make_Array_t_util(al, a_loc, a_type, dims, n_dims);
+        }
+
         ASR::ttype_t* arg_type = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(arg)));
-
         if( ASRUtils::is_array(arg_type) ) {
             a_args[i] = cast_to_descriptor(al, arg);
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3702,6 +3702,7 @@ public:
     }
 
     void visit_Function(const ASR::Function_t &x) {
+        std::cout<<"Function.begin: "<<x.m_name<<std::endl;
         loop_head.clear();
         loop_head_names.clear();
         loop_or_block_end.clear();
@@ -3742,6 +3743,7 @@ public:
         loop_or_block_end_names.clear();
         heap_arrays.clear();
         strings_to_be_deallocated.reserve(al, 1);
+        std::cout<<"Function.end: "<<x.m_name<<std::endl;
     }
 
     void instantiate_function(const ASR::Function_t &x){

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -652,8 +652,8 @@ namespace Abs {
         ASR::ttype_t* output_type = x.m_type;
         std::string input_type_str = ASRUtils::get_type_code(input_type);
         std::string output_type_str = ASRUtils::get_type_code(output_type);
-        if( ASR::is_a<ASR::Complex_t>(*ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_array(input_type))) ) {
-            ASRUtils::require_impl(ASR::is_a<ASR::Real_t>(*output_type),
+        if( ASRUtils::is_complex(*input_type) ) {
+            ASRUtils::require_impl(ASRUtils::is_real(*output_type),
                 "Abs intrinsic must return output of real for complex input, found: " + output_type_str,
                 loc, diagnostics);
             int input_kind = ASRUtils::extract_kind_from_ttype_t(input_type);

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -307,6 +307,20 @@ class ReplaceFunctionCallWithSubroutineCall:
             }
         }
 
+        void replace_ArrayPhysicalCast(ASR::ArrayPhysicalCast_t* x) {
+            ASR::BaseExprReplacer<ReplaceFunctionCallWithSubroutineCall>::replace_ArrayPhysicalCast(x);
+            if( (x->m_old == x->m_new &&
+                x->m_old != ASR::array_physical_typeType::DescriptorArray) ||
+                (x->m_old == x->m_new && x->m_old == ASR::array_physical_typeType::DescriptorArray &&
+                (ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(x->m_arg)) ||
+                ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x->m_arg)))) ||
+                x->m_old != ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg)) ) {
+                *current_expr = x->m_arg;
+            } else {
+                x->m_old = ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg));
+            }
+        }
+
 };
 
 class ReplaceFunctionCallWithSubroutineCallVisitor:


### PR DESCRIPTION
Taking too long. Will touch simpler modules before coming to this. We need to workaround intrinsic usage in `test_linalg.fypp`.