### PR TITLE
fix: compile time evaluation for modulo

### DIFF
--- a/integration_tests/intrinsics_139.f90
+++ b/integration_tests/intrinsics_139.f90
@@ -39,4 +39,8 @@ program intrinsic_139
     print *, modulo(-f,-r2)
     if ( abs(modulo(-f,-r2) + 1.00000000) > 1e-5 ) error stop
 
+    print *, modulo(17,-3)
+    if ( modulo(17,-3) /= -1 ) error stop
+    print*, modulo(-17, 3)
+    if ( modulo(-17,3) /= 1 ) error stop
 end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -2891,7 +2891,7 @@ namespace Modulo {
         if (is_integer(*ASRUtils::expr_type(args[0])) && is_integer(*ASRUtils::expr_type(args[1]))) {
             int64_t a = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
             int64_t b = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
-            return make_ConstantWithType(make_IntegerConstant_t, a - b * std::floor(a/b), t1, loc);
+            return make_ConstantWithType(make_IntegerConstant_t, a - b * std::floor(std::real(a)/b), t1, loc);
         } else if (is_real(*ASRUtils::expr_type(args[0])) && is_real(*ASRUtils::expr_type(args[1]))) {
             double a = ASR::down_cast<ASR::RealConstant_t>(args[0])->m_r;
             double b = ASR::down_cast<ASR::RealConstant_t>(args[1])->m_r;


### PR DESCRIPTION
Fix: https://github.com/lfortran/lfortran/issues/3837