### PR TITLE
Implied loop on structinstancemember

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1124,6 +1124,7 @@ RUN(NAME derived_types_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN derived_types_35_file.txt)
 RUN(NAME derived_types_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME line_continuation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME line_continuation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/derived_types_37.f90
+++ b/integration_tests/derived_types_37.f90
@@ -1,0 +1,37 @@
+program derived_types_37
+    implicit none
+    
+    TYPE test_type2
+        integer :: num
+    END TYPE test_type2
+
+    TYPE test_type1
+        integer :: num
+        integer :: arr_1(3)
+        type(test_type2):: arr_2(3)
+    END TYPE test_type1
+
+    integer :: i
+    
+    TYPE(test_type1), DIMENSION(5) :: main_arr
+
+    
+    main_arr%num = 44
+    do i =1, 5
+        print *, main_arr(i)%num
+        if(main_arr(i)%num /= 44) error stop
+    end do
+    
+    
+    main_arr(1)%arr_1 = 33
+    do i =1, 3
+        print *,main_arr(1)%arr_1(i)
+        if(main_arr(1)%arr_1(i) /= 33) error stop
+    end do
+
+    main_arr(1)%arr_2%num = 22
+    do i =1, 3
+        print *,main_arr(1)%arr_2(i)%num
+        if(main_arr(1)%arr_2(i)%num /= 22) error stop
+    end do
+end program derived_types_37

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8092,6 +8092,69 @@ public:
             tmp = ASR::make_StructInstanceMember_t(al, loc, ASRUtils::EXPR(tmp), tmp2_m_m_ext,
                 ASRUtils::fix_scoped_type(al, tmp2_mem_type, current_scope), nullptr);
         }
+        // Find array in the returning tmp expression. If found set tmp type to that array type.  
+        bool array_found = false;
+        ASR::ttype_t* array_type = nullptr; // will be set if only one single array is found. It'd be used to change the type of tmp.
+        ASR::asr_t* tmp_copy = tmp;
+        while(ASR::is_a<ASR::StructInstanceMember_t>(*ASRUtils::EXPR(tmp_copy)) || 
+            (ASR::is_a<ASR::ArrayItem_t>(*ASRUtils::EXPR(tmp_copy)) &&
+             ASR::is_a<ASR::StructInstanceMember_t>(*(ASR::down_cast<ASR::ArrayItem_t>(ASRUtils::EXPR(tmp_copy)))->m_v))){
+            ASR::StructInstanceMember_t* tmp2 = nullptr;
+            bool check_m_m = true; 
+            if(ASR::is_a<ASR::ArrayItem_t>(*ASRUtils::EXPR(tmp_copy))){
+                tmp2 = ASR::down_cast<ASR::StructInstanceMember_t>(ASR::down_cast<ASR::ArrayItem_t>(ASRUtils::EXPR(tmp_copy))->m_v);
+                check_m_m = false;
+            } else if (ASR::is_a<ASR::StructInstanceMember_t>(*ASRUtils::EXPR(tmp_copy))) {
+                tmp2 = ASR::down_cast<ASR::StructInstanceMember_t>(ASRUtils::EXPR(tmp_copy));
+            }
+
+            if(check_m_m){
+                ASR::ExternalSymbol_t* tmp2_m_m_ext = ASR::down_cast<ASR::ExternalSymbol_t>(tmp2->m_m);
+                if(ASR::is_a<ASR::Variable_t>(*(tmp2_m_m_ext->m_external)) && 
+                    ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(ASRUtils::symbol_type(tmp2_m_m_ext->m_external)))){
+                    if(array_found){
+                        throw SemanticError("Two or more part references with non-zero rank must not be specified.", loc);
+                    }
+                    array_found = true;
+                    array_type = ASRUtils::duplicate_type(al,ASRUtils::symbol_type(tmp2->m_m));                        
+                }
+            }
+            if(tmp2->m_v->type == ASR::exprType::Var){
+                ASR::ttype_t* var_type = ASRUtils::expr_type(tmp2->m_v);
+                if(ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(var_type))){
+                    if(array_found){
+                        throw SemanticError("Two or more part references with non-zero rank must not be specified.", loc);
+                    }
+                    array_found = true;
+                    array_type = ASRUtils::duplicate_type(al,var_type);
+                }
+            }
+            tmp_copy = (ASR::asr_t*)(tmp2->m_v);
+        }
+        if(array_type){
+            if(ASR::is_a<ASR::StructInstanceMember_t>(*ASRUtils::EXPR(tmp))){
+                ASR::StructInstanceMember_t* tmp2 = ASR::down_cast<ASR::StructInstanceMember_t>(ASRUtils::EXPR(tmp)); 
+                if(ASR::is_a<ASR::Array_t>(*array_type)){
+                    (ASR::down_cast<ASR::Array_t>(array_type))->m_type = ASRUtils::type_get_past_array(tmp2->m_type);
+                    tmp2->m_type = array_type;
+                }
+                if(ASR::is_a<ASR::Allocatable_t>(*array_type)){
+                    ASR::down_cast<ASR::Array_t>((ASR::down_cast<ASR::Allocatable_t>(array_type))->m_type)->m_type = ASRUtils::type_get_past_array(ASRUtils::type_get_past_allocatable(tmp2->m_type));
+                    tmp2->m_type = array_type;
+                }
+                
+            } else if (ASR::is_a<ASR::ArrayItem_t>(*ASRUtils::EXPR(tmp))) {
+                ASR::ArrayItem_t* tmp2 = ASR::down_cast<ASR::ArrayItem_t>(ASRUtils::EXPR(tmp));
+                if(ASR::is_a<ASR::Array_t>(*array_type)){
+                    (ASR::down_cast<ASR::Array_t>(array_type))->m_type = ASRUtils::type_get_past_array(tmp2->m_type);
+                    tmp2->m_type = array_type;
+                }
+                if(ASR::is_a<ASR::Allocatable_t>(*array_type)){
+                    ASR::down_cast<ASR::Array_t>((ASR::down_cast<ASR::Allocatable_t>(array_type))->m_type)->m_type = ASRUtils::type_get_past_array(ASRUtils::type_get_past_allocatable(tmp2->m_type));
+                    tmp2->m_type = array_type;
+                }
+            }
+        }
     }
 
     void visit_Name(const AST::Name_t &x) {

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -149,17 +149,57 @@ namespace LCompilers {
                 ai.m_step = nullptr;
                 args.push_back(al, ai);
             }
-
+            ASR::expr_t* arr_expr_copy = arr_expr; 
+            ASR::expr_t** original_arr_expr =&arr_expr_copy; 
+            ASR::expr_t** array_ref_container_node = nullptr; // If we have a structInstanceMember hierarch, It'd be used to emplace the resulting array_ref in the correct node.
+            ASR::expr_t* array_ref = nullptr;
+            ASR::StructInstanceMember_t* tmp = nullptr;
+            
+            // if first depth of hierarchy contains array, don't set array_ref_container_node and return array_ref directly.
+            if (ASR::is_a<ASR::StructInstanceMember_t>(*arr_expr) && 
+                ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(
+                    ASRUtils::symbol_type(ASR::down_cast<ASR::StructInstanceMember_t>(arr_expr)->m_m)))){ 
+                original_arr_expr = &array_ref;
+            }
+            // This while loop is used to fetch the only single array from a structInstanceMember hierarchy.
+            // We assume there's a single array in the hierarachy, as multiple arrays should throw semantic error while building ASR.
+            bool check_m_m = true;
+            while(ASR::is_a<ASR::StructInstanceMember_t>(*arr_expr) && !array_ref_container_node ){
+                tmp = ASR::down_cast<ASR::StructInstanceMember_t>(arr_expr);
+                if(ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(tmp->m_v)))){
+                    arr_expr = tmp->m_v;
+                    array_ref_container_node = &(tmp->m_v); 
+                } else if (ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(ASRUtils::symbol_type(tmp->m_m))) && check_m_m){
+                    array_ref_container_node = &arr_expr;
+                } else if(ASR::is_a<ASR::StructInstanceMember_t>(*tmp->m_v)){
+                    arr_expr = tmp->m_v;
+                    check_m_m =true;    
+                } else if (ASR::is_a<ASR::ArrayItem_t>(*tmp->m_v)){
+                    arr_expr = ASR::down_cast<ASR::ArrayItem_t>(tmp->m_v)->m_v;
+                    check_m_m = false;
+                } else {
+                    break;
+                }
+            }
             ASR::ttype_t* array_ref_type = ASRUtils::duplicate_type_without_dims(
                 al, ASRUtils::expr_type(arr_expr), arr_expr->base.loc);
             fix_struct_type_scope()
-            ASR::expr_t* array_ref = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al,
+            array_ref = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al,
                                         arr_expr->base.loc, arr_expr,
                                         args.p, args.size(),
                                         ASRUtils::type_get_past_array(
                                             ASRUtils::type_get_past_pointer(
                                                 ASRUtils::type_get_past_allocatable(array_ref_type))),
                                         ASR::arraystorageType::RowMajor, nullptr));
+            // Emplace the resulting array_ref in the correct node.                          
+            if(array_ref_container_node){
+                *array_ref_container_node = array_ref;
+                array_ref = *original_arr_expr;
+                if(ASR::is_a<ASR::StructInstanceMember_t>(*array_ref)){
+                    ASR::StructInstanceMember_t* tmp = ASR::down_cast<ASR::StructInstanceMember_t>(array_ref);
+                    tmp->m_type = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_allocatable(tmp->m_type))->m_type; // Using type of the returing array to avoid creating array ref again by array_op pass.
+                }
+            }
             if( perform_cast ) {
                 LCOMPILERS_ASSERT(casted_type != nullptr);
                 array_ref = ASRUtils::EXPR(ASR::make_Cast_t(al, array_ref->base.loc,

--- a/tests/errors/derived_type_06.f90
+++ b/tests/errors/derived_type_06.f90
@@ -1,0 +1,17 @@
+program derived_type_06
+    implicit none
+    
+    TYPE test_type2
+        integer :: num
+    END TYPE test_type2
+
+    TYPE test_type1
+        type(test_type2):: arr_2(3)
+    END TYPE test_type1
+
+    TYPE(test_type1), DIMENSION(5) :: main_arr
+
+    main_arr%arr_2%num = 22
+
+
+end program derived_type_06

--- a/tests/reference/run-derived_type_06-2623a81.json
+++ b/tests/reference/run-derived_type_06-2623a81.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-derived_type_06-2623a81",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/derived_type_06.f90",
+    "infile_hash": "002cfbfb5901ee3c9f0d5e33285543863528f17c4b8096e1a0e49134",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-derived_type_06-2623a81.stderr",
+    "stderr_hash": "13dc71322f8815413728c8a98468757fda295f39e22ab066b2874734",
+    "returncode": 1
+}

--- a/tests/reference/run-derived_type_06-2623a81.stderr
+++ b/tests/reference/run-derived_type_06-2623a81.stderr
@@ -1,0 +1,5 @@
+semantic error: Two or more part references with non-zero rank must not be specified.
+  --> tests/errors/derived_type_06.f90:14:5
+   |
+14 |     main_arr%arr_2%num = 22
+   |     ^^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3480,6 +3480,10 @@ filename = "errors/derived_type_05.f90"
 asr = true
 
 [[test]]
+filename = "errors/derived_type_06.f90"
+run = true
+
+[[test]]
 filename = "errors/array_01.f90"
 asr = true
 


### PR DESCRIPTION
fixes #4348 

Mainly, This fix does the following :
- sets  whole node type of `structInstanceMember` resulting from `visit_nameutils()` to array, if an array is found in the node (it could be buried in the hierarchy). This makes the node detectable by `array_op` pass so it create array reference around it (`arrayItem`).
- It triggers an error if more than on than array found in the hierarchy of `structInstanceMember` (`Two or more part references with non-zero rank must not be specified.`) . though `visit_nameutils()` tends to detect that error but it doesn't. (**It needs some refactoring**).
- When we create array reference in `array_op` pass, we start looking up for the node that's of an array type then we wrap an array item around it.
- Once we finished the work on `array_op` we set the type of `structInstanceMember` to that should get returned after referencing the array.

The fix may seem a little overwhelming due to the nesting of type members.
If you have any thoughts about refactoring the fix, inform me.