### PR TITLE
Throw an error if result of ```NINT``` overflows its kind 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -792,6 +792,7 @@ RUN(NAME intrinsics_238 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # 
 RUN(NAME intrinsics_239 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # erfc_scaled
 RUN(NAME intrinsics_240 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dshiftr
 RUN(NAME intrinsics_241 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # logical
+RUN(NAME intrinsics_242 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nint
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_242.f90
+++ b/integration_tests/intrinsics_242.f90
@@ -1,0 +1,10 @@
+program intrinsics_242
+    integer, parameter :: dp = kind(0.d0)
+
+    print*, nint(1e12_dp, dp)
+    if (nint(1e12_dp, dp) /= 1000000000000_dp) error stop
+
+    print*, nint(1000000000000.0000000000000000_dp, dp)
+    if (nint(1000000000000.0000000000000000_dp, dp) /= 1000000000000_dp) error stop
+
+end program 

--- a/tests/errors/nint_overflow.f90
+++ b/tests/errors/nint_overflow.f90
@@ -1,0 +1,4 @@
+program nint_overflow
+    print*, nint(1e12_8)
+    print*, nint(1000000000000.0000000000000000d0)
+end program

--- a/tests/reference/asr-nint_overflow-bf5738b.json
+++ b/tests/reference/asr-nint_overflow-bf5738b.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-nint_overflow-bf5738b",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/nint_overflow.f90",
+    "infile_hash": "887b0d5e99be9d33310deee68d28e0b7207e7e7c2ac8ede95f302925",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-nint_overflow-bf5738b.stderr",
+    "stderr_hash": "3dfc23e5fabee4c3980707d1c40d9c9f9e241ca9c769becaa9c86f13",
+    "returncode": 2
+}

--- a/tests/reference/asr-nint_overflow-bf5738b.stderr
+++ b/tests/reference/asr-nint_overflow-bf5738b.stderr
@@ -1,0 +1,5 @@
+semantic error: Result of `nint` overflows its kind(4)
+ --> tests/errors/nint_overflow.f90:2:13
+  |
+2 |     print*, nint(1e12_8)
+  |             ^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -409,6 +409,10 @@ filename = "errors/template_error_07.f90"
 asr = true
 
 [[test]]
+filename = "errors/nint_overflow.f90"
+asr = true
+
+[[test]]
 filename = "warnings/dim_assgn_test.f90"
 asr = true
 


### PR DESCRIPTION
Fixes : https://github.com/lfortran/lfortran/issues/4079