### PR TITLE
Improve first build experience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,10 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
 # We don't execute this if we have a tarball
 if (LFORTRAN_BUILD_ALL)
-    find_program(BASH_BIN bash)
-    execute_process(COMMAND "${BASH_BIN}" "-e" "build0.sh" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} RESULT_VARIABLE _BUILD0_EXIT)
+    find_program(RE2C re2c REQUIRED)
+    find_program(BISON bison REQUIRED)
+    find_program(BASH_BIN bash REQUIRED)
+    execute_process(COMMAND "env" "RE2C=${RE2C}" "BISON=${BISON}" "${BASH_BIN}" "-e" "build0.sh" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} RESULT_VARIABLE _BUILD0_EXIT)
     if (NOT _BUILD0_EXIT EQUAL 0)
         message(FATAL_ERROR "Running build0.sh failed (see error above)")
     endif ()

--- a/build0.sh
+++ b/build0.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+RE2C=${RE2C:-re2c}
+BISON=${BISON:-bison}
+
 # Generate the `version` file
 ci/version.sh
 
@@ -16,9 +19,9 @@ python src/libasr/wasm_instructions_visitor.py
 python src/libasr/intrinsic_func_registry_util_gen.py
 
 # Generate the tokenizer and parser
-(cd src/lfortran && re2c -W -b parser/tokenizer.re -o parser/tokenizer.cpp)
-(cd src/lfortran && re2c -W -b parser/preprocessor.re -o parser/preprocessor.cpp)
-(cd src/lfortran/parser && bison -Wall -d -r all parser.yy)
+(cd src/lfortran && ${RE2C} -W -b parser/tokenizer.re -o parser/tokenizer.cpp)
+(cd src/lfortran && ${RE2C} -W -b parser/preprocessor.re -o parser/preprocessor.cpp)
+(cd src/lfortran/parser && ${BISON} -Wall -d -r all parser.yy)
 
 grep -n "'" src/lfortran/parser/parser.yy && echo "Single quote not allowed" && exit 1
 echo "OK"

--- a/ci/version.sh
+++ b/ci/version.sh
@@ -10,9 +10,10 @@
 #
 #     0.6.0-37-g3878937f-dirty
 #
+# In case of a fresh clone without any tag information, a default version is returned.
 
 set -ex
 
-version=$(git describe --tags --dirty)
+version=$(git describe --tags --dirty || echo "-0.0.0-devel")
 version="${version:1}"
 echo $version > version

--- a/src/lfortran/tests/test_cmake_integration.sh
+++ b/src/lfortran/tests/test_cmake_integration.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+set -x
+
+lfortran="$1/lfortran"
+cmakedir="$2/test_cmake_integration"
+
+test -x "${lfortran}"
+test -d "${cmakedir}"
+
+cwd=$PWD
+builddir=_cmake_integration_build
+
+rm -rf $builddir
+mkdir $builddir
+cd $builddir
+cmake ${cmakedir} -DCMAKE_Fortran_COMPILER=${lfortran}
+cmake --build .
+cd ..
+rm -rf $builddir

--- a/src/lfortran/tests/test_cmake_integration/CMakeLists.txt
+++ b/src/lfortran/tests/test_cmake_integration/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(test_project VERSION 0.1
+        DESCRIPTION "hello"
+        LANGUAGES Fortran)
+add_executable(hello hello.f90)

--- a/src/lfortran/tests/test_cmake_integration/hello.f90
+++ b/src/lfortran/tests/test_cmake_integration/hello.f90
@@ -1,0 +1,4 @@
+program hello
+  ! This is a comment line; it is ignored by the compiler
+  print *, 'Hello, World!'
+end program hello


### PR DESCRIPTION
When trying to build lfortran after a clone and a simple 

```
cmake .. -DLFORTRAN_BUILD_ALL=1 
```

I got a few errors (missing packages, version script not working) which should be fixed by these commits