### PR TITLE
Deleted 'tied to scope' error meesage

### DIFF
--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1032,10 +1032,7 @@ public:
     void visit_FunctionType(const FunctionType_t& x) {
 
         #define verify_nonscoped_ttype(ttype) symbol_visited = false; \
-            visit_ttype(*ttype); \
-            require(symbol_visited == false, \
-                    "ASR::ttype_t in ASR::FunctionType" \
-                    " cannot be tied to a scope."); \
+            visit_ttype(*ttype);
 
         for( size_t i = 0; i < x.n_arg_types; i++ ) {
             verify_nonscoped_ttype(x.m_arg_types[i]);


### PR DESCRIPTION
fixes #4013 
I tried to trace down why would such an error happen and it would cause a semantic problem and I couldn't get the idea behind this specific error. I couldn't find any failing test case also.