### PR TITLE
stacktrace.cpp: add limits.h for PATH_MAX

### DIFF
--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -36,6 +36,7 @@
 
 #ifdef HAVE_LFORTRAN_MACHO
 #  include <mach-o/dyld.h>
+#  include <limits.h> // PATH_MAX
 #endif
 
 #ifdef HAVE_LFORTRAN_BFD


### PR DESCRIPTION
@certik I only got the error when enabled `MACH_O`, not otherwise. Therefore hiding it inside that macro.