### PR TITLE
Support kind mismatch in `ibclr`, `btest` and `ibset` and add tests

### DIFF
--- a/integration_tests/intrinsics_166.f90
+++ b/integration_tests/intrinsics_166.f90
@@ -1,11 +1,32 @@
 program intrinsics_166
-    integer :: a1 = 5  
-    integer :: a2 = 8
-    integer :: a3 = -1
-    integer :: a4 = -4
-    integer :: a5 = -2
-    integer :: a6 = -5
-  
+    integer :: a1 = 5, a2 = 8
+    integer(8) :: a3 = -1, a4 = -4
+    integer :: a5 = -2, a6 = -5
+
+    integer, parameter :: i1 = ibset(5, 8)
+    integer, parameter :: i2 = ibset(-1_8, 5)
+    integer, parameter :: i3 = ibset(-4, 2_8)
+    integer(8), parameter :: i4 = ibset(-2_8, 5_8)
+
+    integer, parameter :: ar1(3) = ibset([5, 8, 9], [8, 5, 2])
+    integer(8), parameter :: ar2(3) = ibset([-1_8, -5_8, -10_8], [5, 8, 9])
+
+    integer :: arr1(3), arr3(3)
+    integer(8) :: arr2(3)
+    integer :: res(3)
+    arr1 = [5, 8, 9]
+    arr3 = [8, 5, 2]
+    arr2 = [-1_8, -5_8, -10_8]
+
+    print *, i1
+    if (i1 /= 261) error stop
+    print *, i2
+    if (i2 /= -1) error stop
+    print *, i3
+    if (i3 /= -4) error stop
+    print *, i4
+    if (i4 /= -2) error stop
+
     print*, ibset(5, 8)
     if (ibset(5, 8) /= 261) error stop
     print*, ibset(-1, 5)
@@ -19,6 +40,20 @@ program intrinsics_166
     if (ibset(a2, a4) /= 268435464) error stop
     print*, ibset(a5, a6)
     if (ibset(a5, a6) /= -2) error stop
-  
+
+    print *, ar1
+    if (any(ar1 /= [261, 40, 13])) error stop
+    print *, ar2
+    if (any(ar2 /= [-1, -5, -10])) error stop
+
+    print *, ibset(arr1, arr1)
+    if (any(ibset(arr1, arr1) /= [37, 264, 521])) error stop
+    print *, ibset(arr2, arr1)
+    if (any(ibset(arr2, arr1) /= [-1, -5, -10])) error stop
+
+    res = ibset(arr1, arr3)
+    print *, res
+    if (any(res /= [261, 40, 13])) error stop
+
 end program 
   

--- a/integration_tests/intrinsics_167.f90
+++ b/integration_tests/intrinsics_167.f90
@@ -1,10 +1,31 @@
 program intrinsics_167
-    integer :: a1 = 5  
-    integer :: a2 = 8
-    integer :: a3 = -1
-    integer :: a4 = -4
-    integer :: a5 = -2
-    integer :: a6 = -5
+    integer :: a1 = 5, a2 = 8
+    integer(8) :: a3 = -1, a4 = -4
+    integer :: a5 = -2, a6 = -5
+
+    logical, parameter :: i1 = btest(5, 8)
+    logical, parameter :: i2 = btest(-1_8, 5)
+    logical, parameter :: i3 = btest(-4, 2_8)
+    logical, parameter :: i4 = btest(-2_8, 5_8)
+
+    logical, parameter :: ar1(3) = btest([5, 8, 9], [8, 5, 2])
+    logical(8), parameter :: ar2(3) = btest([-1_8, -5_8, -10_8], [5, 8, 9])
+
+    integer :: arr1(3), arr3(3)
+    integer(8) :: arr2(3)
+    logical :: res(3)
+    arr1 = [5, 8, 9]
+    arr3 = [8, 5, 2]
+    arr2 = [-1_8, -5_8, -10_8]
+
+    print *, i1
+    if (i1 .neqv. .false.) error stop
+    print *, i2
+    if (i2 .neqv. .true.) error stop
+    print *, i3
+    if (i3 .neqv. .true.) error stop
+    print *, i4
+    if (i4 .neqv. .true.) error stop
 
     print*, btest(5, 8)
     if (btest(5, 8) .neqv. .false.) error stop
@@ -19,5 +40,19 @@ program intrinsics_167
     if (btest(a2, a4) .neqv. .false.) error stop
     print*, btest(a5, a6)
     if (btest(a5, a6) .neqv. .true.) error stop
-  
+
+    print *, ar1
+    if (any(ar1 .neqv. [.false., .false., .false.])) error stop
+    print *, ar2
+    if (any(ar2 .neqv. [.true., .true., .true.])) error stop
+
+    print *, btest(arr1, arr1)
+    if (any(btest(arr1, arr1) .neqv. [.false., .false., .false.])) error stop
+    print *, btest(arr2, arr1)
+    if (any(btest(arr2, arr1) .neqv. [.true., .true., .true.])) error stop
+
+    res = btest(arr1, arr3)
+    print *, res
+    if (any(res .neqv. [.false., .false., .false.])) error stop
+
 end program 

--- a/integration_tests/intrinsics_168.f90
+++ b/integration_tests/intrinsics_168.f90
@@ -35,12 +35,10 @@ program intrinsics_168
     print*, ibclr(a1, a2)
     if (ibclr(a1, a2) /= 5) error stop
 
-    ! Does not work yet - #4308
-
-    ! print*, ibclr(a3, a1)
-    ! if (ibclr(a3, a1) /= -33) error stop
-    ! print*, ibclr(a2, a4)
-    ! if (ibclr(a2, a4) /= 8) error stop
+    print*, ibclr(a3, a1)
+    if (ibclr(a3, a1) /= -33) error stop
+    print*, ibclr(a2, a4)
+    if (ibclr(a2, a4) /= 8) error stop
     print*, ibclr(a5, a6)
     if (ibclr(a5, a6) /= -134217730) error stop
 
@@ -51,8 +49,8 @@ program intrinsics_168
 
     print *, ibclr(arr1, arr1)
     if (any(ibclr(arr1, arr1) /= [5, 8, 9])) error stop
-    ! print *, ibclr(arr2, arr1
-    ! if (any(ibclr(arr2, arr1) /= [-33, -134217730, -134217731])) error stop
+    print *, ibclr(arr2, arr1)
+    if (any(ibclr(arr2, arr1) /= [-33, -261, -522])) error stop
 
     res = ibclr(arr1, arr3)
     print *, res

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1814,7 +1814,7 @@ namespace Ibclr {
         * r = ibclr(x, y)
         * r = x & ~( 1 << y )
         */
-        body.push_back(al, b.Assignment(result, b.And(args[0], b.Not(b.BitLshift(b.i_t(1, arg_types[0]), args[1], return_type)))));
+        body.push_back(al, b.Assignment(result, b.And(args[0], b.Not(b.BitLshift(b.i_t(1, arg_types[0]), b.i2i_t(args[1], arg_types[0]), return_type)))));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
@@ -1849,7 +1849,7 @@ namespace Ibset {
         * r = ibset(x, y)
         * r = x | ( 1 << y )
         */
-        body.push_back(al, b.Assignment(result, b.Or(args[0], b.BitLshift(b.i_t(1, arg_types[0]), args[1], return_type))));
+        body.push_back(al, b.Assignment(result, b.Or(args[0], b.BitLshift(b.i_t(1, arg_types[0]), b.i2i_t(args[1], arg_types[0]), return_type))));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
@@ -1885,7 +1885,7 @@ namespace Btest {
         * r = btest(x, y)
         * r = (( x  & ( 1 << y )) == 0) ? .false. : .true.
         */
-        body.push_back(al, b.If(b.Eq(b.And(args[0], b.BitLshift(b.i_t(1, arg_types[0]), args[1], arg_types[0])), b.i_t(0, arg_types[0])), {
+        body.push_back(al, b.If(b.Eq(b.And(args[0], b.BitLshift(b.i_t(1, arg_types[0]), b.i2i_t(args[1], arg_types[0]), arg_types[0])), b.i_t(0, arg_types[0])), {
             b.Assignment(result, b.bool_t(0, return_type))
         }, {
             b.Assignment(result, b.bool_t(1, return_type))


### PR DESCRIPTION
Fixes: #4308 
Towards: #4017
