### PR TITLE
fix: incorrect variable abi type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -909,6 +909,7 @@ RUN(NAME bindc4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc_01 LABELS gfortran llvm EXTRAFILES bindc_01b.f90 bindc_01c.c NOFAST)
 RUN(NAME bindc_02 LABELS gfortran llvm EXTRAFILES bindc_02b.f90 bindc_02c.c NOFAST)
 RUN(NAME bindc_03 LABELS gfortran llvm EXTRAFILES bindc_03c.c NOFAST)
+RUN(NAME bindc_04 LABELS gfortran llvm EXTRAFILES bindc_04c.c NOFAST)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/bindc_04.f90
+++ b/integration_tests/bindc_04.f90
@@ -1,0 +1,36 @@
+module thread_data_module
+use, intrinsic :: iso_c_binding
+type, bind(C) :: thread_data
+type(c_ptr) :: a
+end type thread_data
+end module thread_data_module
+
+subroutine lcompilers_initialise_array(data) bind(C)
+use thread_data_module
+use iso_c_binding
+implicit none
+type(c_ptr), value :: data
+type(thread_data), pointer :: tdata
+real(c_float), pointer :: a(:)
+call c_f_pointer(data, tdata)
+
+call c_f_pointer(tdata%a, a, [5])
+print *, a
+end subroutine
+
+program bindc_04
+use iso_c_binding
+interface
+subroutine lcompilers_initialise_array(data) bind(C)
+import :: c_ptr
+type(c_ptr), value :: data
+end subroutine
+
+subroutine a_func(fn) bind(C, name="a_func")
+import :: c_funptr
+type(c_funptr), value :: fn
+end subroutine
+end interface
+
+call a_func(c_funloc(lcompilers_initialise_array))
+end program bindc_04

--- a/integration_tests/bindc_04c.c
+++ b/integration_tests/bindc_04c.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+void a_func(void *func(void*)) {
+    float array[5];
+    for (int i = 0; i < 5; i++) {
+        array[i] = i;
+    }
+    struct thread_data {
+        float* a;
+    } data;
+    
+    data.a = array;
+    func(&data);
+}

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2592,13 +2592,16 @@ public:
                     }
                 }
                 ASR::intentType s_intent;
+                bool is_argument = false;
                 if (std::find(current_procedure_args.begin(),
                         current_procedure_args.end(), to_lower(s.m_name)) !=
                         current_procedure_args.end()) {
                     s_intent = ASRUtils::intent_unspecified;
+                    is_argument = true;
                 } else {
                     s_intent = ASRUtils::intent_local;
                 }
+                ASR::abiType s_abi = is_argument ? current_procedure_abi_type : ASR::abiType::Source;
                 Vec<ASR::dimension_t> dims;
                 dims.reserve(al, 0);
                 // location for dimension(...) if present
@@ -2699,7 +2702,7 @@ public:
                             dims_attr_loc = ad->base.base.loc;
                             process_dims(al, dims, ad->m_dim, ad->n_dim, is_compile_time, is_char_type,
                                 (s_intent == ASRUtils::intent_in || s_intent == ASRUtils::intent_out ||
-                                s_intent == ASRUtils::intent_inout));
+                                s_intent == ASRUtils::intent_inout) || is_argument);
                         } else {
                             throw SemanticError("Attribute type not implemented yet",
                                     x.base.base.loc);
@@ -2736,8 +2739,8 @@ public:
                 }
                 ASR::symbol_t *type_declaration;
                 ASR::ttype_t *type = determine_type(x.base.base.loc, sym, x.m_vartype, is_pointer,
-                    is_allocatable, dims, type_declaration, current_procedure_abi_type,
-                    s_intent != ASRUtils::intent_local, is_dimension_star);
+                    is_allocatable, dims, type_declaration, s_abi,
+                    (s_intent != ASRUtils::intent_local) || is_argument, is_dimension_star);
                 current_variable_type_ = type;
 
                 ASR::expr_t* init_expr = nullptr;
@@ -3181,7 +3184,7 @@ public:
                         ASR::asr_t *v = ASR::make_Variable_t(al, s.loc, current_scope,
                                 s2c(al, to_lower(s.m_name)), variable_dependencies_vec.p,
                                 variable_dependencies_vec.size(), s_intent, init_expr, value,
-                                storage_type, type, type_declaration, current_procedure_abi_type, s_access, s_presence,
+                                storage_type, type, type_declaration, s_abi, s_access, s_presence,
                                 value_attr);
                         current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(v));
                         if( is_derived_type ) {

--- a/tests/reference/asr-array12-cb81afc.json
+++ b/tests/reference/asr-array12-cb81afc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array12-cb81afc.stdout",
-    "stdout_hash": "99c43db63496355cd762ce814336bad44bd4b83740236de920fc6cbd",
+    "stdout_hash": "f9c64d2dcdd01897a54ab2a3a73261451ff74e251e2f8c5d0784fd80",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array12-cb81afc.stdout
+++ b/tests/reference/asr-array12-cb81afc.stdout
@@ -243,7 +243,7 @@
                                                     Default
                                                     (CPtr)
                                                     ()
-                                                    BindC
+                                                    Source
                                                     Public
                                                     Required
                                                     .false.

--- a/tests/reference/asr-string1-f6332d9.json
+++ b/tests/reference/asr-string1-f6332d9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string1-f6332d9.stdout",
-    "stdout_hash": "e1a1be5db03f9c5f95ebf058b2fd9b1a86743a224e33f3f018af4243",
+    "stdout_hash": "a7bbd4bf56655b0b6e77112e36547558c57fa5751e986b4cc95f0a53",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string1-f6332d9.stdout
+++ b/tests/reference/asr-string1-f6332d9.stdout
@@ -67,7 +67,7 @@
                                                                     Default
                                                                     (Integer 8)
                                                                     ()
-                                                                    BindC
+                                                                    Source
                                                                     Public
                                                                     Required
                                                                     .false.

--- a/tests/reference/asr-string2-3425046.json
+++ b/tests/reference/asr-string2-3425046.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-3425046.stdout",
-    "stdout_hash": "555c5e2889ebd759ebeff7aa179bef296a58b2036dc831ea34fd4297",
+    "stdout_hash": "02a5fd1970385c2b3dbe873c376381eaa4009a1ec1dc0267cf984e5a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-3425046.stdout
+++ b/tests/reference/asr-string2-3425046.stdout
@@ -374,7 +374,7 @@
                                                                     Default
                                                                     (Integer 8)
                                                                     ()
-                                                                    BindC
+                                                                    Source
                                                                     Public
                                                                     Required
                                                                     .false.


### PR DESCRIPTION
Towards #4031, #3777.

The example compiles and works but somehow the output diverges looks like when we do `c_f_pointer(...)` it does not return correct fortran pointer:

```console
% gfortran ./integration_tests/bindc_04.f90 ./integration_tests/bindc_04c.c&& ./a.out
   0.00000000       1.00000000       2.00000000       3.00000000       4.00000000    
% gcc -c ./integration_tests/bindc_04c.c -o a_c.o && lfortran -c ./integration_tests/bindc_04.f90 && lfortran bindc_04.o a_c.o
2.52007390e+26 1.40129846e-45 5.62639831e-23 7.00649232e-45 3.37928510e-36 
```