### PR TITLE
enh: support passing an ArrayItem first and then an Array in `--legacy-array-sections`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1655,6 +1655,7 @@ RUN(NAME simd_02 LABELS gfortran c llvm llvm_nopragma c_nopragma llvm17)
 RUN(NAME legacy_array_sections_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --legacy-array-sections --implicit-interface)
+RUN(NAME legacy_array_sections_04 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface --legacy-array-sections EXTRAFILES legacy_array_sections_04b)
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 

--- a/integration_tests/legacy_array_sections_04.f90
+++ b/integration_tests/legacy_array_sections_04.f90
@@ -1,0 +1,7 @@
+program legacy_array_sections_04
+    real :: afb(4)
+    external :: sub
+    afb = [ 1., 2., 3., 4. ]
+    call sub(afb( 2 ))
+    call sub(afb)
+end program

--- a/integration_tests/legacy_array_sections_04b.f90
+++ b/integration_tests/legacy_array_sections_04b.f90
@@ -1,0 +1,5 @@
+subroutine sub(afb)
+    real afb(3)
+    print *, sum(afb)
+    if ( .not. ( (abs(sum(afb) - 9.0) > 1e-8) .or. (abs(sum(afb) - 3.0) > 1e-8) ) ) error stop
+end subroutine

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1594,6 +1594,8 @@ public:
         v->m_body = body.p;
         v->n_body = body.size();
 
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
         }
@@ -2071,6 +2073,8 @@ public:
         v->n_body = body.size();
         v->m_dependencies = func_deps.p;
         v->n_dependencies = func_deps.size();
+
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1999,6 +1999,8 @@ public:
         v->m_dependencies = func_deps.p;
         v->n_dependencies = func_deps.size();
 
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
         }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4641,21 +4641,23 @@ public:
             }
 
             void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
-                ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
-                ASR::FunctionType_t* f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
-                std::map<int, ASR::ttype_t*> array_arg_index;
-                for (size_t i = 0; i < f->n_args; i++) {
-                    if (ASRUtils::is_array(ASRUtils::expr_type(f->m_args[i]))) {
-                        array_arg_index[i] = f_type->m_arg_types[i];
+                if ( ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(x.m_name)) ) {
+                    ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
+                    ASR::FunctionType_t* f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                    std::map<int, ASR::ttype_t*> array_arg_index;
+                    for (size_t i = 0; i < f->n_args; i++) {
+                        if (ASRUtils::is_array(ASRUtils::expr_type(f->m_args[i]))) {
+                            array_arg_index[i] = f_type->m_arg_types[i];
+                        }
                     }
-                }
-                // iterate only over args of type array.
-                for( auto it: array_arg_index ) {
-                    ASR::expr_t* arg_expr = x.m_args[it.first].m_value;
-                    if ( arg_expr != nullptr ) {
-                        *current_expr = arg_expr;
-                        call_replacer_(array_arg_index);
-                        x.m_args[it.first].m_value = *current_expr;
+                    // iterate only over args of type array.
+                    for( auto it: array_arg_index ) {
+                        ASR::expr_t* arg_expr = x.m_args[it.first].m_value;
+                        if ( arg_expr != nullptr ) {
+                            *current_expr = arg_expr;
+                            call_replacer_(array_arg_index);
+                            x.m_args[it.first].m_value = *current_expr;
+                        }
                     }
                 }
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4649,12 +4649,13 @@ public:
                         array_arg_index[i] = f_type->m_arg_types[i];
                     }
                 }
-                for (size_t i = 0; i < x.n_args; i++) {
-                    ASR::expr_t* arg_expr = x.m_args[i].m_value;
+                // iterate only over args of type array.
+                for( auto it: array_arg_index ) {
+                    ASR::expr_t* arg_expr = x.m_args[it.first].m_value;
                     if ( arg_expr != nullptr ) {
                         *current_expr = arg_expr;
                         call_replacer_(array_arg_index);
-                        x.m_args[i].m_value = *current_expr;
+                        x.m_args[it.first].m_value = *current_expr;
                     }
                 }
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4559,6 +4559,123 @@ public:
         }
     }
 
+    void replace_ArrayItem_in_SubroutineCall(Allocator &al, bool legacy_array_sections, SymbolTable* current_scope) {
+
+    class ReplaceArrayItemWithArraySection: public ASR::BaseExprReplacer<ReplaceArrayItemWithArraySection> {
+        private:
+            Allocator& al;
+        public:
+            ASR::expr_t** current_expr;
+            std::map<int, ASR::ttype_t*> array_arg_index;
+
+            ReplaceArrayItemWithArraySection(Allocator& al_) :
+                al(al_) {}
+
+            void replace_ArrayItem(ASR::ArrayItem_t* x) {
+                Vec<ASR::array_index_t> array_indices; array_indices.reserve(al, x->n_args);
+                ASRUtils::ASRBuilder b(al, x->base.base.loc);
+
+                for ( size_t i = 0; i < x->n_args; i++ ) {
+                    ASR::array_index_t array_index;
+                    array_index.loc = x->m_args[i].loc;
+                    array_index.m_left = x->m_args[i].m_right;
+                    array_index.m_right = b.ArrayUBound(x->m_v, i + 1);
+                    if ( ASRUtils::expr_value(array_index.m_right) ) {
+                        array_index.m_right = ASRUtils::expr_value(array_index.m_right);
+                    }
+                    array_index.m_step = b.i32( i + 1 );
+                    array_indices.push_back(al, array_index);
+                }
+                ASR::ttype_t* new_type = ASRUtils::duplicate_type_with_empty_dims(al, ASRUtils::expr_type(x->m_v));
+                *current_expr = ASRUtils::EXPR(ASR::make_ArraySection_t(al, x->base.base.loc, x->m_v,
+                    array_indices.p, array_indices.n, new_type, nullptr));
+            }
+
+    };
+
+    class LegacyArraySectionsVisitor : public ASR::CallReplacerOnExpressionsVisitor<LegacyArraySectionsVisitor> {
+        private:
+            Allocator& al;
+            ReplaceArrayItemWithArraySection replacer;
+        public:
+            ASR::expr_t** current_expr;
+            LegacyArraySectionsVisitor(Allocator& al_) :
+                al(al_), replacer(al_) {}
+
+            void call_replacer_(std::map<int, ASR::ttype_t*> &array_arg_index) {
+                replacer.array_arg_index = array_arg_index;
+                replacer.current_expr = current_expr;
+                replacer.replace_expr(*current_expr);
+                current_expr = replacer.current_expr;
+            }
+
+            void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {
+                Vec<ASR::stmt_t*> body;
+                body.reserve(al, n_body);
+                for (size_t i=0; i<n_body; i++) {
+                    this->visit_stmt(*m_body[i]);
+                    body.push_back(al, m_body[i]);
+                }
+                m_body = body.p;
+                n_body = body.size();
+            }
+
+            void visit_Function(const ASR::Function_t &x) {
+                ASR::Function_t& xx = const_cast<ASR::Function_t&>(x);
+
+                for (auto &a : xx.m_symtab->get_scope()) {
+                    this->visit_symbol(*a.second);
+                }
+
+                transform_stmts(xx.m_body, xx.n_body);
+            }
+
+            void visit_Program(const ASR::Program_t &x) {
+                ASR::Program_t& xx = const_cast<ASR::Program_t&>(x);
+
+                for (auto &a : xx.m_symtab->get_scope()) {
+                    this->visit_symbol(*a.second);
+                }
+
+                transform_stmts(xx.m_body, xx.n_body);
+            }
+
+            void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
+                ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(x.m_name));
+                ASR::FunctionType_t* f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                std::map<int, ASR::ttype_t*> array_arg_index;
+                for (size_t i = 0; i < f->n_args; i++) {
+                    if (ASRUtils::is_array(ASRUtils::expr_type(f->m_args[i]))) {
+                        array_arg_index[i] = f_type->m_arg_types[i];
+                    }
+                }
+                for (size_t i = 0; i < x.n_args; i++) {
+                    ASR::expr_t* arg_expr = x.m_args[i].m_value;
+                    if ( arg_expr != nullptr ) {
+                        *current_expr = arg_expr;
+                        call_replacer_(array_arg_index);
+                        x.m_args[i].m_value = *current_expr;
+                    }
+                }
+            }
+    };
+
+        if ( legacy_array_sections ) {
+            LegacyArraySectionsVisitor v(al);
+            ASR::asr_t* asr_owner = current_scope->asr_owner;
+            if ( ASR::is_a<ASR::symbol_t>(*asr_owner) ) {
+                ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(asr_owner);
+                if ( ASR::is_a<ASR::Function_t>(*sym) ) {
+                    ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(sym);
+                    v.visit_Function(*f);
+                } else if ( ASR::is_a<ASR::Program_t>(*sym) ) {
+                    ASR::Program_t* p = ASR::down_cast<ASR::Program_t>(sym);
+                    v.visit_Program(*p);
+                }
+            }
+        }
+    }
+
     void legacy_array_sections_helper(ASR::symbol_t *v, Vec<ASR::call_arg_t>& args, const Location &loc) {
         ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(v));
         if (compiler_options.legacy_array_sections) {
@@ -4640,6 +4757,26 @@ public:
                 }
             }
             args = args_with_array_section;
+            // There can be a possibility that initially it is ArrayItem and now we realised
+            // that it must be an ArraySection instead.
+            array_arg_idx.clear();
+            for ( size_t i = 0; i < args.size(); i++ ) {
+                ASR::expr_t* arg_expr = args[i].m_value;
+                if ( arg_expr && ASRUtils::is_array(ASRUtils::expr_type(arg_expr)) ) {
+                    array_arg_idx[i] = ASRUtils::expr_type(arg_expr);
+                }
+            }
+            // bool visit_required = false;
+            for ( auto it: array_arg_idx ) {
+                ASR::expr_t* func_arg = f->m_args[it.first];
+                if ( !ASRUtils::is_array(ASRUtils::EXPR2VAR(func_arg)->m_type) ) {
+                    // create array type with empty dimensions and physical type as PointerToDataArray
+                    ASR::ttype_t* new_type = ASRUtils::duplicate_type_with_empty_dims(al, it.second, ASR::array_physical_typeType::PointerToDataArray, true);
+                    ASRUtils::EXPR2VAR(func_arg)->m_type = new_type;
+                    f_type->m_arg_types[it.first] = new_type;
+                    // visit_required = true;
+                }
+            }
         }
     }
 

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -146,7 +146,7 @@ class ASRBuilder {
         ASR::expr_t* value = nullptr;
         ASR::ttype_t* type = ASRUtils::expr_type(x);
         if ( ASRUtils::is_array(type) ) {
-            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(type);
+            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(type)));
             ASR::dimension_t* dims = array_type->m_dims;
             ASRUtils::extract_dimensions_from_ttype(type, dims);
             int new_dim = dim - 1;
@@ -174,7 +174,7 @@ class ASRBuilder {
         ASR::expr_t* value = nullptr;
         ASR::ttype_t* type = ASRUtils::expr_type(x);
         if ( ASRUtils::is_array(type) ) {
-            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(type);
+            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(type)));
             ASR::dimension_t* dims = array_type->m_dims;
             ASRUtils::extract_dimensions_from_ttype(type, dims);
             int new_dim = dim - 1;

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -143,11 +143,53 @@ class ASRBuilder {
     }
 
     ASR::expr_t* ArrayUBound(ASR::expr_t* x, int64_t dim) {
-        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i32(dim), int32, ASR::arrayboundType::UBound, nullptr));
+        ASR::expr_t* value = nullptr;
+        ASR::ttype_t* type = ASRUtils::expr_type(x);
+        if ( ASRUtils::is_array(type) ) {
+            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(type);
+            ASR::dimension_t* dims = array_type->m_dims;
+            ASRUtils::extract_dimensions_from_ttype(type, dims);
+            int new_dim = dim - 1;
+            if( dims[new_dim].m_start && dims[new_dim].m_length ) {
+                ASR::expr_t* start = ASRUtils::expr_value(dims[new_dim].m_start);
+                ASR::expr_t* length = ASRUtils::expr_value(dims[new_dim].m_length);
+                if( ASRUtils::is_value_constant(start) &&
+                ASRUtils::is_value_constant(length) ) {
+                    int64_t const_lbound = -1;
+                    if( !ASRUtils::extract_value(start, const_lbound) ) {
+                        LCOMPILERS_ASSERT(false);
+                    }
+                    int64_t const_length = -1;
+                    if( !ASRUtils::extract_value(length, const_length) ) {
+                        LCOMPILERS_ASSERT(false);
+                    }
+                    value = i32(const_lbound + const_length - 1);
+                }
+            }
+        }
+        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i32(dim), int32, ASR::arrayboundType::UBound, value));
     }
 
     ASR::expr_t* ArrayLBound(ASR::expr_t* x, int64_t dim) {
-        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i32(dim), int32, ASR::arrayboundType::LBound, nullptr));
+        ASR::expr_t* value = nullptr;
+        ASR::ttype_t* type = ASRUtils::expr_type(x);
+        if ( ASRUtils::is_array(type) ) {
+            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(type);
+            ASR::dimension_t* dims = array_type->m_dims;
+            ASRUtils::extract_dimensions_from_ttype(type, dims);
+            int new_dim = dim - 1;
+            if( dims[new_dim].m_start ) {
+                ASR::expr_t* start = ASRUtils::expr_value(dims[new_dim].m_start);
+                if( ASRUtils::is_value_constant(start) ) {
+                    int64_t const_lbound = -1;
+                    if( !ASRUtils::extract_value(start, const_lbound) ) {
+                        LCOMPILERS_ASSERT(false);
+                    }
+                    value = i32(const_lbound);
+                }
+            }
+        }
+        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i32(dim), int32, ASR::arrayboundType::LBound, value));
     }
 
     inline ASR::expr_t* i_t(int64_t x, ASR::ttype_t* t) {


### PR DESCRIPTION
Towards https://github.com/lfortran/lfortran/issues/4251. With this PR we get a segfault on that example, the reason is passing `afb` as  `afb( * ) ` and this leads to some array physical type problems. Thus I changed it to `afb( 4 )`, this is also not working with main. 