### PR TITLE
Fix a test runner

### DIFF
--- a/src/libasr/compiler_tester/tester.py
+++ b/src/libasr/compiler_tester/tester.py
@@ -125,6 +125,14 @@ def _compare_eq_dict(
         )
     return explanation
 
+def test_for_duplicates(test_data):
+    tests = test_data["test"]
+    filenames = [t["filename"] for t in tests]
+    if len(set(filenames)) != len(filenames):
+        print("There are duplicate test filenames:")
+        duplicates = [item for item in set(filenames) if filenames.count(item) > 1]
+        print(duplicates)
+        sys.exit(1)
 
 def fixdir(s: bytes) -> bytes:
     local_dir = os.getcwd()
@@ -425,6 +433,7 @@ def tester_main(compiler, single_test, is_lcompilers_executable_installed=False)
         os.environ["PATH"] = os.path.join(SRC_DIR, "bin") \
             + os.pathsep + os.environ["PATH"]
     test_data = toml.load(open(os.path.join(ROOT_DIR, "tests", "tests.toml")))
+    test_for_duplicates(test_data)
     filtered_tests = test_data["test"]
     if specific_tests:
         filtered_tests = [test for test in filtered_tests if any(

--- a/src/libasr/compiler_tester/tester.py
+++ b/src/libasr/compiler_tester/tester.py
@@ -314,7 +314,12 @@ def run_test(testname, basename, cmd, infile, update_reference=False,
         raise FileNotFoundError(
             f"The output json file '{jo}' for {testname} does not exist")
 
-    do = json.load(open(jo))
+    try:
+        do = json.load(open(jo))
+    except json.decoder.JSONDecodeError:
+        print("JSON failed to be decoded")
+        print(f"Filename: {jo}")
+        raise
     if update_reference:
         do_update_reference(jo, jr, do)
         return

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -42,10 +42,6 @@ ast = true
 asr = true
 
 [[test]]
-filename = "../integration_tests/template_add_01b.f90"
-asr = true
-
-[[test]]
 filename = "../integration_tests/template_travel_01.f90"
 ast = true
 asr = true
@@ -717,13 +713,6 @@ wat = true
 julia = true
 
 [[test]]
-filename = "../integration_tests/doloop_04.f90"
-asr = true
-llvm = true
-pass = "do_loops"
-
-
-[[test]]
 filename = "../integration_tests/doloop_02.f90"
 asr = true
 llvm = true
@@ -742,6 +731,8 @@ filename = "../integration_tests/doloop_04.f90"
 ast = true
 ast_f90 = true
 asr = true
+llvm = true
+pass = "do_loops"
 
 [[test]]
 filename = "../integration_tests/doloop_05.f90"
@@ -990,10 +981,6 @@ asr = true
 
 [[test]]
 filename = "../integration_tests/array_01_pack.f90"
-asr = true
-
-[[test]]
-filename = "../integration_tests/array_01_transfer.f90"
 asr = true
 
 [[test]]
@@ -1253,10 +1240,6 @@ asr = true
 
 [[test]]
 filename = "../integration_tests/derived_types_11.f90"
-asr = true
-
-[[test]]
-filename = "../integration_tests/derived_types_15.f90"
 asr = true
 
 [[test]]


### PR DESCRIPTION
There were duplicate tests which when run in parallel overwrote the JSON or output and then failed. This PR adds checks into the runner for duplicate tests, so this will not happen again. It then removes all duplicates. I checked the affected issues below and indeed I can see these duplicate tests reported there.

Fixes #3619, #3707, #3736, #3985.