### PR TITLE
fix: allow "variable" as "iostat" and "iomsg" value

### DIFF
--- a/integration_tests/derived_types_36.f90
+++ b/integration_tests/derived_types_36.f90
@@ -31,6 +31,7 @@ program derived_types_36
     type(my_type) :: x
     integer :: iostat
     character(len=20) :: iomsg, tmp
+    character(len=20) :: arr_iomsg(2)
 
     x%a = "tmp234"
     tmp = "tmp1"
@@ -41,7 +42,7 @@ program derived_types_36
     close(10)
 
     open(10, form="formatted", file="derived_types_36_file.txt")
-    read(10, '(a)', iostat=iostat, iomsg=iomsg) tmp
+    read(10, '(a)', iostat=iostat, iomsg=arr_iomsg(1)) tmp
     close(10)
 
     print *, tmp

--- a/integration_tests/file_15.f90
+++ b/integration_tests/file_15.f90
@@ -1,10 +1,11 @@
 program file_15
     implicit none
     integer :: items(10), u = 10, i, n
+    integer :: ios(2)
 
     open(u, file='file_03_data.txt', action='read')
 
-    read(u, *)
+    read(u, *, iostat=ios(1))
     do i = 1, 10
         read(u, *) n
         items(i) = n
@@ -14,4 +15,5 @@ program file_15
 
     if (items(2) /= 102) error stop
     if (sum(items) /= 1055) error stop
+    if (ios(1) /= 0) error stop
 end program file_15

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -510,8 +510,13 @@ public:
                 this->visit_expr(*kwarg.m_value);
                 a_iostat = ASRUtils::EXPR(tmp);
                 ASR::ttype_t* a_iostat_type = ASRUtils::expr_type(a_iostat);
-                if( a_iostat->type != ASR::exprType::Var ||
-                    (!ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(a_iostat_type))) ) {
+                if (!ASRUtils::is_variable(a_iostat)) {
+                    throw SemanticError("Non-variable expression for `iostat`", loc);
+                }
+                if (ASRUtils::is_array(a_iostat_type)) {
+                    throw SemanticError("`iostat` must be scalar", loc);
+                }
+                if (!ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(a_iostat_type))) {
                         throw SemanticError("`iostat` must be of type, Integer", loc);
                 }
             } else if( m_arg_str == std::string("iomsg") ) {
@@ -522,10 +527,15 @@ public:
                 this->visit_expr(*kwarg.m_value);
                 a_iomsg = ASRUtils::EXPR(tmp);
                 ASR::ttype_t* a_iomsg_type = ASRUtils::expr_type(a_iomsg);
-                if( a_iomsg->type != ASR::exprType::Var ||
-                   (!ASR::is_a<ASR::Character_t>(*ASRUtils::type_get_past_pointer(a_iomsg_type))) ) {
-                        throw SemanticError("`iomsg` must be of type, Character", loc);
-                    }
+                if (!ASRUtils::is_variable(a_iomsg)) {
+                    throw SemanticError("Non-variable expression for `iomsg`", loc);
+                }
+                if (ASRUtils::is_array(a_iomsg_type)) {
+                    throw SemanticError("`iomsg` must be scalar", loc);
+                }
+                if (!ASR::is_a<ASR::Character_t>(*ASRUtils::type_get_past_pointer(a_iomsg_type))) {
+                    throw SemanticError("`iomsg` must be of type, Character", loc);
+                }
             } else if( m_arg_str == std::string("size") ) {
                 if( a_size != nullptr ) {
                     throw SemanticError(R"""(Duplicate value of `size` found, `size` has already been specified via arguments or keyword arguments)""",

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1013,12 +1013,8 @@ static inline bool is_variable(ASR::expr_t* a_value) {
             return array_var->m_storage != ASR::storage_typeType::Parameter;
         }
         case ASR::exprType::Var: {
-            ASR::Var_t* var_t = ASR::down_cast<ASR::Var_t>(a_value);
-            if (ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(var_t->m_v))) {
-                ASR::Variable_t* variable_t = ASRUtils::EXPR2VAR(var_t->m_v);
-                return variable_t->m_storage != ASR::storage_typeType::Parameter;
-            }
-            return true;
+            ASR::Variable_t* variable_t = ASRUtils::EXPR2VAR(a_value);
+            return variable_t->m_storage != ASR::storage_typeType::Parameter;
         }
         case ASR::exprType::StringItem:
         case ASR::exprType::StringSection:

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -985,20 +985,21 @@ static inline bool all_args_have_value(const Vec<ASR::expr_t*> &args) {
 }
 
 /*
-See section 9.2 Variable from J3 SD-007r1.pdf for what a "Variable" is
 
-Below is an example verbatim from the document.
-For example, given the declarations:
+This function determines if a given expression represents a variable according
+to the rules of Fortran variable definitions. Here's an illustration of declaration's:
 
+```fortran
+    CHARACTER(len=5) x, y(3)
+    INTEGER, PARAMETER :: i
+    TYPE (EMPLOYEE) e
+        INTEGER age
+    END TYPE EMPLOYEE
 ```
-    CHARACTER (10) A, B (10)
-    TYPE (PERSON) P ! See 7.5.2.1, NOTE
-```
 
-then A, B, B (1), B (1:5), P % AGE, and A (1:1) are all variables.
+then 'x', 'y', 'y(1)', 'y(1:2)', 'e % age' are all variables, while 'i' isn't
 
 TODO: this definitely needs some extensions to include others as "variable"'s
-
 */
 static inline bool is_variable(ASR::expr_t* a_value) {
     if (a_value == nullptr) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1015,8 +1015,7 @@ static inline bool is_variable(ASR::expr_t* a_value) {
         case ASR::exprType::Var: {
             ASR::Var_t* var_t = ASR::down_cast<ASR::Var_t>(a_value);
             if (ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(var_t->m_v))) {
-                ASR::Variable_t* variable_t = ASR::down_cast<ASR::Variable_t>(
-                    ASRUtils::symbol_get_past_external(var_t->m_v));
+                ASR::Variable_t* variable_t = ASRUtils::EXPR2VAR(var_t->m_v);
                 return variable_t->m_storage != ASR::storage_typeType::Parameter;
             }
             return true;

--- a/tests/errors/iostat_constant_integer.f90
+++ b/tests/errors/iostat_constant_integer.f90
@@ -1,10 +1,8 @@
 program iostat_constant_integer
     implicit none
-    integer :: u = 10
     integer, parameter :: ios = 1
+    character(len=100) :: buffer
+    buffer = 'Temporary date for testing purpose'
 
-    open(u, file='tmp.txt')
-
-    read(u, *, iostat=ios)
-    close(u)
+    read(buffer, *, iostat=ios)
 end program iostat_constant_integer

--- a/tests/errors/iostat_constant_integer.f90
+++ b/tests/errors/iostat_constant_integer.f90
@@ -1,0 +1,10 @@
+program iostat_constant_integer
+    implicit none
+    integer :: u = 10
+    integer, parameter :: ios = 1
+
+    open(u, file='tmp.txt')
+
+    read(u, *, iostat=ios)
+    close(u)
+end program iostat_constant_integer

--- a/tests/errors/iostat_non_scalar_value.f90
+++ b/tests/errors/iostat_non_scalar_value.f90
@@ -1,10 +1,8 @@
 program iostat_non_scalar_value
     implicit none
-    integer :: u = 10
-    integer :: ios(2)
+    integer :: ios(2) = 1
+    character(len=100) :: buffer
+    buffer = 'Temporary date for testing purpose'
 
-    open(u, file='tmp.txt')
-
-    read(u, *, iostat=ios(1:1))
-    close(u)
+    read(buffer, *, iostat=ios(1:1))
 end program iostat_non_scalar_value

--- a/tests/errors/iostat_non_scalar_value.f90
+++ b/tests/errors/iostat_non_scalar_value.f90
@@ -1,0 +1,10 @@
+program iostat_non_scalar_value
+    implicit none
+    integer :: u = 10
+    integer :: ios(2)
+
+    open(u, file='tmp.txt')
+
+    read(u, *, iostat=ios(1:1))
+    close(u)
+end program iostat_non_scalar_value

--- a/tests/reference/asr-iostat_constant_integer-4f6f5d4.json
+++ b/tests/reference/asr-iostat_constant_integer-4f6f5d4.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-iostat_constant_integer-4f6f5d4",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/iostat_constant_integer.f90",
+    "infile_hash": "7b90926785fd675bb789ae213025b796288a478e3b18c36f9ad3cbd7",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-iostat_constant_integer-4f6f5d4.stderr",
+    "stderr_hash": "7af322c18ac324e114aa4ec898903e61105fa53f7f08660e3d45444b",
+    "returncode": 2
+}

--- a/tests/reference/asr-iostat_constant_integer-4f6f5d4.json
+++ b/tests/reference/asr-iostat_constant_integer-4f6f5d4.json
@@ -2,12 +2,12 @@
     "basename": "asr-iostat_constant_integer-4f6f5d4",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/iostat_constant_integer.f90",
-    "infile_hash": "7b90926785fd675bb789ae213025b796288a478e3b18c36f9ad3cbd7",
+    "infile_hash": "75139205f9e51e237d4b413809a7001dd54192e2c243a3523c0236a5",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-iostat_constant_integer-4f6f5d4.stderr",
-    "stderr_hash": "7af322c18ac324e114aa4ec898903e61105fa53f7f08660e3d45444b",
+    "stderr_hash": "ac3a5c6e466d47baa24ef5636670716a1804de34604e5dccba05b530",
     "returncode": 2
 }

--- a/tests/reference/asr-iostat_constant_integer-4f6f5d4.stderr
+++ b/tests/reference/asr-iostat_constant_integer-4f6f5d4.stderr
@@ -1,0 +1,5 @@
+semantic error: Non-variable expression for `iostat`
+ --> tests/errors/iostat_constant_integer.f90:8:5
+  |
+8 |     read(u, *, iostat=ios)
+  |     ^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-iostat_constant_integer-4f6f5d4.stderr
+++ b/tests/reference/asr-iostat_constant_integer-4f6f5d4.stderr
@@ -1,5 +1,5 @@
 semantic error: Non-variable expression for `iostat`
- --> tests/errors/iostat_constant_integer.f90:8:5
+ --> tests/errors/iostat_constant_integer.f90:7:5
   |
-8 |     read(u, *, iostat=ios)
-  |     ^^^^^^^^^^^^^^^^^^^^^^ 
+7 |     read(buffer, *, iostat=ios)
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-iostat_non_scalar_value-7d45a6f.json
+++ b/tests/reference/asr-iostat_non_scalar_value-7d45a6f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-iostat_non_scalar_value-7d45a6f",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/iostat_non_scalar_value.f90",
+    "infile_hash": "88c34f6424d28bdb1f5e1fdc5c30b7666e1131e29262d992a4047759",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-iostat_non_scalar_value-7d45a6f.stderr",
+    "stderr_hash": "2d94f2c232ece147eb91aae66003885e5210ce5c9b085634ac7867d0",
+    "returncode": 2
+}

--- a/tests/reference/asr-iostat_non_scalar_value-7d45a6f.json
+++ b/tests/reference/asr-iostat_non_scalar_value-7d45a6f.json
@@ -2,12 +2,12 @@
     "basename": "asr-iostat_non_scalar_value-7d45a6f",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/iostat_non_scalar_value.f90",
-    "infile_hash": "88c34f6424d28bdb1f5e1fdc5c30b7666e1131e29262d992a4047759",
+    "infile_hash": "23f916f0f858452d7da668a9c4d49311f4b09b4eb80d4157d9c79411",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-iostat_non_scalar_value-7d45a6f.stderr",
-    "stderr_hash": "2d94f2c232ece147eb91aae66003885e5210ce5c9b085634ac7867d0",
+    "stderr_hash": "1182d0e11afef20a9ffdc0f982544fb3647c2d72ddd8bea1ac20caec",
     "returncode": 2
 }

--- a/tests/reference/asr-iostat_non_scalar_value-7d45a6f.stderr
+++ b/tests/reference/asr-iostat_non_scalar_value-7d45a6f.stderr
@@ -1,5 +1,5 @@
 semantic error: `iostat` must be scalar
- --> tests/errors/iostat_non_scalar_value.f90:8:5
+ --> tests/errors/iostat_non_scalar_value.f90:7:5
   |
-8 |     read(u, *, iostat=ios(1:1))
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+7 |     read(buffer, *, iostat=ios(1:1))
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-iostat_non_scalar_value-7d45a6f.stderr
+++ b/tests/reference/asr-iostat_non_scalar_value-7d45a6f.stderr
@@ -1,0 +1,5 @@
+semantic error: `iostat` must be scalar
+ --> tests/errors/iostat_non_scalar_value.f90:8:5
+  |
+8 |     read(u, *, iostat=ios(1:1))
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3916,5 +3916,13 @@ filename = "errors/atomic_01.f90"
 asr = true
 
 [[test]]
+filename = "errors/iostat_non_scalar_value.f90"
+asr = true
+
+[[test]]
+filename = "errors/iostat_constant_integer.f90"
+asr = true
+
+[[test]]
 filename = "character_parameter_padding_trimming.f90"
 asr = true


### PR DESCRIPTION
"variable" is as defined in the 2023 FORTRAN documentation as (R907)

Fixes #3947