### PR TITLE
chore: set physical cast of argument correctly while creating implicit interface

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1026,6 +1026,8 @@ RUN(NAME implicit_interface_11 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_12 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_13 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_14 LABELS gfortran) # ! TODO: fix this test
+RUN(NAME implicit_interface_15 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface EXTRAFILES implicit_interface_15b)
+
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_15.f90
+++ b/integration_tests/implicit_interface_15.f90
@@ -1,0 +1,13 @@
+program implicit_interface_15
+real a(3)
+a = [1.0, 12.512, -3.512]
+call stfsm(a)
+end program
+
+
+subroutine stfsm( a )
+real :: a( 0: * )
+external :: strsm
+call strsm( a, 3 )
+return
+end

--- a/integration_tests/implicit_interface_15b.f90
+++ b/integration_tests/implicit_interface_15b.f90
@@ -1,0 +1,10 @@
+subroutine strsm( a, n )
+integer :: i, n
+real :: a(0 : *), res
+print *,"x"
+res = 0.0
+do i = 0, n - 1
+res = res + a(i)
+end do
+print *, res
+end

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5809,8 +5809,9 @@ public:
                 if (ASRUtils::is_array(var_type)) {
                     // For arrays like A(n, m) we use A(*) in BindC, so that
                     // the C ABI is just a pointer
+                    ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(var_type);
                     var_type = ASRUtils::duplicate_type_with_empty_dims(al, var_type,
-                        ASR::array_physical_typeType::PointerToDataArray, true);
+                        array_type->m_physical_type, true);
                 } else if (ASR::is_a<ASR::ArrayItem_t>(*var_expr) && compiler_options.legacy_array_sections) {
                     ASR::symbol_t* func_sym = parent_scope->resolve_symbol(func_name);
                     ASR::Function_t* func = nullptr;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5811,7 +5811,8 @@ public:
                     // the C ABI is just a pointer
                     ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(var_type);
                     var_type = ASRUtils::duplicate_type_with_empty_dims(al, var_type,
-                        array_type->m_physical_type, true);
+                        ( array_type->m_physical_type == ASR::array_physical_typeType::UnboundedPointerToDataArray ) ?
+                        array_type->m_physical_type : ASR::array_physical_typeType::PointerToDataArray, true);
                 } else if (ASR::is_a<ASR::ArrayItem_t>(*var_expr) && compiler_options.legacy_array_sections) {
                     ASR::symbol_t* func_sym = parent_scope->resolve_symbol(func_name);
                     ASR::Function_t* func = nullptr;


### PR DESCRIPTION
Fixes #4445.

PS: It is yet to register test for this PR. How shall I register it?

This is how I test it:

```console
% lfortran -c --generate-object-code ./integration_tests/implicit_interface_15b.f90
% lfortran -c --generate-object-code --implicit-interface ./integration_tests/implicit_interface_15.f90
% lfortran implicit_interface_15.o implicit_interface_15b.o                                            
x
1.00000000e+01
```