### PR TITLE
fix -fdefault-integer-8 verification error for parameters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -871,6 +871,9 @@ RUN(NAME parameter_10 LABELS gfortran llvm NOFAST fortran) # sin
 RUN(NAME parameter_11 LABELS gfortran llvm fortran) # merge
 RUN(NAME parameter_12 LABELS gfortran llvm fortran) # implied do loops
 RUN(NAME parameter_13 LABELS gfortran llvm) # compile time example
+RUN(NAME parameter_14 LABELS gfortran llvm
+    EXTRA_ARGS -fdefault-integer-8
+    GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME modules_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME modules_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/parameter_14.f90
+++ b/integration_tests/parameter_14.f90
@@ -1,0 +1,7 @@
+      PROGRAM ERROR
+
+      REAL ONE
+      PARAMETER (ONE=1.0E+0)
+
+      END
+      

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -763,10 +763,16 @@ public:
         std::string runtime_func_name = "_lfortran_str_slice";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {
+            llvm::Type *integer_ty;
+            if (compiler_options.po.default_integer_kind == 8) {
+                integer_ty = llvm::Type::getInt64Ty(context);
+            } else {
+                integer_ty = llvm::Type::getInt32Ty(context);
+            }
             llvm::FunctionType *function_type = llvm::FunctionType::get(
                     character_type, {
-                        character_type, llvm::Type::getInt32Ty(context),
-                        llvm::Type::getInt32Ty(context), llvm::Type::getInt32Ty(context),
+                        character_type, integer_ty,
+                        integer_ty, integer_ty,
                         llvm::Type::getInt1Ty(context), llvm::Type::getInt1Ty(context)
                     }, false);
             fn = llvm::Function::Create(function_type,
@@ -6545,7 +6551,11 @@ public:
         switch( a_kind ) {
 
             case 4 : {
-                tmp = llvm::ConstantFP::get(context, llvm::APFloat((float)val));
+                if (compiler_options.po.default_integer_kind == 8) {
+                    tmp = llvm::ConstantFP::get(context, llvm::APFloat(val));
+                } else {
+                    tmp = llvm::ConstantFP::get(context, llvm::APFloat((float)val));
+                }
                 break;
             }
             case 8 : {


### PR DESCRIPTION
Fixed #4471
I have found that changing the `visit_RealConstant` inside of `asr_to_llvm.cpp` from:
```
void visit_RealConstant(const ASR::RealConstant_t &x) {
        double val = x.m_r;
        int a_kind = ((ASR::Real_t*)(&(x.m_type->base)))->m_kind;
        switch( a_kind ) {

            case 4 : {
                    tmp = llvm::ConstantFP::get(context, llvm::APFloat((float)val));
                }
                break;
            }
            case 8 : {
                tmp = llvm::ConstantFP::get(context, llvm::APFloat(val));
                break;
            }
            default : {
                break;
            }

        }

    }
```
to
```
void visit_RealConstant(const ASR::RealConstant_t &x) {
        double val = x.m_r;
        int a_kind = ((ASR::Real_t*)(&(x.m_type->base)))->m_kind;
        switch( a_kind ) {

            case 4 : {
                if (compiler_options.po.default_integer_kind == 8) {
                    tmp = llvm::ConstantFP::get(context, llvm::APFloat(val));
                } else {
                    tmp = llvm::ConstantFP::get(context, llvm::APFloat((float)val));
                }
                break;
            }
            case 8 : {
                tmp = llvm::ConstantFP::get(context, llvm::APFloat(val));
                break;
            }
            default : {
                break;
            }

        }

    }
```

Solves the issue. However this makes me wonder whether a_kind is not being used wrong here instead. I've noticed that the flag -fdefault-integer-8 has no impact on the value of a_kind, because of that im unsure if a_kind is not used for other purposes as I am not fully familiar with the codebase yet.