### PR TITLE
Stdlib: Fix assign to string slice

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -651,7 +651,7 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
 
             git checkout lf19
-            git checkout fc82978396ad133cb2519dc02bcc6b40a177fede
+            git checkout 75368513a97dfb349d9b727f096b6249071c7913
             micromamba install -c conda-forge fypp
             ./build_test_lf.sh
             ./build_test_gf.sh

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1015,6 +1015,7 @@ RUN(NAME string_32 LABELS gfortran llvm)
 RUN(NAME string_33 LABELS gfortran llvm)
 RUN(NAME string_34 LABELS gfortran llvm)
 RUN(NAME string_35 LABELS gfortran llvm)
+RUN(NAME string_36 LABELS gfortran llvm)
 
 RUN(NAME nested_01 LABELS gfortran llvm)
 RUN(NAME nested_02 LABELS gfortran llvm)

--- a/integration_tests/string_36.f90
+++ b/integration_tests/string_36.f90
@@ -1,0 +1,13 @@
+program string_36
+    implicit none
+
+    character(len=5) :: hello
+
+    hello = "hello"
+    hello(4:3) = ""
+
+    print *, hello
+
+    if (hello /= "hello") error stop
+
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1640,8 +1640,10 @@ LFORTRAN_API char* _lfortran_str_slice_assign(char* s, char *r, int32_t idx1, in
     }
     if (idx1 == idx2 ||
         (step > 0 && (idx1 > idx2 || idx1 >= s_len)) ||
-        (step < 0 && (idx1 < idx2 || idx2 >= s_len-1)))
-        return "";
+        (step < 0 && (idx1 < idx2 || idx2 >= s_len-1))) {
+        return s;
+    }
+
     char* dest_char = (char*)malloc(s_len);
     strcpy(dest_char, s);
     int s_i = idx1, d_i = 0;


### PR DESCRIPTION
This PR fixes the following issue:
```console
% cat integration_tests/string_36.f90 
program string_36
    implicit none

    character(len=5) :: hello

    hello = "hello"
    hello(4:3) = ""

    print *, hello

    if (hello /= "hello") error stop

end program
% gfortran integration_tests/string_36.f90 
% ./a.out 
 hello
% lfortran_in_main integration_tests/string_36.f90 

ERROR STOP
```