### PR TITLE
Handle `IntegerBinOp_t` when setting array dimension through a module variable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -405,6 +405,7 @@ RUN(NAME arrays_01_real LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackA
 RUN(NAME arrays_01_complex LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_01_logical LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_01_multi_dim LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
+RUN(NAME integer_bin_op_dim_external_module LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_bound_1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_bound_2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_bound_3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -405,7 +405,7 @@ RUN(NAME arrays_01_real LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackA
 RUN(NAME arrays_01_complex LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_01_logical LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_01_multi_dim LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
-RUN(NAME integer_bin_op_dim_external_module LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
+RUN(NAME integer_bin_op_dim_external_module LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_bound_1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_bound_2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_bound_3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/integer_bin_op_dim_external_module.f90
+++ b/integration_tests/integer_bin_op_dim_external_module.f90
@@ -1,0 +1,73 @@
+module xx
+   integer :: nx = 4
+   integer :: ny = 1
+   integer :: nz = 1
+end module xx
+
+subroutine a(cs)
+   use xx
+   integer, dimension(nx * ny - 1), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3])) error stop
+end subroutine
+
+subroutine b(cs)
+   use xx
+   integer, dimension(nx * ny), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3, 4])) error stop
+end subroutine
+
+subroutine c(cs)
+   use xx
+   integer, dimension(2 + 3), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3, 4, 5])) error stop
+end subroutine
+
+subroutine d(cs)
+   use xx
+   integer, dimension(nx - 1), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3])) error stop
+end subroutine
+
+subroutine e(cs)
+   use xx
+   integer, dimension(1 + nx * ny), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3, 4, 5])) error stop
+end subroutine
+
+subroutine f(cs)
+   use xx
+   integer, dimension(nx * ny * nz), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3, 4])) error stop
+end subroutine
+
+subroutine g(cs)
+   use xx
+   integer, dimension(1 + 2 + 3), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3, 4, 5, 6])) error stop
+end subroutine
+
+subroutine h(cs)
+   use xx
+   integer, dimension(nx * ny + ny * nz), intent(in) :: cs
+   print *, cs
+   if (all(cs /= [1, 2, 3, 4, 5])) error stop
+end subroutine
+
+program main
+   integer, dimension(8) :: cs
+   cs = [1, 2, 3, 4, 5, 6, 7, 8]
+   call a(cs)
+   call b(cs)
+   call c(cs)
+   call d(cs)
+   call f(cs)
+   call g(cs)
+   call h(cs)
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1280,8 +1280,8 @@ public:
         } else if (ASR::is_a<ASR::Var_t>(*left) && ASR::is_a<ASR::Var_t>(*right)) {
             // Handle expressions like `nx + ny` where both `nx` and `ny` are 
             // external variables.
-            ASR::symbol_t* first_end_sym = (ASR::symbol_t*)ASR::down_cast<ASR::Var_t>(left)->m_v;
-            ASR::symbol_t* second_end_sym = (ASR::symbol_t*)ASR::down_cast<ASR::Var_t>(right)->m_v;
+            ASR::symbol_t* first_end_sym = ASR::down_cast<ASR::Var_t>(left)->m_v;
+            ASR::symbol_t* second_end_sym = ASR::down_cast<ASR::Var_t>(right)->m_v;
             SymbolTable* first_symbol_scope = ASRUtils::symbol_parent_symtab(first_end_sym);
             SymbolTable* second_symbol_scope = ASRUtils::symbol_parent_symtab(second_end_sym);
             if (ASR::is_a<ASR::ExternalSymbol_t>(*first_end_sym) ||

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1189,61 +1189,55 @@ public:
         return func_name;
     }
 
-    ASR::expr_t* get_transformed_function_call(ASR::symbol_t* end_sym, bool is_argument, ASR::expr_t* end) {
-        SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(end_sym);
-        if (ASR::is_a<ASR::ExternalSymbol_t>(*end_sym) ||
-            (symbol_scope->counter != current_scope->counter && is_argument &&
-            ASRUtils::expr_value(end) == nullptr) ) {
-            /*
-                case: ./integration_tests/arrays_45.f90
-                subroutine a(cs)
-                use xx
-                real, dimension(nx), intent(in) :: cs
-                end subroutine
+    ASR::expr_t* get_transformed_function_call(ASR::symbol_t* end_sym) {
+        /*
+            case: ./integration_tests/arrays_45.f90
+            subroutine a(cs)
+            use xx
+            real, dimension(nx), intent(in) :: cs
+            end subroutine
 
-                transform to:
+            transform to:
 
+            pure integer function __lcompilers_get_nx()
+            use xx
+            get_nx = nx
+            end function
+
+            subroutine a(cs)
+            use xx
+            interface
                 pure integer function __lcompilers_get_nx()
-                use xx
-                get_nx = nx
                 end function
+            end interface
+            real, dimension(__lcompilers_get_nx()), intent(in) :: cs
+            end subroutine
+        */
+        std::string func_name = create_getter_function(end_sym->base.loc, end_sym);
 
-                subroutine a(cs)
-                use xx
-                interface
-                    pure integer function __lcompilers_get_nx()
-                    end function
-                end interface
-                real, dimension(__lcompilers_get_nx()), intent(in) :: cs
-                end subroutine
-            */
-            std::string func_name = create_getter_function(end_sym->base.loc, end_sym);
+        ASRUtils::ASRBuilder b(al, end_sym->base.loc);
+        // create an interface
+        SymbolTable *current_scope_copy = current_scope;
+        current_scope = al.make_new<SymbolTable>(current_scope_copy);
 
-            ASRUtils::ASRBuilder b(al, end_sym->base.loc);
-            // create an interface
-            SymbolTable *current_scope_copy = current_scope;
-            current_scope = al.make_new<SymbolTable>(current_scope_copy);
+        ASR::expr_t* return_var_expr = b.Variable(current_scope, func_name, ASRUtils::symbol_type(end_sym),
+                ASR::intentType::ReturnVar);
 
-            ASR::expr_t* return_var_expr = b.Variable(current_scope, func_name, ASRUtils::symbol_type(end_sym),
-                    ASR::intentType::ReturnVar);
+        ASR::symbol_t* func_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Function_t_util(al, end_sym->base.loc,
+                                current_scope, s2c(al, func_name), nullptr, 0, nullptr, 0, nullptr, 0,
+                                return_var_expr, ASR::abiType::Source,
+                                ASR::accessType::Public, ASR::deftypeType::Interface,
+                                nullptr, false, true, false, false, false, nullptr, 0, false, false, false, nullptr));
 
-            ASR::symbol_t* func_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Function_t_util(al, end_sym->base.loc,
-                                    current_scope, s2c(al, func_name), nullptr, 0, nullptr, 0, nullptr, 0,
-                                    return_var_expr, ASR::abiType::Source,
-                                    ASR::accessType::Public, ASR::deftypeType::Interface,
-                                    nullptr, false, true, false, false, false, nullptr, 0, false, false, false, nullptr));
+        current_scope = current_scope_copy;
+        current_scope->add_symbol(func_name, func_sym);
 
-            current_scope = current_scope_copy;
-            current_scope->add_symbol(func_name, func_sym);
-
-            ASR::expr_t* func_call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, end_sym->base.loc,
-                                    func_sym, func_sym, nullptr, 0, ASRUtils::symbol_type(end_sym), nullptr, nullptr, false));
-            return func_call;
-        }
-        return nullptr;
+        ASR::expr_t* func_call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, end_sym->base.loc,
+                                func_sym, func_sym, nullptr, 0, ASRUtils::symbol_type(end_sym), nullptr, nullptr, false));
+        return func_call;
     }
 
-    ASR::expr_t* convert_integer_binop_to_function_call(ASR::expr_t* end, bool is_argument) {
+    ASR::expr_t* convert_integer_binop_to_function_call(ASR::expr_t* end) {
         ASR::IntegerBinOp_t* end_bin_op = ASR::down_cast<ASR::IntegerBinOp_t>(end);
         ASR::expr_t* left = end_bin_op->m_left;
         ASR::expr_t* right = end_bin_op->m_right;
@@ -1256,9 +1250,9 @@ public:
             */
             ASR::Var_t* end_var = ASR::down_cast<ASR::Var_t>(left);
             ASR::symbol_t* end_sym = end_var->m_v;
-            left = get_transformed_function_call(end_sym, is_argument, end);
+            left = get_transformed_function_call(end_sym);
             if (ASR::is_a<ASR::IntegerBinOp_t>(*right)) {
-                right = convert_integer_binop_to_function_call(right, is_argument);
+                right = convert_integer_binop_to_function_call(right);
             }
         } else if (!ASR::is_a<ASR::Var_t>(*left) && ASR::is_a<ASR::Var_t>(*right)) {
             /* 
@@ -1269,17 +1263,17 @@ public:
             */
             ASR::Var_t* end_var = ASR::down_cast<ASR::Var_t>(right);
             ASR::symbol_t* end_sym = end_var->m_v;
-            right = get_transformed_function_call(end_sym, is_argument, end);
+            right = get_transformed_function_call(end_sym);
             if (ASR::is_a<ASR::IntegerBinOp_t>(*left)) {
-                left = convert_integer_binop_to_function_call(left, is_argument);
+                left = convert_integer_binop_to_function_call(left);
             }
         } else if (ASR::is_a<ASR::Var_t>(*left) && ASR::is_a<ASR::Var_t>(*right)) {
             // Handle expressions like `nx + ny` where both `nx` and `ny` are 
             // external variables.
             ASR::symbol_t* first_end_sym = (ASR::symbol_t*)ASR::down_cast<ASR::Var_t>(left)->m_v;
             ASR::symbol_t* second_end_sym = (ASR::symbol_t*)ASR::down_cast<ASR::Var_t>(right)->m_v;
-            left = get_transformed_function_call(first_end_sym, is_argument, end);
-            right = get_transformed_function_call(second_end_sym, is_argument, end);
+            left = get_transformed_function_call(first_end_sym);
+            right = get_transformed_function_call(second_end_sym);
         } else {
             /* 
             Handle expressions like `a + b` where both `a` and `b` can either be 
@@ -1288,10 +1282,10 @@ public:
             Examples - 1 + 2 and 1 + nx + ny
             */
             if (ASR::is_a<ASR::IntegerBinOp_t>(*left)) {
-                left = convert_integer_binop_to_function_call(left, is_argument);
+                left = convert_integer_binop_to_function_call(left);
             }
             if (ASR::is_a<ASR::IntegerBinOp_t>(*right)) {
-                right = convert_integer_binop_to_function_call(right, is_argument);
+                right = convert_integer_binop_to_function_call(right);
             }
         }
         return ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, end->base.loc,
@@ -1320,9 +1314,14 @@ public:
                 if (ASR::is_a<ASR::Var_t>(*end)) {
                     ASR::Var_t* end_var = ASR::down_cast<ASR::Var_t>(end);
                     ASR::symbol_t* end_sym = end_var->m_v;
-                    end = get_transformed_function_call(end_sym, is_argument, end);
+                    SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(end_sym);
+                    if (ASR::is_a<ASR::ExternalSymbol_t>(*end_sym) ||
+                        (symbol_scope->counter != current_scope->counter && is_argument &&
+                        ASRUtils::expr_value(end) == nullptr) ) {
+                            end = get_transformed_function_call(end_sym);
+                        }
                 } else if(ASR::is_a<ASR::IntegerBinOp_t>(*end)) {
-                    end = convert_integer_binop_to_function_call(end, is_argument);
+                    end = convert_integer_binop_to_function_call(end);
                 }
                 dim.m_length = ASRUtils::compute_length_from_start_end(al, dim.m_start,
                                     end);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1261,6 +1261,71 @@ public:
                                                 func_sym, func_sym, nullptr, 0, ASRUtils::symbol_type(end_sym), nullptr, nullptr, false));
                         end = func_call;
                     }
+                } else if(ASR::is_a<ASR::IntegerBinOp_t>(*end)) {
+                    ASR::IntegerBinOp_t* end_bin_op = ASR::down_cast<ASR::IntegerBinOp_t>(end);
+                    ASR::Var_t* end_var = nullptr;
+                    if (ASR::is_a<ASR::Var_t>(*end_bin_op->m_left)) {
+                        end_var = ASR::down_cast<ASR::Var_t>(end_bin_op->m_left);
+                    } else if (ASR::is_a<ASR::Var_t>(*end_bin_op->m_right)) {
+                        end_var = ASR::down_cast<ASR::Var_t>(end_bin_op->m_right);
+                    }
+
+                    ASR::symbol_t* end_sym = end_var->m_v;
+                    SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(end_sym);
+                    if (ASR::is_a<ASR::ExternalSymbol_t>(*end_sym) ||
+                        (symbol_scope->counter != current_scope->counter && is_argument &&
+                        ASRUtils::expr_value(end) == nullptr) ) {
+                        /*
+                            subroutine a(cs)
+                            use xx
+                            real, dimension(nx - 1), intent(in) :: cs
+                            end subroutine
+
+                            transform to:
+
+                            pure integer function __lcompilers_get_nx()
+                            use xx
+                            get_nx = nx
+                            end function
+
+                            subroutine a(cs)
+                            use xx
+                            interface
+                                pure integer function __lcompilers_get_nx()
+                                end function
+                            end interface
+                            real, dimension(__lcompilers_get_nx() - 1), intent(in) :: cs
+                            end subroutine
+                        */
+                        std::string func_name = create_getter_function(end_sym->base.loc, end_sym);
+
+                        ASRUtils::ASRBuilder b(al, end_sym->base.loc);
+                        // create an interface
+                        SymbolTable *current_scope_copy = current_scope;
+                        current_scope = al.make_new<SymbolTable>(current_scope_copy);
+
+                        ASR::expr_t* return_var_expr = b.Variable(current_scope, func_name, ASRUtils::symbol_type(end_sym),
+                                ASR::intentType::ReturnVar);
+
+                        ASR::symbol_t* func_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Function_t_util(al, end_sym->base.loc,
+                                                current_scope, s2c(al, func_name), nullptr, 0, nullptr, 0, nullptr, 0,
+                                                return_var_expr, ASR::abiType::Source,
+                                                ASR::accessType::Public, ASR::deftypeType::Interface,
+                                                nullptr, false, true, false, false, false, nullptr, 0, false, false, false, nullptr));
+
+                        current_scope = current_scope_copy;
+                        current_scope->add_symbol(func_name, func_sym);
+
+                        ASR::expr_t* func_call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, end_sym->base.loc,
+                                                func_sym, func_sym, nullptr, 0, ASRUtils::symbol_type(end_sym), nullptr, nullptr, false));
+                        if (ASR::is_a<ASR::Var_t>(*end_bin_op->m_left)) {
+                            end = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, end->base.loc, func_call, end_bin_op->m_op,
+                                end_bin_op->m_right, end_bin_op->m_type, end_bin_op->m_value));
+                        } else if (ASR::is_a<ASR::Var_t>(*end_bin_op->m_right)) {
+                            end = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, end->base.loc, end_bin_op->m_left, end_bin_op->m_op,
+                                func_call, end_bin_op->m_type, end_bin_op->m_value));
+                        }                        
+                    }
                 }
                 dim.m_length = ASRUtils::compute_length_from_start_end(al, dim.m_start,
                                     end);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4419,8 +4419,11 @@ ASR::asr_t* make_Cast_t_value(Allocator &al, const Location &a_loc,
         ASR::expr_t* a_arg, ASR::cast_kindType a_kind, ASR::ttype_t* a_type);
 
 static inline ASR::expr_t* compute_length_from_start_end(Allocator& al, ASR::expr_t* start, ASR::expr_t* end) {
-    ASR::expr_t* start_value = ASRUtils::expr_value(start);
+    ASR::expr_t* start_value = nullptr;
     ASR::expr_t* end_value = nullptr;
+    if (start != nullptr) {
+        start_value = ASRUtils::expr_value(start);
+    }
     if (end != nullptr) {
         end_value = ASRUtils::expr_value(end);
     }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4420,7 +4420,10 @@ ASR::asr_t* make_Cast_t_value(Allocator &al, const Location &a_loc,
 
 static inline ASR::expr_t* compute_length_from_start_end(Allocator& al, ASR::expr_t* start, ASR::expr_t* end) {
     ASR::expr_t* start_value = ASRUtils::expr_value(start);
-    ASR::expr_t* end_value = ASRUtils::expr_value(end);
+    ASR::expr_t* end_value = nullptr;
+    if (end != nullptr) {
+        end_value = ASRUtils::expr_value(end);
+    }
 
     // If both start and end have compile time values
     // then length can be computed easily by extracting


### PR DESCRIPTION
fixes #4013 

```fortran
subroutine a(cs)
   use xx
   real, dimension(nx - 1), intent(in) :: cs
end subroutine
```
is transformed to:
```fortran
pure integer function __lcompilers_get_nx()
use xx
get_nx = nx
end function

subroutine a(cs)
   use xx
   interface
      pure integer function __lcompilers_get_nx()
   end function
end interface
real, dimension(__lcompilers_get_nx() - 1), intent(in) :: cs
end subroutine
```

#### Working
```fortran
module xx
   integer :: nx = 4
end module xx

subroutine a(cs)
   use xx
   integer, dimension(nx - 1), intent(in) :: cs
   print *, cs
end subroutine

program main
   integer, dimension(4) :: cs
   cs = [1, 2, 3, 4]
   call a(cs)
end program
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
1 2 3 
```