### PR TITLE
[cli] Accept both --cpp and -cpp to activate preprocessor

### DIFF
--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -28,7 +28,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--version`: Display compiler version information
 - `-W TEXT ...`: Linker flags
 - `-f TEXT ...`: All `-f*` flags (only -fPIC supported for now)
-- `--cpp`: Enable C preprocessing
+- `-cpp`, `--cpp`: Enable C preprocessing
 - `--fixed-form`: Use fixed form Fortran source parsing
 - `--fixed-form-infer`: Use heuristics to infer if a file is in fixed form
 - `--no-prescan`: Turn off prescan

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1502,10 +1502,10 @@ RUN(NAME specfun_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --use-loop-variable-after-loop --implicit-typing)
 
 RUN(NAME cpp_pre_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c
-    EXTRA_ARGS --cpp
+    EXTRA_ARGS -cpp
     GFORTRAN_ARGS -cpp)
 RUN(NAME cpp_pre_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c wasm
-    EXTRA_ARGS --cpp
+    EXTRA_ARGS -cpp
     GFORTRAN_ARGS -cpp)
 RUN(NAME cpp_pre_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c wasm
     EXTRA_ARGS --cpp


### PR DESCRIPTION
GFortran accepts -cpp and lapack makefiles assumes this option is available. Otherwise the build crashes.
For compatibility with existing makefiles / cmakefiles / build system, it's probably a good idea to support that mode as well.