### PR TITLE
Add compile time and runtime tests for scalar for sind, cosd and tand intrinsic

### DIFF
--- a/integration_tests/intrinsics_214.f90
+++ b/integration_tests/intrinsics_214.f90
@@ -1,5 +1,7 @@
 program intrinsics_214
     use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32
+    real(sp) :: a, b, c
+    real(dp) :: d, e, f
     integer :: i
 
     real(dp) :: w(19)
@@ -59,5 +61,49 @@ program intrinsics_214
         print *, sind(x(i))
         if (abs(sind(x(i)) - expected_x(i)) > 1e-5) error stop
     end do
+
+    a = 18.928_sp
+    b = 32.627_sp
+    c = 47.123_sp
+
+    d = 18.829262783_dp
+    e = 32.727262783_dp
+    f = 47.223262783_dp
+
+    print *, sind(a)
+    if (abs(sind(a) - 0.324379712) > 1e-3) error stop
+
+    print *, sind(b)
+    if (abs(sind(b) - 0.539167702) > 1e-3) error stop
+
+    print *, sind(c)
+    if (abs(sind(c) - 0.732816100) > 1e-3) error stop
+
+    print *, sind(18.928_sp)
+    if (abs(sind(18.928_sp) - 0.324379712) > 1e-3) error stop
+
+    print *, sind(32.627_sp)
+    if (abs(sind(32.627_sp) - 0.539167702) > 1e-3) error stop
+
+    print *, sind(47.123_sp)
+    if (abs(sind(47.123_sp) - 0.732816100) > 1e-3) error stop
+
+    print *, sind(d)
+    if (abs(sind(d) - 0.32274913716473685) > 1e-3) error stop
+
+    print *, sind(e)
+    if (abs(sind(e) - 0.54064067144737327) > 1e-3) error stop
+
+    print *, sind(f)
+    if (abs(sind(f) - 0.73400566544830548) > 1e-3) error stop
+
+    print *, sind(18.829262783_dp)
+    if (abs(sind(18.829262783_dp) - 0.32274913716473685) > 1e-3) error stop
+
+    print *, sind(32.727262783_dp)
+    if (abs(sind(32.727262783_dp) - 0.54064067144737327) > 1e-3) error stop
+
+    print *, sind(47.223262783_dp)
+    if (abs(sind(47.223262783_dp) - 0.73400566544830548) > 1e-3) error stop
 
 end program

--- a/integration_tests/intrinsics_215.f90
+++ b/integration_tests/intrinsics_215.f90
@@ -1,5 +1,7 @@
 program intrinsics_215
     use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32
+    real(sp) :: a, b, c
+    real(dp) :: d, e, f
     integer :: i
 
     real(dp) :: w(19)
@@ -60,5 +62,49 @@ program intrinsics_215
         print *, cosd(x(i))
         if (abs(cosd(x(i)) - expected_x(i)) > 1e-5) error stop
     end do
+
+    a = 18.928_sp
+    b = 32.627_sp
+    c = 47.123_sp
+
+    d = 18.829262783_dp
+    e = 32.727262783_dp
+    f = 47.223262783_dp
+
+    print *, cosd(a)
+    if (abs(cosd(a) - 0.945926964) > 1e-3) error stop
+
+    print *, cosd(b)
+    if (abs(cosd(b) - 0.842198431) > 1e-3) error stop
+
+    print *, cosd(c)
+    if (abs(cosd(c) - 0.680426717) > 1e-3) error stop
+
+    print *, cosd(18.928_sp)
+    if (abs(cosd(18.928_sp) - 0.945926964) > 1e-3) error stop
+
+    print *, cosd(32.627_sp)
+    if (abs(cosd(32.627_sp) - 0.842198431) > 1e-3) error stop
+
+    print *, cosd(47.123_sp)
+    if (abs(cosd(47.123_sp) - 0.680426717) > 1e-3) error stop
+
+    print *, cosd(d)
+    if (abs(cosd(d) - 0.94648454528292103) > 1e-3) error stop
+
+    print *, cosd(e)
+    if (abs(cosd(e) - 0.84125362666495140) > 1e-3) error stop
+
+    print *, cosd(f)
+    if (abs(cosd(f) - 0.67914334502356000) > 1e-3) error stop
+
+    print *, cosd(18.829262783_dp)
+    if (abs(cosd(18.829262783_dp) - 0.94648454528292103) > 1e-3) error stop
+
+    print *, cosd(32.727262783_dp)
+    if (abs(cosd(32.727262783_dp) - 0.84125362666495140) > 1e-3) error stop
+
+    print *, cosd(47.223262783_dp)
+    if (abs(cosd(47.223262783_dp) - 0.67914334502356000) > 1e-3) error stop
 
 end program

--- a/integration_tests/intrinsics_216.f90
+++ b/integration_tests/intrinsics_216.f90
@@ -1,5 +1,7 @@
 program intrinsics_216
     use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32
+    real(sp) :: a, b, c
+    real(dp) :: d, e, f
     integer :: i
 
     real(dp) :: w(18)
@@ -59,5 +61,49 @@ program intrinsics_216
         print *, tand(x(i))
         if (abs(tand(x(i)) - expected_x(i)) > 1e-5) error stop
     end do
+
+    a = 18.928_sp
+    b = 32.627_sp
+    c = 47.123_sp
+
+    d = 18.829262783_dp
+    e = 32.727262783_dp
+    f = 47.223262783_dp
+
+    print *, tand(a)
+    if (abs(tand(a) - 0.342922598) > 1e-3) error stop
+
+    print *, tand(b)
+    if (abs(tand(b) - 0.640190780) > 1e-3) error stop
+
+    print *, tand(c)
+    if (abs(tand(c) - 1.07699490) > 1e-3) error stop
+
+    print *, tand(18.928_sp)
+    if (abs(tand(18.928_sp) - 0.342922598) > 1e-3) error stop
+
+    print *, tand(32.627_sp)
+    if (abs(tand(32.627_sp) - 0.640190780) > 1e-3) error stop
+
+    print *, tand(47.123_sp)
+    if (abs(tand(47.123_sp) - 1.07699490) > 1e-3) error stop
+
+    print *, tand(d)
+    if (abs(tand(d) - 0.34099778889496968) > 1e-3) error stop
+
+    print *, tand(e)
+    if (abs(tand(e) - 0.64266073192537432) > 1e-3) error stop
+
+    print *, tand(f)
+    if (abs(tand(f) - 1.0807816506290617) > 1e-3) error stop
+
+    print *, tand(18.829262783_dp)
+    if (abs(tand(18.829262783_dp) - 0.34099778889496968) > 1e-3) error stop
+
+    print *, tand(32.727262783_dp)
+    if (abs(tand(32.727262783_dp) - 0.64266073192537432) > 1e-3) error stop
+
+    print *, tand(47.223262783_dp)
+    if (abs(tand(47.223262783_dp) - 1.0807816506290617) > 1e-3) error stop
 
 end program


### PR DESCRIPTION
Towards: #3067 