### PR TITLE
Start implementing opaque pointers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -705,6 +705,15 @@ jobs:
             ./run_tests.py -b llvm llvmImplicit
             ./run_tests.py -b llvm llvmImplicit -f
 
+      # In LLVM 17 we can only compile a subset for now
+      - name: Test Linux
+        if: contains(matrix.llvm-version, '17') == true
+        shell: bash -e -l {0}
+        run: |
+            src/bin/lfortran --show-llvm examples/expr2.f90
+            src/bin/lfortran examples/expr2.f90
+            ./expr2.out
+
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}
     runs-on: ubuntu-latest

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -263,6 +263,12 @@ public:
         return LLVM::CreateLoad(*builder, x);
     }
 
+    llvm::Value* CreateLoad2(ASR::ttype_t *type, llvm::Value *x) {
+        llvm::Type* el_type = llvm_utils->get_type_from_ttype_t_util(
+            ASRUtils::extract_type(type), module.get());
+        return LLVM::CreateLoad2(*builder, el_type, x);
+    }
+
 
     llvm::Value* CreateGEP(llvm::Value *x, std::vector<llvm::Value *> &idx) {
         return LLVM::CreateGEP(*builder, x, idx);
@@ -6759,7 +6765,7 @@ public:
             tmp = x_v;
             // Load only once since its a value
             if( ptr_loads > 0 ) {
-                tmp = CreateLoad(tmp);
+                tmp = CreateLoad2(x->m_type, tmp);
             }
         }
     }

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10,9 +10,15 @@ namespace LCompilers {
         llvm::Value* CreateLoad(llvm::IRBuilder<> &builder, llvm::Value *x) {
             llvm::Type *t = x->getType();
             LCOMPILERS_ASSERT(t->isPointerTy());
+            LCOMPILERS_ASSERT(t->getNumContainedTypes() > 0);
             llvm::Type *t2 = t->getContainedType(0);
             return builder.CreateLoad(t2, x);
         }
+
+        llvm::Value* CreateLoad2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x) {
+            return builder.CreateLoad(t, x);
+        }
+
 
         llvm::Value* CreateStore(llvm::IRBuilder<> &builder, llvm::Value *x, llvm::Value *y) {
             LCOMPILERS_ASSERT(y->getType()->isPointerTy());

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -166,6 +166,7 @@ namespace LCompilers {
     namespace LLVM {
 
         llvm::Value* CreateLoad(llvm::IRBuilder<> &builder, llvm::Value *x);
+        llvm::Value* CreateLoad2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x);
         llvm::Value* CreateStore(llvm::IRBuilder<> &builder, llvm::Value *x, llvm::Value *y);
         llvm::Value* CreateGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx);
         llvm::Value* CreateInBoundsGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx);


### PR DESCRIPTION
Now the simplest example works with LLVM 17:
```
$ lfortran examples/expr2.f90
25
$ lfortran examples/expr2.f90 --show-llvm
; ModuleID = 'LFortran'
source_filename = "LFortran"

@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1

define i32 @main(i32 %0, ptr %1) {
.entry:
  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
  %x = alloca i32, align 4
  store i32 25, ptr %x, align 4
  %2 = load i32, ptr %x, align 4
  call void (ptr, ...) @_lfortran_printf(ptr @2, i32 %2, ptr @1)
  ret i32 0
}

declare void @_lpython_call_initial_functions(i32, ptr)

declare void @_lfortran_printf(ptr, ...)
```
One can see that now the pointers are not typed, just represented as `ptr`, and when loading them we need to know the type to cast to, and it needs to be determined from ASR. This PR shows how to do that.

We need to clean the approach up and make it systematic and use it everywhere. Furthermore, we need an API that works with both old LLVM versions and new LLVM versions.