### PR TITLE
Implemented Exponent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -684,6 +684,7 @@ RUN(NAME intrinsics_166 LABELS gfortran llvm NOFAST) # ibset
 RUN(NAME intrinsics_167 LABELS gfortran llvm NOFAST) # btest
 RUN(NAME intrinsics_168 LABELS gfortran llvm NOFAST) # ibclr
 RUN(NAME intrinsics_169 LABELS gfortran llvm) # mod
+RUN(NAME intrinsics_170 LABELS gfortran llvm) # exponent
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_170.f90
+++ b/integration_tests/intrinsics_170.f90
@@ -1,0 +1,88 @@
+program intrinsics_170
+    use iso_fortran_env, only: sp => real32, dp => real64
+    real(sp) :: x
+    real(dp) :: y
+    x = 4.1
+    y = 4.1_dp
+    print *, exponent(x)
+    if (exponent(x) /= 3) error stop
+    print *, exponent(4.1_dp)
+    if (exponent(4.1_dp) /= 3) error stop
+    print *, exponent(y)
+    if (exponent(y) /= 3) error stop
+
+    x = 0.5
+    y = 0.5_dp
+
+    print *, exponent(x)
+    if (exponent(x) /= 0) error stop
+
+    print *, exponent(0.5_dp)
+    if (exponent(0.5_dp) /= 0) error stop
+
+    print *, exponent(y)
+    if (exponent(y) /= 0) error stop
+
+    print *, exponent(0.5)
+    if (exponent(0.5) /= 0) error stop
+
+    x = -12.94
+    y = -12.94_dp
+
+    print *, exponent(x)
+    if (exponent(x) /= 4) error stop
+
+    print *, exponent(-12.94_dp)
+    if (exponent(-12.94_dp) /= 4) error stop
+
+    print *, exponent(y)
+    if (exponent(y) /= 4) error stop
+
+    print *, exponent(-12.94)
+    if (exponent(-12.94) /= 4) error stop
+
+    x = 1e+6_sp
+    y = 1e+10_dp
+
+    print *, exponent(x)
+    if (exponent(x) /= 20) error stop
+
+    print *, exponent(1e+10_dp)
+    if (exponent(1e+10_dp) /= 34) error stop
+
+    print *, exponent(y)
+    if (exponent(y) /= 34) error stop
+
+    print *, exponent(1e+6)
+    if (exponent(1e+6) /= 20) error stop
+
+    x = -1e+6_sp
+    y = -1e+10_dp
+
+    print *, exponent(x)
+    if (exponent(x) /= 20) error stop
+
+    print *, exponent(-1e+10_dp)
+    if (exponent(-1e+10_dp) /= 34) error stop
+
+    print *, exponent(y)
+    if (exponent(y) /= 34) error stop
+
+    print *, exponent(-1e+6)
+    if (exponent(-1e+6) /= 20) error stop
+
+    x = 1e-6_sp
+    y = 1e-10_dp
+
+    print *, exponent(x)
+    if (exponent(x) /= -19) error stop
+
+    print *, exponent(1e-10_dp)
+    if (exponent(1e-10_dp) /= -33) error stop
+
+    print *, exponent(y)
+    if (exponent(y) /= -33) error stop
+
+    print *, exponent(1e-6)
+    if (exponent(1e-6) /= -19) error stop
+end program

--- a/integration_tests/intrinsics_170.f90
+++ b/integration_tests/intrinsics_170.f90
@@ -85,4 +85,20 @@ program intrinsics_170
 
     print *, exponent(1e-6)
     if (exponent(1e-6) /= -19) error stop
+
+    x = 0.0
+    y = 0.0_dp
+
+    print *, exponent(x)
+    if (exponent(x) /= 0) error stop
+
+    print *, exponent(0.0_dp)
+    if (exponent(0.0_dp) /= 0) error stop
+
+    print *, exponent(y)
+    if (exponent(y) /= 0) error stop
+
+    print *, exponent(0.0)
+    if (exponent(0.0) /= 0) error stop
+
 end program

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -108,6 +108,7 @@ class ASRBuilder {
     // Expressions -------------------------------------------------------------
     #define i(x, t)   ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, x, t))
     #define i32(x)   ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, x, int32))
+    #define i64(x)   ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, x, int64))
     #define i32_n(x) ASRUtils::EXPR(ASR::make_IntegerUnaryMinus_t(al, loc, i32(abs(x)),   \
         int32, i32(x)))
     #define i32_neg(x, t) ASRUtils::EXPR(ASR::make_IntegerUnaryMinus_t(al, loc, x, t, nullptr))
@@ -225,7 +226,9 @@ class ASRBuilder {
             ASR::binopType::Mul, right, real64, nullptr))
     #define i_tMul(left, right, t) EXPR(ASR::make_IntegerBinOp_t(al, loc, left, \
             ASR::binopType::Mul, right, t, nullptr))
-    #define r_tMul(left, right, t) EXPR(ASR::make_RealBinOp_t(al, loc, left,    \
+    #define i_tAnd(left, right, t) EXPR(ASR::make_IntegerBinOp_t(al, loc, left, \
+            ASR::binopType::BitAnd, right, t, nullptr))
+    #define r_tMul(left, right, t) EXPR(ASR::make_RealBinOp_t(al, loc, left, \
         ASR::binopType::Mul, right, t, nullptr))
 
     #define iPow(left, right, t) EXPR(ASR::make_IntegerBinOp_t(al, loc, left,   \

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -371,6 +371,12 @@ intrinsic_funcs_args = {
             "kind_arg": True
         }
     ],
+    "Exponent": [
+        {
+            "args": [("real",)],
+            "return": "int32",
+        },
+    ],
 }
 
 skip_create_func = ["Partition"]

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -59,6 +59,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Blt)
         INTRINSIC_NAME_CASE(Bge)
         INTRINSIC_NAME_CASE(Ble)
+        INTRINSIC_NAME_CASE(Exponent)
         INTRINSIC_NAME_CASE(Not)
         INTRINSIC_NAME_CASE(Iand)
         INTRINSIC_NAME_CASE(Ior)
@@ -220,6 +221,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {&Blt::instantiate_Blt, &Blt::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Bge),
             {&Bge::instantiate_Bge, &Bge::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::Exponent),
+            {&Exponent::instantiate_Exponent, &Exponent::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Ble),
             {&Ble::instantiate_Ble, &Ble::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Not),
@@ -459,6 +462,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "bge"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Ble),
             "ble"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::Exponent),
+            "exponent"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Not),
             "not"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Iand),
@@ -654,6 +659,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"blt", {&Blt::create_Blt, &Blt::eval_Blt}},
                 {"bge", {&Bge::create_Bge, &Bge::eval_Bge}},
                 {"ble", {&Ble::create_Ble, &Ble::eval_Ble}},
+                {"exponent", {&Exponent::create_Exponent, &Exponent::eval_Exponent}},
                 {"not", {&Not::create_Not, &Not::eval_Not}},
                 {"iand", {&Iand::create_Iand, &Iand::eval_Iand}},
                 {"ior", {&Ior::create_Ior, &Ior::eval_Ior}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1889,7 +1889,8 @@ namespace Exponent {
             if (x == 0.0) {
                 return make_ConstantWithType(make_IntegerConstant_t, 0, arg_type, loc);
             }
-            int32_t ix = *(int32_t*)(&x);
+            int32_t ix;
+            std::memcpy(&ix, &x, sizeof(ix));
             int32_t exponent = ((ix >> 23) & 0xff) - 126;
             return make_ConstantWithType(make_IntegerConstant_t, exponent, arg_type, loc);
         } 
@@ -1898,7 +1899,8 @@ namespace Exponent {
             if (x == 0.0) {
                 return make_ConstantWithType(make_IntegerConstant_t, 0, arg_type, loc);
             }
-            int64_t ix = *(int64_t*)(&x);
+            int64_t ix;
+            std::memcpy(&ix, &x, sizeof(ix));
             int64_t exponent = ((ix >> 52) & 0x7ff) - 1022;
             return make_ConstantWithType(make_IntegerConstant_t, exponent, arg_type, loc);
         }


### PR DESCRIPTION
Fixes: #3496

```
/lfortran (exponent)$ lfortran b.f90
123
234
345
456
567
678
789
8910
91011
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  Binary file "/home/lfortran/src/bin/lfortran", in _start()
  File "./csu/../csu/libc-start.c", line 392, in __libc_start_main_impl()
  File "./csu/../sysdeps/nptl/libc_start_call_main.h", line 58, in __libc_start_call_main()
  File "/home/lfortran/src/bin/lfortran.cpp", line 2394, in ??
    return main_app(argc, argv);
  File "/home/lfortran/src/bin/lfortran.cpp", line 2355, in main_app(int, char**)
    err = compile_to_object_file(arg_file, tmp_o, false,
  File "/home/lfortran/src/bin/lfortran.cpp", line 949, in ??
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
  File "/home/lfortran/src/lfortran/fortran_evaluator.cpp", line 360, in LCompilers::FortranEvaluator::get_llvm3(LCompilers::ASR::TranslationUnit_t&, LCompilers::PassManager&, LCompilers::diag::Diagnostics&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    compiler_options, run_fn, infile);
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 9662, in LCompilers::asr_to_llvm(LCompilers::ASR::TranslationUnit_t&, LCompilers::diag::Diagnostics&, llvm::LLVMContext&, Allocator&, LCompilers::PassManager&, LCompilers::CompilerOptions&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    v.visit_asr((ASR::asr_t&)asr);
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 5111, in LCompilers::ASR::BaseVisitor<LCompilers::ASRToLLVMVisitor>::visit_asr(LCompilers::ASR::asr_t const&)
    void visit_asr(const asr_t &b) { visit_asr_t(b, self()); }
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 5087, in ??
    case asrType::unit: { v.visit_unit((const unit_t &)x); return; }
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 5112, in LCompilers::ASR::BaseVisitor<LCompilers::ASRToLLVMVisitor>::visit_unit(LCompilers::ASR::unit_t const&)
    void visit_unit(const unit_t &b) { visit_unit_t(b, self()); }
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 4818, in ??
    case unitType::TranslationUnit: { v.visit_TranslationUnit((const TranslationUnit_t &)x); return; }
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 938, in LCompilers::ASRToLLVMVisitor::visit_TranslationUnit(LCompilers::ASR::TranslationUnit_t const&)
    visit_symbol(*item.second);
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 5114, in LCompilers::ASR::BaseVisitor<LCompilers::ASRToLLVMVisitor>::visit_symbol(LCompilers::ASR::symbol_t const&)
    void visit_symbol(const symbol_t &b) { visit_symbol_t(b, self()); }
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 4828, in ??
    case symbolType::Function: { v.visit_Function((const Function_t &)x); return; }
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 3733, in LCompilers::ASRToLLVMVisitor::visit_Function(LCompilers::ASR::Function_t const&)
    generate_function(x);
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 3929, in LCompilers::ASRToLLVMVisitor::generate_function(LCompilers::ASR::Function_t const&)
    this->visit_stmt(*x.m_body[i]);
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 5131, in LCompilers::ASR::BaseVisitor<LCompilers::ASRToLLVMVisitor>::visit_stmt(LCompilers::ASR::stmt_t const&)
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 4864, in ??
    case stmtType::If: { v.visit_If((const If_t &)x); return; }
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 5676, in LCompilers::ASRToLLVMVisitor::visit_If(LCompilers::ASR::If_t const&)
    llvm_utils->create_if_else(tmp, [&]() {
  File "/home/lfortran/src/libasr/../libasr/codegen/llvm_utils.h", line 350, in void LCompilers::LLVMUtils::create_if_else<LCompilers::ASRToLLVMVisitor::visit_If(LCompilers::ASR::If_t const&)::{lambda()#1}, LCompilers::ASRToLLVMVisitor::visit_If(LCompilers::ASR::If_t const&)::{lambda()#2}>(llvm::Value*, LCompilers::ASRToLLVMVisitor::visit_If(LCompilers::ASR::If_t const&)::{lambda()#1}, LCompilers::ASRToLLVMVisitor::visit_If(LCompilers::ASR::If_t const&)::{lambda()#2})
    if_block();
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 5678, in LCompilers::ASRToLLVMVisitor::visit_If(LCompilers::ASR::If_t const&)::{lambda()#1}::operator()() const
    this->visit_stmt(*x.m_body[i]);
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 5131, in LCompilers::ASR::BaseVisitor<LCompilers::ASRToLLVMVisitor>::visit_stmt(LCompilers::ASR::stmt_t const&)
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/home/lfortran/src/libasr/../libasr/asr.h", line 4852, in ??
    case stmtType::Assignment: { v.visit_Assignment((const Assignment_t &)x); return; }
  File "/home/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 4748, in LCompilers::ASRToLLVMVisitor::visit_Assignment(LCompilers::ASR::Assignment_t const&)
    ASR::Variable_t *asr_target = EXPR2VAR(x.m_target);
  File "/home/lfortran/src/libasr/../libasr/asr_utils.h", line 284, in ??
    ASR::down_cast<ASR::Var_t>(f)->m_v));
AssertFailed: is_a<T>(*f)
```


The compile time implementation is working fine. But I am facing this issue for runtime implementation. 