### PR TITLE
feat: implement intrinsic `new_line` and remove old runtime code

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -763,6 +763,7 @@ RUN(NAME intrinsics_214 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sind
 RUN(NAME intrinsics_215 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # cosd
 RUN(NAME intrinsics_216 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # tand
 RUN(NAME intrinsics_217 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # all
+RUN(NAME intrinsics_218 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # new_line
 RUN(NAME intrinsics_219 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME parameter_01 LABELS gfortran)

--- a/integration_tests/intrinsics_218.f90
+++ b/integration_tests/intrinsics_218.f90
@@ -1,0 +1,8 @@
+program main
+implicit none
+
+integer, parameter :: new_len = len(new_line('a'))
+print *, new_len
+if (new_len /= 1) error stop
+print*, "Hello, World!", new_line('a')
+end

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -86,7 +86,6 @@ struct IntrinsicProcedures {
             // left unevaluated in body visitor
             {"trim", {m_string, &not_implemented, false}},
             {"len_trim", {m_string, &not_implemented, false}},
-            {"new_line", {m_string, &eval_new_line, false}},
 
             // Subroutines
             {"cpu_time", {m_math, &not_implemented, false}},
@@ -299,14 +298,6 @@ struct IntrinsicProcedures {
         } else {
             throw SemanticError("achar() must have one integer argument", loc);
         }
-    }
-
-    static ASR::expr_t *eval_new_line(Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, const CompilerOptions &) {
-        LCOMPILERS_ASSERT(args.size() == 1);
-        char* new_line_str = (char*)"\n";
-        return ASR::down_cast<ASR::expr_t>(ASR::make_StringConstant_t(
-                    al, loc, new_line_str,
-                    ASRUtils::expr_type(args[0])));
     }
 
 }; // ComptimeEval

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1195,12 +1195,6 @@ public:
         } else {
             r += ASRUtils::symbol_name(x.m_name);
         }
-        if (r == "bit_size") {
-            // TODO: Remove this once bit_size is implemented in IntrinsicElementalFunction
-            visit_expr(*x.m_value);
-            return;
-        }
-
         r += "(";
         for (size_t i = 0; i < x.n_args; i ++) {
             visit_expr(*x.m_args[i].m_value);

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1222,6 +1222,7 @@ public:
             SET_INTRINSIC_NAME(Rank,      "rank"     );
             SET_INTRINSIC_NAME(Tiny,      "tiny"     );
             SET_INTRINSIC_NAME(BitSize,   "bit_size" );
+            SET_INTRINSIC_NAME(NewLine,   "new_line" );
             default : {
                 throw LCompilersException("TypeInquiry: `"
                     + ASRUtils::get_intrinsic_name(x.m_inquiry_id)

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -446,6 +446,12 @@ intrinsic_funcs_args = {
             "return": "int32"
         }
     ],
+    "NewLine": [
+        {
+            "args": [("char",)],
+            "return": "character(-1)"
+        }
+    ],
     "Range": [
         {
             "args": [("int",), ("real",), ("complex",)],
@@ -589,6 +595,7 @@ compile_time_only_fn = [
     "Tiny",
     "Huge",
     "BitSize",
+    "NewLine",
 ]
 
 type_to_asr_type_check = {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -142,6 +142,7 @@ inline std::string get_intrinsic_name(int64_t x) {
         INTRINSIC_NAME_CASE(Precision)
         INTRINSIC_NAME_CASE(Tiny)
         INTRINSIC_NAME_CASE(BitSize)
+        INTRINSIC_NAME_CASE(NewLine)
         INTRINSIC_NAME_CASE(Conjg)
         INTRINSIC_NAME_CASE(Huge)
         INTRINSIC_NAME_CASE(Dprod)
@@ -426,6 +427,8 @@ namespace IntrinsicElementalFunctionRegistry {
         {static_cast<int64_t>(IntrinsicElementalFunctions::Tiny),
             {nullptr, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::BitSize),
+            {nullptr, &UnaryIntrinsicFunction::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::NewLine),
             {nullptr, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Huge),
             {nullptr, &UnaryIntrinsicFunction::verify_args}},
@@ -736,6 +739,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "tiny"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::BitSize),
             "bit_size"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::NewLine),
+            "new_line"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Huge),
             "huge"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicSymbol),
@@ -916,6 +921,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"precision", {&Precision::create_Precision, &Precision::eval_Precision}},
                 {"tiny", {&Tiny::create_Tiny, &Tiny::eval_Tiny}},
                 {"bit_size", {&BitSize::create_BitSize, &BitSize::eval_BitSize}},
+                {"new_line", {&NewLine::create_NewLine, &NewLine::eval_NewLine}},
                 {"conjg", {&Conjg::create_Conjg, &Conjg::eval_Conjg}},
                 {"huge", {&Huge::create_Huge, &Huge::eval_Huge}},
                 {"Symbol", {&SymbolicSymbol::create_SymbolicSymbol, &SymbolicSymbol::eval_SymbolicSymbol}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -143,6 +143,7 @@ enum class IntrinsicElementalFunctions : int64_t {
     Precision,
     Tiny,
     BitSize,
+    NewLine,
     Conjg,
     Huge,
     Popcnt,
@@ -3599,6 +3600,16 @@ namespace BitSize {
     }
 
 } // namespace BitSize
+
+namespace NewLine {
+
+    static ASR::expr_t *eval_NewLine(Allocator &al, const Location &loc,
+            ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
+        char* new_line_str = (char*)"\n";
+        return make_ConstantWithType(make_StringConstant_t, new_line_str, ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, 0, nullptr)), loc);
+    }
+
+} // namespace NewLine
 
 namespace Adjustl {
 

--- a/src/runtime/pure/lfortran_intrinsic_string.f90
+++ b/src/runtime/pure/lfortran_intrinsic_string.f90
@@ -26,12 +26,6 @@ function trim(x) result(r)
     end do
 end function
 
-function new_line(c) result(r)
-    character(len=1), intent(in) :: c
-    character(len=1) :: r
-    r = '\n'
-end function
-
 subroutine date_and_time(date, time, zone, values)
     character(len=*), intent(out), optional :: date, time, zone
     integer, intent(out), optional :: values(8)

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "f4ec4c8d389a8542402e6ac4bbb2afe7eb1b450c53ad14b64d669389",
+    "stdout_hash": "0c9dbfe8f6f7233de282ce67b1355534c2705fd582405f5905aa7262",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -529,7 +529,7 @@
                                                 (ExternalSymbol
                                                     9
                                                     present
-                                                    19 present
+                                                    18 present
                                                     lfortran_intrinsic_builtin
                                                     []
                                                     present

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "b0a7db2febf206caa3f84026a38a7ffd3cfd700ba389f1991edd6e35",
+    "stdout_hash": "8ede7de76a41b08a7cd3c3ca1763516b34cb37621654705ac8ae68d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -529,7 +529,7 @@
                                                 (ExternalSymbol
                                                     13
                                                     present
-                                                    22 present
+                                                    21 present
                                                     lfortran_intrinsic_builtin
                                                     []
                                                     present

--- a/tests/reference/asr-fn5-3d75eb7.json
+++ b/tests/reference/asr-fn5-3d75eb7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn5-3d75eb7.stdout",
-    "stdout_hash": "cd526c55ff455d08ad4f4baac5f1ba5c372ebd28dd0f3cabcd5d8ef4",
+    "stdout_hash": "63c11bb122826ea12e6a631d9cb3feeab853d20d955874c8474c1a68",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn5-3d75eb7.stdout
+++ b/tests/reference/asr-fn5-3d75eb7.stdout
@@ -74,7 +74,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     present
-                                                    14 present
+                                                    13 present
                                                     lfortran_intrinsic_builtin
                                                     []
                                                     present

--- a/tests/reference/asr-fn6-a24010a.json
+++ b/tests/reference/asr-fn6-a24010a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn6-a24010a.stdout",
-    "stdout_hash": "47aca1c702cfbaec7e0578c3ae475c2898df584db7960dc4e741f83e",
+    "stdout_hash": "c2e389bec1c5cd83ab10f0dd40809486190a374f7e069869d0df537a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn6-a24010a.stdout
+++ b/tests/reference/asr-fn6-a24010a.stdout
@@ -572,7 +572,7 @@
                                                             ~select_type_block_:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        30
+                                                                        29
                                                                         {
                                                                             
                                                                         })
@@ -619,7 +619,7 @@
                                                             ~select_type_block_1:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        31
+                                                                        30
                                                                         {
                                                                             
                                                                         })
@@ -666,7 +666,7 @@
                                                             ~select_type_block_2:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        32
+                                                                        31
                                                                         {
                                                                             
                                                                         })
@@ -713,7 +713,7 @@
                                                             ~select_type_block_3:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        33
+                                                                        32
                                                                         {
                                                                             
                                                                         })
@@ -755,7 +755,7 @@
                                                             ~select_type_block_4:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        34
+                                                                        33
                                                                         {
                                                                             
                                                                         })
@@ -797,7 +797,7 @@
                                                             ~select_type_block_5:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        35
+                                                                        34
                                                                         {
                                                                             
                                                                         })
@@ -839,7 +839,7 @@
                                                             ~select_type_block_6:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        36
+                                                                        35
                                                                         {
                                                                             
                                                                         })
@@ -881,11 +881,11 @@
                                                             ~select_type_block_7:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        37
+                                                                        36
                                                                         {
                                                                             len_trim:
                                                                                 (ExternalSymbol
-                                                                                    37
+                                                                                    36
                                                                                     len_trim
                                                                                     23 len_trim
                                                                                     lfortran_intrinsic_string
@@ -924,7 +924,7 @@
                                                                                 ()
                                                                                 [((Var 5 generic))]
                                                                                 (Character 1 -3 (FunctionCall
-                                                                                    37 len_trim
+                                                                                    36 len_trim
                                                                                     ()
                                                                                     [((Var 5 generic))]
                                                                                     (Integer 4)
@@ -946,7 +946,7 @@
                                                             ~select_type_block_8:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        38
+                                                                        37
                                                                         {
                                                                             
                                                                         })

--- a/tests/reference/asr-intrinsics_33-816caef.json
+++ b/tests/reference/asr-intrinsics_33-816caef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_33-816caef.stdout",
-    "stdout_hash": "e4f212033be992807fedae7de33c1d2bb311f18ea5ff6ad758d846df",
+    "stdout_hash": "3e33d2ad4079d6e29c776f443d43d6df6338410c0cc5f468852b9717",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_33-816caef.stdout
+++ b/tests/reference/asr-intrinsics_33-816caef.stdout
@@ -7,16 +7,7 @@
                     (SymbolTable
                         2
                         {
-                            new_line:
-                                (ExternalSymbol
-                                    2
-                                    new_line
-                                    4 new_line
-                                    lfortran_intrinsic_string
-                                    []
-                                    new_line
-                                    Private
-                                )
+                            
                         })
                     intrinsics_29
                     []
@@ -27,21 +18,20 @@
                                     "This is record 1."
                                     (Character 1 17 ())
                                 )
-                                (FunctionCall
-                                    2 new_line
-                                    ()
-                                    [((StringConstant
-                                        "A"
-                                        (Character 1 1 ())
-                                    ))]
+                                (TypeInquiry
+                                    NewLine
                                     (Character 1 1 ())
                                     (StringConstant
-                                        "\n"
+                                        "A"
                                         (Character 1 1 ())
                                     )
-                                    ()
+                                    (Character 1 -1 ())
+                                    (StringConstant
+                                        "\n"
+                                        (Character 1 0 ())
+                                    )
                                 )
-                                (Character 1 18 ())
+                                (Character 1 -1 ())
                                 (StringConstant
                                     "This is record 1.\n"
                                     (Character 1 18 ())
@@ -51,7 +41,7 @@
                                 "This is record 2."
                                 (Character 1 17 ())
                             )
-                            (Character 1 35 ())
+                            (Character 1 -1 ())
                             (StringConstant
                                 "This is record 1.\nThis is record 2."
                                 (Character 1 35 ())
@@ -60,11 +50,7 @@
                         ()
                         ()
                     )]
-                ),
-            iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
-            lfortran_intrinsic_string:
-                (IntrinsicModule lfortran_intrinsic_string)
+                )
         })
     []
 )


### PR DESCRIPTION
Towards: #492
Fixes: #3860
