### PR TITLE
Enh: Modularize the code for intrinsic `any` and `all`

### DIFF
--- a/tests/reference/asr-intrinsics_35-10733ec.json
+++ b/tests/reference/asr-intrinsics_35-10733ec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_35-10733ec.stdout",
-    "stdout_hash": "a13a08e8b0b86a80e666ff42f3666c8e1bc2856b91bd480209b78c48",
+    "stdout_hash": "fb10e9b9cf1d4bb2287d182c00fb8b42c70fb012185414efd11d2429",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_35-10733ec.stdout
+++ b/tests/reference/asr-intrinsics_35-10733ec.stdout
@@ -301,7 +301,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )

--- a/tests/reference/asr-intrinsics_47-bdbe527.json
+++ b/tests/reference/asr-intrinsics_47-bdbe527.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_47-bdbe527.stdout",
-    "stdout_hash": "64f4a8279f76a11ac5cf56bf61ec2f197362399b59067f21868d69ac",
+    "stdout_hash": "c25ee83b1ec4de4a15cffe17ea3362f5773b1e82c79ed84924f3f80c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_47-bdbe527.stdout
+++ b/tests/reference/asr-intrinsics_47-bdbe527.stdout
@@ -95,7 +95,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )
@@ -127,7 +130,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )
@@ -159,7 +165,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )
@@ -191,7 +200,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )
@@ -245,7 +257,10 @@
                             )]
                             0
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
                         )
                         ()
                     )

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "1393719e50bce56e1bd76a2c31e3ea950c61c7416a7baac556a3bbd5",
+    "stdout_hash": "3e801815491ef4efd31e71387bf97afb0522708659904ca132cb9fc1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -8,11 +8,11 @@ source_filename = "LFortran"
 
 @0 = private unnamed_addr constant [1 x i8] zeroinitializer, align 1
 
-define i1 @any_4_1_0_logical____0(i1* %mask, i32* %__1mask, i32* %__2mask) {
+define i1 @Any_4_1_0_logical____0(i1* %mask, i32* %__1mask, i32* %__2mask) {
 .entry:
+  %Any_4_1_0 = alloca i1, align 1
   %__1_i = alloca i32, align 4
-  %any_4_1_0 = alloca i1, align 1
-  store i1 false, i1* %any_4_1_0, align 1
+  store i1 false, i1* %Any_4_1_0, align 1
   %0 = load i32, i32* %__1mask, align 4
   %1 = sub i32 %0, 1
   store i32 %1, i32* %__1_i, align 4
@@ -32,7 +32,7 @@ loop.body:                                        ; preds = %loop.head
   %9 = load i32, i32* %__1_i, align 4
   %10 = add i32 %9, 1
   store i32 %10, i32* %__1_i, align 4
-  %11 = load i1, i1* %any_4_1_0, align 1
+  %11 = load i1, i1* %Any_4_1_0, align 1
   %12 = load i32, i32* %__1_i, align 4
   %13 = load i32, i32* %__1mask, align 4
   %14 = load i32, i32* %__2mask, align 4
@@ -44,14 +44,14 @@ loop.body:                                        ; preds = %loop.head
   %20 = load i1, i1* %19, align 1
   %21 = icmp eq i1 %11, false
   %22 = select i1 %21, i1 %20, i1 %11
-  store i1 %22, i1* %any_4_1_0, align 1
+  store i1 %22, i1* %Any_4_1_0, align 1
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br label %return
 
 return:                                           ; preds = %loop.end
-  %23 = load i1, i1* %any_4_1_0, align 1
+  %23 = load i1, i1* %Any_4_1_0, align 1
   ret i1 %23
 }
 
@@ -140,7 +140,7 @@ loop.end:                                         ; preds = %ifcont8
   %25 = getelementptr [2 x i1], [2 x i1]* %__libasr__created__var__0__logicalnot_unary_op_res, i32 0, i32 0
   store i32 1, i32* %call_arg_value, align 4
   store i32 2, i32* %call_arg_value9, align 4
-  %26 = call i1 @any_4_1_0_logical____0(i1* %25, i32* %call_arg_value, i32* %call_arg_value9)
+  %26 = call i1 @Any_4_1_0_logical____0(i1* %25, i32* %call_arg_value, i32* %call_arg_value9)
   %27 = load i1, i1* %toomany, align 1
   %28 = load i1, i1* %test, align 1
   %29 = xor i1 %28, true


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3966