### PR TITLE
enh: add support for handling arrays on either side of the test expression in `WHERE` clause

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -982,6 +982,7 @@ RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 

--- a/integration_tests/where_11.f90
+++ b/integration_tests/where_11.f90
@@ -1,0 +1,38 @@
+program where_11
+   implicit none
+
+   integer :: a(3)
+   integer :: b(3)
+
+   a = [1, 0, 1]
+   b = [0, 0, 0]
+
+   where (1 == a) b = 11
+   print *, b
+   if (all(b /= [11, 0, 11])) error stop
+
+   where (1 == get_integer_array()) b = 22
+   print *, b
+   if (all(b /= [22, 0, 22])) error stop
+
+   where (1 < get_integer_array()) b = 33
+   print *, b
+   if (all(b /= [22, 33, 22])) error stop
+
+   where ([1, 2, 1] == 1) b = 44
+   print *, b
+   if (all(b /= [44, 33, 44])) error stop
+
+   where (get_integer_array() > 1) b = 55
+   print *, b
+   if (all(b /= [44, 55, 44])) error stop
+
+contains
+
+   function get_integer_array() result(arr)
+      implicit none
+      integer :: arr(3)
+      arr = [1, 2, 1]
+   end function
+
+end program where_11

--- a/tests/reference/pass_where-where_04-2ee4397.json
+++ b/tests/reference/pass_where-where_04-2ee4397.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_where-where_04-2ee4397.stdout",
-    "stdout_hash": "a133a70d6f6134a40624508e8fa96179ff313f8cd535595786bcc475",
+    "stdout_hash": "9c75d0dabc818d46a59cdcca1a8451039349905177e0cddaa327c4e4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_where-where_04-2ee4397.stdout
+++ b/tests/reference/pass_where-where_04-2ee4397.stdout
@@ -152,14 +152,42 @@
                                         ()
                                         ((Var 3 __1_k)
                                         (ArrayBound
-                                            (Var 3 __libasr__created__var__1_x)
+                                            (FunctionCall
+                                                2 solution
+                                                ()
+                                                []
+                                                (Allocatable
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                )
+                                                ()
+                                                ()
+                                            )
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
                                             LBound
                                             ()
                                         )
                                         (ArrayBound
-                                            (Var 3 __libasr__created__var__1_x)
+                                            (FunctionCall
+                                                2 solution
+                                                ()
+                                                []
+                                                (Allocatable
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                )
+                                                ()
+                                                ()
+                                            )
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
                                             UBound


### PR DESCRIPTION
resolves #4335 

```fortran
program main
   
   implicit none

   integer :: a(3)
   integer :: b(3)
   a = [1, 0, 1]
   b = [0, 0, 0]

   where ( 1 == a ) b = 555

   print *, b

end program main
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ gfortran ./examples/example.f90 && ./a.out
         555           0         555
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
555 0 555 
```