### PR TITLE
fix: handle lone `logical` array in `WHERE` clause

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -955,6 +955,7 @@ RUN(NAME where_04 LABELS gfortran) # TODO: Fix this test #1631
 RUN(NAME where_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME where_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 

--- a/integration_tests/where_08.f90
+++ b/integration_tests/where_08.f90
@@ -31,4 +31,4 @@ contains
       value = [.true., .false., .true., .false., .true.]
    end function
 
-end program main
+end program where_08

--- a/integration_tests/where_08.f90
+++ b/integration_tests/where_08.f90
@@ -1,4 +1,4 @@
-program main
+program where_08
    implicit none
    logical :: l1(5)
    logical :: l2(5)

--- a/integration_tests/where_08.f90
+++ b/integration_tests/where_08.f90
@@ -1,0 +1,34 @@
+program main
+   implicit none
+   logical :: l1(5)
+   logical :: l2(5)
+
+   integer :: b(5)
+
+   l1 = [.true., .false., .true., .false., .true.]
+   l2 = [1 < 2, 2 == 2, .true., .false., 2 >= 1]
+
+   where(l1) b = 1
+   print *, b
+   if (all(b /= [1, 0, 1, 0, 1])) error stop
+
+   where(l2) b = 2
+   print *, b
+   if (all(b /= [2, 2, 2, 0, 2])) error stop
+
+   where(get_logical_array()) b = 3
+   print *, b
+   if (all(b /= [3, 2, 3, 0, 3])) error stop
+
+   where([.true., .false., .true., .false., .true.]) b = 4
+   print *, b
+   if (all(b /= [4, 2, 4, 0, 4])) error stop
+
+contains
+   function get_logical_array() result(value)
+      implicit none
+      logical :: value(5)
+      value = [.true., .false., .true., .false., .true.]
+   end function
+
+end program main

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3218,25 +3218,26 @@ public:
         Vec<ASR::stmt_t*> orelse;
         orelse.reserve(al, x.n_orelse);
         transform_stmts(orelse, x.n_orelse, x.m_orelse);
-        // check if ttype of `test` is an array
-        if (!ASRUtils::is_array(ASRUtils::expr_type(test))) {
-            throw SemanticError("'where' clause requires a logical array", test->base.loc);
-        }
-        // check if `test` is stricly an array and not the ttype of an accepted expression
-        if (ASRUtils::is_array(ASRUtils::expr_type(test))
-            && !ASR::is_a<ASR::IntegerCompare_t>(*test) 
-            && !ASR::is_a<ASR::RealCompare_t>(*test)
-            && !ASR::is_a<ASR::LogicalBinOp_t>(*test)) {
-            if (!ASR::is_a<ASR::Logical_t>(
-                    *ASRUtils::type_get_past_array(ASRUtils::expr_type((test))))) {
-                throw SemanticError("'where' clause requires a logical array", test->base.loc);
+        if (ASRUtils::is_array(ASRUtils::expr_type(test))) {
+            if (ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_array(ASRUtils::expr_type(test)))) {
+                // verify that `test` is *not* the ttype of an expression as we then 
+                // are sure that it is a single standalone logical array
+                if  (!ASR::is_a<ASR::IntegerCompare_t>(*test) 
+                    && !ASR::is_a<ASR::RealCompare_t>(*test)
+                    && !ASR::is_a<ASR::LogicalBinOp_t>(*test)) {
+                        // Rewrite into a form "X == true" as a workaround
+                        // until https://github.com/lfortran/lfortran/issues/4330 is fixed
+                        ASR::expr_t* logical_true = ASRUtils::EXPR(
+                                                        ASR::make_LogicalConstant_t(al, x.base.base.loc, true,
+                                                        ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, 4))));
+                        test = ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, x.base.base.loc, test,
+                                    ASR::logicalbinopType::Eqv, logical_true, ASRUtils::expr_type(test), nullptr));
+                }
             } else {
-                ASR::expr_t* logical_true = ASRUtils::EXPR(
-                                                ASR::make_LogicalConstant_t(al, x.base.base.loc, true,
-                                                ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, 4))));
-                test = ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, x.base.base.loc, test,
-                            ASR::logicalbinopType::Eqv, logical_true, ASRUtils::expr_type(test), nullptr));
+                throw SemanticError("the first array argument to `where` must be of type logical", test->base.loc);
             }
+        } else {
+            throw SemanticError("the argument to `where` must be an array", test->base.loc);
         }
         tmp = ASR::make_Where_t(al, x.base.base.loc, test, body.p, body.size(), orelse.p, orelse.size());
     }

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3218,8 +3218,13 @@ public:
         Vec<ASR::stmt_t*> orelse;
         orelse.reserve(al, x.n_orelse);
         transform_stmts(orelse, x.n_orelse, x.m_orelse);
-        if (ASRUtils::is_array(ASRUtils::expr_type(test))) {
-            if (!ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_array(ASRUtils::expr_type((test))))) {
+        // check if `test` is stricly an array and not the ttype of an accepted expression
+        if (ASRUtils::is_array(ASRUtils::expr_type(test))
+            && !ASR::is_a<ASR::IntegerCompare_t>(*test) 
+            && !ASR::is_a<ASR::RealCompare_t>(*test)
+            && !ASR::is_a<ASR::LogicalBinOp_t>(*test)) {
+            if (!ASR::is_a<ASR::Logical_t>(
+                    *ASRUtils::type_get_past_array(ASRUtils::expr_type((test))))) {
                 throw SemanticError("'where' clause requires a logical array", test->base.loc);
             } else {
                 ASR::expr_t* logical_true = ASRUtils::EXPR(

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3218,6 +3218,17 @@ public:
         Vec<ASR::stmt_t*> orelse;
         orelse.reserve(al, x.n_orelse);
         transform_stmts(orelse, x.n_orelse, x.m_orelse);
+        if (ASRUtils::is_array(ASRUtils::expr_type(test))) {
+            if (!ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_array(ASRUtils::expr_type((test))))) {
+                throw SemanticError("'where' clause requires a logical array", test->base.loc);
+            } else {
+                ASR::expr_t* logical_true = ASRUtils::EXPR(
+                                                ASR::make_LogicalConstant_t(al, x.base.base.loc, true,
+                                                ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, 4))));
+                test = ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, x.base.base.loc, test,
+                            ASR::logicalbinopType::Eqv, logical_true, ASRUtils::expr_type(test), nullptr));
+            }
+        }
         tmp = ASR::make_Where_t(al, x.base.base.loc, test, body.p, body.size(), orelse.p, orelse.size());
     }
 

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3218,6 +3218,10 @@ public:
         Vec<ASR::stmt_t*> orelse;
         orelse.reserve(al, x.n_orelse);
         transform_stmts(orelse, x.n_orelse, x.m_orelse);
+        // check if ttype of `test` is an array
+        if (!ASRUtils::is_array(ASRUtils::expr_type(test))) {
+            throw SemanticError("'where' clause requires a logical array", test->base.loc);
+        }
         // check if `test` is stricly an array and not the ttype of an accepted expression
         if (ASRUtils::is_array(ASRUtils::expr_type(test))
             && !ASR::is_a<ASR::IntegerCompare_t>(*test) 

--- a/tests/errors/incorrect_array_type_where_01.f90
+++ b/tests/errors/incorrect_array_type_where_01.f90
@@ -1,0 +1,9 @@
+program main
+   implicit none
+   integer :: b(5)
+
+   where([1, 2, 3, 4, 5]) b = 1
+   print *, b
+   if (all(b /= [1, 0, 1, 0, 1])) error stop
+
+end program main

--- a/tests/errors/incorrect_array_type_where_02.f90
+++ b/tests/errors/incorrect_array_type_where_02.f90
@@ -1,0 +1,12 @@
+program main
+   implicit none
+   integer :: i1(5)
+   integer :: b(5)
+
+   i1 = [1, 2, 3, 4, 5]
+
+   where(i1) b = 1
+   print *, b
+   if (all(b /= [1, 0, 1, 0, 1])) error stop
+
+end program main

--- a/tests/errors/incorrect_type_where_01.f90
+++ b/tests/errors/incorrect_type_where_01.f90
@@ -1,0 +1,7 @@
+program main
+   implicit none
+   integer  :: b(5)
+
+   where(.true.) b = 12121
+   print *, b
+end program main

--- a/tests/errors/incorrect_type_where_02.f90
+++ b/tests/errors/incorrect_type_where_02.f90
@@ -1,0 +1,7 @@
+program main
+   implicit none
+   integer  :: b(5)
+
+   where(1) b = 12121
+   print *, b
+end program main

--- a/tests/errors/incorrect_type_where_03.f90
+++ b/tests/errors/incorrect_type_where_03.f90
@@ -1,0 +1,7 @@
+program main
+   implicit none
+   integer  :: b(5)
+
+   where(max(1.33, 2.67)) b = 12121
+   print *, b
+end program main

--- a/tests/errors/incorrect_type_where_04.f90
+++ b/tests/errors/incorrect_type_where_04.f90
@@ -1,0 +1,13 @@
+module main_module
+   implicit none
+   character(5), parameter :: c = "hello"
+end module main_module
+
+program main
+   use main_module
+   implicit none
+   integer  :: b(5)
+
+   where(c) b = 12121
+   print *, b
+end program main

--- a/tests/reference/asr-incorrect_array_type_where_01-b613ee3.json
+++ b/tests/reference/asr-incorrect_array_type_where_01-b613ee3.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_array_type_where_01-b613ee3",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_array_type_where_01.f90",
+    "infile_hash": "7405582b48138f3053960b0c529eb8efd66eb1f0ba5b64831491897a",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_array_type_where_01-b613ee3.stderr",
+    "stderr_hash": "ecbfd62065f48f80ad37e203d15df32b1931d67c4796b6f667d12f0a",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_array_type_where_01-b613ee3.json
+++ b/tests/reference/asr-incorrect_array_type_where_01-b613ee3.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-incorrect_array_type_where_01-b613ee3.stderr",
-    "stderr_hash": "ecbfd62065f48f80ad37e203d15df32b1931d67c4796b6f667d12f0a",
+    "stderr_hash": "394bb205e8a76416975321bc38ba522a27b12c5da6cfe2bca046baf9",
     "returncode": 2
 }

--- a/tests/reference/asr-incorrect_array_type_where_01-b613ee3.stderr
+++ b/tests/reference/asr-incorrect_array_type_where_01-b613ee3.stderr
@@ -1,4 +1,4 @@
-semantic error: 'where' clause requires a logical array
+semantic error: the first array argument to `where` must be of type logical
  --> tests/errors/incorrect_array_type_where_01.f90:5:10
   |
 5 |    where([1, 2, 3, 4, 5]) b = 1

--- a/tests/reference/asr-incorrect_array_type_where_01-b613ee3.stderr
+++ b/tests/reference/asr-incorrect_array_type_where_01-b613ee3.stderr
@@ -1,0 +1,5 @@
+semantic error: 'where' clause requires a logical array
+ --> tests/errors/incorrect_array_type_where_01.f90:5:10
+  |
+5 |    where([1, 2, 3, 4, 5]) b = 1
+  |          ^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-incorrect_array_type_where_02-b821d8c.json
+++ b/tests/reference/asr-incorrect_array_type_where_02-b821d8c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_array_type_where_02-b821d8c",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_array_type_where_02.f90",
+    "infile_hash": "5668cc071e9f55f2ce6475dee614a22d075cea9d84e433197a7f0ac5",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_array_type_where_02-b821d8c.stderr",
+    "stderr_hash": "ed776060ce70b27e11be355c0ef3f887708db3767c2dec9a39f243d2",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_array_type_where_02-b821d8c.json
+++ b/tests/reference/asr-incorrect_array_type_where_02-b821d8c.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-incorrect_array_type_where_02-b821d8c.stderr",
-    "stderr_hash": "ed776060ce70b27e11be355c0ef3f887708db3767c2dec9a39f243d2",
+    "stderr_hash": "283fe1c585d134850afe27d9f5cdaa5c07ffcfe890b4bb815dfdbf78",
     "returncode": 2
 }

--- a/tests/reference/asr-incorrect_array_type_where_02-b821d8c.stderr
+++ b/tests/reference/asr-incorrect_array_type_where_02-b821d8c.stderr
@@ -1,0 +1,5 @@
+semantic error: 'where' clause requires a logical array
+ --> tests/errors/incorrect_array_type_where_02.f90:8:10
+  |
+8 |    where(i1) b = 1
+  |          ^^ 

--- a/tests/reference/asr-incorrect_array_type_where_02-b821d8c.stderr
+++ b/tests/reference/asr-incorrect_array_type_where_02-b821d8c.stderr
@@ -1,4 +1,4 @@
-semantic error: 'where' clause requires a logical array
+semantic error: the first array argument to `where` must be of type logical
  --> tests/errors/incorrect_array_type_where_02.f90:8:10
   |
 8 |    where(i1) b = 1

--- a/tests/reference/asr-incorrect_type_where_01-8974c02.json
+++ b/tests/reference/asr-incorrect_type_where_01-8974c02.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_type_where_01-8974c02",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_type_where_01.f90",
+    "infile_hash": "b69410e8dc944d0748ba6ceb9a98bb46621c18dc322814e045286eeb",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_type_where_01-8974c02.stderr",
+    "stderr_hash": "3596edafc534b005efc58ebcd70ecc42588b5f3a001618e8a47d9959",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_type_where_01-8974c02.json
+++ b/tests/reference/asr-incorrect_type_where_01-8974c02.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-incorrect_type_where_01-8974c02.stderr",
-    "stderr_hash": "3596edafc534b005efc58ebcd70ecc42588b5f3a001618e8a47d9959",
+    "stderr_hash": "695ca61a08fc7f97084ebac3997c3cf7dc2a84c2a0a786ccd345b928",
     "returncode": 2
 }

--- a/tests/reference/asr-incorrect_type_where_01-8974c02.stderr
+++ b/tests/reference/asr-incorrect_type_where_01-8974c02.stderr
@@ -1,0 +1,5 @@
+semantic error: 'where' clause requires a logical array
+ --> tests/errors/incorrect_type_where_01.f90:5:10
+  |
+5 |    where(.true.) b = 12121
+  |          ^^^^^^ 

--- a/tests/reference/asr-incorrect_type_where_01-8974c02.stderr
+++ b/tests/reference/asr-incorrect_type_where_01-8974c02.stderr
@@ -1,4 +1,4 @@
-semantic error: 'where' clause requires a logical array
+semantic error: the argument to `where` must be an array
  --> tests/errors/incorrect_type_where_01.f90:5:10
   |
 5 |    where(.true.) b = 12121

--- a/tests/reference/asr-incorrect_type_where_02-1746f84.json
+++ b/tests/reference/asr-incorrect_type_where_02-1746f84.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_type_where_02-1746f84",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_type_where_02.f90",
+    "infile_hash": "4fbb3a440309d31eb008cd3fffcf541729477e6ac4fc23854bfa1f00",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_type_where_02-1746f84.stderr",
+    "stderr_hash": "9cc684763c7a835daede875fc12bbdb892b9a512320eb7739745bfc2",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_type_where_02-1746f84.json
+++ b/tests/reference/asr-incorrect_type_where_02-1746f84.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-incorrect_type_where_02-1746f84.stderr",
-    "stderr_hash": "9cc684763c7a835daede875fc12bbdb892b9a512320eb7739745bfc2",
+    "stderr_hash": "d8b1d8a2cb5740cc5f7d42b71949ed0ad6091a1b44477a4ddf915fde",
     "returncode": 2
 }

--- a/tests/reference/asr-incorrect_type_where_02-1746f84.stderr
+++ b/tests/reference/asr-incorrect_type_where_02-1746f84.stderr
@@ -1,0 +1,5 @@
+semantic error: 'where' clause requires a logical array
+ --> tests/errors/incorrect_type_where_02.f90:5:10
+  |
+5 |    where(1) b = 12121
+  |          ^ 

--- a/tests/reference/asr-incorrect_type_where_02-1746f84.stderr
+++ b/tests/reference/asr-incorrect_type_where_02-1746f84.stderr
@@ -1,4 +1,4 @@
-semantic error: 'where' clause requires a logical array
+semantic error: the argument to `where` must be an array
  --> tests/errors/incorrect_type_where_02.f90:5:10
   |
 5 |    where(1) b = 12121

--- a/tests/reference/asr-incorrect_type_where_03-a95b1f2.json
+++ b/tests/reference/asr-incorrect_type_where_03-a95b1f2.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-incorrect_type_where_03-a95b1f2.stderr",
-    "stderr_hash": "276aed3b0e3c3893ade2d573231cc0ea4810bdfe629869135444e3a7",
+    "stderr_hash": "e62bad036d6b387c4724af66f63526d9db27752fdabf6a16662dc60e",
     "returncode": 2
 }

--- a/tests/reference/asr-incorrect_type_where_03-a95b1f2.json
+++ b/tests/reference/asr-incorrect_type_where_03-a95b1f2.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_type_where_03-a95b1f2",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_type_where_03.f90",
+    "infile_hash": "a68b2276cc817ca2db41c25621904b778868e085b956002ce3efba83",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_type_where_03-a95b1f2.stderr",
+    "stderr_hash": "276aed3b0e3c3893ade2d573231cc0ea4810bdfe629869135444e3a7",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_type_where_03-a95b1f2.stderr
+++ b/tests/reference/asr-incorrect_type_where_03-a95b1f2.stderr
@@ -1,4 +1,4 @@
-semantic error: 'where' clause requires a logical array
+semantic error: the argument to `where` must be an array
  --> tests/errors/incorrect_type_where_03.f90:5:10
   |
 5 |    where(max(1.33, 2.67)) b = 12121

--- a/tests/reference/asr-incorrect_type_where_03-a95b1f2.stderr
+++ b/tests/reference/asr-incorrect_type_where_03-a95b1f2.stderr
@@ -1,0 +1,5 @@
+semantic error: 'where' clause requires a logical array
+ --> tests/errors/incorrect_type_where_03.f90:5:10
+  |
+5 |    where(max(1.33, 2.67)) b = 12121
+  |          ^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-incorrect_type_where_04-f7dffdb.json
+++ b/tests/reference/asr-incorrect_type_where_04-f7dffdb.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-incorrect_type_where_04-f7dffdb.stderr",
-    "stderr_hash": "fcd2e225d457438292bea0c2886250f61dfd0430b0e4411d551a0d2d",
+    "stderr_hash": "2f1dc154ac637fbd20a8df4e194b496ba7829d58b3555e4a08845759",
     "returncode": 2
 }

--- a/tests/reference/asr-incorrect_type_where_04-f7dffdb.json
+++ b/tests/reference/asr-incorrect_type_where_04-f7dffdb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_type_where_04-f7dffdb",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_type_where_04.f90",
+    "infile_hash": "42f8ace2a232052937d439ce0f429e27dd6d8ddf373aa4865c19e809",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_type_where_04-f7dffdb.stderr",
+    "stderr_hash": "fcd2e225d457438292bea0c2886250f61dfd0430b0e4411d551a0d2d",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_type_where_04-f7dffdb.stderr
+++ b/tests/reference/asr-incorrect_type_where_04-f7dffdb.stderr
@@ -1,4 +1,4 @@
-semantic error: 'where' clause requires a logical array
+semantic error: the argument to `where` must be an array
   --> tests/errors/incorrect_type_where_04.f90:11:10
    |
 11 |    where(c) b = 12121

--- a/tests/reference/asr-incorrect_type_where_04-f7dffdb.stderr
+++ b/tests/reference/asr-incorrect_type_where_04-f7dffdb.stderr
@@ -1,0 +1,5 @@
+semantic error: 'where' clause requires a logical array
+  --> tests/errors/incorrect_type_where_04.f90:11:10
+   |
+11 |    where(c) b = 12121
+   |          ^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1823,6 +1823,14 @@ filename = "errors/complex_01.f90"
 asr = true
 
 [[test]]
+filename = "errors/incorrect_array_type_where_01.f90"
+asr = true
+
+[[test]]
+filename = "errors/incorrect_array_type_where_02.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/complex_sub_test.f90"
 asr = true
 llvm = true

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1831,6 +1831,22 @@ filename = "errors/incorrect_array_type_where_02.f90"
 asr = true
 
 [[test]]
+filename = "errors/incorrect_type_where_01.f90"
+asr = true
+
+[[test]]
+filename = "errors/incorrect_type_where_02.f90"
+asr = true
+
+[[test]]
+filename = "errors/incorrect_type_where_03.f90"
+asr = true
+
+[[test]]
+filename = "errors/incorrect_type_where_04.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/complex_sub_test.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
fixes #4316 

```fortran
program name
   implicit none
   logical :: a(5)
   integer  :: b(5)
   a = [.true., .false., .true., .false., .true.]
   where(a) b = 12121
   print *, b
end program name
```
is transformed to
```fortran
program name
implicit none
integer(4) :: __1_k
logical(4), dimension(5) :: __libasr__created__var__0__array_constant_
logical(4), dimension(5) :: a
integer(4), dimension(5) :: b
__1_k = lbound(__libasr__created__var__0__array_constant_, 1)
__libasr__created__var__0__array_constant_(__1_k) = .true.
__1_k = __1_k + 1
__libasr__created__var__0__array_constant_(__1_k) = .false.
__1_k = __1_k + 1
__libasr__created__var__0__array_constant_(__1_k) = .true.
__1_k = __1_k + 1
__libasr__created__var__0__array_constant_(__1_k) = .false.
__1_k = __1_k + 1
__libasr__created__var__0__array_constant_(__1_k) = .true.
__1_k = __1_k + 1
a = __libasr__created__var__0__array_constant_
do __1_k = lbound(a, 1), ubound(a, 1), 1
    if (a(__1_k) .eqv. .true.) then
        b(__1_k) = 12121
    end if
end do
print *, b
end program name
```
in the `where` pass.

### Output
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
12121 873032432 12121 -231447168 12121 
```