### PR TITLE
fix: use "to_lower" when resolving symbol in SelectType

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1537,3 +1537,5 @@ RUN(NAME types_real_array_to_complex_array_cast LABELS gfortran llvm llvm_wasm l
 RUN(NAME lbound_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME module_function_with_nopass LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME module_function_without_nopass LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
+RUN(NAME polymorphic_argument LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/polymorphic_argument.f90
+++ b/integration_tests/polymorphic_argument.f90
@@ -1,0 +1,26 @@
+program polymorphic_argument
+    implicit none
+
+    type :: MyStruct
+        integer :: intMember
+        real :: realMember
+    end type MyStruct
+
+    type(MyStruct) :: structInstance
+
+    call unused_dummy_argument(structInstance)
+
+    contains
+
+    subroutine unused_dummy_argument(dummy)
+        class(*), intent(in) :: dummy
+
+        select type(dummy)
+            type is (MyStruct)
+                print *, "Hello world"
+            class default
+                print *, "Surprise!!"
+        end select
+    end subroutine
+
+end program polymorphic_argument

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1321,7 +1321,7 @@ public:
             switch( x.m_body[i]->type ) {
                 case AST::type_stmtType::ClassStmt: {
                     AST::ClassStmt_t* class_stmt = AST::down_cast<AST::ClassStmt_t>(x.m_body[i]);
-                    ASR::symbol_t* sym = current_scope->resolve_symbol(std::string(class_stmt->m_id));
+                    ASR::symbol_t* sym = current_scope->resolve_symbol(to_lower(std::string(class_stmt->m_id)));
                     if( assoc_variable ) {
                         ASR::ttype_t* selector_type = nullptr;
                         ASR::symbol_t* sym_underlying = ASRUtils::symbol_get_past_external(sym);
@@ -1367,7 +1367,7 @@ public:
                 }
                 case AST::type_stmtType::TypeStmtName: {
                     AST::TypeStmtName_t* type_stmt_name = AST::down_cast<AST::TypeStmtName_t>(x.m_body[i]);
-                    ASR::symbol_t* sym = current_scope->resolve_symbol(std::string(type_stmt_name->m_name));
+                    ASR::symbol_t* sym = current_scope->resolve_symbol(to_lower(std::string(type_stmt_name->m_name)));
                     if( assoc_variable ) {
                         ASR::ttype_t* selector_type = nullptr;
                         ASR::symbol_t* sym_underlying = ASRUtils::symbol_get_past_external(sym);


### PR DESCRIPTION
Simple fix to ensure that when resolving symbol we use "to_lower" in SelectType.

I'm naming the file as `polymorphic_arg`, as I intend to used the test file to include test cases for issues like https://github.com/lfortran/lfortran/issues/3677 (which I've been working on)

I wonder if we there is a good reason to keep everything in the user-provided case (and not convert it to lower case, maybe while parsing itself), is the reason that it will make the parser slow?