### PR TITLE
chore: throw error when an argument of incorrect length is passed to `ichar` and `iachar`

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5155,12 +5155,20 @@ public:
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, kind_value));
         ASR::expr_t* iachar_value = nullptr;
         ASR::expr_t* arg_value = ASRUtils::expr_value(arg);
+        ASR::ttype_t* arg_type = ASRUtils::expr_type(arg);
+        if (ASR::is_a<ASR::Character_t>(*arg_type) && !ASR::is_a<ASR::StringSection_t>(*arg)) {
+            ASR::Character_t* char_type = ASR::down_cast<ASR::Character_t>(arg_type);
+            if (char_type->m_len != 1) {
+                throw SemanticError("first argument to `iachar` must be of length one",
+                                    arg->base.loc);
+            }
+        }
         if( arg_value ) {
             std::string arg_str;
             bool is_const_value = ASRUtils::is_value_constant(arg_value, arg_str);
             if( is_const_value ) {
                 if (arg_str.length() != 1) {
-                    throw SemanticError("first argument to iachar must be of length one", arg->base.loc);
+                    throw SemanticError("first argument to `iachar` must be of length one", arg->base.loc);
                 }
                 int64_t ascii_code = uint8_t(arg_str[0]);
                 iachar_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5159,6 +5159,9 @@ public:
             std::string arg_str;
             bool is_const_value = ASRUtils::is_value_constant(arg_value, arg_str);
             if( is_const_value ) {
+                if (arg_str.length() != 1) {
+                    throw SemanticError("first argument to iachar must be of length one", arg->base.loc);
+                }
                 int64_t ascii_code = uint8_t(arg_str[0]);
                 iachar_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc,
                                 ascii_code, type));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5156,7 +5156,9 @@ public:
         ASR::expr_t* iachar_value = nullptr;
         ASR::expr_t* arg_value = ASRUtils::expr_value(arg);
         ASR::ttype_t* arg_type = ASRUtils::expr_type(arg);
-        if (ASR::is_a<ASR::Character_t>(*arg_type) && !ASR::is_a<ASR::StringSection_t>(*arg)) {
+        if (ASR::is_a<ASR::Character_t>(*arg_type) 
+            && !ASR::is_a<ASR::StringSection_t>(*arg)
+            && !ASRUtils::is_allocatable(arg_type)) {
             ASR::Character_t* char_type = ASR::down_cast<ASR::Character_t>(arg_type);
             if (char_type->m_len != 1) {
                 throw SemanticError("first argument to `iachar` must be of length one",

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2076,6 +2076,12 @@ static inline bool is_character(ASR::ttype_t &x) {
                 type_get_past_pointer(&x))));
 }
 
+static inline bool is_character_of_length(ASR::ttype_t &x, int length) {
+    return is_character(x) && ASR::down_cast<ASR::Character_t>(type_get_past_array(
+                                type_get_past_allocatable(
+                                    type_get_past_pointer(&x))))->m_len == length;
+}
+
 static inline bool is_complex(ASR::ttype_t &x) {
     return ASR::is_a<ASR::Complex_t>(
         *type_get_past_array(

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1376,20 +1376,6 @@ public:
         }
         this->visit_expr_wrapper(x.m_arg, true);
         llvm::Value *c = tmp;
-        if (!ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_arg))) {
-            llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
-            builder->CreateStore(tmp, parg);
-            llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
-            llvm_utils->create_if_else(is_len_not_one, [&]() {
-                llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to ichar must be of length one\n");
-                    print_error(context, *module, *builder, {fmt_ptr});
-                int exit_code_int = 1;
-                llvm::Value *exit_code = llvm::ConstantInt::get(context,
-                        llvm::APInt(32, exit_code_int));
-                exit(context, *module, *builder, exit_code);
-            },
-            []() {});
-        }
         std::string runtime_func_name = "_lfortran_ichar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {
@@ -1413,20 +1399,6 @@ public:
         this->visit_expr(*x.m_arg);
         ptr_loads = ptr_loads_copy;
         llvm::Value *c = tmp;
-        if (!ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_arg))) {
-            llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
-            builder->CreateStore(tmp, parg);
-            llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
-            llvm_utils->create_if_else(is_len_not_one, [&]() {
-                llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to iachar must be of length one\n");
-                    print_error(context, *module, *builder, {fmt_ptr});
-                int exit_code_int = 1;
-                llvm::Value *exit_code = llvm::ConstantInt::get(context,
-                        llvm::APInt(32, exit_code_int));
-                exit(context, *module, *builder, exit_code);
-            },
-            []() {});
-        }
         std::string runtime_func_name = "_lfortran_iachar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1376,6 +1376,18 @@ public:
         }
         this->visit_expr_wrapper(x.m_arg, true);
         llvm::Value *c = tmp;
+        llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+        builder->CreateStore(tmp, parg);
+        llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
+        llvm_utils->create_if_else(is_len_not_one, [&]() {
+            llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to ichar must be of length one\n");
+                print_error(context, *module, *builder, {fmt_ptr});
+            int exit_code_int = 1;
+            llvm::Value *exit_code = llvm::ConstantInt::get(context,
+                    llvm::APInt(32, exit_code_int));
+            exit(context, *module, *builder, exit_code);
+        },
+        []() {});
         std::string runtime_func_name = "_lfortran_ichar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {
@@ -1399,6 +1411,18 @@ public:
         this->visit_expr(*x.m_arg);
         ptr_loads = ptr_loads_copy;
         llvm::Value *c = tmp;
+        llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+        builder->CreateStore(tmp, parg);
+        llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
+        llvm_utils->create_if_else(is_len_not_one, [&]() {
+            llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to iachar must be of length one\n");
+                print_error(context, *module, *builder, {fmt_ptr});
+            int exit_code_int = 1;
+            llvm::Value *exit_code = llvm::ConstantInt::get(context,
+                    llvm::APInt(32, exit_code_int));
+            exit(context, *module, *builder, exit_code);
+        },
+        []() {});
         std::string runtime_func_name = "_lfortran_iachar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1376,18 +1376,20 @@ public:
         }
         this->visit_expr_wrapper(x.m_arg, true);
         llvm::Value *c = tmp;
-        llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
-        builder->CreateStore(tmp, parg);
-        llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
-        llvm_utils->create_if_else(is_len_not_one, [&]() {
-            llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to ichar must be of length one\n");
-                print_error(context, *module, *builder, {fmt_ptr});
-            int exit_code_int = 1;
-            llvm::Value *exit_code = llvm::ConstantInt::get(context,
-                    llvm::APInt(32, exit_code_int));
-            exit(context, *module, *builder, exit_code);
-        },
-        []() {});
+        if (!ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_arg))) {
+            llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+            builder->CreateStore(tmp, parg);
+            llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
+            llvm_utils->create_if_else(is_len_not_one, [&]() {
+                llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to ichar must be of length one\n");
+                    print_error(context, *module, *builder, {fmt_ptr});
+                int exit_code_int = 1;
+                llvm::Value *exit_code = llvm::ConstantInt::get(context,
+                        llvm::APInt(32, exit_code_int));
+                exit(context, *module, *builder, exit_code);
+            },
+            []() {});
+        }
         std::string runtime_func_name = "_lfortran_ichar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {
@@ -1411,18 +1413,20 @@ public:
         this->visit_expr(*x.m_arg);
         ptr_loads = ptr_loads_copy;
         llvm::Value *c = tmp;
-        llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
-        builder->CreateStore(tmp, parg);
-        llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
-        llvm_utils->create_if_else(is_len_not_one, [&]() {
-            llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to iachar must be of length one\n");
-                print_error(context, *module, *builder, {fmt_ptr});
-            int exit_code_int = 1;
-            llvm::Value *exit_code = llvm::ConstantInt::get(context,
-                    llvm::APInt(32, exit_code_int));
-            exit(context, *module, *builder, exit_code);
-        },
-        []() {});
+        if (!ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_arg))) {
+            llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+            builder->CreateStore(tmp, parg);
+            llvm::Value *is_len_not_one = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(1));
+            llvm_utils->create_if_else(is_len_not_one, [&]() {
+                llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("Error: first argument to iachar must be of length one\n");
+                    print_error(context, *module, *builder, {fmt_ptr});
+                int exit_code_int = 1;
+                llvm::Value *exit_code = llvm::ConstantInt::get(context,
+                        llvm::APInt(32, exit_code_int));
+                exit(context, *module, *builder, exit_code);
+            },
+            []() {});
+        }
         std::string runtime_func_name = "_lfortran_iachar";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -824,6 +824,7 @@ def compute_arg_condition(no_of_args, args_lists):
         for i in range(no_of_args):
             arg = arg_list[i]
             if (type(arg) == tuple):
+                assert (arg[0] == "char")
                 subcond.append(f"{type_to_asr_type_check[arg[0]]}(*arg_type{i})")
                 subcond.append(f"ASRUtils::is_character_of_length(*arg_type{i}, {arg[1]})")
                 subcond_in_msg.append(arg[0] + " of length " + str(arg[1]))

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -714,7 +714,7 @@ intrinsic_funcs_args = {
     ],
     "Ichar": [
         {
-            "args": [("char",)],
+            "args": [(("char", 1), )],
             "return": "int32",
             "kind_arg": True
         },
@@ -823,8 +823,13 @@ def compute_arg_condition(no_of_args, args_lists):
         subcond_in_msg = []
         for i in range(no_of_args):
             arg = arg_list[i]
-            subcond.append(f"{type_to_asr_type_check[arg]}(*arg_type{i})")
-            subcond_in_msg.append(arg)
+            if (type(arg) == tuple):
+                subcond.append(f"{type_to_asr_type_check[arg[0]]}(*arg_type{i})")
+                subcond.append(f"ASRUtils::is_character_of_length(*arg_type{i}, {arg[1]})")
+                subcond_in_msg.append(arg[0] + " of length " + str(arg[1]))
+            else:
+                subcond.append(f"{type_to_asr_type_check[arg]}(*arg_type{i})")
+                subcond_in_msg.append(arg)
         condition.append(" && ".join(subcond))
         cond_in_msg.append(", ".join(subcond_in_msg))
     return (f"({') || ('.join(condition)})", f"({') or ('.join(cond_in_msg)})")

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -848,6 +848,8 @@ def add_verify_arg_type_src(func_name):
         src += 3 * indent + f'ASRUtils::require_impl(x.m_overload_id == {i}, "Overload Id for {func_name} expected to be {i}, found " + std::to_string(x.m_overload_id), x.base.base.loc, diagnostics);\n'
         compute_arg_types(3 * indent, no_of_args, "x.m_args")
         condition, cond_in_msg = compute_arg_condition(no_of_args, args_lists)
+        if (func_name == "Ichar"):
+            condition = "ASR::is_a<ASR::StringSection_t>(*x.m_args[0]) || ASRUtils::is_allocatable(arg_type0) || " + condition
         src += 3 * indent + f'ASRUtils::require_impl({condition}, "Unexpected args, {func_name} expects {cond_in_msg} as arguments", x.base.base.loc, diagnostics);\n'
         src += 2 * indent + "}\n"
     src += 2 * indent + "else {\n"
@@ -885,7 +887,11 @@ def add_create_func_arg_type_src(func_name):
         src += 2 * indent + f"{else_if} (args.size() == {no_of_args + int(kind_arg)}) " + " {\n"
         compute_arg_types(3 * indent, no_of_args, "args")
         condition, cond_in_msg = compute_arg_condition(no_of_args, args_lists)
-        src += 3 * indent + f'if(!({condition}))' + ' {\n'
+        if (func_name == "Ichar"):
+            condition = "!ASR::is_a<ASR::StringSection_t>(*args[0]) && !ASRUtils::is_allocatable(arg_type0) && " + f"!{condition}"
+            src += 3 * indent + f'if({condition})' + ' {\n'
+        else:
+            src += 3 * indent + f'if(!({condition}))' + ' {\n'
         src += 4 * indent + f'append_error(diag, "Unexpected args, {func_name} expects {cond_in_msg} as arguments", loc);\n'
         src += 4 * indent + f'return nullptr;\n'
         src += 3 * indent + '}\n'

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3936,8 +3936,11 @@ namespace Adjustr {
 namespace Ichar {
 
     static ASR::expr_t *eval_Ichar(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
+        if (strlen(str) != 1) {
+            diag.semantic_error_label("first argument to `ichar` must be of length one", {args[0]->base.loc}, "");
+        }
         char first_char = str[0];
         int result = (int)first_char;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
@@ -3952,8 +3955,7 @@ namespace Ichar {
         auto itr = declare("i", int32, Local);
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
-            ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-            ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -1, nullptr)), nullptr)), int32, nullptr)),
+            ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, args[0], int32, nullptr)),
             return_type)));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3936,11 +3936,8 @@ namespace Adjustr {
 namespace Ichar {
 
     static ASR::expr_t *eval_Ichar(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
         char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        if (strlen(str) != 1) {
-            diag.semantic_error_label("first argument to `ichar` must be of length one", {args[0]->base.loc}, "");
-        }
         char first_char = str[0];
         int result = (int)first_char;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);

--- a/tests/errors/iachar_arg_len_compiletime.f90
+++ b/tests/errors/iachar_arg_len_compiletime.f90
@@ -1,0 +1,3 @@
+program main
+   print *, iachar("Hello")
+end program

--- a/tests/errors/iachar_arg_len_runtime.f90
+++ b/tests/errors/iachar_arg_len_runtime.f90
@@ -1,0 +1,4 @@
+program main
+   character(5):: x = "Hello"
+   print*, iachar(x)
+end program

--- a/tests/errors/ichar_arg_len_compiletime.f90
+++ b/tests/errors/ichar_arg_len_compiletime.f90
@@ -1,0 +1,3 @@
+program main
+   print *, ichar("Hello")
+end program

--- a/tests/errors/ichar_arg_len_runtime.f90
+++ b/tests/errors/ichar_arg_len_runtime.f90
@@ -1,0 +1,5 @@
+program main
+   character(5):: x = "Hello"
+   print*, ichar(x)
+end program
+

--- a/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.json
+++ b/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-iachar_arg_len_compiletime-1ecf087",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/iachar_arg_len_compiletime.f90",
+    "infile_hash": "b4665176437f82ba71ab537205e6414ba879c11f849f07097542ed99",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-iachar_arg_len_compiletime-1ecf087.stderr",
+    "stderr_hash": "0216be68f8f08d46a15cc8980fb621b7da83ead97126729d390d8b44",
+    "returncode": 2
+}

--- a/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.json
+++ b/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-iachar_arg_len_compiletime-1ecf087.stderr",
-    "stderr_hash": "0216be68f8f08d46a15cc8980fb621b7da83ead97126729d390d8b44",
+    "stderr_hash": "3a0ca065568e6f6f610c2c08d1e476dba7a499764361e48485a23456",
     "returncode": 2
 }

--- a/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.stderr
+++ b/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.stderr
@@ -1,0 +1,5 @@
+semantic error: first argument to iachar must be of length one
+ --> tests/errors/iachar_arg_len_compiletime.f90:2:20
+  |
+2 |    print *, iachar("Hello")
+  |                    ^^^^^^^ 

--- a/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.stderr
+++ b/tests/reference/asr-iachar_arg_len_compiletime-1ecf087.stderr
@@ -1,4 +1,4 @@
-semantic error: first argument to iachar must be of length one
+semantic error: first argument to `iachar` must be of length one
  --> tests/errors/iachar_arg_len_compiletime.f90:2:20
   |
 2 |    print *, iachar("Hello")

--- a/tests/reference/asr-ichar_arg_len_compiletime-55503f1.json
+++ b/tests/reference/asr-ichar_arg_len_compiletime-55503f1.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-ichar_arg_len_compiletime-55503f1",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/ichar_arg_len_compiletime.f90",
+    "infile_hash": "a138797e6bb3a57fbf9f7e7e778e330d3878030644f25df77236c611",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-ichar_arg_len_compiletime-55503f1.stderr",
+    "stderr_hash": "49358e78bcd66640c2095c66891dec5a291ba278cfba82ccb607f283",
+    "returncode": 2
+}

--- a/tests/reference/asr-ichar_arg_len_compiletime-55503f1.json
+++ b/tests/reference/asr-ichar_arg_len_compiletime-55503f1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-ichar_arg_len_compiletime-55503f1.stderr",
-    "stderr_hash": "49358e78bcd66640c2095c66891dec5a291ba278cfba82ccb607f283",
+    "stderr_hash": "cd84ea6aa97e9ee8d3a9707ae7324ef00380cbefcb28de958c382ceb",
     "returncode": 2
 }

--- a/tests/reference/asr-ichar_arg_len_compiletime-55503f1.stderr
+++ b/tests/reference/asr-ichar_arg_len_compiletime-55503f1.stderr
@@ -1,5 +1,5 @@
-semantic error: first argument to `ichar` must be of length one
- --> tests/errors/ichar_arg_len_compiletime.f90:2:19
+semantic error: Unexpected args, Ichar expects (char of length 1) as arguments
+ --> tests/errors/ichar_arg_len_compiletime.f90:2:13
   |
 2 |    print *, ichar("Hello")
-  |                   ^^^^^^^ 
+  |             ^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-ichar_arg_len_compiletime-55503f1.stderr
+++ b/tests/reference/asr-ichar_arg_len_compiletime-55503f1.stderr
@@ -1,0 +1,5 @@
+semantic error: first argument to `ichar` must be of length one
+ --> tests/errors/ichar_arg_len_compiletime.f90:2:19
+  |
+2 |    print *, ichar("Hello")
+  |                   ^^^^^^^ 

--- a/tests/reference/run-iachar_arg_len_runtime-9020e30.json
+++ b/tests/reference/run-iachar_arg_len_runtime-9020e30.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-iachar_arg_len_runtime-9020e30",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/iachar_arg_len_runtime.f90",
+    "infile_hash": "44922a5d87f5ece51f150a69abf083eb5bf8d836e9d83daaca683712",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-iachar_arg_len_runtime-9020e30.stderr",
+    "stderr_hash": "9bf072fd6118f34f00a2d7049997c685319078443c56fa8eb6ddd1d3",
+    "returncode": 1
+}

--- a/tests/reference/run-iachar_arg_len_runtime-9020e30.json
+++ b/tests/reference/run-iachar_arg_len_runtime-9020e30.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-iachar_arg_len_runtime-9020e30.stderr",
-    "stderr_hash": "9bf072fd6118f34f00a2d7049997c685319078443c56fa8eb6ddd1d3",
+    "stderr_hash": "e27f637c1e061182bc9d10fb38f9790132600fdc4f85d7a1e33a88f1",
     "returncode": 1
 }

--- a/tests/reference/run-iachar_arg_len_runtime-9020e30.stderr
+++ b/tests/reference/run-iachar_arg_len_runtime-9020e30.stderr
@@ -1,0 +1,1 @@
+Error: first argument to iachar must be of length one

--- a/tests/reference/run-iachar_arg_len_runtime-9020e30.stderr
+++ b/tests/reference/run-iachar_arg_len_runtime-9020e30.stderr
@@ -1,1 +1,5 @@
-Error: first argument to iachar must be of length one
+semantic error: first argument to `iachar` must be of length one
+ --> tests/errors/iachar_arg_len_runtime.f90:3:19
+  |
+3 |    print*, iachar(x)
+  |                   ^ 

--- a/tests/reference/run-ichar_arg_len_runtime-be43591.json
+++ b/tests/reference/run-ichar_arg_len_runtime-be43591.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-ichar_arg_len_runtime-be43591",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/ichar_arg_len_runtime.f90",
+    "infile_hash": "5a768920434e05c74eba9b46f8ba387c48ad3c9b703c00902aa76fbc",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-ichar_arg_len_runtime-be43591.stderr",
+    "stderr_hash": "647c35ab2e09b6de977d5ac67f750a24e7d33e672f0669b2eabfb0a2",
+    "returncode": 1
+}

--- a/tests/reference/run-ichar_arg_len_runtime-be43591.json
+++ b/tests/reference/run-ichar_arg_len_runtime-be43591.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-ichar_arg_len_runtime-be43591.stderr",
-    "stderr_hash": "647c35ab2e09b6de977d5ac67f750a24e7d33e672f0669b2eabfb0a2",
+    "stderr_hash": "31f1dff5a6ab3d77a62a26b2fe7a49af806cb6c9c1bb01b92a442ab2",
     "returncode": 1
 }

--- a/tests/reference/run-ichar_arg_len_runtime-be43591.stderr
+++ b/tests/reference/run-ichar_arg_len_runtime-be43591.stderr
@@ -1,1 +1,5 @@
-Error: first argument to ichar must be of length one
+semantic error: Unexpected args, Ichar expects (char of length 1) as arguments
+ --> tests/errors/ichar_arg_len_runtime.f90:3:12
+  |
+3 |    print*, ichar(x)
+  |            ^^^^^^^^ 

--- a/tests/reference/run-ichar_arg_len_runtime-be43591.stderr
+++ b/tests/reference/run-ichar_arg_len_runtime-be43591.stderr
@@ -1,0 +1,1 @@
+Error: first argument to ichar must be of length one

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3928,6 +3928,22 @@ filename = "errors/atomic_01.f90"
 asr = true
 
 [[test]]
+filename = "errors/ichar_arg_len_runtime.f90"
+run = true
+
+[[test]]
+filename = "errors/ichar_arg_len_compiletime.f90"
+asr = true
+
+[[test]]
+filename = "errors/iachar_arg_len_runtime.f90"
+run = true
+
+[[test]]
+filename = "errors/iachar_arg_len_compiletime.f90"
+asr = true
+
+[[test]]
 filename = "errors/iostat_non_scalar_value.f90"
 asr = true
 


### PR DESCRIPTION
fixes #3734 

## Compile-time
### ichar
```fortran
program main
   print*, ichar("Hello")
end program
```
```console
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
./examples/example.f90:2:17:

    2 |    print*, ichar("Hello")
      |                 1
Error: Argument of ICHAR at (1) must be of length one
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
semantic error: first argument to `ichar` must be of length one
 --> ./examples/example.f90:2:18
  |
2 |    print*, ichar("Hello")
  |                  ^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

### iachar
```fortran
program main
   print*, iachar("Hello")
end program
```
```console
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
./examples/example.f90:2:18:

    2 |    print*, iachar("Hello")
      |                  1
Error: Argument of IACHAR at (1) must be of length one
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
semantic error: first argument to iachar must be of length one
 --> ./examples/example.f90:2:19
  |
2 |    print*, iachar("Hello")
  |                   ^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

## Runtime
### ichar
```fortran
program main
   character(len=5) :: c = "Hello"
   print*, ichar(c)
end program
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
./examples/example.f90:3:17:

    3 |    print*, ichar(c)
      |                 1
Error: Argument of ichar at (1) must be of length one
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
Error: first argument to ichar must be of length one
```


### iachar
```fortran
program main
   character(len=5) :: c = "Hello"
   print*, iachar(c)
end program
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
./examples/example.f90:3:18:

    3 |    print*, iachar(c)
      |                  1
Error: Argument of iachar at (1) must be of length one
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
Error: first argument to iachar must be of length one
```

## Allocatable strings
Allocatable strings are handled in a different way by GFortran. We do the same here.
```fortran
program main
   character(len=:), allocatable :: c
   allocate(character(len=10) :: c)
   c = "Hello"
   print*, iachar(c)
end program
```
```console
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
          72
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
72
```