### PR TITLE
set 'iostat' value as zero when reading from console

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2770,6 +2770,7 @@ LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, int32_t* iostat, in
 LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat) {
     if (unit_num == -1) {
         // Read from stdin
+        *iostat = 0;
         return;
     }
 


### PR DESCRIPTION
fixes #4357

I don't think we've a setup to test things at runtime, as it needs to explicitly accept input from console to ensure that things work, I haven't added any test for it