### PR TITLE
fix: check if a `Var_t` expression is a `Variable_t` before down casting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1332,6 +1332,7 @@ RUN(NAME implied_do_loops1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME implied_do_loops2 LABELS gfortran)
 RUN(NAME implied_do_loops3 LABELS gfortran)
 RUN(NAME implied_do_loops4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME implied_do_loops5 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES

--- a/integration_tests/implied_do_loops5.f90
+++ b/integration_tests/implied_do_loops5.f90
@@ -1,12 +1,16 @@
 MODULE implied_do_loops5
-   INTEGER, DIMENSION(10) :: fixup_counter
+   INTEGER, DIMENSION(5) :: fixup_counter
    INTEGER :: n
 END MODULE implied_do_loops5
 
 PROGRAM test
    USE implied_do_loops5
    IMPLICIT NONE
+   INTEGER, DIMENSION(5) :: result_array
 
+   PRINT *, (fixup_counter(n) + n, n = 1, 5)
+   result_array = (/ (fixup_counter(n) + n, n = 1, 5) /)
 
-   PRINT *, (fixup_counter(n) + n, n=1, 4)
+   if (all(result_array /= [1, 2, 3, 4, 5])) ERROR STOP
+
 END PROGRAM test

--- a/integration_tests/implied_do_loops5.f90
+++ b/integration_tests/implied_do_loops5.f90
@@ -1,12 +1,12 @@
 MODULE implied_do_loops5
    INTEGER, DIMENSION(10) :: fixup_counter
+   INTEGER :: n
 END MODULE implied_do_loops5
 
 PROGRAM test
    USE implied_do_loops5
    IMPLICIT NONE
 
-   INTEGER :: n
 
    PRINT *, (fixup_counter(n) + n, n=1, 4)
 END PROGRAM test

--- a/integration_tests/implied_do_loops5.f90
+++ b/integration_tests/implied_do_loops5.f90
@@ -1,10 +1,10 @@
-MODULE implied_do_loops5
+MODULE module_implied_do_loops5
    INTEGER, DIMENSION(5) :: fixup_counter
    INTEGER :: n
-END MODULE implied_do_loops5
+END MODULE module_implied_do_loops5
 
-PROGRAM test
-   USE implied_do_loops5
+PROGRAM implied_do_loops5
+   USE module_implied_do_loops5
    IMPLICIT NONE
    INTEGER, DIMENSION(5) :: result_array
 
@@ -13,4 +13,4 @@ PROGRAM test
 
    if (all(result_array /= [1, 2, 3, 4, 5])) ERROR STOP
 
-END PROGRAM test
+END PROGRAM implied_do_loops5

--- a/integration_tests/implied_do_loops5.f90
+++ b/integration_tests/implied_do_loops5.f90
@@ -9,7 +9,7 @@ PROGRAM test
    INTEGER, DIMENSION(5) :: result_array
 
    PRINT *, (fixup_counter(n) + n, n = 1, 5)
-   result_array = (/ (fixup_counter(n) + n, n = 1, 5) /)
+   result_array = [(fixup_counter(n) + n, n = 1, 5)]
 
    if (all(result_array /= [1, 2, 3, 4, 5])) ERROR STOP
 

--- a/integration_tests/implied_do_loops5.f90
+++ b/integration_tests/implied_do_loops5.f90
@@ -1,0 +1,12 @@
+MODULE implied_do_loops5
+   INTEGER, DIMENSION(10) :: fixup_counter
+END MODULE implied_do_loops5
+
+PROGRAM test
+   USE implied_do_loops5
+   IMPLICIT NONE
+
+   INTEGER :: n
+
+   PRINT *, (fixup_counter(n) + n, n=1, 4)
+END PROGRAM test

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5907,10 +5907,9 @@ public:
                     contain_loop_vars &= true;
                     return;
                 }
-                if (ASR::is_a<ASR::Variable_t>(*sym)) {
-                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-                    contain_loop_vars &= ASRUtils::is_value_constant(var->m_value);
-                }
+                sym = ASRUtils::symbol_get_past_external(sym);
+                ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
+                contain_loop_vars &= ASRUtils::is_value_constant(var->m_value);
                 return;
             }
 
@@ -6019,10 +6018,9 @@ public:
                 // check if loop_var_index is valid
                 if (loop_var_index >= (int) loop_vars.size()) {
                     // this is compiletime value
-                    if (ASR::is_a<ASR::Variable_t>(*x.m_v)) {
-                        ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(x.m_v);
-                        this->visit_expr(*var->m_value);
-                    }
+
+                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(x.m_v));
+                    this->visit_expr(*var->m_value);
                 } else {
                     value = loop_indices[loop_var_index];
                 }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5907,8 +5907,10 @@ public:
                     contain_loop_vars &= true;
                     return;
                 }
-                ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-                contain_loop_vars &= ASRUtils::is_value_constant(var->m_value);
+                if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
+                    contain_loop_vars &= ASRUtils::is_value_constant(var->m_value);
+                }
                 return;
             }
 
@@ -6017,8 +6019,10 @@ public:
                 // check if loop_var_index is valid
                 if (loop_var_index >= (int) loop_vars.size()) {
                     // this is compiletime value
-                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(x.m_v);
-                    this->visit_expr(*var->m_value);
+                    if (ASR::is_a<ASR::Variable_t>(*x.m_v)) {
+                        ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(x.m_v);
+                        this->visit_expr(*var->m_value);
+                    }
                 } else {
                     value = loop_indices[loop_var_index];
                 }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5907,8 +5907,8 @@ public:
                     contain_loop_vars &= true;
                     return;
                 }
-                sym = ASRUtils::symbol_get_past_external(sym);
-                ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
+                ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(
+                                            ASRUtils::symbol_get_past_external(sym));
                 contain_loop_vars &= ASRUtils::is_value_constant(var->m_value);
                 return;
             }
@@ -6018,8 +6018,8 @@ public:
                 // check if loop_var_index is valid
                 if (loop_var_index >= (int) loop_vars.size()) {
                     // this is compiletime value
-
-                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(x.m_v));
+                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(
+                                                ASRUtils::symbol_get_past_external(x.m_v));
                     this->visit_expr(*var->m_value);
                 } else {
                     value = loop_indices[loop_var_index];


### PR DESCRIPTION
fixes #4202 

```fortran
MODULE solvar_module
   REAL, DIMENSION(10) :: fixup_counter
END MODULE

PROGRAM test
   USE solvar_module
   IMPLICIT NONE

   INTEGER :: n

   PRINT *, (fixup_counter(n),n=1,4)
END PROGRAM test
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 
```