### PR TITLE
fix : Nested array ref in where

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -999,6 +999,7 @@ RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 

--- a/integration_tests/where_12.f90
+++ b/integration_tests/where_12.f90
@@ -1,0 +1,21 @@
+program where_12
+    integer ::arr(3,3,3)
+    integer ::arr2(3,3,3)
+
+    arr = 10
+    arr2 = 11
+    
+    arr(:,2,:) = 0
+    where(arr == 0)
+        arr = 555
+        arr2 = 555
+    end where
+    
+    print *, arr
+    if(any(arr(:,2,:) /= 555) .or. any(arr(:,1,:) /= 10) .or. any(arr(:,3,:) /= 10)) error stop
+
+    ! Test whether the other array got affected or not, just to make sure assignments inside if are handled correctly by where pass.
+    print *, arr2
+    if(any(arr2(:,2,:) /= 555) .or. any(arr2(:,1,:) /= 11) .or. any(arr2(:,3,:) /= 11)) error stop
+    
+end program where_12


### PR DESCRIPTION
fixes #4510 

The fix creates nested do loops based on number of dimensions of the addressed array in the where statement.

fortran code of this initial code https://github.com/lfortran/lfortran/issues/4510#issue-2407913875 after **where** pass  :

```Fortran
do __1_k = lbound(arr, 1), ubound(arr, 1), 1
    do __2_k = lbound(arr, 2), ubound(arr, 2), 1
        do __3_k = lbound(arr, 3), ubound(arr, 3), 1
            if (arr(__1_k, __2_k, __3_k) == 0) then
                arr(__1_k, __2_k, __3_k) = 555
            end if
        end do
    end do
end do
```
_code snippet of nested do loop, not full code._