### PR TITLE
C: Fix name to `_lfortran_d_cpu_time()` in header file

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -220,7 +220,7 @@ LFORTRAN_API int64_t _lfortran_mvbits64(int64_t from, int32_t frompos,
                                         int32_t len, int64_t to, int32_t topos);
 LFORTRAN_API int32_t _lfortran_ibits32(int32_t i, int32_t pos, int32_t len);
 LFORTRAN_API int64_t _lfortran_ibits64(int64_t i, int32_t pos, int32_t len);
-LFORTRAN_API void _lfortran_cpu_time(double *t);
+LFORTRAN_API void _lfortran_d_cpu_time(double *t);
 LFORTRAN_API void _lfortran_i32sys_clock(
         int32_t *count, int32_t *rate, int32_t *max);
 LFORTRAN_API void _lfortran_i64sys_clock(


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/4047