### PR TITLE
enh: add support for `poppar` intrinsic in `fortran` backend

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -713,7 +713,7 @@ RUN(NAME intrinsics_189 LABELS gfortran llvm) # scan
 RUN(NAME intrinsics_190 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_191 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_192 LABELS gfortran llvm) # besselj0
-RUN(NAME intrinsics_193 LABELS gfortran llvm fortran) # poppar
+RUN(NAME intrinsics_193 LABELS gfortran llvm) # poppar
 RUN(NAME intrinsics_194 LABELS gfortran llvm) # min
 RUN(NAME intrinsics_195 LABELS gfortran llvm) # max
 RUN(NAME intrinsics_196 LABELS gfortran llvm) # besselj1
@@ -725,6 +725,7 @@ RUN(NAME intrinsics_201 LABELS gfortran llvm) # any
 RUN(NAME intrinsics_202 LABELS gfortran llvm)
 RUN(NAME intrinsics_203 LABELS gfortran llvm) # asind
 RUN(NAME intrinsics_204 LABELS gfortran llvm) # bessely1
+RUN(NAME intrinsics_206 LABELS gfortran llvm fortran) # poppar
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -713,7 +713,7 @@ RUN(NAME intrinsics_189 LABELS gfortran llvm) # scan
 RUN(NAME intrinsics_190 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_191 LABELS gfortran llvm) # kind
 RUN(NAME intrinsics_192 LABELS gfortran llvm) # besselj0
-RUN(NAME intrinsics_193 LABELS gfortran llvm) # poppar
+RUN(NAME intrinsics_193 LABELS gfortran llvm fortran) # poppar
 RUN(NAME intrinsics_194 LABELS gfortran llvm) # min
 RUN(NAME intrinsics_195 LABELS gfortran llvm) # max
 RUN(NAME intrinsics_196 LABELS gfortran llvm) # besselj1

--- a/integration_tests/intrinsics_206.f90
+++ b/integration_tests/intrinsics_206.f90
@@ -1,0 +1,50 @@
+program intrinsics_206
+    use iso_fortran_env, only: dp => real64
+    integer :: x, y, z
+    integer(dp) :: a, b, c
+
+    x = 44
+    y = -501
+    z = 0
+
+    a = 5468272828_dp
+    b = -3526282829_dp
+    c = 83983_dp
+
+    print *, poppar(x)
+    if(poppar(x) /= 1) error stop
+
+    print *, poppar(44)
+    if(poppar(44) /= 1) error stop
+
+    print *, poppar(y)
+    if(poppar(y) /= 0) error stop
+
+    print *, poppar(-501)
+    if(poppar(-501) /= 0) error stop
+
+    print *, poppar(z)
+    if(poppar(z) /= 0) error stop
+
+    print *, poppar(0)
+    if(poppar(0) /= 0) error stop
+
+    print *, poppar(a)
+    if(poppar(a) /= 1) error stop
+
+    print *, poppar(5468272828_dp)
+    if(poppar(5468272828_dp) /= 1) error stop
+
+    print *, poppar(b)
+    if(poppar(b) /= 0) error stop
+
+    print *, poppar(-3526282829_dp)
+    if(poppar(-3526282829_dp) /= 0) error stop
+
+    print *, poppar(c)
+    if(poppar(c) /= 1) error stop
+
+    print *, poppar(83983_dp)
+    if(poppar(83983_dp) /= 1) error stop
+
+end program

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1268,6 +1268,7 @@ public:
             SET_INTRINSIC_NAME(StringFindSet, "scan");
             SET_INTRINSIC_NAME(SubstrIndex, "index");
             SET_INTRINSIC_NAME(Modulo, "modulo");
+            SET_INTRINSIC_NAME(Poppar, "poppar");
             default : {
                 throw LCompilersException("IntrinsicElementalFunction: `"
                     + ASRUtils::get_intrinsic_name(x.m_intrinsic_id)


### PR DESCRIPTION
Towards: #3416 