### PR TITLE
feat: add support for handling `ArraySection_t` inside `WHERE` clause

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -977,6 +977,7 @@ RUN(NAME where_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 

--- a/integration_tests/where_10.f90
+++ b/integration_tests/where_10.f90
@@ -1,0 +1,92 @@
+program where_10
+   implicit none
+   real, parameter :: zero = 0.0
+
+   integer :: i
+
+   real :: first_array(1, 4)
+   integer :: second_array(2, 4)
+   logical :: third_array(2, 4)
+
+   real :: first_output(1, 4)
+   integer :: second_output(2, 4)
+   logical :: third_output(2, 4)
+
+   first_array = reshape([0.0, 1.0, 0.0, 1.0], [1, 4])
+   second_array = reshape([1, 2, 0, 4, 5, 0, 7, 0], [2, 4])
+   third_array = reshape([.false., .true., .true., .true., .false., .true., .false., .true.], [2, 4])
+
+
+   where (first_array(1, :) == zero)
+      first_array(1, :) = 2.0
+   end where
+
+   print *, first_array
+   first_output = reshape([2.0, 1.0, 2.0, 1.0], [1, 4])
+   if (all(first_array /= first_output)) error stop
+
+   where (second_array(:, 4) /= 0)
+      second_array(:, 4) = 22
+   end where
+
+   print *, second_array
+   second_output = reshape([1, 2, 0, 4, 5, 0, 22, 0], [2, 4])
+   if (all(second_array /= second_output)) error stop
+
+   i = 1
+   where (first_array(i, :) > 1.0)
+      first_array(i, :) = 22.0
+   end where
+
+   print *, first_array
+   first_output = reshape([22.0, 1.0, 22.0, 1.0], [1, 4])
+   if (all(first_array /= first_output)) error stop
+
+   where (third_array(2, :))
+      second_array(2, :) = 1
+   end where
+
+   print *, second_array
+   second_output = reshape([1, 1, 0, 1, 5, 1, 22, 1], [2, 4])
+   if (all(second_array /= second_output)) error stop
+
+   where (third_array(2, :) .neqv. .false.)
+      third_array(2, :) = .false.
+   end where
+
+   print *, third_array
+   third_output = reshape([.false., .false., .true., .false., .false., .false., .false., .false.], [2, 4])
+   if (all(third_array .neqv. third_output)) error stop
+
+
+   ! Assignment like:
+   !     first_array(1, :) = first_array(1, :) + 1
+   ! is currently not supported inside the `WHERE` clause.
+   !
+   ! Uncomment after supporting the above:
+   !
+   ! where (first_array(1, :) > 1.0)
+   !    first_array(1, :) = first_array(1, :) + 1
+   ! end where
+   !
+   ! print *, first_array
+   ! first_output = reshape([3.0, 1.0, 3.0, 1.0], [1, 4])
+   ! if (all(first_array /= first_output)) error stop
+   !
+   ! =========================================================
+   !
+   ! Array section expressions like second_array(:, :)
+   ! is currently not supported inside `WHERE` clause.
+   !
+   ! Uncomment after supporting the above:
+   !
+   ! where (second_array(:, :) /= 0)
+   !    second_array(:, :) = 10
+   ! end where
+   !
+   ! print *, second_array
+   ! second_output = reshape([10, 10, 0, 10, 10, 0, 10, 0], [2, 4])
+   ! if (all(second_array /= second_output)) error stop
+
+
+end program where_10


### PR DESCRIPTION
resolves #4317 

The `array_op` pass converts every array section assignment statement into it's own `DO` loop and uses the loop variable for the assignment. This caused an issue with handling array section assignments inside the `WHERE` clause, as here we need the main `DO` loop variable for both condition check and assignment due to the array shapes being same. 

We add native support for handling `ArraySection_t` in the `where` pass to handle this.

```fortran
where (first_array(1, :) == zero)
    first_array(1, :) = 2.0
end where
```
is converted to
```fortran
first_array(1, __1_k) = 2.00000000e+00
do __1_k = lbound(first_array(1, lbound(first_array, 2):ubound(first_array, 2)), 1), ubound(first_array(1,&
         lbound(first_array, 2):ubound(first_array, 2)), 1), 1
    if (first_array(1, __1_k) == zero) then
        first_array(1, __1_k) = 2.00000000e+00
    end if
end do
```

### Output
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
   2.00000000       1.00000000       2.00000000       1.00000000    
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
2.00000000e+00 1.00000000e+00 2.00000000e+00 1.00000000e+00 

```