### PR TITLE
Parse implied-do-loop with variable declaration

### DIFF
--- a/grammar/AST.asdl
+++ b/grammar/AST.asdl
@@ -208,7 +208,7 @@ expr
         fnarg* args, keyword* fnkw, coarrayarg* coargs, keyword* cokw)
     | ArrayInitializer(decl_attribute? vartype, identifier? classtype, expr* args)
     | ImpliedDoLoop(expr* values, identifier var, expr start, expr end,
-        expr? increment)
+        expr? increment, unit_decl2? implied_var_declaration)
     | Num(int n, string? kind)
     | Real(string n)
     | Complex(expr re, expr im)

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -2334,6 +2334,9 @@ expr
             $$ = IMPLIED_DO_LOOP5($2, $4, $6, $8, $10, $12, @$); }
     | "(" expr "," expr "," expr_list "," id "=" expr "," expr "," expr ")" {
             $$ = IMPLIED_DO_LOOP6($2, $4, $6, $8, $10, $12, $14, @$); }
+    | "(" expr "," var_type "::" id "=" expr "," expr ")" {
+            $$ = VAR_DECL4($4,VAR_SYM_DIM_INIT($6, nullptr, 0, $8, Equal, @$),@$);
+            $$ = IMPLIED_DO_LOOP7($2, $6, $8, $10, $$, @$); }
 
 // ### level-1
     | TK_DEF_OP expr { $$ = UNARY_DEFOP($1, $2, @$); }

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -307,6 +307,12 @@ static inline ast_t* VAR_DECL_PRAGMA2(Allocator &al, Location &loc,
         VEC_CAST(xattr, decl_attribute), xattr.n, \
         varsym.p, varsym.n, trivia_cast(trivia))
 
+#define VAR_DECL4(vartype, varsym, l) \
+        make_Declaration_t(p.m_a, l, \
+        down_cast<decl_attribute_t>(vartype), \
+        nullptr, 0, \
+        varsym, 1, nullptr)
+
 decl_attribute_t** VAR_DECL2b(Allocator &al,
             ast_t *xattr0) {
     decl_attribute_t** a = al.allocate<decl_attribute_t*>(1);
@@ -770,7 +776,22 @@ ast_t* implied_do_loop(Allocator &al, Location &loc,
             name2char(i),
             EXPR(low),
             EXPR(high),
-            EXPR_OPT(incr));
+            EXPR_OPT(incr),nullptr);
+}
+ast_t* implied_do_loop2(Allocator &al, Location &loc,
+        Vec<ast_t*> &ex_list,
+        ast_t* i,
+        ast_t* low,
+        ast_t* high,
+        ast_t* incr,
+        ast_t* var_decl_implied) {
+    return make_ImpliedDoLoop_t(al, loc,
+            EXPRS(ex_list), ex_list.size(),
+            name2char(i),
+            EXPR(low),
+            EXPR(high),
+            EXPR_OPT(incr),
+            down_cast<unit_decl2_t>(var_decl_implied));
 }
 
 ast_t* implied_do1(Allocator &al, Location &loc,
@@ -816,6 +837,18 @@ ast_t* implied_do3(Allocator &al, Location &loc,
     }
     return implied_do_loop(al, loc, v, i, low, high, incr);
 }
+ast_t* implied_do4(Allocator &al, Location &loc,
+        ast_t* ex,
+        ast_t* i,
+        ast_t* low,
+        ast_t* high,
+        ast_t* incr,
+        ast_t* var_decl_implied) {
+    Vec<ast_t*> v;
+    v.reserve(al, 1);
+    v.push_back(al, ex);
+    return implied_do_loop2(al, loc, v, i, low, high, incr,var_decl_implied);
+}
 
 #define IMPLIED_DO_LOOP1(ex, i, low, high, l) \
     implied_do1(p.m_a, l, ex, i, low, high, nullptr)
@@ -830,6 +863,8 @@ ast_t* implied_do3(Allocator &al, Location &loc,
     implied_do2(p.m_a, l, ex1, ex2, i, low, high, incr)
 #define IMPLIED_DO_LOOP6(ex1, ex2, ex_list, i, low, high, incr, l) \
     implied_do3(p.m_a, l, ex1, ex2, ex_list, i, low, high, incr)
+#define IMPLIED_DO_LOOP7(ex, i, low, high, var_decl_implied,l) \
+    implied_do4(p.m_a, l, ex, i, low, high, nullptr, var_decl_implied)
 
 char *str2str_null(Allocator &al, const LCompilers::Str &s) {
     if (s.p == nullptr) {


### PR DESCRIPTION
towards #4033 

I changed the parser to fetch the new syntax. I was questioning the way of how we would declare the variable in the implied loop, for now i added to a `unit_decl2` into `ImpliedDoLoop` 
```Fortran
program array_constructor
   implicit none
   real :: a(10)

   a = [real :: (i*2.5, integer :: i = 1,10)]
   
   print *, a

end program array_constructor
```

```shell
 [(ImpliedDoLoop
                    [(* i (Real "2.5"))]
                    i
                    1
                    10
                    ()
                    (Declaration
                        (AttrType
                            TypeInteger
                            []
                            ()
                            ()
                            None
                        )
                        []
                        [(i
                        []
                        []
                        ()
                        1
                        Equal
                        ())]
                        ()
```