### PR TITLE
Add integration test for `sin`, `cos`, `tan`, `dsin`, `dcos`, `dtan`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -824,6 +824,11 @@ RUN(NAME intrinsics_260 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sum
 RUN(NAME intrinsics_261 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # ceiling
 RUN(NAME intrinsics_262 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # floor
 RUN(NAME intrinsics_263 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # maxval
+RUN(NAME intrinsics_264 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # sin
+RUN(NAME intrinsics_265 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # cos
+RUN(NAME intrinsics_266 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # tan
+RUN(NAME intrinsics_267 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dsin, dcos, dtan
+
 
 RUN(NAME passing_array_01 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME passing_array_02 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_04.f90
+++ b/integration_tests/intrinsics_04.f90
@@ -15,6 +15,6 @@ z = tan(z)
 print *, z
 if (abs(real(z,dp) - 2.57834890405532317E-004_dp) > 1e-10_dp) error stop
 if (abs(real(tan((1.5_sp, 3.5_sp)), sp) - 2.57834879E-004_sp) > 1e-10_dp) error stop
-!if (abs(aimag(z) - 1.0018071108086137_dp) > 1e-10_dp) error stop
+if (abs(aimag(z) - 1.0018071108086137_dp) > 1e-10_dp) error stop
 
 end program intrinsics_04

--- a/integration_tests/intrinsics_264.f90
+++ b/integration_tests/intrinsics_264.f90
@@ -1,0 +1,64 @@
+program intrinsics_264
+    use iso_fortran_env, only: sp => real32, dp => real64
+    implicit none
+    real(sp), parameter :: a1 = sin(1.0_sp)
+    real(dp), parameter :: a2 = sin(1.0_dp) 
+    complex(sp), parameter :: a3 = sin((1.0_sp, 1.5_sp))
+    complex(dp), parameter :: a4 = sin((1.0_dp, 1.5_dp))
+
+    real(sp), parameter :: ar1(3) = sin([1.0_sp, 1.5_sp, 2.0_sp])
+    real(dp), parameter :: ar2(3) = sin([1.0_dp, 1.5_dp, 2.0_dp])
+    complex(sp), parameter :: ac1(3) = sin([(1.0_sp, 1.5_sp), (2.0_sp, 2.5_sp), (3.0_sp, 3.5_sp)])
+    complex(dp), parameter :: ac2(3) = sin([(1.0_dp, 1.5_dp), (2.0_dp, 2.5_dp), (3.0_dp, 3.5_dp)])
+
+    real(sp) :: b1 = 0.5_sp
+    real(dp) :: b2 = 0.7_dp
+    complex(sp) :: b3 = (0.5_sp, 0.7_sp)
+    complex(dp) :: b4 = (0.5_dp, 0.7_dp)
+
+    real(sp) :: br1(3) = [0.5_sp, 0.7_sp, 0.9_sp]
+    real(dp) :: br2(3) = [0.5_dp, 0.7_dp, 0.9_dp]
+    complex(sp) :: bc1(3) = [(0.5_sp, 0.7_sp), (0.9_sp, 1.1_sp), (1.3_sp, 1.5_sp)]
+    complex(dp) :: bc2(3) = [(0.5_dp, 0.7_dp), (0.9_dp, 1.1_dp), (1.3_dp, 1.5_dp)]
+
+    print *, a1
+    if (abs(a1 - 8.41470957e-01_sp) > 1e-6_sp) error stop
+    print *, a2
+    if (abs(a2 - 8.41470984807896507e-01_dp) > 1e-12_dp) error stop
+    print *, a3
+    if (abs(a3 - (1.979484_sp, 1.150455_sp)) > 1e-6_sp) error stop
+    print *, a4
+    if (abs(a4 - (1.9794844356103003_dp, 1.1504545994253859_dp)) > 1e-12_dp) error stop
+
+    print *, ar1
+    if (any(abs(ar1 - [0.841470957_sp, 0.997494996_sp, 0.909297407_sp]) > 1e-6_sp)) error stop
+    print *, ar2
+    if (any(abs(ar2 - [0.84147098480789650_dp, 0.99749498660405445_dp, 0.90929742682568171_dp]) > 1e-12_dp)) error stop
+    print *, ac1
+    if (any(abs(ac1 - [(1.97948444_sp, 1.15045464_sp), (5.57607508_sp, -2.51777339_sp), &
+        (2.33875704_sp, -16.3770771_sp)]) > 1e-6_sp)) error stop
+    print *, ac2
+    if (any(abs(ac2 - [(1.9794844356103003_dp, 1.1504545994253859_dp), (5.5760750444083884_dp, -2.5177734552480526_dp), &
+        (2.3387571511543750_dp, -16.377076888816426_dp)]) > 1e-12_dp)) error stop
+
+    print *, sin(b1)
+    if (abs(sin(b1) - 0.479425550_sp) > 1e-6_sp) error stop
+    print *, sin(b2)
+    if (abs(sin(b2) - 0.64421768723769102_dp) > 1e-12_dp) error stop
+    print *, sin(b3)
+    if (abs(sin(b3) - (0.601760089_sp, 0.665719807_sp)) > 1e-6_sp) error stop
+    print *, sin(b4)
+    if (abs(sin(b4) - (0.60176007656391672_dp, 0.66571982846862043_dp)) > 1e-12_dp) error stop
+
+    print *, sin(br1)
+    if (any(abs(sin(br1) - [0.479425550_sp, 0.644217670_sp, 0.783326924_sp]) > 1e-6_sp)) error stop
+    print *, sin(br2)
+    if (any(abs(sin(br2) - [0.47942553860420301_dp, 0.64421768723769102_dp, 0.78332690962748341_dp]) > 1e-12_dp)) error stop
+    print *, sin(bc1)
+    if (any(abs(sin(bc1) - [(0.601760089_sp, 0.665719807_sp), (1.30699551_sp, 0.830251873_sp), &
+        (2.26668358_sp, 0.569579840_sp)]) > 1e-6_sp)) error stop
+    print *, sin(bc2)
+    if (any(abs(sin(bc2) - [(0.60176007656391672_dp, 0.66571982846862043_dp), (1.3069954824217060_dp, 0.83025178152468282_dp), &
+        (2.2666835402217402_dp, 0.56957976005226330_dp)]) > 1e-12_dp)) error stop
+    
+end program

--- a/integration_tests/intrinsics_265.f90
+++ b/integration_tests/intrinsics_265.f90
@@ -1,0 +1,64 @@
+program intrinsics_265
+    use iso_fortran_env, only: sp => real32, dp => real64
+    implicit none
+    real(sp), parameter :: a1 = cos(1.0_sp)
+    real(dp), parameter :: a2 = cos(1.0_dp) 
+    complex(sp), parameter :: a3 = cos((1.0_sp, 1.5_sp))
+    complex(dp), parameter :: a4 = cos((1.0_dp, 1.5_dp))
+
+    real(sp), parameter :: ar1(3) = cos([1.0_sp, 1.5_sp, 2.0_sp])
+    real(dp), parameter :: ar2(3) = cos([1.0_dp, 1.5_dp, 2.0_dp])
+    complex(sp), parameter :: ac1(3) = cos([(1.0_sp, 1.5_sp), (2.0_sp, 2.5_sp), (3.0_sp, 3.5_sp)])
+    complex(dp), parameter :: ac2(3) = cos([(1.0_dp, 1.5_dp), (2.0_dp, 2.5_dp), (3.0_dp, 3.5_dp)])
+
+    real(sp) :: b1 = 0.5_sp
+    real(dp) :: b2 = 0.7_dp
+    complex(sp) :: b3 = (0.5_sp, 0.7_sp)
+    complex(dp) :: b4 = (0.5_dp, 0.7_dp)
+
+    real(sp) :: br1(3) = [0.5_sp, 0.7_sp, 0.9_sp]
+    real(dp) :: br2(3) = [0.5_dp, 0.7_dp, 0.9_dp]
+    complex(sp) :: bc1(3) = [(0.5_sp, 0.7_sp), (0.9_sp, 1.1_sp), (1.3_sp, 1.5_sp)]
+    complex(dp) :: bc2(3) = [(0.5_dp, 0.7_dp), (0.9_dp, 1.1_dp), (1.3_dp, 1.5_dp)]
+
+    print *, a1
+    if (abs(a1 - 0.540302277_sp) > 1e-6_sp) error stop
+    print *, a2
+    if (abs(a2 - 0.54030230586813977_dp) > 1e-12_dp) error stop
+    print *, a3
+    if (abs(a3 - (1.27101231_sp, -1.79172683_sp)) > 1e-6_sp) error stop
+    print *, a4
+    if (abs(a4 - (1.2710123394623098_dp, -1.7917268800098574_dp)) > 1e-12_dp) error stop
+
+    print *, ar1
+    if (any(abs(ar1 - [0.540302277_sp, 0.0707372017_sp, -0.416146845_sp]) > 1e-6_sp)) error stop
+    print *, ar2
+    if (any(abs(ar2 - [0.54030230586813977_dp, 0.070737201667702906_dp, -0.41614683654714241_dp]) > 1e-12_dp)) error stop
+    print *, ac1
+    if (any(abs(ac1 - [(1.27101231_sp, -1.79172683_sp), (-2.55193281_sp, -5.50143528_sp), &
+        (-16.4069729_sp, -2.33449578_sp)]) > 1e-6_sp)) error stop
+    print *, ac2
+    if (any(abs(ac2 - [(1.2710123394623098_dp, -1.7917268800098574_dp), (-2.5519328677533650_dp, -5.5014353663786872_dp), &
+        (-16.406972071821489_dp, -2.3344956961624304_dp)]) > 1e-12_dp)) error stop
+
+    print *, cos(b1)
+    if (abs(cos(b1) - 0.877582550_sp) > 1e-6_sp) error stop
+    print *, cos(b2)
+    if (abs(cos(b2) - 0.76484218728448850_dp) > 1e-12_dp) error stop
+    print *, cos(b3)
+    if (abs(cos(b3) - (1.10151446_sp, -0.363684386_sp)) > 1e-6_sp) error stop
+    print *, cos(b4)
+    if (abs(cos(b4) - (1.1015144315669947_dp, -0.36368439983078843_dp)) > 1e-12_dp) error stop
+
+    print *, cos(br1)
+    if (any(abs(cos(br1) - [0.877582550_sp, 0.764842212_sp, 0.621609986_sp]) > 1e-6_sp)) error stop
+    print *, cos(br2)
+    if (any(abs(cos(br2) - [0.87758256189037276_dp, 0.76484218728448850_dp, 0.62160996827066439_dp]) > 1e-12_dp)) error stop
+    print *, cos(bc1)
+    if (any(abs(cos(bc1) - [(1.10151446_sp, -0.363684386_sp), (1.03716779_sp, -1.04624867_sp), &
+        (0.629266918_sp, -2.05168462_sp)]) > 1e-6_sp)) error stop
+    print *, cos(bc2)
+    if (any(abs(cos(bc2) - [(1.1015144315669947_dp, -0.36368439983078843_dp), (1.0371677653004676_dp, &
+        -1.0462486051241380_dp), (0.62926681652278482_dp, -2.0516846479972717_dp)]) > 1e-12_dp)) error stop
+    
+end program

--- a/integration_tests/intrinsics_266.f90
+++ b/integration_tests/intrinsics_266.f90
@@ -1,0 +1,64 @@
+program intrinsics_266
+    use iso_fortran_env, only: sp => real32, dp => real64
+    implicit none
+    real(sp), parameter :: a1 = tan(1.0_sp)
+    real(dp), parameter :: a2 = tan(1.0_dp) 
+    complex(sp), parameter :: a3 = tan((1.0_sp, 1.5_sp))
+    complex(dp), parameter :: a4 = tan((1.0_dp, 1.5_dp))
+
+    real(sp), parameter :: ar1(3) = tan([1.0_sp, 1.5_sp, 2.0_sp])
+    real(dp), parameter :: ar2(3) = tan([1.0_dp, 1.5_dp, 2.0_dp])
+    complex(sp), parameter :: ac1(3) = tan([(1.0_sp, 1.5_sp), (2.0_sp, 2.5_sp), (3.0_sp, 3.5_sp)])
+    complex(dp), parameter :: ac2(3) = tan([(1.0_dp, 1.5_dp), (2.0_dp, 2.5_dp), (3.0_dp, 3.5_dp)])
+
+    real(sp) :: b1 = 0.5_sp
+    real(dp) :: b2 = 0.7_dp
+    complex(sp) :: b3 = (0.5_sp, 0.7_sp)
+    complex(dp) :: b4 = (0.5_dp, 0.7_dp)
+
+    real(sp) :: br1(3) = [0.5_sp, 0.7_sp, 0.9_sp]
+    real(dp) :: br2(3) = [0.5_dp, 0.7_dp, 0.9_dp]
+    complex(sp) :: bc1(3) = [(0.5_sp, 0.7_sp), (0.9_sp, 1.1_sp), (1.3_sp, 1.5_sp)]
+    complex(dp) :: bc2(3) = [(0.5_dp, 0.7_dp), (0.9_dp, 1.1_dp), (1.3_dp, 1.5_dp)]
+
+    print *, a1
+    if (abs(a1 - 1.55740772e+00_sp) > 1e-6_sp) error stop
+    print *, a2
+    if (abs(a2 - 1.55740772465490223_dp) > 1e-12_dp) error stop
+    print *, a3
+    if (abs(a3 - (9.421291947E-02_sp, 1.03795874_sp)) > 1e-6_sp) error stop
+    print *, a4
+    if (abs(a4 - (9.42129201295443947E-002_dp, 1.0379587828579324_dp)) > 1e-12_dp) error stop
+
+    print *, ar1
+    if (any(abs(ar1 - [1.55740772_sp, 14.1014194_sp, -2.18503976_sp]) > 1e-6_sp)) error stop
+    print *, ar2
+    if (any(abs(ar2 - [1.55740772465490223_dp, 14.101419947171719_dp, -2.185039863261519_dp]) > 1e-12_dp)) error stop
+    print *, ac1
+    if (any(abs(ac1 - [(9.421291947E-02_sp, 1.03795874_sp), (-1.028875075E-02_sp, 1.00879467_sp), &
+        (-5.086967140E-04_sp, 0.998250306_sp)]) > 1e-6_sp)) error stop
+    print *, ac2
+    if (any(abs(ac2 - [(9.42129201295443947E-002_dp, 1.0379587828579324_dp), (-1.02887508595820281E-002_dp, &
+        1.0087947005319189_dp), (-5.08696693455815119E-004_dp, 0.99825027844029535_dp)]) > 1e-12_dp)) error stop
+
+    print *, tan(b1)
+    if (abs(tan(b1) - 0.546302497_sp) > 1e-6_sp) error stop
+    print *, tan(b2)
+    if (abs(tan(b2) - 0.84228838046307941_dp) > 1e-12_dp) error stop
+    print *, tan(b3)
+    if (abs(tan(b3) - (0.312674940_sp, 0.707602859_sp)) > 1e-6_sp) error stop
+    print *, tan(b4)
+    if (abs(tan(b4) - (0.31267491960977922_dp, 0.70760291160255895_dp)) > 1e-12_dp) error stop
+
+    print *, tan(br1)
+    if (any(abs(tan(br1) - [0.546302497_sp, 0.842288375_sp, 1.26015818_sp]) > 1e-6_sp)) error stop
+    print *, tan(br2)
+    if (any(abs(tan(br2) - [0.54630248984379048_dp, 0.84228838046307941_dp, 1.2601582175503392_dp]) > 1e-12_dp)) error stop
+    print *, tan(bc1)
+    if (any(abs(tan(bc1) - [(0.312674940_sp, 0.707602859_sp), (0.224352330_sp, 1.02681565_sp), &
+        (5.596723780E-02_sp, 1.08762586_sp)]) > 1e-6_sp)) error stop
+    print *, tan(bc2)
+    if (any(abs(tan(bc2) - [(0.31267491960977922_dp, 0.70760291160255895_dp), (0.22435234690709807_dp, 1.0268156677854674_dp), &
+        (5.59672199341484863E-002_dp, 1.0876258337665916_dp)]) > 1e-12_dp)) error stop
+    
+end program

--- a/integration_tests/intrinsics_267.f90
+++ b/integration_tests/intrinsics_267.f90
@@ -1,0 +1,43 @@
+program intrinsics_267
+    use iso_fortran_env, only: sp => real32, dp => real64
+    implicit none
+    real(dp), parameter :: a1 = dsin(1.0_dp)
+    real(dp), parameter :: a2 = dcos(1.0_dp) 
+    real(dp), parameter :: a3 = dtan(1.0_dp)
+    real(dp), parameter :: ar1(3) = dsin([1.0_dp, 1.5_dp, 2.0_dp])
+    real(dp), parameter :: ar2(3) = dcos([1.0_dp, 1.5_dp, 2.0_dp])
+    real(dp), parameter :: ar3(3) = dtan([1.0_dp, 1.5_dp, 2.0_dp])
+    real(dp) :: b = 0.7_dp
+    real(dp) :: br(3) = [0.5_dp, 0.7_dp, 0.9_dp]
+
+    ! dsin 
+    print *, a1
+    if (abs(a1 - 8.41470984807896507e-01_dp) > 1e-12_dp) error stop
+    print *, ar1
+    if (any(abs(ar1 - [0.84147098480789650_dp, 0.99749498660405445_dp, 0.90929742682568171_dp]) > 1e-12_dp)) error stop
+    print *, sin(b)
+    if (abs(sin(b) - 0.64421768723769102_dp) > 1e-12_dp) error stop
+    print *, sin(br)
+    if (any(abs(sin(br) - [0.47942553860420301_dp, 0.64421768723769102_dp, 0.78332690962748341_dp]) > 1e-12_dp)) error stop
+
+    ! dcos
+    print *, a2
+    if (abs(a2 - 5.40302305868139717e-01_dp) > 1e-12_dp) error stop
+    print *, ar2
+    if (any(abs(ar2 - [0.54030230586813977_dp, 0.070737201667702905_dp, -0.41614683654714241_dp]) > 1e-12_dp)) error stop
+    print *, dcos(b)
+    if (abs(dcos(b) - 0.76484218728448849_dp) > 1e-12_dp) error stop
+    print *, dcos(br)
+    if (any(abs(dcos(br) - [0.87758256189037276_dp, 0.76484218728448849_dp, 0.62160996827066441_dp]) > 1e-12_dp)) error stop
+    
+    ! dtan
+    print *, a3
+    if (abs(a3 - 1.55740772465490223_dp) > 1e-12_dp) error stop
+    print *, ar3
+    if (any(abs(ar3 - [1.55740772465490223_dp, 14.101419947171719_dp, -2.185039863261519_dp]) > 1e-12_dp)) error stop
+    print *, dtan(b)
+    if (abs(dtan(b) - 0.84228838046307941_dp) > 1e-12_dp) error stop
+    print *, dtan(br)
+    if (any(abs(dtan(br) - [0.54630248984379048_dp, 0.84228838046307941_dp, 1.2601582175503392_dp]) > 1e-12_dp)) error stop
+    
+end program

--- a/tests/reference/asr-intrinsics_04-524ec3a.json
+++ b/tests/reference/asr-intrinsics_04-524ec3a.json
@@ -2,11 +2,11 @@
     "basename": "asr-intrinsics_04-524ec3a",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_04.f90",
-    "infile_hash": "72abd5481636793081285605c94a07594e96f184ce4f50464854ded4",
+    "infile_hash": "1e045fd457f9f94ff18fafe47e159dd705201527893232761f0d06e8",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_04-524ec3a.stdout",
-    "stdout_hash": "43c6ec76c5ee22a0afe815e3fe84241419ddb5e4e247f639433a3fdc",
+    "stdout_hash": "be3bb556d6062e9844bcbd8956491d33a8cec30f8a69165cabe427b5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_04-524ec3a.stdout
+++ b/tests/reference/asr-intrinsics_04-524ec3a.stdout
@@ -428,6 +428,43 @@
                             ()
                         )]
                         []
+                    )
+                    (If
+                        (RealCompare
+                            (IntrinsicElementalFunction
+                                Abs
+                                [(RealBinOp
+                                    (IntrinsicElementalFunction
+                                        Aimag
+                                        [(Var 2 z)]
+                                        0
+                                        (Real 8)
+                                        ()
+                                    )
+                                    Sub
+                                    (RealConstant
+                                        1.001807
+                                        (Real 8)
+                                    )
+                                    (Real 8)
+                                    ()
+                                )]
+                                0
+                                (Real 8)
+                                ()
+                            )
+                            Gt
+                            (RealConstant
+                                0.000000
+                                (Real 8)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
                     )]
                 ),
             iso_fortran_env:


### PR DESCRIPTION
Towards: #4017 , https://github.com/lfortran/lfortran/issues/3067