### PR TITLE
Fix : asr verify on external symbol

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -882,6 +882,10 @@ RUN(NAME modules_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST)
 RUN(NAME modules_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME modules_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
+    modules_58_module.f90)
+RUN(NAME modules_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
+    modules_59_module.f90)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES

--- a/integration_tests/modules_58.f90
+++ b/integration_tests/modules_58.f90
@@ -1,0 +1,7 @@
+MODULE dealloc_module_58
+    USE module_58_module02, ONLY: mms_deallocate
+END MODULE dealloc_module_58
+
+program test_external_symbol
+    !dummy program
+end program test_external_symbol

--- a/integration_tests/modules_58_module.f90
+++ b/integration_tests/modules_58_module.f90
@@ -1,0 +1,25 @@
+MODULE module_58_module01
+    IMPLICIT NONE
+  
+    INTEGER, PUBLIC :: nx = 1000
+  
+  END MODULE
+  
+  MODULE module_58_module02
+  
+    USE module_58_module01, ONLY: nx
+  
+    IMPLICIT NONE
+    REAL, ALLOCATABLE, DIMENSION(:), PUBLIC :: ref_flux
+  
+    REAL, ALLOCATABLE, DIMENSION(:), PUBLIC :: ref_fluxm
+  
+    CONTAINS
+  
+    SUBROUTINE mms_deallocate
+    END SUBROUTINE mms_deallocate
+  
+    SUBROUTINE mms_allocate ( )
+      ALLOCATE( ref_flux(nx), ref_fluxm(nx) )
+    END SUBROUTINE mms_allocate
+  END MODULE module_58_module02

--- a/integration_tests/modules_59.f90
+++ b/integration_tests/modules_59.f90
@@ -1,0 +1,4 @@
+program test_external_symbol
+    use module_59_module02
+    call mms_allocate()
+end program test_external_symbol

--- a/integration_tests/modules_59_module.f90
+++ b/integration_tests/modules_59_module.f90
@@ -1,0 +1,31 @@
+MODULE module_59_module01
+    IMPLICIT NONE
+  
+    INTEGER, PUBLIC :: nx1 = 1000
+    INTEGER, PUBLIC :: nx2 = 1000
+  
+  END MODULE
+  
+  MODULE module_59_module02
+  
+    USE module_59_module01
+  
+    IMPLICIT NONE
+    REAL, ALLOCATABLE, DIMENSION(:), PUBLIC :: ref_flux
+  
+    REAL, ALLOCATABLE, DIMENSION(:), PUBLIC :: ref_fluxm
+  
+    CONTAINS
+  
+    SUBROUTINE mms_deallocate
+    END SUBROUTINE mms_deallocate
+  
+    SUBROUTINE mms_allocate ( )
+        nx1 = 555
+      ALLOCATE( ref_flux(nx1), ref_fluxm(nx2) )
+      print *,"Size of nx1",nx1
+      if(size(ref_flux) /= 555) error stop
+      print *,"Size of nx2",nx2
+      if(size(ref_fluxm) /= 1000) error stop
+    END SUBROUTINE mms_allocate
+  END MODULE module_59_module02

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -424,14 +424,8 @@ ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
     // Also set the `asr_owner` member correctly for all symbol tables
     ASR::FixParentSymtabVisitor p;
     p.visit_TranslationUnit(*tu);
-
-#if defined(WITH_LFORTRAN_ASSERT)
-    diag::Diagnostics diagnostics;
-    if (!asr_verify(*tu, false, diagnostics)) {
-        std::cerr << diagnostics.render2();
-        throw LCompilersException("Verify failed");
-    };
- #endif
+    
+    //ASR verification will get handled later on.
 
     return node;
 }


### PR DESCRIPTION
closes #3968 ,closes #3977 
The code base is working fine.
 
The problem rises from running `asr_verify()` on `ASR::TranslationUnit` node that has its `ExternalSymbol` nodes not completely built as the `FixExternalSymbol` class start its work after running `asr_verify()`.

**THE FIX** : We would just memoize all `ASR::TranslationUnit` and do `FixExternalSymbol` then finally run `asr_verify` on all of them.
Though we run `asr_verify` on the whole `ASR::TranslationUnit` after inserting all external modules in the main symtab, but it's a good practice to verify every single module we deserialize one by one.

**Visualization :)** 

![Screenshot from 2024-06-05 23-32-53](https://github.com/lfortran/lfortran/assets/75497299/98235341-9d61-4eb7-b02a-979473624038)

![Screenshot from 2024-06-05 23-40-28](https://github.com/lfortran/lfortran/assets/75497299/70e70991-65c3-4fbb-a9b7-46a0a119d15f)

