### PR TITLE
fix: minor bug when creation of module lead to asr verify failure in openmp

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1683,4 +1683,5 @@ RUN(NAME openmp_26 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_27 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_28 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_29 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
-RUN(NAME openmp_30 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_30 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # matmul
+RUN(NAME openmp_31 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)

--- a/integration_tests/openmp_31.f90
+++ b/integration_tests/openmp_31.f90
@@ -1,0 +1,19 @@
+program openmp_31
+    implicit none
+    real :: phi(100)
+    integer :: j
+
+    phi = 10124.142
+
+    !$omp parallel do private(j) shared(phi)
+
+    do j = 1, 100
+        print *, phi(1)
+        phi(1) = phi(1) + 1
+    end do
+
+    !$omp end parallel do
+
+    print *, phi(1)
+    if (abs(phi(1) - 10224.1416) > 1e-8) error stop
+end program openmp_31


### PR DESCRIPTION
Towards #4388, #3777.

With this the example in #4388 compiles but it gives all `0.00`, I think a small piece is missing.