### PR TITLE
enh : Memorize Duplicate `intrinsicsElementalFunction` + `intrinsicsArrayFunction`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -961,7 +961,7 @@ RUN(NAME case_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_04 LABELS gfortran)
 RUN(NAME case_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
-RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) 
+RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME select_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -983,6 +983,7 @@ RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -961,7 +961,7 @@ RUN(NAME case_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_04 LABELS gfortran)
 RUN(NAME case_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
-RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) 
 
 RUN(NAME select_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/where_11.f90
+++ b/integration_tests/where_11.f90
@@ -1,0 +1,48 @@
+MODULE where_11_mod
+    IMPLICIT NONE
+    INTEGER :: a(3)
+    integer :: b(3) 
+    
+    CONTAINS
+    
+    SUBROUTINE test_01
+        where(abs(a) == 1) b = 555
+        print *, b
+        if (any(b /= [555, 555 , 0])) error stop
+        b = 0
+    END SUBROUTINE test_01
+    
+    SUBROUTINE test_02
+        where(abs(a)*1 == 1) b = 556
+        print *, b
+        if (any(b /= [556, 556 , 0])) error stop
+        b = 0
+    END SUBROUTINE test_02
+    
+    SUBROUTINE test_03
+        where(abs(a)*1 + 1 == 2) b = 557
+        print *, b
+        if (any(b /= [557, 557 , 0])) error stop
+        b = -1
+        
+    END SUBROUTINE test_03
+    
+    SUBROUTINE test_04
+        where(min(a, b) == -1 ) b = 558
+        print *, b
+        if (any(b /= [558, 558 , 558])) error stop
+        b = 0
+    END SUBROUTINE test_04
+END MODULE where_11_mod
+    
+PROGRAM where_11
+    USE where_11_mod
+    implicit none
+    a = [1,-1,2]
+    b = 0
+    CALL test_01
+    CALL test_02
+    CALL test_03
+    CALL test_04
+
+END PROGRAM where_11

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -75,7 +75,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
     ASR::dimension_t* op_dims; size_t op_n_dims;
     ASR::expr_t* op_expr;
     std::map<ASR::expr_t*, ASR::expr_t*>& resultvar2value;
-    std::map<void*, ASR::expr_t*> intrinsics2result_var;
+    std::map<ASR::expr_t*, ASR::expr_t*> intrinsics2result_var;
     bool realloc_lhs;
 
     public:
@@ -1294,8 +1294,8 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
 
     template <typename T>
     void replace_intrinsic_function(T* x) {
-        if( intrinsics2result_var[(void*)x] ){
-            *current_expr = intrinsics2result_var[(void*)x];
+        if( intrinsics2result_var[(ASR::expr_t*) x] ){
+            *current_expr = intrinsics2result_var[(ASR::expr_t*) x];
             return;
         }
         LCOMPILERS_ASSERT(current_scope != nullptr);
@@ -1386,7 +1386,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
             result_var_created = true;
         }
         *current_expr = result_var;
-        intrinsics2result_var[(void*)x] = result_var;
+        intrinsics2result_var[(ASR::expr_t*) x] = result_var;
         if( op_expr == &(x->base) ) {
             op_dims = nullptr;
             op_n_dims = ASRUtils::extract_dimensions_from_ttype(

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -75,6 +75,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
     ASR::dimension_t* op_dims; size_t op_n_dims;
     ASR::expr_t* op_expr;
     std::map<ASR::expr_t*, ASR::expr_t*>& resultvar2value;
+    std::map<void*, ASR::expr_t*> intrinsics2result_var;
     bool realloc_lhs;
 
     public:
@@ -1293,6 +1294,10 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
 
     template <typename T>
     void replace_intrinsic_function(T* x) {
+        if( intrinsics2result_var[(void*)x] ){
+            *current_expr = intrinsics2result_var[(void*)x];
+            return;
+        }
         LCOMPILERS_ASSERT(current_scope != nullptr);
         const Location& loc = x->base.base.loc;
         std::vector<bool> array_mask(x->n_args, false);
@@ -1381,6 +1386,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
             result_var_created = true;
         }
         *current_expr = result_var;
+        intrinsics2result_var[(void*)x] = result_var;
         if( op_expr == &(x->base) ) {
             op_dims = nullptr;
             op_n_dims = ASRUtils::extract_dimensions_from_ttype(

--- a/src/libasr/pass/where.cpp
+++ b/src/libasr/pass/where.cpp
@@ -2,7 +2,6 @@
 #include <libasr/containers.h>
 #include <libasr/exception.h>
 #include <libasr/asr_utils.h>
-#include <libasr/asr_builder.h>
 #include <libasr/asr_verify.h>
 #include <libasr/pass/pass_utils.h>
 #include <libasr/pass/replace_where.h>
@@ -442,26 +441,25 @@ public:
             return_var_hash[h] = opt_left;
         }
 
-        ASRUtils::ExprStmtDuplicator dup(al);
         if (opt_left && ASR::is_a<ASR::IntegerCompare_t>(*test)) {
-            int_cmp = ASR::down_cast<ASR::IntegerCompare_t>(dup.duplicate_expr(test));
-            int_cmp->m_left = dup.duplicate_expr(opt_left);
+            int_cmp = ASR::down_cast<ASR::IntegerCompare_t>(test);
+            int_cmp->m_left = opt_left;
         }
         if (opt_left && ASR::is_a<ASR::RealCompare_t>(*test)) {
-            real_cmp = ASR::down_cast<ASR::RealCompare_t>(dup.duplicate_expr(test));
-            real_cmp->m_left = dup.duplicate_expr(opt_left);
+            real_cmp = ASR::down_cast<ASR::RealCompare_t>(test);
+            real_cmp->m_left = opt_left;
         }
         if (opt_left && ASR::is_a<ASR::LogicalBinOp_t>(*test)) {
-            log_bin_op = ASR::down_cast<ASR::LogicalBinOp_t>(dup.duplicate_expr(test));
-            log_bin_op->m_left = dup.duplicate_expr(opt_left);
+            log_bin_op = ASR::down_cast<ASR::LogicalBinOp_t>(test);
+            log_bin_op->m_left = opt_left;
         }
 
         // create do loop head
         ASR::do_loop_head_t head;
         head.loc = loc;
         head.m_v = var;
-        head.m_start = PassUtils::get_bound(opt_left?dup.duplicate_expr(opt_left):dup.duplicate_expr(left), 1, "lbound", al);
-        head.m_end = PassUtils::get_bound(opt_left?dup.duplicate_expr(opt_left):dup.duplicate_expr(left), 1, "ubound", al);
+        head.m_start = PassUtils::get_bound(opt_left?opt_left:left, 1, "lbound", al);
+        head.m_end = PassUtils::get_bound(opt_left?opt_left:left, 1, "ubound", al);
         head.m_increment = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int32_type));
 
         // create do loop body


### PR DESCRIPTION
Fixes #4318 

I noticed that there could be some duplicated node for `intrinsicsElementalFunction` (nodes with same pointer address). They're mainly made by `where` asr_pass, which is great as we can memorize their result and just whenever we encounter them again we can simply get their result without doing all this work.
***

**Why is that related to the issue with intrinsics call inside where ?**

The reason is that after `where` pass did it work it left us with 3 duplicated `intrinsicsElementalFunction`. Whenever you visit a single one of them and you get any of the internal nodes tweaked or replaced, the others get affected as well which results in error in the great helper phase `asr_verify` as one of the node has done its replace phase correctly but the others changed and now they don't fulfill their purpose (whether being inside `arraybound` or `integercompare` ).
***
**Concerns and suggestions**

- I don't know if we should fix the error from `array_op` pass OR to create independent nodes while replacing `where` with `doLoop` in `where` pass.
Notice that :  `intrinsicsElementalFunction` could be a node representing `m_v` for `lbound` + `Ubound` and the replacment for these would be creating 2 independent `__libasr__created__var__X__elemental_func_call_res` and creating do loops for both , with the help of memorizing we won't worry about that.

- If it's a valid idea we can emplace the result in `m_value` of  `intrinsicsElementalFunction`, and whenever we replace `intrinsicsElementalFunction` we would check its value member.