### PR TITLE
Fixes to build with LLVM 17

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -664,7 +664,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm-version: ["10", "14", "15", "16"]
+        llvm-version: ["10", "14", "15", "16", "17"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -698,6 +698,7 @@ jobs:
             cmake --build . -j16 --target install
 
       - name: Test Linux
+        if: ! contains(matrix.llvm-version, '17')
         shell: bash -e -l {0}
         run: |
             cd integration_tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -698,7 +698,7 @@ jobs:
             cmake --build . -j16 --target install
 
       - name: Test Linux
-        if: ! contains(matrix.llvm-version, '17')
+        if: contains(matrix.llvm-version, '17') == false
         shell: bash -e -l {0}
         run: |
             cd integration_tests

--- a/src/libasr/codegen/KaleidoscopeJIT.h
+++ b/src/libasr/codegen/KaleidoscopeJIT.h
@@ -109,7 +109,11 @@ public:
   }
 
   Expected<JITEvaluatedSymbol> lookup(StringRef Name) {
+#if LLVM_VERSION_MAJOR >= 17
+    // TODO
+#else
     return ES->lookup({&JITDL}, Mangle(Name.str()));
+#endif
   }
 };
 


### PR DESCRIPTION
There are two issues that we need to fix with subsequent commits:

* New pass manager
* Symbol lookup

Maybe a few more things. Currently `--show-llvm` or compiling via the LLVM 17 backend does not work.