### PR TITLE
chore: handle allocatable types for intrinsic pack

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -718,6 +718,7 @@ RUN(NAME intrinsics_196 LABELS gfortran llvm) # besselj1
 RUN(NAME intrinsics_197 LABELS gfortran llvm) # bessely0
 RUN(NAME intrinsics_198 LABELS gfortran llvm) # sum
 RUN(NAME intrinsics_199 LABELS gfortran llvm) # count
+RUN(NAME intrinsics_200 LABELS gfortran llvm) # pack
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_200.f90
+++ b/integration_tests/intrinsics_200.f90
@@ -2,8 +2,8 @@ program intrinsics_200
 integer, dimension(5) :: x
 logical, dimension(5) :: mask
 
-x = (/1, 2, 3, 4, 5/)
-mask = (/ .true., .false., .true., .false., .true./)
+x = [1, 2, 3, 4, 5]
+mask = [.true., .false., .true., .false., .true.]
 
 print *, median_all_mask_1_iint8_dp(x, mask)
 if (abs(median_all_mask_1_iint8_dp(x, mask) - 9.0) > 1e-8) error stop

--- a/integration_tests/intrinsics_200.f90
+++ b/integration_tests/intrinsics_200.f90
@@ -1,0 +1,20 @@
+program intrinsics_200
+integer, dimension(5) :: x
+logical, dimension(5) :: mask
+
+x = (/1, 2, 3, 4, 5/)
+mask = (/ .true., .false., .true., .false., .true./)
+
+print *, median_all_mask_1_iint8_dp(x, mask)
+if (abs(median_all_mask_1_iint8_dp(x, mask) - 9.0) > 1e-8) error stop
+contains
+function median_all_mask_1_iint8_dp(x, mask) result(res)
+integer, intent(in) :: x(:)
+logical, intent(in) :: mask(:)
+real :: res
+integer, allocatable :: x_tmp(:)
+
+x_tmp = pack(x, mask)
+res = sum(x_tmp)
+end function median_all_mask_1_iint8_dp
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -2251,6 +2251,7 @@ namespace Pack {
             ASR::expr_t* count = EXPR(Count::create_Count(al, loc, args_count, diag));
             result_dims.push_back(al, b.set_dim(array_dims[0].m_start, count));
             ret_type = ASRUtils::duplicate_type(al, ret_type, &result_dims, ASR::array_physical_typeType::DescriptorArray, true);
+            is_type_allocatable = true;
         }
         if (is_type_allocatable) {
             ret_type = TYPE(ASR::make_Allocatable_t(al, loc, ret_type));
@@ -2282,7 +2283,7 @@ namespace Pack {
         }
         ASR::ttype_t* ret_type = return_type;
         if (overload_id == 2) {
-            ret_type = ASRUtils::duplicate_type(al, return_type, nullptr, ASRUtils::extract_physical_type(return_type), true);
+            ret_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(return_type), nullptr, ASRUtils::extract_physical_type(return_type), true);
             LCOMPILERS_ASSERT(ASR::is_a<ASR::Array_t>(*ret_type));
             ASR::Array_t *ret_type_array = ASR::down_cast<ASR::Array_t>(ret_type);
             if (ASR::is_a<ASR::FunctionCall_t>(*ret_type_array->m_dims[0].m_length)) {

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -320,7 +320,11 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
                         ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(func_call_count);
                         if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*func_call->m_args[0].m_value)) {
                             ASR::ArrayPhysicalCast_t *array_cast = ASR::down_cast<ASR::ArrayPhysicalCast_t>(func_call->m_args[0].m_value);
+                            if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*new_args[1].m_value)) {
                             array_cast->m_arg = ASR::down_cast<ASR::ArrayPhysicalCast_t>(new_args[1].m_value)->m_arg;
+                            } else {
+                                array_cast->m_arg = new_args[1].m_value;
+                            }
                             array_cast->m_old = ASRUtils::extract_physical_type(ASRUtils::expr_type(array_cast->m_arg));
                             array_cast->m_type = ASRUtils::duplicate_type(al, ASRUtils::expr_type(array_cast->m_arg), nullptr,
                                                 ASR::array_physical_typeType::DescriptorArray, true);
@@ -333,7 +337,8 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             result_var_ = PassUtils::create_var(result_counter,
                 std::string(ASRUtils::symbol_name(x->m_name)) + "_res",
                 x->base.base.loc, x->m_type, al, current_scope);
-            if (func_call_count) {
+            if (ASRUtils::is_allocatable(ASRUtils::expr_type(result_var_)) &&
+                func_call_count) {
                 // allocate result array
                 Vec<ASR::alloc_arg_t> alloc_args; alloc_args.reserve(al, 1);
                 Vec<ASR::dimension_t> alloc_dims; alloc_dims.reserve(al, 2);

--- a/tests/reference/asr-array_01_pack-6c829d9.json
+++ b/tests/reference/asr-array_01_pack-6c829d9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_pack-6c829d9.stdout",
-    "stdout_hash": "329074589a86c5b10f39178bad3b48f39ace3169d75d91f9be0079d1",
+    "stdout_hash": "e4d66630aac6532d3bea4c5ce6898805ad7367860bdb576caad4973c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_pack-6c829d9.stdout
+++ b/tests/reference/asr-array_01_pack-6c829d9.stdout
@@ -132,39 +132,41 @@
                                 ()
                             )]
                             2
-                            (Array
-                                (Integer 4)
-                                [((IntegerConstant 1 (Integer 4))
-                                (IntrinsicArrayFunction
-                                    Count
-                                    [(ArrayPhysicalCast
-                                        (IntegerCompare
-                                            (Var 2 m)
-                                            NotEq
-                                            (IntegerConstant 0 (Integer 4))
+                            (Allocatable
+                                (Array
+                                    (Integer 4)
+                                    [((IntegerConstant 1 (Integer 4))
+                                    (IntrinsicArrayFunction
+                                        Count
+                                        [(ArrayPhysicalCast
+                                            (IntegerCompare
+                                                (Var 2 m)
+                                                NotEq
+                                                (IntegerConstant 0 (Integer 4))
+                                                (Array
+                                                    (Logical 4)
+                                                    [((IntegerConstant 1 (Integer 4))
+                                                    (IntegerConstant 6 (Integer 4)))]
+                                                    FixedSizeArray
+                                                )
+                                                ()
+                                            )
+                                            FixedSizeArray
+                                            DescriptorArray
                                             (Array
                                                 (Logical 4)
                                                 [((IntegerConstant 1 (Integer 4))
                                                 (IntegerConstant 6 (Integer 4)))]
-                                                FixedSizeArray
+                                                DescriptorArray
                                             )
                                             ()
-                                        )
-                                        FixedSizeArray
-                                        DescriptorArray
-                                        (Array
-                                            (Logical 4)
-                                            [((IntegerConstant 1 (Integer 4))
-                                            (IntegerConstant 6 (Integer 4)))]
-                                            DescriptorArray
-                                        )
+                                        )]
+                                        0
+                                        (Integer 4)
                                         ()
-                                    )]
-                                    0
-                                    (Integer 4)
-                                    ()
-                                ))]
-                                DescriptorArray
+                                    ))]
+                                    DescriptorArray
+                                )
                             )
                             ()
                         )
@@ -212,39 +214,41 @@
                                     ()
                                 )]
                                 2
-                                (Array
-                                    (Integer 4)
-                                    [((IntegerConstant 1 (Integer 4))
-                                    (IntrinsicArrayFunction
-                                        Count
-                                        [(ArrayPhysicalCast
-                                            (IntegerCompare
-                                                (Var 2 m)
-                                                NotEq
-                                                (IntegerConstant 0 (Integer 4))
+                                (Allocatable
+                                    (Array
+                                        (Integer 4)
+                                        [((IntegerConstant 1 (Integer 4))
+                                        (IntrinsicArrayFunction
+                                            Count
+                                            [(ArrayPhysicalCast
+                                                (IntegerCompare
+                                                    (Var 2 m)
+                                                    NotEq
+                                                    (IntegerConstant 0 (Integer 4))
+                                                    (Array
+                                                        (Logical 4)
+                                                        [((IntegerConstant 1 (Integer 4))
+                                                        (IntegerConstant 6 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                )
+                                                FixedSizeArray
+                                                DescriptorArray
                                                 (Array
                                                     (Logical 4)
                                                     [((IntegerConstant 1 (Integer 4))
                                                     (IntegerConstant 6 (Integer 4)))]
-                                                    FixedSizeArray
+                                                    DescriptorArray
                                                 )
                                                 ()
-                                            )
-                                            FixedSizeArray
-                                            DescriptorArray
-                                            (Array
-                                                (Logical 4)
-                                                [((IntegerConstant 1 (Integer 4))
-                                                (IntegerConstant 6 (Integer 4)))]
-                                                DescriptorArray
-                                            )
+                                            )]
+                                            0
+                                            (Integer 4)
                                             ()
-                                        )]
-                                        0
-                                        (Integer 4)
-                                        ()
-                                    ))]
-                                    DescriptorArray
+                                        ))]
+                                        DescriptorArray
+                                    )
                                 )
                                 ()
                             )]


### PR DESCRIPTION
Fixes #3752. Towards LLVM compilation of `stdlib_stats_median`