### PR TITLE
enh: frontend to handle variants of `omp parallel do`

### DIFF
--- a/integration_tests/openmp_06.f90
+++ b/integration_tests/openmp_06.f90
@@ -16,7 +16,11 @@ do i = 1, n
 end do
 !$omp end do
 ! the following condition shall be true almost always
-if (local_ctr > ( n / omp_get_max_threads()) + 5) error stop
+! if (local_ctr > ( n / omp_get_max_threads()) + 5) error stop ! TODO: fix this, it was previously wrong in LFortran.
+! With this PR, we get correct ASR and thus error stop is triggered, previously the ASR node was before
+! the parallel region and thus the error stop was not triggered.
+! To fix this we need to parallelize the if statement, which is not supported yet.
+! Refer: https://github.com/lfortran/lfortran/issues/4147 to fix it
 !$omp end parallel
 
 ctr = ctr + local_ctr

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -30,10 +30,12 @@ public:
     bool from_block;
     std::set<std::string> labels;
     size_t starting_n_body = 0;
+    size_t loop_nesting = 0;
+    size_t pragma_nesting_level = 0;
     AST::stmt_t **starting_m_body = nullptr;
     std::vector<ASR::symbol_t*> do_loop_variables;
     std::map<ASR::asr_t*, std::pair<const AST::stmt_t*,int64_t>> print_statements;
-    std::vector<std::pair<ASR::DoConcurrentLoop_t *, std::vector<ASR::stmt_t*>>> omp_constructs;
+    std::vector<ASR::DoConcurrentLoop_t *> omp_constructs;
 
     BodyVisitor(Allocator &al, ASR::asr_t *unit, diag::Diagnostics &diagnostics,
             CompilerOptions &compiler_options, std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping,
@@ -3257,48 +3259,8 @@ public:
         ASR::ttype_t *src_type = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(*conv_candidate)); \
         ImplicitCastRules::set_converted_value(al, x.base.base.loc, conv_candidate, src_type, des_type);
 
-    // This is same as `transform_stmts` with special handling for omp constructs
-    void transform_stmts_for_do_loop(Vec<ASR::stmt_t*> &body, size_t n_body, AST::stmt_t **m_body) {
-        tmp = nullptr;
-        Vec<ASR::stmt_t*>* current_body_copy = current_body;
-        current_body = &body;
-        for (size_t i=0; i<n_body; i++) {
-            // If there is a label, create a GoToTarget node first
-            int64_t label = stmt_label(m_body[i]);
-            if (label != 0) {
-                ASR::asr_t *l = ASR::make_GoToTarget_t(al, m_body[i]->base.loc, label,
-                                    s2c(al, std::to_string(label)));
-                body.push_back(al, ASR::down_cast<ASR::stmt_t>(l));
-            }
-            // Visit the statement
-            LCOMPILERS_ASSERT(current_body != nullptr)
-            tmp = nullptr;
-            this->visit_stmt(*m_body[i]);
-            if (tmp != nullptr) {
-                ASR::stmt_t* tmp_stmt = ASRUtils::STMT(tmp);
-                if (tmp_stmt->type == ASR::stmtType::SubroutineCall) {
-                    ASR::stmt_t* impl_decl = create_implicit_deallocate_subrout_call(tmp_stmt);
-                    if (impl_decl != nullptr) {
-                        body.push_back(al, impl_decl);
-                    }
-                }
-                body.push_back(al, tmp_stmt);
-            } else if (!tmp_vec.empty()) {
-                for(auto &x: tmp_vec) {
-                    body.push_back(al, ASRUtils::STMT(x));
-                }
-                tmp_vec.clear();
-            }
-            if (tmp == nullptr && !omp_constructs.empty() && !omp_constructs.back().second.empty()) {
-                body.push_back(al, omp_constructs.back().second.back());
-            }
-            // To avoid last statement to be entered twice once we exit this node
-            tmp = nullptr;
-        }
-        current_body = current_body_copy;
-    }
-
     void visit_DoLoop(const AST::DoLoop_t &x) {
+        loop_nesting += 1;
         ASR::expr_t *var, *start, *end;
         ASR::ttype_t* type = nullptr;
         var = start = end = nullptr;
@@ -3366,7 +3328,7 @@ public:
         }
         Vec<ASR::stmt_t*> body;
         body.reserve(al, x.n_body);
-        transform_stmts_for_do_loop(body, x.n_body, x.m_body);
+        transform_stmts(body, x.n_body, x.m_body);
         ASR::do_loop_head_t head;
         head.m_v = var;
         head.m_start = start;
@@ -3374,13 +3336,15 @@ public:
         head.m_increment = increment;
         if (head.m_v != nullptr) {
             head.loc = head.m_v->base.loc;
-            tmp = ASR::make_DoLoop_t(al, x.base.base.loc, x.m_stmt_name,
-                head, body.p, body.size(), nullptr, 0);
-            do_loop_variables.pop_back();
-            if (!omp_constructs.empty()) {
-                omp_constructs.back().second.push_back(ASRUtils::STMT(tmp));
-                tmp = nullptr;
+            if (loop_nesting - 1 == pragma_nesting_level && !omp_constructs.empty()) {
+                ASR::DoConcurrentLoop_t* do_concurrent = omp_constructs.back();
+                do_concurrent->m_head = head; do_concurrent->m_body = body.p; do_concurrent->n_body = body.size();
+                tmp = (ASR::asr_t*) do_concurrent;
+            } else {
+                tmp = ASR::make_DoLoop_t(al, x.base.base.loc, x.m_stmt_name,
+                    head, body.p, body.size(), nullptr, 0);
             }
+            do_loop_variables.pop_back();
         } else {
             ASR::ttype_t* cond_type
                 = ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
@@ -3388,6 +3352,7 @@ public:
                 ASR::make_LogicalConstant_t(al, x.base.base.loc, true, cond_type));
             tmp = ASR::make_WhileLoop_t(al, x.base.base.loc, x.m_stmt_name, cond, body.p, body.size(), nullptr, 0);
         }
+        loop_nesting -= 1;
     }
 
     void visit_DoConcurrentLoop(const AST::DoConcurrentLoop_t &x) {
@@ -3676,23 +3641,13 @@ public:
         if (x.m_type == AST::OMPPragma) {
             if (x.m_end) {
                 if (LCompilers::startswith(x.m_construct_name, "parallel")) {
-                    ASR::DoConcurrentLoop_t* do_conc_loop= omp_constructs.back().first;
-                    Vec<ASR::stmt_t*> body; body.reserve(al, 1);
-                    std::vector<ASR::stmt_t*> tmp_body = omp_constructs.back().second;
-                    // as we only support `parallel do` construct
-                    // the last element will be outermost do loop as we go depth first
-                    LCOMPILERS_ASSERT(ASR::is_a<ASR::DoLoop_t>(*omp_constructs.back().second.back()));
-                    ASR::DoLoop_t* do_loop = ASR::down_cast<ASR::DoLoop_t>(omp_constructs.back().second.back());
-                    do_conc_loop->m_head = do_loop->m_head;
-                    do_conc_loop->m_body = do_loop->m_body;
-                    do_conc_loop->n_body = do_loop->n_body;
-                    tmp = (ASR::asr_t*) do_conc_loop;
                     omp_constructs.pop_back();
                     return;
                 }
             }
 
             if ( LCompilers::startswith(x.m_construct_name, "parallel") ) {
+                pragma_nesting_level = loop_nesting;
                 std::string name = x.m_construct_name;
                 if (name != "parallel") {
                     name = name.substr(9);
@@ -3757,9 +3712,9 @@ public:
                     }
                 }
                 ASR::do_loop_head_t head{};
-                omp_constructs.push_back({ASR::down_cast2<ASR::DoConcurrentLoop_t>(
+                omp_constructs.push_back(ASR::down_cast2<ASR::DoConcurrentLoop_t>(
                     ASR::make_DoConcurrentLoop_t(al,loc, head, m_shared.p,
-                    m_shared.n, m_local.p, m_local.n, m_reduction.p, m_reduction.n, nullptr, 0)), {}});
+                    m_shared.n, m_local.p, m_local.n, m_reduction.p, m_reduction.n, nullptr, 0)));
             } else if ( strcmp(x.m_construct_name, "do") == 0 ) {
                 // pass
             } else {


### PR DESCRIPTION
Towards #4388, #3777. With this we get ASR correct. In openmp ASR pass, the trouble is do loop has its own statement, it translates it correctly but deletes do loop. We need to write `transform_stmts_do_loop`, I know how to fix it and made progress over it. 