### PR TITLE
Fix array symbol duplication in interactive mode

### DIFF
--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -997,6 +997,20 @@ TEST_CASE("FortranEvaluator integer kind 2") {
     CHECK(r.result.i64 == 5);
 }
 
+TEST_CASE("FortranEvaluator Array 1") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult>
+    r = e.evaluate2("integer :: i(10)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("print *, i");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
+}
+
 TEST_CASE("FortranEvaluator re-declaration 1") {
     CompilerOptions cu;
     cu.interactive = true;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2643,9 +2643,11 @@ public:
             llvm::StructType* array_type = static_cast<llvm::StructType*>(
                 llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get()));
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name, array_type);
-            module->getNamedGlobal(x.m_name)->setInitializer(
-                llvm::ConstantStruct::get(array_type,
-                llvm::Constant::getNullValue(array_type)));
+            if (!external) {
+                module->getNamedGlobal(x.m_name)->setInitializer(
+                    llvm::ConstantStruct::get(array_type,
+                    llvm::Constant::getNullValue(array_type)));
+            }
             llvm_symtab[h] = ptr;
         } else if (x.m_type->type == ASR::ttypeType::Logical) {
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name,


### PR DESCRIPTION
Fixes the following problem:

```bash
❯ lf
Interactive Fortran. Experimental prototype, not ready for end users.
LFortran version: 0.0.0
  * Use Ctrl-D to exit
  * Use Enter to submit
  * Use Alt-Enter or Ctrl-N to make a new line
    - Editing (Keys: Left, Right, Home, End, Backspace, Delete)
    - History (Keys: Up, Down)
>>> integer :: i(10)                                                                                                1,17  ]
>>> print *, i                                                                                                      1,11  ]
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  Binary file "/home/vipul/Workspace/others/lfortran/src/bin/lfortran", in _start()
  Binary file "/lib64/libc.so.6", in __libc_start_main_alias_2()
  Binary file "/lib64/libc.so.6", in __libc_start_call_main()
  File "/home/vipul/Workspace/others/lfortran/src/bin/lfortran.cpp", line 2462, in main()
    return main_app(argc, argv);
  File "/home/vipul/Workspace/others/lfortran/src/bin/lfortran.cpp", line 2256, in main_app(int, char**)
    return prompt(arg_v, compiler_options);
  File "/home/vipul/Workspace/others/lfortran/src/bin/lfortran.cpp", line 298, in prompt()
    res = e.evaluate(input, verbose, lm, lpm, diagnostics);
  File "/home/vipul/Workspace/others/lfortran/src/lfortran/fortran_evaluator.cpp", line 126, in LCompilers::FortranEvaluator::evaluate(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, LCompilers::LocationManager&, LCompilers::PassManager&, LCompilers::diag::Diagnostics&)
    e->add_module(std::move(m));
  File "/home/vipul/Workspace/others/lfortran/src/libasr/codegen/evaluator.cpp", line 244, in LCompilers::LLVMEvaluator::add_module(std::unique_ptr<LCompilers::LLVMModule, std::default_delete<LCompilers::LLVMModule> >)
    add_module(std::move(m->m_m));
LCompilersException: addModule() returned an error: Duplicate definition of symbol 'i'
```