### PR TITLE
Handle character arg, mask, kind and back keywords for `minloc` and `maxloc` 

### DIFF
--- a/a.f90
+++ b/a.f90
@@ -1,0 +1,5 @@
+program arrays_28
+    integer :: arr(3) = [1, 3, 0]
+    print*, maxloc(arr)
+
+end program

--- a/b.f90
+++ b/b.f90
@@ -1,0 +1,7 @@
+program arrays_30
+   implicit none
+   integer    :: i1(4) = [  479,  735, -870,  410]
+   integer    :: res_01(1)
+   res_01 = maxloc(i1)
+end program arrays_30
+

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -816,6 +816,8 @@ RUN(NAME intrinsics_252 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derf
 RUN(NAME intrinsics_253 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # erfc
 RUN(NAME intrinsics_254 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derfc
 RUN(NAME intrinsics_255 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dbesjn, dbesyn
+RUN(NAME intrinsics_260 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # minloc
+RUN(NAME intrinsics_261 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maxloc
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_260.f90
+++ b/integration_tests/intrinsics_260.f90
@@ -1,0 +1,42 @@
+program intrinsics_260
+    integer(4), parameter :: i1(1) = minloc([1,2,3])
+	integer(4), parameter :: i2(1) = minloc([1.0, 2.0, 3.0])
+	integer(4), parameter :: i3(1) = minloc(["aa", "db", "ca"])
+	integer(4), parameter :: i4(1) = minloc([1,2,3], mask = [.true., .true., .true.])
+	integer(8), parameter :: i5(1) = minloc([1,2,3], mask=[.true., .false., .true.], kind = 8)
+	integer(4), parameter :: i6(1) = minloc([1,2,3], mask=[.true., .false., .true.], dim=1)
+	integer(4), parameter :: i7(1) = minloc(["aa", "db", "ca"], mask=[.true., .false., .true.])
+	integer(4), parameter :: i8(1) = minloc(["aa", "db", "ca"], mask=[.true., .false., .true.], dim = 1)
+	integer(4), parameter :: i9(1) = minloc([1, 3, 2], mask = [.true., .false., .true.], back = .true.)
+	integer(4), parameter :: i10(1) = minloc([3, 2, 1, 3], back = .true.)
+	integer(4), parameter :: i11(1) = minloc([3.0, 2.0, 1.0, 3.0], back = .true., dim=1)
+	integer(4), parameter :: i12(1) = minloc(["aa", "db", "ca"], mask = [.false., .false., .false.], kind = 4)
+
+	print *, i1
+	if (i1(1) /= 1) error stop
+	print *, i2
+	if (i2(1) /= 1) error stop
+	print *, i3
+	if (i3(1) /= 1) error stop
+	print *, i4
+	if (i4(1) /= 1) error stop
+	print *, i5
+	if (i5(1) /= 1) error stop
+	print *, i6
+	if (i6(1) /= 1) error stop
+	print *, i7
+	if (i7(1) /= 1) error stop
+	print *, i8
+	if (i8(1) /= 1) error stop
+	print *, i9
+	if (i9(1) /= 1) error stop
+	print *, i10
+	if (i10(1) /= 3) error stop
+	print *, i11
+	if (i11(1) /= 3) error stop
+	print *, i12
+	if (i12(1) /= 0) error stop
+
+	print *, kind(minloc(["aa", "db", "ca"], mask = [.false., .false., .false.], kind = 8))
+	if (kind(minloc(["aa", "db", "ca"], mask = [.false., .false., .false.], kind = 8)) /= 8) error stop
+end program

--- a/integration_tests/intrinsics_261.f90
+++ b/integration_tests/intrinsics_261.f90
@@ -1,0 +1,43 @@
+program intrinsics_261 
+    integer(4), parameter :: i1(1) = maxloc([1,2,3])
+	integer(4), parameter :: i2(1) = maxloc([1.0, 2.0, 3.0])
+	integer(4), parameter :: i3(1) = maxloc(["aa", "db", "ca"])
+	integer(4), parameter :: i4(1) = maxloc([1,2,3], mask = [.true., .true., .true.])
+	integer(8), parameter :: i5(1) = maxloc([1,2,3], mask=[.true., .false., .true.], kind = 8)
+	integer(4), parameter :: i6(1) = maxloc([1,2,3], mask=[.true., .false., .true.], dim=1)
+	integer(4), parameter :: i7(1) = maxloc(["aa", "db", "ca"], mask=[.true., .false., .true.])
+	integer(4), parameter :: i8(1) = maxloc(["aa", "db", "ca"], mask=[.true., .false., .true.], dim = 1)
+	integer(4), parameter :: i9(1) = maxloc([1, 3, 2], mask = [.true., .false., .true.], back = .true.)
+	integer(4), parameter :: i10(1) = maxloc([3, 2, 1, 3], back = .true.)
+	integer(4), parameter :: i11(1) = maxloc([3.0, 2.0, 1.0, 3.0], back = .true., dim=1)
+	integer(4), parameter :: i12(1) = maxloc(["aa", "db", "ca"], mask = [.false., .false., .false.], kind = 4)
+
+	print *, i1
+	if (i1(1) /= 3) error stop
+	print *, i2
+	if (i2(1) /= 3) error stop
+	print *, i3
+	if (i3(1) /= 2) error stop
+	print *, i4
+	if (i4(1) /= 3) error stop
+	print *, i5
+	if (i5(1) /= 3) error stop
+	print *, i6
+	if (i6(1) /= 3) error stop
+	print *, i7
+	if (i7(1) /= 3) error stop
+	print *, i8
+	if (i8(1) /= 3) error stop
+	print *, i9
+	if (i9(1) /= 3) error stop
+	print *, i10
+	if (i10(1) /= 4) error stop
+	print *, i11
+	if (i11(1) /= 4) error stop
+	print *, i12
+	if (i12(1) /= 0) error stop
+
+	print *, kind(maxloc(["aa", "db", "ca"], mask = [.false., .false., .false.], kind = 8))
+	if (kind(maxloc(["aa", "db", "ca"], mask = [.false., .false., .false.], kind = 8)) /= 8) error stop
+    
+end program


### PR DESCRIPTION
Towards: #4017, #492

This is not ready for review. I'm working on this rn.