### PR TITLE
feat: add support for global `COMPLEX` variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -876,6 +876,7 @@ RUN(NAME modules_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST)
+RUN(NAME modules_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES

--- a/integration_tests/modules_57.f90
+++ b/integration_tests/modules_57.f90
@@ -1,0 +1,9 @@
+module module_modules_57
+complex :: c = (3.0, 4.0)
+end module module_modules_57
+
+program modules_57
+use module_modules_57
+print *, abs(c)
+if (abs(abs(c) - 5.0) > 1e-8) error stop
+end program modules_57

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2810,19 +2810,25 @@ public:
             llvm::Constant* ptr = module->getOrInsertGlobal(x.m_name, type);
 
             if (!external) {
+                double x_re = 0.0, x_im = 0.0;
+                if (x.m_value) {
+                    LCOMPILERS_ASSERT(ASR::is_a<ASR::ComplexConstant_t>(*x.m_value));
+                    ASR::ComplexConstant_t* x_cc = ASR::down_cast<ASR::ComplexConstant_t>(x.m_value);
+                    x_re = x_cc->m_re; x_im = x_cc->m_im;
+                }
                 if (init_value) {
                     module->getNamedGlobal(x.m_name)->setInitializer(init_value);
                 } else {
                     switch (a_kind) {
                         case 4: {
-                            re = llvm::ConstantFP::get(context, llvm::APFloat((float) 0.0));
-                            im = llvm::ConstantFP::get(context, llvm::APFloat((float) 0.0));
+                            re = llvm::ConstantFP::get(context, llvm::APFloat((float) x_re));
+                            im = llvm::ConstantFP::get(context, llvm::APFloat((float) x_im));
                             type = complex_type_4;
                             break;
                         }
                         case 8: {
-                            re = llvm::ConstantFP::get(context, llvm::APFloat((double) 0.0));
-                            im = llvm::ConstantFP::get(context, llvm::APFloat((double) 0.0));
+                            re = llvm::ConstantFP::get(context, llvm::APFloat((double) x_re));
+                            im = llvm::ConstantFP::get(context, llvm::APFloat((double) x_im));
                             type = complex_type_8;
                             break;
                         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2801,6 +2801,42 @@ public:
                 llvm::ConstantStruct::get(set_type,
                 llvm::Constant::getNullValue(set_type)));
             llvm_symtab[h] = ptr;
+        } else if (x.m_type->type == ASR::ttypeType::Complex) {
+            int a_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+
+            llvm::Constant* re;
+            llvm::Constant* im;
+            llvm::Type* type = llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get());;
+            llvm::Constant* ptr = module->getOrInsertGlobal(x.m_name, type);
+
+            if (!external) {
+                if (init_value) {
+                    module->getNamedGlobal(x.m_name)->setInitializer(init_value);
+                } else {
+                    switch (a_kind) {
+                        case 4: {
+                            re = llvm::ConstantFP::get(context, llvm::APFloat((float) 0.0));
+                            im = llvm::ConstantFP::get(context, llvm::APFloat((float) 0.0));
+                            type = complex_type_4;
+                            break;
+                        }
+                        case 8: {
+                            re = llvm::ConstantFP::get(context, llvm::APFloat((double) 0.0));
+                            im = llvm::ConstantFP::get(context, llvm::APFloat((double) 0.0));
+                            type = complex_type_8;
+                            break;
+                        }
+                        default: {
+                            throw CodeGenError("kind type is not supported");
+                        }
+                    }
+                    // Create a constant structure to represent the complex number
+                    std::vector<llvm::Constant*> elements = { re, im };
+                    llvm::Constant* complex_init = llvm::ConstantStruct::get(static_cast<llvm::StructType*>(type), elements);
+                    module->getNamedGlobal(x.m_name)->setInitializer(complex_init);
+                }
+            }
+            llvm_symtab[h] = ptr;
         } else if (x.m_type->type == ASR::ttypeType::TypeParameter) {
             // Ignore type variables
         } else {


### PR DESCRIPTION
fixes #4115. fixes #4120.

The implementation is complete in itself, but due to #4120 it currently prints a zero value even when an initial value is available.

```fortran
module test_complex_module
   complex :: c = (3.0, 4.0)
end module test_complex_module

program test_complex_program
   use test_complex_module
   print *, c
end program test_complex_program
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
(0.000000,0.000000)
```