### PR TITLE
chore: hack to load `cptr` in `visit_CPtrToPointer` if it is `StructInstanceMember`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1605,6 +1605,7 @@ RUN(NAME polymorphic_argument LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME openmp_bindc_01 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_bindc_02 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_bindc_03 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 
 RUN(NAME openmp_01 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_02 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)

--- a/integration_tests/bindc_04.f90
+++ b/integration_tests/bindc_04.f90
@@ -2,6 +2,7 @@ module thread_data_module
 use, intrinsic :: iso_c_binding
 type, bind(C) :: thread_data
 type(c_ptr) :: a
+integer(c_int) :: n
 end type thread_data
 end module thread_data_module
 
@@ -9,28 +10,71 @@ subroutine lcompilers_initialise_array(data) bind(C)
 use thread_data_module
 use iso_c_binding
 implicit none
-type(c_ptr), value :: data
+type(c_ptr), intent(in), value :: data
 type(thread_data), pointer :: tdata
 real(c_float), pointer :: a(:)
 call c_f_pointer(data, tdata)
 
 call c_f_pointer(tdata%a, a, [5])
-print *, a
+print *, "Array address in fortran :", tdata%a
+print *, "c_loc(a) :", c_loc(a)
+print *, sum(a)
+if (abs(sum(a) - 10.0) > 1.0e-8) error stop
+end subroutine
+
+subroutine b_func_fortran(data) bind(C)
+use thread_data_module
+use iso_c_binding
+implicit none
+type(c_ptr), intent(in), value :: data
+real(c_float), pointer :: a(:)
+
+call c_f_pointer(data, a, [5])
+print *, "Array address in fortran b_func_fortran:", data
+print *, "c_loc(a) b_func_fortran:", c_loc(a)
+print *, sum(a)
+if (abs(sum(a) - 10.0) > 1.0e-8) error stop
 end subroutine
 
 program bindc_04
 use iso_c_binding
+use thread_data_module
 interface
 subroutine lcompilers_initialise_array(data) bind(C)
 import :: c_ptr
-type(c_ptr), value :: data
+type(c_ptr), intent(in), value :: data
 end subroutine
 
 subroutine a_func(fn) bind(C, name="a_func")
 import :: c_funptr
 type(c_funptr), value :: fn
 end subroutine
+
+subroutine b_func_fortran(data) bind(C)
+import :: c_ptr
+type(c_ptr), intent(in), value :: data
+end subroutine
+
+subroutine b_func(fn) bind(C, name="b_func")
+import :: c_funptr
+type(c_funptr), value :: fn
+end subroutine
+
+subroutine c_func(arr) bind(C, name="c_func")
+import :: c_ptr
+type(c_ptr), value :: arr
+end subroutine
 end interface
+type(thread_data), target :: tdata
+real(c_float), dimension(:), pointer :: a
+
+allocate(a(5))
+a = [1.0, 2.0, 3.0, 4.0, 5.0]
+tdata%a = c_loc(a)
+tdata%n = 5
 
 call a_func(c_funloc(lcompilers_initialise_array))
+call b_func(c_funloc(b_func_fortran))
+call c_func(c_loc(a))
+
 end program bindc_04

--- a/integration_tests/bindc_04c.c
+++ b/integration_tests/bindc_04c.c
@@ -7,8 +7,32 @@ void a_func(void *func(void*)) {
     }
     struct thread_data {
         float* a;
+        int n;
     } data;
     
     data.a = array;
+    // print &array as integer
+    printf("Array address in C: %ld\n", (long int) array);
+    printf("Array[0] address in C: %ld\n", (long int) &array[0]);
+    data.n = 5;
     func(&data);
+}
+
+void b_func(void *func(void*)) {
+    float array[5];
+    for (int i = 0; i < 5; i++) {
+        array[i] = i;
+    }
+    float *data = array;
+    // print &array as integer
+    printf("Array address in C for b_func: %ld\n", (long int) array);
+    func(data);
+}
+
+void c_func(void *array) {
+    printf("Printing array in C for c_func\n");
+    float *data = array;
+    for (int i = 0; i < 5; i++) {
+        printf("%f\n", data[i]);
+    }
 }

--- a/integration_tests/openmp_bindc_03.f90
+++ b/integration_tests/openmp_bindc_03.f90
@@ -1,0 +1,154 @@
+module bindc_03_thread_data_module
+    use, intrinsic :: iso_c_binding
+    type, bind(C) :: thread_data
+        integer(c_int) :: n
+        type(c_ptr) :: a
+    end type thread_data
+end module bindc_03_thread_data_module
+
+module module_openmp_bindc_03
+use iso_c_binding
+implicit none
+
+interface
+subroutine GOMP_parallel (fn, data, num_threads, flags) bind (C, name="GOMP_parallel")
+import :: c_funptr, c_ptr, c_int
+type(c_funptr), value :: fn
+type(c_ptr), value :: data
+integer(c_int), value :: num_threads
+integer(c_int), value :: flags
+end subroutine
+
+subroutine GOMP_barrier() bind(C, name="GOMP_barrier")
+end subroutine
+
+subroutine GOMP_critical_start() bind(C, name="GOMP_critical_start")
+end subroutine
+
+subroutine GOMP_critical_end() bind(C, name="GOMP_critical_end")
+end subroutine
+
+function omp_get_max_threads() bind(c, name="omp_get_max_threads")
+import :: c_int
+integer(c_int) :: omp_get_max_threads
+end function omp_get_max_threads
+
+function omp_get_thread_num() bind(c, name="omp_get_thread_num")
+import :: c_int
+integer(c_int) :: omp_get_thread_num
+end function omp_get_thread_num
+
+subroutine omp_set_num_threads(n) bind(c, name="omp_set_num_threads")
+import :: c_int
+integer(c_int), value :: n
+end subroutine omp_set_num_threads
+
+subroutine GOMP_atomic_start() bind(C, name="GOMP_atomic_start")
+end subroutine
+
+subroutine GOMP_atomic_end() bind(C, name="GOMP_atomic_end")
+end subroutine
+
+end interface
+
+end module
+
+subroutine lcompilers_initialise_array(data) bind(C)
+use bindc_03_thread_data_module
+use iso_c_binding
+use module_openmp_bindc_03
+implicit none
+type(c_ptr), value :: data
+type(thread_data), pointer :: tdata
+real(c_float), pointer :: a(:)
+
+integer(c_int) :: i, n, num_threads, chunk, leftovers, thread_num, start, end
+
+call c_f_pointer(data, tdata)
+
+n = tdata%n
+
+call c_f_pointer(tdata%a, a, [n])
+
+num_threads = omp_get_max_threads()
+chunk = n / num_threads
+leftovers = mod(n, num_threads)
+
+thread_num = omp_get_thread_num()
+start = chunk * thread_num
+
+if (thread_num < leftovers) then
+    start = start + thread_num
+else
+    start = start + leftovers
+end if
+
+end = start + chunk
+
+if (thread_num < leftovers) then
+    end = end + 1
+end if
+
+do i = start + 1, end
+    ! print *, "Thread ", thread_num, " is processing element ", i
+    a(i) = 12.91
+end do
+
+call GOMP_barrier()
+
+end subroutine
+
+subroutine initialize_array(n, a)
+use bindc_03_thread_data_module
+use module_openmp_bindc_03
+implicit none
+
+interface
+subroutine lcompilers_initialise_array(data) bind(C)
+use iso_c_binding
+type(c_ptr), value :: data
+end subroutine
+end interface
+
+integer(c_int), intent(in) :: n
+real(c_float), dimension(:), intent(inout), pointer :: a
+
+type(thread_data), target :: data
+type(c_ptr) :: tdata
+
+data%n = n
+allocate(a(data%n))
+data%a = c_loc(a)
+
+tdata = c_loc(data)
+
+call GOMP_parallel(c_funloc(lcompilers_initialise_array), tdata, 0, 0)
+
+end subroutine
+
+program openmp_bindc_03
+use omp_lib
+use module_openmp_bindc_03
+use bindc_03_thread_data_module
+implicit none
+
+interface
+subroutine initialize_array(n, a)
+use iso_c_binding
+integer(c_int), intent(in) :: n
+real(c_float), intent(inout), dimension(:), pointer :: a
+end subroutine
+end interface
+
+integer(c_int) :: n = 1000000
+real(c_float), dimension(:), pointer :: a
+
+call omp_set_num_threads(4)
+call initialize_array(n, a)
+print *, "Done"
+
+print *, "a[1] = ", a(1)
+print * , "a[1000000] = ", a(1000000)
+if (abs(a(1) - 12.91) > 1e-8) error stop
+if (abs(a(1000000) - 12.91) > 1e-8) error stop
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4172,6 +4172,10 @@ public:
             ptr_loads = 1 - reduce_loads;
             this->visit_expr(*cptr);
             llvm::Value* llvm_cptr = tmp;
+            if (ASR::is_a<ASR::StructInstanceMember_t>(*cptr)) {
+                // TOOD: remove this in future, it is hacky
+                llvm_cptr = CreateLoad(llvm_cptr);
+            }
             ptr_loads = 0;
             this->visit_expr(*fptr);
             llvm::Value* llvm_fptr = tmp;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4173,7 +4173,8 @@ public:
             this->visit_expr(*cptr);
             llvm::Value* llvm_cptr = tmp;
             if (ASR::is_a<ASR::StructInstanceMember_t>(*cptr)) {
-                // TOOD: remove this in future, it is hacky
+                // `type(c_ptr)` requires an extra load here
+                // TODO: be more explicit about ptr_loads: https://github.com/lfortran/lfortran/issues/4245
                 llvm_cptr = CreateLoad(llvm_cptr);
             }
             ptr_loads = 0;


### PR DESCRIPTION
Fixes #4232. Fixes #4031. Towards #3777.