### PR TITLE
fix: erase symbol from old symbol table when importing from a new module

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -270,7 +270,7 @@ RUN(NAME include_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran
 RUN(NAME include_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME include_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c INCLUDE_PATH include_03 fortran)
 
-RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
+RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 
 RUN(NAME cond_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME cond_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -270,6 +270,8 @@ RUN(NAME include_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran
 RUN(NAME include_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME include_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c INCLUDE_PATH include_03 fortran)
 
+RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
+
 RUN(NAME cond_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME cond_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -270,7 +270,7 @@ RUN(NAME include_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran
 RUN(NAME include_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME include_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c INCLUDE_PATH include_03 fortran)
 
-RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
+RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 
 RUN(NAME cond_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME cond_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)

--- a/integration_tests/use_01.f90
+++ b/integration_tests/use_01.f90
@@ -1,0 +1,40 @@
+MODULE one
+   IMPLICIT NONE
+   INTEGER :: nx = 1
+
+CONTAINS
+
+   SUBROUTINE sub (n)
+      INTEGER, INTENT(INOUT) :: n
+      n = n + 1
+   END SUBROUTINE sub
+
+   INTEGER FUNCTION fun() result(i)
+      i = 3
+   END FUNCTION
+
+END MODULE one
+
+
+MODULE two
+   USE one, ONLY: nx, sub, fun
+   IMPLICIT NONE
+END MODULE two
+
+
+PROGRAM test
+   USE two
+   USE one, ONLY: nx, sub, fun
+
+   PRINT *, nx
+   IF (nx /= 1) ERROR STOP
+
+   CALL sub ( nx )
+
+   PRINT *, nx
+   IF (nx /= 2) ERROR STOP
+
+   PRINT *, fun()
+   if (fun() /= 3) ERROR STOP
+
+END PROGRAM test

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2404,8 +2404,9 @@ public:
         if (ASR::is_a<ASR::Function_t>(*t) &&
             ASR::down_cast<ASR::Function_t>(t)->m_return_var == nullptr) {
             if (current_scope->get_symbol(local_sym) != nullptr) {
-                throw SemanticError("Subroutine already defined " + local_sym,
-                    loc);
+                // if the symbol exists in the current scope, we erase it
+                // and write the new symbol which points to the new module
+                current_scope->erase_symbol(local_sym);
             }
             ASR::Function_t *msub = ASR::down_cast<ASR::Function_t>(t);
             // `msub` is the Subroutine in a module. Now we construct
@@ -2438,7 +2439,9 @@ public:
                 }
             }
             if( is_already_defined ) {
-                throw SemanticError("Function already defined", loc);
+                // if the symbol exists in the current scope, we erase it
+                // and write the new symbol which points to the new module
+                current_scope->erase_symbol(local_sym);
             }
             ASR::Function_t *mfn = ASR::down_cast<ASR::Function_t>(t);
             // `mfn` is the Function in a module. Now we construct
@@ -2457,7 +2460,9 @@ public:
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));
         } else if (ASR::is_a<ASR::Variable_t>(*t)) {
             if (current_scope->get_symbol(local_sym) != nullptr) {
-                throw SemanticError("Variable already defined", loc);
+                // if the symbol exists in the current scope, we erase it
+                // and write the new symbol which points to the new module
+                current_scope->erase_symbol(local_sym);
             }
             ASR::Variable_t *mv = ASR::down_cast<ASR::Variable_t>(t);
             // `mv` is the Variable in a module. Now we construct
@@ -2485,7 +2490,9 @@ public:
                 if( imported_struct_type == t ) {
                     return ;
                 }
-                throw SemanticError("Derived type " + local_sym + " already defined.", loc);
+                // if the symbol exists in the current scope, we erase it
+                // and write the new symbol which points to the new module
+                current_scope->erase_symbol(local_sym);
             }
             // `mv` is the Variable in a module. Now we construct
             // an ExternalSymbol that points to it.

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2404,6 +2404,12 @@ public:
         if (ASR::is_a<ASR::Function_t>(*t) &&
             ASR::down_cast<ASR::Function_t>(t)->m_return_var == nullptr) {
             if (current_scope->get_symbol(local_sym) != nullptr) {
+                diag.add(Diagnostic(
+                    "Symbol '" + local_sym + "' from module '" + m->m_name + "' shadows '" + local_sym + "' in the current scope",
+                    Level::Warning, Stage::Semantic, {
+                        Label("", {loc})
+                    }
+                ));
                 // if the symbol exists in the current scope, we erase it
                 // and write the new symbol which points to the new module
                 current_scope->erase_symbol(local_sym);
@@ -2439,6 +2445,12 @@ public:
                 }
             }
             if( is_already_defined ) {
+                diag.add(Diagnostic(
+                    "Symbol '" + local_sym + "' from module '" + m->m_name + "' shadows '" + local_sym + "' in the current scope",
+                    Level::Warning, Stage::Semantic, {
+                        Label("", {loc})
+                    }
+                ));
                 // if the symbol exists in the current scope, we erase it
                 // and write the new symbol which points to the new module
                 current_scope->erase_symbol(local_sym);
@@ -2460,6 +2472,12 @@ public:
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));
         } else if (ASR::is_a<ASR::Variable_t>(*t)) {
             if (current_scope->get_symbol(local_sym) != nullptr) {
+                diag.add(Diagnostic(
+                    "Symbol '" + local_sym + "' from module '" + m->m_name + "' shadows '" + local_sym + "' in the current scope",
+                    Level::Warning, Stage::Semantic, {
+                        Label("", {loc})
+                    }
+                ));
                 // if the symbol exists in the current scope, we erase it
                 // and write the new symbol which points to the new module
                 current_scope->erase_symbol(local_sym);
@@ -2490,6 +2508,12 @@ public:
                 if( imported_struct_type == t ) {
                     return ;
                 }
+                diag.add(Diagnostic(
+                    "Symbol '" + local_sym + "' from module '" + m->m_name + "' shadows '" + local_sym + "' in the current scope",
+                    Level::Warning, Stage::Semantic, {
+                        Label("", {loc})
+                    }
+                ));
                 // if the symbol exists in the current scope, we erase it
                 // and write the new symbol which points to the new module
                 current_scope->erase_symbol(local_sym);


### PR DESCRIPTION
fixes #4165 

```fortran
MODULE one
   IMPLICIT NONE
   INTEGER :: nx = 1
END MODULE one

MODULE two
   USE one, ONLY: nx
   IMPLICIT NONE
END MODULE two

PROGRAM test
   USE two
   USE one, ONLY: nx

   PRINT *, nx
END PROGRAM test
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
1
```