### PR TITLE
fix: add support for initializing global `array` variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -482,6 +482,7 @@ RUN(NAME arrays_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME global_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran)

--- a/integration_tests/global_array_01.f90
+++ b/integration_tests/global_array_01.f90
@@ -1,0 +1,30 @@
+module global_array_module
+   implicit none
+   integer(4), dimension(2) :: arr = [105, 109]
+end module global_array_module
+
+program test_global_array
+   use global_array_module, only: arr
+   implicit none
+   integer :: i
+   integer :: s
+   i = 1
+   print *, arr
+   if (all(arr /= [105, 109])) error stop
+
+   s = sum(arr)
+   print *, s
+   if (s /= 214) error stop
+
+   print *, arr(i)
+   if (arr(i) /= 105) error stop
+
+   arr(i) = 210
+   print *, arr(i)
+   if (arr(i) /= 210) error stop
+
+   print *, arr
+   if (all(arr /= [210, 109])) error stop
+
+end program test_global_array
+

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2680,9 +2680,7 @@ public:
                     llvm::ArrayType* arr_type = llvm::ArrayType::get(type, arr_const_size);
                     module->getNamedGlobal(x.m_name)->setInitializer(llvm::ConstantArray::get(arr_type, arr_elements));
                 } else {
-                    module->getNamedGlobal(x.m_name)->setInitializer(
-                            llvm::ConstantArray::get(llvm::ArrayType::get(type, 0),
-                            llvm::Constant::getNullValue(type)));
+                    module->getNamedGlobal(x.m_name)->setInitializer(llvm::ConstantArray::getNullValue(type));
                 }
             }
             llvm_symtab[h] = ptr;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2664,7 +2664,7 @@ public:
                                 context, llvm::APInt(8 * a_kind, int_const->m_n)));
                         } else if (ASR::is_a<ASR::RealConstant_t>(*elem)) {
                             ASR::RealConstant_t* real_const = ASR::down_cast<ASR::RealConstant_t>(elem);
-                            if (8 * a_kind == 32) {
+                            if (a_kind == 4) {
                                 arr_elements.push_back(llvm::ConstantFP::get(
                                     context, llvm::APFloat((float) real_const->m_r)));
                             } else if (8 * a_kind == 64) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2667,7 +2667,7 @@ public:
                             if (a_kind == 4) {
                                 arr_elements.push_back(llvm::ConstantFP::get(
                                     context, llvm::APFloat((float) real_const->m_r)));
-                            } else if (8 * a_kind == 64) {
+                            } else if (a_kind == 8) {
                                 arr_elements.push_back(llvm::ConstantFP::get(
                                     context, llvm::APFloat((double) real_const->m_r)));
                             }


### PR DESCRIPTION
fixes #3897 

### The issue
The chief cause of the issue was `init_value` being a `nullptr` due to the use of `llvm::dyn_cast` to convert `tmp` of type `llvm::Value*` to `llvm::Constant*`. `tmp` is not a constant value here and so the cast returns a `nullptr` according to the definition of `llvm::dyn_cast<T>(U)`. `init_value` being a `nullptr` caused the initialization of the variable using a `zeroinitializer`, hence leading to the issue.

```llvm
@arr = global [4 x i32] zeroinitializer
```

### The fix
To fix the issue we initialize the global `array` variable manually using the `m_value` of the variable.
```fortran
module test
   implicit none
   integer(4), dimension(2) :: arr = [105, 109]
end module test

program a
   use test, only: arr
   implicit none
   integer :: i
   i = 1
   print *, arr(i)
end program a
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
105
```
### LLVM IR
For the provided MRE, here is the generated LLVM IR:
```llvm
; ModuleID = 'LFortran'
source_filename = "LFortran"

@arr = global [2 x i32] [i32 105, i32 109]
@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1

define i32 @main(i32 %0, i8** %1) {
.entry:
  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
  %i = alloca i32, align 4
  store i32 1, i32* %i, align 4
  %2 = load i32, i32* %i, align 4
  %3 = sub i32 %2, 1
  %4 = mul i32 1, %3
  %5 = add i32 0, %4
  %6 = getelementptr [2 x i32], [2 x i32]* @arr, i32 0, i32 %5
  %7 = load i32, i32* %6, align 4
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
  ret i32 0
}

declare void @_lpython_call_initial_functions(i32, i8**)

declare void @_lfortran_printf(i8*, ...)
```