### PR TITLE
ci: uncomment `abs(X-mean)**2` as is working now

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -652,8 +652,8 @@ jobs:
             cd stdlib
             export PATH="$(pwd)/../src/bin:$PATH"
 
-            git checkout lf19
-            git checkout a6cb00840daca162e0ae07923303c7a3773ec185
+            git checkout lf20
+            git checkout 80435c522b1931f8cec67d918df40a04bddff8be
             micromamba install -c conda-forge fypp
             ./build_test_lf.sh
             ./build_test_gf.sh

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -816,6 +816,7 @@ RUN(NAME intrinsics_252 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derf
 RUN(NAME intrinsics_253 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # erfc
 RUN(NAME intrinsics_254 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derfc
 RUN(NAME intrinsics_255 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dbesjn, dbesyn
+RUN(NAME intrinsics_258 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # abs
 RUN(NAME intrinsics_259 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # lgt, llt, lge, lle
 RUN(NAME intrinsics_260 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sum
 RUN(NAME intrinsics_261 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # ceiling

--- a/integration_tests/intrinsics_258.f90
+++ b/integration_tests/intrinsics_258.f90
@@ -1,0 +1,6 @@
+program intrinsics_258
+    real :: x(5) = [1, 2, 3, 4, 5]
+    integer:: mean 
+    mean = sum(x) / 5
+    print*, sum(abs(x - mean)**2) / (5 - merge(1, 0, .true.))
+end program


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/3809