### PR TITLE
Temporary PR to debug Asr verify windows bug

### DIFF
--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1172,6 +1172,42 @@ end subroutine sa
     CHECK(r.result.i32 == 1);
 }
 
+TEST_CASE("FortranEvaluator asr verify 3") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult>
+    r = e.evaluate2(R"(
+function add(x, y) result(r)
+    real, intent(in) :: x
+    real, intent(in) :: y
+    real :: r
+    r = x + y
+end function add
+)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2(R"(
+function sub(x, y) result(r)
+    real, intent(in) :: x
+    real, intent(in) :: y
+    real :: r
+    r = add(x, -y)
+end function sub
+)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("add(2.0, 3.0)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::real4);
+    CHECK(r.result.f32 == 5.0);
+    r = e.evaluate2("sub(2.0, 3.0)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::real4);
+    CHECK(r.result.f32 == -1.0);
+}
+
 // This test does not work on Windows yet
 // https://github.com/lfortran/lfortran/issues/913
 #if !defined(_WIN32)

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1077,6 +1077,101 @@ end function
 */
 }
 
+TEST_CASE("FortranEvaluator asr verify 1") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult>
+    r = e.evaluate2(R"(
+pure function double(x) result(r)
+    integer, intent(in) :: x
+    integer :: r
+    r = 2 * x
+end function double
+)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2(R"(
+subroutine s(n, x)
+    integer, intent(in) :: n
+    integer, intent(inout) :: x
+    x = double(n)
+end subroutine s
+)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("integer :: x");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("x = double(1)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
+    r = e.evaluate2("x");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 2);
+    r = e.evaluate2("call s(x, x)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
+    r = e.evaluate2("x");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 4);
+}
+
+TEST_CASE("FortranEvaluator asr verify 2") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult>
+    r = e.evaluate2(R"(
+pure function id(x) result(r)
+    integer, intent(in) :: x
+    integer :: r
+    r = x
+end function id
+)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2(R"(
+subroutine sa(l, a)
+    integer, intent(in) :: l
+    integer, intent(inout) :: a(id(l))
+    
+    integer :: i
+    
+    do i = 1, size(a)
+        a(i) = a(i) + 1
+    end do
+end subroutine sa
+)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("integer :: arr(3)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("arr = 0");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
+    r = e.evaluate2("call sa(3, arr)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
+    r = e.evaluate2("arr(1)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 1);
+    r = e.evaluate2("arr(2)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 1);
+    r = e.evaluate2("arr(3)");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 1);
+}
+
 // This test does not work on Windows yet
 // https://github.com/lfortran/lfortran/issues/913
 #if !defined(_WIN32)

--- a/src/libasr/asr_scopes.cpp
+++ b/src/libasr/asr_scopes.cpp
@@ -3,6 +3,7 @@
 
 #include <libasr/asr_scopes.h>
 #include <libasr/asr_utils.h>
+#include <libasr/pass/pass_utils.h>
 
 std::string lcompilers_unique_ID;
 
@@ -39,9 +40,13 @@ void SymbolTable::mark_all_variables_external(Allocator &al) {
             case (ASR::symbolType::Function) : {
                 ASR::Function_t *v = ASR::down_cast<ASR::Function_t>(a.second);
                 ASR::FunctionType_t* v_func_type = ASR::down_cast<ASR::FunctionType_t>(v->m_function_signature);
+                if (v_func_type->m_abi != ASR::abiType::Interactive) {
+                    v->m_body = nullptr;
+                    v->n_body = 0;
+                    PassUtils::UpdateDependenciesVisitor ud(al);
+                    ud.visit_Function(*v);
+                }
                 v_func_type->m_abi = ASR::abiType::Interactive;
-                v->m_body = nullptr;
-                v->n_body = 0;
                 break;
             }
             case (ASR::symbolType::Module) : {

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -420,6 +420,11 @@ public:
     }
 
     void visit_Function(const Function_t &x) {
+        ASR::FunctionType_t* x_func_type = ASR::down_cast<ASR::FunctionType_t>(x.m_function_signature);
+        if (x_func_type->m_abi == abiType::Interactive) {
+            require(x.n_body == 0,
+            "The Function::n_body should be 0 if abi set to Interactive");
+        }
         std::vector<std::string> function_dependencies_copy = function_dependencies;
         function_dependencies.clear();
         function_dependencies.reserve(x.n_dependencies);

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -420,8 +420,7 @@ public:
     }
 
     void visit_Function(const Function_t &x) {
-        ASR::FunctionType_t* x_func_type = ASR::down_cast<ASR::FunctionType_t>(x.m_function_signature);
-        if (x_func_type->m_abi == abiType::Interactive) {
+        if (ASRUtils::get_FunctionType(&x)->m_abi == abiType::Interactive) {
             require(x.n_body == 0,
             "The Function::n_body should be 0 if abi set to Interactive");
         }

--- a/src/libasr/pass/intrinsic_subroutine.cpp
+++ b/src/libasr/pass/intrinsic_subroutine.cpp
@@ -37,7 +37,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
     public:
 
         ReplaceIntrinsicSubroutines(Allocator& al_) :
-        al(al_), remove_original_statement(false) {
+        al(al_), global_scope(nullptr), remove_original_statement(false), parent_body(nullptr) {
             pass_result.n = 0;
         }
 


### PR DESCRIPTION
Will be using this branch to debug the Windows CI error in #4086

---

Bug:

```bash
$ ./src/lfortran/tests/Release/test_lfortran.exe
[doctest] doctest version is "2.4.8"
[doctest] run with "--help" for options
0 0 0 0 0 0 0 0 0 0
JIT session error: Failed to materialize symbols: { (Main, { sub }) }
JIT session error: Failed to materialize symbols: { (Main, { __real@80000000 }) }
===============================================================================
C:\Users\vipul\Documents\Workspace\lfortran\src\lfortran\tests\test_llvm.cpp(1175):
TEST CASE:  FortranEvaluator asr verify 3

C:\Users\vipul\Documents\Workspace\lfortran\src\lfortran\tests\test_llvm.cpp(1175): ERROR: test case THREW exception: lookup() failed to find the symbol '__lfortran_evaluate_4', error: Failed to materialize symbols: { (Main, { __lfortran_evaluate_4 }) }

===============================================================================
[doctest] test cases:  87 |  86 passed | 1 failed | 0 skipped
[doctest] assertions: 607 | 607 passed | 0 failed |
[doctest] Status: FAILURE!
```