### PR TITLE
enh: support `compiletime_broadcast_elemental_intrinsic` for multiple arguments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -709,6 +709,7 @@ RUN(NAME intrinsics_190 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_191 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_192 LABELS gfortran llvm) # besselj0
 RUN(NAME intrinsics_193 LABELS gfortran llvm) # poppar 
+RUN(NAME intrinsics_194 LABELS gfortran llvm)
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -709,7 +709,8 @@ RUN(NAME intrinsics_190 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_191 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_192 LABELS gfortran llvm) # besselj0
 RUN(NAME intrinsics_193 LABELS gfortran llvm) # poppar 
-RUN(NAME intrinsics_194 LABELS gfortran llvm)
+RUN(NAME intrinsics_194 LABELS gfortran llvm) # min
+RUN(NAME intrinsics_195 LABELS gfortran llvm) # max
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_108.f90
+++ b/integration_tests/intrinsics_108.f90
@@ -1,6 +1,7 @@
 program intrinsics_108
     integer(4) :: x, y
     integer(8) :: i, j
+    integer :: arr3(3)
     x = 16
     y = 2
     i = 8
@@ -29,4 +30,15 @@ program intrinsics_108
 
     print*, shiftr(8, 2)
     if ( shiftr(8, 2) /= 2 ) error stop
+
+    ! test broadcasting of `shiftr`
+    arr3 = shiftr([20, 11, 8], 1)
+    if (arr3(1) /= 10) error stop
+    if (arr3(2) /= 5) error stop
+    if (arr3(3) /= 4) error stop
+
+    arr3 = shiftr([20, 11, 8], [1, 2, 3])
+    if (arr3(1) /= 10) error stop
+    if (arr3(2) /= 2) error stop
+    if (arr3(3) /= 1) error stop
 end

--- a/integration_tests/intrinsics_132.f90
+++ b/integration_tests/intrinsics_132.f90
@@ -1,8 +1,11 @@
 program intrinsics_132
     real :: x = 5.8
+    integer, parameter :: array_size = 3
     integer(kind = 4) :: res_4
     integer(kind = 8) :: res_8
     integer :: test_kind
+    integer(kind=4) :: res_4_arr(array_size)
+    integer(kind=8) :: res_8_arr(array_size)
     
     res_4 = floor(x)
     print *, res_4
@@ -60,4 +63,23 @@ program intrinsics_132
     print *, test_kind
     if (test_kind /= 4) error stop
 
+    ! Compile time broadcasting
+    res_4_arr = floor([real:: 1.2, 3.3, 5])
+    print *, res_4_arr(1)
+    if (res_4_arr(1) /= 1) error stop
+    print *, res_4_arr(2)
+    if (res_4_arr(2) /= 3) error stop
+    print *, res_4_arr(3)
+    if (res_4_arr(3) /= 5) error stop
+
+    res_8_arr = floor([real(8) :: 1.2, 3.3, 5], kind=8)
+    print *, res_8_arr(1)
+    if (res_8_arr(1) /= 1) error stop
+    if (kind(res_8_arr(1)) /= 8) error stop
+    print *, res_8_arr(2)
+    if (res_8_arr(2) /= 3) error stop
+    if (kind(res_8_arr(2)) /= 8) error stop
+    print *, res_8_arr(3)
+    if (res_8_arr(3) /= 5) error stop
+    if (kind(res_8_arr(3)) /= 8) error stop
 end program

--- a/integration_tests/intrinsics_133.f90
+++ b/integration_tests/intrinsics_133.f90
@@ -1,8 +1,11 @@
 program intrinsics_133
     real :: x = 5.8
     real :: y = 6.0
+    integer, parameter :: array_size = 3
     integer(kind = 4) :: res_4
     integer(kind = 8) :: res_8
+    integer(kind=4) :: res_4_arr(array_size)
+    integer(kind=8) :: res_8_arr(array_size)
     
     res_4 = Ceiling(x)
     print *, res_4
@@ -68,4 +71,23 @@ program intrinsics_133
     print *, res_8
     if (res_8 /= -412) error stop
 
+    ! Compile time broadcasting
+    res_4_arr = Ceiling([real :: 1.2, 3.3, 5])
+    print *, res_4_arr(1)
+    if (res_4_arr(1) /= 2) error stop
+    print *, res_4_arr(2)
+    if (res_4_arr(2) /= 4) error stop
+    print *, res_4_arr(3)
+    if (res_4_arr(3) /= 5) error stop
+
+    res_8_arr = Ceiling([real(8) :: 1.2, 3.3, 5], kind=8)
+    print *, res_8_arr(1)
+    if (res_8_arr(1) /= 2) error stop
+    if (kind(res_8_arr(1)) /= 8) error stop
+    print *, res_8_arr(2)
+    if (res_8_arr(2) /= 4) error stop
+    if (kind(res_8_arr(2)) /= 8) error stop
+    print *, res_8_arr(3)
+    if (res_8_arr(3) /= 5) error stop
+    if (kind(res_8_arr(3)) /= 8) error stop
 end program

--- a/integration_tests/intrinsics_185.f90
+++ b/integration_tests/intrinsics_185.f90
@@ -6,6 +6,7 @@ program intrinsics_185
     character(3) :: c_plus_plus = "C++"
     character(6) :: fortr = "FORTR"
     character(1) :: n = "N"
+    integer :: arr2(2)
   
     print*, verify("FORTRAN", "AF", .true., 4)    
     if ( verify("FORTRAN", "AF", .true., 4) /= 7 ) error stop   
@@ -28,5 +29,13 @@ program intrinsics_185
     if ( verify(fortr, n, .true., 8) /= 6_8 ) error stop
     print*, verify(fortran, fortran)  
     if ( verify(fortran, fortran) /= 0 ) error stop 
-  
+
+    ! make sure that broadcasting is done correctly for `verify`
+    arr2 = verify(["FORTRAN", "GORTRAN"], ["FO", "GR"])
+    if (arr2(1) /= 3) error stop
+    if (arr2(2) /= 2) error stop
+
+    arr2 = verify(["FORTRAN", "GORTRAN"], ["FN", "NA"], .TRUE.)
+    if (arr2(1) /= 6) error stop
+    if (arr2(2) /= 5) error stop
 end program

--- a/integration_tests/intrinsics_194.f90
+++ b/integration_tests/intrinsics_194.f90
@@ -1,0 +1,7 @@
+program intrinsics_194
+    ! broadcasting "min" intrinsic
+    print *, min([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7])
+    print *, min(1, [-1, 2, 20])
+    print *, min([1, 2, 3], [1, 1, [2]])
+    print *, min([1, 2], -1, -4)
+end program

--- a/integration_tests/intrinsics_194.f90
+++ b/integration_tests/intrinsics_194.f90
@@ -1,7 +1,27 @@
+!> the below test cases test the broadcasting of "min" intrinsic
+!> procedure during compile time
 program intrinsics_194
-    ! broadcasting "min" intrinsic
-    print *, min([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7])
-    print *, min(1, [-1, 2, 20])
-    print *, min([1, 2, 3], [1, 1, [2]])
-    print *, min([1, 2], -1, -4)
+    integer :: arr3(3), arr2(2)
+    arr3 = min([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7])
+    if (arr3(1) /= -1) error stop
+    if (arr3(2) /= -8) error stop
+    if (arr3(3) /= 2) error stop
+    ! not necessary to test the dimensions though
+    ! as the initial assignment itself would raise an
+    ! error if the assignment was incompatible
+    if (size(arr3) /= 3) error stop
+
+    arr3 = min(1, [-1, 2, 20])
+    if (arr3(1) /= -1) error stop
+    if (arr3(2) /= 1) error stop
+    if (arr3(3) /= 1) error stop
+
+    arr3 = min([1, 2, 3], [1, 1, [2]])
+    if (arr3(1) /= 1) error stop
+    if (arr3(2) /= 1) error stop
+    if (arr3(3) /= 2) error stop
+
+    arr2 = min([1, 2], -1, -4)
+    if (arr2(1) /= -4) error stop
+    if (arr2(2) /= -4) error stop
 end program

--- a/integration_tests/intrinsics_195.f90
+++ b/integration_tests/intrinsics_195.f90
@@ -1,0 +1,7 @@
+program intrinsics_195
+    ! broadcasting "max" intrinsic
+    print *, max([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7])
+    print *, max(1, [-1, 2, 20])
+    print *, max([1, 2, 3], [1, 1, [2]])
+    print *, max([1, 2], -1, -4)
+end program

--- a/integration_tests/intrinsics_195.f90
+++ b/integration_tests/intrinsics_195.f90
@@ -1,7 +1,27 @@
+!> the below test cases test the broadcasting of "max" intrinsic
+!> procedure during compile time
 program intrinsics_195
-    ! broadcasting "max" intrinsic
-    print *, max([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7])
-    print *, max(1, [-1, 2, 20])
-    print *, max([1, 2, 3], [1, 1, [2]])
-    print *, max([1, 2], -1, -4)
+    integer :: arr3(3), arr2(2)
+    arr3 = max([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7])
+    if (arr3(1) /= 5) error stop
+    if (arr3(2) /= 5) error stop
+    if (arr3(3) /= 7) error stop
+    ! not necessary to test the dimensions though
+    ! as the initial assignment itself would raise an
+    ! error if the assignment was incompatible
+    if (size(arr3) /= 3) error stop
+
+    arr3 = max(1, [-1, 2, 20])
+    if (arr3(1) /= 1) error stop
+    if (arr3(2) /= 2) error stop
+    if (arr3(3) /= 20) error stop
+
+    arr3 = max([1, 2, 3], [1, 1, [2]])
+    if (arr3(1) /= 1) error stop
+    if (arr3(2) /= 2) error stop
+    if (arr3(3) /= 3) error stop
+
+    arr2 = max([1, 2], -1, -4)
+    if (arr2(1) /= 1) error stop
+    if (arr2(2) /= 2) error stop
 end program

--- a/integration_tests/intrinsics_46.f90
+++ b/integration_tests/intrinsics_46.f90
@@ -4,6 +4,8 @@ program test_ichar
     ! Compile_time
     integer :: i, j, c
     integer(8) :: li_1, lj_1, li_2, lj_2
+    integer(8) :: int_res(4)
+    integer, parameter :: dp = kind(0d0)
     character(len=1) :: c_1 = 'b'
     character(len = 1) :: a = 'a'
     character(len = 1) :: b = 'b'
@@ -27,6 +29,17 @@ program test_ichar
     if (lj_1 /= 97) error stop
     if (li_2 /= 90) error stop
     if (lj_2 /= 122) error stop
+
+    ! Compile time with broadcasting
+    int_res = ichar([' ', 'c', 'd', 'e'], kind=8)
+    if (int_res(1) /= 32) error stop
+    if (kind(int_res(1)) /= dp) error stop
+    if (int_res(2) /= 99) error stop
+    if (kind(int_res(2)) /= dp) error stop
+    if (int_res(3) /= 100) error stop
+    if (kind(int_res(3)) /= dp) error stop
+    if (int_res(4) /= 101) error stop
+    if (kind(int_res(4)) /= dp) error stop
 
     ! Run_time
     c = ichar(c_1)

--- a/integration_tests/intrinsics_58.f90
+++ b/integration_tests/intrinsics_58.f90
@@ -1,6 +1,7 @@
 program intrinsics_58
     integer :: x, y, signval
     real :: x1, y1, signval1
+    integer :: int_res(4)
 
     ! Compile time tests
     if (sign( 5,  10) /=  5) error stop
@@ -12,6 +13,23 @@ program intrinsics_58
     if (sign(-5.,  10.) /=  5.) error stop
     if (sign( 5., -10.) /= -5.) error stop
     if (sign(-5., -10.) /= -5.) error stop
+
+    ! Ensure that compile time broadcasting works
+    !> positive second argument
+    int_res = sign([1, 2, 5, -1], 2)
+    print *, int_res
+    if (int_res(1) /= 1) error stop
+    if (int_res(2) /= 2) error stop
+    if (int_res(3) /= 5) error stop
+    if (int_res(4) /= 1) error stop
+
+    !> negative second argument
+    int_res = sign([1, 2, -5, 1], -3)
+    print *, int_res
+    if (int_res(1) /= -1) error stop
+    if (int_res(2) /= -2) error stop
+    if (int_res(3) /= -5) error stop
+    if (int_res(4) /= -1) error stop
 
     ! Runtime tests
     x = 5

--- a/integration_tests/intrinsics_70.f90
+++ b/integration_tests/intrinsics_70.f90
@@ -1,19 +1,33 @@
 program intrinsics_70
     real :: x
+    real, parameter :: epsilon = 1e-10
+    real :: res_real(4)
+
     x = 4.23
     print *, aint(x)
-    if (abs(aint(x) - 4.0) > 1e-10) error stop
+    if (abs(aint(x) - 4.0) > epsilon) error stop
 
     x = -4.23
     print *, aint(x)
-    if (abs(aint(x)  - (-4.0)) > 1e-10) error stop
+    if (abs(aint(x)  - (-4.0)) > epsilon) error stop
 
     print *, aint(0.0)
-    if (abs(aint(0.0) - 0.0) > 1e-10) error stop
+    if (abs(aint(0.0) - 0.0) > epsilon) error stop
 
     print *, aint(4.23)
-    if (abs(aint(4.23) - 4.0) > 1e-10) error stop
+    if (abs(aint(4.23) - 4.0) > epsilon) error stop
 
     print *, aint(-4.23, 4)
-    if (abs(aint(-4.23, 4) - (-4.0)) > 1e-10) error stop
+    if (abs(aint(-4.23, 4) - (-4.0)) > epsilon) error stop
+
+    ! Compile time broadcasting
+    res_real = aint([real :: 1.2, 3.5, 3.4, 2.1])
+    print *, res_real
+    if (abs(res_real(1) - 1.0) > epsilon) error stop
+    print *, res_real(2)
+    if (abs(res_real(2) - 3.0) > epsilon) error stop
+    print *, res_real(3)
+    if (abs(res_real(3) - 3.0) > epsilon) error stop
+    print *, res_real(4)
+    if (abs(res_real(4) - 2.0) > epsilon) error stop
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5121,6 +5121,11 @@ public:
     /**
      * Broadcast `create_func` to elements of `args`, out of which atleast
      * one element is an array (i.e not a scalar)
+     * 
+     * e.g. of broadcasting:
+     * min([-1, 2, 3], 2, 5, [4, 4, 5], [5, -8, 7]) is broadcasted as:
+     * [min(-1, 2, 5, 4, 5), min(2, 2, 5, 4, -8), min(3, 2, 5, 5, 7)]
+     * 
     */
     void compiletime_broadcast_elemental_intrinsic(
         Vec<ASR::expr_t*> args,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5119,7 +5119,7 @@ public:
     }
 
     /**
-     * Broadcast "create_func" to elements of 'args', out of which atleast
+     * Broadcast `create_func` to elements of `args`, out of which atleast
      * one element is an array (i.e not a scalar)
     */
     void compiletime_broadcast_elemental_intrinsic(
@@ -5140,7 +5140,10 @@ public:
                 if (std::find(array_indices_in_args.begin(), array_indices_in_args.end(), j) != array_indices_in_args.end()) {
                     // Current argument is an array
                     ASR::ArrayConstant_t* array_arg = ASR::down_cast<ASR::ArrayConstant_t>(args[j]);
-                    LCOMPILERS_ASSERT(max_array_size == array_arg->n_args);
+                    if (max_array_size != array_arg->n_args) {
+                        throw SemanticError("Different shape of arguments for broadcasting " +
+                            std::to_string(max_array_size) + " and " + std::to_string(array_arg->n_args), loc);
+                    }
                     intrinsic_args.push_back(al, array_arg->m_args[i]);
                 } else {
                     // Current argument is a scalar, use as is

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5155,12 +5155,12 @@ public:
             }
             // Call the intrinsic function for the current combination of arguments
             result_array->m_args[i] = ASRUtils::expr_value(ASRUtils::EXPR(create_func(al, loc, intrinsic_args, diag)));
-            ASR::Array_t* result_arr_type = ASR::down_cast<ASR::Array_t>(result_array->m_type);
-            result_array->m_type = ASRUtils::make_Array_t_util(al, result_arr_type->base.base.loc,
-                                        ASRUtils::expr_type(result_array->m_args[i]), result_arr_type->m_dims,
-                                        result_arr_type->n_dims, ASR::abiType::Source, false,
-                                        result_arr_type->m_physical_type);
         }
+        ASR::Array_t* result_arr_type = ASR::down_cast<ASR::Array_t>(result_array->m_type);
+        result_array->m_type = ASRUtils::make_Array_t_util(al, result_arr_type->base.base.loc,
+                                    ASRUtils::expr_type(result_array->m_args[0]), result_arr_type->m_dims,
+                                    result_arr_type->n_dims, ASR::abiType::Source, false,
+                                    result_arr_type->m_physical_type);
     }
 
     std::vector<int> find_array_indices_in_args(const Vec<ASR::expr_t*>& args) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5130,7 +5130,8 @@ public:
         const Location& loc,
         Allocator& al)
     {
-        size_t max_array_size = ASR::down_cast<ASR::ArrayConstant_t>(args[array_indices_in_args[0]])->n_args;
+        ASR::expr_t* first_arg_ = ASRUtils::expr_value(args[array_indices_in_args[0]]);
+        size_t max_array_size = ASR::down_cast<ASR::ArrayConstant_t>(first_arg_)->n_args;
 
         for (size_t i = 0; i < max_array_size; i++) {
             Vec<ASR::expr_t*> intrinsic_args;
@@ -5139,7 +5140,9 @@ public:
             for (size_t j = 0; j < args.size(); j++) {
                 if (std::find(array_indices_in_args.begin(), array_indices_in_args.end(), j) != array_indices_in_args.end()) {
                     // Current argument is an array
-                    ASR::ArrayConstant_t* array_arg = ASR::down_cast<ASR::ArrayConstant_t>(args[j]);
+
+                    ASR::expr_t* arg_ = ASRUtils::expr_value(args[j]);
+                    ASR::ArrayConstant_t* array_arg = ASR::down_cast<ASR::ArrayConstant_t>(arg_);
                     if (max_array_size != array_arg->n_args) {
                         throw SemanticError("Different shape of arguments for broadcasting " +
                             std::to_string(max_array_size) + " and " + std::to_string(array_arg->n_args), loc);
@@ -5164,7 +5167,11 @@ public:
         std::vector<int> array_indices_in_args;
 
         for (size_t i = 0; i < args.size(); i++) {
-            if (args[i] && ASR::is_a<ASR::ArrayConstant_t>(*args[i])) {
+            if (!args[i]) {
+                continue;
+            }
+            ASR::expr_t* arg = ASRUtils::expr_value(args[i]);
+            if (arg && ASR::is_a<ASR::ArrayConstant_t>(*arg)) {
                 array_indices_in_args.push_back(i);
             }
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1224,8 +1224,9 @@ static inline bool is_value_in_range(ASR::expr_t* start, ASR::expr_t* end, ASR::
 }
 
 // Returns true if all arguments are evaluated
-static inline bool all_args_evaluated(const Vec<ASR::expr_t*> &args) {
+static inline bool all_args_evaluated(const Vec<ASR::expr_t*> &args, bool ignore_null=false) {
     for (auto &a : args) {
+        if (ignore_null && !a) continue;
         ASR::expr_t* a_value = ASRUtils::expr_value(a);
         if( !is_value_constant(a_value) ) {
             return false;

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4691,9 +4691,9 @@ namespace Max {
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args > 1, "Call to max0 must have at least two arguments",
             x.base.base.loc, diagnostics);
-        ASRUtils::require_impl(ASR::is_a<ASR::Real_t>(*ASRUtils::expr_type(x.m_args[0])) ||
-            ASR::is_a<ASR::Integer_t>(*ASRUtils::expr_type(x.m_args[0])) ||
-            ASR::is_a<ASR::Character_t>(*ASRUtils::expr_type(x.m_args[0])),
+        ASR::ttype_t* arg0_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(x.m_args[0]));
+        ASRUtils::require_impl(ASR::is_a<ASR::Real_t>(*arg0_type) ||
+            ASR::is_a<ASR::Integer_t>(*arg0_type) || ASR::is_a<ASR::Character_t>(*arg0_type),
              "Arguments to max0 must be of real, integer or character type",
             x.base.base.loc, diagnostics);
         for(size_t i=0;i<x.n_args;i++){

--- a/tests/reference/asr-intrinsics_46-0ef4d7a.json
+++ b/tests/reference/asr-intrinsics_46-0ef4d7a.json
@@ -2,11 +2,11 @@
     "basename": "asr-intrinsics_46-0ef4d7a",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_46.f90",
-    "infile_hash": "5713b6eb8a534bbd4c260737dc0b2d0321dd7bda6254771d8530bd59",
+    "infile_hash": "c49925acb22a94e5ab7a30bf0486cad4572363bc82da6f70efa3e9ea",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_46-0ef4d7a.stdout",
-    "stdout_hash": "58ad061531f260dcb77bf96742ee532536df3f65769af3c36ab610d0",
+    "stdout_hash": "1965986d9581f83d38bf626ebe0aa99e56e9beea5e01cf3c4379f9fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_46-0ef4d7a.stdout
+++ b/tests/reference/asr-intrinsics_46-0ef4d7a.stdout
@@ -123,6 +123,31 @@
                                     Required
                                     .false.
                                 ),
+                            dp:
+                                (Variable
+                                    2
+                                    dp
+                                    []
+                                    Local
+                                    (IntrinsicElementalFunction
+                                        Kind
+                                        [(RealConstant
+                                            0.000000
+                                            (Real 8)
+                                        )]
+                                        0
+                                        (Integer 4)
+                                        (IntegerConstant 8 (Integer 4))
+                                    )
+                                    (IntegerConstant 8 (Integer 4))
+                                    Parameter
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             e:
                                 (Variable
                                     2
@@ -154,6 +179,27 @@
                                     ()
                                     Default
                                     (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            int_res:
+                                (Variable
+                                    2
+                                    int_res
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Integer 8)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntegerConstant 4 (Integer 4)))]
+                                        FixedSizeArray
+                                    )
                                     ()
                                     Source
                                     Public
@@ -487,6 +533,235 @@
                                 (Integer 8)
                                 (IntegerConstant 122 (Integer 8))
                             )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 int_res)
+                        (ArrayConstant
+                            [(IntegerConstant 32 (Integer 8))
+                            (IntegerConstant 99 (Integer 8))
+                            (IntegerConstant 100 (Integer 8))
+                            (IntegerConstant 101 (Integer 8))]
+                            (Array
+                                (Integer 8)
+                                [((IntegerConstant 1 (Integer 4))
+                                (IntegerConstant 4 (Integer 4)))]
+                                FixedSizeArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (If
+                        (IntegerCompare
+                            (ArrayItem
+                                (Var 2 int_res)
+                                [(()
+                                (IntegerConstant 1 (Integer 4))
+                                ())]
+                                (Integer 8)
+                                ColMajor
+                                ()
+                            )
+                            NotEq
+                            (Cast
+                                (IntegerConstant 32 (Integer 4))
+                                IntegerToInteger
+                                (Integer 8)
+                                (IntegerConstant 32 (Integer 8))
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (IntrinsicElementalFunction
+                                Kind
+                                [(ArrayItem
+                                    (Var 2 int_res)
+                                    [(()
+                                    (IntegerConstant 1 (Integer 4))
+                                    ())]
+                                    (Integer 8)
+                                    ColMajor
+                                    ()
+                                )]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            NotEq
+                            (Var 2 dp)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (ArrayItem
+                                (Var 2 int_res)
+                                [(()
+                                (IntegerConstant 2 (Integer 4))
+                                ())]
+                                (Integer 8)
+                                ColMajor
+                                ()
+                            )
+                            NotEq
+                            (Cast
+                                (IntegerConstant 99 (Integer 4))
+                                IntegerToInteger
+                                (Integer 8)
+                                (IntegerConstant 99 (Integer 8))
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (IntrinsicElementalFunction
+                                Kind
+                                [(ArrayItem
+                                    (Var 2 int_res)
+                                    [(()
+                                    (IntegerConstant 2 (Integer 4))
+                                    ())]
+                                    (Integer 8)
+                                    ColMajor
+                                    ()
+                                )]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            NotEq
+                            (Var 2 dp)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (ArrayItem
+                                (Var 2 int_res)
+                                [(()
+                                (IntegerConstant 3 (Integer 4))
+                                ())]
+                                (Integer 8)
+                                ColMajor
+                                ()
+                            )
+                            NotEq
+                            (Cast
+                                (IntegerConstant 100 (Integer 4))
+                                IntegerToInteger
+                                (Integer 8)
+                                (IntegerConstant 100 (Integer 8))
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (IntrinsicElementalFunction
+                                Kind
+                                [(ArrayItem
+                                    (Var 2 int_res)
+                                    [(()
+                                    (IntegerConstant 3 (Integer 4))
+                                    ())]
+                                    (Integer 8)
+                                    ColMajor
+                                    ()
+                                )]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            NotEq
+                            (Var 2 dp)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (ArrayItem
+                                (Var 2 int_res)
+                                [(()
+                                (IntegerConstant 4 (Integer 4))
+                                ())]
+                                (Integer 8)
+                                ColMajor
+                                ()
+                            )
+                            NotEq
+                            (Cast
+                                (IntegerConstant 101 (Integer 4))
+                                IntegerToInteger
+                                (Integer 8)
+                                (IntegerConstant 101 (Integer 8))
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (IntrinsicElementalFunction
+                                Kind
+                                [(ArrayItem
+                                    (Var 2 int_res)
+                                    [(()
+                                    (IntegerConstant 4 (Integer 4))
+                                    ())]
+                                    (Integer 8)
+                                    ColMajor
+                                    ()
+                                )]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            NotEq
+                            (Var 2 dp)
                             (Logical 4)
                             ()
                         )


### PR DESCRIPTION
fixes #3673