### PR TITLE
Fix: add type check for `ArrayPhysicalCast` before downcasting 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -808,6 +808,8 @@ RUN(NAME intrinsics_244 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_245 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #cmplx
 RUN(NAME intrinsics_246 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # adjustl
 RUN(NAME intrinsics_247 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # adjustr
+RUN(NAME intrinsics_249 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nested_sum
+RUN(NAME intrinsics_250 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sum
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -806,10 +806,10 @@ RUN(NAME intrinsics_242 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nint
 RUN(NAME intrinsics_243 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sqrt, abs, log (all kind of real)
 RUN(NAME intrinsics_244 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # cshift
 RUN(NAME intrinsics_245 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #cmplx
-RUN(NAME intrinsics_246 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # adjustl
-RUN(NAME intrinsics_247 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # adjustr
-RUN(NAME intrinsics_249 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nested_sum
-RUN(NAME intrinsics_250 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sum
+RUN(NAME intrinsics_246 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # adjustl
+RUN(NAME intrinsics_247 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # adjustr
+RUN(NAME intrinsics_249 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # nested_sum
+RUN(NAME intrinsics_250 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sum
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_249.f90
+++ b/integration_tests/intrinsics_249.f90
@@ -17,4 +17,3 @@ program intrinsics_249
     res = sum(sum(abs(x), dim))
     end function var_2_iint8_dp
 end program
-    

--- a/integration_tests/intrinsics_249.f90
+++ b/integration_tests/intrinsics_249.f90
@@ -1,0 +1,20 @@
+program intrinsics_249
+    use iso_fortran_env, only: dp => real64
+    integer, parameter :: n = 1000
+    integer, parameter :: m = 1000
+    integer, dimension(n,m) :: x
+    real(dp) :: res
+    x = 18
+    res = var_2_iint8_dp(x, 1)
+    print *, res
+    if (abs(res - 18000000.0_dp) > 1e-12) error stop
+    contains
+    function var_2_iint8_dp(x, dim) result(res)
+    use iso_fortran_env, only: dp => real64
+    integer, intent(in) :: x(:,:)
+    integer, intent(in) :: dim
+    real(dp) :: res
+    res = sum(sum(abs(x), dim))
+    end function var_2_iint8_dp
+end program
+    

--- a/integration_tests/intrinsics_250.f90
+++ b/integration_tests/intrinsics_250.f90
@@ -1,0 +1,17 @@
+program intrinsics_50
+integer, dimension(2,2) :: x
+real(8) :: res(2)
+x = 2
+res = func(x, 1)
+contains
+
+function func(x, dim) result(res)
+integer, intent(in) :: x(:,:)
+integer, intent(in) :: dim
+real(8) :: res(2)
+print*, sum(abs(x), dim)
+res = sum(abs(x), dim)
+if (any(res /= [4, 4])) error stop
+end function func
+end program
+    

--- a/integration_tests/intrinsics_250.f90
+++ b/integration_tests/intrinsics_250.f90
@@ -1,4 +1,4 @@
-program intrinsics_50
+program intrinsics_250
 integer, dimension(2,2) :: x
 real(8) :: res(2)
 x = 2
@@ -13,5 +13,4 @@ print*, sum(abs(x), dim)
 res = sum(abs(x), dim)
 if (any(res /= [4, 4])) error stop
 end function func
-end program
-    
+end program   

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -181,19 +181,25 @@ namespace LCompilers {
                         ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(func_call_merge);
                         if (ASR::is_a<ASR::ArraySize_t>(*func_call->m_args[0].m_value)) {
                             ASR::ArraySize_t *array_size = ASR::down_cast<ASR::ArraySize_t>(func_call->m_args[0].m_value);
-                            array_size->m_v = ASR::down_cast<ASR::ArrayPhysicalCast_t>(new_args[map[0]].m_value)->m_arg;
+                            if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*new_args[map[0]].m_value)) {
+                                array_size->m_v = ASR::down_cast<ASR::ArrayPhysicalCast_t>(new_args[map[0]].m_value)->m_arg;
+                            } else {
+                                array_size->m_v = new_args[map[0]].m_value;
+                            }
                             func_call->m_args[0].m_value = ASRUtils::EXPR((ASR::asr_t*) array_size);
                         }
                         if (ASR::is_a<ASR::ArraySize_t>(*func_call->m_args[1].m_value)) {
                             ASR::ArraySize_t *array_size = ASR::down_cast<ASR::ArraySize_t>(func_call->m_args[1].m_value);
-                            array_size->m_v = ASR::down_cast<ASR::ArrayPhysicalCast_t>(new_args[map[1]].m_value)->m_arg;
-
+                            if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*new_args[map[1]].m_value))
+                                array_size->m_v = ASR::down_cast<ASR::ArrayPhysicalCast_t>(new_args[map[1]].m_value)->m_arg;
+                            else {
+                                array_size->m_v = new_args[map[1]].m_value;
+                            }
                             func_call->m_args[1].m_value = ASRUtils::EXPR((ASR::asr_t*) array_size);
                         }
                         if (ASR::is_a<ASR::IntegerCompare_t>(*func_call->m_args[2].m_value)) {
                             ASR::IntegerCompare_t *integer_compare = ASR::down_cast<ASR::IntegerCompare_t>(func_call->m_args[2].m_value);
                             integer_compare->m_right = new_args[map[2]].m_value;
-
                             func_call->m_args[2].m_value = ASRUtils::EXPR((ASR::asr_t*) integer_compare);
                         }
                         res_arr->m_dims[i].m_length = func_call_merge;


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4239
Fixes: https://github.com/lfortran/lfortran/issues/4062
Towards: #4017