### PR TITLE
Add test for `ior`, `ieor`, `iand` and `not` and ensure error for different kind of args

### DIFF
--- a/integration_tests/intrinsics_160.f90
+++ b/integration_tests/intrinsics_160.f90
@@ -1,11 +1,32 @@
 program intrinsics_160
-    integer :: a1 = 5
-    integer :: a2 = 8
-    integer :: a3 = -1
-    integer :: a4 = -4
-    integer :: a5 = -2
-    integer :: a6 = -5
-  
+    integer :: a1 = 5, a2 = 8
+    integer(8) :: a3 = -1, a4 = -4
+    integer :: a5 = -2, a6 = -5
+
+    integer, parameter :: i1 = ior(5, 8)
+    integer, parameter :: i2 = ior(-1, 5)
+    integer, parameter :: i3 = ior(-4_8, 2_8)
+    integer(8), parameter :: i4 = ior(-2_8, 5_8)
+
+    integer, parameter :: ar1(3) = ior([5, 8, 9], [8, 5, 2])
+    integer(8), parameter :: ar2(3) = ior([-1_8, -5_8, -10_8], [5_8, 8_8, 9_8])
+
+    integer :: arr1(3), arr3(3)
+    integer(8) :: arr2(3)
+    integer :: res(3)
+    arr1 = [5, 8, 9]
+    arr3 = [8, 5, 2]
+    arr2 = [-1_8, -5_8, -10_8]
+
+    print *, i1
+    if (i1 /= 13) error stop
+    print *, i2
+    if (i2 /= -1) error stop
+    print *, i3
+    if (i3 /= -2) error stop
+    print *, i4
+    if (i4 /= -1) error stop
+
     print*, ior(5, 8)
     if (ior(5, 8) /= 13) error stop
     print*, ior(-1, 5)
@@ -17,13 +38,25 @@ program intrinsics_160
   
     print*, ior(a1, a2)
     if (ior(a1, a2) /= 13) error stop
-    print*, ior(a3, a1)
-    if (ior(a3, a1) /= -1) error stop
-    print*, ior(a2, a4)
-    if (ior(a2, a4) /= -4) error stop
+    print*, ior(a3, a4)
+    if (ior(a3, a4) /= -1) error stop
+    print*, ior(a2, a5)
+    if (ior(a2, a5) /= -2) error stop
     print*, ior(a5, a6)
     if (ior(a5, a6) /= -1) error stop
-  
-  end program
-  
-  
+
+    print *, ar1
+    if (any(ar1 /= [13, 13, 11])) error stop
+    print *, ar2
+    if (any(ar2 /= [-1, -5, -1])) error stop
+
+    print *, ior(arr1, arr3)
+    if (any(ior(arr1, arr3) /= [13, 13, 11])) error stop
+    print *, ior(arr2, arr2)
+    if (any(ior(arr2, arr2) /= [-1, -5, -10])) error stop
+
+    res = ior(arr1, arr3)
+    print *, res
+    if (any(res /= [13, 13, 11])) error stop
+
+end program 

--- a/integration_tests/intrinsics_161.f90
+++ b/integration_tests/intrinsics_161.f90
@@ -1,11 +1,32 @@
 program intrinsics_161
-    integer :: a1 = 5  
-    integer :: a2 = 8
-    integer :: a3 = -1
-    integer :: a4 = -4
-    integer :: a5 = -2
-    integer :: a6 = -5
-  
+    integer :: a1 = 5, a2 = 8
+    integer(8) :: a3 = -1, a4 = -4
+    integer :: a5 = -2, a6 = -5
+
+    integer, parameter :: i1 = ieor(5, 8)
+    integer, parameter :: i2 = ieor(-1, 5)
+    integer, parameter :: i3 = ieor(-4_8, 2_8)
+    integer(8), parameter :: i4 = ieor(-2_8, 5_8)
+
+    integer, parameter :: ar1(3) = ieor([5, 8, 9], [8, 5, 2])
+    integer(8), parameter :: ar2(3) = ieor([-1_8, -5_8, -10_8], [5_8, 8_8, 9_8])
+
+    integer :: arr1(3), arr3(3)
+    integer(8) :: arr2(3)
+    integer :: res(3)
+    arr1 = [5, 8, 9]
+    arr3 = [8, 5, 2]
+    arr2 = [-1_8, -5_8, -10_8]
+
+    print *, i1
+    if (i1 /= 13) error stop
+    print *, i2
+    if (i2 /= -6) error stop
+    print *, i3
+    if (i3 /= -2) error stop
+    print *, i4
+    if (i4 /= -5) error stop
+
     print*, ieor(5, 8)
     if (ieor(5, 8) /= 13) error stop
     print*, ieor(-1, 5)
@@ -17,12 +38,25 @@ program intrinsics_161
   
     print*, ieor(a1, a2)
     if (ieor(a1, a2) /= 13) error stop
-    print*, ieor(a3, a1)
-    if (ieor(a3, a1) /= -6) error stop
-    print*, ieor(a2, a4)
-    if (ieor(a2, a4) /= -12) error stop
+    print*, ieor(a3, a4)
+    if (ieor(a3, a4) /= 3) error stop
+    print*, ieor(a2, a5)
+    if (ieor(a2, a5) /= -10) error stop
     print*, ieor(a5, a6)
     if (ieor(a5, a6) /= 5) error stop
-  
-  end program
-  
+
+    print *, ar1
+    if (any(ar1 /= [13, 13, 11])) error stop
+    print *, ar2
+    if (any(ar2 /= [-6, -13, -1])) error stop
+
+    print *, ieor(arr1, arr3)
+    if (any(ieor(arr1, arr3) /= [13, 13, 11])) error stop
+    print *, ieor(arr2, arr2)
+    if (any(ieor(arr2, arr2) /= [0, 0, 0])) error stop
+
+    res = ieor(arr1, arr3)
+    print *, res
+    if (any(res /= [13, 13, 11])) error stop
+
+end program 

--- a/integration_tests/intrinsics_162.f90
+++ b/integration_tests/intrinsics_162.f90
@@ -1,7 +1,24 @@
 program intrinsics_162
+    implicit none
     integer :: a1 = 1
-    integer :: a2 = -5
+    integer(8) :: a2 = -5
     integer :: a3 = 0
+    integer, parameter :: i1 = not(1)
+    integer(8), parameter :: i2 = not(-5)
+    integer, parameter :: ar1(3) = not([-1, 43, -8])
+    integer(8), parameter :: ar2(3) = not([-1_8, 43_8, -8_8])
+
+    integer(4) :: arr1(3) = [11, -13, 0]
+    integer(8) :: arr2(3) = [11_8, -13_8, 0_8]
+
+    print *, i1
+    if (i1 /= -2) error stop
+    print *, i2
+    if (i2 /= 4) error stop
+    print *, ar1
+    if (any(ar1 /= [0, -44, 7])) error stop
+    print *, ar2
+    if (any(ar2 /= [0_8, -44_8, 7_8])) error stop
 
     print*, not(a1)
     if (not(a1) /= -2) error stop
@@ -17,4 +34,14 @@ program intrinsics_162
     print*, not(0)
     if (not(0) /= -1) error stop
 
-end
+    print*, not(arr1)
+    if (any(not(arr1) /= [-12, 12, -1])) error stop
+    print*, not(arr2)
+    if (any(not(arr2) /= [-12_8, 12_8, -1_8])) error stop
+
+    print *, kind(not(1))
+    if (kind(not(1)) /= 4) error stop
+    print *, kind(not(5_8))
+    if (kind(not(5_8)) /= 8) error stop
+
+end program

--- a/integration_tests/intrinsics_164.f90
+++ b/integration_tests/intrinsics_164.f90
@@ -1,11 +1,32 @@
 program intrinsics_164
-    integer :: a1 = 5  
-    integer :: a2 = 8
-    integer :: a3 = -1
-    integer :: a4 = -4
-    integer :: a5 = -2
-    integer :: a6 = -5
-  
+    integer :: a1 = 5, a2 = 8
+    integer(8) :: a3 = -1, a4 = -4
+    integer :: a5 = -2, a6 = -5
+
+    integer, parameter :: i1 = iand(5, 8)
+    integer, parameter :: i2 = iand(-1, 5)
+    integer, parameter :: i3 = iand(-4_8, 2_8)
+    integer(8), parameter :: i4 = iand(-2_8, 5_8)
+
+    integer, parameter :: ar1(3) = iand([5, 8, 9], [8, 5, 2])
+    integer(8), parameter :: ar2(3) = iand([-1_8, -5_8, -10_8], [5_8, 8_8, 9_8])
+
+    integer :: arr1(3), arr3(3)
+    integer(8) :: arr2(3)
+    integer :: res(3)
+    arr1 = [5, 8, 9]
+    arr3 = [8, 5, 2]
+    arr2 = [-1_8, -5_8, -10_8]
+
+    print *, i1
+    if (i1 /= 0) error stop
+    print *, i2
+    if (i2 /= 5) error stop
+    print *, i3
+    if (i3 /= 0) error stop
+    print *, i4
+    if (i4 /= 4) error stop
+
     print*, iand(5, 8)
     if (iand(5, 8) /= 0) error stop
     print*, iand(-1, 5)
@@ -17,11 +38,25 @@ program intrinsics_164
   
     print*, iand(a1, a2)
     if (iand(a1, a2) /= 0) error stop
-    print*, iand(a3, a1)
-    if (iand(a3, a1) /= 5) error stop
-    print*, iand(a2, a4)
-    if (iand(a2, a4) /= 8) error stop
+    print*, iand(a3, a4)
+    if (iand(a3, a4) /= -4) error stop
+    print*, iand(a2, a5)
+    if (iand(a2, a5) /= 8) error stop
     print*, iand(a5, a6)
     if (iand(a5, a6) /= -6) error stop
-  
+
+    print *, ar1
+    if (any(ar1 /= [0, 0, 0])) error stop
+    print *, ar2
+    if (any(ar2 /= [5, 8, 0])) error stop
+
+    print *, iand(arr1, arr3)
+    if (any(iand(arr1, arr3) /= [0, 0, 0])) error stop
+    print *, iand(arr2, arr2)
+    if (any(iand(arr2, arr2) /= [-1, -5, -10])) error stop
+
+    res = iand(arr1, arr3)
+    print *, res
+    if (any(res /= [0, 0, 0])) error stop
+
 end program 

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1638,9 +1638,15 @@ namespace Not {
 namespace Iand {
 
     static ASR::expr_t *eval_Iand(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int64_t val1 = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
         int64_t val2 = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+        int kind1 = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
+        int kind2 = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_type);
+        if (kind1 != kind2) {
+            append_error(diag, "The kind of first argument of `iand` intrinsic must be the same as second argument", loc);
+            return nullptr;
+        }
         int64_t result;
         result = val1 & val2;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
@@ -1674,9 +1680,15 @@ namespace Iand {
 namespace Ior {
 
     static ASR::expr_t *eval_Ior(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int64_t val1 = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
         int64_t val2 = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+        int kind1 = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
+        int kind2 = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_type);
+        if (kind1 != kind2) {
+            append_error(diag, "The kind of first argument of `ior` intrinsic must be the same as second argument", loc);
+            return nullptr;
+        }
         int64_t result;
         result = val1 | val2;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
@@ -1710,9 +1722,15 @@ namespace Ior {
 namespace Ieor {
 
     static ASR::expr_t *eval_Ieor(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int64_t val1 = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
         int64_t val2 = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+        int kind1 = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
+        int kind2 = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_type);
+        if (kind1 != kind2) {
+            append_error(diag, "The kind of first argument of `ieor` intrinsic must be the same as second argument", loc);
+            return nullptr;
+        }
         int64_t result;
         result = val1 ^ val2;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);

--- a/tests/errors/intrinsics_04.f90
+++ b/tests/errors/intrinsics_04.f90
@@ -1,0 +1,3 @@
+program intrinsics_04
+    print *, iand(1, 1_8)
+end program

--- a/tests/errors/intrinsics_05.f90
+++ b/tests/errors/intrinsics_05.f90
@@ -1,0 +1,3 @@
+program intrinsics_05
+    print *, ior(1, 1_8)
+end program

--- a/tests/errors/intrinsics_06.f90
+++ b/tests/errors/intrinsics_06.f90
@@ -1,0 +1,3 @@
+program intrinsics_06
+    print *, ieor(1, 1_8)
+end program

--- a/tests/reference/asr-intrinsics_04-fbc7b3a.json
+++ b/tests/reference/asr-intrinsics_04-fbc7b3a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics_04-fbc7b3a",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics_04.f90",
+    "infile_hash": "5a2801f3caef8c6df8fe201070cb5cb553ef28ba42ac97cb7d0e5433",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics_04-fbc7b3a.stderr",
+    "stderr_hash": "a31b408638dd6187d1e48eb4f233d3cc5412afc3640eba864e65ed24",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics_04-fbc7b3a.stderr
+++ b/tests/reference/asr-intrinsics_04-fbc7b3a.stderr
@@ -1,0 +1,5 @@
+semantic error: The kind of first argument of `iand` intrinsic must be the same as second argument
+ --> tests/errors/intrinsics_04.f90:2:14
+  |
+2 |     print *, iand(1, 1_8)
+  |              ^^^^^^^^^^^^ 

--- a/tests/reference/asr-intrinsics_05-a2b71c6.json
+++ b/tests/reference/asr-intrinsics_05-a2b71c6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics_05-a2b71c6",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics_05.f90",
+    "infile_hash": "a0b26c89376dc415c9180441ee41b111288a075487d7393f2d5e77e4",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics_05-a2b71c6.stderr",
+    "stderr_hash": "3a73f12ef5c63f13adf2e3a2e6962f4fe4799ce80d2d3e9de7dd5ad1",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics_05-a2b71c6.stderr
+++ b/tests/reference/asr-intrinsics_05-a2b71c6.stderr
@@ -1,0 +1,5 @@
+semantic error: The kind of first argument of `ior` intrinsic must be the same as second argument
+ --> tests/errors/intrinsics_05.f90:2:14
+  |
+2 |     print *, ior(1, 1_8)
+  |              ^^^^^^^^^^^ 

--- a/tests/reference/asr-intrinsics_06-1ff7a26.json
+++ b/tests/reference/asr-intrinsics_06-1ff7a26.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics_06-1ff7a26",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics_06.f90",
+    "infile_hash": "2cae4d6194dc457cd08420747ec727afd75ae55121f2c54a6fccaddc",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics_06-1ff7a26.stderr",
+    "stderr_hash": "665421d7b10c6357c50c82c965a770fc5686c3e99bfcc94080069899",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics_06-1ff7a26.stderr
+++ b/tests/reference/asr-intrinsics_06-1ff7a26.stderr
@@ -1,0 +1,5 @@
+semantic error: The kind of first argument of `ieor` intrinsic must be the same as second argument
+ --> tests/errors/intrinsics_06.f90:2:14
+  |
+2 |     print *, ieor(1, 1_8)
+  |              ^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4017,3 +4017,15 @@ asr_openmp = true
 [[test]]
 filename = "errors/intrinsics_03.f90"
 asr = true
+
+[[test]]
+filename = "errors/intrinsics_04.f90"
+asr = true
+
+[[test]]
+filename = "errors/intrinsics_05.f90"
+asr = true
+
+[[test]]
+filename = "errors/intrinsics_06.f90"
+asr = true


### PR DESCRIPTION
Towards: #4017, #3067
Fixes: #4372 