### PR TITLE
fix return_type of bit_size intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -782,6 +782,7 @@ RUN(NAME intrinsics_230 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_231 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # dgamma
 RUN(NAME intrinsics_234 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # parity
 RUN(NAME intrinsics_235 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # lgamma algama dlgama
+RUN(NAME intrinsics_236 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # bit_size, huge
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_236.f90
+++ b/integration_tests/intrinsics_236.f90
@@ -1,0 +1,15 @@
+program intrinsics_236
+    implicit none
+    integer,parameter:: ik1 = selected_int_kind(1)
+    print "(A,I0)", &
+        'ik1                   = ',ik1,&
+        'kind(bit_size(1_ik1)) = ',kind(bit_size(1_ik1)), &
+        'kind(huge(1_ik1))     = ',kind(huge(1_ik1)),&
+        'huge(1_ik1)           = ',huge(1_ik1)
+
+    if (1_ik1 /= 1) error stop
+    if (kind(bit_size(1_ik1)) /= 1) error stop
+    if (kind(huge(1_ik1)) /= 1) error stop
+    if (huge(1_ik1) /= 127) error stop
+
+end program

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -605,7 +605,7 @@ intrinsic_funcs_args = {
     "BitSize": [
         {
             "args": [("int",)],
-            "return": "int32"
+            "ret_type_arg_idx": 0
         }
     ],
     "NewLine": [

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3763,9 +3763,9 @@ namespace Rank {
 namespace BitSize {
 
     static ASR::expr_t *eval_BitSize(Allocator &al, const Location &loc,
-            ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
         int kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0]));
-        return make_ConstantWithType(make_IntegerConstant_t, 8*kind, int32, loc);
+        return make_ConstantWithType(make_IntegerConstant_t, 8*kind, t1, loc);
     }
 
 } // namespace BitSize

--- a/tests/reference/asr-bits_02-e48c6d3.json
+++ b/tests/reference/asr-bits_02-e48c6d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bits_02-e48c6d3.stdout",
-    "stdout_hash": "f48236911cdf24683a613dcc52175bf5be038cd71e351337d44e7589",
+    "stdout_hash": "ec78d71b1551184dc54abad357a441426a3d9971089700c1ef2bab77",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bits_02-e48c6d3.stdout
+++ b/tests/reference/asr-bits_02-e48c6d3.stdout
@@ -71,10 +71,15 @@
                                     block_size
                                     []
                                     Local
-                                    (TypeInquiry
-                                        BitSize
-                                        (Integer 8)
-                                        (IntegerConstant 0 (Integer 8))
+                                    (Cast
+                                        (TypeInquiry
+                                            BitSize
+                                            (Integer 8)
+                                            (IntegerConstant 0 (Integer 8))
+                                            (Integer 8)
+                                            (IntegerConstant 64 (Integer 8))
+                                        )
+                                        IntegerToInteger
                                         (Integer 4)
                                         (IntegerConstant 64 (Integer 4))
                                     )


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3999
Towards: #4017 