### PR TITLE
use opaque pointers instead of typed pointers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -716,6 +716,7 @@ jobs:
             src/bin/lfortran --show-llvm integration_tests/print_03.f90
             src/bin/lfortran integration_tests/print_03.f90
             ./print_03.out
+            src/bin/lfortran --show-llvm tests/subroutine3.f90
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -713,6 +713,9 @@ jobs:
             src/bin/lfortran --show-llvm examples/expr2.f90
             src/bin/lfortran examples/expr2.f90
             ./expr2.out
+            src/bin/lfortran --show-llvm integration_tests/print_03.f90
+            src/bin/lfortran integration_tests/print_03.f90
+            ./print_03.out
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -720,6 +720,12 @@ jobs:
             src/bin/lfortran --show-llvm integration_tests/module_function_without_nopass.f90
             src/bin/lfortran integration_tests/module_function_without_nopass.f90
             ./module_function_without_nopass.out
+            src/bin/lfortran --show-llvm integration_tests/module_function_with_nopass.f90
+            src/bin/lfortran integration_tests/module_function_with_nopass.f90
+            ./module_function_with_nopass.out
+            src/bin/lfortran --show-llvm integration_tests/elemental_01.f90
+            src/bin/lfortran integration_tests/elemental_01.f90
+            ./elemental_01.out
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -729,6 +729,12 @@ jobs:
             src/bin/lfortran --show-llvm integration_tests/elemental_04.f90
             src/bin/lfortran integration_tests/elemental_04.f90
             ./elemental_04.out
+            src/bin/lfortran --show-llvm integration_tests/integration_tests/types_23.f90
+            src/bin/lfortran integration_tests/types_23.f90
+            ./types_23.out
+            src/bin/lfortran --show-llvm integration_tests/character_01.f90
+            src/bin/lfortran integration_tests/character_01.f90
+            ./character_01.out
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -726,6 +726,9 @@ jobs:
             src/bin/lfortran --show-llvm integration_tests/elemental_01.f90
             src/bin/lfortran integration_tests/elemental_01.f90
             ./elemental_01.out
+            src/bin/lfortran --show-llvm integration_tests/elemental_04.f90
+            src/bin/lfortran integration_tests/elemental_04.f90
+            ./elemental_04.out
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -729,7 +729,7 @@ jobs:
             src/bin/lfortran --show-llvm integration_tests/elemental_04.f90
             src/bin/lfortran integration_tests/elemental_04.f90
             ./elemental_04.out
-            src/bin/lfortran --show-llvm integration_tests/integration_tests/types_23.f90
+            src/bin/lfortran --show-llvm integration_tests/types_23.f90
             src/bin/lfortran integration_tests/types_23.f90
             ./types_23.out
             src/bin/lfortran --show-llvm integration_tests/character_01.f90

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -717,6 +717,9 @@ jobs:
             src/bin/lfortran integration_tests/print_03.f90
             ./print_03.out
             src/bin/lfortran --show-llvm tests/subroutine3.f90
+            src/bin/lfortran --show-llvm integration_tests/module_function_without_nopass.f90
+            src/bin/lfortran integration_tests/module_function_without_nopass.f90
+            ./module_function_without_nopass.out
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -840,8 +840,12 @@ public:
         std::vector<llvm::Value *> idx = {
             llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
             llvm::ConstantInt::get(context, llvm::APInt(32, 1))};
-        llvm::Value *pim = CreateGEP(pc, idx);
-        return CreateLoad(pim);
+        llvm::Value *pim = LLVM::CreateGEP2(*builder, complex_type, pc, idx);
+        if (complex_type == complex_type_4) {
+            return LLVM::CreateLoad2(*builder, llvm::Type::getFloatTy(context), pim);
+        } else {
+            return LLVM::CreateLoad2(*builder, llvm::Type::getDoubleTy(context), pim);
+        }
     }
 
     llvm::Value *complex_from_floats(llvm::Value *re, llvm::Value *im,
@@ -3701,7 +3705,7 @@ public:
                             builder->CreateStore(s_malloc, target_var);
                             tmp = lfortran_str_copy(target_var, init_value);
                             if (v->m_intent == intent_local) {
-                                strings_to_be_deallocated.push_back(al, CreateLoad(target_var));
+                                strings_to_be_deallocated.push_back(al, CreateLoad2(v->m_type, target_var));
                             }
                         } else {
                             builder->CreateStore(init_value, target_var);
@@ -3728,7 +3732,7 @@ public:
                                 string_init(context, *module, *builder, arg_size, init_value);
                                 builder->CreateStore(init_value, target_var);
                                 if (v->m_intent == intent_local) {
-                                    strings_to_be_deallocated.push_back(al, CreateLoad(target_var));
+                                    strings_to_be_deallocated.push_back(al, CreateLoad2(v->m_type, target_var));
                                 }
                             } else if (strlen == -2) {
                                 // Allocatable string. Initialize to `nullptr` (unallocated)

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3956,7 +3956,7 @@ public:
             ASR::Variable_t *asr_retval = EXPR2VAR(x.m_return_var);
             uint32_t h = get_hash((ASR::asr_t*)asr_retval);
             llvm::Value *ret_val = llvm_symtab[h];
-            llvm::Value *ret_val2 = CreateLoad(ret_val);
+            llvm::Value *ret_val2 = CreateLoad2(asr_retval->m_type, ret_val);
             // Handle Complex type return value for BindC:
             if (ASRUtils::get_FunctionType(x)->m_abi == ASR::abiType::BindC) {
                 ASR::ttype_t* arg_type = asr_retval->m_type;
@@ -9849,7 +9849,7 @@ public:
                         start_new_block(elseBB);
                     }
                     start_new_block(mergeBB);
-                    tmp = LLVM::CreateLoad(*builder, target);
+                    tmp = LLVM::CreateLoad2(*builder, target_type, target);
                     break;
                 } else {
                     LCOMPILERS_ASSERT(false);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3396,7 +3396,7 @@ public:
         }
         llvm::Type* vtab_type = type2vtabtype[struct_type_sym];
         llvm::Value* vtab_obj = builder->CreateAlloca(vtab_type);
-        llvm::Value* struct_type_hash_ptr = llvm_utils->create_gep(vtab_obj, 0);
+        llvm::Value* struct_type_hash_ptr = llvm_utils->create_gep2(vtab_type, vtab_obj, 0);
         llvm::Value* struct_type_hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
             llvm::APInt(64, get_class_hash(struct_type_sym)));
         builder->CreateStore(struct_type_hash, struct_type_hash_ptr);
@@ -8773,10 +8773,11 @@ public:
             }
             llvm::Value* dt_polymorphic = builder->CreateAlloca(
                 llvm_utils->getClassType(s_m_args0_type, true));
-            llvm::Value* hash_ptr = llvm_utils->create_gep(dt_polymorphic, 0);
+            llvm::Type* _type = llvm_utils->get_type_from_ttype_t_util(s_m_args0_type, module.get());
+            llvm::Value* hash_ptr = llvm_utils->create_gep2(_type, dt_polymorphic, 0);
             llvm::Value* hash = llvm::ConstantInt::get(llvm_utils->getIntType(8), llvm::APInt(64, get_class_hash(struct_sym)));
             builder->CreateStore(hash, hash_ptr);
-            llvm::Value* class_ptr = llvm_utils->create_gep(dt_polymorphic, 1);
+            llvm::Value* class_ptr = llvm_utils->create_gep2(_type, dt_polymorphic, 1);
             builder->CreateStore(builder->CreateBitCast(dt, llvm_utils->getStructType(s_m_args0_type, module.get(), true)), class_ptr);
             return dt_polymorphic;
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9742,7 +9742,6 @@ public:
         llvm::Value* dim_val = tmp;
 
         ASR::ttype_t* x_mv_type = ASRUtils::expr_type(x.m_v);
-        llvm::Type *llvm_x_mv_type = llvm_utils->get_type_from_ttype_t_util(x_mv_type, module.get());
         ASR::array_physical_typeType physical_type = ASRUtils::extract_physical_type(x_mv_type);
         switch( physical_type ) {
             case ASR::array_physical_typeType::DescriptorArray: {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -273,6 +273,22 @@ public:
         return LLVM::CreateGEP(*builder, x, idx);
     }
 
+    llvm::Value* CreateGEP2(ASR::ttype_t *type, llvm::Value *x, std::vector<llvm::Value *> &idx) {
+        llvm::Type* llvm_type = llvm_utils->get_type_from_ttype_t_util(
+            ASRUtils::extract_type(type), module.get()
+        );
+        return LLVM::CreateGEP2(*builder, llvm_type, x, idx);
+    }
+
+
+    llvm::Value* CreateGEP2(ASR::ttype_t *type, llvm::Value *x, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        llvm::Type* llvm_type = llvm_utils->get_type_from_ttype_t_util(type, module.get());
+        return LLVM::CreateGEP2(*builder, llvm_type, x, idx_vec);
+    }
+
     #define load_non_array_non_character_pointers(expr, type, llvm_value) if( ASR::is_a<ASR::StructInstanceMember_t>(*expr) && \
         !ASRUtils::is_array(type) && \
         LLVM::is_llvm_pointer(*type) && \
@@ -5167,7 +5183,7 @@ public:
                 !ASR::is_a<ASR::ArrayConstant_t>(*ASRUtils::expr_value(m_arg))) ||
                 ASRUtils::expr_value(m_arg) == nullptr ) &&
                 !ASR::is_a<ASR::ArrayConstructor_t>(*m_arg) ) {
-                tmp = llvm_utils->create_gep(tmp, 0);
+                tmp = CreateGEP2(ASRUtils::expr_type(m_arg), tmp, 0);
             }
         } else if(
             m_new == ASR::array_physical_typeType::UnboundedPointerToDataArray &&

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5398,12 +5398,7 @@ public:
             switch( select_type_stmts[i]->type ) {
                 case ASR::type_stmtType::TypeStmtName: {
                     ASR::ttype_t* selector_var_type = ASRUtils::expr_type(x.m_selector);
-                    llvm::Type* llvm_type_selector = llvm_utils->get_type_from_ttype_t_util(
-                        selector_var_type, module.get()
-                    );
-                    llvm::Value* vptr_int_hash = CreateLoad2(
-                        selector_var_type, llvm_utils->create_gep2(llvm_type_selector, llvm_selector, 0)
-                    );
+                    llvm::Value* vptr_int_hash = CreateLoad(llvm_utils->create_gep(llvm_selector, 0));
                     if( ASRUtils::is_array(selector_var_type) ) {
                         vptr_int_hash = CreateLoad(llvm_utils->create_gep(vptr_int_hash, 0));
                     }

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -222,6 +222,15 @@ namespace LCompilers {
         }
 
         llvm::Value* SimpleCMODescriptor::
+        get_pointer_to_dimension_descriptor_array(llvm::Type* type, llvm::Value* arr, bool load) {
+            llvm::Value* dim_des_arr_ptr = llvm_utils->create_gep2(type, arr, 2);
+            if( !load ) {
+                return dim_des_arr_ptr;
+            }
+            return LLVM::CreateLoad(*builder, dim_des_arr_ptr);
+        }
+
+        llvm::Value* SimpleCMODescriptor::
         get_rank(llvm::Value* arr, bool get_pointer) {
             llvm::Value* rank_ptr = llvm_utils->create_gep(arr, 4);
             if( get_pointer ) {
@@ -620,7 +629,7 @@ namespace LCompilers {
             return idx;
         }
 
-        llvm::Value* SimpleCMODescriptor::get_single_element(llvm::Type *el_type, llvm::Value* array,
+        llvm::Value* SimpleCMODescriptor::get_single_element(llvm::Type *type, llvm::Type *el_type, llvm::Value* array,
             std::vector<llvm::Value*>& m_args, int n_args, bool data_only,
             bool is_fixed_size, llvm::Value** llvm_diminfo, bool polymorphic,
             llvm::Type* polymorphic_type, bool is_unbounded_pointer_to_data) {
@@ -633,7 +642,7 @@ namespace LCompilers {
                 LCOMPILERS_ASSERT(llvm_diminfo);
                 idx = cmo_convertor_single_element_data_only(llvm_diminfo, m_args, n_args, check_for_bounds, is_unbounded_pointer_to_data);
                 if( is_fixed_size ) {
-                    tmp = llvm_utils->create_gep2(el_type, array, idx);
+                    tmp = llvm_utils->create_gep2(type, array, idx);
                 } else {
                     tmp = llvm_utils->create_ptr_gep2(el_type, array, idx);
                 }

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -620,7 +620,7 @@ namespace LCompilers {
             return idx;
         }
 
-        llvm::Value* SimpleCMODescriptor::get_single_element(llvm::Value* array,
+        llvm::Value* SimpleCMODescriptor::get_single_element(llvm::Type *el_type, llvm::Value* array,
             std::vector<llvm::Value*>& m_args, int n_args, bool data_only,
             bool is_fixed_size, llvm::Value** llvm_diminfo, bool polymorphic,
             llvm::Type* polymorphic_type, bool is_unbounded_pointer_to_data) {
@@ -633,7 +633,7 @@ namespace LCompilers {
                 LCOMPILERS_ASSERT(llvm_diminfo);
                 idx = cmo_convertor_single_element_data_only(llvm_diminfo, m_args, n_args, check_for_bounds, is_unbounded_pointer_to_data);
                 if( is_fixed_size ) {
-                    tmp = llvm_utils->create_gep(array, idx);
+                    tmp = llvm_utils->create_gep2(el_type, array, idx);
                 } else {
                     tmp = llvm_utils->create_ptr_gep(array, idx);
                 }

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -629,7 +629,7 @@ namespace LCompilers {
             return idx;
         }
 
-        llvm::Value* SimpleCMODescriptor::get_single_element(llvm::Type *type, llvm::Type *el_type, llvm::Value* array,
+        llvm::Value* SimpleCMODescriptor::get_single_element(llvm::Type *type, llvm::Value* array,
             std::vector<llvm::Value*>& m_args, int n_args, bool data_only,
             bool is_fixed_size, llvm::Value** llvm_diminfo, bool polymorphic,
             llvm::Type* polymorphic_type, bool is_unbounded_pointer_to_data) {
@@ -644,7 +644,7 @@ namespace LCompilers {
                 if( is_fixed_size ) {
                     tmp = llvm_utils->create_gep2(type, array, idx);
                 } else {
-                    tmp = llvm_utils->create_ptr_gep2(el_type, array, idx);
+                    tmp = llvm_utils->create_ptr_gep2(type, array, idx);
                 }
             } else {
                 idx = cmo_convertor_single_element(array, m_args, n_args, check_for_bounds);

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -635,7 +635,7 @@ namespace LCompilers {
                 if( is_fixed_size ) {
                     tmp = llvm_utils->create_gep2(el_type, array, idx);
                 } else {
-                    tmp = llvm_utils->create_ptr_gep(array, idx);
+                    tmp = llvm_utils->create_ptr_gep2(el_type, array, idx);
                 }
             } else {
                 idx = cmo_convertor_single_element(array, m_args, n_args, check_for_bounds);

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -267,7 +267,7 @@ namespace LCompilers {
                 * to the rules implemented by current class.
                 */
                 virtual
-                llvm::Value* get_single_element(llvm::Type *type, llvm::Type *el_type, llvm::Value* array,
+                llvm::Value* get_single_element(llvm::Type *type, llvm::Value* array,
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
@@ -438,7 +438,7 @@ namespace LCompilers {
                 llvm::Value* get_stride(llvm::Value* dim_des, bool load=true);
 
                 virtual
-                llvm::Value* get_single_element(llvm::Type *type, llvm::Type *el_type, llvm::Value* array,
+                llvm::Value* get_single_element(llvm::Type *type, llvm::Value* array,
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -247,6 +247,9 @@ namespace LCompilers {
                 * implemented by current class.
                 */
                 virtual
+                llvm::Value* get_pointer_to_dimension_descriptor_array(llvm::Type *type, llvm::Value* arr, bool load=true) = 0;
+
+                virtual
                 llvm::Value* get_pointer_to_dimension_descriptor_array(llvm::Value* arr, bool load=true) = 0;
 
                 /*
@@ -264,7 +267,7 @@ namespace LCompilers {
                 * to the rules implemented by current class.
                 */
                 virtual
-                llvm::Value* get_single_element(llvm::Type *el_type, llvm::Value* array,
+                llvm::Value* get_single_element(llvm::Type *type, llvm::Type *el_type, llvm::Value* array,
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
@@ -422,6 +425,9 @@ namespace LCompilers {
                     bool load=true);
 
                 virtual
+                llvm::Value* get_pointer_to_dimension_descriptor_array(llvm::Type* type, llvm::Value* arr, bool load=true);
+
+                virtual
                 llvm::Value* get_pointer_to_dimension_descriptor_array(llvm::Value* arr, bool load=true);
 
                 virtual
@@ -432,7 +438,7 @@ namespace LCompilers {
                 llvm::Value* get_stride(llvm::Value* dim_des, bool load=true);
 
                 virtual
-                llvm::Value* get_single_element(llvm::Type *el_type, llvm::Value* array,
+                llvm::Value* get_single_element(llvm::Type *type, llvm::Type *el_type, llvm::Value* array,
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -264,7 +264,7 @@ namespace LCompilers {
                 * to the rules implemented by current class.
                 */
                 virtual
-                llvm::Value* get_single_element(llvm::Value* array,
+                llvm::Value* get_single_element(llvm::Type *el_type, llvm::Value* array,
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
@@ -432,7 +432,7 @@ namespace LCompilers {
                 llvm::Value* get_stride(llvm::Value* dim_des, bool load=true);
 
                 virtual
-                llvm::Value* get_single_element(llvm::Value* array,
+                llvm::Value* get_single_element(llvm::Type *el_type, llvm::Value* array,
                     std::vector<llvm::Value*>& m_args, int n_args,
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -25,7 +25,6 @@ namespace LCompilers {
             return builder.CreateStore(x, y);
         }
 
-
         llvm::Value* CreateGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx) {
             llvm::Type *t = x->getType();
             LCOMPILERS_ASSERT(t->isPointerTy());
@@ -41,8 +40,15 @@ namespace LCompilers {
         llvm::Value* CreateInBoundsGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx) {
             llvm::Type *t = x->getType();
             LCOMPILERS_ASSERT(t->isPointerTy());
+            LCOMPILERS_ASSERT(t->getNumContainedTypes() > 0);
             llvm::Type *t2 = t->getContainedType(0);
             return builder.CreateInBoundsGEP(t2, x, idx);
+        }
+
+        llvm::Value* CreateInBoundsGEP2(
+            llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx
+        ) {
+            return builder.CreateInBoundsGEP(t, x, idx);
         }
 
         llvm::Value* lfortran_malloc(llvm::LLVMContext &context, llvm::Module &module,
@@ -1586,9 +1592,20 @@ namespace LCompilers {
         return LLVM::CreateInBoundsGEP(*builder, ptr, idx_vec);
     }
 
+    llvm::Value* LLVMUtils::create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        return LLVM::CreateInBoundsGEP2(*builder, type, ptr, idx_vec);
+    }
+
     llvm::Value* LLVMUtils::create_ptr_gep(llvm::Value* ptr, llvm::Value* idx) {
         std::vector<llvm::Value*> idx_vec = {idx};
         return LLVM::CreateInBoundsGEP(*builder, ptr, idx_vec);
+    }
+
+    llvm::Value* LLVMUtils::create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, llvm::Value* idx) {
+        std::vector<llvm::Value*> idx_vec = {idx};
+        return LLVM::CreateInBoundsGEP2(*builder, type, ptr, idx_vec);
     }
 
     llvm::Type* LLVMUtils::getIntType(int a_kind, bool get_pointer) {

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -45,9 +45,7 @@ namespace LCompilers {
             return builder.CreateInBoundsGEP(t2, x, idx);
         }
 
-        llvm::Value* CreateInBoundsGEP2(
-            llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx
-        ) {
+        llvm::Value* CreateInBoundsGEP2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx) {
             return builder.CreateInBoundsGEP(t, x, idx);
         }
 

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -29,8 +29,13 @@ namespace LCompilers {
         llvm::Value* CreateGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx) {
             llvm::Type *t = x->getType();
             LCOMPILERS_ASSERT(t->isPointerTy());
+            LCOMPILERS_ASSERT(t->getNumContainedTypes() > 0);
             llvm::Type *t2 = t->getContainedType(0);
             return builder.CreateGEP(t2, x, idx);
+        }
+
+        llvm::Value* CreateGEP2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx) {
+            return builder.CreateGEP(t, x, idx);
         }
 
         llvm::Value* CreateInBoundsGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx) {
@@ -1554,11 +1559,25 @@ namespace LCompilers {
         return LLVM::CreateGEP(*builder, ds, idx_vec);
     }
 
+    llvm::Value* LLVMUtils::create_gep2(llvm::Type *t, llvm::Value* ds, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        return LLVM::CreateGEP2(*builder, t, ds, idx_vec);
+    }
+
     llvm::Value* LLVMUtils::create_gep(llvm::Value* ds, llvm::Value* idx) {
         std::vector<llvm::Value*> idx_vec = {
         llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
         idx};
         return LLVM::CreateGEP(*builder, ds, idx_vec);
+    }
+
+    llvm::Value* LLVMUtils::create_gep2(llvm::Type *t, llvm::Value* ds, llvm::Value* idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        idx};
+        return LLVM::CreateGEP2(*builder, t, ds, idx_vec);
     }
 
     llvm::Value* LLVMUtils::create_ptr_gep(llvm::Value* ptr, int idx) {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -169,6 +169,7 @@ namespace LCompilers {
         llvm::Value* CreateLoad2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x);
         llvm::Value* CreateStore(llvm::IRBuilder<> &builder, llvm::Value *x, llvm::Value *y);
         llvm::Value* CreateGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx);
+        llvm::Value* CreateGEP2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx);
         llvm::Value* CreateInBoundsGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx);
         llvm::Value* lfortran_malloc(llvm::LLVMContext &context, llvm::Module &module,
                 llvm::IRBuilder<> &builder, llvm::Value* arg_size);
@@ -245,7 +246,11 @@ namespace LCompilers {
 
             llvm::Value* create_gep(llvm::Value* ds, int idx);
 
+            llvm::Value* create_gep2(llvm::Type *t, llvm::Value* ds, int idx);
+
             llvm::Value* create_gep(llvm::Value* ds, llvm::Value* idx);
+
+            llvm::Value* create_gep2(llvm::Type *t, llvm::Value* ds, llvm::Value* idx);
 
             llvm::Value* create_ptr_gep(llvm::Value* ptr, int idx);
 

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -171,6 +171,7 @@ namespace LCompilers {
         llvm::Value* CreateGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx);
         llvm::Value* CreateGEP2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx);
         llvm::Value* CreateInBoundsGEP(llvm::IRBuilder<> &builder, llvm::Value *x, std::vector<llvm::Value *> &idx);
+        llvm::Value* CreateInBoundsGEP2(llvm::IRBuilder<> &builder, llvm::Type *t, llvm::Value *x, std::vector<llvm::Value *> &idx);
         llvm::Value* lfortran_malloc(llvm::LLVMContext &context, llvm::Module &module,
                 llvm::IRBuilder<> &builder, llvm::Value* arg_size);
         llvm::Value* lfortran_realloc(llvm::LLVMContext &context, llvm::Module &module,
@@ -254,7 +255,11 @@ namespace LCompilers {
 
             llvm::Value* create_ptr_gep(llvm::Value* ptr, int idx);
 
+            llvm::Value* create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, int idx);
+
             llvm::Value* create_ptr_gep(llvm::Value* ptr, llvm::Value* idx);
+
+            llvm::Value* create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, llvm::Value* idx);
 
             llvm::Type* getIntType(int a_kind, bool get_pointer=false);
 


### PR DESCRIPTION
Extend the work done in https://github.com/lfortran/lfortran/pull/4206 to have the output LLVM IR as opaque pointers instead of typed pointers, see:
* https://releases.llvm.org/17.0.1/docs/ReleaseNotes.html#changes-to-the-llvm-ir
* https://releases.llvm.org/17.0.1/docs/OpaquePointers.html