### PR TITLE
Throw error when length of argument `c` to `ichar` and `iachar` is not one

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5104,6 +5104,9 @@ public:
             std::string arg_str;
             bool is_const_value = ASRUtils::is_value_constant(arg_value, arg_str);
             if( is_const_value ) {
+                if (arg_str.length() != 1) {
+                    throw SemanticError("Argument to Ichar must be of length one", arg->base.loc);
+                }
                 int64_t ascii_code = arg_str[0];
                 ichar_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc,
                                 ascii_code, type));
@@ -5125,6 +5128,9 @@ public:
             std::string arg_str;
             bool is_const_value = ASRUtils::is_value_constant(arg_value, arg_str);
             if( is_const_value ) {
+                if (arg_str.length() != 1) {
+                    throw SemanticError("Argument to Iachar must be of length one", arg->base.loc);
+                }
                 int64_t ascii_code = uint8_t(arg_str[0]);
                 iachar_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc,
                                 ascii_code, type));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1370,6 +1370,19 @@ public:
         }
         this->visit_expr_wrapper(x.m_arg, true);
         llvm::Value *c = tmp;
+
+        llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+        builder->CreateStore(tmp, parg);
+        llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
+        llvm_utils->create_if_else(is_len_not_one, [&]() {
+            llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: Argument to Ichar must be of length one\n");
+                print_error(context, *module, *builder, {fmt_ptr});
+            int exit_code_int = 1;
+            llvm::Value *exit_code = llvm::ConstantInt::get(context,
+                    llvm::APInt(32, exit_code_int));
+            exit(context, *module, *builder, exit_code);
+        },
+        []() {});
         std::string runtime_func_name = "_lfortran_ichar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {
@@ -1393,6 +1406,19 @@ public:
         this->visit_expr(*x.m_arg);
         ptr_loads = ptr_loads_copy;
         llvm::Value *c = tmp;
+
+        llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+        builder->CreateStore(tmp, parg);
+        llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
+        llvm_utils->create_if_else(is_len_not_one, [&]() {
+            llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: Argument to Iachar must be of length one\n");
+                print_error(context, *module, *builder, {fmt_ptr});
+            int exit_code_int = 1;
+            llvm::Value *exit_code = llvm::ConstantInt::get(context,
+                    llvm::APInt(32, exit_code_int));
+            exit(context, *module, *builder, exit_code);
+        },
+        []() {});
         std::string runtime_func_name = "_lfortran_iachar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3858,8 +3858,7 @@ namespace Ichar {
         auto itr = declare("i", int32, Local);
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
-            ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-            ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -1, nullptr)), nullptr)), int32, nullptr)),
+            ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, args[0], int32, nullptr)),
             return_type)));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,

--- a/tests/errors/iachar_arg_len_compiletime.f90
+++ b/tests/errors/iachar_arg_len_compiletime.f90
@@ -1,0 +1,4 @@
+program main
+   print*, iachar("Hello")
+end
+

--- a/tests/errors/iachar_arg_len_runtime.f90
+++ b/tests/errors/iachar_arg_len_runtime.f90
@@ -1,0 +1,5 @@
+program main
+   character(5):: x = "Hello"
+   print*, iachar(x)
+end
+

--- a/tests/errors/ichar_arg_len_compiletime.f90
+++ b/tests/errors/ichar_arg_len_compiletime.f90
@@ -1,0 +1,5 @@
+program main
+   print*, ichar("Hello")
+end
+
+

--- a/tests/errors/ichar_arg_len_runtime.f90
+++ b/tests/errors/ichar_arg_len_runtime.f90
@@ -1,0 +1,6 @@
+program main
+   character(5):: x = "Hello"
+   print*, ichar(x)
+end
+
+

--- a/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.json
+++ b/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-iachar_arg_len_compiletime-1ecf087",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/iachar_arg_len_compiletime.f90",
+    "infile_hash": "17664eaa7222de57ec18bd7594c49acc3768417a5d75b461cd5756bc",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-iachar_arg_len_compiletime-1ecf087.stderr",
+    "stderr_hash": "9dbe530b41b246b65245b186bba7e2cf5955ed2ef024480a2b5e2fb8",
+    "returncode": 2
+}

--- a/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.stderr
+++ b/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.stderr
@@ -1,0 +1,5 @@
+semantic error: Argument to Iachar must be of length one
+ --> tests/errors/iachar_arg_len_compiletime.f90:2:19
+  |
+2 |    print*, iachar("Hello")
+  |                   ^^^^^^^ 

--- a/tests/reference/asr-ichar_arg_len_compiletime-55503f1.json
+++ b/tests/reference/asr-ichar_arg_len_compiletime-55503f1.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-ichar_arg_len_compiletime-55503f1",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/ichar_arg_len_compiletime.f90",
+    "infile_hash": "327f18ab0e29ef4f059faa3ac9d1846bafe288d8cf4b1cf01874f1ed",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-ichar_arg_len_compiletime-55503f1.stdout",
+    "stdout_hash": "cf0c177fe7410b50ba9f57cdab5575fdbef7e0004e27d9027423cf5b",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-ichar_arg_len_compiletime-55503f1.stdout
+++ b/tests/reference/asr-ichar_arg_len_compiletime-55503f1.stdout
@@ -1,0 +1,31 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            main:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            
+                        })
+                    main
+                    []
+                    [(Print
+                        [(IntrinsicElementalFunction
+                            Ichar
+                            [(StringConstant
+                                "Hello"
+                                (Character 1 5 ())
+                            )]
+                            0
+                            (Integer 4)
+                            (IntegerConstant 72 (Integer 4))
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/run-iachar_arg_len_runtime-9020e30.json
+++ b/tests/reference/run-iachar_arg_len_runtime-9020e30.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-iachar_arg_len_runtime-9020e30",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/iachar_arg_len_runtime.f90",
+    "infile_hash": "3689b2410275bca4f8b3d3c3c0e593f35bd18db2d00b78e32dd0e372",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-iachar_arg_len_runtime-9020e30.stderr",
+    "stderr_hash": "168f1aa3d97740754b794f3cd253cdef0c535dfb1ffcf6f9fd33b01c",
+    "returncode": 1
+}

--- a/tests/reference/run-iachar_arg_len_runtime-9020e30.stderr
+++ b/tests/reference/run-iachar_arg_len_runtime-9020e30.stderr
@@ -1,0 +1,1 @@
+Error: Argument to Iachar must be of length one

--- a/tests/reference/run-ichar_arg_len_runtime-be43591.json
+++ b/tests/reference/run-ichar_arg_len_runtime-be43591.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-ichar_arg_len_runtime-be43591",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/ichar_arg_len_runtime.f90",
+    "infile_hash": "551ca1f9a9d3ed04290e0498fc5c44d2d5f8f572d05b24e5a10e2691",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-ichar_arg_len_runtime-be43591.stderr",
+    "stderr_hash": "b63ba29397f882b86c2824b0e4f1c26c7239bc2b355f3b4e3f5a4674",
+    "returncode": 1
+}

--- a/tests/reference/run-ichar_arg_len_runtime-be43591.stderr
+++ b/tests/reference/run-ichar_arg_len_runtime-be43591.stderr
@@ -1,0 +1,1 @@
+Error: Argument to Ichar must be of length one

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3925,5 +3925,21 @@ filename = "errors/iostat_constant_integer.f90"
 asr = true
 
 [[test]]
+filename = "errors/ichar_arg_len_runtime.f90"
+run = true
+
+[[test]]
+filename = "errors/ichar_arg_len_compiletime.f90"
+asr = true
+
+[[test]]
+filename = "errors/iachar_arg_len_runtime.f90"
+run = true
+
+[[test]]
+filename = "errors/iachar_arg_len_compiletime.f90"
+asr = true
+
+[[test]]
 filename = "character_parameter_padding_trimming.f90"
 asr = true


### PR DESCRIPTION
fixes #3734 

### Compile-time
```fortran
program main
   print*, iachar("Hello")
end
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
semantic error: Argument to Iachar must be of length one
 --> ./examples/example.f90:2:19
  |
2 |    print*, iachar("Hello")
  |                   ^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

### Run-time
```fortran
program main
   character(5):: x = "Hello"
   print*, iachar(x)
end
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
Error: Argument to Iachar must be of length one
```

### TODO

- [ ] Handle compile-time argument verification for `ichar`.