### PR TITLE
Update test for `scan` intrinsic and handle kind = 8 for `verify` and `scan` intrinsic

### DIFF
--- a/integration_tests/intrinsics_185.f90
+++ b/integration_tests/intrinsics_185.f90
@@ -10,7 +10,7 @@ program intrinsics_185
     character(len=5) :: string = "hello"
     character(len=1) :: set(2) = ["l", "h"]
     integer, parameter :: i1 = verify("FORTRAN", "AF", .true., 4)
-    ! integer, parameter :: i2 = verify("FORTRAN", "FOO", kind = 8) ! does not work yet #4226
+    integer, parameter :: i2 = verify("FORTRAN", "FOO", kind = 8)
     integer, parameter :: i3 = verify("FORTRAN", "C++", .true.)
     integer, parameter :: i4 = verify("FORTR", "N")
     integer, parameter :: i5 = verify("FORTRAN", "FORTRAN", .true.)
@@ -19,8 +19,8 @@ program intrinsics_185
 
     print*, i1
     if (i1 /= 7) error stop
-    ! print*, i2
-    ! if (i2 /= 3_8) error stop
+    print*, i2
+    if (i2 /= 3_8) error stop
     print*, i3
     if (i3 /= 7) error stop
     print*, i4

--- a/integration_tests/intrinsics_189.f90
+++ b/integration_tests/intrinsics_189.f90
@@ -2,6 +2,36 @@ program intrinsics_189
     character(7) :: fortran = "FORTRAN"
     character(2) :: ao = "AO"
     character(3) :: c_plus_plus = "C++"
+    integer, parameter :: i1 = scan("FORTRAN", "AO")
+    integer, parameter :: i2 = scan("FORTRAN", "AO", kind = 4)
+    integer, parameter :: i3 = scan("FORTRAN", "AO", .TRUE., 8)
+    integer, parameter :: i4 = scan("FORTRAN", "C++")
+    integer, parameter :: ar1(2) = scan(["LFORTRAN", "GFORTRAN"], ["AO", "AO"])
+    integer, parameter :: ar2(2) = scan(["LFORTRAN", "GFORTRAN"], ["LO", "TR"], kind = 4)
+
+    character(8) :: arr1(2)
+    character(2) :: arr2(2)
+    character(4) :: arr3(3)
+    character(2) :: arr4(3)
+
+    arr1 = ["LFORTRAN", "GFORTRAN"]
+    arr2 = ["AO", "AO"]
+    arr3 = ["LFOR", "TRAN", "GFOR"]
+    arr4 = ["LO", "TR", "AN"]
+    
+    print*, i1
+    if (i1 /= 2) error stop
+    print*, i2
+    if (i2 /= 2) error stop
+    print*, i3
+    if (i3 /= 6_8) error stop
+    print*, i4
+    if (i4 /= 0) error stop
+
+    print*, ar1
+    if (any(ar1 /= [3, 3])) error stop
+    print*, ar2
+    if (any(ar2 /= [1, 4])) error stop
 
     print*, scan("FORTRAN", "AO", kind = 4) 
     if (scan("fortran", "ao", kind = 4) /= 2) error stop         
@@ -16,6 +46,13 @@ program intrinsics_189
     if (scan(fortran, ao, .true., 8) /= 6_8) error stop
     print*, scan(fortran, c_plus_plus) 
     if (scan(fortran, c_plus_plus) /= 0) error stop
+
+    print*, scan(arr1, arr2)
+    if (any(scan(arr1, arr2) /= [3, 3])) error stop
+    print*, scan(arr1, arr2, kind = 4)
+    if (any(scan(arr1, arr2, kind = 4) /= [3, 3])) error stop
+    print*, scan(arr3, arr4)
+    if (any(scan(arr3, arr4) /= [1, 1, 0])) error stop
 
 end program
   

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4338,11 +4338,10 @@ namespace Repeat {
 namespace StringContainsSet {
 
     static ASR::expr_t *eval_StringContainsSet(Allocator &al, const Location &loc,
-            ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
         char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
         char* set = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
-        int64_t kind = ASR::down_cast<ASR::IntegerConstant_t>(args[3])->m_n;
         size_t len = std::strlen(string);
         int64_t result = 0;
         if (back) {
@@ -4360,9 +4359,7 @@ namespace StringContainsSet {
                 }
             }
         }
-
-        ASR::ttype_t* return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, kind));
-        return make_ConstantWithType(make_IntegerConstant_t, result, return_type, loc);
+        return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_StringContainsSet(Allocator &al, const Location &loc,
@@ -4472,11 +4469,10 @@ namespace StringContainsSet {
 namespace StringFindSet {
 
     static ASR::expr_t *eval_StringFindSet(Allocator &al, const Location &loc,
-            ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
         char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
         char* set = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
-        int64_t kind = ASR::down_cast<ASR::IntegerConstant_t>(args[3])->m_n;
         size_t len = std::strlen(string);
         int64_t result = 0;
         if (back) {
@@ -4494,9 +4490,7 @@ namespace StringFindSet {
                 }
             }
         }
-
-        ASR::ttype_t* return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, kind));
-        return make_ConstantWithType(make_IntegerConstant_t, result, return_type, loc);
+        return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_StringFindSet(Allocator &al, const Location &loc,


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4226
Towards: #4017
