### PR TITLE
feat: add support for element-wise operations on logical arrays using the `WHERE` statement

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -945,6 +945,7 @@ RUN(NAME where_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME where_04 LABELS gfortran) # TODO: Fix this test #1631
 RUN(NAME where_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME where_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 

--- a/integration_tests/where_07.f90
+++ b/integration_tests/where_07.f90
@@ -1,0 +1,55 @@
+program where_07
+   implicit none
+
+   integer :: call_num
+
+   logical(4), dimension(4) :: l
+
+   l = [.true., .false., .true., .false.]
+   call_num = 1
+
+   ! neqv operator
+   where (l .neqv. .true.)
+      l = .true.
+   end where
+
+   print *, l
+   IF (all(l .neqv. [.true., .true., .true., .true.])) ERROR STOP
+
+   ! or operator
+   where (l .or. .false.)
+      l = get_boolean_false()
+   end where
+
+   print *, l
+   IF (all(l .neqv. [.false., .true., .false., .true.])) ERROR STOP
+
+   ! and operator
+   where (l .and. get_boolean_true())
+      l = .false.
+   end where
+
+   print *, l
+   IF (all(l .neqv. [.false., .false., .false., .false.])) ERROR STOP
+
+   ! eqv operator
+   where (l .eqv. get_boolean_false())
+      l = .true.
+   end where
+
+   print *, l
+   IF (all(l .neqv. [.true., .false., .true., .true.])) ERROR STOP
+
+contains
+
+   pure logical function get_boolean_true() result(value)
+      implicit none
+      value = .true.
+   end function get_boolean_true
+
+   pure logical function get_boolean_false() result(value)
+      implicit none
+      value = .false.
+   end function get_boolean_false
+
+end program where_07


### PR DESCRIPTION
fixes #4238 

```fortran
PROGRAM test_program
   IMPLICIT NONE

   LOGICAL(4), DIMENSION(4) :: l

   l = [.TRUE., .FALSE., .TRUE., .FALSE.]

   WHERE (l .neqv. .TRUE.)
      l = .TRUE.
   END WHERE

   print *, l

END PROGRAM test_program
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
True True True True 
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
 T T T T
```