### PR TITLE
Fix: handle initialisation of Intrinsic elemental functions to compile time constant

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -763,6 +763,7 @@ RUN(NAME intrinsics_214 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sind
 RUN(NAME intrinsics_215 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # cosd
 RUN(NAME intrinsics_216 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # tand
 RUN(NAME intrinsics_217 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # all
+RUN(NAME intrinsics_219 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_219.f90
+++ b/integration_tests/intrinsics_219.f90
@@ -1,0 +1,4 @@
+program intrinsics_219
+    integer :: x = sum([1, 2, 3])
+    if (x /= 6) error stop
+end

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3037,7 +3037,11 @@ public:
                                 }
                             } else if ( ASR::is_a<ASR::ArrayConstructor_t>(*init_expr) ||
                                 ( ASR::is_a<ASR::Cast_t>(*init_expr) &&
-                                ASR::is_a<ASR::ArrayConstructor_t>(*ASR::down_cast<ASR::Cast_t>(init_expr)->m_arg) ) ) {
+                                ASR::is_a<ASR::ArrayConstructor_t>(*ASR::down_cast<ASR::Cast_t>(init_expr)->m_arg) )
+                                || ASR::is_a<ASR::IntrinsicElementalFunction_t>(*init_expr) ||
+                                ASR::is_a<ASR::IntrinsicArrayFunction_t>(*init_expr) || 
+                                ASR::is_a<ASR::TypeInquiry_t>(*init_expr) ||
+                                ASR::is_a<ASR::StringLen_t>(*init_expr) ) {
                                 value = init_expr;
                             } else {
                                 throw SemanticError("Initialization of `" + std::string(x.m_syms[i].m_name) +


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/3860#issuecomment-2051719754
