### PR TITLE
fix: Update installation.md in doc

### DIFF
--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -78,7 +78,7 @@ export PATH="$HOME/conda_root/bin:$PATH"
 ```
 Then prepare the environment:
 ```bash
-conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml
+conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml zstd-static pandoc gcc gxx
 conda activate lf
 ```
 Clone the LFortran git repository:

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -78,7 +78,7 @@ export PATH="$HOME/conda_root/bin:$PATH"
 ```
 Then prepare the environment:
 ```bash
-conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml zstd-static pandoc gcc gxx
+conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml zstd-static pandoc gcc gxx libcxx
 conda activate lf
 ```
 Clone the LFortran git repository:


### PR DESCRIPTION
When building from git source, I noticed that there are some packages that are not listed in the current documentation but are required.

I also noticed that builds fail if the gcc and gxx installed on the system are out of date, so I added the latest gcc and gxx from conda-forge.