### PR TITLE
fix: intrinsic sum, any calls existing function with incorrect signature

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -719,6 +719,7 @@ RUN(NAME intrinsics_197 LABELS gfortran llvm) # bessely0
 RUN(NAME intrinsics_198 LABELS gfortran llvm) # sum
 RUN(NAME intrinsics_199 LABELS gfortran llvm) # count
 RUN(NAME intrinsics_200 LABELS gfortran llvm) # pack
+RUN(NAME intrinsics_201 LABELS gfortran llvm) # any
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_201.f90
+++ b/integration_tests/intrinsics_201.f90
@@ -1,0 +1,24 @@
+program intrinsics_201
+real, dimension(3) :: x = [1.0, 2.0, 3.0]
+logical, dimension(3) :: mask = [.true., .false., .true.]
+integer, dimension(3) :: y = [1, 2, 3]
+
+print *, median_all_1_rsp_sp(x)
+if (median_all_1_rsp_sp(x)) error stop
+print *, median_all_mask_1_iint8_dp(y, mask)
+if (median_all_mask_1_iint8_dp(y, mask)) error stop
+contains
+function median_all_1_rsp_sp (x) result(res)
+use ieee_arithmetic
+real, intent(in) :: x(:)
+logical :: res
+res = any(ieee_is_nan(x))
+end function median_all_1_rsp_sp
+
+function median_all_mask_1_iint8_dp(x, mask) result(res)
+integer, intent(in) :: x(:)
+logical, intent(in) :: mask(:)
+logical :: res
+res = any(shape(x) /= shape(mask))
+end function median_all_mask_1_iint8_dp
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -636,7 +636,9 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
             ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(s);
             int orig_array_rank = ASRUtils::extract_n_dims_from_ttype(
                                     ASRUtils::expr_type(f->m_args[0]));
-            if (ASRUtils::types_equal(ASRUtils::expr_type(f->m_args[0]),
+            bool same_allocatable_type = (ASRUtils::is_allocatable(arg_type) ==
+                                    ASRUtils::is_allocatable(ASRUtils::expr_type(f->m_args[0])));
+            if (same_allocatable_type && ASRUtils::types_equal(ASRUtils::expr_type(f->m_args[0]),
                     arg_type) && orig_array_rank == rank) {
                 return builder.Call(s, new_args, return_type, nullptr);
             } else {
@@ -1272,8 +1274,10 @@ namespace Any {
                 ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(s);
                 int orig_array_rank = ASRUtils::extract_n_dims_from_ttype(
                                         ASRUtils::expr_type(f->m_args[0]));
-                if (ASRUtils::types_equal(ASRUtils::expr_type(f->m_args[0]),
-                        arg_type) && orig_array_rank == rank) {
+                bool same_allocatable_type = (ASRUtils::is_allocatable(arg_type) ==
+                                        ASRUtils::is_allocatable(ASRUtils::expr_type(f->m_args[0])));
+                if (same_allocatable_type && ASRUtils::types_equal(ASRUtils::expr_type(f->m_args[0]),
+                        ASRUtils::expr_type(new_args[0].m_value), true) && orig_array_rank == rank) {
                     return builder.Call(s, new_args, logical_return_type, nullptr);
                 } else {
                     new_func_name += std::to_string(i);


### PR DESCRIPTION
Fixes #3765. With this, #3762 and #3759 we get `stdlib_stats_median` compiled to LLVM.