### PR TITLE
enh: openmp pass to handle pragma inside do loop

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1686,3 +1686,4 @@ RUN(NAME openmp_28 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_29 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_30 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # matmul
 RUN(NAME openmp_31 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_32 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)

--- a/integration_tests/openmp_32.f90
+++ b/integration_tests/openmp_32.f90
@@ -1,0 +1,20 @@
+program openmp_32
+    use omp_lib
+    implicit none
+    real :: phi
+    integer :: j, i
+
+    phi = 10124.142
+
+    call omp_set_num_threads(4)
+    do i = 1, 10
+        !$omp parallel do private(j) reduction(+:phi)
+        do j = 1, 100
+            phi = phi + 1.0
+        end do
+        !$omp end parallel do
+    end do
+
+    print *, phi
+    if (abs(phi - 11124.1416) > 1e-8) error stop
+end program openmp_32

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -446,7 +446,6 @@ class DoConcurrentVisitor :
                 pass_result.n = 0;
                 current_stmt_index = i;
                 pass_result.reserve(al, 1);
-                pass_result_allocatable.reserve(al, 1);
                 remove_original_statement = false;
                 visit_stmt(*m_body[i]);
                 for (size_t j=0; j < pass_result.size(); j++) {

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -436,6 +436,34 @@ class DoConcurrentVisitor :
             remove_original_statement = remove_original_statement_copy;
         }
 
+        void transform_stmts_do_loop(ASR::stmt_t **&m_body, size_t &n_body) {
+            bool remove_original_statement_copy = remove_original_statement;
+            Vec<ASR::stmt_t*> body;
+            body.reserve(al, n_body);
+            current_m_body = m_body;
+            current_n_body = n_body;
+            for (size_t i=0; i<n_body; i++) {
+                pass_result.n = 0;
+                current_stmt_index = i;
+                pass_result.reserve(al, 1);
+                pass_result_allocatable.reserve(al, 1);
+                remove_original_statement = false;
+                visit_stmt(*m_body[i]);
+                for (size_t j=0; j < pass_result.size(); j++) {
+                    body.push_back(al, pass_result[j]);
+                }
+                if( !remove_original_statement ) {
+                    body.push_back(al, m_body[i]);
+                }
+            }
+            m_body = body.p;
+            n_body = body.size();
+            current_m_body = nullptr;
+            current_n_body = 0;
+            pass_result.n = 0;
+            remove_original_statement = remove_original_statement_copy;
+        }
+
         std::string import_all(const ASR::Module_t* m, bool to_submodule=false) {
             // Import all symbols from the module, e.g.:
             //     use a
@@ -1306,10 +1334,14 @@ class DoConcurrentVisitor :
             pass_result.push_back(al, ASRUtils::STMT(ASR::make_SubroutineCall_t(al, x.base.base.loc, current_scope->get_symbol("gomp_parallel"), nullptr,
                                 call_args.p, call_args.n, nullptr)));
 
-            // update all reduction variables in statements after this.
-            ReductionVariableVisitor rvv(al, current_scope, ASRUtils::symbol_name(thread_data_sym), data_expr, reduction_variables);
-            for (size_t i = current_stmt_index + 1; i < current_n_body; i++) {
-                rvv.visit_stmt(*current_m_body[i]);
+            for (auto it: reduction_variables) {
+                ASR::symbol_t* actual_sym = current_scope->resolve_symbol(it);
+                ASR::symbol_t* sym = current_scope->get_symbol(std::string(ASRUtils::symbol_name(thread_data_sym)) + "_" + it);
+                LCOMPILERS_ASSERT(sym != nullptr);
+                pass_result.push_back(al, b.Assignment(
+                    b.Var(actual_sym),
+                    ASRUtils::EXPR(ASR::make_StructInstanceMember_t(al, x.base.base.loc, data_expr, sym, ASRUtils::symbol_type(sym), nullptr)
+                )));
             }
             reduction_variables.clear();
 
@@ -1353,6 +1385,15 @@ class DoConcurrentVisitor :
 
             transform_stmts(xx.m_body, xx.n_body);
             current_scope = current_scope_copy;
+        }
+
+        void visit_DoLoop(const ASR::DoLoop_t &x) {
+            ASR::DoLoop_t& xx = const_cast<ASR::DoLoop_t&>(x);
+
+            visit_do_loop_head(xx.m_head);
+
+            transform_stmts_do_loop(xx.m_body, xx.n_body);
+            transform_stmts_do_loop(xx.m_orelse, xx.n_orelse);
         }
 
 };


### PR DESCRIPTION
Fixes #4388. Towads #3777. With this PR we get it working.
> Serial

```console
% gfortran b.f90 && ./a.out 
 Done steps  =           100
 Done steps  =           200
 Done steps  =           300
 Done steps  =           400
 Done steps  =           500
 Done steps  =           600
 Done steps  =           700
 Done steps  =           800
 Done steps  =           900
 Done steps  =          1000
   8.1156792211894978E-023   3.5746070221702888E-022   5.2919810042527039E-023   1.2024036703484373E-022

% lfortran b.f90 
style suggestion: Use '==' instead of '.eq.'
   --> b.f90:161:36
    |
161 |         if ( mod( tsteps, nprint ) .eq. 0 ) print *, 'Done steps  =  ', tsteps
    |                                    ^^^^ help: write this as '=='


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
Done steps  =   100
Done steps  =   200
Done steps  =   300
Done steps  =   400
Done steps  =   500
Done steps  =   600
Done steps  =   700
Done steps  =   800
Done steps  =   900
Done steps  =   1000
8.11890548559992338e-23 5.29347833517143053e-23 
3.57477363872004304e-22 1.20244357112337166e-22 

```


> openmp

```console
% lfortran b.f90 --openmp --openmp-lib-dir=$CONDA_PREFIX/lib       
style suggestion: Use '==' instead of '.eq.'
   --> b.f90:161:36
    |
161 |         if ( mod( tsteps, nprint ) .eq. 0 ) print *, 'Done steps  =  ', tsteps
    |                                    ^^^^ help: write this as '=='


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
Done steps  =   100
Done steps  =   200
Done steps  =   300
Done steps  =   400
Done steps  =   500
Done steps  =   600
Done steps  =   700
Done steps  =   800
Done steps  =   900
Done steps  =   1000
8.11890548559992338e-23 5.29347833517143053e-23 
3.57477363872004304e-22 1.20244357112337166e-22 

% gfortran b.f90 -fopenmp && ./a.out
 Done steps  =           100
 Done steps  =           200
 Done steps  =           300
 Done steps  =           400
 Done steps  =           500
 Done steps  =           600
 Done steps  =           700
 Done steps  =           800
 Done steps  =           900
 Done steps  =          1000
  0.57349606629159489       0.56949953099083217       0.56946976603681299       0.56929291068471366 
```