### PR TITLE
Add test for non-scalar kind arg for `int` intrinsic

### DIFF
--- a/tests/errors/int_01.f90
+++ b/tests/errors/int_01.f90
@@ -1,0 +1,3 @@
+program main
+    real(8), parameter :: ar1(3) = int([1, 2, 3], [8, 8, 8])
+end program

--- a/tests/reference/asr-int_01-9bf3eb9.json
+++ b/tests/reference/asr-int_01-9bf3eb9.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-int_01-9bf3eb9",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/int_01.f90",
+    "infile_hash": "77368d4c89de62e3f870622426296e4ddb2cf8cdd43b42822433401a",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-int_01-9bf3eb9.stderr",
+    "stderr_hash": "8341fb653e48fb782a653dbdb51a84f43e57eaaac0f26d8fa911eaa8",
+    "returncode": 2
+}

--- a/tests/reference/asr-int_01-9bf3eb9.stderr
+++ b/tests/reference/asr-int_01-9bf3eb9.stderr
@@ -1,0 +1,5 @@
+semantic error: kind argument to int(a, kind) is not a constant integer
+ --> tests/errors/int_01.f90:2:36
+  |
+2 |     real(8), parameter :: ar1(3) = int([1, 2, 3], [8, 8, 8])
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4077,3 +4077,7 @@ asr = true
 [[test]]
 filename = "errors/intrinsics11.f90"
 asr = true
+
+[[test]]
+filename = "errors/int_01.f90"
+asr = true


### PR DESCRIPTION
Adding this to make sure that the error persists even with the new implementation of `int` intrinsic.
Ref: https://github.com/lfortran/lfortran/issues/4539#issuecomment-2256116600
Towards: #4017
