### PR TITLE
fix: handle `allocatable` logical array inside `WHERE` clause

### DIFF
--- a/integration_tests/where_08.f90
+++ b/integration_tests/where_08.f90
@@ -3,10 +3,19 @@ program where_08
    logical :: l1(5)
    logical :: l2(5)
 
+   logical, allocatable, dimension(:) :: l3
+   logical, allocatable, dimension(:) :: l4
+
    integer :: b(5)
 
    l1 = [.true., .false., .true., .false., .true.]
    l2 = [1 < 2, 2 == 2, .true., .false., 2 >= 1]
+
+   allocate(l3(5))
+   l3 = [.true., .false., .false., .true., .false.]
+   
+   allocate(l4(5))
+   l4 = .true.
 
    where(l1) b = 1
    print *, b
@@ -23,6 +32,14 @@ program where_08
    where([.true., .false., .true., .false., .true.]) b = 4
    print *, b
    if (all(b /= [4, 2, 4, 0, 4])) error stop
+
+   where(l3) b = 5
+   print *, b
+   if (all(b /= [5, 2, 4, 5, 4])) error stop
+
+   where(l4) b = 6
+   print *, b
+   if (all(b /= [6, 6, 6, 6, 6])) error stop
 
 contains
    function get_logical_array() result(value)

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3219,7 +3219,7 @@ public:
         orelse.reserve(al, x.n_orelse);
         transform_stmts(orelse, x.n_orelse, x.m_orelse);
         if (ASRUtils::is_array(ASRUtils::expr_type(test))) {
-            if (ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_array(ASRUtils::expr_type(test)))) {
+            if (ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(test)))) {
                 // verify that `test` is *not* the ttype of an expression as we then 
                 // are sure that it is a single standalone logical array
                 if  (!ASR::is_a<ASR::IntegerCompare_t>(*test) 


### PR DESCRIPTION
#4320 had missed handling this, leading to some errors in compiling SNAP. This PR fixes it.