### PR TITLE
Fix : Memorize Pointer arrays for later initialization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -492,6 +492,7 @@ RUN(NAME arrays_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_50 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES arrays_50_mod.f90)
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME global_array_pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # GFortran

--- a/integration_tests/global_array_pointer_01.f90
+++ b/integration_tests/global_array_pointer_01.f90
@@ -1,0 +1,28 @@
+module global_array_pointer_01_mod
+    implicit none
+    integer, dimension(:), pointer :: ptr_in
+    integer, target :: i(1)
+    contains 
+    subroutine sub_arr_pointer1
+        ptr_in => i
+        i = [343]
+        print *, ptr_in(1)
+        print *, i(1)
+        if(ptr_in(1) /= 343) error stop 
+    end subroutine sub_arr_pointer1
+
+    subroutine sub_arr_pointer2
+        ptr_in(1) = 0
+        print *, ptr_in(1)
+        print *, i(1)
+        if(i(1) /= 0) error stop
+    end subroutine sub_arr_pointer2
+end module global_array_pointer_01_mod
+
+program global_array_pointer_01
+    use global_array_pointer_01_mod
+    implicit none
+    call sub_arr_pointer1
+    call sub_arr_pointer2
+end program global_array_pointer_01
+

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2818,13 +2818,13 @@ public:
                 m_dims, n_dims, a_kind, module.get());
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name,
                 x_ptr);
-            if (x.m_type->type == ASR::ttypeType::Allocatable){
+            if (ASRUtils::is_array(x.m_type)) { //memorize arrays only.
                 llvm::Type* type_ = llvm_utils->get_type_from_ttype_t_util(
-                            ASRUtils::type_get_past_allocatable(x.m_type), module.get(), x.m_abi);
+                           ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(x.m_type)), module.get(), x.m_abi);
                 allocatable_array_details.push_back({ptr,
                         type_,
                         x.m_type,
-                        (down_cast<ASR::Array_t>((down_cast<ASR::Allocatable_t>(x.m_type))->m_type))->n_dims});
+                        ASRUtils::extract_dimensions_from_ttype(x.m_type, m_dims)});
             }
             if (!external) {
                 if (init_value) {


### PR DESCRIPTION
fixes #4464 

The problem is the exact same as the one here https://github.com/lfortran/lfortran/pull/4111/files.

We needed to initialize to global array variable then we chose to memorize the data for such arrays,  and once we call `visit_program`   while creating LLVM IR the memorized data would be used to initialize the arrays inside the main function of the LLVM IR.