### PR TITLE
raise-error: semantic error on invalid character string arguments of array constructor

### DIFF
--- a/tests/errors/array_constructor_with_asterisk_in_type_spec.f90
+++ b/tests/errors/array_constructor_with_asterisk_in_type_spec.f90
@@ -1,0 +1,3 @@
+program array_constructor_with_asterisk_in_type_spec
+    print *, [character(*) :: "a", "b", "ball", "cat"]
+end program

--- a/tests/errors/array_constructor_with_different_char_lengths.f90
+++ b/tests/errors/array_constructor_with_different_char_lengths.f90
@@ -1,0 +1,3 @@
+program array_constructor_with_different_char_lengths
+    print *, ["a", "b", "ball", "cat"]
+end program

--- a/tests/reference/asr-array_constructor_with_asterisk_in_type_spec-24efd03.json
+++ b/tests/reference/asr-array_constructor_with_asterisk_in_type_spec-24efd03.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-array_constructor_with_asterisk_in_type_spec-24efd03",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/array_constructor_with_asterisk_in_type_spec.f90",
+    "infile_hash": "32cd88de1530bbe18208a1999a4a3eb975c5e679d7a5f417966d2507",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-array_constructor_with_asterisk_in_type_spec-24efd03.stderr",
+    "stderr_hash": "a54c91b46642660539c1dc2e3abfad83c7c1b128c15b0bbcbec31518",
+    "returncode": 2
+}

--- a/tests/reference/asr-array_constructor_with_asterisk_in_type_spec-24efd03.stderr
+++ b/tests/reference/asr-array_constructor_with_asterisk_in_type_spec-24efd03.stderr
@@ -1,0 +1,5 @@
+semantic error: Type-spec cannot contain an asterisk for a type parameter
+ --> tests/errors/array_constructor_with_asterisk_in_type_spec.f90:2:14
+  |
+2 |     print *, [character(*) :: "a", "b", "ball", "cat"]
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-array_constructor_with_different_char_lengths-5ba8b29.json
+++ b/tests/reference/asr-array_constructor_with_different_char_lengths-5ba8b29.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-array_constructor_with_different_char_lengths-5ba8b29",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/array_constructor_with_different_char_lengths.f90",
+    "infile_hash": "61dc3cb74e4af0fdc0ee167225903f7143b7f920c38c4f7c5c4bfc3a",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-array_constructor_with_different_char_lengths-5ba8b29.stderr",
+    "stderr_hash": "646eae0030ddaf3e0ef573ad8a04e67a143812eae6c2ff7e3a9e363c",
+    "returncode": 2
+}

--- a/tests/reference/asr-array_constructor_with_different_char_lengths-5ba8b29.stderr
+++ b/tests/reference/asr-array_constructor_with_different_char_lengths-5ba8b29.stderr
@@ -1,0 +1,5 @@
+semantic error: Different `character` lengths 1 and 4 in array constructor
+ --> tests/errors/array_constructor_with_different_char_lengths.f90:2:25
+  |
+2 |     print *, ["a", "b", "ball", "cat"]
+  |                         ^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3835,6 +3835,14 @@ filename = "errors/array_constructor_with_different_kind.f90"
 asr = true
 
 [[test]]
+filename = "errors/array_constructor_with_asterisk_in_type_spec.f90"
+asr = true
+
+[[test]]
+filename = "errors/array_constructor_with_different_char_lengths.f90"
+asr = true
+
+[[test]]
 filename = "errors/incompatible_ranks_allocatable_arr1.f90"
 asr = true
 


### PR DESCRIPTION
According to J3 document, length of all character strings of an array constructor should be same, if type-spec is ommited