### PR TITLE
[enh]: Implement 'parity' intrinsic function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -703,6 +703,7 @@ RUN(NAME intrinsics_184 LABELS gfortran llvm) # selected_char_kind
 RUN(NAME intrinsics_185 LABELS gfortran llvm) # verify
 RUN(NAME intrinsics_186 LABELS gfortran llvm) # verify
 RUN(NAME intrinsics_187 LABELS gfortran llvm) # popcnt
+RUN(NAME intrinsics_parity LABELS gfortran llvm)
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_parity.f90
+++ b/integration_tests/intrinsics_parity.f90
@@ -1,0 +1,19 @@
+program intrinsics_parity
+    logical, dimension(2, 3) :: x
+    logical :: parity_result_dim1(3)
+    logical :: parity_result_dim2(2)
+    x = reshape([.TRUE., .FALSE., .FALSE., .TRUE., .FALSE., .FALSE.], [2, 3])
+
+    if (parity([.TRUE., .FALSE.]) .neqv. .TRUE.) error stop
+    if (parity([.TRUE., .FALSE., .FALSE., .TRUE.]) .neqv. .FALSE.) error stop
+
+    parity_result_dim1 = parity(x, dim=1)
+    if (parity_result_dim1(1) .neqv. .TRUE.) error stop
+    if (parity_result_dim1(2) .neqv. .TRUE.) error stop
+    if (parity_result_dim1(3) .neqv. .FALSE.) error stop
+
+    parity_result_dim2 = parity(x, dim=2)
+    if (parity_result_dim2(1) .neqv. .TRUE.) error stop
+    if (parity_result_dim2(2) .neqv. .TRUE.) error stop
+    print *, parity_result_dim2
+end program intrinsics_parity

--- a/integration_tests/intrinsics_parity.f90
+++ b/integration_tests/intrinsics_parity.f90
@@ -15,5 +15,4 @@ program intrinsics_parity
     parity_result_dim2 = parity(x, dim=2)
     if (parity_result_dim2(1) .neqv. .TRUE.) error stop
     if (parity_result_dim2(2) .neqv. .TRUE.) error stop
-    print *, parity_result_dim2
 end program intrinsics_parity

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -758,6 +758,7 @@ public:
         {"random_number", {IntrinsicSignature({"r"}, 1, 1)}},
         {"mvbits", {IntrinsicSignature({"from", "frompos", "len", "to", "topos"}, 5, 5)}},
         {"popcnt", {IntrinsicSignature({"i"}, 1, 1)}},
+        {"parity", {IntrinsicSignature({"mask", "dim"}, 1, 2)}},
     };
 
     std::map<std::string, std::string> intrinsic_mapping = {

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -780,10 +780,24 @@ class ASRBuilder {
             ASRUtils::TYPE(ASR::make_Logical_t( al, loc, 4)), nullptr));
     }
 
+    ASR::expr_t* ElementalXor(ASR::expr_t* left, ASR::expr_t* right,
+        const Location& loc) {
+        return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,
+            left, ASR::Xor, right,
+            ASRUtils::TYPE(ASR::make_Logical_t( al, loc, 4)), nullptr));
+    }
+
     ASR::expr_t* LogicalOr(ASR::expr_t* left, ASR::expr_t* right,
         const Location& loc) {
         return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,
             left, ASR::Or, right, ASRUtils::expr_type(left),
+            nullptr));
+    }
+
+    ASR::expr_t* LogicalXor(ASR::expr_t* left, ASR::expr_t* right,
+        const Location& loc) {
+        return ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, loc,
+            left, ASR::Xor, right, ASRUtils::expr_type(left),
             nullptr));
     }
 


### PR DESCRIPTION
[Parity GNU GCC docs](https://gcc.gnu.org/onlinedocs/gfortran/PARITY.html#:~:text=8.213%20PARITY%20%E2%80%94%20Reduction%20with%20exclusive%20OR%20%C2%B6&text=XOR.%20%2C%20of%20MASK%20along%20dimension%20DIM%20.&text=(Optional)%20shall%20be%20a%20scalar,the%20same%20type%20as%20MASK%20.)