### PR TITLE
Warning free build on Mac M1

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2449,7 +2449,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
-        (void)!scanf(INT64, p);
+        (void)!scanf("%" PRId64, p);
         return;
     }
 
@@ -2463,7 +2463,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     if (unit_file_bin) {
         (void)!fread(p, sizeof(*p), 1, filep);
     } else {
-        (void)!fscanf(filep, INT64, p);
+        (void)!fscanf(filep, "%" PRId64, p);
     }
 }
 


### PR DESCRIPTION
I just made a fresh build and on my Mac machine and got these warnings.

```
/Users/anurag/Library/projects/open_source/lfortran/src/libasr/runtime/lfortran_intrinsics.c:2452:29: warning: format specifies type 'long *' but the argument has type 'int64_t *' (aka 'long long *') [-Wformat]
        (void)!scanf(INT64, p);
                     ~~~~~  ^
/Users/anurag/Library/projects/open_source/lfortran/src/libasr/runtime/lfortran_intrinsics.c:2466:37: warning: format specifies type 'long *' but the argument has type 'int64_t *' (aka 'long long *') [-Wformat]
        (void)!fscanf(filep, INT64, p);
                             ~~~~~  ^
```