### PR TITLE
enh: add support for `c_funptr` and `c_funloc`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -866,7 +866,7 @@ RUN(NAME bindc3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc_01 LABELS gfortran llvm EXTRAFILES bindc_01b.f90 bindc_01c.c NOFAST)
 RUN(NAME bindc_02 LABELS gfortran llvm EXTRAFILES bindc_02b.f90 bindc_02c.c NOFAST)
-RUN(NAME bindc_03 LABELS gfortran llvm EXTRAFILES bindc_03c.c)
+RUN(NAME bindc_03 LABELS gfortran llvm EXTRAFILES bindc_03c.c NOFAST)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -866,6 +866,7 @@ RUN(NAME bindc3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc_01 LABELS gfortran llvm EXTRAFILES bindc_01b.f90 bindc_01c.c NOFAST)
 RUN(NAME bindc_02 LABELS gfortran llvm EXTRAFILES bindc_02b.f90 bindc_02c.c NOFAST)
+RUN(NAME bindc_03 LABELS gfortran llvm EXTRAFILES bindc_03c.c)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/bindc_03.f90
+++ b/integration_tests/bindc_03.f90
@@ -1,0 +1,38 @@
+subroutine fn() bind(c)
+print *, "Hello from fn in fortran"
+end subroutine
+
+subroutine test_val( val ) bind(c)
+use iso_c_binding
+integer(c_int), value :: val
+print *, "val = ", val
+if ( val /= 42 ) error stop
+end subroutine
+
+program bindc_03
+use iso_c_binding
+implicit none
+interface
+subroutine fn() bind(c)
+end subroutine
+
+subroutine test_val( val ) bind(c)
+import :: c_int
+integer(c_int), value :: val
+end subroutine
+
+subroutine execute_function( fn ) bind(c, name = "execute_function")
+import :: c_funptr
+type(c_funptr), value :: fn
+end subroutine
+
+subroutine execute_function_with_arg( fn, val ) bind(c, name = "execute_function_with_arg")
+import :: c_funptr, c_int
+integer(c_int), value :: val
+type(c_funptr), value :: fn
+end subroutine
+end interface
+
+call execute_function( c_funloc( fn ) )
+call execute_function_with_arg( c_funloc( test_val ), 42 )
+end program

--- a/integration_tests/bindc_03c.c
+++ b/integration_tests/bindc_03c.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+
+void execute_function( void (*func)() ) {
+    printf("Executing function in C\n");
+    func();
+}
+
+void execute_function_with_arg( void (*func)(int *), int* arg ) {
+    printf("Executing function with arg in C\n");
+    func(arg);
+}

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -903,7 +903,7 @@ public:
     IntrinsicProcedures intrinsic_procedures;
     IntrinsicProceduresAsASRNodes intrinsic_procedures_as_asr_nodes;
     std::set<std::string> intrinsic_module_procedures_as_asr_nodes = {
-        "c_loc", "c_f_pointer", "c_associated"
+        "c_loc", "c_f_pointer", "c_associated", "c_funloc"
     };
 
     ASR::accessType dflt_access = ASR::Public;
@@ -3368,6 +3368,8 @@ public:
                 type = ASRUtils::make_Array_t_util(
                     al, loc, type, dims.p, dims.size(), abi, is_argument);
             } else if (v && ASRUtils::is_c_ptr(v, derived_type_name)) {
+                type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
+            } else if (v && ASRUtils::is_c_funptr(v, derived_type_name)) {
                 type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
             } else {
                 if (!v) {
@@ -6471,6 +6473,8 @@ public:
                         tmp = create_PointerToCptr(x);
                     } else if (var_name == "c_associated") {
                         tmp = create_Associated(x);
+                    } else if (var_name == "c_funloc") {
+                        tmp = create_PointerToCptr(x);
                     } else {
                         LCOMPILERS_ASSERT(false)
                     }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -921,6 +921,21 @@ static inline bool is_c_ptr(ASR::symbol_t* v, std::string v_name="") {
     return false;
 }
 
+static inline bool is_c_funptr(ASR::symbol_t* v, std::string v_name="") {
+    if( v_name == "" ) {
+        v_name = ASRUtils::symbol_name(v);
+    }
+    ASR::symbol_t* v_orig = ASRUtils::symbol_get_past_external(v);
+    if( ASR::is_a<ASR::StructType_t>(*v_orig) ) {
+        ASR::Module_t* der_type_module = ASRUtils::get_sym_module0(v_orig);
+        return (der_type_module && std::string(der_type_module->m_name) ==
+                "lfortran_intrinsic_iso_c_binding" &&
+                der_type_module->m_intrinsic &&
+                v_name == "c_funptr");
+    }
+    return false;
+}
+
 // Returns true if the Function is intrinsic, otherwise false
 template <typename T>
 static inline bool is_intrinsic_procedure(const T *fn) {

--- a/src/runtime/pure/lfortran_intrinsic_iso_c_binding.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_c_binding.f90
@@ -5,6 +5,10 @@ type :: c_ptr
     integer ptr
 end type
 
+type :: c_funptr
+    integer ptr
+end type
+
 integer, parameter :: c_int8_t = 1
 integer, parameter :: c_int16_t = 2
 integer, parameter :: c_int32_t = 4
@@ -42,6 +46,13 @@ interface
     !type(c_ptr) function c_loc(x)
     integer function c_loc(x)
     import c_ptr
+    !type(*), intent(in) :: x
+    integer, intent(in) :: x
+    end function
+
+    !type(c_funptr) function c_funloc(x)
+    integer function c_funloc(x)
+    import c_funptr
     !type(*), intent(in) :: x
     integer, intent(in) :: x
     end function

--- a/tests/reference/asr-array12-cb81afc.json
+++ b/tests/reference/asr-array12-cb81afc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array12-cb81afc.stdout",
-    "stdout_hash": "d8eab26f79bcab17935ad788fa86e2a055d28050e34372207f3da9de",
+    "stdout_hash": "99c43db63496355cd762ce814336bad44bd4b83740236de920fc6cbd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array12-cb81afc.stdout
+++ b/tests/reference/asr-array12-cb81afc.stdout
@@ -50,11 +50,11 @@
                             get_current_directory:
                                 (Function
                                     (SymbolTable
-                                        10
+                                        12
                                         {
                                             buffersize:
                                                 (Variable
-                                                    10
+                                                    12
                                                     buffersize
                                                     []
                                                     Local
@@ -70,7 +70,7 @@
                                                 ),
                                             cpath:
                                                 (Variable
-                                                    10
+                                                    12
                                                     cpath
                                                     []
                                                     Local
@@ -93,7 +93,7 @@
                                                 ),
                                             path:
                                                 (Variable
-                                                    10
+                                                    12
                                                     path
                                                     []
                                                     Out
@@ -111,7 +111,7 @@
                                                 ),
                                             tmp:
                                                 (Variable
-                                                    10
+                                                    12
                                                     tmp
                                                     []
                                                     Local
@@ -144,9 +144,9 @@
                                         .false.
                                     )
                                     [getcwd]
-                                    [(Var 10 path)]
+                                    [(Var 12 path)]
                                     [(Allocate
-                                        [((Var 10 cpath)
+                                        [((Var 12 cpath)
                                         [((IntegerConstant 1 (Integer 4))
                                         (IntegerConstant 1000 (Integer 4)))]
                                         ()
@@ -156,12 +156,12 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 10 tmp)
+                                        (Var 12 tmp)
                                         (FunctionCall
                                             2 getcwd
                                             ()
-                                            [((Var 10 cpath))
-                                            ((Var 10 buffersize))]
+                                            [((Var 12 cpath))
+                                            ((Var 12 buffersize))]
                                             (CPtr)
                                             ()
                                             ()
@@ -170,7 +170,7 @@
                                     )
                                     (If
                                         (PointerAssociated
-                                            (Var 10 tmp)
+                                            (Var 12 tmp)
                                             ()
                                             (Logical 4)
                                             ()
@@ -180,14 +180,14 @@
                                                 "PWD: "
                                                 (Character 1 5 ())
                                             )
-                                            (Var 10 tmp)]
+                                            (Var 12 tmp)]
                                             ()
                                             ()
                                         )]
                                         []
                                     )
                                     (ImplicitDeallocate
-                                        [(Var 10 cpath)]
+                                        [(Var 12 cpath)]
                                     )]
                                     ()
                                     Public
@@ -198,11 +198,11 @@
                             getcwd:
                                 (Function
                                     (SymbolTable
-                                        9
+                                        11
                                         {
                                             buf:
                                                 (Variable
-                                                    9
+                                                    11
                                                     buf
                                                     []
                                                     In
@@ -218,7 +218,7 @@
                                                 ),
                                             bufsize:
                                                 (Variable
-                                                    9
+                                                    11
                                                     bufsize
                                                     []
                                                     In
@@ -234,7 +234,7 @@
                                                 ),
                                             path:
                                                 (Variable
-                                                    9
+                                                    11
                                                     path
                                                     []
                                                     ReturnVar
@@ -266,10 +266,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 9 buf)
-                                    (Var 9 bufsize)]
+                                    [(Var 11 buf)
+                                    (Var 11 bufsize)]
                                     []
-                                    (Var 9 path)
+                                    (Var 11 path)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-c_ptr_02-fce1b0e.json
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-c_ptr_02-fce1b0e.stdout",
-    "stdout_hash": "ae14069dc9865136aee1984136c8484e692092b3fbc02a76fe5f843d",
+    "stdout_hash": "a08b9fef1101cd5a58136d5b9730259975b79c9388795c7b58ed4efa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-c_ptr_02-fce1b0e.stdout
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.stdout
@@ -110,6 +110,26 @@
                                     c_float_complex
                                     Public
                                 ),
+                            c_funloc:
+                                (ExternalSymbol
+                                    2
+                                    c_funloc
+                                    4 c_funloc
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_funloc
+                                    Public
+                                ),
+                            c_funptr:
+                                (ExternalSymbol
+                                    2
+                                    c_funptr
+                                    4 c_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_funptr
+                                    Public
+                                ),
                             c_int:
                                 (ExternalSymbol
                                     2

--- a/tests/reference/asr-modules_15b-09f8335.json
+++ b/tests/reference/asr-modules_15b-09f8335.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_15b-09f8335.stdout",
-    "stdout_hash": "74b5df9667cb0cb0df9f39da64afa07a87f3ad6c109cdd293f23a944",
+    "stdout_hash": "b43e5ba8d2e8f2881375fb1012445154fbf5dd0e5a0259b2823d88fd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_15b-09f8335.stdout
+++ b/tests/reference/asr-modules_15b-09f8335.stdout
@@ -112,11 +112,11 @@
                             call_fortran_f32:
                                 (Function
                                     (SymbolTable
-                                        47
+                                        49
                                         {
                                             i:
                                                 (Variable
-                                                    47
+                                                    49
                                                     i
                                                     []
                                                     In
@@ -132,7 +132,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    47
+                                                    49
                                                     r
                                                     []
                                                     ReturnVar
@@ -163,9 +163,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 47 i)]
+                                    [(Var 49 i)]
                                     []
-                                    (Var 47 r)
+                                    (Var 49 r)
                                     Public
                                     .false.
                                     .false.
@@ -174,11 +174,11 @@
                             call_fortran_f32_value:
                                 (Function
                                     (SymbolTable
-                                        48
+                                        50
                                         {
                                             i:
                                                 (Variable
-                                                    48
+                                                    50
                                                     i
                                                     []
                                                     In
@@ -194,7 +194,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    48
+                                                    50
                                                     r
                                                     []
                                                     ReturnVar
@@ -225,9 +225,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 48 i)]
+                                    [(Var 50 i)]
                                     []
-                                    (Var 48 r)
+                                    (Var 50 r)
                                     Public
                                     .false.
                                     .false.
@@ -236,11 +236,11 @@
                             call_fortran_f64:
                                 (Function
                                     (SymbolTable
-                                        49
+                                        51
                                         {
                                             i:
                                                 (Variable
-                                                    49
+                                                    51
                                                     i
                                                     []
                                                     In
@@ -256,7 +256,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    49
+                                                    51
                                                     r
                                                     []
                                                     ReturnVar
@@ -287,9 +287,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 49 i)]
+                                    [(Var 51 i)]
                                     []
-                                    (Var 49 r)
+                                    (Var 51 r)
                                     Public
                                     .false.
                                     .false.
@@ -298,11 +298,11 @@
                             call_fortran_f64_value:
                                 (Function
                                     (SymbolTable
-                                        50
+                                        52
                                         {
                                             i:
                                                 (Variable
-                                                    50
+                                                    52
                                                     i
                                                     []
                                                     In
@@ -318,7 +318,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    50
+                                                    52
                                                     r
                                                     []
                                                     ReturnVar
@@ -349,139 +349,15 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 50 i)]
+                                    [(Var 52 i)]
                                     []
-                                    (Var 50 r)
+                                    (Var 52 r)
                                     Public
                                     .false.
                                     .false.
                                     ()
                                 ),
                             call_fortran_i32:
-                                (Function
-                                    (SymbolTable
-                                        41
-                                        {
-                                            i:
-                                                (Variable
-                                                    41
-                                                    i
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .true.
-                                                ),
-                                            r:
-                                                (Variable
-                                                    41
-                                                    r
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    call_fortran_i32
-                                    (FunctionType
-                                        [(Integer 4)]
-                                        (Integer 4)
-                                        BindC
-                                        Interface
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    []
-                                    [(Var 41 i)]
-                                    []
-                                    (Var 41 r)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            call_fortran_i32_value:
-                                (Function
-                                    (SymbolTable
-                                        42
-                                        {
-                                            i:
-                                                (Variable
-                                                    42
-                                                    i
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .true.
-                                                ),
-                                            r:
-                                                (Variable
-                                                    42
-                                                    r
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    call_fortran_i32_value
-                                    (FunctionType
-                                        [(Integer 4)]
-                                        (Integer 4)
-                                        BindC
-                                        Interface
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    []
-                                    [(Var 42 i)]
-                                    []
-                                    (Var 42 r)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            call_fortran_i32_value2:
                                 (Function
                                     (SymbolTable
                                         43
@@ -519,13 +395,13 @@
                                                     .false.
                                                 )
                                         })
-                                    call_fortran_i32_value2
+                                    call_fortran_i32
                                     (FunctionType
                                         [(Integer 4)]
                                         (Integer 4)
                                         BindC
                                         Interface
-                                        "call_fortran_i32_value"
+                                        ()
                                         .false.
                                         .false.
                                         .false.
@@ -543,7 +419,7 @@
                                     .false.
                                     ()
                                 ),
-                            call_fortran_i64:
+                            call_fortran_i32_value:
                                 (Function
                                     (SymbolTable
                                         44
@@ -557,7 +433,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Integer 8)
+                                                    (Integer 4)
                                                     ()
                                                     BindC
                                                     Public
@@ -573,7 +449,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Integer 8)
+                                                    (Integer 4)
                                                     ()
                                                     BindC
                                                     Public
@@ -581,10 +457,10 @@
                                                     .false.
                                                 )
                                         })
-                                    call_fortran_i64
+                                    call_fortran_i32_value
                                     (FunctionType
-                                        [(Integer 8)]
-                                        (Integer 8)
+                                        [(Integer 4)]
+                                        (Integer 4)
                                         BindC
                                         Interface
                                         ()
@@ -605,7 +481,7 @@
                                     .false.
                                     ()
                                 ),
-                            call_fortran_i64_value:
+                            call_fortran_i32_value2:
                                 (Function
                                     (SymbolTable
                                         45
@@ -619,7 +495,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Integer 8)
+                                                    (Integer 4)
                                                     ()
                                                     BindC
                                                     Public
@@ -635,7 +511,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Integer 8)
+                                                    (Integer 4)
                                                     ()
                                                     BindC
                                                     Public
@@ -643,13 +519,13 @@
                                                     .false.
                                                 )
                                         })
-                                    call_fortran_i64_value
+                                    call_fortran_i32_value2
                                     (FunctionType
-                                        [(Integer 8)]
-                                        (Integer 8)
+                                        [(Integer 4)]
+                                        (Integer 4)
                                         BindC
                                         Interface
-                                        ()
+                                        "call_fortran_i32_value"
                                         .false.
                                         .false.
                                         .false.
@@ -667,7 +543,7 @@
                                     .false.
                                     ()
                                 ),
-                            call_fortran_i64_value2:
+                            call_fortran_i64:
                                 (Function
                                     (SymbolTable
                                         46
@@ -705,13 +581,13 @@
                                                     .false.
                                                 )
                                         })
-                                    call_fortran_i64_value2
+                                    call_fortran_i64
                                     (FunctionType
                                         [(Integer 8)]
                                         (Integer 8)
                                         BindC
                                         Interface
-                                        "call_fortran_i64_value"
+                                        ()
                                         .false.
                                         .false.
                                         .false.
@@ -729,14 +605,138 @@
                                     .false.
                                     ()
                                 ),
+                            call_fortran_i64_value:
+                                (Function
+                                    (SymbolTable
+                                        47
+                                        {
+                                            i:
+                                                (Variable
+                                                    47
+                                                    i
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .true.
+                                                ),
+                                            r:
+                                                (Variable
+                                                    47
+                                                    r
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    call_fortran_i64_value
+                                    (FunctionType
+                                        [(Integer 8)]
+                                        (Integer 8)
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 47 i)]
+                                    []
+                                    (Var 47 r)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            call_fortran_i64_value2:
+                                (Function
+                                    (SymbolTable
+                                        48
+                                        {
+                                            i:
+                                                (Variable
+                                                    48
+                                                    i
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .true.
+                                                ),
+                                            r:
+                                                (Variable
+                                                    48
+                                                    r
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    call_fortran_i64_value2
+                                    (FunctionType
+                                        [(Integer 8)]
+                                        (Integer 8)
+                                        BindC
+                                        Interface
+                                        "call_fortran_i64_value"
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 48 i)]
+                                    []
+                                    (Var 48 r)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
                             f_double_complex_value_return:
                                 (Function
                                     (SymbolTable
-                                        18
+                                        20
                                         {
                                             b:
                                                 (Variable
-                                                    18
+                                                    20
                                                     b
                                                     []
                                                     In
@@ -752,7 +752,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    18
+                                                    20
                                                     r
                                                     []
                                                     ReturnVar
@@ -783,9 +783,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 18 b)]
+                                    [(Var 20 b)]
                                     []
-                                    (Var 18 r)
+                                    (Var 20 r)
                                     Public
                                     .false.
                                     .false.
@@ -794,11 +794,11 @@
                             f_float_complex_value_return:
                                 (Function
                                     (SymbolTable
-                                        17
+                                        19
                                         {
                                             b:
                                                 (Variable
-                                                    17
+                                                    19
                                                     b
                                                     []
                                                     In
@@ -814,7 +814,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    17
+                                                    19
                                                     r
                                                     []
                                                     ReturnVar
@@ -845,9 +845,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 17 b)]
+                                    [(Var 19 b)]
                                     []
-                                    (Var 17 r)
+                                    (Var 19 r)
                                     Public
                                     .false.
                                     .false.
@@ -856,11 +856,11 @@
                             f_int_double:
                                 (Function
                                     (SymbolTable
-                                        10
+                                        12
                                         {
                                             a:
                                                 (Variable
-                                                    10
+                                                    12
                                                     a
                                                     []
                                                     In
@@ -876,7 +876,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    10
+                                                    12
                                                     b
                                                     []
                                                     In
@@ -892,7 +892,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    10
+                                                    12
                                                     r
                                                     []
                                                     ReturnVar
@@ -924,86 +924,6 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 10 a)
-                                    (Var 10 b)]
-                                    []
-                                    (Var 10 r)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            f_int_double_complex:
-                                (Function
-                                    (SymbolTable
-                                        12
-                                        {
-                                            a:
-                                                (Variable
-                                                    12
-                                                    a
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            b:
-                                                (Variable
-                                                    12
-                                                    b
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Complex 8)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            r:
-                                                (Variable
-                                                    12
-                                                    r
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    f_int_double_complex
-                                    (FunctionType
-                                        [(Integer 4)
-                                        (Complex 8)]
-                                        (Integer 4)
-                                        BindC
-                                        Interface
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    []
                                     [(Var 12 a)
                                     (Var 12 b)]
                                     []
@@ -1013,7 +933,7 @@
                                     .false.
                                     ()
                                 ),
-                            f_int_double_complex2:
+                            f_int_double_complex:
                                 (Function
                                     (SymbolTable
                                         14
@@ -1067,14 +987,14 @@
                                                     .false.
                                                 )
                                         })
-                                    f_int_double_complex2
+                                    f_int_double_complex
                                     (FunctionType
                                         [(Integer 4)
                                         (Complex 8)]
                                         (Integer 4)
                                         BindC
                                         Interface
-                                        "f_int_double_complex"
+                                        ()
                                         .false.
                                         .false.
                                         .false.
@@ -1093,7 +1013,7 @@
                                     .false.
                                     ()
                                 ),
-                            f_int_double_complex_value:
+                            f_int_double_complex2:
                                 (Function
                                     (SymbolTable
                                         16
@@ -1112,7 +1032,7 @@
                                                     BindC
                                                     Public
                                                     Required
-                                                    .true.
+                                                    .false.
                                                 ),
                                             b:
                                                 (Variable
@@ -1128,11 +1048,91 @@
                                                     BindC
                                                     Public
                                                     Required
-                                                    .true.
+                                                    .false.
                                                 ),
                                             r:
                                                 (Variable
                                                     16
+                                                    r
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    f_int_double_complex2
+                                    (FunctionType
+                                        [(Integer 4)
+                                        (Complex 8)]
+                                        (Integer 4)
+                                        BindC
+                                        Interface
+                                        "f_int_double_complex"
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 16 a)
+                                    (Var 16 b)]
+                                    []
+                                    (Var 16 r)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            f_int_double_complex_value:
+                                (Function
+                                    (SymbolTable
+                                        18
+                                        {
+                                            a:
+                                                (Variable
+                                                    18
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .true.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    18
+                                                    b
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Complex 8)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .true.
+                                                ),
+                                            r:
+                                                (Variable
+                                                    18
                                                     r
                                                     []
                                                     ReturnVar
@@ -1164,10 +1164,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 16 a)
-                                    (Var 16 b)]
+                                    [(Var 18 a)
+                                    (Var 18 b)]
                                     []
-                                    (Var 16 r)
+                                    (Var 18 r)
                                     Public
                                     .false.
                                     .false.
@@ -1176,11 +1176,11 @@
                             f_int_double_value:
                                 (Function
                                     (SymbolTable
-                                        20
+                                        22
                                         {
                                             a:
                                                 (Variable
-                                                    20
+                                                    22
                                                     a
                                                     []
                                                     In
@@ -1196,7 +1196,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    20
+                                                    22
                                                     b
                                                     []
                                                     In
@@ -1212,7 +1212,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    20
+                                                    22
                                                     r
                                                     []
                                                     ReturnVar
@@ -1244,10 +1244,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 20 a)
-                                    (Var 20 b)]
+                                    [(Var 22 a)
+                                    (Var 22 b)]
                                     []
-                                    (Var 20 r)
+                                    (Var 22 r)
                                     Public
                                     .false.
                                     .false.
@@ -1256,11 +1256,11 @@
                             f_int_double_value_name:
                                 (Function
                                     (SymbolTable
-                                        27
+                                        29
                                         {
                                             a:
                                                 (Variable
-                                                    27
+                                                    29
                                                     a
                                                     []
                                                     In
@@ -1276,7 +1276,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    27
+                                                    29
                                                     b
                                                     []
                                                     In
@@ -1292,7 +1292,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    27
+                                                    29
                                                     r
                                                     []
                                                     ReturnVar
@@ -1324,10 +1324,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 27 a)
-                                    (Var 27 b)]
+                                    [(Var 29 a)
+                                    (Var 29 b)]
                                     []
-                                    (Var 27 r)
+                                    (Var 29 r)
                                     Public
                                     .false.
                                     .false.
@@ -1336,11 +1336,11 @@
                             f_int_doublearray:
                                 (Function
                                     (SymbolTable
-                                        23
+                                        25
                                         {
                                             b:
                                                 (Variable
-                                                    23
+                                                    25
                                                     b
                                                     [n]
                                                     In
@@ -1350,7 +1350,7 @@
                                                     (Array
                                                         (Real 8)
                                                         [((IntegerConstant 1 (Integer 4))
-                                                        (Var 23 n))]
+                                                        (Var 25 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1361,7 +1361,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    23
+                                                    25
                                                     n
                                                     []
                                                     In
@@ -1377,7 +1377,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    23
+                                                    25
                                                     r
                                                     []
                                                     ReturnVar
@@ -1418,10 +1418,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 23 n)
-                                    (Var 23 b)]
+                                    [(Var 25 n)
+                                    (Var 25 b)]
                                     []
-                                    (Var 23 r)
+                                    (Var 25 r)
                                     Public
                                     .false.
                                     .false.
@@ -1430,11 +1430,11 @@
                             f_int_doublearray_star:
                                 (Function
                                     (SymbolTable
-                                        26
+                                        28
                                         {
                                             b:
                                                 (Variable
-                                                    26
+                                                    28
                                                     b
                                                     []
                                                     In
@@ -1455,7 +1455,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    26
+                                                    28
                                                     n
                                                     []
                                                     In
@@ -1471,7 +1471,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    26
+                                                    28
                                                     r
                                                     []
                                                     ReturnVar
@@ -1508,10 +1508,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 26 n)
-                                    (Var 26 b)]
+                                    [(Var 28 n)
+                                    (Var 28 b)]
                                     []
-                                    (Var 26 r)
+                                    (Var 28 r)
                                     Public
                                     .false.
                                     .false.
@@ -1520,11 +1520,11 @@
                             f_int_float:
                                 (Function
                                     (SymbolTable
-                                        9
+                                        11
                                         {
                                             a:
                                                 (Variable
-                                                    9
+                                                    11
                                                     a
                                                     []
                                                     In
@@ -1540,7 +1540,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    9
+                                                    11
                                                     b
                                                     []
                                                     In
@@ -1556,7 +1556,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    9
+                                                    11
                                                     r
                                                     []
                                                     ReturnVar
@@ -1588,86 +1588,6 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 9 a)
-                                    (Var 9 b)]
-                                    []
-                                    (Var 9 r)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            f_int_float_complex:
-                                (Function
-                                    (SymbolTable
-                                        11
-                                        {
-                                            a:
-                                                (Variable
-                                                    11
-                                                    a
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            b:
-                                                (Variable
-                                                    11
-                                                    b
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Complex 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            r:
-                                                (Variable
-                                                    11
-                                                    r
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    f_int_float_complex
-                                    (FunctionType
-                                        [(Integer 4)
-                                        (Complex 4)]
-                                        (Integer 4)
-                                        BindC
-                                        Interface
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    []
                                     [(Var 11 a)
                                     (Var 11 b)]
                                     []
@@ -1677,7 +1597,7 @@
                                     .false.
                                     ()
                                 ),
-                            f_int_float_complex2:
+                            f_int_float_complex:
                                 (Function
                                     (SymbolTable
                                         13
@@ -1731,14 +1651,14 @@
                                                     .false.
                                                 )
                                         })
-                                    f_int_float_complex2
+                                    f_int_float_complex
                                     (FunctionType
                                         [(Integer 4)
                                         (Complex 4)]
                                         (Integer 4)
                                         BindC
                                         Interface
-                                        "f_int_float_complex"
+                                        ()
                                         .false.
                                         .false.
                                         .false.
@@ -1757,7 +1677,7 @@
                                     .false.
                                     ()
                                 ),
-                            f_int_float_complex_value:
+                            f_int_float_complex2:
                                 (Function
                                     (SymbolTable
                                         15
@@ -1776,7 +1696,7 @@
                                                     BindC
                                                     Public
                                                     Required
-                                                    .true.
+                                                    .false.
                                                 ),
                                             b:
                                                 (Variable
@@ -1792,11 +1712,91 @@
                                                     BindC
                                                     Public
                                                     Required
-                                                    .true.
+                                                    .false.
                                                 ),
                                             r:
                                                 (Variable
                                                     15
+                                                    r
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    f_int_float_complex2
+                                    (FunctionType
+                                        [(Integer 4)
+                                        (Complex 4)]
+                                        (Integer 4)
+                                        BindC
+                                        Interface
+                                        "f_int_float_complex"
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 15 a)
+                                    (Var 15 b)]
+                                    []
+                                    (Var 15 r)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            f_int_float_complex_value:
+                                (Function
+                                    (SymbolTable
+                                        17
+                                        {
+                                            a:
+                                                (Variable
+                                                    17
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .true.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    17
+                                                    b
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Complex 4)
+                                                    ()
+                                                    BindC
+                                                    Public
+                                                    Required
+                                                    .true.
+                                                ),
+                                            r:
+                                                (Variable
+                                                    17
                                                     r
                                                     []
                                                     ReturnVar
@@ -1828,10 +1828,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 15 a)
-                                    (Var 15 b)]
+                                    [(Var 17 a)
+                                    (Var 17 b)]
                                     []
-                                    (Var 15 r)
+                                    (Var 17 r)
                                     Public
                                     .false.
                                     .false.
@@ -1840,11 +1840,11 @@
                             f_int_float_value:
                                 (Function
                                     (SymbolTable
-                                        19
+                                        21
                                         {
                                             a:
                                                 (Variable
-                                                    19
+                                                    21
                                                     a
                                                     []
                                                     In
@@ -1860,7 +1860,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    19
+                                                    21
                                                     b
                                                     []
                                                     In
@@ -1876,7 +1876,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    19
+                                                    21
                                                     r
                                                     []
                                                     ReturnVar
@@ -1908,10 +1908,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 19 a)
-                                    (Var 19 b)]
+                                    [(Var 21 a)
+                                    (Var 21 b)]
                                     []
-                                    (Var 19 r)
+                                    (Var 21 r)
                                     Public
                                     .false.
                                     .false.
@@ -1920,11 +1920,11 @@
                             f_int_floatarray:
                                 (Function
                                     (SymbolTable
-                                        22
+                                        24
                                         {
                                             b:
                                                 (Variable
-                                                    22
+                                                    24
                                                     b
                                                     [n]
                                                     In
@@ -1934,7 +1934,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 1 (Integer 4))
-                                                        (Var 22 n))]
+                                                        (Var 24 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1945,7 +1945,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    22
+                                                    24
                                                     n
                                                     []
                                                     In
@@ -1961,7 +1961,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    22
+                                                    24
                                                     r
                                                     []
                                                     ReturnVar
@@ -2002,10 +2002,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 22 n)
-                                    (Var 22 b)]
+                                    [(Var 24 n)
+                                    (Var 24 b)]
                                     []
-                                    (Var 22 r)
+                                    (Var 24 r)
                                     Public
                                     .false.
                                     .false.
@@ -2014,11 +2014,11 @@
                             f_int_floatarray_star:
                                 (Function
                                     (SymbolTable
-                                        25
+                                        27
                                         {
                                             b:
                                                 (Variable
-                                                    25
+                                                    27
                                                     b
                                                     []
                                                     In
@@ -2039,7 +2039,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    25
+                                                    27
                                                     n
                                                     []
                                                     In
@@ -2055,7 +2055,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    25
+                                                    27
                                                     r
                                                     []
                                                     ReturnVar
@@ -2092,10 +2092,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 25 n)
-                                    (Var 25 b)]
+                                    [(Var 27 n)
+                                    (Var 27 b)]
                                     []
-                                    (Var 25 r)
+                                    (Var 27 r)
                                     Public
                                     .false.
                                     .false.
@@ -2104,11 +2104,11 @@
                             f_int_intarray:
                                 (Function
                                     (SymbolTable
-                                        21
+                                        23
                                         {
                                             b:
                                                 (Variable
-                                                    21
+                                                    23
                                                     b
                                                     [n]
                                                     In
@@ -2118,7 +2118,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 1 (Integer 4))
-                                                        (Var 21 n))]
+                                                        (Var 23 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -2129,7 +2129,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    21
+                                                    23
                                                     n
                                                     []
                                                     In
@@ -2145,7 +2145,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    21
+                                                    23
                                                     r
                                                     []
                                                     ReturnVar
@@ -2186,10 +2186,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 21 n)
-                                    (Var 21 b)]
+                                    [(Var 23 n)
+                                    (Var 23 b)]
                                     []
-                                    (Var 21 r)
+                                    (Var 23 r)
                                     Public
                                     .false.
                                     .false.
@@ -2198,11 +2198,11 @@
                             f_int_intarray_star:
                                 (Function
                                     (SymbolTable
-                                        24
+                                        26
                                         {
                                             b:
                                                 (Variable
-                                                    24
+                                                    26
                                                     b
                                                     []
                                                     In
@@ -2223,7 +2223,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    24
+                                                    26
                                                     n
                                                     []
                                                     In
@@ -2239,7 +2239,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    24
+                                                    26
                                                     r
                                                     []
                                                     ReturnVar
@@ -2276,10 +2276,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 24 n)
-                                    (Var 24 b)]
+                                    [(Var 26 n)
+                                    (Var 26 b)]
                                     []
-                                    (Var 24 r)
+                                    (Var 26 r)
                                     Public
                                     .false.
                                     .false.
@@ -2288,11 +2288,11 @@
                             f_string:
                                 (Function
                                     (SymbolTable
-                                        51
+                                        53
                                         {
                                             r:
                                                 (Variable
-                                                    51
+                                                    53
                                                     r
                                                     []
                                                     ReturnVar
@@ -2308,7 +2308,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    51
+                                                    53
                                                     s
                                                     []
                                                     In
@@ -2339,14 +2339,14 @@
                                         .false.
                                     )
                                     [f_string0]
-                                    [(Var 51 s)]
+                                    [(Var 53 s)]
                                     [(Assignment
-                                        (Var 51 r)
+                                        (Var 53 r)
                                         (FunctionCall
                                             2 f_string0
                                             ()
                                             [((StringConcat
-                                                (Var 51 s)
+                                                (Var 53 s)
                                                 (Var 2 c_null_char)
                                                 (Character 1 -1 ())
                                                 ()
@@ -2357,7 +2357,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 51 r)
+                                    (Var 53 r)
                                     Public
                                     .false.
                                     .false.
@@ -2366,11 +2366,11 @@
                             f_string0:
                                 (Function
                                     (SymbolTable
-                                        40
+                                        42
                                         {
                                             r:
                                                 (Variable
-                                                    40
+                                                    42
                                                     r
                                                     []
                                                     ReturnVar
@@ -2386,7 +2386,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    40
+                                                    42
                                                     s
                                                     []
                                                     In
@@ -2417,9 +2417,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 40 s)]
+                                    [(Var 42 s)]
                                     []
-                                    (Var 40 r)
+                                    (Var 42 r)
                                     Public
                                     .false.
                                     .false.
@@ -2428,11 +2428,11 @@
                             fortran_f32:
                                 (Function
                                     (SymbolTable
-                                        56
+                                        58
                                         {
                                             i:
                                                 (Variable
-                                                    56
+                                                    58
                                                     i
                                                     []
                                                     In
@@ -2448,7 +2448,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    56
+                                                    58
                                                     r
                                                     []
                                                     ReturnVar
@@ -2479,11 +2479,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 56 i)]
+                                    [(Var 58 i)]
                                     [(Assignment
-                                        (Var 56 r)
+                                        (Var 58 r)
                                         (RealBinOp
-                                            (Var 56 i)
+                                            (Var 58 i)
                                             Add
                                             (RealConstant
                                                 2.300000
@@ -2494,7 +2494,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 56 r)
+                                    (Var 58 r)
                                     Public
                                     .false.
                                     .false.
@@ -2503,11 +2503,11 @@
                             fortran_f32_value:
                                 (Function
                                     (SymbolTable
-                                        57
+                                        59
                                         {
                                             i:
                                                 (Variable
-                                                    57
+                                                    59
                                                     i
                                                     []
                                                     In
@@ -2523,7 +2523,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    57
+                                                    59
                                                     r
                                                     []
                                                     ReturnVar
@@ -2554,11 +2554,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 57 i)]
+                                    [(Var 59 i)]
                                     [(Assignment
-                                        (Var 57 r)
+                                        (Var 59 r)
                                         (RealBinOp
-                                            (Var 57 i)
+                                            (Var 59 i)
                                             Add
                                             (RealConstant
                                                 2.300000
@@ -2569,7 +2569,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 57 r)
+                                    (Var 59 r)
                                     Public
                                     .false.
                                     .false.
@@ -2578,11 +2578,11 @@
                             fortran_f64:
                                 (Function
                                     (SymbolTable
-                                        58
+                                        60
                                         {
                                             i:
                                                 (Variable
-                                                    58
+                                                    60
                                                     i
                                                     []
                                                     In
@@ -2598,7 +2598,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    58
+                                                    60
                                                     r
                                                     []
                                                     ReturnVar
@@ -2629,11 +2629,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 58 i)]
+                                    [(Var 60 i)]
                                     [(Assignment
-                                        (Var 58 r)
+                                        (Var 60 r)
                                         (RealBinOp
-                                            (Var 58 i)
+                                            (Var 60 i)
                                             Add
                                             (RealConstant
                                                 2.300000
@@ -2644,7 +2644,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 58 r)
+                                    (Var 60 r)
                                     Public
                                     .false.
                                     .false.
@@ -2653,11 +2653,11 @@
                             fortran_f64_value:
                                 (Function
                                     (SymbolTable
-                                        59
+                                        61
                                         {
                                             i:
                                                 (Variable
-                                                    59
+                                                    61
                                                     i
                                                     []
                                                     In
@@ -2673,7 +2673,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    59
+                                                    61
                                                     r
                                                     []
                                                     ReturnVar
@@ -2704,11 +2704,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 59 i)]
+                                    [(Var 61 i)]
                                     [(Assignment
-                                        (Var 59 r)
+                                        (Var 61 r)
                                         (RealBinOp
-                                            (Var 59 i)
+                                            (Var 61 i)
                                             Add
                                             (RealConstant
                                                 2.300000
@@ -2719,7 +2719,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 59 r)
+                                    (Var 61 r)
                                     Public
                                     .false.
                                     .false.
@@ -2728,11 +2728,11 @@
                             fortran_i32:
                                 (Function
                                     (SymbolTable
-                                        52
+                                        54
                                         {
                                             i:
                                                 (Variable
-                                                    52
+                                                    54
                                                     i
                                                     []
                                                     In
@@ -2748,7 +2748,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    52
+                                                    54
                                                     r
                                                     []
                                                     ReturnVar
@@ -2779,11 +2779,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 52 i)]
+                                    [(Var 54 i)]
                                     [(Assignment
-                                        (Var 52 r)
+                                        (Var 54 r)
                                         (IntegerBinOp
-                                            (Var 52 i)
+                                            (Var 54 i)
                                             Add
                                             (IntegerConstant 2 (Integer 4))
                                             (Integer 4)
@@ -2791,7 +2791,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 52 r)
+                                    (Var 54 r)
                                     Public
                                     .false.
                                     .false.
@@ -2800,11 +2800,11 @@
                             fortran_i32_value:
                                 (Function
                                     (SymbolTable
-                                        53
+                                        55
                                         {
                                             i:
                                                 (Variable
-                                                    53
+                                                    55
                                                     i
                                                     []
                                                     In
@@ -2820,7 +2820,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    53
+                                                    55
                                                     r
                                                     []
                                                     ReturnVar
@@ -2851,11 +2851,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 53 i)]
+                                    [(Var 55 i)]
                                     [(Assignment
-                                        (Var 53 r)
+                                        (Var 55 r)
                                         (IntegerBinOp
-                                            (Var 53 i)
+                                            (Var 55 i)
                                             Add
                                             (IntegerConstant 2 (Integer 4))
                                             (Integer 4)
@@ -2863,7 +2863,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 53 r)
+                                    (Var 55 r)
                                     Public
                                     .false.
                                     .false.
@@ -2872,11 +2872,11 @@
                             fortran_i64:
                                 (Function
                                     (SymbolTable
-                                        54
+                                        56
                                         {
                                             i:
                                                 (Variable
-                                                    54
+                                                    56
                                                     i
                                                     []
                                                     In
@@ -2892,7 +2892,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    54
+                                                    56
                                                     r
                                                     []
                                                     ReturnVar
@@ -2923,11 +2923,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 54 i)]
+                                    [(Var 56 i)]
                                     [(Assignment
-                                        (Var 54 r)
+                                        (Var 56 r)
                                         (IntegerBinOp
-                                            (Var 54 i)
+                                            (Var 56 i)
                                             Add
                                             (Cast
                                                 (IntegerConstant 2 (Integer 4))
@@ -2940,7 +2940,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 54 r)
+                                    (Var 56 r)
                                     Public
                                     .false.
                                     .false.
@@ -2949,11 +2949,11 @@
                             fortran_i64_value:
                                 (Function
                                     (SymbolTable
-                                        55
+                                        57
                                         {
                                             i:
                                                 (Variable
-                                                    55
+                                                    57
                                                     i
                                                     []
                                                     In
@@ -2969,7 +2969,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    55
+                                                    57
                                                     r
                                                     []
                                                     ReturnVar
@@ -3000,11 +3000,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 55 i)]
+                                    [(Var 57 i)]
                                     [(Assignment
-                                        (Var 55 r)
+                                        (Var 57 r)
                                         (IntegerBinOp
-                                            (Var 55 i)
+                                            (Var 57 i)
                                             Add
                                             (Cast
                                                 (IntegerConstant 2 (Integer 4))
@@ -3017,7 +3017,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 55 r)
+                                    (Var 57 r)
                                     Public
                                     .false.
                                     .false.
@@ -3026,11 +3026,11 @@
                             sub_int_double:
                                 (Function
                                     (SymbolTable
-                                        29
+                                        31
                                         {
                                             a:
                                                 (Variable
-                                                    29
+                                                    31
                                                     a
                                                     []
                                                     In
@@ -3046,7 +3046,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    29
+                                                    31
                                                     b
                                                     []
                                                     In
@@ -3062,7 +3062,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    29
+                                                    31
                                                     r
                                                     []
                                                     Out
@@ -3095,9 +3095,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 29 a)
-                                    (Var 29 b)
-                                    (Var 29 r)]
+                                    [(Var 31 a)
+                                    (Var 31 b)
+                                    (Var 31 r)]
                                     []
                                     ()
                                     Public
@@ -3108,11 +3108,11 @@
                             sub_int_double_complex:
                                 (Function
                                     (SymbolTable
-                                        31
+                                        33
                                         {
                                             a:
                                                 (Variable
-                                                    31
+                                                    33
                                                     a
                                                     []
                                                     In
@@ -3128,7 +3128,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    31
+                                                    33
                                                     b
                                                     []
                                                     In
@@ -3144,7 +3144,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    31
+                                                    33
                                                     r
                                                     []
                                                     Out
@@ -3177,9 +3177,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 31 a)
-                                    (Var 31 b)
-                                    (Var 31 r)]
+                                    [(Var 33 a)
+                                    (Var 33 b)
+                                    (Var 33 r)]
                                     []
                                     ()
                                     Public
@@ -3190,11 +3190,11 @@
                             sub_int_double_complex_value:
                                 (Function
                                     (SymbolTable
-                                        35
+                                        37
                                         {
                                             a:
                                                 (Variable
-                                                    35
+                                                    37
                                                     a
                                                     []
                                                     In
@@ -3210,7 +3210,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    35
+                                                    37
                                                     b
                                                     []
                                                     In
@@ -3226,7 +3226,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    35
+                                                    37
                                                     r
                                                     []
                                                     Out
@@ -3259,9 +3259,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 35 a)
-                                    (Var 35 b)
-                                    (Var 35 r)]
+                                    [(Var 37 a)
+                                    (Var 37 b)
+                                    (Var 37 r)]
                                     []
                                     ()
                                     Public
@@ -3272,11 +3272,11 @@
                             sub_int_double_value:
                                 (Function
                                     (SymbolTable
-                                        33
+                                        35
                                         {
                                             a:
                                                 (Variable
-                                                    33
+                                                    35
                                                     a
                                                     []
                                                     In
@@ -3292,7 +3292,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    33
+                                                    35
                                                     b
                                                     []
                                                     In
@@ -3308,7 +3308,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    33
+                                                    35
                                                     r
                                                     []
                                                     Out
@@ -3341,9 +3341,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 33 a)
-                                    (Var 33 b)
-                                    (Var 33 r)]
+                                    [(Var 35 a)
+                                    (Var 35 b)
+                                    (Var 35 r)]
                                     []
                                     ()
                                     Public
@@ -3354,11 +3354,11 @@
                             sub_int_double_value_name:
                                 (Function
                                     (SymbolTable
-                                        39
+                                        41
                                         {
                                             a:
                                                 (Variable
-                                                    39
+                                                    41
                                                     a
                                                     []
                                                     In
@@ -3374,7 +3374,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    39
+                                                    41
                                                     b
                                                     []
                                                     In
@@ -3390,7 +3390,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    39
+                                                    41
                                                     r
                                                     []
                                                     Out
@@ -3423,9 +3423,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 39 a)
-                                    (Var 39 b)
-                                    (Var 39 r)]
+                                    [(Var 41 a)
+                                    (Var 41 b)
+                                    (Var 41 r)]
                                     []
                                     ()
                                     Public
@@ -3436,11 +3436,11 @@
                             sub_int_doublearray:
                                 (Function
                                     (SymbolTable
-                                        38
+                                        40
                                         {
                                             b:
                                                 (Variable
-                                                    38
+                                                    40
                                                     b
                                                     [n]
                                                     In
@@ -3450,7 +3450,7 @@
                                                     (Array
                                                         (Real 8)
                                                         [((IntegerConstant 1 (Integer 4))
-                                                        (Var 38 n))]
+                                                        (Var 40 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -3461,7 +3461,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    38
+                                                    40
                                                     n
                                                     []
                                                     In
@@ -3477,7 +3477,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    38
+                                                    40
                                                     r
                                                     []
                                                     Out
@@ -3519,9 +3519,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 38 n)
-                                    (Var 38 b)
-                                    (Var 38 r)]
+                                    [(Var 40 n)
+                                    (Var 40 b)
+                                    (Var 40 r)]
                                     []
                                     ()
                                     Public
@@ -3532,11 +3532,11 @@
                             sub_int_float:
                                 (Function
                                     (SymbolTable
-                                        28
+                                        30
                                         {
                                             a:
                                                 (Variable
-                                                    28
+                                                    30
                                                     a
                                                     []
                                                     In
@@ -3552,7 +3552,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    28
+                                                    30
                                                     b
                                                     []
                                                     In
@@ -3568,7 +3568,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    28
+                                                    30
                                                     r
                                                     []
                                                     Out
@@ -3601,9 +3601,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 28 a)
-                                    (Var 28 b)
-                                    (Var 28 r)]
+                                    [(Var 30 a)
+                                    (Var 30 b)
+                                    (Var 30 r)]
                                     []
                                     ()
                                     Public
@@ -3614,11 +3614,11 @@
                             sub_int_float_complex:
                                 (Function
                                     (SymbolTable
-                                        30
+                                        32
                                         {
                                             a:
                                                 (Variable
-                                                    30
+                                                    32
                                                     a
                                                     []
                                                     In
@@ -3634,7 +3634,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    30
+                                                    32
                                                     b
                                                     []
                                                     In
@@ -3650,7 +3650,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    30
+                                                    32
                                                     r
                                                     []
                                                     Out
@@ -3683,9 +3683,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 30 a)
-                                    (Var 30 b)
-                                    (Var 30 r)]
+                                    [(Var 32 a)
+                                    (Var 32 b)
+                                    (Var 32 r)]
                                     []
                                     ()
                                     Public
@@ -3696,11 +3696,11 @@
                             sub_int_float_complex_value:
                                 (Function
                                     (SymbolTable
-                                        34
+                                        36
                                         {
                                             a:
                                                 (Variable
-                                                    34
+                                                    36
                                                     a
                                                     []
                                                     In
@@ -3716,7 +3716,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    34
+                                                    36
                                                     b
                                                     []
                                                     In
@@ -3732,7 +3732,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    34
+                                                    36
                                                     r
                                                     []
                                                     Out
@@ -3765,9 +3765,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 34 a)
-                                    (Var 34 b)
-                                    (Var 34 r)]
+                                    [(Var 36 a)
+                                    (Var 36 b)
+                                    (Var 36 r)]
                                     []
                                     ()
                                     Public
@@ -3778,11 +3778,11 @@
                             sub_int_float_value:
                                 (Function
                                     (SymbolTable
-                                        32
+                                        34
                                         {
                                             a:
                                                 (Variable
-                                                    32
+                                                    34
                                                     a
                                                     []
                                                     In
@@ -3798,7 +3798,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    32
+                                                    34
                                                     b
                                                     []
                                                     In
@@ -3814,7 +3814,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    32
+                                                    34
                                                     r
                                                     []
                                                     Out
@@ -3847,9 +3847,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 32 a)
-                                    (Var 32 b)
-                                    (Var 32 r)]
+                                    [(Var 34 a)
+                                    (Var 34 b)
+                                    (Var 34 r)]
                                     []
                                     ()
                                     Public
@@ -3860,11 +3860,11 @@
                             sub_int_floatarray:
                                 (Function
                                     (SymbolTable
-                                        37
+                                        39
                                         {
                                             b:
                                                 (Variable
-                                                    37
+                                                    39
                                                     b
                                                     [n]
                                                     In
@@ -3874,7 +3874,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 1 (Integer 4))
-                                                        (Var 37 n))]
+                                                        (Var 39 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -3885,7 +3885,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    37
+                                                    39
                                                     n
                                                     []
                                                     In
@@ -3901,7 +3901,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    37
+                                                    39
                                                     r
                                                     []
                                                     Out
@@ -3943,9 +3943,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 37 n)
-                                    (Var 37 b)
-                                    (Var 37 r)]
+                                    [(Var 39 n)
+                                    (Var 39 b)
+                                    (Var 39 r)]
                                     []
                                     ()
                                     Public
@@ -3956,11 +3956,11 @@
                             sub_int_intarray:
                                 (Function
                                     (SymbolTable
-                                        36
+                                        38
                                         {
                                             b:
                                                 (Variable
-                                                    36
+                                                    38
                                                     b
                                                     [n]
                                                     In
@@ -3970,7 +3970,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 1 (Integer 4))
-                                                        (Var 36 n))]
+                                                        (Var 38 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -3981,7 +3981,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    36
+                                                    38
                                                     n
                                                     []
                                                     In
@@ -3997,7 +3997,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    36
+                                                    38
                                                     r
                                                     []
                                                     Out
@@ -4039,9 +4039,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 36 n)
-                                    (Var 36 b)
-                                    (Var 36 r)]
+                                    [(Var 38 n)
+                                    (Var 38 b)
+                                    (Var 38 r)]
                                     []
                                     ()
                                     Public

--- a/tests/reference/asr-string1-f6332d9.json
+++ b/tests/reference/asr-string1-f6332d9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string1-f6332d9.stdout",
-    "stdout_hash": "f88de6676fdd6eacf920fa54b228577f06bf1c54ad8126b2726b504a",
+    "stdout_hash": "e1a1be5db03f9c5f95ebf058b2fd9b1a86743a224e33f3f018af4243",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string1-f6332d9.stdout
+++ b/tests/reference/asr-string1-f6332d9.stdout
@@ -49,16 +49,16 @@
                             f_string_cptr:
                                 (Function
                                     (SymbolTable
-                                        11
+                                        13
                                         {
                                             c_strlen:
                                                 (Function
                                                     (SymbolTable
-                                                        12
+                                                        14
                                                         {
                                                             r:
                                                                 (Variable
-                                                                    12
+                                                                    14
                                                                     r
                                                                     []
                                                                     ReturnVar
@@ -74,7 +74,7 @@
                                                                 ),
                                                             s:
                                                                 (Variable
-                                                                    12
+                                                                    14
                                                                     s
                                                                     []
                                                                     In
@@ -105,9 +105,9 @@
                                                         .false.
                                                     )
                                                     []
-                                                    [(Var 12 s)]
+                                                    [(Var 14 s)]
                                                     []
-                                                    (Var 12 r)
+                                                    (Var 14 r)
                                                     Public
                                                     .false.
                                                     .false.
@@ -115,7 +115,7 @@
                                                 ),
                                             cptr:
                                                 (Variable
-                                                    11
+                                                    13
                                                     cptr
                                                     []
                                                     In
@@ -131,7 +131,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    11
+                                                    13
                                                     s
                                                     []
                                                     ReturnVar
@@ -166,25 +166,25 @@
                                         .false.
                                     )
                                     [f_string_cptr_n]
-                                    [(Var 11 cptr)]
+                                    [(Var 13 cptr)]
                                     [(Assignment
-                                        (Var 11 s)
+                                        (Var 13 s)
                                         (FunctionCall
                                             2 f_string_cptr_n
                                             ()
-                                            [((Var 11 cptr))
+                                            [((Var 13 cptr))
                                             ((FunctionCall
-                                                11 c_strlen
+                                                13 c_strlen
                                                 ()
-                                                [((Var 11 cptr))]
+                                                [((Var 13 cptr))]
                                                 (Integer 8)
                                                 ()
                                                 ()
                                             ))]
                                             (Character 1 -3 (FunctionCall
-                                                11 c_strlen
+                                                13 c_strlen
                                                 ()
-                                                [((Var 11 cptr))]
+                                                [((Var 13 cptr))]
                                                 (Integer 8)
                                                 ()
                                                 ()
@@ -194,7 +194,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 11 s)
+                                    (Var 13 s)
                                     Public
                                     .false.
                                     .false.
@@ -203,11 +203,11 @@
                             f_string_cptr_n:
                                 (Function
                                     (SymbolTable
-                                        13
+                                        15
                                         {
                                             cptr:
                                                 (Variable
-                                                    13
+                                                    15
                                                     cptr
                                                     []
                                                     In
@@ -223,7 +223,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    13
+                                                    15
                                                     n
                                                     []
                                                     In
@@ -239,14 +239,14 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    13
+                                                    15
                                                     s
                                                     [n]
                                                     ReturnVar
                                                     ()
                                                     ()
                                                     Default
-                                                    (Character 1 -3 (Var 13 n))
+                                                    (Character 1 -3 (Var 15 n))
                                                     ()
                                                     Source
                                                     Public
@@ -275,10 +275,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 13 cptr)
-                                    (Var 13 n)]
+                                    [(Var 15 cptr)
+                                    (Var 15 n)]
                                     []
-                                    (Var 13 s)
+                                    (Var 15 s)
                                     Public
                                     .false.
                                     .false.
@@ -287,11 +287,11 @@
                             f_string~genericprocedure:
                                 (Function
                                     (SymbolTable
-                                        10
+                                        12
                                         {
                                             c_string:
                                                 (Variable
-                                                    10
+                                                    12
                                                     c_string
                                                     []
                                                     In
@@ -312,7 +312,7 @@
                                                 ),
                                             f_string:
                                                 (Variable
-                                                    10
+                                                    12
                                                     f_string
                                                     []
                                                     ReturnVar
@@ -352,9 +352,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 10 c_string)]
+                                    [(Var 12 c_string)]
                                     []
-                                    (Var 10 f_string)
+                                    (Var 12 f_string)
                                     Public
                                     .false.
                                     .false.
@@ -363,11 +363,11 @@
                             string_t:
                                 (StructType
                                     (SymbolTable
-                                        9
+                                        11
                                         {
                                             s:
                                                 (Variable
-                                                    9
+                                                    11
                                                     s
                                                     []
                                                     Local

--- a/tests/reference/asr-string2-3425046.json
+++ b/tests/reference/asr-string2-3425046.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-3425046.stdout",
-    "stdout_hash": "41bf57f0403f40fd74e00874e0b20a1243c25ecf32c62fec901eb041",
+    "stdout_hash": "555c5e2889ebd759ebeff7aa179bef296a58b2036dc831ea34fd4297",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-3425046.stdout
+++ b/tests/reference/asr-string2-3425046.stdout
@@ -70,11 +70,11 @@
                             get_temp_filename:
                                 (Function
                                     (SymbolTable
-                                        17
+                                        19
                                         {
                                             c_tempfile:
                                                 (Variable
-                                                    17
+                                                    19
                                                     c_tempfile
                                                     []
                                                     Local
@@ -97,7 +97,7 @@
                                                 ),
                                             f_string@f_string~genericprocedure:
                                                 (ExternalSymbol
-                                                    17
+                                                    19
                                                     f_string@f_string~genericprocedure
                                                     4 f_string~genericprocedure
                                                     fpm_strings
@@ -107,7 +107,7 @@
                                                 ),
                                             tempfile:
                                                 (Variable
-                                                    17
+                                                    19
                                                     tempfile
                                                     []
                                                     ReturnVar
@@ -144,11 +144,11 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 17 tempfile)
+                                        (Var 19 tempfile)
                                         (FunctionCall
-                                            17 f_string@f_string~genericprocedure
+                                            19 f_string@f_string~genericprocedure
                                             2 f_string
-                                            [((Var 17 c_tempfile))]
+                                            [((Var 19 c_tempfile))]
                                             (Allocatable
                                                 (Character 1 -2 ())
                                             )
@@ -157,7 +157,7 @@
                                         )
                                         ()
                                     )]
-                                    (Var 17 tempfile)
+                                    (Var 19 tempfile)
                                     Public
                                     .false.
                                     .false.
@@ -166,11 +166,11 @@
                             list_files:
                                 (Function
                                     (SymbolTable
-                                        16
+                                        18
                                         {
                                             dir_entry_c:
                                                 (Variable
-                                                    16
+                                                    18
                                                     dir_entry_c
                                                     []
                                                     Local
@@ -186,7 +186,7 @@
                                                 ),
                                             dir_handle:
                                                 (Variable
-                                                    16
+                                                    18
                                                     dir_handle
                                                     []
                                                     Local
@@ -202,7 +202,7 @@
                                                 ),
                                             f_string@f_string_cptr:
                                                 (ExternalSymbol
-                                                    16
+                                                    18
                                                     f_string@f_string_cptr
                                                     4 f_string_cptr
                                                     fpm_strings
@@ -212,7 +212,7 @@
                                                 ),
                                             string_fortran:
                                                 (Variable
-                                                    16
+                                                    18
                                                     string_fortran
                                                     []
                                                     Local
@@ -255,7 +255,7 @@
                                         [(If
                                             (LogicalNot
                                                 (PointerAssociated
-                                                    (Var 16 dir_entry_c)
+                                                    (Var 18 dir_entry_c)
                                                     ()
                                                     (Logical 4)
                                                     ()
@@ -267,11 +267,11 @@
                                                 ()
                                             )]
                                             [(Assignment
-                                                (Var 16 string_fortran)
+                                                (Var 18 string_fortran)
                                                 (FunctionCall
-                                                    16 f_string@f_string_cptr
+                                                    18 f_string@f_string_cptr
                                                     2 f_string
-                                                    [((Var 16 dir_entry_c))]
+                                                    [((Var 18 dir_entry_c))]
                                                     (Allocatable
                                                         (Character 1 -2 ())
                                                     )
@@ -284,7 +284,7 @@
                                         []
                                     )
                                     (ImplicitDeallocate
-                                        [(Var 16 string_fortran)]
+                                        [(Var 18 string_fortran)]
                                     )]
                                     ()
                                     Public


### PR DESCRIPTION
Fixes #3989. Fixes #3992. Fixes #3991.

With this PR we get the toy example compiled with LFortran

```console
% lfortran -c libgompinterop.f90 && lfortran d.f90 -L/Users/pranavchiku/repos/llvm-project/openmp/build/runtime/src/ -lomp -Wl,-rpath,/Users/pranavchiku/repos/llvm-project/openmp/build/runtime/src/
Max threads:  8
Hello from thread  3
Hello from thread  1
Hello from thread  2
Hello from thread  0
Hello from thread  4
Hello from thread  6
Hello from thread  7
Hello from thread  5
```