### PR TITLE
make RealType independent of -fdefault-integer-8

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -873,9 +873,7 @@ RUN(NAME parameter_10 LABELS gfortran llvm NOFAST fortran) # sin
 RUN(NAME parameter_11 LABELS gfortran llvm fortran) # merge
 RUN(NAME parameter_12 LABELS gfortran llvm fortran) # implied do loops
 RUN(NAME parameter_13 LABELS gfortran llvm) # compile time example
-RUN(NAME parameter_14 LABELS gfortran llvm
-    EXTRA_ARGS -fdefault-integer-8
-    GFORTRAN_ARGS -fdefault-integer-8)
+RUN(NAME parameter_14 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME modules_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME modules_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -873,6 +873,9 @@ RUN(NAME parameter_10 LABELS gfortran llvm NOFAST fortran) # sin
 RUN(NAME parameter_11 LABELS gfortran llvm fortran) # merge
 RUN(NAME parameter_12 LABELS gfortran llvm fortran) # implied do loops
 RUN(NAME parameter_13 LABELS gfortran llvm) # compile time example
+RUN(NAME parameter_14 LABELS gfortran llvm
+    EXTRA_ARGS -fdefault-integer-8
+    GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME modules_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME modules_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/parameter_14.f90
+++ b/integration_tests/parameter_14.f90
@@ -1,0 +1,7 @@
+      PROGRAM ERROR
+
+      REAL ONE
+      PARAMETER (ONE=1.0E+0)
+
+      END
+

--- a/integration_tests/parameter_14.f90
+++ b/integration_tests/parameter_14.f90
@@ -1,7 +1,7 @@
-      PROGRAM ERROR
-
-      REAL ONE
-      PARAMETER (ONE=1.0E+0)
-
-      END
+program parameter_14
+real :: x
+parameter ( x = 12.9E+0 )
+print *, x
+if ( abs( x - 12.9 ) > 1e-8 ) error stop
+end
 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3242,7 +3242,10 @@ public:
         ASR::ttype_t *type;
         type_declaration = nullptr;
 
-        int a_kind = compiler_options.po.default_integer_kind;
+        int a_kind = 4;
+        if (sym_type->m_type == AST::decl_typeType::TypeInteger) {
+            a_kind = compiler_options.po.default_integer_kind;
+        }
 
         // general assignments and checks except when it's a
         // "Character" declaration


### PR DESCRIPTION
As discussed with @Pranavchiku in #4473, this PR Fixes #4471.
The current `determine_type` function in `ast_common_visitor.h` uses `compiler_options.po.default_integer_kind` in order to determine the `a_kind` value which is passed on to create the ASR variable type. This means that the Real values are also affected by this flag which is visible in the MRE from #4471. 