### PR TITLE
Deregister features from fortran backend which are not in use yet (for which no tests exist)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -363,6 +363,7 @@ RUN(NAME functions_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_09 LABELS gfortran)
 RUN(NAME functions_10 LABELS gfortran)
 RUN(NAME functions_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME functions_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME functions_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME functions_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_16 LABELS gfortran)
@@ -542,7 +543,7 @@ RUN(NAME int_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm) # int body
 RUN(NAME int_02 LABELS gfortran wasm) # int symboltable
 RUN(NAME int_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # large int and prints array
 
-RUN(NAME intrinsics_01 LABELS gfortran) # sqrt, abs, log
+RUN(NAME intrinsics_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sqrt, abs, log
 RUN(NAME intrinsics_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sin
 RUN(NAME intrinsics_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # cos
 RUN(NAME intrinsics_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # tan
@@ -563,7 +564,7 @@ RUN(NAME intrinsics_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # 
 RUN(NAME intrinsics_17b LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran) # log
 RUN(NAME intrinsics_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trig
 RUN(NAME intrinsics_18c LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # trig
-RUN(NAME intrinsics_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # floor
+RUN(NAME intrinsics_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # multiple intrinsics
 RUN(NAME intrinsics_19c LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # exp, log, sqrt
 RUN(NAME intrinsics_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trig
 RUN(NAME intrinsics_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm) # modulo and mod
@@ -579,7 +580,7 @@ RUN(NAME intrinsics_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # 
 RUN(NAME intrinsics_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm) # ceiling
 RUN(NAME intrinsics_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # merge
 RUN(NAME intrinsics_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # new_line
-RUN(NAME intrinsics_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm) # epsilon
+RUN(NAME intrinsics_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran) # epsilon
 RUN(NAME intrinsics_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # any
 RUN(NAME intrinsics_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # adjustl
 RUN(NAME intrinsics_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # merge
@@ -716,13 +717,13 @@ RUN(NAME intrinsics_166 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST for
 RUN(NAME intrinsics_167 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # btest
 RUN(NAME intrinsics_168 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # ibclr
 RUN(NAME intrinsics_169 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # mod
-RUN(NAME intrinsics_170 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # exponent
+RUN(NAME intrinsics_170 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # exponent
 RUN(NAME intrinsics_171 LABELS llvm llvm_wasm llvm_wasm_emcc) # tolowercase
 RUN(NAME intrinsics_172 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # count
 RUN(NAME intrinsics_173 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # fraction
 RUN(NAME intrinsics_174 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # shape
 RUN(NAME intrinsics_175 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # pack
-RUN(NAME intrinsics_176 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # setexponent
+RUN(NAME intrinsics_176 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # set_exponent
 RUN(NAME intrinsics_177 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # adjustr
 RUN(NAME intrinsics_178 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # rrspacing
 RUN(NAME intrinsics_179 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sum
@@ -766,7 +767,7 @@ RUN(NAME intrinsics_216 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # tand
 RUN(NAME intrinsics_217 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # all
 RUN(NAME intrinsics_218 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # new_line
 RUN(NAME intrinsics_219 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #parameter, sum
-RUN(NAME intrinsics_220 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # mergebits
+RUN(NAME intrinsics_220 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # merge_bits
 RUN(NAME intrinsics_221 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # sum
 RUN(NAME intrinsics_222 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dreal
 RUN(NAME intrinsics_223 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nearest
@@ -776,6 +777,7 @@ RUN(NAME intrinsics_226 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_227 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # norm2
 RUN(NAME intrinsics_228 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # derf
 RUN(NAME intrinsics_229 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derfc
+RUN(NAME intrinsics_230 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # bessel
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)
@@ -1215,7 +1217,7 @@ RUN(NAME sqrt_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME sin_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME sin_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME sin_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
-RUN(NAME sin_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME sin_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME cos_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME bits_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME bits_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/intrinsics_230.f90
+++ b/integration_tests/intrinsics_230.f90
@@ -1,0 +1,73 @@
+program intrinsic_230
+    use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32
+    implicit none
+    real(dp), parameter :: res0_j0(2) = bessel_j0([3.3398640543782485_dp, 3.3398640543782485_dp])
+    real(dp), parameter :: res0_j1(2) = bessel_j1([3.3398640543782485_dp, 5.039184326269492_dp])
+    real(dp), parameter :: res0_jn(2) = bessel_jn(1, [3.3398640543782485_dp, 5.039184326269492_dp])
+    real(dp), parameter :: res0_y0(2) = bessel_y0([3.3398640543782485_dp, 3.3398640543782485_dp])
+    real(dp), parameter :: res0_y1(2) = bessel_y1([3.3398640543782485_dp, 5.039184326269492_dp])
+    real(dp), parameter :: res0_yn(2) = bessel_yn(1, [3.3398640543782485_dp, 5.039184326269492_dp])
+
+    real(dp) :: res1_j0(2)
+    real(dp) :: res1_j1(2)
+    real(dp) :: res1_jn(2)
+    real(dp) :: res1_y0(2)
+    real(dp) :: res1_y1(2)
+    real(dp) :: res1_yn(2)
+
+    res1_j0 = bessel_j0([3.3398640543782485_dp, 3.3398640543782485_dp])
+    res1_j1 = bessel_j1([3.3398640543782485_dp, 5.039184326269492_dp])
+    res1_jn = bessel_jn(1, [3.3398640543782485_dp, 5.039184326269492_dp])
+    res1_y0 = bessel_y0([3.3398640543782485_dp, 3.3398640543782485_dp])
+    res1_y1 = bessel_y1([3.3398640543782485_dp, 5.039184326269492_dp])
+    res1_yn = bessel_yn(1, [3.3398640543782485_dp, 5.039184326269492_dp])
+
+    print*, res0_j0
+    if (abs(res0_j0(1) - (-0.35276533724012676)) > 1e6) error stop
+    if (abs(res0_j0(2) - (-0.35276533724012676)) > 1e6) error stop
+
+    print*, res0_j1
+    if (abs(res0_j1(1) - 0.581545886001298) > 1e6) error stop
+    if (abs(res0_j1(2) - 0.581545886001298) > 1e6) error stop
+
+    print*, res0_jn
+    if (abs(res0_jn(1) - 0.581545886001298) > 1e6) error stop
+    if (abs(res0_jn(2) - 0.581545886001298) > 1e6) error stop
+
+    print*, res0_y0
+    if (abs(res0_y0(1) - 0.281323269014833) > 1e6) error stop
+    if (abs(res0_y0(2) - 0.281323269014833) > 1e6) error stop
+
+    print*, res0_y1
+    if (abs(res0_y1(1) - 0.506133477927775) > 1e6) error stop
+    if (abs(res0_y1(2) - 0.506133477927775) > 1e6) error stop
+
+    print*, res0_yn
+    if (abs(res0_yn(1) - 0.506133477927775) > 1e6) error stop
+    if (abs(res0_yn(2) - 0.506133477927775) > 1e6) error stop
+    
+    print*, res1_j0
+    if (abs(res1_j0(1) - (-0.35276533724012676)) > 1e6) error stop
+    if (abs(res1_j0(2) - (-0.35276533724012676)) > 1e6) error stop
+
+    print*, res1_j1
+    if (abs(res1_j1(1) - 0.581545886001298) > 1e6) error stop
+    if (abs(res1_j1(2) - 0.581545886001298) > 1e6) error stop
+
+    print*, res1_jn
+    if (abs(res1_jn(1) - 0.581545886001298) > 1e6) error stop
+    if (abs(res1_jn(2) - 0.581545886001298) > 1e6) error stop
+
+    print*, res1_y0
+    if (abs(res1_y0(1) - 0.281323269014833) > 1e6) error stop
+    if (abs(res1_y0(2) - 0.281323269014833) > 1e6) error stop
+
+    print*, res1_y1
+    if (abs(res1_y1(1) - 0.506133477927775) > 1e6) error stop
+    if (abs(res1_y1(2) - 0.506133477927775) > 1e6) error stop
+
+    print*, res1_yn
+    if (abs(res1_yn(1) - 0.506133477927775) > 1e6) error stop
+    if (abs(res1_yn(2) - 0.506133477927775) > 1e6) error stop
+
+end

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1350,10 +1350,8 @@ public:
             SET_INTRINSIC_NAME(SetExponent, "set_exponent");
             SET_INTRINSIC_NAME(Leadz, "leadz");
             SET_INTRINSIC_NAME(Hypot, "hypot");
-            SET_INTRINSIC_NAME(Radix, "radix");
             SET_INTRINSIC_NAME(Scale, "scale");
             SET_INTRINSIC_NAME(Dprod, "dprod");
-            SET_INTRINSIC_NAME(Range, "range");
             SET_INTRINSIC_NAME(Sign, "sign");
             SET_INTRINSIC_NAME(Aint, "aint");
             SET_INTRINSIC_NAME(Popcnt, "popcnt");
@@ -1362,13 +1360,7 @@ public:
             SET_INTRINSIC_NAME(Dim, "dim");
             SET_INTRINSIC_NAME(Ifix, "ifix");
             SET_INTRINSIC_NAME(Idint, "idint");
-            SET_INTRINSIC_NAME(Epsilon, "epsilon");
-            SET_INTRINSIC_NAME(Precision, "precision");
-            SET_INTRINSIC_NAME(Tiny, "tiny");
-            SET_INTRINSIC_NAME(BitSize, "bit_size");
-            SET_INTRINSIC_NAME(NewLine, "new_line");
             SET_INTRINSIC_NAME(Conjg, "conjg");
-            SET_INTRINSIC_NAME(Huge, "huge");
             default : {
                 throw LCompilersException("IntrinsicElementalFunction: `"
                     + ASRUtils::get_intrinsic_name(x.m_intrinsic_id)

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1328,8 +1328,6 @@ public:
             SET_INTRINSIC_NAME(LogGamma, "log_gamma");
             SET_INTRINSIC_NAME(Erf, "erf");
             SET_INTRINSIC_NAME(Erfc, "erfc");
-            SET_INTRINSIC_NAME(Trunc, "trunc");
-            SET_INTRINSIC_NAME(Fix, "fix");
             SET_INTRINSIC_NAME(Gamma, "gamma");
             SET_INTRINSIC_NAME(BesselJ0, "bessel_j0");
             SET_INTRINSIC_NAME(BesselJ1, "bessel_j1");
@@ -1346,22 +1344,12 @@ public:
             SET_INTRINSIC_NAME(Spacing, "spacing");
             SET_INTRINSIC_NAME(BesselJN, "bessel_jn");
             SET_INTRINSIC_NAME(BesselYN, "bessel_yn");
-            SET_INTRINSIC_NAME(Mvbits, "mvbits");
             SET_INTRINSIC_NAME(Mergebits, "merge_bits");
             SET_INTRINSIC_NAME(Exponent, "exponent");
             SET_INTRINSIC_NAME(Fraction, "fraction");
             SET_INTRINSIC_NAME(SetExponent, "set_exponent");
             SET_INTRINSIC_NAME(Leadz, "leadz");
-            SET_INTRINSIC_NAME(ToLowerCase, "_lfortran_tolowercase");
             SET_INTRINSIC_NAME(Hypot, "hypot");
-            SET_INTRINSIC_NAME(ListIndex, "list.index");
-            SET_INTRINSIC_NAME(ListReverse, "list.reverse");
-            SET_INTRINSIC_NAME(ListPop, "list.pop");
-            SET_INTRINSIC_NAME(ListReserve, "list.reserve");
-            SET_INTRINSIC_NAME(DictKeys, "dict.keys");
-            SET_INTRINSIC_NAME(DictValues, "dict.values");
-            SET_INTRINSIC_NAME(SetAdd, "set.add");
-            SET_INTRINSIC_NAME(SetRemove, "set.remove");
             SET_INTRINSIC_NAME(Radix, "radix");
             SET_INTRINSIC_NAME(Scale, "scale");
             SET_INTRINSIC_NAME(Dprod, "dprod");
@@ -1381,28 +1369,6 @@ public:
             SET_INTRINSIC_NAME(NewLine, "new_line");
             SET_INTRINSIC_NAME(Conjg, "conjg");
             SET_INTRINSIC_NAME(Huge, "huge");
-            SET_INTRINSIC_NAME(SymbolicAdd, "SymbolicAdd");
-            SET_INTRINSIC_NAME(SymbolicSub, "SymbolicSub");
-            SET_INTRINSIC_NAME(SymbolicMul, "SymbolicMul");
-            SET_INTRINSIC_NAME(SymbolicDiv, "SymbolicDiv");
-            SET_INTRINSIC_NAME(SymbolicPow, "SymbolicPow");
-            SET_INTRINSIC_NAME(SymbolicPi, "pi");
-            SET_INTRINSIC_NAME(SymbolicE, "E");
-            SET_INTRINSIC_NAME(SymbolicInteger, "SymbolicInteger");
-            SET_INTRINSIC_NAME(SymbolicDiff, "diff");
-            SET_INTRINSIC_NAME(SymbolicExpand, "expand");
-            SET_INTRINSIC_NAME(SymbolicSin, "SymbolicSin");
-            SET_INTRINSIC_NAME(SymbolicCos, "SymbolicCos");
-            SET_INTRINSIC_NAME(SymbolicLog, "SymbolicLog");
-            SET_INTRINSIC_NAME(SymbolicExp, "SymbolicExp");
-            SET_INTRINSIC_NAME(SymbolicAbs, "SymbolicAbs");
-            SET_INTRINSIC_NAME(SymbolicHasSymbolQ, "has");
-            SET_INTRINSIC_NAME(SymbolicAddQ, "AddQ");
-            SET_INTRINSIC_NAME(SymbolicMulQ, "MulQ");
-            SET_INTRINSIC_NAME(SymbolicPowQ, "PowQ");
-            SET_INTRINSIC_NAME(SymbolicLogQ, "LogQ");
-            SET_INTRINSIC_NAME(SymbolicSinQ, "SinQ");
-            SET_INTRINSIC_NAME(SymbolicGetArgument, "GetArgument");
             default : {
                 throw LCompilersException("IntrinsicElementalFunction: `"
                     + ASRUtils::get_intrinsic_name(x.m_intrinsic_id)


### PR DESCRIPTION
I've also shifted the intrinsic Inquiry functions from elemental functions.
Towards: https://github.com/lfortran/lfortran/pull/4054#discussion_r1611988947, #4017 
