### PR TITLE
Remove unneeded visit expr

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7489,7 +7489,6 @@ public:
                         llvm::Function::ExternalLinkage, runtime_func_name,
                             *module);
             }
-            this->visit_expr_wrapper(x.m_unit, true);
             builder->CreateCall(fn, {unit_val, iostat});
         }
     }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2618,6 +2618,11 @@ LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, int32_t* iostat, ch
 }
 
 LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat) {
+    if (unit_num == -1) {
+        // Read from stdin
+        return;
+    }
+
     bool unit_file_bin;
     FILE* fp = get_file_pointer_from_unit(unit_num, &unit_file_bin);
     if (!fp) {


### PR DESCRIPTION
and get back stdin read working.

```console
% lfortran examples/chat_01.f90 
Please enter your name:
Joe
---------WELCOME TO CHAT_01---------
Please pick an option:
1) Say Hi
2) Say Hello
3) Say Good Morning
4) Say Happy Birthday
5) Exit the chat

Enter your choice:
1
Hi Joe

Please pick an option:
1) Say Hi
2) Say Hello
3) Say Good Morning
4) Say Happy Birthday
5) Exit the chat

Enter your choice:
2
Hello Joe

Please pick an option:
1) Say Hi
2) Say Hello
3) Say Good Morning
4) Say Happy Birthday
5) Exit the chat

Enter your choice:
3
Good Morning Joe

Please pick an option:
1) Say Hi
2) Say Hello
3) Say Good Morning
4) Say Happy Birthday
5) Exit the chat

Enter your choice:
4
Happy Birthday Joe!

Please pick an option:
1) Say Hi
2) Say Hello
3) Say Good Morning
4) Say Happy Birthday
5) Exit the chat

Enter your choice:
5
```