### PR TITLE
refactor (revert): rename function `getStruct` back to `getStructType`

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4482,7 +4482,7 @@ public:
                     ASRUtils::type_get_past_pointer(target_type));
                 ASR::Struct_t* struct_type_t = ASR::down_cast<ASR::Struct_t>(
                     ASRUtils::symbol_get_past_external(class_t->m_class_type));
-                llvm_value = builder->CreateBitCast(llvm_value, llvm_utils->getStruct(struct_type_t, module.get(), true));
+                llvm_value = builder->CreateBitCast(llvm_value, llvm_utils->getStructType(struct_type_t, module.get(), true));
                 builder->CreateStore(llvm_value, llvm_target);
             } else if( is_target_class && is_value_class ) {
                 [[maybe_unused]] ASR::Class_t* target_class_t = ASR::down_cast<ASR::Class_t>(
@@ -5381,7 +5381,7 @@ public:
                     ASR::TypeStmtName_t* type_stmt_name = ASR::down_cast<ASR::TypeStmtName_t>(select_type_stmts[i]);
                     ASR::symbol_t* type_sym = ASRUtils::symbol_get_past_external(type_stmt_name->m_sym);
                     if( ASR::is_a<ASR::Struct_t>(*type_sym) ) {
-                        current_select_type_block_type = llvm_utils->getStruct(
+                        current_select_type_block_type = llvm_utils->getStructType(
                             ASR::down_cast<ASR::Struct_t>(type_sym), module.get(), true);
                         current_select_type_block_der_type = ASR::down_cast<ASR::Struct_t>(type_sym)->m_name;
                     } else {
@@ -5404,7 +5404,7 @@ public:
                     ASR::ClassStmt_t* class_stmt = ASR::down_cast<ASR::ClassStmt_t>(select_type_stmts[i]);
                     ASR::symbol_t* class_sym = ASRUtils::symbol_get_past_external(class_stmt->m_sym);
                     if( ASR::is_a<ASR::Struct_t>(*class_sym) ) {
-                        current_select_type_block_type = llvm_utils->getStruct(
+                        current_select_type_block_type = llvm_utils->getStructType(
                             ASR::down_cast<ASR::Struct_t>(class_sym), module.get(), true);
                         current_select_type_block_der_type = ASR::down_cast<ASR::Struct_t>(class_sym)->m_name;
                     } else {
@@ -8773,7 +8773,7 @@ public:
             llvm::Value* hash = llvm::ConstantInt::get(llvm_utils->getIntType(8), llvm::APInt(64, get_class_hash(struct_sym)));
             builder->CreateStore(hash, hash_ptr);
             llvm::Value* class_ptr = llvm_utils->create_gep(dt_polymorphic, 1);
-            builder->CreateStore(builder->CreateBitCast(dt, llvm_utils->getStruct(s_m_args0_type, module.get(), true)), class_ptr);
+            builder->CreateStore(builder->CreateBitCast(dt, llvm_utils->getStructType(s_m_args0_type, module.get(), true)), class_ptr);
             return dt_polymorphic;
         }
         return dt;
@@ -9153,7 +9153,7 @@ public:
             {
                 std::vector<llvm::Value*> args;
                 ASR::Struct_t* struct_type_t = ASR::down_cast<ASR::Struct_t>(type_sym);
-                llvm::Type* target_dt_type = llvm_utils->getStruct(struct_type_t, module.get(), true);
+                llvm::Type* target_dt_type = llvm_utils->getStructType(struct_type_t, module.get(), true);
                 llvm::Type* target_class_dt_type = llvm_utils->getClassType(struct_type_t);
                 llvm::Value* target_dt = builder->CreateAlloca(target_class_dt_type);
                 llvm::Value* target_dt_hash_ptr = llvm_utils->create_gep(target_dt, 0);
@@ -9240,7 +9240,7 @@ public:
             {
                 std::vector<llvm::Value*> args;
                 ASR::Struct_t* struct_type_t = ASR::down_cast<ASR::Struct_t>(type_sym);
-                llvm::Type* target_dt_type = llvm_utils->getStruct(struct_type_t, module.get(), true);
+                llvm::Type* target_dt_type = llvm_utils->getStructType(struct_type_t, module.get(), true);
                 llvm::Type* target_class_dt_type = llvm_utils->getClassType(struct_type_t);
                 llvm::Value* target_dt = builder->CreateAlloca(target_class_dt_type);
                 llvm::Value* target_dt_hash_ptr = llvm_utils->create_gep(target_dt, 0);

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -166,7 +166,7 @@ namespace LCompilers {
                 break;
             }
             case ASR::ttypeType::StructType: {
-                llvm_mem_type = getStruct(mem_type, module);
+                llvm_mem_type = getStructType(mem_type, module);
                 break;
             }
             case ASR::ttypeType::EnumType: {
@@ -233,7 +233,7 @@ namespace LCompilers {
         }
     }
 
-    llvm::Type* LLVMUtils::getStruct(ASR::Struct_t* der_type, llvm::Module* module, bool is_pointer) {
+    llvm::Type* LLVMUtils::getStructType(ASR::Struct_t* der_type, llvm::Module* module, bool is_pointer) {
         std::string der_type_name = std::string(der_type->m_name);
         createStructTypeContext(der_type);
         if (std::find(struct_type_stack.begin(), struct_type_stack.end(),
@@ -252,7 +252,7 @@ namespace LCompilers {
             if( der_type->m_parent != nullptr ) {
                 ASR::Struct_t *par_der_type = ASR::down_cast<ASR::Struct_t>(
                                                         ASRUtils::symbol_get_past_external(der_type->m_parent));
-                llvm::Type* par_llvm = getStruct(par_der_type, module);
+                llvm::Type* par_llvm = getStructType(par_der_type, module);
                 member_types.push_back(par_llvm);
                 dertype2parent[der_type_name] = std::string(par_der_type->m_name);
                 member_idx += 1;
@@ -275,7 +275,7 @@ namespace LCompilers {
         return (llvm::Type*) *der_type_llvm;
     }
 
-    llvm::Type* LLVMUtils::getStruct(ASR::ttype_t* _type, llvm::Module* module, bool is_pointer) {
+    llvm::Type* LLVMUtils::getStructType(ASR::ttype_t* _type, llvm::Module* module, bool is_pointer) {
         ASR::Struct_t* der_type;
         if( ASR::is_a<ASR::StructType_t>(*_type) ) {
             ASR::StructType_t* der = ASR::down_cast<ASR::StructType_t>(_type);
@@ -289,7 +289,7 @@ namespace LCompilers {
             LCOMPILERS_ASSERT(false);
             return nullptr; // silence a warning
         }
-        llvm::Type* type = getStruct(der_type, module, is_pointer);
+        llvm::Type* type = getStructType(der_type, module, is_pointer);
         LCOMPILERS_ASSERT(type != nullptr);
         return type;
     }
@@ -410,7 +410,7 @@ namespace LCompilers {
                 member_types.push_back(getClassType(class_type_t, is_pointer));
             } else if( ASR::is_a<ASR::Struct_t>(*der_sym) ) {
                 ASR::Struct_t* struct_type_t = ASR::down_cast<ASR::Struct_t>(der_sym);
-                member_types.push_back(getStruct(struct_type_t, module, is_pointer));
+                member_types.push_back(getStructType(struct_type_t, module, is_pointer));
             }
             der_type_llvm = llvm::StructType::create(context, member_types, der_type_name);
             name2dertype[der_type_name] = der_type_llvm;
@@ -498,7 +498,7 @@ namespace LCompilers {
                 break;
             }
             case ASR::ttypeType::StructType: {
-                el_type = getStruct(m_type_, module);
+                el_type = getStructType(m_type_, module);
                 break;
             }
             case ASR::ttypeType::Union: {
@@ -770,7 +770,7 @@ namespace LCompilers {
                 break;
             }
             case (ASR::ttypeType::StructType) : {
-                type = getStruct(asr_type, module, true);
+                type = getStructType(asr_type, module, true);
                 break;
             }
             case (ASR::ttypeType::Class) : {
@@ -1434,7 +1434,7 @@ namespace LCompilers {
                 break;
             }
             case (ASR::ttypeType::StructType) : {
-                llvm_type = getStruct(asr_type, module, false);
+                llvm_type = getStructType(asr_type, module, false);
                 break;
             }
             case (ASR::ttypeType::Class) : {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -272,9 +272,9 @@ namespace LCompilers {
 
             void createStructTypeContext(ASR::Struct_t* der_type);
 
-            llvm::Type* getStruct(ASR::Struct_t* der_type, llvm::Module* module, bool is_pointer=false);
+            llvm::Type* getStructType(ASR::Struct_t* der_type, llvm::Module* module, bool is_pointer=false);
 
-            llvm::Type* getStruct(ASR::ttype_t* _type, llvm::Module* module, bool is_pointer=false);
+            llvm::Type* getStructType(ASR::ttype_t* _type, llvm::Module* module, bool is_pointer=false);
 
             llvm::Type* getUnionType(ASR::UnionType_t* union_type,
                 llvm::Module* module, bool is_pointer=false);


### PR DESCRIPTION
Rename function `getStruct` back to `getStructType`. This mistake was caught while working on #4269.