### PR TITLE
Support array type return_type for elemental intrinsics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -795,6 +795,7 @@ RUN(NAME intrinsics_233 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_234 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # parity
 RUN(NAME intrinsics_235 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # lgamma algama dlgama
 RUN(NAME intrinsics_236 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # bit_size, huge
+RUN(NAME intrinsics_237 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sngl
 RUN(NAME intrinsics_238 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # maskl, idl
 RUN(NAME intrinsics_239 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # erfc_scaled
 RUN(NAME intrinsics_240 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dshiftr

--- a/integration_tests/intrinsics_230.f90
+++ b/integration_tests/intrinsics_230.f90
@@ -70,4 +70,4 @@ program intrinsic_230
     if (abs(res1_yn(1) - 0.39357815895597936) > 1e-6) error stop
     if (abs(res1_yn(2) - 0.13456148643731775) > 1e-6) error stop
 
-end
+end program

--- a/integration_tests/intrinsics_237.f90
+++ b/integration_tests/intrinsics_237.f90
@@ -1,0 +1,19 @@
+program intrinsics_237
+    use iso_fortran_env, only: dp => real64, sp => real32
+    implicit none
+    
+    real(sp) :: i1(2) = [1.0_sp, 2.0_sp]
+    real(sp), parameter :: i2 = sum(sngl([1.0_sp, 2.0_sp]))
+    real(dp) :: i3(2) = [1.0_dp, 2.0_dp]
+    real(dp), parameter :: i4 = sum(sngl([1.0_dp, 2.0_dp]))
+
+    print *, sum(sngl(i1))
+    if (sum(sngl(i1)) /= 3.0) error stop
+    print *, i2
+    if (i2 /= 3.0) error stop
+    print *, sum(sngl(i3))
+    if (sum(sngl(i3)) /= 3.0) error stop
+    print *, i4
+    if (i4 /= 3.0) error stop
+
+end program

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -461,7 +461,7 @@ intrinsic_funcs_args = {
     "Sngl": [
         {
             "args": [("real",)],
-            "return": "real32"
+            "return": "real32",
         }
     ],
     "SignFromValue": [
@@ -928,7 +928,7 @@ def add_create_func_return_src(func_name):
         src += indent * 4 +         "return nullptr;\n"
         src += indent * 3 +     "}\n"
         src += indent * 3 +     "set_kind_to_ttype_t(return_type, kind);\n"
-        src += indent * 2 + "}\n"
+        src += indent * 2 + "}\n"        
     src += indent * 2 + "ASR::expr_t *m_value = nullptr;\n"
     src += indent * 2 + f"Vec<ASR::expr_t*> m_args; m_args.reserve(al, {no_of_args});\n"
     for _i in range(no_of_args):
@@ -944,6 +944,12 @@ def add_create_func_return_src(func_name):
             "ASRUtils::expr_type(m_args[0]), m_args[0], return_type, m_value);\n"
 
     else:
+        if ret_type_val:
+            src += indent * 2 + "ASR::ttype_t* type = ASRUtils::expr_type(args[0]);\n"
+            src += indent * 2 + "if (ASR::is_a<ASR::Array_t>(*type)) {\n"
+            src += indent * 3 + "ASR::Array_t* e = ASR::down_cast<ASR::Array_t>(type);\n"
+            src += indent * 3 + f"return_type = TYPE(ASR::make_Array_t(al, type->base.loc, {ret_type_val}, e->m_dims, e->n_dims, ASR::array_physical_typeType::FixedSizeArray));\n"
+            src += indent * 2 + "}\n"
         src += indent * 2 + "if (all_args_evaluated(m_args)) {\n"
         src += indent * 3 +     f"Vec<ASR::expr_t*> args_values; args_values.reserve(al, {no_of_args});\n"
         for _i in range(no_of_args):

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4053,15 +4053,14 @@ namespace Ichar {
     static inline ASR::expr_t* instantiate_Ichar(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
-        declare_basic_variables("_lcompilers_optimization_ichar_" + type_to_str_python(arg_types[0]));
+        declare_basic_variables("_lcompilers_ichar_" + type_to_str_python(arg_types[0]));
         fill_func_arg("str", ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -1, nullptr)));
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
             ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-            ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -1, nullptr)), nullptr)), int32, nullptr)),
-            return_type)));
+            ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -1, nullptr)), nullptr)), int32, nullptr)), return_type)));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);

--- a/tests/reference/asr-intrinsics_46-0ef4d7a.json
+++ b/tests/reference/asr-intrinsics_46-0ef4d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_46-0ef4d7a.stdout",
-    "stdout_hash": "cb53d9d8f7157483d52dc160a17d72a798c737d024ca153d93e75956",
+    "stdout_hash": "8cd7064d74bf90632c97df1fa920744ad1ae1bebd44a9aef0a0eb2f3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_46-0ef4d7a.stdout
+++ b/tests/reference/asr-intrinsics_46-0ef4d7a.stdout
@@ -1487,7 +1487,12 @@
                             Ichar
                             [(Var 2 e)]
                             0
-                            (Integer 4)
+                            (Array
+                                (Integer 4)
+                                [((IntegerConstant 1 (Integer 4))
+                                (IntegerConstant 3 (Integer 4)))]
+                                FixedSizeArray
+                            )
                             ()
                         )]
                         ()
@@ -1502,7 +1507,12 @@
                                         Ichar
                                         [(Var 2 e)]
                                         0
-                                        (Integer 4)
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4))
+                                            (IntegerConstant 3 (Integer 4)))]
+                                            FixedSizeArray
+                                        )
                                         ()
                                     )
                                     NotEq


### PR DESCRIPTION
Towards: #4017 
Fixes: https://github.com/lfortran/lfortran/issues/4059