### PR TITLE
fix: population of optional args in intrinsics while compile time evalution of implied do loops

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -785,6 +785,7 @@ RUN(NAME intrinsics_233 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_234 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # parity
 RUN(NAME intrinsics_235 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # lgamma algama dlgama
 RUN(NAME intrinsics_236 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # bit_size, huge
+RUN(NAME intrinsics_238 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskl, idl
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -785,7 +785,7 @@ RUN(NAME intrinsics_233 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_234 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fortran) # parity
 RUN(NAME intrinsics_235 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # lgamma algama dlgama
 RUN(NAME intrinsics_236 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # bit_size, huge
-RUN(NAME intrinsics_238 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskl, idl
+RUN(NAME intrinsics_238 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # maskl, idl
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_238.f90
+++ b/integration_tests/intrinsics_238.f90
@@ -1,12 +1,9 @@
 program intrinsics_238
-    implicit none
-  
-    integer :: i
-    integer :: res(5)
-    res = [ (maskl(i), i=1, 5) ]
-    do i = 1, 5
-      print*, res(i)
-      if (maskl(i) /= res(i) ) error stop
-    end do
-  
-  end program
+implicit none
+integer :: i
+integer, parameter :: res(5) = [ (maskl(i), i=1, 5) ]
+do i = 1, 5
+print*, res(i), maskl(i)
+if (maskl(i) /= res(i) ) error stop
+end do
+end program

--- a/integration_tests/intrinsics_238.f90
+++ b/integration_tests/intrinsics_238.f90
@@ -1,0 +1,12 @@
+program intrinsics_238
+    implicit none
+  
+    integer :: i
+    integer :: res(5)
+    res = [ (maskl(i), i=1, 5) ]
+    do i = 1, 5
+      print*, res(i)
+      if (maskl(i) /= res(i) ) error stop
+    end do
+  
+  end program


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4070