### PR TITLE
enh: append compiler version to dumped asr pass output file name

### DIFF
--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -355,7 +355,7 @@ namespace LCompilers {
                         outfile << generate_visualize_html(json) << "\n";
                         outfile.close();
                     }
-                    std::ofstream outfile ("pass_" + str_i + "_" + passes[i] + ".clj");
+                    std::ofstream outfile ("pass_" + str_i + "_" + passes[i] + "_" + LFORTRAN_VERSION + ".clj");
                     outfile << ";; ASR after applying the pass: " << passes[i]
                         << "\n" << pickle(*asr, false, true, pass_options.with_intrinsic_mods) << "\n";
                     outfile.close();
@@ -369,7 +369,7 @@ namespace LCompilers {
                     }
                     std::string str_i = std::to_string(i+1);
                     if ( i < 9 )  str_i = "0" + str_i;
-                    std::ofstream outfile ("pass_fortran_" + str_i + "_" + passes[i] + ".f90");
+                    std::ofstream outfile ("pass_fortran_" + str_i + "_" + passes[i] + "_" + LFORTRAN_VERSION + ".f90");
                     outfile << "! Fortran code after applying the pass: " << passes[i]
                         << "\n" << fortran_code.result << "\n";
                     outfile.close();


### PR DESCRIPTION
This will be very helpful while debugging https://github.com/lfortran/lfortran/pull/3748 ( simplifier ) pass. One side we can have LFortran in release mode and dump asr pass output, on other side we can have LFortran Debug mode built in that PR and dumped asr passes. With this PR, both dumped files will be different and we can compare side by side for example:

> For Debug mode

pass_01_nested_vars_0.38.0-47-ge01154101.clj

> For release mode

pass_01_nested_vars_0.38.0.clj

In main, when doing `--dump-all-passes` it overwrites existing files and thus every time we wish to check an ASR pass output we have to again dump it.