### PR TITLE
Throw error for comparison of different types of operands

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -179,9 +179,11 @@ public:
     }
 
     if( overloaded == nullptr ) {
-        LCOMPILERS_ASSERT(
-            ASRUtils::check_equal_type(ASRUtils::expr_type(left),
-                                    ASRUtils::expr_type(right)));
+        if (!ASRUtils::check_equal_type(ASRUtils::expr_type(left),
+                                    ASRUtils::expr_type(right))) {
+            throw SemanticError("Operands of comparison operator are of different types",
+                                x.base.base.loc);
+        }
     }
     size_t left_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(left));
     size_t right_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(right));

--- a/tests/errors/compare_01.f90
+++ b/tests/errors/compare_01.f90
@@ -1,0 +1,11 @@
+program compare_01
+    character(1) :: x
+    integer :: i
+    x = 'u'
+    i = 10
+    if (i > x) then
+        print *, "Hello World"
+    else
+        print *, "New world"
+    end if
+end program

--- a/tests/reference/asr-compare_01-c98905f.json
+++ b/tests/reference/asr-compare_01-c98905f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-compare_01-c98905f",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/compare_01.f90",
+    "infile_hash": "21afd80a6b0d843b42712983504099e18283c93b9a98101e0613e6c9",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-compare_01-c98905f.stderr",
+    "stderr_hash": "5015812ef55e87ef0ec0a5deec02333e66183f99b81ff453e5301e8e",
+    "returncode": 2
+}

--- a/tests/reference/asr-compare_01-c98905f.stderr
+++ b/tests/reference/asr-compare_01-c98905f.stderr
@@ -1,0 +1,5 @@
+semantic error: Operands of comparison operator are of different types
+ --> tests/errors/compare_01.f90:6:9
+  |
+6 |     if (i > x) then
+  |         ^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3766,3 +3766,7 @@ asr = true
 [[test]]
 filename = "errors/fixed_number_of_args.f90"
 asr = true
+
+[[test]]
+filename = "errors/compare_01.f90"
+asr = true


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3444