### PR TITLE
refactor: generalise fortran backend for all intrinsic functions

### DIFF
--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1226,7 +1226,7 @@ public:
         src = out;
     }
 
-    void setElementalIntrinsicName(std::string &out, std::string func_name, const ASR::IntrinsicElementalFunction_t &x) {
+    void visit_IntrinsicElementalFunction_helper(std::string &out, std::string func_name, const ASR::IntrinsicElementalFunction_t &x) {
         out += func_name;
         visit_expr(*x.m_args[0]);
         out += "(" + src;
@@ -1251,10 +1251,10 @@ public:
         else if(intrinsic_func_name == "LogGamma") intrinsic_func_name = "log_gamma";
         else if(intrinsic_func_name == "SetExponent") intrinsic_func_name = "set_exponent";
         else if(intrinsic_func_name == "Mergebits") intrinsic_func_name = "merge_bits";
-        setElementalIntrinsicName(out, intrinsic_func_name, x);
+        visit_IntrinsicElementalFunction_helper(out, intrinsic_func_name, x);
     }
 
-    void setInquiryTypeIntrinsicName(std::string &out, std::string func_name, const ASR::TypeInquiry_t &x) {
+    void visit_TypeInquiry_helper(std::string &out, std::string func_name, const ASR::TypeInquiry_t &x) {
         out += func_name;
         visit_expr(*x.m_arg);
         out += "(" + src + ")";
@@ -1266,10 +1266,10 @@ public:
         std::string intrinsic_func_name = ASRUtils::get_intrinsic_name(static_cast<int64_t>(x.m_inquiry_id));
         if(intrinsic_func_name == "BitSize") intrinsic_func_name = "bit_size";
         else if(intrinsic_func_name == "NewLine") intrinsic_func_name = "new_line";
-        setInquiryTypeIntrinsicName(out, intrinsic_func_name, x);
+        visit_TypeInquiry_helper(out, intrinsic_func_name, x);
     }
 
-    void setArrIntrinsicName(std::string &out, std::string func_name, const ASR::IntrinsicArrayFunction_t &x) {
+    void visit_IntrinsicArrayFunction_helper(std::string &out, std::string func_name, const ASR::IntrinsicArrayFunction_t &x) {
         out += func_name;
         visit_expr(*x.m_args[0]);
         out += "(" + src;
@@ -1286,7 +1286,7 @@ public:
         std::string out;
         std::string intrinsic_func_name = ASRUtils::get_array_intrinsic_name(static_cast<int64_t>(x.m_arr_intrinsic_id));
         if(intrinsic_func_name == "DotProduct") intrinsic_func_name = "dot_product";
-        setArrIntrinsicName(out, intrinsic_func_name, x);
+        visit_IntrinsicArrayFunction_helper(out, intrinsic_func_name, x);
     }
 
     // void visit_IntrinsicImpureFunction(const ASR::IntrinsicImpureFunction_t &x) {}

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1205,30 +1205,6 @@ public:
         src = r;
     }
 
-    void visit_TypeInquiry(const ASR::TypeInquiry_t &x) {
-        std::string out = "";
-        switch (x.m_inquiry_id) {
-            SET_INTRINSIC_NAME(Epsilon,   "epsilon"  );
-            SET_INTRINSIC_NAME(Huge,      "huge"     );
-            SET_INTRINSIC_NAME(Precision, "precision");
-            SET_INTRINSIC_NAME(Radix,     "radix"    );
-            SET_INTRINSIC_NAME(Range,     "range"    );
-            SET_INTRINSIC_NAME(Rank,      "rank"     );
-            SET_INTRINSIC_NAME(Tiny,      "tiny"     );
-            SET_INTRINSIC_NAME(BitSize,   "bit_size" );
-            SET_INTRINSIC_NAME(NewLine,   "new_line" );
-            SET_INTRINSIC_NAME(Kind,      "kind"     );
-            default : {
-                throw LCompilersException("TypeInquiry: `"
-                    + ASRUtils::get_intrinsic_name(x.m_inquiry_id)
-                    + "` is not implemented");
-            }
-        }
-        this->visit_expr(*x.m_arg);
-        out += "(" + src + ")";
-        src = out;
-    }
-
     void visit_IntrinsicImpureSubroutine( const ASR::IntrinsicImpureSubroutine_t &x ) {
         std::string out;
         out = "call ";
@@ -1250,133 +1226,47 @@ public:
         src = out;
     }
 
-    void visit_IntrinsicElementalFunction(const ASR::IntrinsicElementalFunction_t &x) {
-        std::string out;
-        switch (x.m_intrinsic_id) {
-            SET_INTRINSIC_NAME(Abs, "abs");
-            SET_INTRINSIC_NAME(Exp, "exp");
-            SET_INTRINSIC_NAME(Max, "max");
-            SET_INTRINSIC_NAME(Min, "min");
-            SET_INTRINSIC_NAME(Sqrt, "sqrt");
-            SET_INTRINSIC_NAME(Mod, "mod");
-            SET_INTRINSIC_NAME(Sin, "sin");
-            SET_INTRINSIC_NAME(Cos, "cos");
-            SET_INTRINSIC_NAME(Tan, "tan");
-            SET_INTRINSIC_NAME(Sind, "sind");
-            SET_INTRINSIC_NAME(Cosd, "cosd");
-            SET_INTRINSIC_NAME(Tand, "tand");
-            SET_INTRINSIC_NAME(Asin, "asin");
-            SET_INTRINSIC_NAME(Acos, "acos");
-            SET_INTRINSIC_NAME(Atan, "atan");
-            SET_INTRINSIC_NAME(Asind, "asind");
-            SET_INTRINSIC_NAME(Acosd, "acosd");
-            SET_INTRINSIC_NAME(Atand, "atand");
-            SET_INTRINSIC_NAME(Sinh, "sinh");
-            SET_INTRINSIC_NAME(Cosh, "cosh");
-            SET_INTRINSIC_NAME(Tanh, "tanh");
-            SET_INTRINSIC_NAME(Asinh, "asinh");
-            SET_INTRINSIC_NAME(Acosh, "acosh");
-            SET_INTRINSIC_NAME(Atanh, "atanh");
-            SET_INTRINSIC_NAME(Char, "char");
-            SET_INTRINSIC_NAME(StringContainsSet, "verify");
-            SET_INTRINSIC_NAME(StringFindSet, "scan");
-            SET_INTRINSIC_NAME(SubstrIndex, "index");
-            SET_INTRINSIC_NAME(Modulo, "modulo");
-            SET_INTRINSIC_NAME(Poppar, "poppar");
-            SET_INTRINSIC_NAME(Merge, "merge");
-            SET_INTRINSIC_NAME(Aimag, "aimag");
-            SET_INTRINSIC_NAME(SelectedIntKind, "selected_int_kind");
-            SET_INTRINSIC_NAME(SelectedRealKind, "selected_real_kind");
-            SET_INTRINSIC_NAME(SelectedCharKind, "selected_char_kind");
-            SET_INTRINSIC_NAME(Bgt, "bgt");
-            SET_INTRINSIC_NAME(Blt, "blt");
-            SET_INTRINSIC_NAME(Bge, "bge");
-            SET_INTRINSIC_NAME(Ble, "ble");
-            SET_INTRINSIC_NAME(Lgt, "lgt");
-            SET_INTRINSIC_NAME(Llt, "llt");
-            SET_INTRINSIC_NAME(Lge, "lge");
-            SET_INTRINSIC_NAME(Lle, "lle");
-            SET_INTRINSIC_NAME(Iand, "iand");
-            SET_INTRINSIC_NAME(Ior, "ior");
-            SET_INTRINSIC_NAME(Ieor, "ieor");
-            SET_INTRINSIC_NAME(Ibclr, "ibclr");
-            SET_INTRINSIC_NAME(Ibset, "ibset");
-            SET_INTRINSIC_NAME(Btest, "btest");
-            SET_INTRINSIC_NAME(Ibits, "ibits");
-            SET_INTRINSIC_NAME(Not, "not");
-            SET_INTRINSIC_NAME(Digits, "digits");
-            SET_INTRINSIC_NAME(Rrspacing, "rrspacing");
-            SET_INTRINSIC_NAME(Repeat, "repeat");
-            SET_INTRINSIC_NAME(Adjustl, "adjustl");
-            SET_INTRINSIC_NAME(Adjustr, "adjustr");
-            SET_INTRINSIC_NAME(Ichar, "ichar");
-            SET_INTRINSIC_NAME(MaxExponent, "maxexponent");
-            SET_INTRINSIC_NAME(MinExponent, "minexponent");
-            SET_INTRINSIC_NAME(Shiftr, "shiftr");
-            SET_INTRINSIC_NAME(Rshift, "rshift");
-            SET_INTRINSIC_NAME(Shiftl, "shiftl");
-            SET_INTRINSIC_NAME(Dshiftl, "dshiftl");
-            SET_INTRINSIC_NAME(Ishft, "ishft");
-            SET_INTRINSIC_NAME(Ishftc, "ishftc");
-            SET_INTRINSIC_NAME(Floor, "floor");
-            SET_INTRINSIC_NAME(Ceiling, "ceiling");
-            SET_INTRINSIC_NAME(Maskr, "maskr");
-            SET_INTRINSIC_NAME(Maskl, "maskl");
-            SET_INTRINSIC_NAME(Sngl, "sngl");
-            SET_INTRINSIC_NAME(Log, "log");
-            SET_INTRINSIC_NAME(Log10, "log10");
-            SET_INTRINSIC_NAME(Isnan, "isnan");
-            SET_INTRINSIC_NAME(LogGamma, "log_gamma");
-            SET_INTRINSIC_NAME(Erf, "erf");
-            SET_INTRINSIC_NAME(Erfc, "erfc");
-            SET_INTRINSIC_NAME(ErfcScaled, "erfc_scaled");
-            SET_INTRINSIC_NAME(Gamma, "gamma");
-            SET_INTRINSIC_NAME(BesselJ0, "bessel_j0");
-            SET_INTRINSIC_NAME(BesselJ1, "bessel_j1");
-            SET_INTRINSIC_NAME(BesselY0, "bessel_y0");
-            SET_INTRINSIC_NAME(BesselY1, "bessel_y1");
-            SET_INTRINSIC_NAME(Atan2, "atan2");
-            SET_INTRINSIC_NAME(Dreal, "dreal");
-            SET_INTRINSIC_NAME(Exp2, "exp2");
-            SET_INTRINSIC_NAME(Expm1, "expm1");
-            SET_INTRINSIC_NAME(FMA, "fma");
-            SET_INTRINSIC_NAME(FloorDiv, "floordiv");
-            SET_INTRINSIC_NAME(Trailz, "trailz");
-            SET_INTRINSIC_NAME(Nearest, "nearest");
-            SET_INTRINSIC_NAME(Spacing, "spacing");
-            SET_INTRINSIC_NAME(BesselJN, "bessel_jn");
-            SET_INTRINSIC_NAME(BesselYN, "bessel_yn");
-            SET_INTRINSIC_NAME(Mergebits, "merge_bits");
-            SET_INTRINSIC_NAME(Exponent, "exponent");
-            SET_INTRINSIC_NAME(Fraction, "fraction");
-            SET_INTRINSIC_NAME(SetExponent, "set_exponent");
-            SET_INTRINSIC_NAME(Leadz, "leadz");
-            SET_INTRINSIC_NAME(Hypot, "hypot");
-            SET_INTRINSIC_NAME(Scale, "scale");
-            SET_INTRINSIC_NAME(Dprod, "dprod");
-            SET_INTRINSIC_NAME(Sign, "sign");
-            SET_INTRINSIC_NAME(Aint, "aint");
-            SET_INTRINSIC_NAME(Popcnt, "popcnt");
-            SET_INTRINSIC_NAME(Nint, "nint");
-            SET_INTRINSIC_NAME(Anint, "anint");
-            SET_INTRINSIC_NAME(Dim, "dim");
-            SET_INTRINSIC_NAME(Ifix, "ifix");
-            SET_INTRINSIC_NAME(Idint, "idint");
-            SET_INTRINSIC_NAME(Conjg, "conjg");
-            default : {
-                throw LCompilersException("IntrinsicElementalFunction: `"
-                    + ASRUtils::get_intrinsic_name(x.m_intrinsic_id)
-                    + "` is not implemented");
-            }
-        }
-        out += "(";
-        for (size_t i = 0; i < x.n_args; i ++) {
+    void setElementalIntrinsicName(std::string &out, std::string func_name, const ASR::IntrinsicElementalFunction_t &x) {
+        out += func_name;
+        visit_expr(*x.m_args[0]);
+        out += "(" + src;
+        for (size_t i = 1; i < x.n_args; i++) {
+            out += ", ";
             visit_expr(*x.m_args[i]);
             out += src;
-            if (i < x.n_args-1) out += ", ";
         }
         out += ")";
         src = out;
+    }
+
+    void visit_IntrinsicElementalFunction(const ASR::IntrinsicElementalFunction_t &x) {
+        std::string out;
+        std::string intrinsic_func_name = ASRUtils::get_intrinsic_name(static_cast<int64_t>(x.m_intrinsic_id));
+        if(intrinsic_func_name == "StringFindSet") intrinsic_func_name = "scan";
+        else if(intrinsic_func_name == "StringContainsSet") intrinsic_func_name = "verify";
+        else if(intrinsic_func_name == "SubstrIndex") intrinsic_func_name = "index";
+        else if(intrinsic_func_name == "SelectedRealKind") intrinsic_func_name = "selected_real_kind";
+        else if(intrinsic_func_name == "SelectedIntKind") intrinsic_func_name = "selected_int_kind";
+        else if(intrinsic_func_name == "SelectedCharKind") intrinsic_func_name = "selected_char_kind";
+        else if(intrinsic_func_name == "LogGamma") intrinsic_func_name = "log_gamma";
+        else if(intrinsic_func_name == "SetExponent") intrinsic_func_name = "set_exponent";
+        else if(intrinsic_func_name == "Mergebits") intrinsic_func_name = "merge_bits";
+        setElementalIntrinsicName(out, intrinsic_func_name, x);
+    }
+
+    void setInquiryTypeIntrinsicName(std::string &out, std::string func_name, const ASR::TypeInquiry_t &x) {
+        out += func_name;
+        visit_expr(*x.m_arg);
+        out += "(" + src + ")";
+        src = out;
+    }
+
+    void visit_TypeInquiry(const ASR::TypeInquiry_t &x) {
+        std::string out;
+        std::string intrinsic_func_name = ASRUtils::get_intrinsic_name(static_cast<int64_t>(x.m_inquiry_id));
+        if(intrinsic_func_name == "BitSize") intrinsic_func_name = "bit_size";
+        else if(intrinsic_func_name == "NewLine") intrinsic_func_name = "new_line";
+        setInquiryTypeIntrinsicName(out, intrinsic_func_name, x);
     }
 
     void setArrIntrinsicName(std::string &out, std::string func_name, const ASR::IntrinsicArrayFunction_t &x) {
@@ -1390,7 +1280,6 @@ public:
         }
         out += ")";
         src = out;
-        out = "";
     }
 
     void visit_IntrinsicArrayFunction(const ASR::IntrinsicArrayFunction_t &x) {
@@ -1398,8 +1287,6 @@ public:
         std::string intrinsic_func_name = ASRUtils::get_array_intrinsic_name(static_cast<int64_t>(x.m_arr_intrinsic_id));
         if(intrinsic_func_name == "DotProduct") intrinsic_func_name = "dot_product";
         setArrIntrinsicName(out, intrinsic_func_name, x);
-        out += "(" + src + ")";
-        src = out;
     }
 
     // void visit_IntrinsicImpureFunction(const ASR::IntrinsicImpureFunction_t &x) {}

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -108,6 +108,7 @@ inline std::string get_intrinsic_name(int64_t x) {
         INTRINSIC_NAME_CASE(StringFindSet)
         INTRINSIC_NAME_CASE(SubstrIndex)
         INTRINSIC_NAME_CASE(Range)
+        INTRINSIC_NAME_CASE(Radix)
         INTRINSIC_NAME_CASE(Hypot)
         INTRINSIC_NAME_CASE(SelectedIntKind)
         INTRINSIC_NAME_CASE(SelectedRealKind)


### PR DESCRIPTION
Towards: #4017 
With this, we do not explicitly need to register intrinsic functions in asr to fortran backend. It is handled automatically.