### PR TITLE
lex body statements inside do while loops

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -325,6 +325,7 @@ RUN(NAME if_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm c)
 
 RUN(NAME while_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c)
 RUN(NAME while_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm c)
+RUN(NAME while_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm EXTRA_ARGS --fixed-form)
 
 RUN(NAME doloop_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c cpp x86 wasm)
 RUN(NAME doloop_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c cpp x86 wasm)

--- a/integration_tests/while_03.f90
+++ b/integration_tests/while_03.f90
@@ -1,0 +1,23 @@
+      program while_03
+      implicit none
+      integer :: n, i, j
+
+      i = 0
+      n = 2
+
+      do while ( n >= 2 )
+         if( n >= i ) then
+            if( n >= i ) then
+               do j= i+1,n
+                  i = j + i
+               end do
+            endif
+            n = n - 1
+         else
+            i = j + i
+         endif
+      end do
+
+      return
+      end
+

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1409,7 +1409,6 @@ struct FixedFormRecursiveDescent {
             next_line(cur); // Does not generate any code?
             while(lex_procedure(cur));
         }
-        //std::cout << "CUR IS: " << cur << std::endl;
         if (next_is(cur, "endprogram")) {
             push_token_advance(cur, "endprogram");
             tokenize_line(cur);

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1325,7 +1325,7 @@ struct FixedFormRecursiveDescent {
         push_token_advance(cur, "while");
         tokenize_line(cur); // tokenize rest of line where `do while` starts
         while (!next_is(cur, "enddo\n")) {
-            tokenize_line(cur);
+            lex_body_statement(cur);
         }
         push_token_advance(cur, "enddo");
         tokenize_line(cur);
@@ -1409,6 +1409,7 @@ struct FixedFormRecursiveDescent {
             next_line(cur); // Does not generate any code?
             while(lex_procedure(cur));
         }
+        //std::cout << "CUR IS: " << cur << std::endl;
         if (next_is(cur, "endprogram")) {
             push_token_advance(cur, "endprogram");
             tokenize_line(cur);
@@ -1540,7 +1541,6 @@ struct FixedFormRecursiveDescent {
         // we can define a global assignment
         unsigned char *nline = cur; next_line(nline);
         // eat_label(cur);
-
         if (next_is(cur, "include")) {
             push_token_advance(cur, "include");
             tokenize_line(cur);
@@ -1587,7 +1587,6 @@ bool FixedFormTokenizer::tokenize_input(diag::Diagnostics &diagnostics, Allocato
         f.t.string_start = string_start;
         f.t.cur_line = string_start;
         f.t.line_num = 1;
-
         f.lex_global_scope(cur);
         tokens = std::move(f.tokens);
         stypes = std::move(f.stypes);


### PR DESCRIPTION
Fixes #4492. The do while lexing function did not lex the body statements inside, instead it would tokenize each line until a `doend` label was reached which does not allow for nested loops inside of do-while loops. This PR aims to fix that.