### PR TITLE
enh: support mask for compile time evaluation of `iparity`, `minval` and `maxval`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -816,12 +816,14 @@ RUN(NAME intrinsics_252 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derf
 RUN(NAME intrinsics_253 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # erfc
 RUN(NAME intrinsics_254 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derfc
 RUN(NAME intrinsics_255 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dbesjn, dbesyn
+RUN(NAME intrinsics_256 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # minval
 RUN(NAME intrinsics_257 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # product
 RUN(NAME intrinsics_258 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # abs
 RUN(NAME intrinsics_259 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # lgt, llt, lge, lle
 RUN(NAME intrinsics_260 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sum
 RUN(NAME intrinsics_261 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # ceiling
 RUN(NAME intrinsics_262 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # floor
+RUN(NAME intrinsics_263 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # maxval
 
 RUN(NAME passing_array_01 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME passing_array_02 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_232.f90
+++ b/integration_tests/intrinsics_232.f90
@@ -2,9 +2,21 @@ program intrinsics_232
     implicit none
     
     integer, parameter :: i1 = iparity([1,2,3,4,5,6,7,8,9,10,11])
+    integer(8), parameter :: i2 = product([1, 2, 3], [.true., .true., .true.])
+    integer(4), parameter :: i3 = product([11, 2, 5], 1, mask = [.true., .false., .true.])
     integer :: i(10) = [1,2,3,4,5,6,7,8,9,10]
     integer :: x(5) = [ 1, 2, 3, 4, 5 ]
     logical :: mask(5) = [ .TRUE., .FALSE., .TRUE., .FALSE., .TRUE. ]
+    integer :: dim = 1
+
+    print *, i1
+    if ( i1 /= 0 ) error stop
+
+    print *, i2
+    if ( i2 /= 6 ) error stop
+
+    print *, i3
+    if ( i3 /= 55 ) error stop
 
     print *, iparity( array = x, mask = mask )
     if ( .not. iparity( array = x, mask = mask ) == 7 ) error stop
@@ -15,13 +27,16 @@ program intrinsics_232
     print *, iparity( x, mask )
     if ( .not. iparity( x, mask ) == 7 ) error stop
 
-    print *, i1
-    if ( i1 /= 0 ) error stop
+    print *, iparity( x, mask = mask, dim = dim )
+    if ( .not. iparity( x, mask = mask, dim = dim ) == 7 ) error stop
 
     print *, iparity([1,2,4,5,6,8,10,11])
     if ( iparity([1,2,4,5,6,8,10,11]) /= 13 ) error stop
 
     print *, iparity(i)
     if ( iparity(i) /= 11 ) error stop
+
+    print *, iparity(i, [.true., .false., .true., .false., .true., .false., .true., .false., .true., .false.])
+    if ( iparity(i, [.true., .false., .true., .false., .true., .false., .true., .false., .true., .false.]) /= 9 ) error stop
     
 end program

--- a/integration_tests/intrinsics_256.f90
+++ b/integration_tests/intrinsics_256.f90
@@ -1,0 +1,45 @@
+program intrinsics_256
+    implicit none
+    integer(4), parameter :: i1 = minval([1, 2, 3])
+    real(4), parameter :: i2 = minval([1.0, 2.0, 3.0])
+    integer(8), parameter :: i3 = minval([1, 2, 3], [.true., .true., .true.])
+    real(8), parameter :: i4 = minval([1.5_8, 22.9_8, 3.0_8], mask = [.true., .false., .true.])
+    integer(4), parameter :: i5 = minval([11, 2, 5], 1, mask = [.true., .false., .true.])
+    real(4), parameter :: i6 = minval([1.0, 3.0, 55.9], mask = [.true., .false., .true.], dim = 1)
+
+    integer(4) :: ar1(4) = [1, 2, 7, 9]
+    real(4) :: ar2(4) = [1.0, 3.1, 7.2, 9.0]
+    logical(4) :: mask(4) = [.true., .false., .true., .true.]
+    integer(4) :: dim = 1
+
+    print *, i1
+    if (i1 /= 1) error stop
+    print *, i2
+    if (abs(i2 - 1.00000000e+00) > 1e-6) error stop
+    print *, i3
+    if (i3 /= 1) error stop
+    print *, i4
+    if (abs(i4 - 1.50000000000000000e+00) > 1e-12) error stop
+    print *, i5
+    if (i5 /= 5) error stop
+    print *, i6
+    if (abs(i6 - 1.00000000e+00) > 1e-6) error stop
+
+    print *, minval(ar1)
+    if (minval(ar1) /= 1) error stop
+    print *, minval(ar2)
+    if (abs(minval(ar2) - 1.00000000e+00) >1e-6 ) error stop
+    print *, minval(ar1, mask)
+    if (minval(ar1, mask) /= 1) error stop
+    print *, minval(ar2, mask = mask)
+    if (abs(minval(ar2, mask = mask) - 1.00000000e+00) > 1e-6) error stop
+    print *, minval(ar1, dim)
+    if (minval(ar1, dim) /= 1) error stop
+    print *, minval(ar2, dim = dim)
+    if (abs(minval(ar2, dim = dim) - 1.00000000e+00) > 1e-6) error stop
+    print *, minval(ar1, mask = mask, dim = dim)
+    if (minval(ar1, mask = mask, dim = dim) /= 1) error stop
+    print *, minval(ar2, dim, mask)
+    if (abs(minval(ar2, dim, mask) - 1.00000000e+00) > 1e-6) error stop
+
+end program

--- a/integration_tests/intrinsics_257.f90
+++ b/integration_tests/intrinsics_257.f90
@@ -1,64 +1,64 @@
 program intrinsics_257
     implicit none
-        integer(4), parameter :: i1 = product([1, 2, 3])
-        real(4), parameter :: i2 = product([1.0, 2.0, 3.0])
-        complex(4), parameter :: i3 = product([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
-        integer(8), parameter :: i4 = product([1, 2, 3], [.true., .true., .true.])
-        real(8), parameter :: i5 = product([1.5_8, 22.9_8, 3.0_8], mask=[.true., .false., .true.])
-        complex(8), parameter :: i6 = product([(1.5_8, 2.2_8), (22.9_8, 1.4_8), (3.0_8, 1.1_8)], mask=[.true., .false., .true.])
-        integer(4), parameter :: i7 = product([11, 2, 5], 1, mask=[.true., .false., .true.])
-        real(4), parameter :: i8 = product([1.0, 3.0, 55.9], mask=[.true., .false., .true.], dim = 1)
-        complex(4), parameter :: i9 = product([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dim = 1, mask=[.true., .false., .true.])
-    
-        integer(4) :: ar1(4) = [1, 2, 7, 9]
-        real(4) :: ar2(4) = [1.0, 3.1, 7.2, 9.0]
-        complex(4) :: ar3(4) = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0)]
-        logical(4) :: mask(4) = [.true., .false., .true., .true.]
-        integer(4) :: dim = 1
-    
-        print *, i1
-        if (i1 /= 6) error stop
-        print *, i2
-        if (abs(i2 - 6.0) > 1e-6) error stop
-        print *, i3
-        if (abs(i3 - (-85.0000000, 20.0000000)) > 1e-6) error stop
-        print *, i4
-        if (i4 /= 6) error stop
-        print *, i5
-        if (abs(i5 - 4.5_8) > 1e-12) error stop
-        print *, i6
-        if (abs(i6 - (2.0799999999999996,8.2500000000000000)) > 1e-6) error stop
-        print *, i7
-        if (i7 /= 55) error stop
-        print *, i8
-        if (abs(i8 - 55.9000015) > 1e-6) error stop
-        print *, i9
-        if (abs(i9 - (-7.00000000,16.0000000)) > 1e-6) error stop
-    
-        print *, product(ar1)
-        if (product(ar1) /= 126) error stop
-        print *, product(ar2)
-        if (abs(product(ar2) - 200.879974) >1e-6 ) error stop
-        print *, product(ar3)
-        ! if (abs(product(ar3) - (-755.000000,-540.000000)) > 1e-6) error stop ! wrong answer
-        print *, product(ar1, mask=mask)
-        if (product(ar1, mask=mask) /= 63) error stop
-        print *, product(ar2, mask=mask)
-        if (abs(product(ar2, mask=mask) - 64.7999954) > 1e-6) error stop
-        print *, product(ar3, mask=mask)
-        ! if (abs(product(ar3, mask=mask) - (-177.000000, 56.0000000)) > 1e-6) error stop
-        print *, product(ar1, dim=dim)
-        if (product(ar1, dim=dim) /= 126) error stop
-        print *, product(ar2, dim=dim)
-        if (abs(product(ar2, dim=dim) - 200.879974) > 1e-6) error stop
-        print *, product(ar3, dim=dim)
-        ! if (abs(product(ar3, dim=dim) - (-755.000000,-540.000000)) > 1e-6) error stop
-        print *, product(ar1, mask=mask, dim=dim)
-        if (product(ar1, mask=mask, dim=dim) /= 63) error stop
-        print *, product(ar2, mask=mask, dim=dim)
-        if (abs(product(ar2, mask=mask, dim=dim) - 64.7999954) > 1e-6) error stop
-        print *, product(ar3, mask=mask, dim=dim)
-        ! if (abs(product(ar3, mask=mask, dim=dim) - (-177.000000,56.0000000)) > 1e-6) error stop
-    
-    end program
+    integer(4), parameter :: i1 = product([1, 2, 3])
+    real(4), parameter :: i2 = product([1.0, 2.0, 3.0])
+    complex(4), parameter :: i3 = product([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+    integer(8), parameter :: i4 = product([1, 2, 3], [.true., .true., .true.])
+    real(8), parameter :: i5 = product([1.5_8, 22.9_8, 3.0_8], mask = [.true., .false., .true.])
+    complex(8), parameter :: i6 = product([(1.5_8, 2.2_8), (22.9_8, 1.4_8), (3.0_8, 1.1_8)], mask = [.true., .false., .true.])
+    integer(4), parameter :: i7 = product([11, 2, 5], 1, mask = [.true., .false., .true.])
+    real(4), parameter :: i8 = product([1.0, 3.0, 55.9], mask = [.true., .false., .true.], dim = 1)
+    complex(4), parameter :: i9 = product([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dim = 1, mask = [.true., .false., .true.])
+
+    integer(4) :: ar1(4) = [1, 2, 7, 9]
+    real(4) :: ar2(4) = [1.0, 3.1, 7.2, 9.0]
+    complex(4) :: ar3(4) = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0)]
+    logical(4) :: mask(4) = [.true., .false., .true., .true.]
+    integer(4) :: dim = 1
+
+    print *, i1
+    if (i1 /= 6) error stop
+    print *, i2
+    if (abs(i2 - 6.0) > 1e-6) error stop
+    print *, i3
+    if (abs(i3 - (-85.0000000, 20.0000000)) > 1e-6) error stop
+    print *, i4
+    if (i4 /= 6) error stop
+    print *, i5
+    if (abs(i5 - 4.5_8) > 1e-12) error stop
+    print *, i6
+    if (abs(i6 - (2.0799999999999996,8.2500000000000000)) > 1e-6) error stop
+    print *, i7
+    if (i7 /= 55) error stop
+    print *, i8
+    if (abs(i8 - 55.9000015) > 1e-6) error stop
+    print *, i9
+    if (abs(i9 - (-7.00000000,16.0000000)) > 1e-6) error stop
+
+    print *, product(ar1)
+    if (product(ar1) /= 126) error stop
+    print *, product(ar2)
+    if (abs(product(ar2) - 200.879974) >1e-6 ) error stop
+    print *, product(ar3)
+    ! if (abs(product(ar3) - (-755.000000,-540.000000)) > 1e-6) error stop ! wrong answer
+    print *, product(ar1, mask = mask)
+    if (product(ar1, mask = mask) /= 63) error stop
+    print *, product(ar2, mask = mask)
+    if (abs(product(ar2, mask = mask) - 64.7999954) > 1e-6) error stop
+    print *, product(ar3, mask = mask)
+    ! if (abs(product(ar3, mask = mask) - (-177.000000, 56.0000000)) > 1e-6) error stop
+    print *, product(ar1, dim = dim)
+    if (product(ar1, dim = dim) /= 126) error stop
+    print *, product(ar2, dim = dim)
+    if (abs(product(ar2, dim = dim) - 200.879974) > 1e-6) error stop
+    print *, product(ar3, dim = dim)
+    ! if (abs(product(ar3, dim = dim) - (-755.000000,-540.000000)) > 1e-6) error stop
+    print *, product(ar1, mask = mask, dim = dim)
+    if (product(ar1, mask = mask, dim = dim) /= 63) error stop
+    print *, product(ar2, mask = mask, dim = dim)
+    if (abs(product(ar2, mask = mask, dim = dim) - 64.7999954) > 1e-6) error stop
+    print *, product(ar3, mask = mask, dim = dim)
+    ! if (abs(product(ar3, mask = mask, dim = dim) - (-177.000000,56.0000000)) > 1e-6) error stop
+
+end program
     

--- a/integration_tests/intrinsics_260.f90
+++ b/integration_tests/intrinsics_260.f90
@@ -1,14 +1,14 @@
 program intrinsics_260
-implicit none
+    implicit none
     integer(4), parameter :: i1 = sum([1, 2, 3])
 	real(4), parameter :: i2 = sum([1.0, 2.0, 3.0])
 	complex(4), parameter :: i3 = sum([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
 	integer(8), parameter :: i4 = sum([1, 2, 3], [.true., .true., .true.])
-	real(8), parameter :: i5 = sum([1.5_8, 22.9_8, 3.0_8], mask=[.true., .false., .true.])
-	complex(8), parameter :: i6 = sum([(1.5_8, 2.2_8), (22.9_8, 1.4_8), (3.0_8, 1.1_8)], mask=[.true., .false., .true.])
-	integer(4), parameter :: i7 = sum([11, 2, 5], 1, mask=[.true., .false., .true.])
-	real(4), parameter :: i8 = sum([1.0, 3.0, 55.9], mask=[.true., .false., .true.], dim = 1)
-    complex(4), parameter :: i9 = sum([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dim = 1, mask=[.true., .false., .true.])
+	real(8), parameter :: i5 = sum([1.5_8, 22.9_8, 3.0_8], mask = [.true., .false., .true.])
+	complex(8), parameter :: i6 = sum([(1.5_8, 2.2_8), (22.9_8, 1.4_8), (3.0_8, 1.1_8)], mask = [.true., .false., .true.])
+	integer(4), parameter :: i7 = sum([11, 2, 5], 1, [.true., .false., .true.])
+	real(4), parameter :: i8 = sum([1.0, 3.0, 55.9], mask = [.true., .false., .true.], dim = 1)
+    complex(4), parameter :: i9 = sum([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dim = 1, mask = [.true., .false., .true.])
 
     integer(4) :: ar1(4) = [1, 2, 7, 9]
     real(4) :: ar2(4) = [1.0, 3.1, 7.2, 9.0]
@@ -41,23 +41,23 @@ implicit none
     if (abs(sum(ar2) - 20.3) >1e-6 ) error stop
     print *, sum(ar3)
     if (abs(sum(ar3) - (16.0, 20.0)) > 1e-6) error stop
-    print *, sum(ar1, mask=mask)
-    if (sum(ar1, mask=mask) /= 17) error stop
-    print *, sum(ar2, mask=mask)
-    if (abs(sum(ar2, mask=mask) - 17.2) > 1e-6) error stop
-    print *, sum(ar3, mask=mask)
-    if (abs(sum(ar3, mask=mask) - (13.0, 16.0)) > 1e-6) error stop
-    print *, sum(ar1, dim=dim)
-    if (sum(ar1, dim=dim) /= 19) error stop
-    print *, sum(ar2, dim=dim)
-    if (abs(sum(ar2, dim=dim) - 20.3) > 1e-6) error stop
-    print *, sum(ar3, dim=dim)
-    if (abs(sum(ar3, dim=dim) - (16.0, 20.0)) > 1e-6) error stop
-    print *, sum(ar1, mask=mask, dim=dim)
-    if (sum(ar1, mask=mask, dim=dim) /= 17) error stop
-    print *, sum(ar2, mask=mask, dim=dim)
-    if (abs(sum(ar2, mask=mask, dim=dim) - 17.2) > 1e-6) error stop
-    print *, sum(ar3, mask=mask, dim=dim)
-    if (abs(sum(ar3, mask=mask, dim=dim) - (13.0, 16.0)) > 1e-6) error stop
+    print *, sum(ar1, mask = mask)
+    if (sum(ar1, mask = mask) /= 17) error stop
+    print *, sum(ar2, mask)
+    if (abs(sum(ar2, mask) - 17.2) > 1e-6) error stop
+    print *, sum(ar3, mask = mask)
+    if (abs(sum(ar3, mask = mask) - (13.0, 16.0)) > 1e-6) error stop
+    print *, sum(ar1, dim)
+    if (sum(ar1, dim) /= 19) error stop
+    print *, sum(ar2, dim = dim)
+    if (abs(sum(ar2, dim = dim) - 20.3) > 1e-6) error stop
+    print *, sum(ar3, dim)
+    if (abs(sum(ar3, dim) - (16.0, 20.0)) > 1e-6) error stop
+    print *, sum(ar1, mask = mask, dim = dim)
+    if (sum(ar1, mask = mask, dim = dim) /= 17) error stop
+    print *, sum(ar2, dim, mask)
+    if (abs(sum(ar2, dim, mask) - 17.2) > 1e-6) error stop
+    print *, sum(ar3, mask = mask, dim = dim)
+    if (abs(sum(ar3, mask = mask, dim = dim) - (13.0, 16.0)) > 1e-6) error stop
 
 end program

--- a/integration_tests/intrinsics_263.f90
+++ b/integration_tests/intrinsics_263.f90
@@ -1,0 +1,45 @@
+program intrinsics_263
+    implicit none
+    integer(4), parameter :: i1 = maxval([1, 2, 3])
+    real(4), parameter :: i2 = maxval([1.0, 2.0, 3.0])
+    integer(8), parameter :: i3 = maxval([1, 2, 3], [.true., .true., .true.])
+    real(8), parameter :: i4 = maxval([1.5_8, 22.9_8, 3.0_8], mask = [.true., .false., .true.])
+    integer(4), parameter :: i5 = maxval([11, 2, 5], 1, mask = [.true., .false., .true.])
+    real(4), parameter :: i6 = maxval([1.0, 3.0, 55.9], mask = [.true., .false., .true.], dim = 1)
+
+    integer(4) :: ar1(4) = [1, 2, 7, 9]
+    real(4) :: ar2(4) = [1.0, 3.1, 7.2, 9.0]
+    logical(4) :: mask(4) = [.true., .false., .true., .true.]
+    integer(4) :: dim = 1
+
+    print *, i1
+    if (i1 /= 3) error stop
+    print *, i2
+    if (abs(i2 - 3.00000000e+00) > 1e-6) error stop
+    print *, i3
+    if (i3 /= 3) error stop
+    print *, i4
+    if (abs(i4 - 3.00000000000000000e+00) > 1e-12) error stop
+    print *, i5
+    if (i5 /= 11) error stop
+    print *, i6
+    if (abs(i6 - 5.59000015e+01) > 1e-6) error stop
+
+    print *, maxval(ar1)
+    if (maxval(ar1) /= 9) error stop
+    print *, maxval(ar2)
+    if (abs(maxval(ar2) - 9.00000000e+00) >1e-6 ) error stop
+    print *, maxval(ar1, mask)
+    if (maxval(ar1, mask) /= 9) error stop
+    print *, maxval(ar2, mask = mask)
+    if (abs(maxval(ar2, mask = mask) - 9.00000000e+00) > 1e-6) error stop
+    print *, maxval(ar1, dim)
+    if (maxval(ar1, dim) /= 9) error stop
+    print *, maxval(ar2, dim = dim)
+    if (abs(maxval(ar2, dim = dim) - 9.00000000e+00) > 1e-6) error stop
+    print *, maxval(ar1, mask = mask, dim = dim)
+    if (maxval(ar1, mask = mask, dim = dim) /= 9) error stop
+    print *, maxval(ar2, dim, mask)
+    if (abs(maxval(ar2, dim, mask) - 9.00000000e+00) > 1e-6) error stop
+
+end program


### PR DESCRIPTION
Towards: #4017
