### PR TITLE
ASR->LLVM: change CreateLoad to CreateLoad2

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1428,7 +1428,7 @@ public:
         }
         this->visit_expr(*x.m_arg);
         if (tmp->getType()->isPointerTy()) {
-            tmp = CreateLoad(tmp);
+            tmp = CreateLoad2(x.m_type, tmp);
         }
         llvm::Value *c = tmp;
         int64_t kind_value = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x.m_arg));


### PR DESCRIPTION
Now we need to change the other 162 occurences. Sometimes it is as simple as
this PR. Some other times it requires to pass throug the type via the function
hierarchy in the ASR->LLVM backend.