### PR TITLE
feat: implement intrinsic `compiler_version`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1688,3 +1688,5 @@ RUN(NAME openmp_29 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_30 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # matmul
 RUN(NAME openmp_31 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_32 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
+
+RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/compiler_version_01.f90
+++ b/integration_tests/compiler_version_01.f90
@@ -1,0 +1,5 @@
+program compiler_version_01
+    use, intrinsic :: iso_fortran_env
+    implicit none
+    print *, compiler_version()
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -839,6 +839,7 @@ public:
         {"dim", {IntrinsicSignature({"X", "Y"}, 2, 2)}},
         {"selected_real_kind", {IntrinsicSignature({"p", "r", "radix"}, 0, 3)}},
         {"nearest", {IntrinsicSignature({"x", "s"}, 2, 2)}},
+        {"compiler_version", {IntrinsicSignature({}, 0, 0)}},
         {"ishftc", {IntrinsicSignature({"i", "shift"}, 2, 2)}},
         {"ichar", {IntrinsicSignature({"C", "kind"}, 1, 2)}},
         {"char", {IntrinsicSignature({"I", "kind"}, 1, 2)}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -63,6 +63,7 @@ inline std::string get_intrinsic_name(int64_t x) {
         INTRINSIC_NAME_CASE(Trailz)
         INTRINSIC_NAME_CASE(Isnan)
         INTRINSIC_NAME_CASE(Nearest)
+        INTRINSIC_NAME_CASE(CompilerVersion)
         INTRINSIC_NAME_CASE(Spacing)
         INTRINSIC_NAME_CASE(Modulo)
         INTRINSIC_NAME_CASE(BesselJ0)
@@ -280,6 +281,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {&Isnan::instantiate_Isnan, &Isnan::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Nearest),
             {&Nearest::instantiate_Nearest, &Nearest::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerVersion),
+            {nullptr, &CompilerVersion::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Spacing),
             {&Spacing::instantiate_Spacing, &Spacing::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Modulo),
@@ -593,6 +596,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "isnan"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Nearest),
             "nearest"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerVersion),
+            "compiler_version"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Spacing),
             "spacing"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Modulo),
@@ -896,6 +901,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"trailz", {&Trailz::create_Trailz, &Trailz::eval_Trailz}},
                 {"isnan", {&Isnan::create_Isnan, &Isnan::eval_Isnan}},
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
+                {"compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
                 {"spacing", {&Spacing::create_Spacing, &Spacing::eval_Spacing}},
                 {"modulo", {&Modulo::create_Modulo, &Modulo::eval_Modulo}},
                 {"bessel_jn", {&BesselJN::create_BesselJN, &BesselJN::eval_BesselJN}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -134,6 +134,7 @@ enum class IntrinsicElementalFunctions : int64_t {
     Dprod,
     Range,
     Sign,
+    CompilerVersion,
     SignFromValue,
     Logical,
     Nint,
@@ -943,6 +944,33 @@ namespace Range {
     }
 
 }  // namespace Range
+
+namespace CompilerVersion {
+
+    static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
+        ASRUtils::require_impl(x.n_args == 0,
+            "ASR Verify: compiler_version() takes no argument",
+            x.base.base.loc, diagnostics);
+    }
+
+    static ASR::expr_t *eval_CompilerVersion(Allocator &al, const Location &loc,
+            ASR::ttype_t */*t1*/, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
+        ASRUtils::ASRBuilder b(al, loc);
+        return b.StringConstant(LFORTRAN_VERSION, character(-1));
+    }
+
+    static inline ASR::asr_t* create_CompilerVersion(Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
+        ASR::ttype_t *return_type = character(-1);
+        ASR::expr_t *m_value = nullptr;
+        return_type = ASRUtils::extract_type(return_type);
+        m_value = eval_CompilerVersion(al, loc, return_type, args, diag);
+            if (diag.has_error()) {
+                return nullptr;
+            }
+        return ASR::make_IntrinsicElementalFunction_t(al, loc, static_cast<int64_t>(IntrinsicElementalFunctions::CompilerVersion),
+                nullptr, 0, 0, return_type, m_value);
+    }
+} // namespace CompilerVersion
 
 namespace Sign {
 


### PR DESCRIPTION
I am firstly sorry for duplicating efforts, I didn't checkout https://github.com/lfortran/lfortran/pull/4422. I think this approach is cleaner and fits with our design of implementing intrinsic. I am not sure if there is any further cleaning possible in this PR, I would appreciate any feedback.