### PR TITLE
feat: add `lcompilers_test_module`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -740,7 +740,7 @@ RUN(NAME intrinsics_206 LABELS gfortran llvm llvm_wasm fortran) # poppar
 RUN(NAME intrinsics_207 LABELS gfortran llvm llvm_wasm) # double precision intrinsics
 RUN(NAME intrinsics_208 LABELS gfortran llvm llvm_wasm) # bit_size
 RUN(NAME intrinsics_209 LABELS gfortran llvm llvm_wasm) # atand
-RUN(NAME intrinsics_210 LABELS gfortran llvm llvm_wasm) # bessel_jn
+RUN(NAME intrinsics_210 LABELS gfortran llvm llvm_wasm EXTRAFILES lcompilers_test_module.f90) # bessel_jn
 RUN(NAME intrinsics_211 LABELS gfortran llvm llvm_wasm) # bessel_yn
 RUN(NAME intrinsics_212 LABELS gfortran llvm) # specific type intrinsics
 RUN(NAME intrinsics_213 LABELS gfortran llvm) # cpu_time

--- a/integration_tests/intrinsics_210.f90
+++ b/integration_tests/intrinsics_210.f90
@@ -1,4 +1,5 @@
 program intrinsics_210
+    use lcompilers_test_module
     use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32
     integer(4) :: n(40)
     real(dp) :: x(40)
@@ -36,10 +37,7 @@ program intrinsics_210
         6.9929712255690990E-039_dp, 7.0335789790577674E-041_dp, 6.8007546900796684E-043_dp, 6.3118158714187534E-045_dp, &
         -3.3890445848758326E-002_dp, 6.2626337984015854E-003_dp, 3.5724011188705031E-002_dp, 7.5701847451948119E-003_dp]
 
-      do i = 1, size(res)
-            print *, res(i)
-            if (abs(res(i) - expected_res(i)) > 1e-5_dp) error stop
-      end do
+    call lcompilers_test(res, expected_res)
 
     n = [0, 1, 2, 3, &
         4, 5, 6, 7, &
@@ -75,10 +73,7 @@ program intrinsics_210
         0.0000000000000000_dp, 0.0000000000000000_dp, 0.0000000000000000_dp, 0.0000000000000000_dp, &
         -3.5113774172006770E-002_dp, -1.2362051018001158E-002_dp, 3.1067922823692470E-002_dp, 2.5002750863701195E-002_dp] 
 
-    do i = 1, size(x)
-        print *, bessel_jn(n(i), x(i)), "i = ", i
-        if (abs(bessel_jn(n(i), x(i)) - expected(i)) > 1e-12_dp) error stop
-    end do
+    call lcompilers_test(bessel_jn(n, x), expected)
 
 
     y = [1036.462826483388272_sp, 1.7197292882018389_sp, 10.2368267382872828_sp, 0.17197292882018389_sp, &
@@ -97,8 +92,5 @@ program intrinsics_210
         4.41184424E-31_sp, 5.28522317E-33_sp, 6.04228548E-35_sp, 6.58917622E-37_sp, &
         -3.08027826E-02_sp, 1.36694657E-02_sp, 3.46039571E-02_sp, -6.74327370E-04_sp]
 
-    do i = 1, size(y)
-        print *, bessel_jn(n(i), y(i)), "i = ", i
-        if (abs(bessel_jn(n(i), y(i)) - expected_y(i)) > 1e-6) error stop
-    end do
+    call lcompilers_test(bessel_jn(n(1:size(y)), y), expected_y, 10.0_sp)
 end program

--- a/integration_tests/lcompilers_test_module.f90
+++ b/integration_tests/lcompilers_test_module.f90
@@ -1,0 +1,37 @@
+module lcompilers_test_module
+use iso_fortran_env, only: sp => real32, dp => real64
+
+interface lcompilers_test
+procedure :: lcompilers_test_r32_r32
+procedure :: lcompilers_test_r64_r64
+end interface
+
+contains
+elemental subroutine lcompilers_test_r32_r32(actual, expected, tol)
+real(sp), intent(in) :: actual
+real(sp), intent(in) :: expected
+real(sp), optional, intent(in) :: tol
+
+if (present(tol)) then
+  if (abs(actual - expected) > tol * 1e-8_sp) error stop
+else
+  if (abs(actual - expected) > 1e-8_sp) error stop
+end if
+end subroutine
+
+elemental impure subroutine lcompilers_test_r64_r64(actual, expected, tol)
+real(dp), intent(in) :: actual
+real(dp), intent(in) :: expected
+real(dp), optional, intent(in) :: tol
+
+if (present(tol)) then
+  if (abs(actual - expected) > tol * 1e-12_dp) error stop
+else
+  print *, actual, expected
+  print *, abs(actual - expected)
+  if (abs(actual - expected) > 1e-12_dp) error stop
+end if
+end subroutine
+
+
+end module

--- a/integration_tests/lcompilers_test_module.f90
+++ b/integration_tests/lcompilers_test_module.f90
@@ -2,16 +2,19 @@ module lcompilers_test_module
 use iso_fortran_env, only: sp => real32, dp => real64
 
 interface lcompilers_test
-procedure :: lcompilers_test_r32_r32
-procedure :: lcompilers_test_r64_r64
+  module procedure :: lcompilers_test_r32_r32
+  module procedure :: lcompilers_test_r64_r64
 end interface
 
 contains
-elemental subroutine lcompilers_test_r32_r32(actual, expected, tol)
+
+elemental impure subroutine lcompilers_test_r32_r32(actual, expected, tol)
 real(sp), intent(in) :: actual
 real(sp), intent(in) :: expected
 real(sp), optional, intent(in) :: tol
 
+print *, "actual: ", actual
+print *, "expected: ", expected
 if (present(tol)) then
   if (abs(actual - expected) > tol * 1e-8_sp) error stop
 else
@@ -24,14 +27,13 @@ real(dp), intent(in) :: actual
 real(dp), intent(in) :: expected
 real(dp), optional, intent(in) :: tol
 
+print *, "actual: ", actual
+print *, "expected: ", expected
 if (present(tol)) then
   if (abs(actual - expected) > tol * 1e-12_dp) error stop
 else
-  print *, actual, expected
-  print *, abs(actual - expected)
   if (abs(actual - expected) > 1e-12_dp) error stop
 end if
 end subroutine
-
 
 end module


### PR DESCRIPTION
## Description

This PR aims to add in house `lcompilers_test_module` that provides api `lcompilers_test( actual, expected, tol )`.

## Why?

With this module we can simple remove those `if( abs( actual - expected ) - 1e-10 ) error stop` statements.

## How?

1. integration tests

```cmake
RUN(NAME intrinsics_210 LABELS gfortran llvm llvm_wasm EXTRAFILES lcompilers_test_module.f90) # bessel_jn
```

2. tests

```toml
[[test]]
filename = "../integration_tests/intrinsics_210.f90"
asr = true
extrafiles = "../integration_tests/lcompilers_test_module.f90"
```

---

I am open to discussion if we need this or not.