### PR TITLE
Fix: fix `len` function for intrinsic elemental function as input argument

### DIFF
--- a/integration_tests/intrinsics_104.f90
+++ b/integration_tests/intrinsics_104.f90
@@ -1,9 +1,13 @@
 program intrinsics_104
-implicit none
-
-integer, parameter :: new_len = len(new_line('a'))
-
-print *, new_len
-if (new_len /= 1) error stop
-
+    implicit none
+    
+    integer, parameter :: new_len = len(new_line('a'))
+    integer, parameter :: new_len2 = len(adjustl('a'))
+    
+    print *, new_len
+    if (new_len /= 1) error stop
+    
+    print*, new_len2
+    if (new_len2 /= 1) error stop
+    
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3087,6 +3087,9 @@ public:
                             if (ASRUtils::is_dimension_empty(dims.p, dims.n)) {
                                 type = a->m_type;
                             }
+                        } if (ASR::is_a<ASR::StringLen_t>(*value)) {
+                            ASR::StringLen_t *a = ASR::down_cast<ASR::StringLen_t>(value);
+                            value = a->m_value;
                         }
                     } else {
                         implicit_save = true;
@@ -4925,7 +4928,11 @@ public:
             len_compiletime = make_ConstantWithType(
                 make_IntegerConstant_t, input_string.size(), type, x.base.base.loc);
         }
-
+        ASR::expr_t* value = ASRUtils::expr_value(v_Var);
+        if (value && ASR::is_a<ASR::StringConstant_t>(*value)) {
+            len_compiletime = make_ConstantWithType(
+                make_IntegerConstant_t, strlen(ASR::down_cast<ASR::StringConstant_t>(value)->m_s), type, x.base.base.loc);
+        }
         return ASR::make_StringLen_t(al, x.base.base.loc, v_Var, type, len_compiletime);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3860