### PR TITLE
Fix: support array type arg in inquiry functions and update tests for `precision` and `epsilon`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -835,6 +835,7 @@ RUN(NAME intrinsics_270 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # atan
 RUN(NAME intrinsics_271 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # leadz
 RUN(NAME intrinsics_272 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trailz
 RUN(NAME intrinsics_273 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dprod
+RUN(NAME intrinsics_274 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # epsilon
 
 RUN(NAME passing_array_01 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME passing_array_02 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_138.f90
+++ b/integration_tests/intrinsics_138.f90
@@ -1,15 +1,50 @@
-program prec_and_range
-    
-    real(kind=4) :: x(2)
-    complex(kind=8) :: y
-  
-    print*, precision(1.0)
-    if (precision(1.0) /= 6) error stop
+program intrinsics_138
+    implicit none
+
+    real :: x = 3.143
+    complex(4) :: y = (2.33, 4.1)
+    real(kind=4) :: x1(2)
+    complex(kind=8) :: y1
+
+    integer(4), parameter :: r1 = precision(1._4)
+    integer(8), parameter :: r2 = precision(67._8)
+    integer, parameter :: r3 = precision((1, 2))
+    integer(4), parameter :: ar1 = precision([11.3_4, 1.7_4, 0.0_4])
+    integer(8), parameter :: ar2 = precision([11.3_8, 1.7_8, 0.0_8])
+    integer, parameter :: ar3 = precision([(1, 2), (3, 4), (11, 22)])
+
+    real(4) :: arr1(3) = [11.3_4, 1.7_4, 0.0_4]
+    complex(8) :: arr2(3) = [(11.3_8, 1.7_8), (0.0_8, 1.1_8), (5.0_8, 0.1_8)]
+
+    print *, r1
+    if (r1 /= 6) error stop
+    print *, r2
+    if (r2 /= 15) error stop
+
+    print *, ar1
+    if (ar1 /= 6) error stop
+    print *, ar2
+    if (ar2 /= 15) error stop
+
     print *, precision(x)
     if (precision(x) /= 6) error stop
+    print *, precision(y)
+    if (precision(y) /= 6) error stop
+    print *, precision(1._8) ** 0.5
+    if (abs(precision(1._8) ** 0.5_8 - 3.87298346) > 1e-6) error stop
+
+    print*, precision(1.0)
+    if (precision(1.0) /= 6) error stop
+    print *, precision(x1)
+    if (precision(x1) /= 6) error stop
     print *, precision(1.0d0)
     if (precision(1.0d0) /= 15) error stop
-    print *, precision(y)
-    if (precision(y) /= 15) error stop
+    print *, precision(y1)
+    if (precision(y1) /= 15) error stop
 
-end program prec_and_range
+    print *, precision(arr1)
+    if (precision(arr1) /= 6) error stop
+    print *, precision(arr2)
+    if (precision(arr2) /= 15) error stop
+
+end program

--- a/integration_tests/intrinsics_274.f90
+++ b/integration_tests/intrinsics_274.f90
@@ -1,0 +1,38 @@
+program intrinsics_274
+    use iso_fortran_env, only: sp => real32, dp => real64
+    implicit none
+
+    real :: x = 3.143
+    real(dp) :: y = 2.33
+
+    real(sp), parameter :: r1 = epsilon(1._sp)
+    real(dp), parameter :: r2 = epsilon(67._dp)
+    real(sp), parameter :: ar1 = epsilon([11.3_sp, 1.7_sp, 0.0_sp])
+    real(dp), parameter :: ar2 = epsilon([11.3_dp, 1.7_dp, 0.0_dp])
+
+    real(sp) :: arr1(3) = [11.3_sp, 1.7_sp, 0.0_sp]
+    real(dp) :: arr2(3) = [19.3_dp, 3.7_dp, 0.0_dp]
+
+    print *, r1
+    if (abs(r1 - 1.19209290E-07) > 1e-6) error stop
+    print *, r2
+    if (abs(r2 - 2.2204460492503131E-016_dp) > 1e-12_dp) error stop
+
+    print *, ar1
+    if (abs(ar1 - 1.19209290E-07) > 1e-6) error stop
+    print *, ar2
+    if (abs(ar2 - 2.2204460492503131E-016_dp) > 1e-12_dp) error stop
+
+    print *, epsilon(x)
+    if (abs(epsilon(x) - 1.19209290E-07) > 1e-6) error stop
+    print *, epsilon(y)
+    if (abs(epsilon(y) - 2.2204460492503131E-016_dp) > 1e-12_dp) error stop
+    print *, epsilon(1._dp) ** 0.5 !Part of Minpack
+    if (abs((epsilon(1._dp) ** 0.5_dp) - 1.4901161193847656E-008_dp) > 1e-12_dp) error stop
+
+    print *, epsilon(arr1)
+    if (abs(epsilon(arr1) - 1.19209290E-07) > 1e-6) error stop
+    print *, epsilon(arr2)
+    if (abs(epsilon(arr2) - 2.2204460492503131E-016_dp) > 1e-12_dp) error stop
+
+end program

--- a/integration_tests/intrinsics_93.f90
+++ b/integration_tests/intrinsics_93.f90
@@ -6,8 +6,8 @@ program intrinsics_93
     integer(8), parameter :: i2 = digits(63)
     integer, parameter :: i3 = digits(24.5_sp)
     integer(8), parameter :: i4 = digits(53.5_dp)
-    ! integer, parameter :: ar1 = digits([1, 33, 56]) ! Does not work #4368
-    ! integer, parameter :: ar2 = digits([1.0_sp, 33.0_sp, 56.0_sp])
+    integer, parameter :: ar1 = digits([1, 33, 56]) ! Does not work #4368
+    integer, parameter :: ar2 = digits([1.0_sp, 33.0_sp, 56.0_sp])
     integer :: i 
     integer(8) :: j
     real :: x 
@@ -23,10 +23,10 @@ program intrinsics_93
     if (i3 /= 24) error stop
     print *, i4
     if (i4 /= 53) error stop
-    ! print *, ar1
-    ! if (ar1 /= 31) error stop
-    ! print *, ar2
-    ! if (ar2 /= 24) error stop
+    print *, ar1
+    if (ar1 /= 31) error stop
+    print *, ar2
+    if (ar2 /= 24) error stop
     
     print *, digits(i)
     if (digits(i) /= 31) error stop

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5666,8 +5666,9 @@ public:
                         ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function(var_name);
 
                     std::vector<int> array_indices_in_args = find_array_indices_in_args(args);
+                    std::vector<std::string> inquiry_functions = {"epsilon", "radix", "range", "precision", "rank", "tiny", "huge", "bit_size", "new_line", "digits"};
                     if (are_all_args_evaluated &&
-                        var_name != "tiny" && var_name != "rank" &&
+                        (std::find(inquiry_functions.begin(), inquiry_functions.end(), var_name) == inquiry_functions.end()) &&
                         !array_indices_in_args.empty())
                     {
                         ASR::expr_t* arg = ASRUtils::expr_value(args[array_indices_in_args[0]]);


### PR DESCRIPTION
Towards: #4017, #3067
Fixes: #4368 