### PR TITLE
Support to redefine of function in REPL

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -935,7 +935,6 @@ int compile_to_object_file(const std::string &infile,
         return 0;
     }
 
-    std::unique_ptr<LCompilers::LLVMModule> m;
     diagnostics.diagnostics.clear();
     if (compiler_options.emit_debug_info) {
 #ifndef HAVE_RUNTIME_STACKTRACE
@@ -950,25 +949,23 @@ int compile_to_object_file(const std::string &infile,
         return 1;
 #endif
     }
-    LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
+    LCompilers::Result<bool>
         res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
     std::cerr << diagnostics.render(lm, compiler_options);
-    if (res.ok) {
-        m = std::move(res.result);
-    } else {
+    if (!res.ok) {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return 5;
     }
 
     if (compiler_options.po.fast) {
-        e.opt(*m->m_m);
+        fe.e->opt();
     }
 
     // LLVM -> Machine code (saves to an object file)
     if (assembly) {
-        e.save_asm_file(*(m->m_m), outfile);
+        fe.e->save_asm_file(outfile);
     } else {
-        e.save_object_file(*(m->m_m), outfile);
+        fe.e->save_object_file(outfile);
     }
 
     return 0;

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -120,9 +120,10 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
     }
 
     std::string return_type = e->get_return_type(run_fn);
+    
+    e->evaluate_module_context_pair();
 
     // LLVM -> Machine code -> Execution
-    e->add_module();
     if (return_type == "integer4") {
         int32_t r = e->execfn<int32_t>(run_fn);
         result.type = EvalResult::integer4;

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -79,10 +79,10 @@ public:
     Result<std::string> get_llvm(const std::string &code,
         LocationManager &lm, LCompilers::PassManager& pass_manager,
         diag::Diagnostics &diagnostics);
-    Result<std::unique_ptr<LLVMModule>> get_llvm2(const std::string &code,
+    Result<bool> get_llvm2(const std::string &code,
         LocationManager &lm, LCompilers::PassManager& pass_manager,
         diag::Diagnostics &diagnostics);
-    Result<std::unique_ptr<LLVMModule>> get_llvm3(ASR::TranslationUnit_t &asr,
+    Result<bool> get_llvm3(ASR::TranslationUnit_t &asr,
         LCompilers::PassManager& pass_manager,
         diag::Diagnostics &diagnostics, const std::string &infile);
     Result<std::string> get_asm(const std::string &code,
@@ -111,10 +111,13 @@ public:
     Result<std::string> get_fmt(const std::string &code, LocationManager &lm,
         diag::Diagnostics &diagnostics);
 
+#ifdef HAVE_LFORTRAN_LLVM
+    std::unique_ptr<LLVMEvaluator> e;
+#endif
+
 private:
     Allocator al;
 #ifdef HAVE_LFORTRAN_LLVM
-    std::unique_ptr<LLVMEvaluator> e;
     int eval_count;
 #endif
     SymbolTable *symbol_table;

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -380,23 +380,22 @@ end function)";
     CHECK(LCompilers::pickle(*asr) == "(TranslationUnit (SymbolTable 1 {f: (Function (SymbolTable 2 {f: (Variable 2 f [] ReturnVar () () Default (Integer 4) () Source Public Required .false.)}) f (FunctionType [] (Integer 4) Source Implementation () .false. .false. .false. .false. .false. [] .false.) [] [] [(Assignment (Var 2 f) (IntegerConstant 5 (Integer 4)) ())] (Var 2 f) Public .false. .false. ())}) [])");
 
     // ASR -> LLVM
-    LCompilers::LLVMEvaluator e;
+    std::unique_ptr<LCompilers::LLVMEvaluator> e = std::make_unique<LCompilers::LLVMEvaluator>();
     LCompilers::PassManager lpm;
     lpm.use_default_passes();
     CompilerOptions co;
     co.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
     co.platform = LCompilers::get_platform();
-    LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
-        res = LCompilers::asr_to_llvm(*asr, diagnostics, e.get_context(), al,
+    LCompilers::Result<bool>
+        res = LCompilers::asr_to_llvm(*asr, diagnostics, e, al,
             lpm, co, "f", "");
     REQUIRE(res.ok);
-    std::unique_ptr<LCompilers::LLVMModule> m = std::move(res.result);
     //std::cout << "Module:" << std::endl;
     //std::cout << m->str() << std::endl;
 
     // LLVM -> Machine code -> Execution
-    e.add_module(std::move(m));
-    CHECK(e.execfn<int32_t>("f") == 5);
+    e->add_module();
+    CHECK(e->execfn<int32_t>("f") == 5);
 }
 
 TEST_CASE("ASR -> LLVM 2") {
@@ -420,20 +419,20 @@ end function)";
         diagnostics, nullptr, false, compiler_options));
     CHECK(LCompilers::pickle(*asr) == "(TranslationUnit (SymbolTable 3 {f: (Function (SymbolTable 4 {f: (Variable 4 f [] ReturnVar () () Default (Integer 4) () Source Public Required .false.)}) f (FunctionType [] (Integer 4) Source Implementation () .false. .false. .false. .false. .false. [] .false.) [] [] [(Assignment (Var 4 f) (IntegerConstant 4 (Integer 4)) ())] (Var 4 f) Public .false. .false. ())}) [])");
     // ASR -> LLVM
-    LCompilers::LLVMEvaluator e;
+    std::unique_ptr<LCompilers::LLVMEvaluator> e = std::make_unique<LCompilers::LLVMEvaluator>();
     LCompilers::PassManager lpm;
     lpm.use_default_passes();
-    LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
-        res = LCompilers::asr_to_llvm(*asr, diagnostics, e.get_context(), al,
+    LCompilers::Result<bool>
+        res = LCompilers::asr_to_llvm(*asr, diagnostics, e, al,
             lpm, compiler_options, "f", "");
     REQUIRE(res.ok);
-    std::unique_ptr<LCompilers::LLVMModule> m = std::move(res.result);
+    // std::unique_ptr<LCompilers::LLVMModule> m = std::move(res.result);
     //std::cout << "Module:" << std::endl;
     //std::cout << m->str() << std::endl;
 
     // LLVM -> Machine code -> Execution
-    e.add_module(std::move(m));
-    CHECK(e.execfn<int32_t>("f") == 4);
+    e->add_module();
+    CHECK(e->execfn<int32_t>("f") == 4);
 }
 
 TEST_CASE("FortranEvaluator 1") {

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -25,15 +25,13 @@ TEST_CASE("llvm 1") {
     //LFortran::LLVMEvaluator::print_version_message();
 
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 define i64 @f1()
 {
     ret i64 4
 }
     )""");
     CHECK(e.execfn<int64_t>("f1") == 4);
-    e.add_module("");
-//    CHECK(e.execfn<int64_t>("f1") == 4);
 
 /*
     e.add_module(R"""(
@@ -50,14 +48,14 @@ define i64 @f1()
 
 TEST_CASE("llvm 1 fail") {
     LCompilers::LLVMEvaluator e;
-    CHECK_THROWS_AS(e.add_module(R"""(
+    CHECK_THROWS_AS(e.add_module_with_code(R"""(
 define i64 @f1()
 {
     ; FAIL: "=x" is incorrect syntax
     %1 =x alloca i64
 }
         )"""), LCompilers::LCompilersException);
-    CHECK_THROWS_WITH(e.add_module(R"""(
+    CHECK_THROWS_WITH(e.add_module_with_code(R"""(
 define i64 @f1()
 {
     ; FAIL: "=x" is incorrect syntax
@@ -69,7 +67,7 @@ define i64 @f1()
 
 TEST_CASE("llvm 2") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @count = global i64 0
 
 define i64 @f1()
@@ -81,7 +79,7 @@ define i64 @f1()
     )""");
     CHECK(e.execfn<int64_t>("f1") == 4);
 
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @count = external global i64
 
 define i64 @f2()
@@ -92,7 +90,7 @@ define i64 @f2()
     )""");
     CHECK(e.execfn<int64_t>("f2") == 4);
 
-    CHECK_THROWS_AS(e.add_module(R"""(
+    CHECK_THROWS_AS(e.add_module_with_code(R"""(
 define i64 @f3()
 {
     ; FAIL: @count is not defined
@@ -104,11 +102,11 @@ define i64 @f3()
 
 TEST_CASE("llvm 3") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @count = global i64 5
     )""");
 
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @count = external global i64
 
 define i64 @f1()
@@ -191,7 +189,7 @@ define void @inc()
 
 TEST_CASE("llvm 4") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @count = global i64 5
 
 define i64 @f1()
@@ -247,7 +245,7 @@ define void @inc2()
 
 TEST_CASE("llvm array 1") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 ; Sum the three elements in %a
 define i64 @sum3(i64* %a)
 {
@@ -289,7 +287,7 @@ define i64 @f()
 
 TEST_CASE("llvm array 2") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 %array = type {i64, [3 x i64]}
 
 ; Sum the three elements in %a
@@ -339,7 +337,7 @@ int f(int a, int b) {
 TEST_CASE("llvm callback 0") {
     LCompilers::LLVMEvaluator e;
     std::string addr = std::to_string((int64_t)f);
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 define i64 @addrcaller(i64 %a, i64 %b)
 {
     %f = inttoptr i64 )""" + addr + R"""( to i64 (i64, i64)*
@@ -633,7 +631,7 @@ end module funcmod)");
 // Tests passing the complex struct by reference
 TEST_CASE("llvm complex type") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 %complex = type { float, float }
 
 define float @sum2(%complex* %a)
@@ -669,7 +667,7 @@ define float @f()
 // Tests passing the complex struct by value
 TEST_CASE("llvm complex type value") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 %complex = type { float, float }
 
 define float @sum2(%complex %a_value)
@@ -708,7 +706,7 @@ define float @f()
 // Tests passing boolean by reference
 TEST_CASE("llvm boolean type") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 
 define i1 @and_func(i1* %p, i1* %q)
 {
@@ -738,7 +736,7 @@ define i1 @b()
 // Tests passing boolean by value
 TEST_CASE("llvm boolean type") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 
 define i1 @and_func(i1 %p, i1 %q)
 {
@@ -768,7 +766,7 @@ define i1 @b()
 // Tests pointers
 TEST_CASE("llvm pointers 1") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @r = global i64 0
 
 define i64 @f()
@@ -791,7 +789,7 @@ define i64 @f()
 
 TEST_CASE("llvm pointers 2") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 @r = global float 0.0
 
 define i64 @f()
@@ -810,7 +808,7 @@ define i64 @f()
 
 TEST_CASE("llvm pointers 3") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 ; Takes a variable and returns a pointer to it
 define i64 @pointer_reference(float* %var)
 {
@@ -850,7 +848,7 @@ define float @f()
 
 TEST_CASE("llvm pointers 4") {
     LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
+    e.add_module_with_code(R"""(
 ; Takes a variable and returns a pointer to it
 define float* @pointer_reference(float* %var)
 {

--- a/src/libasr/asr_scopes.h
+++ b/src/libasr/asr_scopes.h
@@ -73,7 +73,7 @@ struct SymbolTable {
 
     // Add a new symbol that did not exist before
     void add_symbol(const std::string &name, ASR::symbol_t* symbol) {
-        // LCOMPILERS_ASSERT(scope.find(name) == scope.end())
+        LCOMPILERS_ASSERT(scope.find(name) == scope.end())
         scope[name] = symbol;
     }
 

--- a/src/libasr/asr_scopes.h
+++ b/src/libasr/asr_scopes.h
@@ -73,7 +73,7 @@ struct SymbolTable {
 
     // Add a new symbol that did not exist before
     void add_symbol(const std::string &name, ASR::symbol_t* symbol) {
-        LCOMPILERS_ASSERT(scope.find(name) == scope.end())
+        // LCOMPILERS_ASSERT(scope.find(name) == scope.end())
         scope[name] = symbol;
     }
 

--- a/src/libasr/codegen/KaleidoscopeJIT.h
+++ b/src/libasr/codegen/KaleidoscopeJIT.h
@@ -26,6 +26,11 @@
 #include "llvm/IR/LLVMContext.h"
 #include <memory>
 
+#if LLVM_VERSION_MAJOR < 12
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <libasr/exception.h>
+#endif
+
 #if LLVM_VERSION_MAJOR >= 13
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #endif
@@ -40,28 +45,64 @@ namespace llvm {
 namespace orc {
 
 class KaleidoscopeJIT {
+
+#if LLVM_VERSION_MAJOR < 12
+  using ObjLayerT = LegacyRTDyldObjectLinkingLayer;
+  using CompileLayerT = LegacyIRCompileLayer<ObjLayerT, SimpleCompiler>;
+#endif
+
 private:
   std::unique_ptr<ExecutionSession> ES;
+#if LLVM_VERSION_MAJOR >= 12
   RTDyldObjectLinkingLayer ObjectLayer;
   IRCompileLayer CompileLayer;
-
   DataLayout DL;
   MangleAndInterner Mangle;
   JITDylib &JITDL;
+#else
+  std::shared_ptr<SymbolResolver> Resolver;
+  std::unique_ptr<TargetMachine> TM;
+  ObjLayerT ObjectLayer;
+  CompileLayerT CompileLayer;
+  std::vector<VModuleKey> ModuleKeys;
+#endif
+  DataLayout DL;
 
 public:
+#if LLVM_VERSION_MAJOR >= 12
   KaleidoscopeJIT(std::unique_ptr<ExecutionSession> ES, JITTargetMachineBuilder JTMB, DataLayout DL)
       :
         ES(std::move(ES)),
+#else
+  KaleidoscopeJIT()
+      :
+        ES(std::make_unique<ExecutionSession>()),
+#endif
+#if LLVM_VERSION_MAJOR >= 12
         ObjectLayer(*this->ES,
                     []() { return std::make_unique<SectionMemoryManager>(); }),
         CompileLayer(*this->ES, ObjectLayer, std::make_unique<ConcurrentIRCompiler>(std::move(JTMB))),
         DL(std::move(DL)), Mangle(*this->ES, this->DL),
-        JITDL(
-#if LLVM_VERSION_MAJOR >= 11
-            cantFail
+        JITDL(cantFail(this->ES->createJITDylib("Main")))
+#else
+        Resolver(createLegacyLookupResolver(
+            *ES,
+            [this](StringRef Name) {
+              return lookup(std::string(Name));
+            },
+            [](Error Err) { cantFail(std::move(Err), "lookupFlags failed"); })),
+        TM(EngineBuilder().selectTarget()),
+        ObjectLayer(AcknowledgeORCv1Deprecation, *ES,
+                    [this](VModuleKey) {
+                      return ObjLayerT::Resources{
+                          std::make_shared<SectionMemoryManager>(), Resolver};
+                    }),
+        CompileLayer(AcknowledgeORCv1Deprecation, ObjectLayer,
+                     SimpleCompiler(*TM)),
+        DL(TM->createDataLayout())
 #endif
-          (this->ES->createJITDylib("Main"))) {
+         {
+#if LLVM_VERSION_MAJOR >= 12
     JITDL.addGenerator(
         cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(
             DL.getGlobalPrefix())));
@@ -69,8 +110,12 @@ public:
       ObjectLayer.setOverrideObjectFlagsWithResponsibilityFlags(true);
       ObjectLayer.setAutoClaimResponsibilityForObjectSymbols(true);
     }
+#else
+    llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
+#endif
   }
 
+#if LLVM_VERSION_MAJOR >= 12
   static Expected<std::unique_ptr<KaleidoscopeJIT>> Create() {
 #if LLVM_VERSION_MAJOR >= 13
     auto EPC = SelfExecutorProcessControl::Create();
@@ -98,17 +143,33 @@ public:
     return std::make_unique<KaleidoscopeJIT>(std::move(ES), std::move(JTMB),
                                              std::move(*DL));
   }
+#endif
 
   const DataLayout &getDataLayout() const { return DL; }
 
-  JITDylib &getMainJITDylib() { return JITDL; }
+  // JITDylib &getMainJITDylib() { return JITDL; }
 
+#if LLVM_VERSION_MAJOR >= 12
   Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> Ctx, ResourceTrackerSP RT) {
     auto res =  CompileLayer.add(RT,
                             ThreadSafeModule(std::move(M), std::move(Ctx)));
     return res;
   }
+#else
+  VModuleKey addModule(std::unique_ptr<Module> M) {
+    auto K = ES->allocateVModule();
+    cantFail(CompileLayer.addModule(K, std::move(M)));
+    ModuleKeys.push_back(K);
+    return K;
+  }
 
+  void removeModule(VModuleKey K) {
+    ModuleKeys.erase(find(ModuleKeys, K));
+    cantFail(CompileLayer.removeModule(K));
+  }
+#endif
+
+#if LLVM_VERSION_MAJOR >= 12
   Expected<JITEvaluatedSymbol> lookup(StringRef Name) {
 #if LLVM_VERSION_MAJOR >= 17
     // TODO
@@ -116,6 +177,45 @@ public:
     return ES->lookup({&JITDL}, Mangle(Name.str()));
 #endif
   }
+#else
+  JITSymbol lookup(const std::string &Name) {
+#ifdef _WIN32
+    // The symbol lookup of ObjectLinkingLayer uses the SymbolRef::SF_Exported
+    // flag to decide whether a symbol will be visible or not, when we call
+    // IRCompileLayer::findSymbolIn with ExportedSymbolsOnly set to true.
+    //
+    // But for Windows COFF objects, this flag is currently never set.
+    // For a potential solution see: https://reviews.llvm.org/rL258665
+    // For now, we allow non-exported symbols on Windows as a workaround.
+    const bool ExportedSymbolsOnly = false;
+#else
+    const bool ExportedSymbolsOnly = true;
+#endif
+
+    // Search modules in reverse order: from last added to first added.
+    // This is the opposite of the usual search order for dlsym, but makes more
+    // sense in a REPL where we want to bind to the newest available definition.
+    for (auto H : make_range(ModuleKeys.rbegin(), ModuleKeys.rend()))
+      if (auto Sym = CompileLayer.findSymbolIn(H, Name, ExportedSymbolsOnly))
+        return Sym;
+
+    // If we can't find the symbol in the JIT, try looking in the host process.
+    if (auto SymAddr = RTDyldMemoryManager::getSymbolAddressInProcess(Name))
+      return JITSymbol(SymAddr, JITSymbolFlags::Exported);
+
+#ifdef _WIN32
+    // For Windows retry without "_" at beginning, as RTDyldMemoryManager uses
+    // GetProcAddress and standard libraries like msvcrt.dll use names
+    // with and without "_" (for example "_itoa" but "sin").
+    if (Name.length() > 2 && Name[0] == '_')
+      if (auto SymAddr =
+              RTDyldMemoryManager::getSymbolAddressInProcess(Name.substr(1)))
+        return JITSymbol(SymAddr, JITSymbolFlags::Exported);
+#endif
+
+    return nullptr;
+  }
+#endif
 };
 
 } // end namespace orc

--- a/src/libasr/codegen/KaleidoscopeJIT.h
+++ b/src/libasr/codegen/KaleidoscopeJIT.h
@@ -101,8 +101,10 @@ public:
 
   const DataLayout &getDataLayout() const { return DL; }
 
-  Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> Ctx) {
-    auto res =  CompileLayer.add(JITDL,
+  JITDylib &getMainJITDylib() { return JITDL; }
+
+  Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> Ctx, ResourceTrackerSP RT) {
+    auto res =  CompileLayer.add(RT,
                             ThreadSafeModule(std::move(M), std::move(Ctx)));
     return res;
   }

--- a/src/libasr/codegen/KaleidoscopeJIT.h
+++ b/src/libasr/codegen/KaleidoscopeJIT.h
@@ -101,10 +101,9 @@ public:
 
   const DataLayout &getDataLayout() const { return DL; }
 
-  Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> &Ctx) {
+  Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> Ctx) {
     auto res =  CompileLayer.add(JITDL,
                             ThreadSafeModule(std::move(M), std::move(Ctx)));
-    Ctx = std::make_unique<LLVMContext>();
     return res;
   }
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3977,11 +3977,10 @@ public:
                 + std::string(x.m_name) + "'");
             */
             F = llvm_symtab_fn[h];
-        } else if ((F = evaluator->get_module().getFunction(x.m_name))) {
+        } else if ((compiler_options.interactive) && (F = evaluator->get_module().getFunction(x.m_name))) {
             // It is possible that the function prototype is present, but llvm_symtab_fn.find(h) returns end
             // This can only happen in interactive mode
             // This happens because the prototype was generated from previous REPL block and hash has changed
-            LCOMPILERS_ASSERT(compiler_options.interactive);
             llvm_symtab_fn[h] = F;
         } else {
             llvm::FunctionType* function_type = llvm_utils->get_function_type(x, &evaluator->get_module());

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3977,6 +3977,12 @@ public:
                 + std::string(x.m_name) + "'");
             */
             F = llvm_symtab_fn[h];
+        } else if ((F = evaluator->get_module().getFunction(x.m_name))) {
+            // It is possible that the function prototype is present, but llvm_symtab_fn.find(h) returns end
+            // This can only happen in interactive mode
+            // This happens because the prototype was generated from previous REPL block and hash has changed
+            LCOMPILERS_ASSERT(compiler_options.interactive);
+            llvm_symtab_fn[h] = F;
         } else {
             llvm::FunctionType* function_type = llvm_utils->get_function_type(x, &evaluator->get_module());
             if( ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface ) {

--- a/src/libasr/codegen/asr_to_llvm.h
+++ b/src/libasr/codegen/asr_to_llvm.h
@@ -7,13 +7,13 @@
 
 namespace LCompilers {
 
-    Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
-            diag::Diagnostics &diagnostics,
-            llvm::LLVMContext &context, Allocator &al,
-            LCompilers::PassManager& pass_manager,
-            CompilerOptions &compiler_options,
-            const std::string &run_fn,
-            const std::string &infile);
+    Result<bool> asr_to_llvm(ASR::TranslationUnit_t &asr,
+        diag::Diagnostics &diagnostics,
+        std::unique_ptr<LLVMEvaluator> &evaluator,
+        Allocator &al,
+        LCompilers::PassManager& pass_manager,
+        CompilerOptions &co, const std::string &run_fn,
+        const std::string &infile, bool interactive=false);
 
 } // namespace LCompilers
 

--- a/src/libasr/codegen/asr_to_llvm.h
+++ b/src/libasr/codegen/asr_to_llvm.h
@@ -13,7 +13,7 @@ namespace LCompilers {
         Allocator &al,
         LCompilers::PassManager& pass_manager,
         CompilerOptions &co, const std::string &run_fn,
-        const std::string &infile, bool interactive=false);
+        const std::string &infile);
 
 } // namespace LCompilers
 

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -67,6 +67,9 @@
 #include <libasr/asr.h>
 #include <libasr/string_utils.h>
 
+extern "C" {
+float _lfortran_stan(float x);
+}
 
 namespace LCompilers {
 
@@ -131,6 +134,8 @@ LLVMEvaluator::LLVMEvaluator(const std::string &t)
 
     // For some reason the JIT requires a different TargetMachine
     jit = cantFail(llvm::orc::KaleidoscopeJIT::Create());
+    
+    _lfortran_stan(0.5);
 }
 
 LLVMEvaluator::~LLVMEvaluator()

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -175,6 +175,8 @@ void LLVMEvaluator::add_module_with_code(const std::string &source) {
     std::cout << "---------------------------------------------" << std::endl;
     */
     add_module();
+    context = std::make_unique<llvm::LLVMContext>();
+    module = std::make_unique<llvm::Module>("LFortran", *context);
 }
 
 void LLVMEvaluator::add_module(std::string symbol_name) {

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -32,8 +32,13 @@ class LLVMEvaluator
 {
 private:
     std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit;
+#if LLVM_VERSION_MAJOR >= 12
     std::unordered_map<std::string, std::pair<std::unique_ptr<llvm::Module>, std::unique_ptr<llvm::LLVMContext>>> llvm_modules;
     std::unordered_map<std::string, llvm::orc::ResourceTrackerSP> RT_map;
+#else
+    std::unordered_map<std::string, std::unique_ptr<llvm::Module>> llvm_modules;
+    std::unordered_map<std::string, llvm::orc::VModuleKey> RT_map;
+#endif
     std::unique_ptr<llvm::LLVMContext> context;
     std::unique_ptr<llvm::Module> module;
     std::string target_triple;

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -4,7 +4,9 @@
 #include <complex>
 #include <iostream>
 #include <memory>
+#include <unordered_map> 
 
+#include <llvm/ExecutionEngine/Orc/Core.h>
 #include <libasr/alloc.h>
 #include <libasr/asr_scopes.h>
 #include <libasr/asr.h>
@@ -30,6 +32,8 @@ class LLVMEvaluator
 {
 private:
     std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit;
+    std::unordered_map<std::string, std::pair<std::unique_ptr<llvm::Module>, std::unique_ptr<llvm::LLVMContext>>> llvm_modules;
+    std::unordered_map<std::string, llvm::orc::ResourceTrackerSP> RT_map;
     std::unique_ptr<llvm::LLVMContext> context;
     std::unique_ptr<llvm::Module> module;
     std::string target_triple;
@@ -38,8 +42,10 @@ public:
     LLVMEvaluator(const std::string &t = "");
     ~LLVMEvaluator();
     std::unique_ptr<llvm::Module> parse_module(const std::string &source);
-    void add_module(const std::string &source);
-    void add_module();
+    void add_module_with_code(const std::string &source);
+    void add_module(std::string symbol_name="");
+    void append_module_context_pair(std::string symbol_name);
+    void evaluate_module_context_pair();
     intptr_t get_symbol_address(const std::string &name);
     std::string get_asm();
     void save_asm_file( const std::string &filename);

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -26,22 +26,12 @@ namespace llvm {
 
 namespace LCompilers {
 
-class LLVMModule
-{
-public:
-    std::unique_ptr<llvm::Module> m_m;
-    LLVMModule(std::unique_ptr<llvm::Module> m);
-    ~LLVMModule();
-    std::string str();
-    // Return a function return type as a string (real / integer)
-    std::string get_return_type(const std::string &fn_name);
-};
-
 class LLVMEvaluator
 {
 private:
     std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit;
     std::unique_ptr<llvm::LLVMContext> context;
+    std::unique_ptr<llvm::Module> module;
     std::string target_triple;
     llvm::TargetMachine *TM;
 public:
@@ -49,17 +39,18 @@ public:
     ~LLVMEvaluator();
     std::unique_ptr<llvm::Module> parse_module(const std::string &source);
     void add_module(const std::string &source);
-    void add_module(std::unique_ptr<llvm::Module> mod);
-    void add_module(std::unique_ptr<LLVMModule> m);
+    void add_module();
     intptr_t get_symbol_address(const std::string &name);
-    std::string get_asm(llvm::Module &m);
-    void save_asm_file(llvm::Module &m, const std::string &filename);
-    void save_object_file(llvm::Module &m, const std::string &filename);
+    std::string get_asm();
+    void save_asm_file( const std::string &filename);
+    void save_object_file( const std::string &filename);
     void create_empty_object_file(const std::string &filename);
-    void opt(llvm::Module &m);
+    void opt();
     static std::string module_to_string(llvm::Module &m);
     static void print_version_message();
     llvm::LLVMContext &get_context();
+    llvm::Module &get_module();
+    std::string get_return_type(const std::string &fn_name);
     static void print_targets();
     static std::string get_default_target_triple();
 


### PR DESCRIPTION
Example:
```text
>>> function f(x) result(r)
... integer :: x
... integer :: r
... r = x
... end function f
>>> f(1)
1
>>> function f(x) result(r)
... integer :: x
... integer :: r
... r = x + 1
... end function f
>>> f(1)
2
>>> function f(x) result(r)
... real :: x
... real :: r
... r = x * x
... end function f
>>> f(1.5)
2.25
```

TODO:
- [ ] Add tests
- [ ] Check LLVM version compatibility
- [ ] Fix bug with dependency (Can be done in a separate PR?)

---
Reference:
Bug with dependency (Example)
```text
>>> function add(x, y) result(r)
... integer :: x
... integer :: y
... integer :: r
... r = x + y
... end function add
>>> add(2, 3)
5
>>> function sub(x, y) result(r)
... integer :: x
... integer :: y
... integer :: r
... r = add(x, -y)
... end function sub
>>> sub(2, 3)
-1
>>> function add(x, y) result(r)
... integer :: x
... integer :: y
... integer :: r
... r = x + y + 1
... end function add
>>> sub(2, 3)
[1]    95183 segmentation fault (core dumped)  /home/vipul/Workspace/others/lfortran/src/bin/lfortran   
```

Discussion: https://lfortran.zulipchat.com/#narrow/stream/197339-general/topic/LPython.3A.20Interactive.20Shell.20Discussion/near/447108665