### PR TITLE
refactor: use existing function to determine nopass value in function calls

### DIFF
--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -418,15 +418,9 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
             if( x.m_dt )
             visit_expr(*x.m_dt);
         }
-        ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external(x.m_name);
-        bool nopass { false };
-        if (ASR::is_a<ASR::ClassProcedure_t>(*func_sym)) {
-            ASR::ClassProcedure_t* class_proc = ASR::down_cast<ASR::ClassProcedure_t>(func_sym);
-            nopass = class_proc->m_is_nopass;
-        }
         ASR::FunctionCall_t& xx = const_cast<ASR::FunctionCall_t&>(x);
         ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt,
-            nullptr, false, nopass);
+            nullptr, false, ASRUtils::get_class_proc_nopass_val(x.m_name));
     }
 
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {

--- a/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
+++ b/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
@@ -205,15 +205,10 @@ class FixArrayPhysicalCast: public ASR::BaseExprReplacer<FixArrayPhysicalCast> {
 
         void replace_FunctionCall(ASR::FunctionCall_t* x) {
             ASR::BaseExprReplacer<FixArrayPhysicalCast>::replace_FunctionCall(x);
-            ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external((*x).m_name);
-            bool is_nopass { false };
-            if (ASR::is_a<ASR::ClassProcedure_t>(*func_sym)) {
-                ASR::ClassProcedure_t* class_proc = ASR::down_cast<ASR::ClassProcedure_t>(func_sym);
-                is_nopass = class_proc->m_is_nopass;
-            }
             ASR::expr_t* call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(
                 al, x->base.base.loc, x->m_name, x->m_original_name, x->m_args,
-                x->n_args, x->m_type, x->m_value, x->m_dt, is_nopass));
+                x->n_args, x->m_type, x->m_value, x->m_dt,
+                ASRUtils::get_class_proc_nopass_val((*x).m_name)));
             ASR::FunctionCall_t* function_call = ASR::down_cast<ASR::FunctionCall_t>(call);
             x->m_args = function_call->m_args;
             x->n_args = function_call->n_args;

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -477,16 +477,10 @@ class ReplaceFunctionCallsWithOptionalArguments: public ASR::BaseExprReplacer<Re
             new_func_calls.find(*current_expr) != new_func_calls.end() ) {
             return ;
         }
-        bool is_nopass { false };
-        ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external((*x).m_name);
-        if (ASR::is_a<ASR::ClassProcedure_t>(*func_sym)) {
-            ASR::ClassProcedure_t* class_proc = ASR::down_cast<ASR::ClassProcedure_t>(func_sym);
-            is_nopass = class_proc->m_is_nopass;
-        }
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al,
                             x->base.base.loc, x->m_name, x->m_original_name,
                             new_args.p, new_args.size(), x->m_type, x->m_value,
-                            x->m_dt, is_nopass));
+                            x->m_dt, ASRUtils::get_class_proc_nopass_val((*x).m_name)));
         new_func_calls.insert(*current_expr);
     }
 


### PR DESCRIPTION
Minor refactoring, which I probably should've already done in https://github.com/lfortran/lfortran/pull/3711