### PR TITLE
fix: array handling for `derf` and add test for `erf` and `derf`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -811,6 +811,8 @@ RUN(NAME intrinsics_247 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_248 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST fotran) # eoshift
 RUN(NAME intrinsics_249 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # nested_sum
 RUN(NAME intrinsics_250 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sum
+RUN(NAME intrinsics_251 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # erf
+RUN(NAME intrinsics_252 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derf
 
 RUN(NAME parameter_01 LABELS gfortran)
 RUN(NAME parameter_02 LABELS gfortran)

--- a/integration_tests/intrinsics_251.f90
+++ b/integration_tests/intrinsics_251.f90
@@ -1,0 +1,55 @@
+program intrinsics_251
+    use, intrinsic :: iso_fortran_env, only: sp => real32, dp => real64
+    real(sp), parameter :: r1 = erf(1.1_sp)
+    real(dp), parameter :: r2 = erf(40.12_dp)
+    real(sp), parameter :: ar1(3) = erf([0.5_sp, -1.5_sp, 2.2_sp])
+    real(dp), parameter :: ar2(2) = erf([-0.2_dp, 0.0_dp])
+    real(sp) :: x
+    real(dp) :: y, z
+    real(sp) :: arr1(3)
+    real(dp) :: arr2(3), res(3)
+
+    x = 6.738377383_sp
+    y = 3.1473863781_dp
+    z = 7389.83936383_dp
+
+    print *, erf(x)
+    if (abs(erf(x) - 1.00000000e+00_sp) > 1e-6) error stop
+    print *, erf(y)
+    if (abs(erf(y) - 9.99991455910536065e-01_dp) > 1e-12) error stop
+    print *, erf(z)
+    if (abs(erf(z) - 1.00000000000000000e+00_dp) > 1e-12) error stop
+
+    x = -6.738377383_sp
+    y = -3.1473863781_dp
+    z = -7389.83936383_dp
+
+    print *, erf(x)
+    if (abs(erf(x) - (-1.00000000e+00_sp)) > 1e-6) error stop
+    print *, erf(y)
+    if (abs(erf(y) - (-9.99991455910536065e-01_dp)) > 1e-12) error stop
+    print *, erf(z)
+    if (abs(erf(z) - (-1.00000000000000000e+00_dp)) > 1e-12) error stop
+
+    print *, r1
+    if (abs(r1 - 8.80205095e-01_sp) > 1e-6_sp) error stop
+
+    print *, r2
+    if (abs(r2 - 1.00000000000000000e+00_dp) > 1e-12_dp) error stop
+
+    print *, ar1
+    if (any(abs(ar1 - [5.20499885e-01_sp, -9.66105163e-01_sp, 9.98137176e-01_sp]) > 1e-6_sp)) error stop
+
+    print *, ar2
+    if (any(abs(ar2 - [-2.22702589210478474e-01_dp, 0.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+
+    arr1 = [-6.738377383_sp, -3.1473863781_sp, -7389.83936383_sp]
+    print *, erf(arr1)
+    if (any(abs(erf(arr1) - [-1.00000000e+00_sp, -9.99991477e-01_sp, -1.00000000e+00_sp]) > 1e-6_sp)) error stop
+
+    arr2 = [6.738377383_dp, 3.1473863781_dp, 7389.83936383_dp]
+    res = erf(arr2)
+    print *, res
+    if (any(abs(res - [1.00000000000000000e+00_dp, 9.99991455910536065e-01_dp, 1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+
+end program

--- a/integration_tests/intrinsics_252.f90
+++ b/integration_tests/intrinsics_252.f90
@@ -36,18 +36,21 @@ program intrinsics_252
     if (abs(r2 - 1.00000000000000000e+00_dp) > 1e-12_dp) error stop
 
     print *, ar1
-    if (any(abs(ar1 - [5.20499877813046519e-01_dp, -9.66105146475310761e-01_dp, 9.98137153702018165e-01_dp]) > 1e-12_dp)) error stop
+    if (any(abs(ar1 - [5.20499877813046519e-01_dp, -9.66105146475310761e-01_dp, &
+    9.98137153702018165e-01_dp]) > 1e-12_dp)) error stop
 
     print *, ar2
     if (any(abs(ar2 - [-2.22702589210478474e-01_dp, 0.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
 
     arr1 = [-6.738377383_dp, -3.1473863781_dp, -7389.83936383_dp]
     print *, derf(arr1)
-    if (any(abs(derf(arr1) - [-1.00000000000000000e+00_dp, -9.99991455910536065e-01_dp, -1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+    if (any(abs(derf(arr1) - [-1.00000000000000000e+00_dp, -9.99991455910536065e-01_dp, &
+    -1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
 
     arr2 = [6.738377383_dp, 3.1473863781_dp, 7389.83936383_dp]
     res = derf(arr2)
     print *, res
-    if (any(abs(res - [1.00000000000000000e+00_dp, 9.99991455910536065e-01_dp, 1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+    if (any(abs(res - [1.00000000000000000e+00_dp, 9.99991455910536065e-01_dp, & 
+    1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
 
 end program

--- a/integration_tests/intrinsics_252.f90
+++ b/integration_tests/intrinsics_252.f90
@@ -1,0 +1,53 @@
+program intrinsics_252
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    real(dp), parameter :: r1 = derf(1.1_dp)
+    real(dp), parameter :: r2 = derf(40.12_dp)
+    real(dp), parameter :: ar1(3) = derf([0.5_dp, -1.5_dp, 2.2_dp])
+    real(dp), parameter :: ar2(2) = derf([-0.2_dp, 0.0_dp])
+    real(dp) :: x, y, z
+    real(dp) :: arr1(3), arr2(3), res(3)
+
+    x = 6.738377383_dp
+    y = 3.1473863781_dp
+    z = 7389.83936383_dp
+
+    print *, derf(x)
+    if (abs(derf(x) - 1.00000000000000000e+00_dp) > 1e-12) error stop
+    print *, derf(y)
+    if (abs(derf(y) - 9.99991455910536065e-01_dp) > 1e-12) error stop
+    print *, derf(z)
+    if (abs(derf(z) - 1.00000000000000000e+00_dp) > 1e-12) error stop
+
+    x = -6.738377383_dp
+    y = -3.1473863781_dp
+    z = -7389.83936383_dp
+
+    print *, derf(x)
+    if (abs(derf(x) - (-1.00000000000000000e+00_dp)) > 1e-12) error stop
+    print *, derf(y)
+    if (abs(derf(y) - (-9.99991455910536065e-01_dp)) > 1e-12) error stop
+    print *, derf(z)
+    if (abs(derf(z) - (-1.00000000000000000e+00_dp)) > 1e-12) error stop
+
+    print *, r1
+    if (abs(r1 - 8.80205069574081733e-01_dp) > 1e-12_dp) error stop
+
+    print *, r2
+    if (abs(r2 - 1.00000000000000000e+00_dp) > 1e-12_dp) error stop
+
+    print *, ar1
+    if (any(abs(ar1 - [5.20499877813046519e-01_dp, -9.66105146475310761e-01_dp, 9.98137153702018165e-01_dp]) > 1e-12_dp)) error stop
+
+    print *, ar2
+    if (any(abs(ar2 - [-2.22702589210478474e-01_dp, 0.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+
+    arr1 = [-6.738377383_dp, -3.1473863781_dp, -7389.83936383_dp]
+    print *, derf(arr1)
+    if (any(abs(derf(arr1) - [-1.00000000000000000e+00_dp, -9.99991455910536065e-01_dp, -1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+
+    arr2 = [6.738377383_dp, 3.1473863781_dp, 7389.83936383_dp]
+    res = derf(arr2)
+    print *, res
+    if (any(abs(res - [1.00000000000000000e+00_dp, 9.99991455910536065e-01_dp, 1.00000000000000000e+00_dp]) > 1e-12_dp)) error stop
+
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5393,7 +5393,7 @@ public:
         if (intrinsic_mapping[intrinsic_name].second == "int4") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     if (!is_integer(*arg_type)) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
                                             " must be of integer type", loc);
@@ -5403,7 +5403,7 @@ public:
         } else if (intrinsic_mapping[intrinsic_name].second == "real") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     if (!is_real(*arg_type)) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
                                             " must be of real type", loc);
@@ -5413,7 +5413,7 @@ public:
         } else if (intrinsic_mapping[intrinsic_name].second == "real4") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_real(*arg_type) || kind != 4) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
@@ -5424,7 +5424,7 @@ public:
         } else if (intrinsic_mapping[intrinsic_name].second == "real8") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_real(*arg_type) || kind != 8) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
@@ -5435,7 +5435,7 @@ public:
         } else if (intrinsic_mapping[intrinsic_name].second == "complex") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     if (!is_complex(*arg_type)) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
                                             " must be of complex type", loc);
@@ -5445,7 +5445,7 @@ public:
         } else if (intrinsic_mapping[intrinsic_name].second == "complex4") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_complex(*arg_type) || kind != 4) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
@@ -5456,7 +5456,7 @@ public:
         } else if (intrinsic_mapping[intrinsic_name].second == "complex8") {
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i] != nullptr) {
-                    ASR::ttype_t *arg_type = ASRUtils::expr_type(args[i]);
+                    ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_complex(*arg_type) || kind != 8) {
                         throw SemanticError("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4264
Towards: #4017 