### PR TITLE
Fix: add type check for struct before downcasting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -976,6 +976,7 @@ RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME generic_name_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/generic_name_02.f90
+++ b/integration_tests/generic_name_02.f90
@@ -1,0 +1,10 @@
+program generic_name_02
+    call p("abc")
+    contains
+
+    subroutine p(a)
+        Class(*), intent(in) :: a
+        print *, "Hello World"
+    end subroutine
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8731,11 +8731,13 @@ public:
                     builder->CreateBitCast(dt, llvm::Type::getVoidTy(context)->getPointerTo()),
                     polymorphic_addr);
                 llvm::Value* type_id_addr = llvm_utils->create_gep(abstract_, 0);
-                ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(arg_type);
-                ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(struct_t->m_derived_type);
-                llvm::Value* hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
-                    llvm::APInt(64, get_class_hash(struct_sym)));
-                builder->CreateStore(hash, type_id_addr);
+                if (ASR::is_a<ASR::Struct_t>(*arg_type)) {
+                    ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(arg_type);
+                    ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(struct_t->m_derived_type);
+                    llvm::Value* hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
+                        llvm::APInt(64, get_class_hash(struct_sym)));
+                    builder->CreateStore(hash, type_id_addr);
+                }
                 return abstract_;
             }
         } else if( ASR::is_a<ASR::Struct_t>(*ASRUtils::type_get_past_array(arg_type)) ) {


### PR DESCRIPTION
Towards: #3732 