### PR TITLE
create a basic block for return in program always

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1262,6 +1262,8 @@ RUN(NAME return_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME return_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # contains module
 RUN(NAME return_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME return_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME return_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME return_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME file_01 LABELS gfortran llvm COPY_TO_BIN file_01_data.txt)
 RUN(NAME file_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_01_data.txt)

--- a/integration_tests/return_05.f90
+++ b/integration_tests/return_05.f90
@@ -1,0 +1,7 @@
+subroutine f()
+end subroutine
+
+program main
+    return
+    print *, "Hello world"
+end program main

--- a/integration_tests/return_06.f90
+++ b/integration_tests/return_06.f90
@@ -1,0 +1,3 @@
+program main
+    return
+end program main

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3182,6 +3182,7 @@ public:
             string_init(context, *module, *builder, value.second, init_value);
             builder->CreateStore(init_value, value.first);
         }
+        proc_return = llvm::BasicBlock::Create(context, "return");
         for (size_t i=0; i<x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
@@ -3190,6 +3191,7 @@ public:
         }
         call_lcompilers_free_strings();
 
+        start_new_block(proc_return);
         llvm::Value *ret_val2 = llvm::ConstantInt::get(context,
             llvm::APInt(32, 0));
         builder->CreateRet(ret_val2);

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "f38a9faaa66e5256e5bfb19ff468b4200b2d3035b4987af38b6ad001",
+    "stdout_hash": "a3b87c2aa6200714777b93ec05b2ce1ee4a55124ca97c9c856ca85b4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -768,6 +768,9 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
+  br label %return
+
+return:                                           ; preds = %ifcont12
   ret i32 0
 }
 

--- a/tests/reference/llvm-array2-4254183.json
+++ b/tests/reference/llvm-array2-4254183.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array2-4254183.stdout",
-    "stdout_hash": "43bce7749678875425c71fbb7b2a1e4be39dce03f4595c6e69989598",
+    "stdout_hash": "925eef131605b22eb13aabc93aefb3d05a162b500b4868ad90aee806",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array2-4254183.stdout
+++ b/tests/reference/llvm-array2-4254183.stdout
@@ -14,6 +14,9 @@ define i32 @main(i32 %0, i8** %1) {
   %h = alloca [24 x float], align 4
   %i = alloca [36 x i32], align 4
   %j = alloca [20 x i1], align 1
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "bde4a8669025ec9c0254415d34999602463e28565984f74e0f670ac2",
+    "stdout_hash": "fe7995a00f187fb7d83f0cb8a85863428b3c4715116ef91f401a39f5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -561,6 +561,9 @@ else155:                                          ; preds = %ifcont152
 ifcont156:                                        ; preds = %else155, %then154
   %21 = load i32, i32* %array_bound153, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont156
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01-91893af.json
+++ b/tests/reference/llvm-arrays_01-91893af.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01-91893af.stdout",
-    "stdout_hash": "e874efe3a11a46629971d978a87540e79856383fdc042ec0c4f96f72",
+    "stdout_hash": "38c7bae1009a9646ebc08991629f92d35cca0309b86740f2f4234455",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01-91893af.stdout
+++ b/tests/reference/llvm-arrays_01-91893af.stdout
@@ -306,6 +306,9 @@ else38:                                           ; preds = %ifcont36
   br label %ifcont39
 
 ifcont39:                                         ; preds = %else38, %then37
+  br label %return
+
+return:                                           ; preds = %ifcont39
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.json
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_complex-c90dbdd.stdout",
-    "stdout_hash": "af4178667e43ab32d87e18f968283836642b262668a4af2d2f54ff68",
+    "stdout_hash": "4109e73b564179546107d0b8ce780f71151a2422ec811e7b1b954593",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
@@ -859,6 +859,9 @@ else56:                                           ; preds = %ifcont54
   br label %ifcont57
 
 ifcont57:                                         ; preds = %else56, %then55
+  br label %return
+
+return:                                           ; preds = %ifcont57
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "a68aeaeb2a5c2c80681780899756ec7a523a42e30fd58b1d81b22580",
+    "stdout_hash": "85af90bb9c7a30b63492cda74e0435c7878b9417f0a275731807bafc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -461,6 +461,9 @@ else59:                                           ; preds = %ifcont57
   br label %ifcont60
 
 ifcont60:                                         ; preds = %else59, %then58
+  br label %return
+
+return:                                           ; preds = %ifcont60
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_real-6c5e850.json
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_real-6c5e850.stdout",
-    "stdout_hash": "f66e96f7e60354ec6c2d413365d8246b92255c1e0ca17c2da6bcdaed",
+    "stdout_hash": "843c13d55b07d0658ef69a2298dd2936c447af99e89f38a7c31bf87f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_real-6c5e850.stdout
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.stdout
@@ -425,6 +425,9 @@ else56:                                           ; preds = %ifcont54
   br label %ifcont57
 
 ifcont57:                                         ; preds = %else56, %then55
+  br label %return
+
+return:                                           ; preds = %ifcont57
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_size-aaed99f.json
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_size-aaed99f.stdout",
-    "stdout_hash": "4cb1bb04177f2163aee1f645f525293fe07a22677a156fa60cb2b940",
+    "stdout_hash": "b10209af93857e1578a161fc8eb5ebe17d61ba4726d6310103fdf37f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_size-aaed99f.stdout
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.stdout
@@ -346,6 +346,9 @@ else44:                                           ; preds = %ifcont42
   br label %ifcont45
 
 ifcont45:                                         ; preds = %else44, %then43
+  br label %return
+
+return:                                           ; preds = %ifcont45
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_03_func-98941b2.json
+++ b/tests/reference/llvm-arrays_03_func-98941b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_03_func-98941b2.stdout",
-    "stdout_hash": "e4c4e1b64ca16b9716a3d4df67b6fb2a179152a5adbd8d26cf4165aa",
+    "stdout_hash": "11923cd7211cd9bbc70de1b34b8e878bcbe073b5e8464336ac14d434",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_03_func-98941b2.stdout
+++ b/tests/reference/llvm-arrays_03_func-98941b2.stdout
@@ -101,6 +101,9 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_04_func-2aa342e.json
+++ b/tests/reference/llvm-arrays_04_func-2aa342e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_04_func-2aa342e.stdout",
-    "stdout_hash": "d92c46991120f16e842e1b7bb400fd6082f10e7c6cc152d13ae00e98",
+    "stdout_hash": "d4d0ea130f24b18b8c7ccab0a1c69b8326c02f4966a3249b53f39046",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_04_func-2aa342e.stdout
+++ b/tests/reference/llvm-arrays_04_func-2aa342e.stdout
@@ -120,6 +120,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_06-538e67d.json
+++ b/tests/reference/llvm-arrays_06-538e67d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_06-538e67d.stdout",
-    "stdout_hash": "c74ebf6dd03c77c96ed03b934e55c41d4348ca27242a501e18776f5e",
+    "stdout_hash": "37db11464032392c2ff6b954571b2266c56e58a76ea2a955e1aaa31c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_06-538e67d.stdout
+++ b/tests/reference/llvm-arrays_06-538e67d.stdout
@@ -1250,6 +1250,9 @@ loop.end238:                                      ; preds = %ifcont217
 loop.end239:                                      ; preds = %ifcont199
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %loop.end239
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_08_func-85e526b.json
+++ b/tests/reference/llvm-arrays_08_func-85e526b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_08_func-85e526b.stdout",
-    "stdout_hash": "0b29d71bc724fc4ce3abcbd90892237d2c65b0bb37af9a66f4e467fb",
+    "stdout_hash": "42ec262d1b57aa024b132d64d8a8663cfca7416d9440fb315cf2e9ee",
     "stderr": "llvm-arrays_08_func-85e526b.stderr",
     "stderr_hash": "d70481e5625f20fa12d3e8bdad4a5dfa6912ac62ade8fc840a5da64b",
     "returncode": 0

--- a/tests/reference/llvm-arrays_08_func-85e526b.stdout
+++ b/tests/reference/llvm-arrays_08_func-85e526b.stdout
@@ -178,6 +178,9 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_13-8ff7d44.json
+++ b/tests/reference/llvm-arrays_13-8ff7d44.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_13-8ff7d44.stdout",
-    "stdout_hash": "69d91d43dd703b564c90a7beebbe3abf35dfde52ec535cfa4193a504",
+    "stdout_hash": "51cf76f7f8b6cfa2613bf5d46309fe3ab2324211db500a354939102f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_13-8ff7d44.stdout
+++ b/tests/reference/llvm-arrays_13-8ff7d44.stdout
@@ -532,6 +532,9 @@ loop.end11:                                       ; preds = %loop.head
   call void @check_real(%array** %r)
   %173 = load %array*, %array** %r, align 8
   call void @check_real_without_pointer(%array* %173)
+  br label %return
+
+return:                                           ; preds = %loop.end11
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_25-5b87ac7.json
+++ b/tests/reference/llvm-arrays_25-5b87ac7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_25-5b87ac7.stdout",
-    "stdout_hash": "c8825369b440b994fd12d7d633a0ae2006d1cf6d50868548841d80c0",
+    "stdout_hash": "8eba7fd883e42b4cd6fdff86724020c165bda165643d99e43d128abc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_25-5b87ac7.stdout
+++ b/tests/reference/llvm-arrays_25-5b87ac7.stdout
@@ -271,6 +271,9 @@ loop.end3:                                        ; preds = %loop.head1
   %148 = load i32, i32* %147, align 4
   store i32 %148, i32* %call_arg_value4, align 4
   call void @decode_integer____0(i32* %134, i32* %call_arg_value, i32* %call_arg_value4)
+  br label %return
+
+return:                                           ; preds = %loop.end3
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_1-636d572.json
+++ b/tests/reference/llvm-arrays_op_1-636d572.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_1-636d572.stdout",
-    "stdout_hash": "7f9ab698c5eca6ad058078a11e13c114cba14bf669ce730ef4e9b67f",
+    "stdout_hash": "6aada93e260d07eb367be463c13e0a9962b561f513581247c29852d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_1-636d572.stdout
+++ b/tests/reference/llvm-arrays_op_1-636d572.stdout
@@ -1856,6 +1856,9 @@ else323:                                          ; preds = %ifcont321
   br label %ifcont324
 
 ifcont324:                                        ; preds = %else323, %then322
+  br label %return
+
+return:                                           ; preds = %ifcont324
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_2-c36ad8d.json
+++ b/tests/reference/llvm-arrays_op_2-c36ad8d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_2-c36ad8d.stdout",
-    "stdout_hash": "6282da8186da22d6a242fe2d4da366164b08a4fb0f086f8e211205d3",
+    "stdout_hash": "e242a9b979c752bb120f54b40792ce5832cc46f8bdafcaa4727d4028",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_2-c36ad8d.stdout
+++ b/tests/reference/llvm-arrays_op_2-c36ad8d.stdout
@@ -2167,6 +2167,9 @@ else469:                                          ; preds = %ifcont467
   br label %ifcont470
 
 ifcont470:                                        ; preds = %else469, %then468
+  br label %return
+
+return:                                           ; preds = %ifcont470
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "2a28eb8eb290ab50b4e9a7566cd2d034e9fb97bf3749478fe4299493",
+    "stdout_hash": "dfc22d2584b0bbd1e8d191b5ffebaa3fd19ca4eaaf4a658e1d080163",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -2004,6 +2004,9 @@ else63:                                           ; preds = %ifcont61
   br label %ifcont64
 
 ifcont64:                                         ; preds = %else63, %then62
+  br label %return
+
+return:                                           ; preds = %ifcont64
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_5-8426b5a.json
+++ b/tests/reference/llvm-arrays_op_5-8426b5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_5-8426b5a.stdout",
-    "stdout_hash": "94ddff0d415d660bc399c75f5aa5f3dc694235b475a40af4421c53f7",
+    "stdout_hash": "e01d72dc1cb6c217715d5a7a558d6fd807f9ccf9c8e9c964c74e956b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_5-8426b5a.stdout
+++ b/tests/reference/llvm-arrays_op_5-8426b5a.stdout
@@ -4002,6 +4002,9 @@ loop.end866:                                      ; preds = %ifcont794
   store i32 1, i32* %call_arg_value872, align 4
   store i32 1, i32* %call_arg_value873, align 4
   call void @check_complex__________0(%complex_4* %748, i32* %call_arg_value867, i32* %call_arg_value868, i32* %call_arg_value869, i32* %call_arg_value870, i32* %call_arg_value871, i32* %call_arg_value872, i32* %call_arg_value873)
+  br label %return
+
+return:                                           ; preds = %loop.end866
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_7-aeeda6d.json
+++ b/tests/reference/llvm-arrays_op_7-aeeda6d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_7-aeeda6d.stdout",
-    "stdout_hash": "0aa1e1a20b4d2192f407d0c9be0091b8e91f33be537fe3ae7354c53a",
+    "stdout_hash": "9fd1452f767df5d957754555f4172113c8d5dc802eb6573e9e908b2e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_7-aeeda6d.stdout
+++ b/tests/reference/llvm-arrays_op_7-aeeda6d.stdout
@@ -181,6 +181,9 @@ loop.body17:                                      ; preds = %ifcont16
 loop.end18:                                       ; preds = %ifcont16
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %loop.end18
   ret i32 0
 }
 

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "e90f633abe3b151805a5131cdb9e72218eccf3b9fa2816e43813e181",
+    "stdout_hash": "ee93f5f1b33c2dcd2294e01c939ed10182edb4569feea72b154d8fe3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -112,6 +112,9 @@ define i32 @main(i32 %0, i8** %1) {
   %44 = load float, float* %43, align 4
   %45 = fpext float %44 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @23, i32 0, i32 0), double %41, double %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "24f36aa054f23237a6c74e92d2590bc5990978d303a86f41ba037cdb",
+    "stdout_hash": "e98fac8a0d3deaa3d0054d9a72786aef1b5212bc4434a25d55150e9d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -58,6 +58,9 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
+  br label %return
+
+return:                                           ; preds = %ifcont3
   ret i32 0
 }
 

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "411009da70f37eda4d4359e2d54e796e3e616eb46182c8e2db507c14",
+    "stdout_hash": "c16183bbc19713cdf26351cf99025b0aae9df376bc79c8dbc08a9fa6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -90,6 +90,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "2ea0fc8ddff27d57eb10dadd6bf26fa7ab2f3b0c78615c59e2fe62c8",
+    "stdout_hash": "269137be1acc65019785d8595901785b62380e85d5722e36debf41d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -84,6 +84,9 @@ define i32 @main(i32 %0, i8** %1) {
   %48 = getelementptr %complex_8, %complex_8* %47, i32 0, i32 1
   %49 = load double, double* %48, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([41 x i8], [41 x i8]* @2, i32 0, i32 0), double %22, double %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %30, double %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %38, double %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %46, double %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "893fa63274d5809a1db0cf9d8dfc5ee3a82aa53cd74180e3b3b28f24",
+    "stdout_hash": "7a432ed8ff845b689bb9350c5f2756d1d24a5d018e41afa096738f33",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = fpext float %5 to double
   %7 = load double, double* %u, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([35 x i8], [35 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-bindc1-345b88c.json
+++ b/tests/reference/llvm-bindc1-345b88c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc1-345b88c.stdout",
-    "stdout_hash": "d8ddba869f74951269effc1a86074ef31f19fe46a79450d7319ca391",
+    "stdout_hash": "ed62e79c0e5a0784b1a8ea7aca98a9b2f74fadb88da3a623f1907edd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc1-345b88c.stdout
+++ b/tests/reference/llvm-bindc1-345b88c.stdout
@@ -10,6 +10,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32*, i32** %x, align 8
   %3 = bitcast i32* %2 to void*
   store void* %3, void** %p, align 8
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "d82e46ca53d3ac64fddb344b40906ac97b8b499389df3da32f46c6a1",
+    "stdout_hash": "d110d202384cfa05273bd36cd7d4b2cb1b18058dc27589f229677026",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -33,6 +33,9 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = bitcast i16* %y to void*
   %13 = ptrtoint void* %12 to i64
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @5, i32 0, i32 0), i64 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i64 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "d6094454d298a575d39b8d0383efa3f35514c061e5f2168c1cb46b22",
+    "stdout_hash": "f75028697d460b8bf7cf6ff56dc9c93f0703cdff32eaa9573fbbe5e6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @5, i32 0, i32 0), i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @8, i32 0, i32 0), i64 -1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "2058dc8f0a8aa01a4c445a16a6daef9e3b6209bea1b61462a765f69b",
+    "stdout_hash": "4eaafe5f9ff8d375508ac033aee4acfa0988fe5b8ec89a573b428c7c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -21,6 +21,9 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = load i32, i32* %boz_2, align 4
   %4 = load i32, i32* %boz_3, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "18d53697ae5cd0ccb8bf87632495b99a49133161d84ffbc3b0b3bc17",
+    "stdout_hash": "3939fc4e10f07fd453af5c0d86b75dfbca98fad1dc4748b66c6ad5df",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -59,6 +59,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.500000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_callback_01_foo(float* %call_arg_value, float* %call_arg_value1)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "f4500a5ade61d2a1ed011a0f073ca87032a9e4068f9881eedf0af3b3",
+    "stdout_hash": "f96bcd8ac3057a18a8e878d10dc882ba73e314e214a1ccb4781bdfea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -75,6 +75,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 2.000000e+00, float* %call_arg_value1, align 4
   %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @main.res)
   store float %2, float* @main.res, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "c885cc65048cfbedc6af03f67a419598e3e01b4dead6f5b6fc5cb100",
+    "stdout_hash": "72beb87f0458c8355038e5afb5c9fe8ebc68f90dcb4fbe4732d3a0dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -89,6 +89,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.500000e+00, float* %call_arg_value2, align 4
   store float 2.000000e+00, float* %call_arg_value3, align 4
   call void @__module_callback_03_foo2(float* %call_arg_value2, float* %call_arg_value3)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-callback_04-0d9515f.json
+++ b/tests/reference/llvm-callback_04-0d9515f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_04-0d9515f.stdout",
-    "stdout_hash": "639b794044c59c42bbe4ef726d0a3fc76d04921eb69e1dbfb91afbb2",
+    "stdout_hash": "03615459743504f31c1b70444197ef13278f867582b51aedb86768bc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_04-0d9515f.stdout
+++ b/tests/reference/llvm-callback_04-0d9515f.stdout
@@ -46,6 +46,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_dr)
   call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_fortran)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "d44fe1d3b71c3860c425447d819c32c946c7f4baaf2439a8da0929d8",
+    "stdout_hash": "07b64d915269a1dabfd563e1400f3c120bf51b71d3421362a580a84b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -54,6 +54,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 5, i32* @main.x, align 4
   call void @__module_callback_05_px_call1(i32* @main.x)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "172c44aa92b32f948e10f5efc659f9756213ee7b44afb797765728ec",
+    "stdout_hash": "f86f0ac6ffedb5be4d1e60714b462e5b2df51d6fada64004e6a6cacc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -150,6 +150,9 @@ else20:                                           ; preds = %ifcont18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
+  br label %return
+
+return:                                           ; preds = %ifcont21
   ret i32 0
 }
 

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "ebcb786f955f87bcdfd2e0c579bba56dce1fc33520501630ae11ec8c",
+    "stdout_hash": "438d953ef94e360dbc7852368bd45d17ded8316f8016b937b5e28a7a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -412,6 +412,9 @@ ifcont53:                                         ; preds = %ifcont52, %then39
 ifcont54:                                         ; preds = %ifcont53, %then37
   %102 = load i32, i32* %marks, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @98, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @95, i32 0, i32 0), i32 %102, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont54
   ret i32 0
 }
 

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "06d683945e25e3dce81d1e661bd5aaef906e9f4aa8b561de14d21ec8",
+    "stdout_hash": "fa6e4f1e2bcab9023b963fb765e1ec92ff1e4b5b28d9421e351addcc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -102,6 +102,9 @@ ifcont8:                                          ; preds = %else7, %then6
 ifcont9:                                          ; preds = %ifcont8, %then4
   %15 = load i32, i32* %marks, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont9
   ret i32 0
 }
 

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "c5ac8ce47cd30dc5838029ae1c432d91ebd3791f0f9cd68e7c59af9f",
+    "stdout_hash": "5649419ea18bc4957ca2230c81e2161965061cd89d2d1f17fefa8a94",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -81,6 +81,9 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %circle_polymorphic, %circle_polymorphic* %8, i32 0, i32 1
   store %circle* %c, %circle** %10, align 8
   call void @__module_class_circle1_circle_print(%circle_polymorphic* %8)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "a29b7d73785514a258fdfec0ab5623e00004097accb30ee05ff618d8",
+    "stdout_hash": "9fbdf0cafc28d2e11ab34b9f5d7b15bfc3c98f88609faa6dab96e034",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -84,6 +84,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_class_circle2__xx_lcompilers_changed_main_xx()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-class_03-d370451.json
+++ b/tests/reference/llvm-class_03-d370451.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_03-d370451.stdout",
-    "stdout_hash": "6c43f9383461c9ed9621149688084aa2dc07d2094c4be85a75cc77a1",
+    "stdout_hash": "b0cbab9bab96649664513997adbfc570fbb1345535cd3592f0cbcc94",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_03-d370451.stdout
+++ b/tests/reference/llvm-class_03-d370451.stdout
@@ -86,6 +86,9 @@ define i32 @main(i32 %0, i8** %1) {
   %49 = getelementptr %employee, %employee* %jill, i32 0, i32 1
   %50 = load i32, i32* %49, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([25 x i8], [25 x i8]* @14, i32 0, i32 0), i8* %37, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @13, i32 0, i32 0), i8* %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0), i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0), i8* %46, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @13, i32 0, i32 0), i8* %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0), i32 %50, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "06baf633c5794aa3b39951dc21ae6d66f558359d048d2c9972854958",
+    "stdout_hash": "931e643e72c20db0b3fcd1dfe0322c11bcadbeb93dc6ada5ae3e6141",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -80,6 +80,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex1-0e93fa9.json
+++ b/tests/reference/llvm-complex1-0e93fa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex1-0e93fa9.stdout",
-    "stdout_hash": "66f5e3bb2657168cf9910563896d04756ef0a6f8923dfb90487261b6",
+    "stdout_hash": "1d30668182ca63bc6ea30e5f72241811d021cc77d0c3b0bded3071d8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex1-0e93fa9.stdout
+++ b/tests/reference/llvm-complex1-0e93fa9.stdout
@@ -14,6 +14,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 4.000000e+00, float* %4, align 4
   %5 = load %complex_4, %complex_4* %2, align 4
   store %complex_4 %5, %complex_4* %x, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "7551e75902f3dd561cbf9d8444f9703543ae1fe68ef4ef1650650d53",
+    "stdout_hash": "2196524e848eab5f995987f1943312bad397b817e55bdb13a41a0684",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -118,6 +118,9 @@ define i32 @main(i32 %0, i8** %1) {
   %66 = load float, float* %65, align 4
   %67 = fpext float %66 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @8, i32 0, i32 0), double %63, double %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "ee28e3eae1b17f0bf5d24450302e5ba1d28692d8b8f044fb4b9dde60",
+    "stdout_hash": "052081ad9d5ab3c4f4d6f9dbfeb9606f251eb8059ea6ed89b510013f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -118,6 +118,9 @@ define i32 @main(i32 %0, i8** %1) {
   %66 = load float, float* %65, align 4
   %67 = fpext float %66 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @8, i32 0, i32 0), double %63, double %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "26aa4c84193e37ca7351f2673ce6d315870f5e7713157ca54e8d9a82",
+    "stdout_hash": "31d6c886fb3899f1b1c1e7c1d5df428b87197b559d51eb96185deadb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -67,6 +67,9 @@ define i32 @main(i32 %0, i8** %1) {
   %37 = load float, float* %36, align 4
   %38 = fpext float %37 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([30 x i8], [30 x i8]* @2, i32 0, i32 0), double %17, double %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %25, double %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %34, double %38, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "32178f71d400b528c1cadaf5b38b5a3f7da4c6d80cdcbf2cbcb4b6c1",
+    "stdout_hash": "6c05784cbedc41289dda74e50e96ed10b87716cfcf3302a0fc5681f3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -69,6 +69,9 @@ define i32 @main(i32 %0, i8** %1) {
   %35 = getelementptr %complex_8, %complex_8* %34, i32 0, i32 1
   %36 = load double, double* %35, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([32 x i8], [32 x i8]* @2, i32 0, i32 0), double %18, double %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %26, double %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %33, double %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "bf94a51b7aec013f4e5e96c56f19ca2f226eaeaaf7f484d9ae8cf08a",
+    "stdout_hash": "ac11e978b29d782b7a872d6f93be37bb033f43b7776aff636567a745",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -105,6 +105,9 @@ define i32 @main(i32 %0, i8** %1) {
   %58 = load float, float* %57, align 4
   %59 = fpext float %58 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @8, i32 0, i32 0), double %55, double %59, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "0fe79e7b07f1519c003c3681f7c316cfa6152703c9c242c8e281e69b",
+    "stdout_hash": "c324f6e46a6b3c5e544221a5493177d4dbc07494f413b06052473572",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -49,6 +49,9 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = load float, float* %22, align 4
   %24 = fpext float %23 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @2, i32 0, i32 0), double %20, double %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "2452e786af99ef52f374831b96cb05758e83806478e07ec6ddbd488a",
+    "stdout_hash": "14f88d18045e24a66ff97bdae6869fd0e74a83007f5386c4954e0d21",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -120,6 +120,9 @@ define i32 @main(i32 %0, i8** %1) {
   %67 = load float, float* %66, align 4
   %68 = fpext float %67 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @8, i32 0, i32 0), double %64, double %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "5d5950151d3724d7160c6af405ae582bad2b65029b91b4d950b5111a",
+    "stdout_hash": "1c28b3f40e891e4c43c3361805aba7af654c40765ffb3909319ae66a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = fpext float %5 to double
   %7 = load double, double* %u, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([35 x i8], [35 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-derived_types_01-ca40b30.json
+++ b/tests/reference/llvm-derived_types_01-ca40b30.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_01-ca40b30.stdout",
-    "stdout_hash": "a3a0a942aa1b3ab2c3f656f1d4096b1e9624fd78163ba49fb7f4ef36",
+    "stdout_hash": "491d51ee8ae9fc1bdfbfe1aa67d2d6132a29d870379d4c6a8e49f53b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_01-ca40b30.stdout
+++ b/tests/reference/llvm-derived_types_01-ca40b30.stdout
@@ -124,6 +124,9 @@ define i32 @main(i32 %0, i8** %1) {
   %71 = load float, float* %70, align 4
   %72 = fpext float %71 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @11, i32 0, i32 0), double %58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), double %68, double %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "8114e8fbbc90d47cd1193d8fe1379a129af3daf5bd8a7b23bbb836ae",
+    "stdout_hash": "87341eb2dd14c4b8627fcda92b5ab8ff017050a46e1cd0a78dfe0ad8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -186,6 +186,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-do7-8069d7a.json
+++ b/tests/reference/llvm-do7-8069d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-do7-8069d7a.stdout",
-    "stdout_hash": "ad6efc32c887489c812fccbd0a2e722a214f718673c35f068bcc0fed",
+    "stdout_hash": "c60cbb67ed092ce10a0a931c97e72fc56d39475a7406750a1b440424",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-do7-8069d7a.stdout
+++ b/tests/reference/llvm-do7-8069d7a.stdout
@@ -39,6 +39,9 @@ loop.body:                                        ; preds = %loop.head
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
+  br label %return
+
+return:                                           ; preds = %loop.end
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "a2c3c98df1949f4f081d845ff13e11a0c1058164897daddccda8333a",
+    "stdout_hash": "fbc51bff77710aa889bbe9bdca0ecb321ea8b4a49b60959d7c132398",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -469,6 +469,9 @@ else59:                                           ; preds = %loop.end57
 ifcont60:                                         ; preds = %else59, %then58
   %122 = load i32, i32* %j, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i32 %122, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont60
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "b4e7b8d220f9f97a0b3f6c03e15e63f684fd4bfbdfbf37692ad227ef",
+    "stdout_hash": "1d23925570cdba69b6274e1b81b3784505fe9ed2e190f29006859f4c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -177,6 +177,9 @@ else17:                                           ; preds = %loop.end15
 ifcont18:                                         ; preds = %else17, %then16
   %52 = load i32, i32* %a, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont18
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "b39d515a2301522e13b974cfff18b4b7d3be3b186463c89ba76f69b4",
+    "stdout_hash": "9f30ecdebacc78beec3897b8cc54f234c71e52760bcb3b1cf7ad0fc2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -186,6 +186,9 @@ else24:                                           ; preds = %loop.end22
 ifcont25:                                         ; preds = %else24, %then23
   %42 = load i32, i32* %j, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont25
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "f4119c193155eebf0e40118530ac5e2bf8ef9608981f13f2b263ceea",
+    "stdout_hash": "3ea522b53bdea99a02b419f1aa2593b4c4feb9b81ec1f94e7208b809",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -318,6 +318,9 @@ goto_target:                                      ; preds = %loop.body28
   br label %loop.head27
 
 loop.end29:                                       ; preds = %loop.head27
+  br label %return
+
+return:                                           ; preds = %loop.end29
   ret i32 0
 }
 

--- a/tests/reference/llvm-expr5-00f7fd9.json
+++ b/tests/reference/llvm-expr5-00f7fd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr5-00f7fd9.stdout",
-    "stdout_hash": "0898417fed250cb765fc03c843a4b7e2f73fed91aec22a5fe2b70a9b",
+    "stdout_hash": "e14d19b84426b47e84cdf922cd500bd385b26ea1a44528a490e0e901",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr5-00f7fd9.stdout
+++ b/tests/reference/llvm-expr5-00f7fd9.stdout
@@ -23,6 +23,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "5334d67a90c14e700462c2b5274d793054ddf77e3b27b017df0bb192",
+    "stdout_hash": "a3244b9d9e214238273b047f81f29e31167ed2ac08ca12a6106a20f5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -40,6 +40,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @b()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "28d1ff81a405dd169b309e1bf7b0f35744bf999819966d4e85e29ad9",
+    "stdout_hash": "6b81e1c62f8c4d8046115490b6d6e39d74d14ac60c326d72920dcdb3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -14,6 +14,9 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 1, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-functions_14-f13c087.json
+++ b/tests/reference/llvm-functions_14-f13c087.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-functions_14-f13c087.stdout",
-    "stdout_hash": "6310dc2874115d6a32c38cfaa2338bb588a216dbc298734af2df03c0",
+    "stdout_hash": "25d72f2e9f126730dbb3e52d0bd997c52ed85b481ed9fba1f1df4398",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-functions_14-f13c087.stdout
+++ b/tests/reference/llvm-functions_14-f13c087.stdout
@@ -14,6 +14,9 @@ declare i32 @expr()
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "f311263496b8ee32930de57ff992034ad148b3ac24489d89c3afd7d2",
+    "stdout_hash": "27a1f2d15fca8571ff8c5f87058cd840811033a4536f73605dee0327",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -201,6 +201,9 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
+  br label %return
+
+return:                                           ; preds = %ifcont9
   ret i32 0
 }
 

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "be6c2c8deb24d303332b1a0455178edb0e06a442e29b2f1a2d9d6e3e",
+    "stdout_hash": "f3baa94741485b60ed26cfa779583f020cfe946097df6bcfe3bf3661",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -171,6 +171,9 @@ ifcont:                                           ; preds = %else, %then
   %23 = add i32 %22, 1
   store i32 %23, i32* %__1_k, align 4
   call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "d901aaba8987a52b239277fbe18d32460e2b87905c6dc31081971c2d",
+    "stdout_hash": "4b4f85ee858fd5455b20e47b82547cc561df91214745deebff306472",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -75,6 +75,9 @@ define i32 @main(i32 %0, i8** %1) {
   %22 = load float, float* %21, align 4
   %23 = fpext float %22 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([50 x i8], [50 x i8]* @10, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), double 4.000000e+00, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), double %19, double %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), double -4.000000e+00, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "e11f15aea77a7ed1dae5d3f9e8c65c0ecaced7ef9c8e0009079a3617",
+    "stdout_hash": "a4d8bdb69b8f141eaca30b34c9bb035d26d36e02241fd97f1ff56fbe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -15,6 +15,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* @int_dp.u, align 4
   %3 = load i64, i64* @int_dp.v, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "8d3d6fa6f0ed5be35bdb430767524455d338eac5cb00620119f3238d",
+    "stdout_hash": "4cee6c94efa82a8d16b9c60fe4b68ddaf31daf56249bfd5bcb38f72f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -19,6 +19,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* @int_dp_param.u, align 4
   %3 = load i64, i64* @int_dp_param.v, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "752a4e24d0c9c54abc34e848efbeafc7d2bb4747492b303efdf36958",
+    "stdout_hash": "39b61585c5074ad5af74436967e318d403ab63524bfbb4182850f6d1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -45,6 +45,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0.000000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_dflt_intent_foo(float* %call_arg_value, float* %call_arg_value1)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-interface_12-2e5ecb8.json
+++ b/tests/reference/llvm-interface_12-2e5ecb8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-interface_12-2e5ecb8.stdout",
-    "stdout_hash": "815ca7d5abd17cc7a81b5bae768446a45a5b440bb8e5ec496d8c157c",
+    "stdout_hash": "9700245bb9a12348ba44f585dddd27c41fced325dfc840eeb9f22453",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-interface_12-2e5ecb8.stdout
+++ b/tests/reference/llvm-interface_12-2e5ecb8.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @find_fit(void ([1 x float]*)* @expression)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "894cb50a087496954418ac400e35c24a633b3b2f18a67082ed4668cf",
+    "stdout_hash": "98bda6114deb28afcf19178bb203bd5d5c24c76db1914c1ea3f3ab18",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -203,6 +203,9 @@ else16:                                           ; preds = %ifcont11
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %then15
+  br label %return
+
+return:                                           ; preds = %ifcont17
   ret i32 0
 }
 

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "ef1aae5cf71a7437a6b11faa7c24a02ff030a396d6e638cbc1ad85e4",
+    "stdout_hash": "89587eefed33e7761dec79fbfa1294c35256a7a3f296ed0f7d36f2b6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -220,6 +220,9 @@ else16:                                           ; preds = %ifcont14
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %then15
+  br label %return
+
+return:                                           ; preds = %ifcont17
   ret i32 0
 }
 

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "419c83a228ceb4c79a9fe704b1f0878e891b7488d4997ed58e1b81ee",
+    "stdout_hash": "dac7b9dc9d8f01bdc7ced87edf64d79daf652d11484df26e8b226d8b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -27,6 +27,9 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = load float, float* %x, align 4
   %7 = fpext float %6 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @8, i32 0, i32 0), double %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "6341ef03fd01a6642bd431e8f61de54f0893682df74f32ef599cea47",
+    "stdout_hash": "96d23aacedda3a7c42cf2385d9c91adab8fc0efe9e7545147ec9848c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -57,6 +57,9 @@ define i32 @main(i32 %0, i8** %1) {
   %14 = load float, float* %x, align 4
   %15 = fpext float %14 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @20, i32 0, i32 0), double %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-issue532-d63b703.json
+++ b/tests/reference/llvm-issue532-d63b703.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-issue532-d63b703.stdout",
-    "stdout_hash": "de8886bdb5b86970a042b8ee00f309cf6bcf9e3e192cb4875ab3b2b0",
+    "stdout_hash": "3610f6bb1a4dc4e9951706f66f7f2976cb3ec5d83f77017197126069",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-issue532-d63b703.stdout
+++ b/tests/reference/llvm-issue532-d63b703.stdout
@@ -4,6 +4,9 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "a4ead02784de3fd730c4f274376b5982068076807519cfc46cede4d6",
+    "stdout_hash": "4310ab22248e10e19185ede9d91f40d7b62e0ead56d2ac037098324b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = icmp eq i1 %5, false
   %7 = select i1 %6, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @6, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-logical2-94a2259.json
+++ b/tests/reference/llvm-logical2-94a2259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical2-94a2259.stdout",
-    "stdout_hash": "a891e9cec187523f4e9a7f36c3dfd4f9facab76f7acad2dda97a308d",
+    "stdout_hash": "8015fa95e4865b8c6f3b3c2c421c883fe38df24ed78f2a21ed90d64e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical2-94a2259.stdout
+++ b/tests/reference/llvm-logical2-94a2259.stdout
@@ -32,6 +32,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-logical3-4bbf8ea.json
+++ b/tests/reference/llvm-logical3-4bbf8ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical3-4bbf8ea.stdout",
-    "stdout_hash": "2e8afdbbfdb5d7df89fce8277709ed4b13eaf7801ac4b5ffa0a62ad5",
+    "stdout_hash": "e940ccb71907d278463ca86078e63b4c13abedf7fd6167c0c5ac7b64",
     "stderr": "llvm-logical3-4bbf8ea.stderr",
     "stderr_hash": "d7e28e54d198e14f86c18ab4c4ad128018b9bc6523fb945b05607a57",
     "returncode": 0

--- a/tests/reference/llvm-logical3-4bbf8ea.stdout
+++ b/tests/reference/llvm-logical3-4bbf8ea.stdout
@@ -267,6 +267,9 @@ else23:                                           ; preds = %ifcont21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
+  br label %return
+
+return:                                           ; preds = %ifcont24
   ret i32 0
 }
 

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "60a411e8c84e42de6dff5d40d6da4254a1cce1b3e28908ca2468bfa6",
+    "stdout_hash": "fcb1293abf09db0116e0940a73bc5c629fa3924b17f929d8abfcd63a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -30,6 +30,9 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = icmp eq i1 %8, false
   %10 = select i1 %9, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @8, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-modules_01-1b129c3.json
+++ b/tests/reference/llvm-modules_01-1b129c3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_01-1b129c3.stdout",
-    "stdout_hash": "53ca508c5ae9d17413f892bb8912d3049d3d89b28d63b53ffa6a1689",
+    "stdout_hash": "05628b15eeb8c1b740fe5adb48dc24bbc6dab5ce91b77a859601475b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_01-1b129c3.stdout
+++ b/tests/reference/llvm-modules_01-1b129c3.stdout
@@ -21,6 +21,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_modules_01_a_b()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "d46ea02521a3e0643353bc564fd262e152f3be156ab22fa9417a5e93",
+    "stdout_hash": "024455938470e1a7f9f7502e7805e24efdfe401ebe70e7a16ad4f6be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -31,6 +31,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %2, i32* %i, align 4
   %3 = load i32, i32* %i, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "72bc66f29f4b7df73a7a3e9439c65d3d452a749b159129d87470e31b",
+    "stdout_hash": "ef679399a2163699bc1bbfe4faa8298c2d854398f93ee370792d57ae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -30,6 +30,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* @j, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
   call void @__module_modules_11_module11_access_internally()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "de46891c66b65c71a5e2bfa8d12eb4e42f53ee11edf4ed6a50ccb4e6",
+    "stdout_hash": "04968162f230b6d00ebca63e3191759b93d6ca4b987dd3f518af48cf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -36,6 +36,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %2, i32* %f, align 4
   %3 = load i32, i32* %f, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "3e801815491ef4efd31e71387bf97afb0522708659904ca132cb9fc1",
+    "stdout_hash": "d4f9ed9312bfb7b471510a0070363c29fa0f579928a7fde2102f466d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -203,6 +203,9 @@ define i32 @main(i32 %0, i8** %1) {
   store %fpm_run_settings* %settings, %fpm_run_settings** %8, align 8
   store i1 true, i1* %call_arg_value, align 1
   call void @__module_modules_36_fpm_main_01_cmd_run(%fpm_run_settings_polymorphic* %6, i1* %call_arg_value)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "77d134f7d8c4726d1c29d031dc0c57f8eefb2952731517b570498c4e",
+    "stdout_hash": "4577937893086269baf49a8c78771d0892e763633dcb619c447e99ff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -120,6 +120,9 @@ loop.end:                                         ; preds = %loop.head
   store i32 4, i32* %31, align 4
   %32 = call i8* @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %18, i8** %prefix_arg, %array* %array_descriptor)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %loop.end
   ret i32 0
 }
 

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "724aa12f7349672c5b289ffe7b34b98ce3cbd2e5ea47bcc9d7efef2e",
+    "stdout_hash": "5b404204112b752b4a9a059dc5017911a8d06b2f2586c213366cb13b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -45,6 +45,9 @@ define i32 @main(i32 %0, i8** %1) {
   %c = alloca i32, align 4
   %2 = call i32 @__module_nested_01_a_b()
   store i32 %2, i32* %c, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "f09df009cf91254be8355ac36864172cc74797a23393f79454934f79",
+    "stdout_hash": "be22d4f23ae6d329cbceeb43df63552a7f8e671981326d6537280b21",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -34,6 +34,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_02_a_b()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "a9b6e29b372ae19f7da1eb2286c84aa7c0b245aab27ef27f97f44619",
+    "stdout_hash": "29de0246e0447401e6cc8d0fb0db81c4bf80aa08237e5aa7fb8a407e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -47,6 +47,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_03_a_b()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "09f3b8ce4f8c34c6400ace0120ef0ea961806411aca530acf9e8aed7",
+    "stdout_hash": "d02896fcc035d4073e4ea00bf70bddbc1c27901d7b93b1cc7d7caf97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -74,6 +74,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 5, i32* %call_arg_value, align 4
   %2 = call i32 @__module_nested_04_a_b(i32* %call_arg_value)
   store i32 %2, i32* %test, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "97bac73e74103a69148255b77b02b44ebd58e1b0ae7375126622bd33",
+    "stdout_hash": "05a8ccaa10ab3bd97aac4aa555b43ded1c2883fb37c5b985fa9ede18",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -74,6 +74,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_05_a_b()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "02040272f10f38600909dc1a33462801a0c8f9720aab40c216ac0b44",
+    "stdout_hash": "4bb2ee19da27573cb974512e798d5f830977bad6f8ee38d5fc849786",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -47,6 +47,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store float 6.000000e+00, float* %call_arg_value, align 4
   call void @__module_nested_06_a_b(float* %call_arg_value)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nullify_01-810c9d3.json
+++ b/tests/reference/llvm-nullify_01-810c9d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_01-810c9d3.stdout",
-    "stdout_hash": "5f705ab6c4028fba9702e609f52db3c95d962aed356b0f1fb1cf1d4f",
+    "stdout_hash": "be84d4a52522dbdb73606dcc77b99d735fd69743377d721abd4e268c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_01-810c9d3.stdout
+++ b/tests/reference/llvm-nullify_01-810c9d3.stdout
@@ -15,6 +15,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %2, align 4
   store i32* null, i32** %p1, align 8
   store i32* null, i32** %p2, align 8
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-nullify_02-3c7ee61.json
+++ b/tests/reference/llvm-nullify_02-3c7ee61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_02-3c7ee61.stdout",
-    "stdout_hash": "598e0e132e995867139f84e91d3f7c88a1ba78a4d51ab97cabba0a87",
+    "stdout_hash": "6866a24f285db352148bcfe73842a0e3b5704f67a442a70bd313c18f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_02-3c7ee61.stdout
+++ b/tests/reference/llvm-nullify_02-3c7ee61.stdout
@@ -18,6 +18,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 2, i32* %3, align 4
   store float* null, float** %p1, align 8
   store i32* null, i32** %p2, align 8
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "c2eb0f5b1f34467e1f6cfa4f8e8b9b4a1794dddec9402d3f7ece2443",
+    "stdout_hash": "e2a886d59b2a6265630290d8dd830ff748037edc3c29cf1e56da6a31",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -129,6 +129,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @34, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0))
   %17 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %f)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "3b75eaafaaf3923409bd0ab7e582ed9c176195ac9017e4b85698e6a4",
+    "stdout_hash": "7040e5d91a7737e77b2546457e9af1ccd05efa0cd6b6bda7f72daddc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -43,6 +43,9 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = icmp eq i1 %5, false
   %7 = select i1 %6, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "55fe3b9aaf8261462e643cf8c87476f155ba4c8a50315fd703e9cb41",
+    "stdout_hash": "36811f2b3353ffc342822da343cfc4447a0dca3fe8fe4cade7ba9cd7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -149,6 +149,9 @@ define i32 @main(i32 %0, i8** %1) {
   %24 = icmp eq i1 %23, false
   %25 = select i1 %24, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @46, i32 0, i32 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "df38ee1135fff78650926e301c3111f6d670625c24486c76d81b7d4b",
+    "stdout_hash": "05003defbcce4ad16b58c26352bab9b28ecf8b977cfb738e93dac733",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = load i32, i32* %x, align 4
   %9 = add i32 25, %8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([21 x i8], [21 x i8]* @5, i32 0, i32 0), i32 %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "89ea0d2591666d54bbe806838c31cbb7c6ee0fb3991a300b09d9906c",
+    "stdout_hash": "cdbfaf5d617c93576bde5422d176e1d9e3b4a464a056c26bbd0ead30",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -18,6 +18,9 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = load i32, i32* %i, align 4
   %4 = add i32 %3, 1
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "5c272a955126418b797ab3e07e75a448da0d1c66090a6d3fa464861d",
+    "stdout_hash": "bcbd5a9f2f7dfc67832e70938f59ab908570b63b0b765d5f447fcec6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -66,6 +66,9 @@ loop.body:                                        ; preds = %loop.head
 loop.end:                                         ; preds = %loop.head
   %11 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
   store i32 %11, i32* %z, align 4
+  br label %return
+
+return:                                           ; preds = %loop.end
   ret i32 0
 }
 

--- a/tests/reference/llvm-program_cmake_01-caf8f48.json
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_cmake_01-caf8f48.stdout",
-    "stdout_hash": "ed2fca49fc757a9688a054a4b81c21d9a0f28625581a852760dd6ed1",
+    "stdout_hash": "cbce6e42837400c3eb565dbfc9e0bbf53bb868575476b5c0cbad5d32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_cmake_01-caf8f48.stdout
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.stdout
@@ -10,6 +10,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "61cfa5e75b71432570da316001636adea432e1d9fcf7f2754d4e9472",
+    "stdout_hash": "b589ebf19dbfc5961beaf110baff3977e456d5be400070fb7e15b133",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -20,6 +20,9 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = load float, float* %zero, align 4
   %6 = fpext float %5 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([26 x i8], [26 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "86b048f700e00e8e4d972491ba8d6a32e014d224252e4a7a7b078d92",
+    "stdout_hash": "a30ee14bd190e3ff486cc197efc57e0a5a77c35e35f14cfb58c6b874",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load double, double* @real_dp_param.v, align 8
   %5 = load double, double* @real_dp_param.zero, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([27 x i8], [27 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), double %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "c11190d7150216f12362b690b9b8733df70906416189b96d2cc54251",
+    "stdout_hash": "b5c0263f5c1f0492badf02a931aee8261ea7f2730a9d13590e787104",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -72,6 +72,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 10, i32* @n, align 4
   call void @__module_recursion_01_sub1(i32* @x)
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "dced47aea9a1a677f5c02ba5b5378797ba56dbba94fdb238ad5f6784",
+    "stdout_hash": "d7f5b52dc2f1bdeba869b90907cf716f44dfa90504c06e0aeb4f9713",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -122,6 +122,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %2, i32* %r, align 4
   %3 = load i32, i32* %r, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "19cfd750429a76bb32d2f4a4c869b8a11c118e02503a8ef85980bbf4",
+    "stdout_hash": "aa498762d8af778832bc25874c59fc924cf18208e26eae7afabcf5ab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -136,6 +136,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %2, i32* %r, align 4
   %3 = load i32, i32* %r, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "7902b2e76eb95e5568460e4ea2b125b13f386e4643527fa9e2d79cbc",
+    "stdout_hash": "116ac206fb7ce113eb233977f1bc8b91ac9523d107eafcf05ea148f9",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -55,6 +55,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i32 @main1()
   store i32 %2, i32* %main_out, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "8a6df8b45640c7241b9a0cc9e4196741709bb9bd9465c4f6a922b1ed",
+    "stdout_hash": "48f0ac389a5a37dba8e56d28eeb3b755268f4d8d46472af4641e148e",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -118,6 +118,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %8, i32* %c, align 4
   %9 = load i32, i32* %c, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "539e02278f5d07ea337005a8f29f26ccfa2de310b1ee08312b14f7bc",
+    "stdout_hash": "7fd26c3514e78cc6fe933386ed1e7eefa3a16821be7c22eedeea3021",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -53,6 +53,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 999, i32* @main.main_out, align 4
   call void @main1(i32* @main.main_out)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-return_05-b1ab26b.json
+++ b/tests/reference/llvm-return_05-b1ab26b.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-return_05-b1ab26b",
+    "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/return_05.f90",
+    "infile_hash": "d9114cec325b855f8ac7853b0cb0e9438d43c6ae5e3d6872a59aa6b6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-return_05-b1ab26b.stdout",
+    "stdout_hash": "a86d2a742a15718bbe0f51887c53dd74c480bdcb7ef381ddb8a3c98d",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-return_05-b1ab26b.stdout
+++ b/tests/reference/llvm-return_05-b1ab26b.stdout
@@ -1,0 +1,32 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@2 = private unnamed_addr constant [12 x i8] c"Hello world\00", align 1
+@3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define void @f() {
+.entry:
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  br label %return
+
+unreachable_after_return:                         ; No predecessors!
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %unreachable_after_return, %.entry
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lfortran_printf(i8*, ...)

--- a/tests/reference/llvm-return_06-ec98b0b.json
+++ b/tests/reference/llvm-return_06-ec98b0b.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-return_06-ec98b0b",
+    "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/return_06.f90",
+    "infile_hash": "45589b7367a00e9dbec0cb3bfe91894d24c7914fda043a53043d4276",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-return_06-ec98b0b.stdout",
+    "stdout_hash": "4f47823a6ab6e6f0c28f21e4bc3d18dbe1e2fed2592ad716b7dfec02",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-return_06-ec98b0b.stdout
+++ b/tests/reference/llvm-return_06-ec98b0b.stdout
@@ -1,0 +1,16 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  br label %return
+
+unreachable_after_return:                         ; No predecessors!
+  br label %return
+
+return:                                           ; preds = %unreachable_after_return, %.entry
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "5ec1e54972f2ab432b9656208f32352a6861b5d86b43614240d6c83f",
+    "stdout_hash": "8483a8195305378be2fa28696517d74674f3b64bf8b64c0d55580adc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -12,6 +12,9 @@ define i32 @main(i32 %0, i8** %1) {
   store double 0x3FEFEB7A9B2C6D8B, double* %x, align 8
   %2 = load double, double* %x, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @2, i32 0, i32 0), double %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-stop-866225f.json
+++ b/tests/reference/llvm-stop-866225f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-stop-866225f.stdout",
-    "stdout_hash": "2a4544f27ca1ef24270ecc39a004587d8b159e4be9f7d6681077596e",
+    "stdout_hash": "e7d0fed935ad52e15e97ab173c9fcca3207d04ca784046fa74d94d81",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-stop-866225f.stdout
+++ b/tests/reference/llvm-stop-866225f.stdout
@@ -23,6 +23,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "10b57a14c1cdba841a85771f591c15fe24a2b1ef87098ae0848fc86f",
+    "stdout_hash": "9841b99c7cd56166464457636d89d2588185a314faaa4200406d72f5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -19,6 +19,9 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = load i8*, i8** @print_01.my_name, align 8
   %4 = load i8*, i8** @print_01.my_name, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([1 x i8], [1 x i8]* @4, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "4b5118c36419836228cad83ca22bf86b6388fd7d22fb045ce560b0d4",
+    "stdout_hash": "1c0c13918b1b65e202ce282d15313b3bf3bb93abfdb30f0c31561c6f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -47,6 +47,9 @@ define i32 @main(i32 %0, i8** %1) {
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([1 x i8], [1 x i8]* @7, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @7, i32 0, i32 0), i8* %11, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @7, i32 0, i32 0), i8* %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
   %13 = load i8*, i8** %greetings, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "3de93dc6e60468852184bc040f40e16408e53d7406157dc8b9e51188",
+    "stdout_hash": "603782061fc8147f2617aa1ffcb03b4406202357a7dc3c5e63d1e506",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -90,6 +90,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i8* %40, i8** %combined, align 8
   %41 = load i8*, i8** %combined, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "42492589f69a5114e7e619b14ba91f3a95783212bddabefe60ff8ae3",
+    "stdout_hash": "881b4fcb100aa5977f4d771190ec495f369fce42bc3ea2bce5b1a3d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -179,6 +179,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "cd372f9ab23cc27594470f2ed7840d1ea9476edaeeb659783687e479",
+    "stdout_hash": "8b81cf5d4a3ebcf37abd4ff79af4039f7e3198672982066bb5158500",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -184,6 +184,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "004ceb2f64becdcc7ae04de540be8713c97c7490c88882ccf46e4b46",
+    "stdout_hash": "6cf67e393e43ac5c5cf90a6d0cbcf527e135d5b30deaff8a54983d3d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -57,6 +57,9 @@ else5:                                            ; preds = %ifcont3
 
 ifcont6:                                          ; preds = %else5, %then4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @11, i32 0, i32 0), i32 48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %ifcont6
   ret i32 0
 }
 

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "265f1e9883a0d221e8a686e5831d0d39074f5c36d6aa80e30ea5c089",
+    "stdout_hash": "9c933aeb52d2289142d673aca832171b9f33403f27b027c313baba9d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -200,6 +200,9 @@ else25:                                           ; preds = %ifcont22
   br label %ifcont26
 
 ifcont26:                                         ; preds = %else25, %then24
+  br label %return
+
+return:                                           ; preds = %ifcont26
   ret i32 0
 }
 

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "0887be733887f1748534bc40a3243763d4304fbee180fd17e5ff8e3b",
+    "stdout_hash": "2d043673dccc692a529063ec790aa3d7471a195852750a83ba76cf62",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -157,6 +157,9 @@ else14:                                           ; preds = %ifcont12
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
+  br label %return
+
+return:                                           ; preds = %ifcont15
   ret i32 0
 }
 

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "fc9faa850e85bd4f8832584558acdda5b067fd2de149389b16258d0d",
+    "stdout_hash": "1af78a0e295e26e2a1ebbcf6cb1d6c285e37a32be0053cd80eb2f797",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @print_int()
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-sum_02-43f30ca.json
+++ b/tests/reference/llvm-sum_02-43f30ca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sum_02-43f30ca.stdout",
-    "stdout_hash": "a535720becaa5525d83e2a01683d1a63f3e2e0431afe7ecd7ee7d1f3",
+    "stdout_hash": "79a538510d6e52736e507b3ccda6dcad7675a7f1edda743312f1fdb4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sum_02-43f30ca.stdout
+++ b/tests/reference/llvm-sum_02-43f30ca.stdout
@@ -192,6 +192,9 @@ else:                                             ; preds = %loop.end3
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
   ret i32 0
 }
 

--- a/tests/reference/llvm-types_01-642cab3.json
+++ b/tests/reference/llvm-types_01-642cab3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_01-642cab3.stdout",
-    "stdout_hash": "8368218c01cfa24078338c88902bf756049549f02f6f5ff6516f927a",
+    "stdout_hash": "c35662de8ece33395abcc550828dd8f5eec3bcc38e940c763be4d7fd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_01-642cab3.stdout
+++ b/tests/reference/llvm-types_01-642cab3.stdout
@@ -10,6 +10,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.000000e+00, float* %r, align 4
   store float 2.000000e+00, float* %r, align 4
   store float 3.000000e+00, float* %r, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-types_02-b5bfe0b.json
+++ b/tests/reference/llvm-types_02-b5bfe0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_02-b5bfe0b.stdout",
-    "stdout_hash": "755f5c89fbae2d6e61d645871b4fb278e4ed0766a0c3f204cf36e1eb",
+    "stdout_hash": "12d518605be57463718181d26837f59f308655f124ff67ad86c43d53",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_02-b5bfe0b.stdout
+++ b/tests/reference/llvm-types_02-b5bfe0b.stdout
@@ -11,6 +11,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* %i, align 4
   %3 = sitofp i32 %2 to float
   store float %3, float* %r, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "f9427c29de4c8e3d5de589ddc243dba81bca77e9557934f534d0c45b",
+    "stdout_hash": "81815223e1eef819aa6a8b7c9774e0bbfc3bfb3b3ba1985cc350c19d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -22,6 +22,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %5, i32* %i, align 4
   %6 = load i32, i32* %i, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-types_04-92449d7.json
+++ b/tests/reference/llvm-types_04-92449d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_04-92449d7.stdout",
-    "stdout_hash": "6af699970e7535036afa1f0a4adfe6c4b1689c23b2a49a880898f39e",
+    "stdout_hash": "64bc1d823e989c3b986836c49fd16bcb4d5ba790509ced9473c72af6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_04-92449d7.stdout
+++ b/tests/reference/llvm-types_04-92449d7.stdout
@@ -85,6 +85,9 @@ define i32 @main(i32 %0, i8** %1) {
   %60 = sitofp i32 %59 to float
   %61 = fdiv float %58, %60
   store float %61, float* %x, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
-    "stdout_hash": "fd1a9e204306d700709b6685d8d2fccc4058ea7fdac3df9c974068ca",
+    "stdout_hash": "acbd8c0ef7cf1fe1535eb5d2d9b9bd18d5a6ff3308670e6a191ea5c9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_05-aa71aa9.stdout
+++ b/tests/reference/llvm-types_05-aa71aa9.stdout
@@ -20,6 +20,9 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 0, i32* %i, align 4
   store i32 0, i32* %i, align 4
   store i32 0, i32* %i, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/reference/llvm-types_06-6f66d2c.json
+++ b/tests/reference/llvm-types_06-6f66d2c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_06-6f66d2c.stdout",
-    "stdout_hash": "0fc22f0a08541fa9c862646fad85720d6c2b6b603fc0d34fc520a99e",
+    "stdout_hash": "da72dfdd7290a68e5525570ca9909aa1505d62718e88e15e0332b135",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_06-6f66d2c.stdout
+++ b/tests/reference/llvm-types_06-6f66d2c.stdout
@@ -441,6 +441,9 @@ else68:                                           ; preds = %ifcont66
   br label %ifcont69
 
 ifcont69:                                         ; preds = %else68, %then67
+  br label %return
+
+return:                                           ; preds = %ifcont69
   ret i32 0
 }
 

--- a/tests/reference/llvm-variables_03-4ba9d62.json
+++ b/tests/reference/llvm-variables_03-4ba9d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-variables_03-4ba9d62.stdout",
-    "stdout_hash": "2a5da5dc96a958480e4eea9797262ed58cb0359f4eeb928895d76099",
+    "stdout_hash": "c75938aba67ceb0276b4dbc38479463be7bcdd17abbd0a0852efffa5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-variables_03-4ba9d62.stdout
+++ b/tests/reference/llvm-variables_03-4ba9d62.stdout
@@ -85,6 +85,9 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
+  br label %return
+
+return:                                           ; preds = %ifcont9
   ret i32 0
 }
 

--- a/tests/reference/llvm-while_01-3496096.json
+++ b/tests/reference/llvm-while_01-3496096.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_01-3496096.stdout",
-    "stdout_hash": "bc0538785190de87fa1a2d1eefadf4651beb3385b267b4a9de80c2ec",
+    "stdout_hash": "a11deeb82e6eb96b3719f5685416f050f855842068ab57a2920b96ac",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_01-3496096.stdout
+++ b/tests/reference/llvm-while_01-3496096.stdout
@@ -163,6 +163,9 @@ else20:                                           ; preds = %ifcont18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
+  br label %return
+
+return:                                           ; preds = %ifcont21
   ret i32 0
 }
 

--- a/tests/reference/llvm-while_02-3db2b04.json
+++ b/tests/reference/llvm-while_02-3db2b04.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_02-3db2b04.stdout",
-    "stdout_hash": "61bd70e5e95ee423b18e9fe9e431978306e31945a4a3a20aae96a1db",
+    "stdout_hash": "4e7de11da77bc0f399a028bd479fd2d7689d13af264ed42bad670b3a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_02-3db2b04.stdout
+++ b/tests/reference/llvm-while_02-3db2b04.stdout
@@ -191,6 +191,9 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
+  br label %return
+
+return:                                           ; preds = %ifcont27
   ret i32 0
 }
 

--- a/tests/reference/llvm-write3-49c0266.json
+++ b/tests/reference/llvm-write3-49c0266.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-write3-49c0266.stdout",
-    "stdout_hash": "d06a4ee30e6f6ec911338625edff112b1116d504f9f7fc00cea4863b",
+    "stdout_hash": "7a519debc1c690ebc19f17753383f5d10ec8b5c4bbfd47e547adc2eb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-write3-49c0266.stdout
+++ b/tests/reference/llvm-write3-49c0266.stdout
@@ -15,6 +15,9 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* %nwrite, align 4
   %3 = alloca i32, align 4
   call void (i32, i32*, i8*, ...) @_lfortran_file_write(i32 %2, i32* %3, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
   ret i32 0
 }
 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2480,6 +2480,14 @@ filename = "../integration_tests/return_03.f90"
 llvm = true
 
 [[test]]
+filename = "../integration_tests/return_05.f90"
+llvm = true
+
+[[test]]
+filename = "../integration_tests/return_06.f90"
+llvm = true
+
+[[test]]
 filename = "../integration_tests/modules_13.f90"
 llvm = true
 


### PR DESCRIPTION
Fixes #4375, this treats program same way as functions (i.e. having a basic block for return)

The approach is a little different than what's suggested in https://github.com/lfortran/lfortran/issues/4375#issue-2370290147.

This approach ensures that we don't actually ever make use of `unreachable_after_return` basic block, and any statements right after `return` (which aren't reachable) aren't executed.