### PR TITLE
Fix intrinsic `dcmplx` and remove old node

### DIFF
--- a/integration_tests/complex_07.f90
+++ b/integration_tests/complex_07.f90
@@ -6,6 +6,12 @@ program complex_07
     complex :: y = cmplx(img_part)
     complex :: z = cmplx(real_part, img_part)
     double complex :: c1, x2, y2, z2
+
+    integer :: i = 42
+    real :: x1 = 3.14
+    complex :: z1
+    z1 = cmplx(i, x1)
+
     c1 = (12, 24)
     print *, c1
     x2 = dcmplx(real_part)
@@ -18,5 +24,15 @@ program complex_07
     if (abs(y2 - (img_part, 0)) > 1e-5) error stop
     if (abs(z2 - (real_part, img_part)) > 1e-5) error stop
 
+    print *, dcmplx(i)
+    if (abs(dcmplx(i) - (42.000000,0.000000)) > 1e-5) error stop
+    print *, dcmplx(x1)
+    if (abs(dcmplx(x1) - (3.140000,0.000000)) > 1e-5) error stop
+    print *, dcmplx(z1)
+    if (abs(dcmplx(z1) - (42.000000,3.140000)) > 1e-5) error stop
+    print *, dcmplx(x1, i)
+    if (abs(dcmplx(x1, i) - (3.140000,42.000000)) > 1e-5) error stop
+
     print *, x, y, z
+
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -839,6 +839,8 @@ public:
 
         {"dmin1", "min"},
         {"dmax1", "max"},
+
+        {"dcmplx", "cmplx"}
     };
 
     ASR::asr_t *tmp;
@@ -4857,40 +4859,6 @@ public:
         return ASR::make_PointerAssociated_t(al, x.base.base.loc, ptr_, tgt_, associated_type_, nullptr);
     }
 
-    ASR::asr_t* create_DCmplx(const AST::FuncCallOrArray_t& x) {
-        Vec<ASR::expr_t*> args;
-        std::vector<std::string> kwarg_names = {"x", "y"};
-        handle_intrinsic_node_args(x, args, kwarg_names, 1, 2, "dcmplx");
-        ASR::expr_t *x_ = args[0], *y_ = args[1];
-        if( ASR::is_a<ASR::Complex_t>(*ASRUtils::expr_type(x_)) ) {
-            if( y_ != nullptr ) {
-                throw SemanticError("The first argument of `dcmplx` intrinsic"
-                                    " is of complex type, the second argument "
-                                    "in this case must be absent",
-                                    x.base.base.loc);
-            }
-            return (ASR::asr_t*) x_;
-        }
-        int64_t kind_value = 8;
-        if( y_ == nullptr ) {
-            ASR::ttype_t* real_type = ASRUtils::TYPE(ASR::make_Real_t(al,
-                                        x.base.base.loc, kind_value));
-            y_ = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc,
-                                                         0.0, real_type));
-        }
-        ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc, kind_value));
-        ASR::expr_t* x_value = ASRUtils::expr_value(x_);
-        ASR::expr_t* y_value = ASRUtils::expr_value(y_);
-        ASR::expr_t* cc_expr = nullptr;
-        double x_value_ = 0.0;
-        double y_value_ = 0.0;
-        if (x_value && y_value && ASRUtils::extract_value(x_value, x_value_) && ASRUtils::extract_value(y_value, y_value_)) {
-            cc_expr = ASRUtils::EXPR(ASR::make_ComplexConstant_t(al, x.base.base.loc,
-                                                                 x_value_, y_value_, type));
-        }
-        return ASR::make_ComplexConstructor_t(al, x.base.base.loc, x_, y_, type, cc_expr);
-    }
-
     ASR::asr_t* create_Ichar(const AST::FuncCallOrArray_t& x) {
         Vec<ASR::expr_t*> args;
         std::vector<std::string> kwarg_names = {"C", "kind"};
@@ -5313,8 +5281,6 @@ public:
                 tmp = create_BitCast(x);
             } else if( var_name == "cmplx" ) {
                 tmp = create_Cmplx(x);
-            } else if( var_name == "dcmplx" ) {
-                tmp = create_DCmplx(x);
             } else if( var_name == "reshape" ) {
                 tmp = create_ArrayReshape(x);
             } else if( var_name == "ichar" ) {

--- a/tests/reference/asr-complex_07-71c3c47.json
+++ b/tests/reference/asr-complex_07-71c3c47.json
@@ -2,11 +2,11 @@
     "basename": "asr-complex_07-71c3c47",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/complex_07.f90",
-    "infile_hash": "4ffb7dd9ba776ecaf99109ed420aaee7f5c931e4cdfb1a7947599ee7",
+    "infile_hash": "fb49a785b3424190cd1c321680f4566fa5dc0ea30569ab7624004d2f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex_07-71c3c47.stdout",
-    "stdout_hash": "9fc93fd54a640929d87266ac0a9dc0a8e701a2b97e5cf3d647a811d2",
+    "stdout_hash": "f9d27c3cf582d1a72f24ad4da9e4d07c9cf38c17d4dc997f5e9306e4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex_07-71c3c47.stdout
+++ b/tests/reference/asr-complex_07-71c3c47.stdout
@@ -23,6 +23,22 @@
                                     Required
                                     .false.
                                 ),
+                            i:
+                                (Variable
+                                    2
+                                    i
+                                    []
+                                    Local
+                                    (IntegerConstant 42 (Integer 4))
+                                    (IntegerConstant 42 (Integer 4))
+                                    Save
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             img_part:
                                 (Variable
                                     2
@@ -95,6 +111,28 @@
                                     )
                                     Save
                                     (Complex 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            x1:
+                                (Variable
+                                    2
+                                    x1
+                                    []
+                                    Local
+                                    (RealConstant
+                                        3.140000
+                                        (Real 4)
+                                    )
+                                    (RealConstant
+                                        3.140000
+                                        (Real 4)
+                                    )
+                                    Save
+                                    (Real 4)
                                     ()
                                     Source
                                     Public
@@ -203,6 +241,22 @@
                                     Required
                                     .false.
                                 ),
+                            z1:
+                                (Variable
+                                    2
+                                    z1
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Complex 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             z2:
                                 (Variable
                                     2
@@ -223,6 +277,21 @@
                     complex_07
                     []
                     [(Assignment
+                        (Var 2 z1)
+                        (ComplexConstructor
+                            (Cast
+                                (Var 2 i)
+                                IntegerToReal
+                                (Real 4)
+                                ()
+                            )
+                            (Var 2 x1)
+                            (Complex 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Assignment
                         (Var 2 c1)
                         (Cast
                             (ComplexConstructor
@@ -252,12 +321,29 @@
                     )
                     (Assignment
                         (Var 2 x2)
-                        (ComplexConstructor
-                            (Var 2 real_part)
-                            (RealConstant
-                                0.000000
-                                (Real 8)
+                        (Cast
+                            (ComplexConstructor
+                                (Cast
+                                    (Var 2 real_part)
+                                    IntegerToReal
+                                    (Real 4)
+                                    (RealConstant
+                                        42.000000
+                                        (Real 4)
+                                    )
+                                )
+                                (RealConstant
+                                    0.000000
+                                    (Real 4)
+                                )
+                                (Complex 4)
+                                (ComplexConstant
+                                    42.000000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
+                            ComplexToComplex
                             (Complex 8)
                             (ComplexConstant
                                 42.000000
@@ -269,12 +355,21 @@
                     )
                     (Assignment
                         (Var 2 y2)
-                        (ComplexConstructor
-                            (Var 2 img_part)
-                            (RealConstant
-                                0.000000
-                                (Real 8)
+                        (Cast
+                            (ComplexConstructor
+                                (Var 2 img_part)
+                                (RealConstant
+                                    0.000000
+                                    (Real 4)
+                                )
+                                (Complex 4)
+                                (ComplexConstant
+                                    3.140000
+                                    0.000000
+                                    (Complex 4)
+                                )
                             )
+                            ComplexToComplex
                             (Complex 8)
                             (ComplexConstant
                                 3.140000
@@ -286,9 +381,26 @@
                     )
                     (Assignment
                         (Var 2 z2)
-                        (ComplexConstructor
-                            (Var 2 real_part)
-                            (Var 2 img_part)
+                        (Cast
+                            (ComplexConstructor
+                                (Cast
+                                    (Var 2 real_part)
+                                    IntegerToReal
+                                    (Real 4)
+                                    (RealConstant
+                                        42.000000
+                                        (Real 4)
+                                    )
+                                )
+                                (Var 2 img_part)
+                                (Complex 4)
+                                (ComplexConstant
+                                    42.000000
+                                    3.140000
+                                    (Complex 4)
+                                )
+                            )
+                            ComplexToComplex
                             (Complex 8)
                             (ComplexConstant
                                 42.000000
@@ -562,6 +674,260 @@
                                     0.000010
                                     (Real 8)
                                 )
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        [(ComplexConstructor
+                            (Cast
+                                (Var 2 i)
+                                IntegerToReal
+                                (Real 4)
+                                ()
+                            )
+                            (RealConstant
+                                0.000000
+                                (Real 4)
+                            )
+                            (Complex 4)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )
+                    (If
+                        (RealCompare
+                            (IntrinsicElementalFunction
+                                Abs
+                                [(ComplexBinOp
+                                    (ComplexConstructor
+                                        (Cast
+                                            (Var 2 i)
+                                            IntegerToReal
+                                            (Real 4)
+                                            ()
+                                        )
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4)
+                                        )
+                                        (Complex 4)
+                                        ()
+                                    )
+                                    Sub
+                                    (ComplexConstructor
+                                        (RealConstant
+                                            42.000000
+                                            (Real 4)
+                                        )
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4)
+                                        )
+                                        (Complex 4)
+                                        (ComplexConstant
+                                            42.000000
+                                            0.000000
+                                            (Complex 4)
+                                        )
+                                    )
+                                    (Complex 4)
+                                    ()
+                                )]
+                                0
+                                (Real 4)
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000010
+                                (Real 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        [(ComplexConstructor
+                            (Var 2 x1)
+                            (RealConstant
+                                0.000000
+                                (Real 4)
+                            )
+                            (Complex 4)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )
+                    (If
+                        (RealCompare
+                            (IntrinsicElementalFunction
+                                Abs
+                                [(ComplexBinOp
+                                    (ComplexConstructor
+                                        (Var 2 x1)
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4)
+                                        )
+                                        (Complex 4)
+                                        ()
+                                    )
+                                    Sub
+                                    (ComplexConstructor
+                                        (RealConstant
+                                            3.140000
+                                            (Real 4)
+                                        )
+                                        (RealConstant
+                                            0.000000
+                                            (Real 4)
+                                        )
+                                        (Complex 4)
+                                        (ComplexConstant
+                                            3.140000
+                                            0.000000
+                                            (Complex 4)
+                                        )
+                                    )
+                                    (Complex 4)
+                                    ()
+                                )]
+                                0
+                                (Real 4)
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000010
+                                (Real 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        [(Var 2 z1)]
+                        ()
+                        ()
+                    )
+                    (If
+                        (RealCompare
+                            (IntrinsicElementalFunction
+                                Abs
+                                [(ComplexBinOp
+                                    (Var 2 z1)
+                                    Sub
+                                    (ComplexConstructor
+                                        (RealConstant
+                                            42.000000
+                                            (Real 4)
+                                        )
+                                        (RealConstant
+                                            3.140000
+                                            (Real 4)
+                                        )
+                                        (Complex 4)
+                                        (ComplexConstant
+                                            42.000000
+                                            3.140000
+                                            (Complex 4)
+                                        )
+                                    )
+                                    (Complex 4)
+                                    ()
+                                )]
+                                0
+                                (Real 4)
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000010
+                                (Real 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        [(ComplexConstructor
+                            (Var 2 x1)
+                            (Cast
+                                (Var 2 i)
+                                IntegerToReal
+                                (Real 4)
+                                ()
+                            )
+                            (Complex 4)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )
+                    (If
+                        (RealCompare
+                            (IntrinsicElementalFunction
+                                Abs
+                                [(ComplexBinOp
+                                    (ComplexConstructor
+                                        (Var 2 x1)
+                                        (Cast
+                                            (Var 2 i)
+                                            IntegerToReal
+                                            (Real 4)
+                                            ()
+                                        )
+                                        (Complex 4)
+                                        ()
+                                    )
+                                    Sub
+                                    (ComplexConstructor
+                                        (RealConstant
+                                            3.140000
+                                            (Real 4)
+                                        )
+                                        (RealConstant
+                                            42.000000
+                                            (Real 4)
+                                        )
+                                        (Complex 4)
+                                        (ComplexConstant
+                                            3.140000
+                                            42.000000
+                                            (Complex 4)
+                                        )
+                                    )
+                                    (Complex 4)
+                                    ()
+                                )]
+                                0
+                                (Real 4)
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000010
+                                (Real 4)
                             )
                             (Logical 4)
                             ()


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3832