### PR TITLE
enh: declare integer variables before visiting nested function in llvm backend

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -363,6 +363,7 @@ RUN(NAME subroutines_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME subroutines_09 LABELS gfortran)
 RUN(NAME subroutines_10 LABELS gfortran)
 RUN(NAME subroutines_11 LABELS gfortran)
+RUN(NAME subroutines_12 LABELS gfortran llvm)
 
 RUN(NAME functions_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm)
 RUN(NAME functions_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/subroutines_12.f90
+++ b/integration_tests/subroutines_12.f90
@@ -1,0 +1,22 @@
+PROGRAM subroutines_12
+
+IMPLICIT NONE
+
+INTEGER :: nang = 2
+
+CALL my_subroutine
+
+CONTAINS
+
+SUBROUTINE my_subroutine
+
+INTEGER, DIMENSION(nang) :: fxhv
+
+fxhv = [1, 2]
+
+PRINT *, fxhv
+if ( sum(fxhv) /= 3 ) error stop
+
+END SUBROUTINE my_subroutine
+
+END PROGRAM subroutines_12

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "0032747fdf2c25222184159041dedd48b6c14a1fe8579b654cfc45af",
+    "stdout_hash": "258f2ebc8c97946ae623d19d16bd897de2c131c5c6739d7c52b2c908",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -35,6 +35,290 @@ source_filename = "LFortran"
 @28 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @29 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %r = alloca i32, align 4
+  %stat = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %c = alloca %array*, align 8
+  store %array* null, %array** %c, align 8
+  %arr_desc = alloca %array, align 8
+  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %3 = alloca i32, align 4
+  store i32 3, i32* %3, align 4
+  %4 = load i32, i32* %3, align 4
+  %5 = alloca %dimension_descriptor, i32 %4, align 8
+  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
+  %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
+  store i32 3, i32* %6, align 4
+  %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
+  store i32* null, i32** %7, align 8
+  store %array* %arr_desc, %array** %c, align 8
+  %r1 = alloca i32, align 4
+  %stat2 = alloca i32, align 4
+  store i32 1, i32* %stat2, align 4
+  %8 = load %array*, %array** %c, align 8
+  %9 = ptrtoint %array* %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %then, label %else
+
+then:                                             ; preds = %.entry
+  %11 = alloca %array, align 8
+  %12 = getelementptr %array, %array* %11, i32 0, i32 2
+  %13 = alloca i32, align 4
+  store i32 3, i32* %13, align 4
+  %14 = load i32, i32* %13, align 4
+  %15 = alloca %dimension_descriptor, i32 %14, align 8
+  store %dimension_descriptor* %15, %dimension_descriptor** %12, align 8
+  %16 = getelementptr %array, %array* %11, i32 0, i32 4
+  store i32 3, i32* %16, align 4
+  store %array* %11, %array** %c, align 8
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %17 = load %array*, %array** %c, align 8
+  %18 = getelementptr %array, %array* %17, i32 0, i32 1
+  store i32 0, i32* %18, align 4
+  %19 = getelementptr %array, %array* %17, i32 0, i32 2
+  %20 = load %dimension_descriptor*, %dimension_descriptor** %19, align 8
+  %21 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 0
+  %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 0
+  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 1
+  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 2
+  store i32 1, i32* %22, align 4
+  store i32 1, i32* %23, align 4
+  store i32 3, i32* %24, align 4
+  %25 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 1
+  %26 = getelementptr %dimension_descriptor, %dimension_descriptor* %25, i32 0, i32 0
+  %27 = getelementptr %dimension_descriptor, %dimension_descriptor* %25, i32 0, i32 1
+  %28 = getelementptr %dimension_descriptor, %dimension_descriptor* %25, i32 0, i32 2
+  store i32 3, i32* %26, align 4
+  store i32 1, i32* %27, align 4
+  store i32 3, i32* %28, align 4
+  %29 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 2
+  %30 = getelementptr %dimension_descriptor, %dimension_descriptor* %29, i32 0, i32 0
+  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %29, i32 0, i32 1
+  %32 = getelementptr %dimension_descriptor, %dimension_descriptor* %29, i32 0, i32 2
+  store i32 9, i32* %30, align 4
+  store i32 1, i32* %31, align 4
+  store i32 3, i32* %32, align 4
+  %33 = getelementptr %array, %array* %17, i32 0, i32 0
+  %34 = alloca i32, align 4
+  store i32 108, i32* %34, align 4
+  %35 = load i32, i32* %34, align 4
+  %36 = call i8* @_lfortran_malloc(i32 %35)
+  %37 = bitcast i8* %36 to i32*
+  store i32* %37, i32** %33, align 8
+  store i32 0, i32* %stat2, align 4
+  %38 = load i32, i32* %stat2, align 4
+  %39 = icmp ne i32 %38, 0
+  br i1 %39, label %then3, label %else4
+
+then3:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont5
+
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
+
+ifcont5:                                          ; preds = %else4, %then3
+  %40 = load %array*, %array** %c, align 8
+  %41 = getelementptr %array, %array* %40, i32 0, i32 2
+  %42 = load %dimension_descriptor*, %dimension_descriptor** %41, align 8
+  %43 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 0
+  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 1
+  %45 = load i32, i32* %44, align 4
+  %46 = sub i32 1, %45
+  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 0
+  %48 = load i32, i32* %47, align 4
+  %49 = mul i32 %48, %46
+  %50 = add i32 0, %49
+  %51 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 1
+  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 1
+  %53 = load i32, i32* %52, align 4
+  %54 = sub i32 1, %53
+  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 0
+  %56 = load i32, i32* %55, align 4
+  %57 = mul i32 %56, %54
+  %58 = add i32 %50, %57
+  %59 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 2
+  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
+  %61 = load i32, i32* %60, align 4
+  %62 = sub i32 1, %61
+  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
+  %64 = load i32, i32* %63, align 4
+  %65 = mul i32 %64, %62
+  %66 = add i32 %58, %65
+  %67 = getelementptr %array, %array* %40, i32 0, i32 1
+  %68 = load i32, i32* %67, align 4
+  %69 = add i32 %66, %68
+  %70 = getelementptr %array, %array* %40, i32 0, i32 0
+  %71 = load i32*, i32** %70, align 8
+  %72 = getelementptr inbounds i32, i32* %71, i32 %69
+  store i32 3, i32* %72, align 4
+  %73 = load %array*, %array** %c, align 8
+  %74 = getelementptr %array, %array* %73, i32 0, i32 0
+  %75 = load i32*, i32** %74, align 8
+  %76 = ptrtoint i32* %75 to i64
+  %77 = icmp ne i64 %76, 0
+  br i1 %77, label %then6, label %else7
+
+then6:                                            ; preds = %ifcont5
+  %78 = getelementptr %array, %array* %73, i32 0, i32 0
+  %79 = load i32*, i32** %78, align 8
+  %80 = alloca i8*, align 8
+  %81 = bitcast i32* %79 to i8*
+  store i8* %81, i8** %80, align 8
+  %82 = load i8*, i8** %80, align 8
+  call void @_lfortran_free(i8* %82)
+  %83 = getelementptr %array, %array* %73, i32 0, i32 0
+  store i32* null, i32** %83, align 8
+  br label %ifcont8
+
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
+
+ifcont8:                                          ; preds = %else7, %then6
+  call void @h(%array** %c)
+  %84 = call i32 @g(%array** %c)
+  store i32 %84, i32* %r1, align 4
+  %85 = load %array*, %array** %c, align 8
+  %86 = getelementptr %array, %array* %85, i32 0, i32 2
+  %87 = load %dimension_descriptor*, %dimension_descriptor** %86, align 8
+  %88 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %87, i32 0
+  %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %88, i32 0, i32 1
+  %90 = load i32, i32* %89, align 4
+  %91 = sub i32 1, %90
+  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %88, i32 0, i32 0
+  %93 = load i32, i32* %92, align 4
+  %94 = mul i32 %93, %91
+  %95 = add i32 0, %94
+  %96 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %87, i32 1
+  %97 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 1
+  %98 = load i32, i32* %97, align 4
+  %99 = sub i32 1, %98
+  %100 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 0
+  %101 = load i32, i32* %100, align 4
+  %102 = mul i32 %101, %99
+  %103 = add i32 %95, %102
+  %104 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %87, i32 2
+  %105 = getelementptr %dimension_descriptor, %dimension_descriptor* %104, i32 0, i32 1
+  %106 = load i32, i32* %105, align 4
+  %107 = sub i32 1, %106
+  %108 = getelementptr %dimension_descriptor, %dimension_descriptor* %104, i32 0, i32 0
+  %109 = load i32, i32* %108, align 4
+  %110 = mul i32 %109, %107
+  %111 = add i32 %103, %110
+  %112 = getelementptr %array, %array* %85, i32 0, i32 1
+  %113 = load i32, i32* %112, align 4
+  %114 = add i32 %111, %113
+  %115 = getelementptr %array, %array* %85, i32 0, i32 0
+  %116 = load i32*, i32** %115, align 8
+  %117 = getelementptr inbounds i32, i32* %116, i32 %114
+  %118 = load i32, i32* %117, align 4
+  %119 = icmp ne i32 %118, 8
+  br i1 %119, label %then9, label %else10
+
+then9:                                            ; preds = %ifcont8
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont11
+
+else10:                                           ; preds = %ifcont8
+  br label %ifcont11
+
+ifcont11:                                         ; preds = %else10, %then9
+  %120 = load %array*, %array** %c, align 8
+  %121 = getelementptr %array, %array* %120, i32 0, i32 2
+  %122 = load %dimension_descriptor*, %dimension_descriptor** %121, align 8
+  %123 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %122, i32 0
+  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %123, i32 0, i32 1
+  %125 = load i32, i32* %124, align 4
+  %126 = sub i32 1, %125
+  %127 = getelementptr %dimension_descriptor, %dimension_descriptor* %123, i32 0, i32 0
+  %128 = load i32, i32* %127, align 4
+  %129 = mul i32 %128, %126
+  %130 = add i32 0, %129
+  %131 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %122, i32 1
+  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %131, i32 0, i32 1
+  %133 = load i32, i32* %132, align 4
+  %134 = sub i32 1, %133
+  %135 = getelementptr %dimension_descriptor, %dimension_descriptor* %131, i32 0, i32 0
+  %136 = load i32, i32* %135, align 4
+  %137 = mul i32 %136, %134
+  %138 = add i32 %130, %137
+  %139 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %122, i32 2
+  %140 = getelementptr %dimension_descriptor, %dimension_descriptor* %139, i32 0, i32 1
+  %141 = load i32, i32* %140, align 4
+  %142 = sub i32 1, %141
+  %143 = getelementptr %dimension_descriptor, %dimension_descriptor* %139, i32 0, i32 0
+  %144 = load i32, i32* %143, align 4
+  %145 = mul i32 %144, %142
+  %146 = add i32 %138, %145
+  %147 = getelementptr %array, %array* %120, i32 0, i32 1
+  %148 = load i32, i32* %147, align 4
+  %149 = add i32 %146, %148
+  %150 = getelementptr %array, %array* %120, i32 0, i32 0
+  %151 = load i32*, i32** %150, align 8
+  %152 = getelementptr inbounds i32, i32* %151, i32 %149
+  %153 = load i32, i32* %152, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i32 %153, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  %154 = load %array*, %array** %c, align 8
+  %155 = getelementptr %array, %array* %154, i32 0, i32 0
+  %156 = load i32*, i32** %155, align 8
+  %157 = ptrtoint i32* %156 to i64
+  %158 = icmp ne i64 %157, 0
+  br i1 %158, label %then12, label %else13
+
+then12:                                           ; preds = %ifcont11
+  %159 = getelementptr %array, %array* %154, i32 0, i32 0
+  %160 = load i32*, i32** %159, align 8
+  %161 = alloca i8*, align 8
+  %162 = bitcast i32* %160 to i8*
+  store i8* %162, i8** %161, align 8
+  %163 = load i8*, i8** %161, align 8
+  call void @_lfortran_free(i8* %163)
+  %164 = getelementptr %array, %array* %154, i32 0, i32 0
+  store i32* null, i32** %164, align 8
+  br label %ifcont14
+
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
+
+ifcont14:                                         ; preds = %else13, %then12
+  %165 = load %array*, %array** %c, align 8
+  %166 = getelementptr %array, %array* %165, i32 0, i32 0
+  %167 = load i32*, i32** %166, align 8
+  %168 = ptrtoint i32* %167 to i64
+  %169 = icmp ne i64 %168, 0
+  br i1 %169, label %then15, label %else16
+
+then15:                                           ; preds = %ifcont14
+  %170 = getelementptr %array, %array* %165, i32 0, i32 0
+  %171 = load i32*, i32** %170, align 8
+  %172 = alloca i8*, align 8
+  %173 = bitcast i32* %171 to i8*
+  store i8* %173, i8** %172, align 8
+  %174 = load i8*, i8** %172, align 8
+  call void @_lfortran_free(i8* %174)
+  %175 = getelementptr %array, %array* %165, i32 0, i32 0
+  store i32* null, i32** %175, align 8
+  br label %ifcont17
+
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
+
+ifcont17:                                         ; preds = %else16, %then15
+  br label %return
+
+return:                                           ; preds = %ifcont17
+  ret i32 0
+}
+
 define void @f(%array** %c) {
 .entry:
   %0 = load %array*, %array** %c, align 8
@@ -535,287 +819,5 @@ declare void @_lcompilers_print_error(i8*, ...)
 declare void @exit(i32)
 
 declare void @_lfortran_free(i8*)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %c = alloca %array*, align 8
-  store %array* null, %array** %c, align 8
-  %arr_desc = alloca %array, align 8
-  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %3 = alloca i32, align 4
-  store i32 3, i32* %3, align 4
-  %4 = load i32, i32* %3, align 4
-  %5 = alloca %dimension_descriptor, i32 %4, align 8
-  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
-  %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
-  store i32 3, i32* %6, align 4
-  %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %7, align 8
-  store %array* %arr_desc, %array** %c, align 8
-  %r = alloca i32, align 4
-  %stat = alloca i32, align 4
-  store i32 1, i32* %stat, align 4
-  %8 = load %array*, %array** %c, align 8
-  %9 = ptrtoint %array* %8 to i32
-  %10 = icmp eq i32 %9, 0
-  br i1 %10, label %then, label %else
-
-then:                                             ; preds = %.entry
-  %11 = alloca %array, align 8
-  %12 = getelementptr %array, %array* %11, i32 0, i32 2
-  %13 = alloca i32, align 4
-  store i32 3, i32* %13, align 4
-  %14 = load i32, i32* %13, align 4
-  %15 = alloca %dimension_descriptor, i32 %14, align 8
-  store %dimension_descriptor* %15, %dimension_descriptor** %12, align 8
-  %16 = getelementptr %array, %array* %11, i32 0, i32 4
-  store i32 3, i32* %16, align 4
-  store %array* %11, %array** %c, align 8
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %17 = load %array*, %array** %c, align 8
-  %18 = getelementptr %array, %array* %17, i32 0, i32 1
-  store i32 0, i32* %18, align 4
-  %19 = getelementptr %array, %array* %17, i32 0, i32 2
-  %20 = load %dimension_descriptor*, %dimension_descriptor** %19, align 8
-  %21 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 0
-  %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 0
-  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 1
-  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 2
-  store i32 1, i32* %22, align 4
-  store i32 1, i32* %23, align 4
-  store i32 3, i32* %24, align 4
-  %25 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 1
-  %26 = getelementptr %dimension_descriptor, %dimension_descriptor* %25, i32 0, i32 0
-  %27 = getelementptr %dimension_descriptor, %dimension_descriptor* %25, i32 0, i32 1
-  %28 = getelementptr %dimension_descriptor, %dimension_descriptor* %25, i32 0, i32 2
-  store i32 3, i32* %26, align 4
-  store i32 1, i32* %27, align 4
-  store i32 3, i32* %28, align 4
-  %29 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 2
-  %30 = getelementptr %dimension_descriptor, %dimension_descriptor* %29, i32 0, i32 0
-  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %29, i32 0, i32 1
-  %32 = getelementptr %dimension_descriptor, %dimension_descriptor* %29, i32 0, i32 2
-  store i32 9, i32* %30, align 4
-  store i32 1, i32* %31, align 4
-  store i32 3, i32* %32, align 4
-  %33 = getelementptr %array, %array* %17, i32 0, i32 0
-  %34 = alloca i32, align 4
-  store i32 108, i32* %34, align 4
-  %35 = load i32, i32* %34, align 4
-  %36 = call i8* @_lfortran_malloc(i32 %35)
-  %37 = bitcast i8* %36 to i32*
-  store i32* %37, i32** %33, align 8
-  store i32 0, i32* %stat, align 4
-  %38 = load i32, i32* %stat, align 4
-  %39 = icmp ne i32 %38, 0
-  br i1 %39, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
-  %40 = load %array*, %array** %c, align 8
-  %41 = getelementptr %array, %array* %40, i32 0, i32 2
-  %42 = load %dimension_descriptor*, %dimension_descriptor** %41, align 8
-  %43 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 0
-  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 1
-  %45 = load i32, i32* %44, align 4
-  %46 = sub i32 1, %45
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 0
-  %48 = load i32, i32* %47, align 4
-  %49 = mul i32 %48, %46
-  %50 = add i32 0, %49
-  %51 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 1
-  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 1
-  %53 = load i32, i32* %52, align 4
-  %54 = sub i32 1, %53
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 0
-  %56 = load i32, i32* %55, align 4
-  %57 = mul i32 %56, %54
-  %58 = add i32 %50, %57
-  %59 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 2
-  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
-  %61 = load i32, i32* %60, align 4
-  %62 = sub i32 1, %61
-  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
-  %64 = load i32, i32* %63, align 4
-  %65 = mul i32 %64, %62
-  %66 = add i32 %58, %65
-  %67 = getelementptr %array, %array* %40, i32 0, i32 1
-  %68 = load i32, i32* %67, align 4
-  %69 = add i32 %66, %68
-  %70 = getelementptr %array, %array* %40, i32 0, i32 0
-  %71 = load i32*, i32** %70, align 8
-  %72 = getelementptr inbounds i32, i32* %71, i32 %69
-  store i32 3, i32* %72, align 4
-  %73 = load %array*, %array** %c, align 8
-  %74 = getelementptr %array, %array* %73, i32 0, i32 0
-  %75 = load i32*, i32** %74, align 8
-  %76 = ptrtoint i32* %75 to i64
-  %77 = icmp ne i64 %76, 0
-  br i1 %77, label %then4, label %else5
-
-then4:                                            ; preds = %ifcont3
-  %78 = getelementptr %array, %array* %73, i32 0, i32 0
-  %79 = load i32*, i32** %78, align 8
-  %80 = alloca i8*, align 8
-  %81 = bitcast i32* %79 to i8*
-  store i8* %81, i8** %80, align 8
-  %82 = load i8*, i8** %80, align 8
-  call void @_lfortran_free(i8* %82)
-  %83 = getelementptr %array, %array* %73, i32 0, i32 0
-  store i32* null, i32** %83, align 8
-  br label %ifcont6
-
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
-
-ifcont6:                                          ; preds = %else5, %then4
-  call void @h(%array** %c)
-  %84 = call i32 @g(%array** %c)
-  store i32 %84, i32* %r, align 4
-  %85 = load %array*, %array** %c, align 8
-  %86 = getelementptr %array, %array* %85, i32 0, i32 2
-  %87 = load %dimension_descriptor*, %dimension_descriptor** %86, align 8
-  %88 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %87, i32 0
-  %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %88, i32 0, i32 1
-  %90 = load i32, i32* %89, align 4
-  %91 = sub i32 1, %90
-  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %88, i32 0, i32 0
-  %93 = load i32, i32* %92, align 4
-  %94 = mul i32 %93, %91
-  %95 = add i32 0, %94
-  %96 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %87, i32 1
-  %97 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 1
-  %98 = load i32, i32* %97, align 4
-  %99 = sub i32 1, %98
-  %100 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 0
-  %101 = load i32, i32* %100, align 4
-  %102 = mul i32 %101, %99
-  %103 = add i32 %95, %102
-  %104 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %87, i32 2
-  %105 = getelementptr %dimension_descriptor, %dimension_descriptor* %104, i32 0, i32 1
-  %106 = load i32, i32* %105, align 4
-  %107 = sub i32 1, %106
-  %108 = getelementptr %dimension_descriptor, %dimension_descriptor* %104, i32 0, i32 0
-  %109 = load i32, i32* %108, align 4
-  %110 = mul i32 %109, %107
-  %111 = add i32 %103, %110
-  %112 = getelementptr %array, %array* %85, i32 0, i32 1
-  %113 = load i32, i32* %112, align 4
-  %114 = add i32 %111, %113
-  %115 = getelementptr %array, %array* %85, i32 0, i32 0
-  %116 = load i32*, i32** %115, align 8
-  %117 = getelementptr inbounds i32, i32* %116, i32 %114
-  %118 = load i32, i32* %117, align 4
-  %119 = icmp ne i32 %118, 8
-  br i1 %119, label %then7, label %else8
-
-then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont9
-
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
-
-ifcont9:                                          ; preds = %else8, %then7
-  %120 = load %array*, %array** %c, align 8
-  %121 = getelementptr %array, %array* %120, i32 0, i32 2
-  %122 = load %dimension_descriptor*, %dimension_descriptor** %121, align 8
-  %123 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %122, i32 0
-  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %123, i32 0, i32 1
-  %125 = load i32, i32* %124, align 4
-  %126 = sub i32 1, %125
-  %127 = getelementptr %dimension_descriptor, %dimension_descriptor* %123, i32 0, i32 0
-  %128 = load i32, i32* %127, align 4
-  %129 = mul i32 %128, %126
-  %130 = add i32 0, %129
-  %131 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %122, i32 1
-  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %131, i32 0, i32 1
-  %133 = load i32, i32* %132, align 4
-  %134 = sub i32 1, %133
-  %135 = getelementptr %dimension_descriptor, %dimension_descriptor* %131, i32 0, i32 0
-  %136 = load i32, i32* %135, align 4
-  %137 = mul i32 %136, %134
-  %138 = add i32 %130, %137
-  %139 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %122, i32 2
-  %140 = getelementptr %dimension_descriptor, %dimension_descriptor* %139, i32 0, i32 1
-  %141 = load i32, i32* %140, align 4
-  %142 = sub i32 1, %141
-  %143 = getelementptr %dimension_descriptor, %dimension_descriptor* %139, i32 0, i32 0
-  %144 = load i32, i32* %143, align 4
-  %145 = mul i32 %144, %142
-  %146 = add i32 %138, %145
-  %147 = getelementptr %array, %array* %120, i32 0, i32 1
-  %148 = load i32, i32* %147, align 4
-  %149 = add i32 %146, %148
-  %150 = getelementptr %array, %array* %120, i32 0, i32 0
-  %151 = load i32*, i32** %150, align 8
-  %152 = getelementptr inbounds i32, i32* %151, i32 %149
-  %153 = load i32, i32* %152, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i32 %153, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  %154 = load %array*, %array** %c, align 8
-  %155 = getelementptr %array, %array* %154, i32 0, i32 0
-  %156 = load i32*, i32** %155, align 8
-  %157 = ptrtoint i32* %156 to i64
-  %158 = icmp ne i64 %157, 0
-  br i1 %158, label %then10, label %else11
-
-then10:                                           ; preds = %ifcont9
-  %159 = getelementptr %array, %array* %154, i32 0, i32 0
-  %160 = load i32*, i32** %159, align 8
-  %161 = alloca i8*, align 8
-  %162 = bitcast i32* %160 to i8*
-  store i8* %162, i8** %161, align 8
-  %163 = load i8*, i8** %161, align 8
-  call void @_lfortran_free(i8* %163)
-  %164 = getelementptr %array, %array* %154, i32 0, i32 0
-  store i32* null, i32** %164, align 8
-  br label %ifcont12
-
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
-
-ifcont12:                                         ; preds = %else11, %then10
-  %165 = load %array*, %array** %c, align 8
-  %166 = getelementptr %array, %array* %165, i32 0, i32 0
-  %167 = load i32*, i32** %166, align 8
-  %168 = ptrtoint i32* %167 to i64
-  %169 = icmp ne i64 %168, 0
-  br i1 %169, label %then13, label %else14
-
-then13:                                           ; preds = %ifcont12
-  %170 = getelementptr %array, %array* %165, i32 0, i32 0
-  %171 = load i32*, i32** %170, align 8
-  %172 = alloca i8*, align 8
-  %173 = bitcast i32* %171 to i8*
-  store i8* %173, i8** %172, align 8
-  %174 = load i8*, i8** %172, align 8
-  call void @_lfortran_free(i8* %174)
-  %175 = getelementptr %array, %array* %165, i32 0, i32 0
-  store i32* null, i32** %175, align 8
-  br label %ifcont15
-
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
-
-ifcont15:                                         ; preds = %else14, %then13
-  br label %return
-
-return:                                           ; preds = %ifcont15
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-arrays_01-91893af.json
+++ b/tests/reference/llvm-arrays_01-91893af.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01-91893af.stdout",
-    "stdout_hash": "38c7bae1009a9646ebc08991629f92d35cca0309b86740f2f4234455",
+    "stdout_hash": "0e42673de4da6a07e4282bf89ffa332b930fd8349648a284cffdd9c4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01-91893af.stdout
+++ b/tests/reference/llvm-arrays_01-91893af.stdout
@@ -40,29 +40,30 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x i32], align 4
   %b = alloca [4 x i32], align 4
-  %i = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  %i1 = alloca i32, align 4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 3
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %i1, align 4
   %8 = sub i32 %7, 1
   %9 = mul i32 1, %8
   %10 = add i32 0, %9
   %11 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 %10
-  %12 = load i32, i32* %i, align 4
+  %12 = load i32, i32* %i1, align 4
   %13 = add i32 %12, 10
   store i32 %13, i32* %11, align 4
   br label %loop.head
@@ -85,130 +86,130 @@ ifcont:                                           ; preds = %else, %then
   %17 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 1
   %18 = load i32, i32* %17, align 4
   %19 = icmp ne i32 %18, 12
-  br i1 %19, label %then1, label %else2
+  br i1 %19, label %then2, label %else3
 
-then1:                                            ; preds = %ifcont
+then2:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont4
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else3:                                            ; preds = %ifcont
+  br label %ifcont4
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont4:                                          ; preds = %else3, %then2
   %20 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 2
   %21 = load i32, i32* %20, align 4
   %22 = icmp ne i32 %21, 13
-  br i1 %22, label %then4, label %else5
+  br i1 %22, label %then5, label %else6
 
-then4:                                            ; preds = %ifcont3
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont7
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else6:                                            ; preds = %ifcont4
+  br label %ifcont7
 
-ifcont6:                                          ; preds = %else5, %then4
-  store i32 10, i32* %i, align 4
-  br label %loop.head7
+ifcont7:                                          ; preds = %else6, %then5
+  store i32 10, i32* %i1, align 4
+  br label %loop.head8
 
-loop.head7:                                       ; preds = %loop.body8, %ifcont6
-  %23 = load i32, i32* %i, align 4
+loop.head8:                                       ; preds = %loop.body9, %ifcont7
+  %23 = load i32, i32* %i1, align 4
   %24 = add i32 %23, 1
   %25 = icmp sle i32 %24, 14
-  br i1 %25, label %loop.body8, label %loop.end9
+  br i1 %25, label %loop.body9, label %loop.end10
 
-loop.body8:                                       ; preds = %loop.head7
-  %26 = load i32, i32* %i, align 4
+loop.body9:                                       ; preds = %loop.head8
+  %26 = load i32, i32* %i1, align 4
   %27 = add i32 %26, 1
-  store i32 %27, i32* %i, align 4
-  %28 = load i32, i32* %i, align 4
+  store i32 %27, i32* %i1, align 4
+  %28 = load i32, i32* %i1, align 4
   %29 = sub i32 %28, 10
   %30 = sub i32 %29, 1
   %31 = mul i32 1, %30
   %32 = add i32 0, %31
   %33 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %32
-  %34 = load i32, i32* %i, align 4
+  %34 = load i32, i32* %i1, align 4
   store i32 %34, i32* %33, align 4
-  br label %loop.head7
+  br label %loop.head8
 
-loop.end9:                                        ; preds = %loop.head7
+loop.end10:                                       ; preds = %loop.head8
   %35 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %36 = load i32, i32* %35, align 4
   %37 = icmp ne i32 %36, 11
-  br i1 %37, label %then10, label %else11
+  br i1 %37, label %then11, label %else12
 
-then10:                                           ; preds = %loop.end9
+then11:                                           ; preds = %loop.end10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont13
 
-else11:                                           ; preds = %loop.end9
-  br label %ifcont12
+else12:                                           ; preds = %loop.end10
+  br label %ifcont13
 
-ifcont12:                                         ; preds = %else11, %then10
+ifcont13:                                         ; preds = %else12, %then11
   %38 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %39 = load i32, i32* %38, align 4
   %40 = icmp ne i32 %39, 12
-  br i1 %40, label %then13, label %else14
+  br i1 %40, label %then14, label %else15
 
-then13:                                           ; preds = %ifcont12
+then14:                                           ; preds = %ifcont13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont16
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else15:                                           ; preds = %ifcont13
+  br label %ifcont16
 
-ifcont15:                                         ; preds = %else14, %then13
+ifcont16:                                         ; preds = %else15, %then14
   %41 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %42 = load i32, i32* %41, align 4
   %43 = icmp ne i32 %42, 13
-  br i1 %43, label %then16, label %else17
+  br i1 %43, label %then17, label %else18
 
-then16:                                           ; preds = %ifcont15
+then17:                                           ; preds = %ifcont16
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont19
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else18:                                           ; preds = %ifcont16
+  br label %ifcont19
 
-ifcont18:                                         ; preds = %else17, %then16
+ifcont19:                                         ; preds = %else18, %then17
   %44 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %45 = load i32, i32* %44, align 4
   %46 = icmp ne i32 %45, 14
-  br i1 %46, label %then19, label %else20
+  br i1 %46, label %then20, label %else21
 
-then19:                                           ; preds = %ifcont18
+then20:                                           ; preds = %ifcont19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont22
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else21:                                           ; preds = %ifcont19
+  br label %ifcont22
 
-ifcont21:                                         ; preds = %else20, %then19
-  store i32 0, i32* %i, align 4
-  br label %loop.head22
+ifcont22:                                         ; preds = %else21, %then20
+  store i32 0, i32* %i1, align 4
+  br label %loop.head23
 
-loop.head22:                                      ; preds = %loop.body23, %ifcont21
-  %47 = load i32, i32* %i, align 4
+loop.head23:                                      ; preds = %loop.body24, %ifcont22
+  %47 = load i32, i32* %i1, align 4
   %48 = add i32 %47, 1
   %49 = icmp sle i32 %48, 3
-  br i1 %49, label %loop.body23, label %loop.end24
+  br i1 %49, label %loop.body24, label %loop.end25
 
-loop.body23:                                      ; preds = %loop.head22
-  %50 = load i32, i32* %i, align 4
+loop.body24:                                      ; preds = %loop.head23
+  %50 = load i32, i32* %i1, align 4
   %51 = add i32 %50, 1
-  store i32 %51, i32* %i, align 4
-  %52 = load i32, i32* %i, align 4
+  store i32 %51, i32* %i1, align 4
+  %52 = load i32, i32* %i1, align 4
   %53 = sub i32 %52, 1
   %54 = mul i32 1, %53
   %55 = add i32 0, %54
   %56 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %55
-  %57 = load i32, i32* %i, align 4
+  %57 = load i32, i32* %i1, align 4
   %58 = sub i32 %57, 1
   %59 = mul i32 1, %58
   %60 = add i32 0, %59
@@ -216,51 +217,51 @@ loop.body23:                                      ; preds = %loop.head22
   %62 = load i32, i32* %61, align 4
   %63 = sub i32 %62, 10
   store i32 %63, i32* %56, align 4
-  br label %loop.head22
+  br label %loop.head23
 
-loop.end24:                                       ; preds = %loop.head22
+loop.end25:                                       ; preds = %loop.head23
   %64 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %65 = load i32, i32* %64, align 4
   %66 = icmp ne i32 %65, 1
-  br i1 %66, label %then25, label %else26
+  br i1 %66, label %then26, label %else27
 
-then25:                                           ; preds = %loop.end24
+then26:                                           ; preds = %loop.end25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont27
+  br label %ifcont28
 
-else26:                                           ; preds = %loop.end24
-  br label %ifcont27
+else27:                                           ; preds = %loop.end25
+  br label %ifcont28
 
-ifcont27:                                         ; preds = %else26, %then25
+ifcont28:                                         ; preds = %else27, %then26
   %67 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %68 = load i32, i32* %67, align 4
   %69 = icmp ne i32 %68, 2
-  br i1 %69, label %then28, label %else29
+  br i1 %69, label %then29, label %else30
 
-then28:                                           ; preds = %ifcont27
+then29:                                           ; preds = %ifcont28
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont31
 
-else29:                                           ; preds = %ifcont27
-  br label %ifcont30
+else30:                                           ; preds = %ifcont28
+  br label %ifcont31
 
-ifcont30:                                         ; preds = %else29, %then28
+ifcont31:                                         ; preds = %else30, %then29
   %70 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %71 = load i32, i32* %70, align 4
   %72 = icmp ne i32 %71, 3
-  br i1 %72, label %then31, label %else32
+  br i1 %72, label %then32, label %else33
 
-then31:                                           ; preds = %ifcont30
+then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont34
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else33:                                           ; preds = %ifcont31
+  br label %ifcont34
 
-ifcont33:                                         ; preds = %else32, %then31
+ifcont34:                                         ; preds = %else33, %then32
   %73 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %74 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %75 = load i32, i32* %74, align 4
@@ -277,17 +278,17 @@ ifcont33:                                         ; preds = %else32, %then31
   %85 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %86 = load i32, i32* %85, align 4
   %87 = icmp ne i32 %86, 17
-  br i1 %87, label %then34, label %else35
+  br i1 %87, label %then35, label %else36
 
-then34:                                           ; preds = %ifcont33
+then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont37
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else36:                                           ; preds = %ifcont34
+  br label %ifcont37
 
-ifcont36:                                         ; preds = %else35, %then34
+ifcont37:                                         ; preds = %else36, %then35
   %88 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %89 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %90 = load i32, i32* %89, align 4
@@ -295,20 +296,20 @@ ifcont36:                                         ; preds = %else35, %then34
   %91 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %92 = load i32, i32* %91, align 4
   %93 = icmp ne i32 %92, 11
-  br i1 %93, label %then37, label %else38
+  br i1 %93, label %then38, label %else39
 
-then37:                                           ; preds = %ifcont36
+then38:                                           ; preds = %ifcont37
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont39
+  br label %ifcont40
 
-else38:                                           ; preds = %ifcont36
-  br label %ifcont39
+else39:                                           ; preds = %ifcont37
+  br label %ifcont40
 
-ifcont39:                                         ; preds = %else38, %then37
+ifcont40:                                         ; preds = %else39, %then38
   br label %return
 
-return:                                           ; preds = %ifcont39
+return:                                           ; preds = %ifcont40
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.json
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_complex-c90dbdd.stdout",
-    "stdout_hash": "4109e73b564179546107d0b8ce780f71151a2422ec811e7b1b954593",
+    "stdout_hash": "eb30752ca40b45929345d63968a2d2781ddd6060442a0ed85f1c5d27",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
@@ -54,31 +54,33 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x %complex_4], align 8
   %b = alloca [4 x %complex_4], align 8
   %c = alloca [4 x %complex_4], align 8
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 3
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %i1, align 4
   %8 = sub i32 %7, 1
   %9 = mul i32 1, %8
   %10 = add i32 0, %9
   %11 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 %10
-  %12 = load i32, i32* %i, align 4
+  %12 = load i32, i32* %i1, align 4
   %13 = add i32 %12, 10
   %14 = sitofp i32 %13 to float
   %15 = alloca %complex_4, align 8
@@ -156,17 +158,17 @@ ifcont:                                           ; preds = %else, %then
   %58 = fcmp one float %48, %51
   %59 = fcmp one float %54, %57
   %60 = or i1 %58, %59
-  br i1 %60, label %then1, label %else2
+  br i1 %60, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont5:                                          ; preds = %else4, %then3
   %61 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 2
   %62 = load %complex_4, %complex_4* %61, align 4
   %63 = alloca %complex_4, align 8
@@ -194,37 +196,37 @@ ifcont3:                                          ; preds = %else2, %then1
   %79 = fcmp one float %69, %72
   %80 = fcmp one float %75, %78
   %81 = or i1 %79, %80
-  br i1 %81, label %then4, label %else5
+  br i1 %81, label %then6, label %else7
 
-then4:                                            ; preds = %ifcont3
+then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
-  store i32 10, i32* %i, align 4
-  br label %loop.head7
+ifcont8:                                          ; preds = %else7, %then6
+  store i32 10, i32* %i1, align 4
+  br label %loop.head9
 
-loop.head7:                                       ; preds = %loop.body8, %ifcont6
-  %82 = load i32, i32* %i, align 4
+loop.head9:                                       ; preds = %loop.body10, %ifcont8
+  %82 = load i32, i32* %i1, align 4
   %83 = add i32 %82, 1
   %84 = icmp sle i32 %83, 14
-  br i1 %84, label %loop.body8, label %loop.end9
+  br i1 %84, label %loop.body10, label %loop.end11
 
-loop.body8:                                       ; preds = %loop.head7
-  %85 = load i32, i32* %i, align 4
+loop.body10:                                      ; preds = %loop.head9
+  %85 = load i32, i32* %i1, align 4
   %86 = add i32 %85, 1
-  store i32 %86, i32* %i, align 4
-  %87 = load i32, i32* %i, align 4
+  store i32 %86, i32* %i1, align 4
+  %87 = load i32, i32* %i1, align 4
   %88 = sub i32 %87, 10
   %89 = sub i32 %88, 1
   %90 = mul i32 1, %89
   %91 = add i32 0, %90
   %92 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 %91
-  %93 = load i32, i32* %i, align 4
+  %93 = load i32, i32* %i1, align 4
   %94 = sitofp i32 %93 to float
   %95 = alloca %complex_4, align 8
   %96 = getelementptr %complex_4, %complex_4* %95, i32 0, i32 0
@@ -233,9 +235,9 @@ loop.body8:                                       ; preds = %loop.head7
   store float 0.000000e+00, float* %97, align 4
   %98 = load %complex_4, %complex_4* %95, align 4
   store %complex_4 %98, %complex_4* %92, align 4
-  br label %loop.head7
+  br label %loop.head9
 
-loop.end9:                                        ; preds = %loop.head7
+loop.end11:                                       ; preds = %loop.head9
   %99 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 0
   %100 = load %complex_4, %complex_4* %99, align 4
   %101 = alloca %complex_4, align 8
@@ -263,17 +265,17 @@ loop.end9:                                        ; preds = %loop.head7
   %117 = fcmp one float %107, %110
   %118 = fcmp one float %113, %116
   %119 = or i1 %117, %118
-  br i1 %119, label %then10, label %else11
+  br i1 %119, label %then12, label %else13
 
-then10:                                           ; preds = %loop.end9
+then12:                                           ; preds = %loop.end11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %loop.end9
-  br label %ifcont12
+else13:                                           ; preds = %loop.end11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
+ifcont14:                                         ; preds = %else13, %then12
   %120 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 1
   %121 = load %complex_4, %complex_4* %120, align 4
   %122 = alloca %complex_4, align 8
@@ -301,17 +303,17 @@ ifcont12:                                         ; preds = %else11, %then10
   %138 = fcmp one float %128, %131
   %139 = fcmp one float %134, %137
   %140 = or i1 %138, %139
-  br i1 %140, label %then13, label %else14
+  br i1 %140, label %then15, label %else16
 
-then13:                                           ; preds = %ifcont12
+then15:                                           ; preds = %ifcont14
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont17
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
 
-ifcont15:                                         ; preds = %else14, %then13
+ifcont17:                                         ; preds = %else16, %then15
   %141 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 2
   %142 = load %complex_4, %complex_4* %141, align 4
   %143 = alloca %complex_4, align 8
@@ -339,17 +341,17 @@ ifcont15:                                         ; preds = %else14, %then13
   %159 = fcmp one float %149, %152
   %160 = fcmp one float %155, %158
   %161 = or i1 %159, %160
-  br i1 %161, label %then16, label %else17
+  br i1 %161, label %then18, label %else19
 
-then16:                                           ; preds = %ifcont15
+then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont20
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else19:                                           ; preds = %ifcont17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %else17, %then16
+ifcont20:                                         ; preds = %else19, %then18
   %162 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
   %163 = load %complex_4, %complex_4* %162, align 4
   %164 = alloca %complex_4, align 8
@@ -377,36 +379,36 @@ ifcont18:                                         ; preds = %else17, %then16
   %180 = fcmp one float %170, %173
   %181 = fcmp one float %176, %179
   %182 = or i1 %180, %181
-  br i1 %182, label %then19, label %else20
+  br i1 %182, label %then21, label %else22
 
-then19:                                           ; preds = %ifcont18
+then21:                                           ; preds = %ifcont20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont23
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else22:                                           ; preds = %ifcont20
+  br label %ifcont23
 
-ifcont21:                                         ; preds = %else20, %then19
-  store i32 0, i32* %i, align 4
-  br label %loop.head22
+ifcont23:                                         ; preds = %else22, %then21
+  store i32 0, i32* %i1, align 4
+  br label %loop.head24
 
-loop.head22:                                      ; preds = %loop.body23, %ifcont21
-  %183 = load i32, i32* %i, align 4
+loop.head24:                                      ; preds = %loop.body25, %ifcont23
+  %183 = load i32, i32* %i1, align 4
   %184 = add i32 %183, 1
   %185 = icmp sle i32 %184, 3
-  br i1 %185, label %loop.body23, label %loop.end24
+  br i1 %185, label %loop.body25, label %loop.end26
 
-loop.body23:                                      ; preds = %loop.head22
-  %186 = load i32, i32* %i, align 4
+loop.body25:                                      ; preds = %loop.head24
+  %186 = load i32, i32* %i1, align 4
   %187 = add i32 %186, 1
-  store i32 %187, i32* %i, align 4
-  %188 = load i32, i32* %i, align 4
+  store i32 %187, i32* %i1, align 4
+  %188 = load i32, i32* %i1, align 4
   %189 = sub i32 %188, 1
   %190 = mul i32 1, %189
   %191 = add i32 0, %190
   %192 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 %191
-  %193 = load i32, i32* %i, align 4
+  %193 = load i32, i32* %i1, align 4
   %194 = sub i32 %193, 1
   %195 = mul i32 1, %194
   %196 = add i32 0, %195
@@ -426,9 +428,9 @@ loop.body23:                                      ; preds = %loop.head22
   call void @_lfortran_complex_sub_32(%complex_4* %203, %complex_4* %204, %complex_4* %205)
   %206 = load %complex_4, %complex_4* %205, align 4
   store %complex_4 %206, %complex_4* %192, align 4
-  br label %loop.head22
+  br label %loop.head24
 
-loop.end24:                                       ; preds = %loop.head22
+loop.end26:                                       ; preds = %loop.head24
   %207 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 0
   %208 = load %complex_4, %complex_4* %207, align 4
   %209 = alloca %complex_4, align 8
@@ -456,17 +458,17 @@ loop.end24:                                       ; preds = %loop.head22
   %225 = fcmp one float %215, %218
   %226 = fcmp one float %221, %224
   %227 = or i1 %225, %226
-  br i1 %227, label %then25, label %else26
+  br i1 %227, label %then27, label %else28
 
-then25:                                           ; preds = %loop.end24
+then27:                                           ; preds = %loop.end26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont27
+  br label %ifcont29
 
-else26:                                           ; preds = %loop.end24
-  br label %ifcont27
+else28:                                           ; preds = %loop.end26
+  br label %ifcont29
 
-ifcont27:                                         ; preds = %else26, %then25
+ifcont29:                                         ; preds = %else28, %then27
   %228 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 1
   %229 = load %complex_4, %complex_4* %228, align 4
   %230 = alloca %complex_4, align 8
@@ -494,17 +496,17 @@ ifcont27:                                         ; preds = %else26, %then25
   %246 = fcmp one float %236, %239
   %247 = fcmp one float %242, %245
   %248 = or i1 %246, %247
-  br i1 %248, label %then28, label %else29
+  br i1 %248, label %then30, label %else31
 
-then28:                                           ; preds = %ifcont27
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont32
 
-else29:                                           ; preds = %ifcont27
-  br label %ifcont30
+else31:                                           ; preds = %ifcont29
+  br label %ifcont32
 
-ifcont30:                                         ; preds = %else29, %then28
+ifcont32:                                         ; preds = %else31, %then30
   %249 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 2
   %250 = load %complex_4, %complex_4* %249, align 4
   %251 = alloca %complex_4, align 8
@@ -532,17 +534,17 @@ ifcont30:                                         ; preds = %else29, %then28
   %267 = fcmp one float %257, %260
   %268 = fcmp one float %263, %266
   %269 = or i1 %267, %268
-  br i1 %269, label %then31, label %else32
+  br i1 %269, label %then33, label %else34
 
-then31:                                           ; preds = %ifcont30
+then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont35
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else34:                                           ; preds = %ifcont32
+  br label %ifcont35
 
-ifcont33:                                         ; preds = %else32, %then31
+ifcont35:                                         ; preds = %else34, %then33
   %270 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
   %271 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 0
   %272 = load %complex_4, %complex_4* %271, align 4
@@ -601,17 +603,17 @@ ifcont33:                                         ; preds = %else32, %then31
   %309 = fcmp one float %299, %302
   %310 = fcmp one float %305, %308
   %311 = or i1 %309, %310
-  br i1 %311, label %then34, label %else35
+  br i1 %311, label %then36, label %else37
 
-then34:                                           ; preds = %ifcont33
+then36:                                           ; preds = %ifcont35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont38
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else37:                                           ; preds = %ifcont35
+  br label %ifcont38
 
-ifcont36:                                         ; preds = %else35, %then34
+ifcont38:                                         ; preds = %else37, %then36
   %312 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
   %313 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 0
   %314 = load %complex_4, %complex_4* %313, align 4
@@ -643,45 +645,45 @@ ifcont36:                                         ; preds = %else35, %then34
   %333 = fcmp one float %323, %326
   %334 = fcmp one float %329, %332
   %335 = or i1 %333, %334
-  br i1 %335, label %then37, label %else38
+  br i1 %335, label %then39, label %else40
 
-then37:                                           ; preds = %ifcont36
+then39:                                           ; preds = %ifcont38
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont39
+  br label %ifcont41
 
-else38:                                           ; preds = %ifcont36
-  br label %ifcont39
+else40:                                           ; preds = %ifcont38
+  br label %ifcont41
 
-ifcont39:                                         ; preds = %else38, %then37
-  store i32 0, i32* %i, align 4
-  br label %loop.head40
-
-loop.head40:                                      ; preds = %loop.end44, %ifcont39
-  %336 = load i32, i32* %i, align 4
-  %337 = add i32 %336, 1
-  %338 = icmp sle i32 %337, 2
-  br i1 %338, label %loop.body41, label %loop.end45
-
-loop.body41:                                      ; preds = %loop.head40
-  %339 = load i32, i32* %i, align 4
-  %340 = add i32 %339, 1
-  store i32 %340, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+ifcont41:                                         ; preds = %else40, %then39
+  store i32 0, i32* %i1, align 4
   br label %loop.head42
 
-loop.head42:                                      ; preds = %loop.body43, %loop.body41
-  %341 = load i32, i32* %j, align 4
-  %342 = add i32 %341, 1
-  %343 = icmp sle i32 %342, 2
-  br i1 %343, label %loop.body43, label %loop.end44
+loop.head42:                                      ; preds = %loop.end46, %ifcont41
+  %336 = load i32, i32* %i1, align 4
+  %337 = add i32 %336, 1
+  %338 = icmp sle i32 %337, 2
+  br i1 %338, label %loop.body43, label %loop.end47
 
 loop.body43:                                      ; preds = %loop.head42
-  %344 = load i32, i32* %j, align 4
+  %339 = load i32, i32* %i1, align 4
+  %340 = add i32 %339, 1
+  store i32 %340, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head44
+
+loop.head44:                                      ; preds = %loop.body45, %loop.body43
+  %341 = load i32, i32* %j2, align 4
+  %342 = add i32 %341, 1
+  %343 = icmp sle i32 %342, 2
+  br i1 %343, label %loop.body45, label %loop.end46
+
+loop.body45:                                      ; preds = %loop.head44
+  %344 = load i32, i32* %j2, align 4
   %345 = add i32 %344, 1
-  store i32 %345, i32* %j, align 4
-  %346 = load i32, i32* %i, align 4
-  %347 = load i32, i32* %j, align 4
+  store i32 %345, i32* %j2, align 4
+  %346 = load i32, i32* %i1, align 4
+  %347 = load i32, i32* %j2, align 4
   %348 = sub i32 %346, 1
   %349 = mul i32 1, %348
   %350 = add i32 0, %349
@@ -689,8 +691,8 @@ loop.body43:                                      ; preds = %loop.head42
   %352 = mul i32 2, %351
   %353 = add i32 %350, %352
   %354 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 %353
-  %355 = load i32, i32* %i, align 4
-  %356 = load i32, i32* %j, align 4
+  %355 = load i32, i32* %i1, align 4
+  %356 = load i32, i32* %j2, align 4
   %357 = add i32 %355, %356
   %358 = add i32 %357, 10
   %359 = sitofp i32 %358 to float
@@ -701,12 +703,12 @@ loop.body43:                                      ; preds = %loop.head42
   store float 0.000000e+00, float* %362, align 4
   %363 = load %complex_4, %complex_4* %360, align 4
   store %complex_4 %363, %complex_4* %354, align 4
+  br label %loop.head44
+
+loop.end46:                                       ; preds = %loop.head44
   br label %loop.head42
 
-loop.end44:                                       ; preds = %loop.head42
-  br label %loop.head40
-
-loop.end45:                                       ; preds = %loop.head40
+loop.end47:                                       ; preds = %loop.head42
   %364 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 0
   %365 = load %complex_4, %complex_4* %364, align 4
   %366 = alloca %complex_4, align 8
@@ -734,17 +736,17 @@ loop.end45:                                       ; preds = %loop.head40
   %382 = fcmp one float %372, %375
   %383 = fcmp one float %378, %381
   %384 = or i1 %382, %383
-  br i1 %384, label %then46, label %else47
+  br i1 %384, label %then48, label %else49
 
-then46:                                           ; preds = %loop.end45
+then48:                                           ; preds = %loop.end47
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont48
+  br label %ifcont50
 
-else47:                                           ; preds = %loop.end45
-  br label %ifcont48
+else49:                                           ; preds = %loop.end47
+  br label %ifcont50
 
-ifcont48:                                         ; preds = %else47, %then46
+ifcont50:                                         ; preds = %else49, %then48
   %385 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 2
   %386 = load %complex_4, %complex_4* %385, align 4
   %387 = alloca %complex_4, align 8
@@ -772,17 +774,17 @@ ifcont48:                                         ; preds = %else47, %then46
   %403 = fcmp one float %393, %396
   %404 = fcmp one float %399, %402
   %405 = or i1 %403, %404
-  br i1 %405, label %then49, label %else50
+  br i1 %405, label %then51, label %else52
 
-then49:                                           ; preds = %ifcont48
+then51:                                           ; preds = %ifcont50
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont51
+  br label %ifcont53
 
-else50:                                           ; preds = %ifcont48
-  br label %ifcont51
+else52:                                           ; preds = %ifcont50
+  br label %ifcont53
 
-ifcont51:                                         ; preds = %else50, %then49
+ifcont53:                                         ; preds = %else52, %then51
   %406 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 1
   %407 = load %complex_4, %complex_4* %406, align 4
   %408 = alloca %complex_4, align 8
@@ -810,17 +812,17 @@ ifcont51:                                         ; preds = %else50, %then49
   %424 = fcmp one float %414, %417
   %425 = fcmp one float %420, %423
   %426 = or i1 %424, %425
-  br i1 %426, label %then52, label %else53
+  br i1 %426, label %then54, label %else55
 
-then52:                                           ; preds = %ifcont51
+then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont54
+  br label %ifcont56
 
-else53:                                           ; preds = %ifcont51
-  br label %ifcont54
+else55:                                           ; preds = %ifcont53
+  br label %ifcont56
 
-ifcont54:                                         ; preds = %else53, %then52
+ifcont56:                                         ; preds = %else55, %then54
   %427 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 3
   %428 = load %complex_4, %complex_4* %427, align 4
   %429 = alloca %complex_4, align 8
@@ -848,20 +850,20 @@ ifcont54:                                         ; preds = %else53, %then52
   %445 = fcmp one float %435, %438
   %446 = fcmp one float %441, %444
   %447 = or i1 %445, %446
-  br i1 %447, label %then55, label %else56
+  br i1 %447, label %then57, label %else58
 
-then55:                                           ; preds = %ifcont54
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont57
+  br label %ifcont59
 
-else56:                                           ; preds = %ifcont54
-  br label %ifcont57
+else58:                                           ; preds = %ifcont56
+  br label %ifcont59
 
-ifcont57:                                         ; preds = %else56, %then55
+ifcont59:                                         ; preds = %else58, %then57
   br label %return
 
-return:                                           ; preds = %ifcont57
+return:                                           ; preds = %ifcont59
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "85af90bb9c7a30b63492cda74e0435c7878b9417f0a275731807bafc",
+    "stdout_hash": "0b1c63e088b79f96df299b8a57ec5edef151161fe2b642dca993acfe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -52,33 +52,35 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x i1], align 1
   %b = alloca [4 x i1], align 1
   %c = alloca [4 x i1], align 1
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
   %2 = getelementptr [3 x i1], [3 x i1]* %a, i32 0, i32 0
   store i1 true, i1* %2, align 1
-  store i32 1, i32* %i, align 4
+  store i32 1, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, i32* %i1, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 3
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, i32* %i1, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %i, align 4
+  store i32 %7, i32* %i1, align 4
+  %8 = load i32, i32* %i1, align 4
   %9 = sub i32 %8, 1
   %10 = mul i32 1, %9
   %11 = add i32 0, %10
   %12 = getelementptr [3 x i1], [3 x i1]* %a, i32 0, i32 %11
-  %13 = load i32, i32* %i, align 4
+  %13 = load i32, i32* %i1, align 4
   %14 = sub i32 %13, 1
   %15 = sub i32 %14, 1
   %16 = mul i32 1, %15
@@ -106,53 +108,53 @@ else:                                             ; preds = %loop.end
 ifcont:                                           ; preds = %else, %then
   %24 = getelementptr [3 x i1], [3 x i1]* %a, i32 0, i32 1
   %25 = load i1, i1* %24, align 1
-  br i1 %25, label %then1, label %else2
+  br i1 %25, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont5:                                          ; preds = %else4, %then3
   %26 = getelementptr [3 x i1], [3 x i1]* %a, i32 0, i32 2
   %27 = load i1, i1* %26, align 1
   %28 = xor i1 %27, true
-  br i1 %28, label %then4, label %else5
+  br i1 %28, label %then6, label %else7
 
-then4:                                            ; preds = %ifcont3
+then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
+ifcont8:                                          ; preds = %else7, %then6
   %29 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 0
   store i1 false, i1* %29, align 1
-  store i32 11, i32* %i, align 4
-  br label %loop.head7
+  store i32 11, i32* %i1, align 4
+  br label %loop.head9
 
-loop.head7:                                       ; preds = %loop.body8, %ifcont6
-  %30 = load i32, i32* %i, align 4
+loop.head9:                                       ; preds = %loop.body10, %ifcont8
+  %30 = load i32, i32* %i1, align 4
   %31 = add i32 %30, 1
   %32 = icmp sle i32 %31, 14
-  br i1 %32, label %loop.body8, label %loop.end9
+  br i1 %32, label %loop.body10, label %loop.end11
 
-loop.body8:                                       ; preds = %loop.head7
-  %33 = load i32, i32* %i, align 4
+loop.body10:                                      ; preds = %loop.head9
+  %33 = load i32, i32* %i1, align 4
   %34 = add i32 %33, 1
-  store i32 %34, i32* %i, align 4
-  %35 = load i32, i32* %i, align 4
+  store i32 %34, i32* %i1, align 4
+  %35 = load i32, i32* %i1, align 4
   %36 = sub i32 %35, 10
   %37 = sub i32 %36, 1
   %38 = mul i32 1, %37
   %39 = add i32 0, %38
   %40 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 %39
-  %41 = load i32, i32* %i, align 4
+  %41 = load i32, i32* %i1, align 4
   %42 = sub i32 %41, 10
   %43 = sub i32 %42, 1
   %44 = sub i32 %43, 1
@@ -162,82 +164,82 @@ loop.body8:                                       ; preds = %loop.head7
   %48 = load i1, i1* %47, align 1
   %49 = xor i1 %48, true
   store i1 %49, i1* %40, align 1
-  br label %loop.head7
+  br label %loop.head9
 
-loop.end9:                                        ; preds = %loop.head7
+loop.end11:                                       ; preds = %loop.head9
   %50 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 0
   %51 = load i1, i1* %50, align 1
-  br i1 %51, label %then10, label %else11
+  br i1 %51, label %then12, label %else13
 
-then10:                                           ; preds = %loop.end9
+then12:                                           ; preds = %loop.end11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %loop.end9
-  br label %ifcont12
+else13:                                           ; preds = %loop.end11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
+ifcont14:                                         ; preds = %else13, %then12
   %52 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 1
   %53 = load i1, i1* %52, align 1
   %54 = xor i1 %53, true
-  br i1 %54, label %then13, label %else14
+  br i1 %54, label %then15, label %else16
 
-then13:                                           ; preds = %ifcont12
+then15:                                           ; preds = %ifcont14
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont17
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
 
-ifcont15:                                         ; preds = %else14, %then13
+ifcont17:                                         ; preds = %else16, %then15
   %55 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 2
   %56 = load i1, i1* %55, align 1
-  br i1 %56, label %then16, label %else17
+  br i1 %56, label %then18, label %else19
 
-then16:                                           ; preds = %ifcont15
+then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont20
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else19:                                           ; preds = %ifcont17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %else17, %then16
+ifcont20:                                         ; preds = %else19, %then18
   %57 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 3
   %58 = load i1, i1* %57, align 1
   %59 = xor i1 %58, true
-  br i1 %59, label %then19, label %else20
+  br i1 %59, label %then21, label %else22
 
-then19:                                           ; preds = %ifcont18
+then21:                                           ; preds = %ifcont20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont23
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else22:                                           ; preds = %ifcont20
+  br label %ifcont23
 
-ifcont21:                                         ; preds = %else20, %then19
-  store i32 0, i32* %i, align 4
-  br label %loop.head22
+ifcont23:                                         ; preds = %else22, %then21
+  store i32 0, i32* %i1, align 4
+  br label %loop.head24
 
-loop.head22:                                      ; preds = %loop.body23, %ifcont21
-  %60 = load i32, i32* %i, align 4
+loop.head24:                                      ; preds = %loop.body25, %ifcont23
+  %60 = load i32, i32* %i1, align 4
   %61 = add i32 %60, 1
   %62 = icmp sle i32 %61, 3
-  br i1 %62, label %loop.body23, label %loop.end24
+  br i1 %62, label %loop.body25, label %loop.end26
 
-loop.body23:                                      ; preds = %loop.head22
-  %63 = load i32, i32* %i, align 4
+loop.body25:                                      ; preds = %loop.head24
+  %63 = load i32, i32* %i1, align 4
   %64 = add i32 %63, 1
-  store i32 %64, i32* %i, align 4
-  %65 = load i32, i32* %i, align 4
+  store i32 %64, i32* %i1, align 4
+  %65 = load i32, i32* %i1, align 4
   %66 = sub i32 %65, 1
   %67 = mul i32 1, %66
   %68 = add i32 0, %67
   %69 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 %68
-  %70 = load i32, i32* %i, align 4
+  %70 = load i32, i32* %i1, align 4
   %71 = sub i32 %70, 1
   %72 = mul i32 1, %71
   %73 = add i32 0, %72
@@ -246,48 +248,48 @@ loop.body23:                                      ; preds = %loop.head22
   %76 = icmp eq i1 %75, false
   %77 = select i1 %76, i1 %75, i1 false
   store i1 %77, i1* %69, align 1
-  br label %loop.head22
+  br label %loop.head24
 
-loop.end24:                                       ; preds = %loop.head22
+loop.end26:                                       ; preds = %loop.head24
   %78 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 0
   %79 = load i1, i1* %78, align 1
-  br i1 %79, label %then25, label %else26
+  br i1 %79, label %then27, label %else28
 
-then25:                                           ; preds = %loop.end24
+then27:                                           ; preds = %loop.end26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont27
+  br label %ifcont29
 
-else26:                                           ; preds = %loop.end24
-  br label %ifcont27
+else28:                                           ; preds = %loop.end26
+  br label %ifcont29
 
-ifcont27:                                         ; preds = %else26, %then25
+ifcont29:                                         ; preds = %else28, %then27
   %80 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 1
   %81 = load i1, i1* %80, align 1
-  br i1 %81, label %then28, label %else29
+  br i1 %81, label %then30, label %else31
 
-then28:                                           ; preds = %ifcont27
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont32
 
-else29:                                           ; preds = %ifcont27
-  br label %ifcont30
+else31:                                           ; preds = %ifcont29
+  br label %ifcont32
 
-ifcont30:                                         ; preds = %else29, %then28
+ifcont32:                                         ; preds = %else31, %then30
   %82 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 2
   %83 = load i1, i1* %82, align 1
-  br i1 %83, label %then31, label %else32
+  br i1 %83, label %then33, label %else34
 
-then31:                                           ; preds = %ifcont30
+then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont35
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else34:                                           ; preds = %ifcont32
+  br label %ifcont35
 
-ifcont33:                                         ; preds = %else32, %then31
+ifcont35:                                         ; preds = %else34, %then33
   %84 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 3
   %85 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 0
   %86 = load i1, i1* %85, align 1
@@ -307,17 +309,17 @@ ifcont33:                                         ; preds = %else32, %then31
   %99 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 3
   %100 = load i1, i1* %99, align 1
   %101 = xor i1 %100, true
-  br i1 %101, label %then34, label %else35
+  br i1 %101, label %then36, label %else37
 
-then34:                                           ; preds = %ifcont33
+then36:                                           ; preds = %ifcont35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont38
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else37:                                           ; preds = %ifcont35
+  br label %ifcont38
 
-ifcont36:                                         ; preds = %else35, %then34
+ifcont38:                                         ; preds = %else37, %then36
   %102 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 3
   %103 = getelementptr [3 x i1], [3 x i1]* %a, i32 0, i32 0
   %104 = load i1, i1* %103, align 1
@@ -325,58 +327,58 @@ ifcont36:                                         ; preds = %else35, %then34
   %105 = getelementptr [4 x i1], [4 x i1]* %b, i32 0, i32 3
   %106 = load i1, i1* %105, align 1
   %107 = xor i1 %106, true
-  br i1 %107, label %then37, label %else38
+  br i1 %107, label %then39, label %else40
 
-then37:                                           ; preds = %ifcont36
+then39:                                           ; preds = %ifcont38
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont39
+  br label %ifcont41
 
-else38:                                           ; preds = %ifcont36
-  br label %ifcont39
+else40:                                           ; preds = %ifcont38
+  br label %ifcont41
 
-ifcont39:                                         ; preds = %else38, %then37
-  store i32 0, i32* %i, align 4
-  br label %loop.head40
-
-loop.head40:                                      ; preds = %loop.end47, %ifcont39
-  %108 = load i32, i32* %i, align 4
-  %109 = add i32 %108, 1
-  %110 = icmp sle i32 %109, 2
-  br i1 %110, label %loop.body41, label %loop.end48
-
-loop.body41:                                      ; preds = %loop.head40
-  %111 = load i32, i32* %i, align 4
-  %112 = add i32 %111, 1
-  store i32 %112, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+ifcont41:                                         ; preds = %else40, %then39
+  store i32 0, i32* %i1, align 4
   br label %loop.head42
 
-loop.head42:                                      ; preds = %ifcont46, %loop.body41
-  %113 = load i32, i32* %j, align 4
-  %114 = add i32 %113, 1
-  %115 = icmp sle i32 %114, 2
-  br i1 %115, label %loop.body43, label %loop.end47
+loop.head42:                                      ; preds = %loop.end49, %ifcont41
+  %108 = load i32, i32* %i1, align 4
+  %109 = add i32 %108, 1
+  %110 = icmp sle i32 %109, 2
+  br i1 %110, label %loop.body43, label %loop.end50
 
 loop.body43:                                      ; preds = %loop.head42
-  %116 = load i32, i32* %j, align 4
+  %111 = load i32, i32* %i1, align 4
+  %112 = add i32 %111, 1
+  store i32 %112, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head44
+
+loop.head44:                                      ; preds = %ifcont48, %loop.body43
+  %113 = load i32, i32* %j2, align 4
+  %114 = add i32 %113, 1
+  %115 = icmp sle i32 %114, 2
+  br i1 %115, label %loop.body45, label %loop.end49
+
+loop.body45:                                      ; preds = %loop.head44
+  %116 = load i32, i32* %j2, align 4
   %117 = add i32 %116, 1
-  store i32 %117, i32* %j, align 4
-  %118 = load i32, i32* %i, align 4
-  %119 = load i32, i32* %j, align 4
+  store i32 %117, i32* %j2, align 4
+  %118 = load i32, i32* %i1, align 4
+  %119 = load i32, i32* %j2, align 4
   %120 = add i32 %118, %119
-  %121 = load i32, i32* %i, align 4
-  %122 = load i32, i32* %j, align 4
+  %121 = load i32, i32* %i1, align 4
+  %122 = load i32, i32* %j2, align 4
   %123 = add i32 %121, %122
   %124 = sdiv i32 %123, 2
   %125 = mul i32 2, %124
   %126 = sub i32 %120, %125
   %127 = icmp eq i32 %126, 1
-  br i1 %127, label %then44, label %else45
+  br i1 %127, label %then46, label %else47
 
-then44:                                           ; preds = %loop.body43
-  %128 = load i32, i32* %i, align 4
-  %129 = load i32, i32* %j, align 4
+then46:                                           ; preds = %loop.body45
+  %128 = load i32, i32* %i1, align 4
+  %129 = load i32, i32* %j2, align 4
   %130 = sub i32 %128, 1
   %131 = mul i32 1, %130
   %132 = add i32 0, %131
@@ -385,11 +387,11 @@ then44:                                           ; preds = %loop.body43
   %135 = add i32 %132, %134
   %136 = getelementptr [4 x i1], [4 x i1]* %c, i32 0, i32 %135
   store i1 true, i1* %136, align 1
-  br label %ifcont46
+  br label %ifcont48
 
-else45:                                           ; preds = %loop.body43
-  %137 = load i32, i32* %i, align 4
-  %138 = load i32, i32* %j, align 4
+else47:                                           ; preds = %loop.body45
+  %137 = load i32, i32* %i1, align 4
+  %138 = load i32, i32* %j2, align 4
   %139 = sub i32 %137, 1
   %140 = mul i32 1, %139
   %141 = add i32 0, %140
@@ -398,72 +400,72 @@ else45:                                           ; preds = %loop.body43
   %144 = add i32 %141, %143
   %145 = getelementptr [4 x i1], [4 x i1]* %c, i32 0, i32 %144
   store i1 false, i1* %145, align 1
-  br label %ifcont46
+  br label %ifcont48
 
-ifcont46:                                         ; preds = %else45, %then44
+ifcont48:                                         ; preds = %else47, %then46
+  br label %loop.head44
+
+loop.end49:                                       ; preds = %loop.head44
   br label %loop.head42
 
-loop.end47:                                       ; preds = %loop.head42
-  br label %loop.head40
-
-loop.end48:                                       ; preds = %loop.head40
+loop.end50:                                       ; preds = %loop.head42
   %146 = getelementptr [4 x i1], [4 x i1]* %c, i32 0, i32 0
   %147 = load i1, i1* %146, align 1
-  br i1 %147, label %then49, label %else50
+  br i1 %147, label %then51, label %else52
 
-then49:                                           ; preds = %loop.end48
+then51:                                           ; preds = %loop.end50
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont51
+  br label %ifcont53
 
-else50:                                           ; preds = %loop.end48
-  br label %ifcont51
+else52:                                           ; preds = %loop.end50
+  br label %ifcont53
 
-ifcont51:                                         ; preds = %else50, %then49
+ifcont53:                                         ; preds = %else52, %then51
   %148 = getelementptr [4 x i1], [4 x i1]* %c, i32 0, i32 2
   %149 = load i1, i1* %148, align 1
   %150 = xor i1 %149, true
-  br i1 %150, label %then52, label %else53
+  br i1 %150, label %then54, label %else55
 
-then52:                                           ; preds = %ifcont51
+then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont54
+  br label %ifcont56
 
-else53:                                           ; preds = %ifcont51
-  br label %ifcont54
+else55:                                           ; preds = %ifcont53
+  br label %ifcont56
 
-ifcont54:                                         ; preds = %else53, %then52
+ifcont56:                                         ; preds = %else55, %then54
   %151 = getelementptr [4 x i1], [4 x i1]* %c, i32 0, i32 1
   %152 = load i1, i1* %151, align 1
   %153 = xor i1 %152, true
-  br i1 %153, label %then55, label %else56
+  br i1 %153, label %then57, label %else58
 
-then55:                                           ; preds = %ifcont54
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont57
+  br label %ifcont59
 
-else56:                                           ; preds = %ifcont54
-  br label %ifcont57
+else58:                                           ; preds = %ifcont56
+  br label %ifcont59
 
-ifcont57:                                         ; preds = %else56, %then55
+ifcont59:                                         ; preds = %else58, %then57
   %154 = getelementptr [4 x i1], [4 x i1]* %c, i32 0, i32 3
   %155 = load i1, i1* %154, align 1
-  br i1 %155, label %then58, label %else59
+  br i1 %155, label %then60, label %else61
 
-then58:                                           ; preds = %ifcont57
+then60:                                           ; preds = %ifcont59
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont60
+  br label %ifcont62
 
-else59:                                           ; preds = %ifcont57
-  br label %ifcont60
+else61:                                           ; preds = %ifcont59
+  br label %ifcont62
 
-ifcont60:                                         ; preds = %else59, %then58
+ifcont62:                                         ; preds = %else61, %then60
   br label %return
 
-return:                                           ; preds = %ifcont60
+return:                                           ; preds = %ifcont62
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_real-6c5e850.json
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_real-6c5e850.stdout",
-    "stdout_hash": "843c13d55b07d0658ef69a2298dd2936c447af99e89f38a7c31bf87f",
+    "stdout_hash": "64d2d7476348b4393ac12bb67b70f87dc55faccf91d20f2ca2550bca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_real-6c5e850.stdout
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.stdout
@@ -52,31 +52,33 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x double], align 8
   %b = alloca [4 x double], align 8
   %c = alloca [4 x double], align 8
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 3
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %i1, align 4
   %8 = sub i32 %7, 1
   %9 = mul i32 1, %8
   %10 = add i32 0, %9
   %11 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 %10
-  %12 = load i32, i32* %i, align 4
+  %12 = load i32, i32* %i1, align 4
   %13 = add i32 %12, 10
   %14 = sitofp i32 %13 to double
   store double %14, double* %11, align 8
@@ -100,131 +102,131 @@ ifcont:                                           ; preds = %else, %then
   %18 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 1
   %19 = load double, double* %18, align 8
   %20 = fcmp one double %19, 1.200000e+01
-  br i1 %20, label %then1, label %else2
+  br i1 %20, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont5:                                          ; preds = %else4, %then3
   %21 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 2
   %22 = load double, double* %21, align 8
   %23 = fcmp one double %22, 1.300000e+01
-  br i1 %23, label %then4, label %else5
+  br i1 %23, label %then6, label %else7
 
-then4:                                            ; preds = %ifcont3
+then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
-  store i32 10, i32* %i, align 4
-  br label %loop.head7
+ifcont8:                                          ; preds = %else7, %then6
+  store i32 10, i32* %i1, align 4
+  br label %loop.head9
 
-loop.head7:                                       ; preds = %loop.body8, %ifcont6
-  %24 = load i32, i32* %i, align 4
+loop.head9:                                       ; preds = %loop.body10, %ifcont8
+  %24 = load i32, i32* %i1, align 4
   %25 = add i32 %24, 1
   %26 = icmp sle i32 %25, 14
-  br i1 %26, label %loop.body8, label %loop.end9
+  br i1 %26, label %loop.body10, label %loop.end11
 
-loop.body8:                                       ; preds = %loop.head7
-  %27 = load i32, i32* %i, align 4
+loop.body10:                                      ; preds = %loop.head9
+  %27 = load i32, i32* %i1, align 4
   %28 = add i32 %27, 1
-  store i32 %28, i32* %i, align 4
-  %29 = load i32, i32* %i, align 4
+  store i32 %28, i32* %i1, align 4
+  %29 = load i32, i32* %i1, align 4
   %30 = sub i32 %29, 10
   %31 = sub i32 %30, 1
   %32 = mul i32 1, %31
   %33 = add i32 0, %32
   %34 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 %33
-  %35 = load i32, i32* %i, align 4
+  %35 = load i32, i32* %i1, align 4
   %36 = sitofp i32 %35 to double
   store double %36, double* %34, align 8
-  br label %loop.head7
+  br label %loop.head9
 
-loop.end9:                                        ; preds = %loop.head7
+loop.end11:                                       ; preds = %loop.head9
   %37 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 0
   %38 = load double, double* %37, align 8
   %39 = fcmp one double %38, 1.100000e+01
-  br i1 %39, label %then10, label %else11
+  br i1 %39, label %then12, label %else13
 
-then10:                                           ; preds = %loop.end9
+then12:                                           ; preds = %loop.end11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %loop.end9
-  br label %ifcont12
+else13:                                           ; preds = %loop.end11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
+ifcont14:                                         ; preds = %else13, %then12
   %40 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 1
   %41 = load double, double* %40, align 8
   %42 = fcmp one double %41, 1.200000e+01
-  br i1 %42, label %then13, label %else14
+  br i1 %42, label %then15, label %else16
 
-then13:                                           ; preds = %ifcont12
+then15:                                           ; preds = %ifcont14
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont17
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
 
-ifcont15:                                         ; preds = %else14, %then13
+ifcont17:                                         ; preds = %else16, %then15
   %43 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 2
   %44 = load double, double* %43, align 8
   %45 = fcmp one double %44, 1.300000e+01
-  br i1 %45, label %then16, label %else17
+  br i1 %45, label %then18, label %else19
 
-then16:                                           ; preds = %ifcont15
+then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont20
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else19:                                           ; preds = %ifcont17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %else17, %then16
+ifcont20:                                         ; preds = %else19, %then18
   %46 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %47 = load double, double* %46, align 8
   %48 = fcmp one double %47, 1.400000e+01
-  br i1 %48, label %then19, label %else20
+  br i1 %48, label %then21, label %else22
 
-then19:                                           ; preds = %ifcont18
+then21:                                           ; preds = %ifcont20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont23
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else22:                                           ; preds = %ifcont20
+  br label %ifcont23
 
-ifcont21:                                         ; preds = %else20, %then19
-  store i32 0, i32* %i, align 4
-  br label %loop.head22
+ifcont23:                                         ; preds = %else22, %then21
+  store i32 0, i32* %i1, align 4
+  br label %loop.head24
 
-loop.head22:                                      ; preds = %loop.body23, %ifcont21
-  %49 = load i32, i32* %i, align 4
+loop.head24:                                      ; preds = %loop.body25, %ifcont23
+  %49 = load i32, i32* %i1, align 4
   %50 = add i32 %49, 1
   %51 = icmp sle i32 %50, 3
-  br i1 %51, label %loop.body23, label %loop.end24
+  br i1 %51, label %loop.body25, label %loop.end26
 
-loop.body23:                                      ; preds = %loop.head22
-  %52 = load i32, i32* %i, align 4
+loop.body25:                                      ; preds = %loop.head24
+  %52 = load i32, i32* %i1, align 4
   %53 = add i32 %52, 1
-  store i32 %53, i32* %i, align 4
-  %54 = load i32, i32* %i, align 4
+  store i32 %53, i32* %i1, align 4
+  %54 = load i32, i32* %i1, align 4
   %55 = sub i32 %54, 1
   %56 = mul i32 1, %55
   %57 = add i32 0, %56
   %58 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 %57
-  %59 = load i32, i32* %i, align 4
+  %59 = load i32, i32* %i1, align 4
   %60 = sub i32 %59, 1
   %61 = mul i32 1, %60
   %62 = add i32 0, %61
@@ -232,51 +234,51 @@ loop.body23:                                      ; preds = %loop.head22
   %64 = load double, double* %63, align 8
   %65 = fsub double %64, 1.000000e+01
   store double %65, double* %58, align 8
-  br label %loop.head22
+  br label %loop.head24
 
-loop.end24:                                       ; preds = %loop.head22
+loop.end26:                                       ; preds = %loop.head24
   %66 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 0
   %67 = load double, double* %66, align 8
   %68 = fcmp one double %67, 1.000000e+00
-  br i1 %68, label %then25, label %else26
+  br i1 %68, label %then27, label %else28
 
-then25:                                           ; preds = %loop.end24
+then27:                                           ; preds = %loop.end26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont27
+  br label %ifcont29
 
-else26:                                           ; preds = %loop.end24
-  br label %ifcont27
+else28:                                           ; preds = %loop.end26
+  br label %ifcont29
 
-ifcont27:                                         ; preds = %else26, %then25
+ifcont29:                                         ; preds = %else28, %then27
   %69 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 1
   %70 = load double, double* %69, align 8
   %71 = fcmp one double %70, 2.000000e+00
-  br i1 %71, label %then28, label %else29
+  br i1 %71, label %then30, label %else31
 
-then28:                                           ; preds = %ifcont27
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont32
 
-else29:                                           ; preds = %ifcont27
-  br label %ifcont30
+else31:                                           ; preds = %ifcont29
+  br label %ifcont32
 
-ifcont30:                                         ; preds = %else29, %then28
+ifcont32:                                         ; preds = %else31, %then30
   %72 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 2
   %73 = load double, double* %72, align 8
   %74 = fcmp one double %73, 3.000000e+00
-  br i1 %74, label %then31, label %else32
+  br i1 %74, label %then33, label %else34
 
-then31:                                           ; preds = %ifcont30
+then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont35
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else34:                                           ; preds = %ifcont32
+  br label %ifcont35
 
-ifcont33:                                         ; preds = %else32, %then31
+ifcont35:                                         ; preds = %else34, %then33
   %75 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %76 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 0
   %77 = load double, double* %76, align 8
@@ -293,17 +295,17 @@ ifcont33:                                         ; preds = %else32, %then31
   %87 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %88 = load double, double* %87, align 8
   %89 = fcmp one double %88, 1.700000e+01
-  br i1 %89, label %then34, label %else35
+  br i1 %89, label %then36, label %else37
 
-then34:                                           ; preds = %ifcont33
+then36:                                           ; preds = %ifcont35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont38
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else37:                                           ; preds = %ifcont35
+  br label %ifcont38
 
-ifcont36:                                         ; preds = %else35, %then34
+ifcont38:                                         ; preds = %else37, %then36
   %90 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %91 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 0
   %92 = load double, double* %91, align 8
@@ -311,45 +313,45 @@ ifcont36:                                         ; preds = %else35, %then34
   %93 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %94 = load double, double* %93, align 8
   %95 = fcmp one double %94, 1.100000e+01
-  br i1 %95, label %then37, label %else38
+  br i1 %95, label %then39, label %else40
 
-then37:                                           ; preds = %ifcont36
+then39:                                           ; preds = %ifcont38
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont39
+  br label %ifcont41
 
-else38:                                           ; preds = %ifcont36
-  br label %ifcont39
+else40:                                           ; preds = %ifcont38
+  br label %ifcont41
 
-ifcont39:                                         ; preds = %else38, %then37
-  store i32 0, i32* %i, align 4
-  br label %loop.head40
-
-loop.head40:                                      ; preds = %loop.end44, %ifcont39
-  %96 = load i32, i32* %i, align 4
-  %97 = add i32 %96, 1
-  %98 = icmp sle i32 %97, 2
-  br i1 %98, label %loop.body41, label %loop.end45
-
-loop.body41:                                      ; preds = %loop.head40
-  %99 = load i32, i32* %i, align 4
-  %100 = add i32 %99, 1
-  store i32 %100, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+ifcont41:                                         ; preds = %else40, %then39
+  store i32 0, i32* %i1, align 4
   br label %loop.head42
 
-loop.head42:                                      ; preds = %loop.body43, %loop.body41
-  %101 = load i32, i32* %j, align 4
-  %102 = add i32 %101, 1
-  %103 = icmp sle i32 %102, 2
-  br i1 %103, label %loop.body43, label %loop.end44
+loop.head42:                                      ; preds = %loop.end46, %ifcont41
+  %96 = load i32, i32* %i1, align 4
+  %97 = add i32 %96, 1
+  %98 = icmp sle i32 %97, 2
+  br i1 %98, label %loop.body43, label %loop.end47
 
 loop.body43:                                      ; preds = %loop.head42
-  %104 = load i32, i32* %j, align 4
+  %99 = load i32, i32* %i1, align 4
+  %100 = add i32 %99, 1
+  store i32 %100, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head44
+
+loop.head44:                                      ; preds = %loop.body45, %loop.body43
+  %101 = load i32, i32* %j2, align 4
+  %102 = add i32 %101, 1
+  %103 = icmp sle i32 %102, 2
+  br i1 %103, label %loop.body45, label %loop.end46
+
+loop.body45:                                      ; preds = %loop.head44
+  %104 = load i32, i32* %j2, align 4
   %105 = add i32 %104, 1
-  store i32 %105, i32* %j, align 4
-  %106 = load i32, i32* %i, align 4
-  %107 = load i32, i32* %j, align 4
+  store i32 %105, i32* %j2, align 4
+  %106 = load i32, i32* %i1, align 4
+  %107 = load i32, i32* %j2, align 4
   %108 = sub i32 %106, 1
   %109 = mul i32 1, %108
   %110 = add i32 0, %109
@@ -357,77 +359,77 @@ loop.body43:                                      ; preds = %loop.head42
   %112 = mul i32 2, %111
   %113 = add i32 %110, %112
   %114 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 %113
-  %115 = load i32, i32* %i, align 4
-  %116 = load i32, i32* %j, align 4
+  %115 = load i32, i32* %i1, align 4
+  %116 = load i32, i32* %j2, align 4
   %117 = add i32 %115, %116
   %118 = add i32 %117, 10
   %119 = sitofp i32 %118 to double
   store double %119, double* %114, align 8
+  br label %loop.head44
+
+loop.end46:                                       ; preds = %loop.head44
   br label %loop.head42
 
-loop.end44:                                       ; preds = %loop.head42
-  br label %loop.head40
-
-loop.end45:                                       ; preds = %loop.head40
+loop.end47:                                       ; preds = %loop.head42
   %120 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 0
   %121 = load double, double* %120, align 8
   %122 = fcmp one double %121, 1.200000e+01
-  br i1 %122, label %then46, label %else47
+  br i1 %122, label %then48, label %else49
 
-then46:                                           ; preds = %loop.end45
+then48:                                           ; preds = %loop.end47
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont48
+  br label %ifcont50
 
-else47:                                           ; preds = %loop.end45
-  br label %ifcont48
+else49:                                           ; preds = %loop.end47
+  br label %ifcont50
 
-ifcont48:                                         ; preds = %else47, %then46
+ifcont50:                                         ; preds = %else49, %then48
   %123 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 2
   %124 = load double, double* %123, align 8
   %125 = fcmp one double %124, 1.300000e+01
-  br i1 %125, label %then49, label %else50
+  br i1 %125, label %then51, label %else52
 
-then49:                                           ; preds = %ifcont48
+then51:                                           ; preds = %ifcont50
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont51
+  br label %ifcont53
 
-else50:                                           ; preds = %ifcont48
-  br label %ifcont51
+else52:                                           ; preds = %ifcont50
+  br label %ifcont53
 
-ifcont51:                                         ; preds = %else50, %then49
+ifcont53:                                         ; preds = %else52, %then51
   %126 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 1
   %127 = load double, double* %126, align 8
   %128 = fcmp one double %127, 1.300000e+01
-  br i1 %128, label %then52, label %else53
+  br i1 %128, label %then54, label %else55
 
-then52:                                           ; preds = %ifcont51
+then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont54
+  br label %ifcont56
 
-else53:                                           ; preds = %ifcont51
-  br label %ifcont54
+else55:                                           ; preds = %ifcont53
+  br label %ifcont56
 
-ifcont54:                                         ; preds = %else53, %then52
+ifcont56:                                         ; preds = %else55, %then54
   %129 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 3
   %130 = load double, double* %129, align 8
   %131 = fcmp one double %130, 1.400000e+01
-  br i1 %131, label %then55, label %else56
+  br i1 %131, label %then57, label %else58
 
-then55:                                           ; preds = %ifcont54
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont57
+  br label %ifcont59
 
-else56:                                           ; preds = %ifcont54
-  br label %ifcont57
+else58:                                           ; preds = %ifcont56
+  br label %ifcont59
 
-ifcont57:                                         ; preds = %else56, %then55
+ifcont59:                                         ; preds = %else58, %then57
   br label %return
 
-return:                                           ; preds = %ifcont57
+return:                                           ; preds = %ifcont59
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01_size-aaed99f.json
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_size-aaed99f.stdout",
-    "stdout_hash": "b10209af93857e1578a161fc8eb5ebe17d61ba4726d6310103fdf37f",
+    "stdout_hash": "e4893a0e1a74dfcfb7fed93fc2a0a23ad36b8d94e6caba71e7cf77dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_size-aaed99f.stdout
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.stdout
@@ -46,15 +46,18 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a = alloca [3 x i32], align 4
-  %b = alloca [4 x i32], align 4
   %i = alloca i32, align 4
   %size_a = alloca i32, align 4
   %size_b = alloca i32, align 4
-  store i32 3, i32* %size_a, align 4
-  store i32 4, i32* %size_b, align 4
-  %2 = load i32, i32* %size_a, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a = alloca [3 x i32], align 4
+  %b = alloca [4 x i32], align 4
+  %i1 = alloca i32, align 4
+  %size_a2 = alloca i32, align 4
+  %size_b3 = alloca i32, align 4
+  store i32 3, i32* %size_a2, align 4
+  store i32 4, i32* %size_b3, align 4
+  %2 = load i32, i32* %size_a2, align 4
   %3 = icmp ne i32 %2, 3
   br i1 %3, label %then, label %else
 
@@ -67,39 +70,39 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %4 = load i32, i32* %size_b, align 4
+  %4 = load i32, i32* %size_b3, align 4
   %5 = icmp ne i32 %4, 4
-  br i1 %5, label %then1, label %else2
+  br i1 %5, label %then4, label %else5
 
-then1:                                            ; preds = %ifcont
+then4:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont6
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else5:                                            ; preds = %ifcont
+  br label %ifcont6
 
-ifcont3:                                          ; preds = %else2, %then1
-  store i32 0, i32* %i, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %loop.body, %ifcont3
-  %6 = load i32, i32* %i, align 4
+loop.head:                                        ; preds = %loop.body, %ifcont6
+  %6 = load i32, i32* %i1, align 4
   %7 = add i32 %6, 1
-  %8 = load i32, i32* %size_a, align 4
+  %8 = load i32, i32* %size_a2, align 4
   %9 = icmp sle i32 %7, %8
   br i1 %9, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %10 = load i32, i32* %i, align 4
+  %10 = load i32, i32* %i1, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %i, align 4
-  %12 = load i32, i32* %i, align 4
+  store i32 %11, i32* %i1, align 4
+  %12 = load i32, i32* %i1, align 4
   %13 = sub i32 %12, 1
   %14 = mul i32 1, %13
   %15 = add i32 0, %14
   %16 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 %15
-  %17 = load i32, i32* %i, align 4
+  %17 = load i32, i32* %i1, align 4
   %18 = add i32 %17, 10
   store i32 %18, i32* %16, align 4
   br label %loop.head
@@ -108,38 +111,24 @@ loop.end:                                         ; preds = %loop.head
   %19 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %20 = load i32, i32* %19, align 4
   %21 = icmp ne i32 %20, 11
-  br i1 %21, label %then4, label %else5
+  br i1 %21, label %then7, label %else8
 
-then4:                                            ; preds = %loop.end
+then7:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont6
-
-else5:                                            ; preds = %loop.end
-  br label %ifcont6
-
-ifcont6:                                          ; preds = %else5, %then4
-  %22 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 1
-  %23 = load i32, i32* %22, align 4
-  %24 = icmp ne i32 %23, 12
-  br i1 %24, label %then7, label %else8
-
-then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont9
 
-else8:                                            ; preds = %ifcont6
+else8:                                            ; preds = %loop.end
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %25 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 2
-  %26 = load i32, i32* %25, align 4
-  %27 = icmp ne i32 %26, 13
-  br i1 %27, label %then10, label %else11
+  %22 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 1
+  %23 = load i32, i32* %22, align 4
+  %24 = icmp ne i32 %23, 12
+  br i1 %24, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont12
 
@@ -147,67 +136,67 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  store i32 10, i32* %i, align 4
-  br label %loop.head13
+  %25 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 2
+  %26 = load i32, i32* %25, align 4
+  %27 = icmp ne i32 %26, 13
+  br i1 %27, label %then13, label %else14
 
-loop.head13:                                      ; preds = %loop.body14, %ifcont12
-  %28 = load i32, i32* %i, align 4
+then13:                                           ; preds = %ifcont12
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont15
+
+else14:                                           ; preds = %ifcont12
+  br label %ifcont15
+
+ifcont15:                                         ; preds = %else14, %then13
+  store i32 10, i32* %i1, align 4
+  br label %loop.head16
+
+loop.head16:                                      ; preds = %loop.body17, %ifcont15
+  %28 = load i32, i32* %i1, align 4
   %29 = add i32 %28, 1
-  %30 = load i32, i32* %size_b, align 4
+  %30 = load i32, i32* %size_b3, align 4
   %31 = add i32 10, %30
   %32 = icmp sle i32 %29, %31
-  br i1 %32, label %loop.body14, label %loop.end15
+  br i1 %32, label %loop.body17, label %loop.end18
 
-loop.body14:                                      ; preds = %loop.head13
-  %33 = load i32, i32* %i, align 4
+loop.body17:                                      ; preds = %loop.head16
+  %33 = load i32, i32* %i1, align 4
   %34 = add i32 %33, 1
-  store i32 %34, i32* %i, align 4
-  %35 = load i32, i32* %i, align 4
+  store i32 %34, i32* %i1, align 4
+  %35 = load i32, i32* %i1, align 4
   %36 = sub i32 %35, 10
   %37 = sub i32 %36, 1
   %38 = mul i32 1, %37
   %39 = add i32 0, %38
   %40 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %39
-  %41 = load i32, i32* %i, align 4
+  %41 = load i32, i32* %i1, align 4
   store i32 %41, i32* %40, align 4
-  br label %loop.head13
+  br label %loop.head16
 
-loop.end15:                                       ; preds = %loop.head13
+loop.end18:                                       ; preds = %loop.head16
   %42 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %43 = load i32, i32* %42, align 4
   %44 = icmp ne i32 %43, 11
-  br i1 %44, label %then16, label %else17
+  br i1 %44, label %then19, label %else20
 
-then16:                                           ; preds = %loop.end15
+then19:                                           ; preds = %loop.end18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont18
-
-else17:                                           ; preds = %loop.end15
-  br label %ifcont18
-
-ifcont18:                                         ; preds = %else17, %then16
-  %45 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
-  %46 = load i32, i32* %45, align 4
-  %47 = icmp ne i32 %46, 12
-  br i1 %47, label %then19, label %else20
-
-then19:                                           ; preds = %ifcont18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont21
 
-else20:                                           ; preds = %ifcont18
+else20:                                           ; preds = %loop.end18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  %48 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
-  %49 = load i32, i32* %48, align 4
-  %50 = icmp ne i32 %49, 13
-  br i1 %50, label %then22, label %else23
+  %45 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
+  %46 = load i32, i32* %45, align 4
+  %47 = icmp ne i32 %46, 12
+  br i1 %47, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont24
 
@@ -215,13 +204,13 @@ else23:                                           ; preds = %ifcont21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
-  %51 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  %52 = load i32, i32* %51, align 4
-  %53 = icmp ne i32 %52, 14
-  br i1 %53, label %then25, label %else26
+  %48 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
+  %49 = load i32, i32* %48, align 4
+  %50 = icmp ne i32 %49, 13
+  br i1 %50, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont27
 
@@ -229,26 +218,40 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  store i32 0, i32* %i, align 4
-  br label %loop.head28
+  %51 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
+  %52 = load i32, i32* %51, align 4
+  %53 = icmp ne i32 %52, 14
+  br i1 %53, label %then28, label %else29
 
-loop.head28:                                      ; preds = %loop.body29, %ifcont27
-  %54 = load i32, i32* %i, align 4
+then28:                                           ; preds = %ifcont27
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont30
+
+else29:                                           ; preds = %ifcont27
+  br label %ifcont30
+
+ifcont30:                                         ; preds = %else29, %then28
+  store i32 0, i32* %i1, align 4
+  br label %loop.head31
+
+loop.head31:                                      ; preds = %loop.body32, %ifcont30
+  %54 = load i32, i32* %i1, align 4
   %55 = add i32 %54, 1
-  %56 = load i32, i32* %size_a, align 4
+  %56 = load i32, i32* %size_a2, align 4
   %57 = icmp sle i32 %55, %56
-  br i1 %57, label %loop.body29, label %loop.end30
+  br i1 %57, label %loop.body32, label %loop.end33
 
-loop.body29:                                      ; preds = %loop.head28
-  %58 = load i32, i32* %i, align 4
+loop.body32:                                      ; preds = %loop.head31
+  %58 = load i32, i32* %i1, align 4
   %59 = add i32 %58, 1
-  store i32 %59, i32* %i, align 4
-  %60 = load i32, i32* %i, align 4
+  store i32 %59, i32* %i1, align 4
+  %60 = load i32, i32* %i1, align 4
   %61 = sub i32 %60, 1
   %62 = mul i32 1, %61
   %63 = add i32 0, %62
   %64 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %63
-  %65 = load i32, i32* %i, align 4
+  %65 = load i32, i32* %i1, align 4
   %66 = sub i32 %65, 1
   %67 = mul i32 1, %66
   %68 = add i32 0, %67
@@ -256,44 +259,30 @@ loop.body29:                                      ; preds = %loop.head28
   %70 = load i32, i32* %69, align 4
   %71 = sub i32 %70, 10
   store i32 %71, i32* %64, align 4
-  br label %loop.head28
+  br label %loop.head31
 
-loop.end30:                                       ; preds = %loop.head28
+loop.end33:                                       ; preds = %loop.head31
   %72 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %73 = load i32, i32* %72, align 4
   %74 = icmp ne i32 %73, 1
-  br i1 %74, label %then31, label %else32
+  br i1 %74, label %then34, label %else35
 
-then31:                                           ; preds = %loop.end30
+then34:                                           ; preds = %loop.end33
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont33
-
-else32:                                           ; preds = %loop.end30
-  br label %ifcont33
-
-ifcont33:                                         ; preds = %else32, %then31
-  %75 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
-  %76 = load i32, i32* %75, align 4
-  %77 = icmp ne i32 %76, 2
-  br i1 %77, label %then34, label %else35
-
-then34:                                           ; preds = %ifcont33
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont36
 
-else35:                                           ; preds = %ifcont33
+else35:                                           ; preds = %loop.end33
   br label %ifcont36
 
 ifcont36:                                         ; preds = %else35, %then34
-  %78 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
-  %79 = load i32, i32* %78, align 4
-  %80 = icmp ne i32 %79, 3
-  br i1 %80, label %then37, label %else38
+  %75 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
+  %76 = load i32, i32* %75, align 4
+  %77 = icmp ne i32 %76, 2
+  br i1 %77, label %then37, label %else38
 
 then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont39
 
@@ -301,6 +290,20 @@ else38:                                           ; preds = %ifcont36
   br label %ifcont39
 
 ifcont39:                                         ; preds = %else38, %then37
+  %78 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
+  %79 = load i32, i32* %78, align 4
+  %80 = icmp ne i32 %79, 3
+  br i1 %80, label %then40, label %else41
+
+then40:                                           ; preds = %ifcont39
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont42
+
+else41:                                           ; preds = %ifcont39
+  br label %ifcont42
+
+ifcont42:                                         ; preds = %else41, %then40
   %81 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %82 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %83 = load i32, i32* %82, align 4
@@ -317,28 +320,10 @@ ifcont39:                                         ; preds = %else38, %then37
   %93 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %94 = load i32, i32* %93, align 4
   %95 = icmp ne i32 %94, 17
-  br i1 %95, label %then40, label %else41
-
-then40:                                           ; preds = %ifcont39
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont42
-
-else41:                                           ; preds = %ifcont39
-  br label %ifcont42
-
-ifcont42:                                         ; preds = %else41, %then40
-  %96 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  %97 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
-  %98 = load i32, i32* %97, align 4
-  store i32 %98, i32* %96, align 4
-  %99 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  %100 = load i32, i32* %99, align 4
-  %101 = icmp ne i32 %100, 11
-  br i1 %101, label %then43, label %else44
+  br i1 %95, label %then43, label %else44
 
 then43:                                           ; preds = %ifcont42
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont45
 
@@ -346,9 +331,27 @@ else44:                                           ; preds = %ifcont42
   br label %ifcont45
 
 ifcont45:                                         ; preds = %else44, %then43
+  %96 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
+  %97 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
+  %98 = load i32, i32* %97, align 4
+  store i32 %98, i32* %96, align 4
+  %99 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
+  %100 = load i32, i32* %99, align 4
+  %101 = icmp ne i32 %100, 11
+  br i1 %101, label %then46, label %else47
+
+then46:                                           ; preds = %ifcont45
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont48
+
+else47:                                           ; preds = %ifcont45
+  br label %ifcont48
+
+ifcont48:                                         ; preds = %else47, %then46
   br label %return
 
-return:                                           ; preds = %ifcont45
+return:                                           ; preds = %ifcont48
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_03_func-98941b2.json
+++ b/tests/reference/llvm-arrays_03_func-98941b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_03_func-98941b2.stdout",
-    "stdout_hash": "11923cd7211cd9bbc70de1b34b8e878bcbe073b5e8464336ac14d434",
+    "stdout_hash": "1a81af6bdc9498f7ddd30aa4f45cd4b3272f895913c1dbb93c6dceab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_03_func-98941b2.stdout
+++ b/tests/reference/llvm-arrays_03_func-98941b2.stdout
@@ -8,6 +8,65 @@ source_filename = "LFortran"
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value3 = alloca i32, align 4
+  %call_arg_value = alloca i32, align 4
+  %i = alloca i32, align 4
+  %s = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %s2 = alloca i32, align 4
+  %x = alloca [10 x i32], align 4
+  store i32 0, i32* %i1, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.body, %.entry
+  %2 = load i32, i32* %i1, align 4
+  %3 = add i32 %2, 1
+  %4 = icmp sle i32 %3, 10
+  br i1 %4, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %loop.head
+  %5 = load i32, i32* %i1, align 4
+  %6 = add i32 %5, 1
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %i1, align 4
+  %8 = sub i32 %7, 1
+  %9 = mul i32 1, %8
+  %10 = add i32 0, %9
+  %11 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 %10
+  %12 = load i32, i32* %i1, align 4
+  store i32 %12, i32* %11, align 4
+  br label %loop.head
+
+loop.end:                                         ; preds = %loop.head
+  %13 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 0
+  store i32 1, i32* %call_arg_value, align 4
+  store i32 10, i32* %call_arg_value3, align 4
+  %14 = call i32 @mysum_integer____0(i32* %13, i32* %call_arg_value, i32* %call_arg_value3)
+  store i32 %14, i32* %s2, align 4
+  %15 = load i32, i32* %s2, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  %16 = load i32, i32* %s2, align 4
+  %17 = icmp ne i32 %16, 55
+  br i1 %17, label %then, label %else
+
+then:                                             ; preds = %loop.end
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %loop.end
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
+  ret i32 0
+}
+
 define i32 @mysum_integer____0(i32* %a, i32* %__1a, i32* %__2a) {
 .entry:
   %i = alloca i32, align 4
@@ -48,63 +107,6 @@ loop.end:                                         ; preds = %loop.head
 return:                                           ; preds = %loop.end
   %18 = load i32, i32* %r, align 4
   ret i32 %18
-}
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value1 = alloca i32, align 4
-  %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i = alloca i32, align 4
-  %s = alloca i32, align 4
-  %x = alloca [10 x i32], align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 10
-  br i1 %4, label %loop.body, label %loop.end
-
-loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
-  %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %i, align 4
-  %8 = sub i32 %7, 1
-  %9 = mul i32 1, %8
-  %10 = add i32 0, %9
-  %11 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 %10
-  %12 = load i32, i32* %i, align 4
-  store i32 %12, i32* %11, align 4
-  br label %loop.head
-
-loop.end:                                         ; preds = %loop.head
-  %13 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 0
-  store i32 1, i32* %call_arg_value, align 4
-  store i32 10, i32* %call_arg_value1, align 4
-  %14 = call i32 @mysum_integer____0(i32* %13, i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %14, i32* %s, align 4
-  %15 = load i32, i32* %s, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %16 = load i32, i32* %s, align 4
-  %17 = icmp ne i32 %16, 55
-  br i1 %17, label %then, label %else
-
-then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-else:                                             ; preds = %loop.end
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  br label %return
-
-return:                                           ; preds = %ifcont
-  ret i32 0
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-arrays_04_func-2aa342e.json
+++ b/tests/reference/llvm-arrays_04_func-2aa342e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_04_func-2aa342e.stdout",
-    "stdout_hash": "d4d0ea130f24b18b8c7ccab0a1c69b8326c02f4966a3249b53f39046",
+    "stdout_hash": "ddb5c3393a833ffbcd26addf0e2e28c3ad628f8f699dde38717e5ffc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_04_func-2aa342e.stdout
+++ b/tests/reference/llvm-arrays_04_func-2aa342e.stdout
@@ -13,6 +13,47 @@ source_filename = "LFortran"
 @9 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @10 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value2 = alloca float, align 4
+  %call_arg_value1 = alloca i32, align 4
+  %call_arg_value = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a = alloca [3 x float], align 4
+  %b = alloca float, align 4
+  %2 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 0
+  store float 3.000000e+00, float* %2, align 4
+  %3 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 1
+  store float 2.000000e+00, float* %3, align 4
+  %4 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 2
+  store float 1.000000e+00, float* %4, align 4
+  %5 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 0
+  store i32 1, i32* %call_arg_value, align 4
+  store i32 3, i32* %call_arg_value1, align 4
+  %6 = call float @sum_real____0(float* %5, i32* %call_arg_value, i32* %call_arg_value1)
+  store float %6, float* %b, align 4
+  %7 = load float, float* %b, align 4
+  %8 = fsub float %7, 6.000000e+00
+  store float %8, float* %call_arg_value2, align 4
+  %9 = call float @abs(float* %call_arg_value2)
+  %10 = fcmp ogt float %9, 0x3EE4F8B580000000
+  br i1 %10, label %then, label %else
+
+then:                                             ; preds = %.entry
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
+  ret i32 0
+}
+
 define float @abs(float* %a) {
 .entry:
   %r = alloca float, align 4
@@ -84,47 +125,6 @@ return:                                           ; preds = %loop.end
 }
 
 declare void @_lfortran_printf(i8*, ...)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value2 = alloca float, align 4
-  %call_arg_value1 = alloca i32, align 4
-  %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a = alloca [3 x float], align 4
-  %b = alloca float, align 4
-  %2 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 0
-  store float 3.000000e+00, float* %2, align 4
-  %3 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 1
-  store float 2.000000e+00, float* %3, align 4
-  %4 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 2
-  store float 1.000000e+00, float* %4, align 4
-  %5 = getelementptr [3 x float], [3 x float]* %a, i32 0, i32 0
-  store i32 1, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value1, align 4
-  %6 = call float @sum_real____0(float* %5, i32* %call_arg_value, i32* %call_arg_value1)
-  store float %6, float* %b, align 4
-  %7 = load float, float* %b, align 4
-  %8 = fsub float %7, 6.000000e+00
-  store float %8, float* %call_arg_value2, align 4
-  %9 = call float @abs(float* %call_arg_value2)
-  %10 = fcmp ogt float %9, 0x3EE4F8B580000000
-  br i1 %10, label %then, label %else
-
-then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  br label %return
-
-return:                                           ; preds = %ifcont
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-arrays_06-538e67d.json
+++ b/tests/reference/llvm-arrays_06-538e67d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_06-538e67d.stdout",
-    "stdout_hash": "37db11464032392c2ff6b954571b2266c56e58a76ea2a955e1aaa31c",
+    "stdout_hash": "94a89d8aaca256128606159fd4af4d2df5030b9f0294187dd66550a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_06-538e67d.stdout
+++ b/tests/reference/llvm-arrays_06-538e67d.stdout
@@ -55,43 +55,42 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %array_bound228 = alloca i32, align 4
-  %array_bound219 = alloca i32, align 4
-  %array_bound210 = alloca i32, align 4
-  %array_bound201 = alloca i32, align 4
-  %array_bound192 = alloca i32, align 4
+  %array_bound240 = alloca i32, align 4
+  %array_bound231 = alloca i32, align 4
+  %array_bound222 = alloca i32, align 4
+  %array_bound213 = alloca i32, align 4
+  %array_bound204 = alloca i32, align 4
+  %array_bound195 = alloca i32, align 4
   %array_bound183 = alloca i32, align 4
-  %array_bound171 = alloca i32, align 4
-  %array_bound162 = alloca i32, align 4
-  %array_bound153 = alloca i32, align 4
-  %array_bound144 = alloca i32, align 4
-  %array_bound135 = alloca i32, align 4
-  %array_bound126 = alloca i32, align 4
-  %array_bound120 = alloca i32, align 4
-  %array_bound115 = alloca i32, align 4
-  %array_bound109 = alloca i32, align 4
-  %array_bound104 = alloca i32, align 4
-  %array_bound100 = alloca i32, align 4
-  %array_bound93 = alloca i32, align 4
-  %array_bound87 = alloca i32, align 4
-  %array_bound82 = alloca i32, align 4
-  %array_bound76 = alloca i32, align 4
-  %array_bound71 = alloca i32, align 4
-  %array_bound67 = alloca i32, align 4
-  %array_bound60 = alloca i32, align 4
-  %array_bound54 = alloca i32, align 4
-  %array_bound49 = alloca i32, align 4
-  %array_bound43 = alloca i32, align 4
-  %array_bound38 = alloca i32, align 4
-  %array_bound34 = alloca i32, align 4
-  %array_bound27 = alloca i32, align 4
-  %array_bound21 = alloca i32, align 4
-  %array_bound16 = alloca i32, align 4
-  %array_bound10 = alloca i32, align 4
-  %array_bound5 = alloca i32, align 4
-  %array_bound1 = alloca i32, align 4
+  %array_bound174 = alloca i32, align 4
+  %array_bound165 = alloca i32, align 4
+  %array_bound156 = alloca i32, align 4
+  %array_bound147 = alloca i32, align 4
+  %array_bound138 = alloca i32, align 4
+  %array_bound132 = alloca i32, align 4
+  %array_bound127 = alloca i32, align 4
+  %array_bound121 = alloca i32, align 4
+  %array_bound116 = alloca i32, align 4
+  %array_bound112 = alloca i32, align 4
+  %array_bound105 = alloca i32, align 4
+  %array_bound99 = alloca i32, align 4
+  %array_bound94 = alloca i32, align 4
+  %array_bound88 = alloca i32, align 4
+  %array_bound83 = alloca i32, align 4
+  %array_bound79 = alloca i32, align 4
+  %array_bound72 = alloca i32, align 4
+  %array_bound66 = alloca i32, align 4
+  %array_bound61 = alloca i32, align 4
+  %array_bound55 = alloca i32, align 4
+  %array_bound50 = alloca i32, align 4
+  %array_bound46 = alloca i32, align 4
+  %array_bound39 = alloca i32, align 4
+  %array_bound33 = alloca i32, align 4
+  %array_bound28 = alloca i32, align 4
+  %array_bound22 = alloca i32, align 4
+  %array_bound17 = alloca i32, align 4
+  %array_bound13 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__1_k = alloca i32, align 4
   %__1_t = alloca i32, align 4
   %__1_v = alloca i32, align 4
@@ -101,16 +100,29 @@ define i32 @main(i32 %0, i8** %1) {
   %__3_k = alloca i32, align 4
   %__3_t = alloca i32, align 4
   %__3_v = alloca i32, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  %k = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_k1 = alloca i32, align 4
+  %__1_t2 = alloca i32, align 4
+  %__1_v3 = alloca i32, align 4
+  %__2_k4 = alloca i32, align 4
+  %__2_t5 = alloca i32, align 4
+  %__2_v6 = alloca i32, align 4
+  %__3_k7 = alloca i32, align 4
+  %__3_t8 = alloca i32, align 4
+  %__3_v9 = alloca i32, align 4
   %__libasr__created__var__0__array_constructor_ = alloca [6 x i32], align 4
   %__libasr__created__var__1__array_constructor_ = alloca [6 x i32], align 4
   %__libasr__created__var__2__array_constructor_ = alloca [6 x i32], align 4
   %__libasr__created__var__3__array_constructor_ = alloca [6 x i32], align 4
   %a = alloca [27 x i32], align 4
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  %k = alloca i32, align 4
+  %i10 = alloca i32, align 4
+  %j11 = alloca i32, align 4
+  %k12 = alloca i32, align 4
   %x = alloca [6 x i32], align 4
-  store i32 4, i32* %j, align 4
+  store i32 4, i32* %j11, align 4
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry
@@ -122,894 +134,894 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %then
   %2 = load i32, i32* %array_bound, align 4
-  store i32 %2, i32* %__1_k, align 4
-  store i32 0, i32* %i, align 4
+  store i32 %2, i32* %__1_k1, align 4
+  store i32 0, i32* %i10, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %ifcont
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, i32* %i10, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 6
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, i32* %i10, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %__1_k, align 4
+  store i32 %7, i32* %i10, align 4
+  %8 = load i32, i32* %__1_k1, align 4
   %9 = sub i32 %8, 1
   %10 = mul i32 1, %9
   %11 = add i32 0, %10
   %12 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__0__array_constructor_, i32 0, i32 %11
-  %13 = load i32, i32* %i, align 4
+  %13 = load i32, i32* %i10, align 4
   %14 = mul i32 %13, 2
   store i32 %14, i32* %12, align 4
-  %15 = load i32, i32* %__1_k, align 4
+  %15 = load i32, i32* %__1_k1, align 4
   %16 = add i32 %15, 1
-  store i32 %16, i32* %__1_k, align 4
+  store i32 %16, i32* %__1_k1, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 true, label %then2, label %else3
+  br i1 true, label %then14, label %else15
 
-then2:                                            ; preds = %loop.end
-  store i32 1, i32* %array_bound1, align 4
-  br label %ifcont4
+then14:                                           ; preds = %loop.end
+  store i32 1, i32* %array_bound13, align 4
+  br label %ifcont16
 
-else3:                                            ; preds = %loop.end
-  br label %ifcont4
+else15:                                           ; preds = %loop.end
+  br label %ifcont16
 
-ifcont4:                                          ; preds = %else3, %then2
-  %17 = load i32, i32* %array_bound1, align 4
-  store i32 %17, i32* %__1_v, align 4
-  br i1 true, label %then6, label %else7
+ifcont16:                                         ; preds = %else15, %then14
+  %17 = load i32, i32* %array_bound13, align 4
+  store i32 %17, i32* %__1_v3, align 4
+  br i1 true, label %then18, label %else19
 
-then6:                                            ; preds = %ifcont4
-  store i32 1, i32* %array_bound5, align 4
-  br label %ifcont8
+then18:                                           ; preds = %ifcont16
+  store i32 1, i32* %array_bound17, align 4
+  br label %ifcont20
 
-else7:                                            ; preds = %ifcont4
-  br label %ifcont8
+else19:                                           ; preds = %ifcont16
+  br label %ifcont20
 
-ifcont8:                                          ; preds = %else7, %then6
-  %18 = load i32, i32* %array_bound5, align 4
+ifcont20:                                         ; preds = %else19, %then18
+  %18 = load i32, i32* %array_bound17, align 4
   %19 = sub i32 %18, 1
-  store i32 %19, i32* %__1_t, align 4
-  br label %loop.head9
+  store i32 %19, i32* %__1_t2, align 4
+  br label %loop.head21
 
-loop.head9:                                       ; preds = %loop.body14, %ifcont8
-  %20 = load i32, i32* %__1_t, align 4
+loop.head21:                                      ; preds = %loop.body26, %ifcont20
+  %20 = load i32, i32* %__1_t2, align 4
   %21 = add i32 %20, 1
-  br i1 true, label %then11, label %else12
+  br i1 true, label %then23, label %else24
 
-then11:                                           ; preds = %loop.head9
-  store i32 6, i32* %array_bound10, align 4
-  br label %ifcont13
+then23:                                           ; preds = %loop.head21
+  store i32 6, i32* %array_bound22, align 4
+  br label %ifcont25
 
-else12:                                           ; preds = %loop.head9
-  br label %ifcont13
+else24:                                           ; preds = %loop.head21
+  br label %ifcont25
 
-ifcont13:                                         ; preds = %else12, %then11
-  %22 = load i32, i32* %array_bound10, align 4
+ifcont25:                                         ; preds = %else24, %then23
+  %22 = load i32, i32* %array_bound22, align 4
   %23 = icmp sle i32 %21, %22
-  br i1 %23, label %loop.body14, label %loop.end15
+  br i1 %23, label %loop.body26, label %loop.end27
 
-loop.body14:                                      ; preds = %ifcont13
-  %24 = load i32, i32* %__1_t, align 4
+loop.body26:                                      ; preds = %ifcont25
+  %24 = load i32, i32* %__1_t2, align 4
   %25 = add i32 %24, 1
-  store i32 %25, i32* %__1_t, align 4
-  %26 = load i32, i32* %__1_t, align 4
+  store i32 %25, i32* %__1_t2, align 4
+  %26 = load i32, i32* %__1_t2, align 4
   %27 = sub i32 %26, 1
   %28 = mul i32 1, %27
   %29 = add i32 0, %28
   %30 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %29
-  %31 = load i32, i32* %__1_v, align 4
+  %31 = load i32, i32* %__1_v3, align 4
   %32 = sub i32 %31, 1
   %33 = mul i32 1, %32
   %34 = add i32 0, %33
   %35 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__0__array_constructor_, i32 0, i32 %34
   %36 = load i32, i32* %35, align 4
   store i32 %36, i32* %30, align 4
-  %37 = load i32, i32* %__1_v, align 4
+  %37 = load i32, i32* %__1_v3, align 4
   %38 = add i32 %37, 1
-  store i32 %38, i32* %__1_v, align 4
-  br label %loop.head9
+  store i32 %38, i32* %__1_v3, align 4
+  br label %loop.head21
 
-loop.end15:                                       ; preds = %ifcont13
-  br i1 true, label %then17, label %else18
+loop.end27:                                       ; preds = %ifcont25
+  br i1 true, label %then29, label %else30
 
-then17:                                           ; preds = %loop.end15
-  store i32 1, i32* %array_bound16, align 4
-  br label %ifcont19
+then29:                                           ; preds = %loop.end27
+  store i32 1, i32* %array_bound28, align 4
+  br label %ifcont31
 
-else18:                                           ; preds = %loop.end15
-  br label %ifcont19
+else30:                                           ; preds = %loop.end27
+  br label %ifcont31
 
-ifcont19:                                         ; preds = %else18, %then17
-  %39 = load i32, i32* %array_bound16, align 4
+ifcont31:                                         ; preds = %else30, %then29
+  %39 = load i32, i32* %array_bound28, align 4
   %40 = sub i32 %39, 1
-  store i32 %40, i32* %__1_k, align 4
-  br label %loop.head20
+  store i32 %40, i32* %__1_k1, align 4
+  br label %loop.head32
 
-loop.head20:                                      ; preds = %loop.body25, %ifcont19
-  %41 = load i32, i32* %__1_k, align 4
+loop.head32:                                      ; preds = %loop.body37, %ifcont31
+  %41 = load i32, i32* %__1_k1, align 4
   %42 = add i32 %41, 1
-  br i1 true, label %then22, label %else23
+  br i1 true, label %then34, label %else35
 
-then22:                                           ; preds = %loop.head20
-  store i32 6, i32* %array_bound21, align 4
-  br label %ifcont24
+then34:                                           ; preds = %loop.head32
+  store i32 6, i32* %array_bound33, align 4
+  br label %ifcont36
 
-else23:                                           ; preds = %loop.head20
-  br label %ifcont24
+else35:                                           ; preds = %loop.head32
+  br label %ifcont36
 
-ifcont24:                                         ; preds = %else23, %then22
-  %43 = load i32, i32* %array_bound21, align 4
+ifcont36:                                         ; preds = %else35, %then34
+  %43 = load i32, i32* %array_bound33, align 4
   %44 = icmp sle i32 %42, %43
-  br i1 %44, label %loop.body25, label %loop.end26
+  br i1 %44, label %loop.body37, label %loop.end38
 
-loop.body25:                                      ; preds = %ifcont24
-  %45 = load i32, i32* %__1_k, align 4
+loop.body37:                                      ; preds = %ifcont36
+  %45 = load i32, i32* %__1_k1, align 4
   %46 = add i32 %45, 1
-  store i32 %46, i32* %__1_k, align 4
-  %47 = load i32, i32* %__1_k, align 4
+  store i32 %46, i32* %__1_k1, align 4
+  %47 = load i32, i32* %__1_k1, align 4
   %48 = sub i32 %47, 1
   %49 = mul i32 1, %48
   %50 = add i32 0, %49
   %51 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %50
   %52 = load i32, i32* %51, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  br label %loop.head20
+  br label %loop.head32
 
-loop.end26:                                       ; preds = %ifcont24
+loop.end38:                                       ; preds = %ifcont36
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  br i1 true, label %then28, label %else29
+  br i1 true, label %then40, label %else41
 
-then28:                                           ; preds = %loop.end26
-  store i32 1, i32* %array_bound27, align 4
-  br label %ifcont30
+then40:                                           ; preds = %loop.end38
+  store i32 1, i32* %array_bound39, align 4
+  br label %ifcont42
 
-else29:                                           ; preds = %loop.end26
-  br label %ifcont30
+else41:                                           ; preds = %loop.end38
+  br label %ifcont42
 
-ifcont30:                                         ; preds = %else29, %then28
-  %53 = load i32, i32* %array_bound27, align 4
-  store i32 %53, i32* %__1_k, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head31
+ifcont42:                                         ; preds = %else41, %then40
+  %53 = load i32, i32* %array_bound39, align 4
+  store i32 %53, i32* %__1_k1, align 4
+  store i32 0, i32* %i10, align 4
+  br label %loop.head43
 
-loop.head31:                                      ; preds = %loop.body32, %ifcont30
-  %54 = load i32, i32* %i, align 4
+loop.head43:                                      ; preds = %loop.body44, %ifcont42
+  %54 = load i32, i32* %i10, align 4
   %55 = add i32 %54, 1
   %56 = icmp sle i32 %55, 3
-  br i1 %56, label %loop.body32, label %loop.end33
+  br i1 %56, label %loop.body44, label %loop.end45
 
-loop.body32:                                      ; preds = %loop.head31
-  %57 = load i32, i32* %i, align 4
+loop.body44:                                      ; preds = %loop.head43
+  %57 = load i32, i32* %i10, align 4
   %58 = add i32 %57, 1
-  store i32 %58, i32* %i, align 4
-  %59 = load i32, i32* %__1_k, align 4
+  store i32 %58, i32* %i10, align 4
+  %59 = load i32, i32* %__1_k1, align 4
   %60 = sub i32 %59, 1
   %61 = mul i32 1, %60
   %62 = add i32 0, %61
   %63 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %62
-  %64 = load i32, i32* %i, align 4
+  %64 = load i32, i32* %i10, align 4
   %65 = add i32 %64, 1
   store i32 %65, i32* %63, align 4
-  %66 = load i32, i32* %__1_k, align 4
+  %66 = load i32, i32* %__1_k1, align 4
   %67 = add i32 %66, 1
-  store i32 %67, i32* %__1_k, align 4
-  %68 = load i32, i32* %__1_k, align 4
+  store i32 %67, i32* %__1_k1, align 4
+  %68 = load i32, i32* %__1_k1, align 4
   %69 = sub i32 %68, 1
   %70 = mul i32 1, %69
   %71 = add i32 0, %70
   %72 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %71
-  %73 = load i32, i32* %i, align 4
+  %73 = load i32, i32* %i10, align 4
   %74 = mul i32 %73, 2
   store i32 %74, i32* %72, align 4
-  %75 = load i32, i32* %__1_k, align 4
+  %75 = load i32, i32* %__1_k1, align 4
   %76 = add i32 %75, 1
-  store i32 %76, i32* %__1_k, align 4
-  br label %loop.head31
+  store i32 %76, i32* %__1_k1, align 4
+  br label %loop.head43
 
-loop.end33:                                       ; preds = %loop.head31
-  br i1 true, label %then35, label %else36
+loop.end45:                                       ; preds = %loop.head43
+  br i1 true, label %then47, label %else48
 
-then35:                                           ; preds = %loop.end33
-  store i32 1, i32* %array_bound34, align 4
-  br label %ifcont37
+then47:                                           ; preds = %loop.end45
+  store i32 1, i32* %array_bound46, align 4
+  br label %ifcont49
 
-else36:                                           ; preds = %loop.end33
-  br label %ifcont37
+else48:                                           ; preds = %loop.end45
+  br label %ifcont49
 
-ifcont37:                                         ; preds = %else36, %then35
-  %77 = load i32, i32* %array_bound34, align 4
-  store i32 %77, i32* %__1_v, align 4
-  br i1 true, label %then39, label %else40
+ifcont49:                                         ; preds = %else48, %then47
+  %77 = load i32, i32* %array_bound46, align 4
+  store i32 %77, i32* %__1_v3, align 4
+  br i1 true, label %then51, label %else52
 
-then39:                                           ; preds = %ifcont37
-  store i32 1, i32* %array_bound38, align 4
-  br label %ifcont41
+then51:                                           ; preds = %ifcont49
+  store i32 1, i32* %array_bound50, align 4
+  br label %ifcont53
 
-else40:                                           ; preds = %ifcont37
-  br label %ifcont41
+else52:                                           ; preds = %ifcont49
+  br label %ifcont53
 
-ifcont41:                                         ; preds = %else40, %then39
-  %78 = load i32, i32* %array_bound38, align 4
+ifcont53:                                         ; preds = %else52, %then51
+  %78 = load i32, i32* %array_bound50, align 4
   %79 = sub i32 %78, 1
-  store i32 %79, i32* %__1_t, align 4
-  br label %loop.head42
+  store i32 %79, i32* %__1_t2, align 4
+  br label %loop.head54
 
-loop.head42:                                      ; preds = %loop.body47, %ifcont41
-  %80 = load i32, i32* %__1_t, align 4
+loop.head54:                                      ; preds = %loop.body59, %ifcont53
+  %80 = load i32, i32* %__1_t2, align 4
   %81 = add i32 %80, 1
-  br i1 true, label %then44, label %else45
+  br i1 true, label %then56, label %else57
 
-then44:                                           ; preds = %loop.head42
-  store i32 6, i32* %array_bound43, align 4
-  br label %ifcont46
+then56:                                           ; preds = %loop.head54
+  store i32 6, i32* %array_bound55, align 4
+  br label %ifcont58
 
-else45:                                           ; preds = %loop.head42
-  br label %ifcont46
+else57:                                           ; preds = %loop.head54
+  br label %ifcont58
 
-ifcont46:                                         ; preds = %else45, %then44
-  %82 = load i32, i32* %array_bound43, align 4
+ifcont58:                                         ; preds = %else57, %then56
+  %82 = load i32, i32* %array_bound55, align 4
   %83 = icmp sle i32 %81, %82
-  br i1 %83, label %loop.body47, label %loop.end48
+  br i1 %83, label %loop.body59, label %loop.end60
 
-loop.body47:                                      ; preds = %ifcont46
-  %84 = load i32, i32* %__1_t, align 4
+loop.body59:                                      ; preds = %ifcont58
+  %84 = load i32, i32* %__1_t2, align 4
   %85 = add i32 %84, 1
-  store i32 %85, i32* %__1_t, align 4
-  %86 = load i32, i32* %__1_t, align 4
+  store i32 %85, i32* %__1_t2, align 4
+  %86 = load i32, i32* %__1_t2, align 4
   %87 = sub i32 %86, 1
   %88 = mul i32 1, %87
   %89 = add i32 0, %88
   %90 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %89
-  %91 = load i32, i32* %__1_v, align 4
+  %91 = load i32, i32* %__1_v3, align 4
   %92 = sub i32 %91, 1
   %93 = mul i32 1, %92
   %94 = add i32 0, %93
   %95 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %94
   %96 = load i32, i32* %95, align 4
   store i32 %96, i32* %90, align 4
-  %97 = load i32, i32* %__1_v, align 4
+  %97 = load i32, i32* %__1_v3, align 4
   %98 = add i32 %97, 1
-  store i32 %98, i32* %__1_v, align 4
-  br label %loop.head42
+  store i32 %98, i32* %__1_v3, align 4
+  br label %loop.head54
 
-loop.end48:                                       ; preds = %ifcont46
-  br i1 true, label %then50, label %else51
+loop.end60:                                       ; preds = %ifcont58
+  br i1 true, label %then62, label %else63
 
-then50:                                           ; preds = %loop.end48
-  store i32 1, i32* %array_bound49, align 4
-  br label %ifcont52
+then62:                                           ; preds = %loop.end60
+  store i32 1, i32* %array_bound61, align 4
+  br label %ifcont64
 
-else51:                                           ; preds = %loop.end48
-  br label %ifcont52
+else63:                                           ; preds = %loop.end60
+  br label %ifcont64
 
-ifcont52:                                         ; preds = %else51, %then50
-  %99 = load i32, i32* %array_bound49, align 4
+ifcont64:                                         ; preds = %else63, %then62
+  %99 = load i32, i32* %array_bound61, align 4
   %100 = sub i32 %99, 1
-  store i32 %100, i32* %__1_k, align 4
-  br label %loop.head53
+  store i32 %100, i32* %__1_k1, align 4
+  br label %loop.head65
 
-loop.head53:                                      ; preds = %loop.body58, %ifcont52
-  %101 = load i32, i32* %__1_k, align 4
+loop.head65:                                      ; preds = %loop.body70, %ifcont64
+  %101 = load i32, i32* %__1_k1, align 4
   %102 = add i32 %101, 1
-  br i1 true, label %then55, label %else56
+  br i1 true, label %then67, label %else68
 
-then55:                                           ; preds = %loop.head53
-  store i32 6, i32* %array_bound54, align 4
-  br label %ifcont57
+then67:                                           ; preds = %loop.head65
+  store i32 6, i32* %array_bound66, align 4
+  br label %ifcont69
 
-else56:                                           ; preds = %loop.head53
-  br label %ifcont57
+else68:                                           ; preds = %loop.head65
+  br label %ifcont69
 
-ifcont57:                                         ; preds = %else56, %then55
-  %103 = load i32, i32* %array_bound54, align 4
+ifcont69:                                         ; preds = %else68, %then67
+  %103 = load i32, i32* %array_bound66, align 4
   %104 = icmp sle i32 %102, %103
-  br i1 %104, label %loop.body58, label %loop.end59
+  br i1 %104, label %loop.body70, label %loop.end71
 
-loop.body58:                                      ; preds = %ifcont57
-  %105 = load i32, i32* %__1_k, align 4
+loop.body70:                                      ; preds = %ifcont69
+  %105 = load i32, i32* %__1_k1, align 4
   %106 = add i32 %105, 1
-  store i32 %106, i32* %__1_k, align 4
-  %107 = load i32, i32* %__1_k, align 4
+  store i32 %106, i32* %__1_k1, align 4
+  %107 = load i32, i32* %__1_k1, align 4
   %108 = sub i32 %107, 1
   %109 = mul i32 1, %108
   %110 = add i32 0, %109
   %111 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %110
   %112 = load i32, i32* %111, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 %112, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  br label %loop.head53
+  br label %loop.head65
 
-loop.end59:                                       ; preds = %ifcont57
+loop.end71:                                       ; preds = %ifcont69
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  br i1 true, label %then61, label %else62
+  br i1 true, label %then73, label %else74
 
-then61:                                           ; preds = %loop.end59
-  store i32 1, i32* %array_bound60, align 4
-  br label %ifcont63
+then73:                                           ; preds = %loop.end71
+  store i32 1, i32* %array_bound72, align 4
+  br label %ifcont75
 
-else62:                                           ; preds = %loop.end59
-  br label %ifcont63
+else74:                                           ; preds = %loop.end71
+  br label %ifcont75
 
-ifcont63:                                         ; preds = %else62, %then61
-  %113 = load i32, i32* %array_bound60, align 4
-  store i32 %113, i32* %__1_k, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head64
+ifcont75:                                         ; preds = %else74, %then73
+  %113 = load i32, i32* %array_bound72, align 4
+  store i32 %113, i32* %__1_k1, align 4
+  store i32 0, i32* %i10, align 4
+  br label %loop.head76
 
-loop.head64:                                      ; preds = %loop.body65, %ifcont63
-  %114 = load i32, i32* %i, align 4
+loop.head76:                                      ; preds = %loop.body77, %ifcont75
+  %114 = load i32, i32* %i10, align 4
   %115 = add i32 %114, 1
   %116 = icmp sle i32 %115, 2
-  br i1 %116, label %loop.body65, label %loop.end66
+  br i1 %116, label %loop.body77, label %loop.end78
 
-loop.body65:                                      ; preds = %loop.head64
-  %117 = load i32, i32* %i, align 4
+loop.body77:                                      ; preds = %loop.head76
+  %117 = load i32, i32* %i10, align 4
   %118 = add i32 %117, 1
-  store i32 %118, i32* %i, align 4
-  %119 = load i32, i32* %__1_k, align 4
+  store i32 %118, i32* %i10, align 4
+  %119 = load i32, i32* %__1_k1, align 4
   %120 = sub i32 %119, 1
   %121 = mul i32 1, %120
   %122 = add i32 0, %121
   %123 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__2__array_constructor_, i32 0, i32 %122
-  %124 = load i32, i32* %i, align 4
+  %124 = load i32, i32* %i10, align 4
   %125 = add i32 %124, 1
   store i32 %125, i32* %123, align 4
-  %126 = load i32, i32* %__1_k, align 4
+  %126 = load i32, i32* %__1_k1, align 4
   %127 = add i32 %126, 1
-  store i32 %127, i32* %__1_k, align 4
-  %128 = load i32, i32* %__1_k, align 4
+  store i32 %127, i32* %__1_k1, align 4
+  %128 = load i32, i32* %__1_k1, align 4
   %129 = sub i32 %128, 1
   %130 = mul i32 1, %129
   %131 = add i32 0, %130
   %132 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__2__array_constructor_, i32 0, i32 %131
-  %133 = load i32, i32* %i, align 4
+  %133 = load i32, i32* %i10, align 4
   %134 = sitofp i32 %133 to float
   %135 = call float @llvm.pow.f32(float %134, float 2.000000e+00)
   %136 = fptosi float %135 to i32
   store i32 %136, i32* %132, align 4
-  %137 = load i32, i32* %__1_k, align 4
+  %137 = load i32, i32* %__1_k1, align 4
   %138 = add i32 %137, 1
-  store i32 %138, i32* %__1_k, align 4
-  %139 = load i32, i32* %__1_k, align 4
+  store i32 %138, i32* %__1_k1, align 4
+  %139 = load i32, i32* %__1_k1, align 4
   %140 = sub i32 %139, 1
   %141 = mul i32 1, %140
   %142 = add i32 0, %141
   %143 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__2__array_constructor_, i32 0, i32 %142
-  %144 = load i32, i32* %i, align 4
+  %144 = load i32, i32* %i10, align 4
   %145 = mul i32 %144, 2
   store i32 %145, i32* %143, align 4
-  %146 = load i32, i32* %__1_k, align 4
+  %146 = load i32, i32* %__1_k1, align 4
   %147 = add i32 %146, 1
-  store i32 %147, i32* %__1_k, align 4
-  br label %loop.head64
+  store i32 %147, i32* %__1_k1, align 4
+  br label %loop.head76
 
-loop.end66:                                       ; preds = %loop.head64
-  br i1 true, label %then68, label %else69
+loop.end78:                                       ; preds = %loop.head76
+  br i1 true, label %then80, label %else81
 
-then68:                                           ; preds = %loop.end66
-  store i32 1, i32* %array_bound67, align 4
-  br label %ifcont70
+then80:                                           ; preds = %loop.end78
+  store i32 1, i32* %array_bound79, align 4
+  br label %ifcont82
 
-else69:                                           ; preds = %loop.end66
-  br label %ifcont70
+else81:                                           ; preds = %loop.end78
+  br label %ifcont82
 
-ifcont70:                                         ; preds = %else69, %then68
-  %148 = load i32, i32* %array_bound67, align 4
-  store i32 %148, i32* %__1_v, align 4
-  br i1 true, label %then72, label %else73
+ifcont82:                                         ; preds = %else81, %then80
+  %148 = load i32, i32* %array_bound79, align 4
+  store i32 %148, i32* %__1_v3, align 4
+  br i1 true, label %then84, label %else85
 
-then72:                                           ; preds = %ifcont70
-  store i32 1, i32* %array_bound71, align 4
-  br label %ifcont74
+then84:                                           ; preds = %ifcont82
+  store i32 1, i32* %array_bound83, align 4
+  br label %ifcont86
 
-else73:                                           ; preds = %ifcont70
-  br label %ifcont74
+else85:                                           ; preds = %ifcont82
+  br label %ifcont86
 
-ifcont74:                                         ; preds = %else73, %then72
-  %149 = load i32, i32* %array_bound71, align 4
+ifcont86:                                         ; preds = %else85, %then84
+  %149 = load i32, i32* %array_bound83, align 4
   %150 = sub i32 %149, 1
-  store i32 %150, i32* %__1_t, align 4
-  br label %loop.head75
+  store i32 %150, i32* %__1_t2, align 4
+  br label %loop.head87
 
-loop.head75:                                      ; preds = %loop.body80, %ifcont74
-  %151 = load i32, i32* %__1_t, align 4
+loop.head87:                                      ; preds = %loop.body92, %ifcont86
+  %151 = load i32, i32* %__1_t2, align 4
   %152 = add i32 %151, 1
-  br i1 true, label %then77, label %else78
+  br i1 true, label %then89, label %else90
 
-then77:                                           ; preds = %loop.head75
-  store i32 6, i32* %array_bound76, align 4
-  br label %ifcont79
+then89:                                           ; preds = %loop.head87
+  store i32 6, i32* %array_bound88, align 4
+  br label %ifcont91
 
-else78:                                           ; preds = %loop.head75
-  br label %ifcont79
+else90:                                           ; preds = %loop.head87
+  br label %ifcont91
 
-ifcont79:                                         ; preds = %else78, %then77
-  %153 = load i32, i32* %array_bound76, align 4
+ifcont91:                                         ; preds = %else90, %then89
+  %153 = load i32, i32* %array_bound88, align 4
   %154 = icmp sle i32 %152, %153
-  br i1 %154, label %loop.body80, label %loop.end81
+  br i1 %154, label %loop.body92, label %loop.end93
 
-loop.body80:                                      ; preds = %ifcont79
-  %155 = load i32, i32* %__1_t, align 4
+loop.body92:                                      ; preds = %ifcont91
+  %155 = load i32, i32* %__1_t2, align 4
   %156 = add i32 %155, 1
-  store i32 %156, i32* %__1_t, align 4
-  %157 = load i32, i32* %__1_t, align 4
+  store i32 %156, i32* %__1_t2, align 4
+  %157 = load i32, i32* %__1_t2, align 4
   %158 = sub i32 %157, 1
   %159 = mul i32 1, %158
   %160 = add i32 0, %159
   %161 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %160
-  %162 = load i32, i32* %__1_v, align 4
+  %162 = load i32, i32* %__1_v3, align 4
   %163 = sub i32 %162, 1
   %164 = mul i32 1, %163
   %165 = add i32 0, %164
   %166 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__2__array_constructor_, i32 0, i32 %165
   %167 = load i32, i32* %166, align 4
   store i32 %167, i32* %161, align 4
-  %168 = load i32, i32* %__1_v, align 4
+  %168 = load i32, i32* %__1_v3, align 4
   %169 = add i32 %168, 1
-  store i32 %169, i32* %__1_v, align 4
-  br label %loop.head75
+  store i32 %169, i32* %__1_v3, align 4
+  br label %loop.head87
 
-loop.end81:                                       ; preds = %ifcont79
-  br i1 true, label %then83, label %else84
+loop.end93:                                       ; preds = %ifcont91
+  br i1 true, label %then95, label %else96
 
-then83:                                           ; preds = %loop.end81
-  store i32 1, i32* %array_bound82, align 4
-  br label %ifcont85
+then95:                                           ; preds = %loop.end93
+  store i32 1, i32* %array_bound94, align 4
+  br label %ifcont97
 
-else84:                                           ; preds = %loop.end81
-  br label %ifcont85
+else96:                                           ; preds = %loop.end93
+  br label %ifcont97
 
-ifcont85:                                         ; preds = %else84, %then83
-  %170 = load i32, i32* %array_bound82, align 4
+ifcont97:                                         ; preds = %else96, %then95
+  %170 = load i32, i32* %array_bound94, align 4
   %171 = sub i32 %170, 1
-  store i32 %171, i32* %__1_k, align 4
-  br label %loop.head86
+  store i32 %171, i32* %__1_k1, align 4
+  br label %loop.head98
 
-loop.head86:                                      ; preds = %loop.body91, %ifcont85
-  %172 = load i32, i32* %__1_k, align 4
+loop.head98:                                      ; preds = %loop.body103, %ifcont97
+  %172 = load i32, i32* %__1_k1, align 4
   %173 = add i32 %172, 1
-  br i1 true, label %then88, label %else89
+  br i1 true, label %then100, label %else101
 
-then88:                                           ; preds = %loop.head86
-  store i32 6, i32* %array_bound87, align 4
-  br label %ifcont90
+then100:                                          ; preds = %loop.head98
+  store i32 6, i32* %array_bound99, align 4
+  br label %ifcont102
 
-else89:                                           ; preds = %loop.head86
-  br label %ifcont90
+else101:                                          ; preds = %loop.head98
+  br label %ifcont102
 
-ifcont90:                                         ; preds = %else89, %then88
-  %174 = load i32, i32* %array_bound87, align 4
+ifcont102:                                        ; preds = %else101, %then100
+  %174 = load i32, i32* %array_bound99, align 4
   %175 = icmp sle i32 %173, %174
-  br i1 %175, label %loop.body91, label %loop.end92
+  br i1 %175, label %loop.body103, label %loop.end104
 
-loop.body91:                                      ; preds = %ifcont90
-  %176 = load i32, i32* %__1_k, align 4
+loop.body103:                                     ; preds = %ifcont102
+  %176 = load i32, i32* %__1_k1, align 4
   %177 = add i32 %176, 1
-  store i32 %177, i32* %__1_k, align 4
-  %178 = load i32, i32* %__1_k, align 4
+  store i32 %177, i32* %__1_k1, align 4
+  %178 = load i32, i32* %__1_k1, align 4
   %179 = sub i32 %178, 1
   %180 = mul i32 1, %179
   %181 = add i32 0, %180
   %182 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %181
   %183 = load i32, i32* %182, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i32 %183, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
-  br label %loop.head86
+  br label %loop.head98
 
-loop.end92:                                       ; preds = %ifcont90
+loop.end104:                                      ; preds = %ifcont102
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
-  br i1 true, label %then94, label %else95
+  br i1 true, label %then106, label %else107
 
-then94:                                           ; preds = %loop.end92
-  store i32 1, i32* %array_bound93, align 4
-  br label %ifcont96
+then106:                                          ; preds = %loop.end104
+  store i32 1, i32* %array_bound105, align 4
+  br label %ifcont108
 
-else95:                                           ; preds = %loop.end92
-  br label %ifcont96
+else107:                                          ; preds = %loop.end104
+  br label %ifcont108
 
-ifcont96:                                         ; preds = %else95, %then94
-  %184 = load i32, i32* %array_bound93, align 4
-  store i32 %184, i32* %__1_k, align 4
-  store i32 1, i32* %i, align 4
-  br label %loop.head97
+ifcont108:                                        ; preds = %else107, %then106
+  %184 = load i32, i32* %array_bound105, align 4
+  store i32 %184, i32* %__1_k1, align 4
+  store i32 1, i32* %i10, align 4
+  br label %loop.head109
 
-loop.head97:                                      ; preds = %loop.body98, %ifcont96
-  %185 = load i32, i32* %i, align 4
+loop.head109:                                     ; preds = %loop.body110, %ifcont108
+  %185 = load i32, i32* %i10, align 4
   %186 = add i32 %185, 1
   %187 = icmp sle i32 %186, 2
-  br i1 %187, label %loop.body98, label %loop.end99
+  br i1 %187, label %loop.body110, label %loop.end111
 
-loop.body98:                                      ; preds = %loop.head97
-  %188 = load i32, i32* %i, align 4
+loop.body110:                                     ; preds = %loop.head109
+  %188 = load i32, i32* %i10, align 4
   %189 = add i32 %188, 1
-  store i32 %189, i32* %i, align 4
-  %190 = load i32, i32* %__1_k, align 4
+  store i32 %189, i32* %i10, align 4
+  %190 = load i32, i32* %__1_k1, align 4
   %191 = sub i32 %190, 1
   %192 = mul i32 1, %191
   %193 = add i32 0, %192
   %194 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %193
-  %195 = load i32, i32* %i, align 4
+  %195 = load i32, i32* %i10, align 4
   %196 = mul i32 2, %195
   store i32 %196, i32* %194, align 4
-  %197 = load i32, i32* %__1_k, align 4
+  %197 = load i32, i32* %__1_k1, align 4
   %198 = add i32 %197, 1
-  store i32 %198, i32* %__1_k, align 4
-  %199 = load i32, i32* %__1_k, align 4
+  store i32 %198, i32* %__1_k1, align 4
+  %199 = load i32, i32* %__1_k1, align 4
   %200 = sub i32 %199, 1
   %201 = mul i32 1, %200
   %202 = add i32 0, %201
   %203 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %202
-  %204 = load i32, i32* %i, align 4
+  %204 = load i32, i32* %i10, align 4
   %205 = mul i32 3, %204
   store i32 %205, i32* %203, align 4
-  %206 = load i32, i32* %__1_k, align 4
+  %206 = load i32, i32* %__1_k1, align 4
   %207 = add i32 %206, 1
-  store i32 %207, i32* %__1_k, align 4
-  %208 = load i32, i32* %__1_k, align 4
+  store i32 %207, i32* %__1_k1, align 4
+  %208 = load i32, i32* %__1_k1, align 4
   %209 = sub i32 %208, 1
   %210 = mul i32 1, %209
   %211 = add i32 0, %210
   %212 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %211
-  %213 = load i32, i32* %i, align 4
+  %213 = load i32, i32* %i10, align 4
   %214 = mul i32 4, %213
   store i32 %214, i32* %212, align 4
-  %215 = load i32, i32* %__1_k, align 4
+  %215 = load i32, i32* %__1_k1, align 4
   %216 = add i32 %215, 1
-  store i32 %216, i32* %__1_k, align 4
-  %217 = load i32, i32* %__1_k, align 4
+  store i32 %216, i32* %__1_k1, align 4
+  %217 = load i32, i32* %__1_k1, align 4
   %218 = sub i32 %217, 1
   %219 = mul i32 1, %218
   %220 = add i32 0, %219
   %221 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %220
-  %222 = load i32, i32* %i, align 4
+  %222 = load i32, i32* %i10, align 4
   %223 = add i32 %222, 1
   store i32 %223, i32* %221, align 4
-  %224 = load i32, i32* %__1_k, align 4
+  %224 = load i32, i32* %__1_k1, align 4
   %225 = add i32 %224, 1
-  store i32 %225, i32* %__1_k, align 4
-  %226 = load i32, i32* %__1_k, align 4
+  store i32 %225, i32* %__1_k1, align 4
+  %226 = load i32, i32* %__1_k1, align 4
   %227 = sub i32 %226, 1
   %228 = mul i32 1, %227
   %229 = add i32 0, %228
   %230 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %229
-  %231 = load i32, i32* %i, align 4
+  %231 = load i32, i32* %i10, align 4
   %232 = sitofp i32 %231 to float
   %233 = call float @llvm.pow.f32(float %232, float 2.000000e+00)
   %234 = fptosi float %233 to i32
   store i32 %234, i32* %230, align 4
-  %235 = load i32, i32* %__1_k, align 4
+  %235 = load i32, i32* %__1_k1, align 4
   %236 = add i32 %235, 1
-  store i32 %236, i32* %__1_k, align 4
-  %237 = load i32, i32* %__1_k, align 4
+  store i32 %236, i32* %__1_k1, align 4
+  %237 = load i32, i32* %__1_k1, align 4
   %238 = sub i32 %237, 1
   %239 = mul i32 1, %238
   %240 = add i32 0, %239
   %241 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %240
-  %242 = load i32, i32* %i, align 4
+  %242 = load i32, i32* %i10, align 4
   %243 = mul i32 %242, 2
   store i32 %243, i32* %241, align 4
-  %244 = load i32, i32* %__1_k, align 4
+  %244 = load i32, i32* %__1_k1, align 4
   %245 = add i32 %244, 1
-  store i32 %245, i32* %__1_k, align 4
-  br label %loop.head97
+  store i32 %245, i32* %__1_k1, align 4
+  br label %loop.head109
 
-loop.end99:                                       ; preds = %loop.head97
-  br i1 true, label %then101, label %else102
+loop.end111:                                      ; preds = %loop.head109
+  br i1 true, label %then113, label %else114
 
-then101:                                          ; preds = %loop.end99
-  store i32 1, i32* %array_bound100, align 4
-  br label %ifcont103
+then113:                                          ; preds = %loop.end111
+  store i32 1, i32* %array_bound112, align 4
+  br label %ifcont115
 
-else102:                                          ; preds = %loop.end99
-  br label %ifcont103
+else114:                                          ; preds = %loop.end111
+  br label %ifcont115
 
-ifcont103:                                        ; preds = %else102, %then101
-  %246 = load i32, i32* %array_bound100, align 4
-  store i32 %246, i32* %__1_v, align 4
-  br i1 true, label %then105, label %else106
+ifcont115:                                        ; preds = %else114, %then113
+  %246 = load i32, i32* %array_bound112, align 4
+  store i32 %246, i32* %__1_v3, align 4
+  br i1 true, label %then117, label %else118
 
-then105:                                          ; preds = %ifcont103
-  store i32 1, i32* %array_bound104, align 4
-  br label %ifcont107
+then117:                                          ; preds = %ifcont115
+  store i32 1, i32* %array_bound116, align 4
+  br label %ifcont119
 
-else106:                                          ; preds = %ifcont103
-  br label %ifcont107
+else118:                                          ; preds = %ifcont115
+  br label %ifcont119
 
-ifcont107:                                        ; preds = %else106, %then105
-  %247 = load i32, i32* %array_bound104, align 4
+ifcont119:                                        ; preds = %else118, %then117
+  %247 = load i32, i32* %array_bound116, align 4
   %248 = sub i32 %247, 1
-  store i32 %248, i32* %__1_t, align 4
-  br label %loop.head108
+  store i32 %248, i32* %__1_t2, align 4
+  br label %loop.head120
 
-loop.head108:                                     ; preds = %loop.body113, %ifcont107
-  %249 = load i32, i32* %__1_t, align 4
+loop.head120:                                     ; preds = %loop.body125, %ifcont119
+  %249 = load i32, i32* %__1_t2, align 4
   %250 = add i32 %249, 1
-  br i1 true, label %then110, label %else111
+  br i1 true, label %then122, label %else123
 
-then110:                                          ; preds = %loop.head108
-  store i32 6, i32* %array_bound109, align 4
-  br label %ifcont112
+then122:                                          ; preds = %loop.head120
+  store i32 6, i32* %array_bound121, align 4
+  br label %ifcont124
 
-else111:                                          ; preds = %loop.head108
-  br label %ifcont112
+else123:                                          ; preds = %loop.head120
+  br label %ifcont124
 
-ifcont112:                                        ; preds = %else111, %then110
-  %251 = load i32, i32* %array_bound109, align 4
+ifcont124:                                        ; preds = %else123, %then122
+  %251 = load i32, i32* %array_bound121, align 4
   %252 = icmp sle i32 %250, %251
-  br i1 %252, label %loop.body113, label %loop.end114
+  br i1 %252, label %loop.body125, label %loop.end126
 
-loop.body113:                                     ; preds = %ifcont112
-  %253 = load i32, i32* %__1_t, align 4
+loop.body125:                                     ; preds = %ifcont124
+  %253 = load i32, i32* %__1_t2, align 4
   %254 = add i32 %253, 1
-  store i32 %254, i32* %__1_t, align 4
-  %255 = load i32, i32* %__1_t, align 4
+  store i32 %254, i32* %__1_t2, align 4
+  %255 = load i32, i32* %__1_t2, align 4
   %256 = sub i32 %255, 1
   %257 = mul i32 1, %256
   %258 = add i32 0, %257
   %259 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %258
-  %260 = load i32, i32* %__1_v, align 4
+  %260 = load i32, i32* %__1_v3, align 4
   %261 = sub i32 %260, 1
   %262 = mul i32 1, %261
   %263 = add i32 0, %262
   %264 = getelementptr [6 x i32], [6 x i32]* %__libasr__created__var__3__array_constructor_, i32 0, i32 %263
   %265 = load i32, i32* %264, align 4
   store i32 %265, i32* %259, align 4
-  %266 = load i32, i32* %__1_v, align 4
+  %266 = load i32, i32* %__1_v3, align 4
   %267 = add i32 %266, 1
-  store i32 %267, i32* %__1_v, align 4
-  br label %loop.head108
+  store i32 %267, i32* %__1_v3, align 4
+  br label %loop.head120
 
-loop.end114:                                      ; preds = %ifcont112
-  br i1 true, label %then116, label %else117
+loop.end126:                                      ; preds = %ifcont124
+  br i1 true, label %then128, label %else129
 
-then116:                                          ; preds = %loop.end114
-  store i32 1, i32* %array_bound115, align 4
-  br label %ifcont118
+then128:                                          ; preds = %loop.end126
+  store i32 1, i32* %array_bound127, align 4
+  br label %ifcont130
 
-else117:                                          ; preds = %loop.end114
-  br label %ifcont118
+else129:                                          ; preds = %loop.end126
+  br label %ifcont130
 
-ifcont118:                                        ; preds = %else117, %then116
-  %268 = load i32, i32* %array_bound115, align 4
+ifcont130:                                        ; preds = %else129, %then128
+  %268 = load i32, i32* %array_bound127, align 4
   %269 = sub i32 %268, 1
-  store i32 %269, i32* %__1_k, align 4
-  br label %loop.head119
+  store i32 %269, i32* %__1_k1, align 4
+  br label %loop.head131
 
-loop.head119:                                     ; preds = %loop.body124, %ifcont118
-  %270 = load i32, i32* %__1_k, align 4
+loop.head131:                                     ; preds = %loop.body136, %ifcont130
+  %270 = load i32, i32* %__1_k1, align 4
   %271 = add i32 %270, 1
-  br i1 true, label %then121, label %else122
+  br i1 true, label %then133, label %else134
 
-then121:                                          ; preds = %loop.head119
-  store i32 6, i32* %array_bound120, align 4
-  br label %ifcont123
+then133:                                          ; preds = %loop.head131
+  store i32 6, i32* %array_bound132, align 4
+  br label %ifcont135
 
-else122:                                          ; preds = %loop.head119
-  br label %ifcont123
+else134:                                          ; preds = %loop.head131
+  br label %ifcont135
 
-ifcont123:                                        ; preds = %else122, %then121
-  %272 = load i32, i32* %array_bound120, align 4
+ifcont135:                                        ; preds = %else134, %then133
+  %272 = load i32, i32* %array_bound132, align 4
   %273 = icmp sle i32 %271, %272
-  br i1 %273, label %loop.body124, label %loop.end125
+  br i1 %273, label %loop.body136, label %loop.end137
 
-loop.body124:                                     ; preds = %ifcont123
-  %274 = load i32, i32* %__1_k, align 4
+loop.body136:                                     ; preds = %ifcont135
+  %274 = load i32, i32* %__1_k1, align 4
   %275 = add i32 %274, 1
-  store i32 %275, i32* %__1_k, align 4
-  %276 = load i32, i32* %__1_k, align 4
+  store i32 %275, i32* %__1_k1, align 4
+  %276 = load i32, i32* %__1_k1, align 4
   %277 = sub i32 %276, 1
   %278 = mul i32 1, %277
   %279 = add i32 0, %278
   %280 = getelementptr [6 x i32], [6 x i32]* %x, i32 0, i32 %279
   %281 = load i32, i32* %280, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i32 %281, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  br label %loop.head119
+  br label %loop.head131
 
-loop.end125:                                      ; preds = %ifcont123
+loop.end137:                                      ; preds = %ifcont135
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
-  br i1 true, label %then127, label %else128
+  br i1 true, label %then139, label %else140
 
-then127:                                          ; preds = %loop.end125
-  store i32 1, i32* %array_bound126, align 4
-  br label %ifcont133
+then139:                                          ; preds = %loop.end137
+  store i32 1, i32* %array_bound138, align 4
+  br label %ifcont145
 
-else128:                                          ; preds = %loop.end125
-  br i1 false, label %then129, label %else130
+else140:                                          ; preds = %loop.end137
+  br i1 false, label %then141, label %else142
 
-then129:                                          ; preds = %else128
-  store i32 1, i32* %array_bound126, align 4
-  br label %ifcont133
+then141:                                          ; preds = %else140
+  store i32 1, i32* %array_bound138, align 4
+  br label %ifcont145
 
-else130:                                          ; preds = %else128
-  br i1 false, label %then131, label %else132
+else142:                                          ; preds = %else140
+  br i1 false, label %then143, label %else144
 
-then131:                                          ; preds = %else130
-  store i32 1, i32* %array_bound126, align 4
-  br label %ifcont133
+then143:                                          ; preds = %else142
+  store i32 1, i32* %array_bound138, align 4
+  br label %ifcont145
 
-else132:                                          ; preds = %else130
-  br label %ifcont133
+else144:                                          ; preds = %else142
+  br label %ifcont145
 
-ifcont133:                                        ; preds = %else132, %then131, %then129, %then127
-  %282 = load i32, i32* %array_bound126, align 4
+ifcont145:                                        ; preds = %else144, %then143, %then141, %then139
+  %282 = load i32, i32* %array_bound138, align 4
   %283 = sub i32 %282, 1
-  store i32 %283, i32* %__1_t, align 4
-  br label %loop.head134
+  store i32 %283, i32* %__1_t2, align 4
+  br label %loop.head146
 
-loop.head134:                                     ; preds = %loop.end181, %ifcont133
-  %284 = load i32, i32* %__1_t, align 4
+loop.head146:                                     ; preds = %loop.end193, %ifcont145
+  %284 = load i32, i32* %__1_t2, align 4
   %285 = add i32 %284, 1
-  br i1 true, label %then136, label %else137
+  br i1 true, label %then148, label %else149
 
-then136:                                          ; preds = %loop.head134
-  store i32 3, i32* %array_bound135, align 4
-  br label %ifcont142
+then148:                                          ; preds = %loop.head146
+  store i32 3, i32* %array_bound147, align 4
+  br label %ifcont154
 
-else137:                                          ; preds = %loop.head134
-  br i1 false, label %then138, label %else139
+else149:                                          ; preds = %loop.head146
+  br i1 false, label %then150, label %else151
 
-then138:                                          ; preds = %else137
-  store i32 3, i32* %array_bound135, align 4
-  br label %ifcont142
+then150:                                          ; preds = %else149
+  store i32 3, i32* %array_bound147, align 4
+  br label %ifcont154
 
-else139:                                          ; preds = %else137
-  br i1 false, label %then140, label %else141
+else151:                                          ; preds = %else149
+  br i1 false, label %then152, label %else153
 
-then140:                                          ; preds = %else139
-  store i32 3, i32* %array_bound135, align 4
-  br label %ifcont142
+then152:                                          ; preds = %else151
+  store i32 3, i32* %array_bound147, align 4
+  br label %ifcont154
 
-else141:                                          ; preds = %else139
-  br label %ifcont142
+else153:                                          ; preds = %else151
+  br label %ifcont154
 
-ifcont142:                                        ; preds = %else141, %then140, %then138, %then136
-  %286 = load i32, i32* %array_bound135, align 4
+ifcont154:                                        ; preds = %else153, %then152, %then150, %then148
+  %286 = load i32, i32* %array_bound147, align 4
   %287 = icmp sle i32 %285, %286
-  br i1 %287, label %loop.body143, label %loop.end182
+  br i1 %287, label %loop.body155, label %loop.end194
 
-loop.body143:                                     ; preds = %ifcont142
-  %288 = load i32, i32* %__1_t, align 4
+loop.body155:                                     ; preds = %ifcont154
+  %288 = load i32, i32* %__1_t2, align 4
   %289 = add i32 %288, 1
-  store i32 %289, i32* %__1_t, align 4
-  br i1 false, label %then145, label %else146
+  store i32 %289, i32* %__1_t2, align 4
+  br i1 false, label %then157, label %else158
 
-then145:                                          ; preds = %loop.body143
-  store i32 1, i32* %array_bound144, align 4
-  br label %ifcont151
+then157:                                          ; preds = %loop.body155
+  store i32 1, i32* %array_bound156, align 4
+  br label %ifcont163
 
-else146:                                          ; preds = %loop.body143
-  br i1 true, label %then147, label %else148
+else158:                                          ; preds = %loop.body155
+  br i1 true, label %then159, label %else160
 
-then147:                                          ; preds = %else146
-  store i32 1, i32* %array_bound144, align 4
-  br label %ifcont151
+then159:                                          ; preds = %else158
+  store i32 1, i32* %array_bound156, align 4
+  br label %ifcont163
 
-else148:                                          ; preds = %else146
-  br i1 false, label %then149, label %else150
+else160:                                          ; preds = %else158
+  br i1 false, label %then161, label %else162
 
-then149:                                          ; preds = %else148
-  store i32 1, i32* %array_bound144, align 4
-  br label %ifcont151
+then161:                                          ; preds = %else160
+  store i32 1, i32* %array_bound156, align 4
+  br label %ifcont163
 
-else150:                                          ; preds = %else148
-  br label %ifcont151
+else162:                                          ; preds = %else160
+  br label %ifcont163
 
-ifcont151:                                        ; preds = %else150, %then149, %then147, %then145
-  %290 = load i32, i32* %array_bound144, align 4
+ifcont163:                                        ; preds = %else162, %then161, %then159, %then157
+  %290 = load i32, i32* %array_bound156, align 4
   %291 = sub i32 %290, 1
-  store i32 %291, i32* %__2_t, align 4
-  br label %loop.head152
+  store i32 %291, i32* %__2_t5, align 4
+  br label %loop.head164
 
-loop.head152:                                     ; preds = %loop.end180, %ifcont151
-  %292 = load i32, i32* %__2_t, align 4
+loop.head164:                                     ; preds = %loop.end192, %ifcont163
+  %292 = load i32, i32* %__2_t5, align 4
   %293 = add i32 %292, 1
-  br i1 false, label %then154, label %else155
+  br i1 false, label %then166, label %else167
 
-then154:                                          ; preds = %loop.head152
-  store i32 3, i32* %array_bound153, align 4
-  br label %ifcont160
+then166:                                          ; preds = %loop.head164
+  store i32 3, i32* %array_bound165, align 4
+  br label %ifcont172
 
-else155:                                          ; preds = %loop.head152
-  br i1 true, label %then156, label %else157
+else167:                                          ; preds = %loop.head164
+  br i1 true, label %then168, label %else169
 
-then156:                                          ; preds = %else155
-  store i32 3, i32* %array_bound153, align 4
-  br label %ifcont160
+then168:                                          ; preds = %else167
+  store i32 3, i32* %array_bound165, align 4
+  br label %ifcont172
 
-else157:                                          ; preds = %else155
-  br i1 false, label %then158, label %else159
+else169:                                          ; preds = %else167
+  br i1 false, label %then170, label %else171
 
-then158:                                          ; preds = %else157
-  store i32 3, i32* %array_bound153, align 4
-  br label %ifcont160
+then170:                                          ; preds = %else169
+  store i32 3, i32* %array_bound165, align 4
+  br label %ifcont172
 
-else159:                                          ; preds = %else157
-  br label %ifcont160
+else171:                                          ; preds = %else169
+  br label %ifcont172
 
-ifcont160:                                        ; preds = %else159, %then158, %then156, %then154
-  %294 = load i32, i32* %array_bound153, align 4
+ifcont172:                                        ; preds = %else171, %then170, %then168, %then166
+  %294 = load i32, i32* %array_bound165, align 4
   %295 = icmp sle i32 %293, %294
-  br i1 %295, label %loop.body161, label %loop.end181
+  br i1 %295, label %loop.body173, label %loop.end193
 
-loop.body161:                                     ; preds = %ifcont160
-  %296 = load i32, i32* %__2_t, align 4
+loop.body173:                                     ; preds = %ifcont172
+  %296 = load i32, i32* %__2_t5, align 4
   %297 = add i32 %296, 1
-  store i32 %297, i32* %__2_t, align 4
-  br i1 false, label %then163, label %else164
+  store i32 %297, i32* %__2_t5, align 4
+  br i1 false, label %then175, label %else176
 
-then163:                                          ; preds = %loop.body161
-  store i32 1, i32* %array_bound162, align 4
-  br label %ifcont169
+then175:                                          ; preds = %loop.body173
+  store i32 1, i32* %array_bound174, align 4
+  br label %ifcont181
 
-else164:                                          ; preds = %loop.body161
-  br i1 false, label %then165, label %else166
+else176:                                          ; preds = %loop.body173
+  br i1 false, label %then177, label %else178
 
-then165:                                          ; preds = %else164
-  store i32 1, i32* %array_bound162, align 4
-  br label %ifcont169
+then177:                                          ; preds = %else176
+  store i32 1, i32* %array_bound174, align 4
+  br label %ifcont181
 
-else166:                                          ; preds = %else164
-  br i1 true, label %then167, label %else168
+else178:                                          ; preds = %else176
+  br i1 true, label %then179, label %else180
 
-then167:                                          ; preds = %else166
-  store i32 1, i32* %array_bound162, align 4
-  br label %ifcont169
+then179:                                          ; preds = %else178
+  store i32 1, i32* %array_bound174, align 4
+  br label %ifcont181
 
-else168:                                          ; preds = %else166
-  br label %ifcont169
+else180:                                          ; preds = %else178
+  br label %ifcont181
 
-ifcont169:                                        ; preds = %else168, %then167, %then165, %then163
-  %298 = load i32, i32* %array_bound162, align 4
+ifcont181:                                        ; preds = %else180, %then179, %then177, %then175
+  %298 = load i32, i32* %array_bound174, align 4
   %299 = sub i32 %298, 1
-  store i32 %299, i32* %__3_t, align 4
-  br label %loop.head170
+  store i32 %299, i32* %__3_t8, align 4
+  br label %loop.head182
 
-loop.head170:                                     ; preds = %loop.body179, %ifcont169
-  %300 = load i32, i32* %__3_t, align 4
+loop.head182:                                     ; preds = %loop.body191, %ifcont181
+  %300 = load i32, i32* %__3_t8, align 4
   %301 = add i32 %300, 1
-  br i1 false, label %then172, label %else173
+  br i1 false, label %then184, label %else185
 
-then172:                                          ; preds = %loop.head170
-  store i32 3, i32* %array_bound171, align 4
-  br label %ifcont178
+then184:                                          ; preds = %loop.head182
+  store i32 3, i32* %array_bound183, align 4
+  br label %ifcont190
 
-else173:                                          ; preds = %loop.head170
-  br i1 false, label %then174, label %else175
+else185:                                          ; preds = %loop.head182
+  br i1 false, label %then186, label %else187
 
-then174:                                          ; preds = %else173
-  store i32 3, i32* %array_bound171, align 4
-  br label %ifcont178
+then186:                                          ; preds = %else185
+  store i32 3, i32* %array_bound183, align 4
+  br label %ifcont190
 
-else175:                                          ; preds = %else173
-  br i1 true, label %then176, label %else177
+else187:                                          ; preds = %else185
+  br i1 true, label %then188, label %else189
 
-then176:                                          ; preds = %else175
-  store i32 3, i32* %array_bound171, align 4
-  br label %ifcont178
+then188:                                          ; preds = %else187
+  store i32 3, i32* %array_bound183, align 4
+  br label %ifcont190
 
-else177:                                          ; preds = %else175
-  br label %ifcont178
+else189:                                          ; preds = %else187
+  br label %ifcont190
 
-ifcont178:                                        ; preds = %else177, %then176, %then174, %then172
-  %302 = load i32, i32* %array_bound171, align 4
+ifcont190:                                        ; preds = %else189, %then188, %then186, %then184
+  %302 = load i32, i32* %array_bound183, align 4
   %303 = icmp sle i32 %301, %302
-  br i1 %303, label %loop.body179, label %loop.end180
+  br i1 %303, label %loop.body191, label %loop.end192
 
-loop.body179:                                     ; preds = %ifcont178
-  %304 = load i32, i32* %__3_t, align 4
+loop.body191:                                     ; preds = %ifcont190
+  %304 = load i32, i32* %__3_t8, align 4
   %305 = add i32 %304, 1
-  store i32 %305, i32* %__3_t, align 4
-  %306 = load i32, i32* %__1_t, align 4
-  %307 = load i32, i32* %__2_t, align 4
-  %308 = load i32, i32* %__3_t, align 4
+  store i32 %305, i32* %__3_t8, align 4
+  %306 = load i32, i32* %__1_t2, align 4
+  %307 = load i32, i32* %__2_t5, align 4
+  %308 = load i32, i32* %__3_t8, align 4
   %309 = sub i32 %306, 1
   %310 = mul i32 1, %309
   %311 = add i32 0, %310
@@ -1021,210 +1033,210 @@ loop.body179:                                     ; preds = %ifcont178
   %317 = add i32 %314, %316
   %318 = getelementptr [27 x i32], [27 x i32]* %a, i32 0, i32 %317
   store i32 7, i32* %318, align 4
-  br label %loop.head170
+  br label %loop.head182
 
-loop.end180:                                      ; preds = %ifcont178
-  br label %loop.head152
+loop.end192:                                      ; preds = %ifcont190
+  br label %loop.head164
 
-loop.end181:                                      ; preds = %ifcont160
-  br label %loop.head134
+loop.end193:                                      ; preds = %ifcont172
+  br label %loop.head146
 
-loop.end182:                                      ; preds = %ifcont142
-  br i1 true, label %then184, label %else185
+loop.end194:                                      ; preds = %ifcont154
+  br i1 true, label %then196, label %else197
 
-then184:                                          ; preds = %loop.end182
-  store i32 1, i32* %array_bound183, align 4
-  br label %ifcont190
+then196:                                          ; preds = %loop.end194
+  store i32 1, i32* %array_bound195, align 4
+  br label %ifcont202
 
-else185:                                          ; preds = %loop.end182
-  br i1 false, label %then186, label %else187
+else197:                                          ; preds = %loop.end194
+  br i1 false, label %then198, label %else199
 
-then186:                                          ; preds = %else185
-  store i32 1, i32* %array_bound183, align 4
-  br label %ifcont190
+then198:                                          ; preds = %else197
+  store i32 1, i32* %array_bound195, align 4
+  br label %ifcont202
 
-else187:                                          ; preds = %else185
-  br i1 false, label %then188, label %else189
+else199:                                          ; preds = %else197
+  br i1 false, label %then200, label %else201
 
-then188:                                          ; preds = %else187
-  store i32 1, i32* %array_bound183, align 4
-  br label %ifcont190
+then200:                                          ; preds = %else199
+  store i32 1, i32* %array_bound195, align 4
+  br label %ifcont202
 
-else189:                                          ; preds = %else187
-  br label %ifcont190
+else201:                                          ; preds = %else199
+  br label %ifcont202
 
-ifcont190:                                        ; preds = %else189, %then188, %then186, %then184
-  %319 = load i32, i32* %array_bound183, align 4
+ifcont202:                                        ; preds = %else201, %then200, %then198, %then196
+  %319 = load i32, i32* %array_bound195, align 4
   %320 = sub i32 %319, 1
-  store i32 %320, i32* %__1_k, align 4
-  br label %loop.head191
+  store i32 %320, i32* %__1_k1, align 4
+  br label %loop.head203
 
-loop.head191:                                     ; preds = %loop.end238, %ifcont190
-  %321 = load i32, i32* %__1_k, align 4
+loop.head203:                                     ; preds = %loop.end250, %ifcont202
+  %321 = load i32, i32* %__1_k1, align 4
   %322 = add i32 %321, 1
-  br i1 true, label %then193, label %else194
+  br i1 true, label %then205, label %else206
 
-then193:                                          ; preds = %loop.head191
-  store i32 3, i32* %array_bound192, align 4
-  br label %ifcont199
+then205:                                          ; preds = %loop.head203
+  store i32 3, i32* %array_bound204, align 4
+  br label %ifcont211
 
-else194:                                          ; preds = %loop.head191
-  br i1 false, label %then195, label %else196
+else206:                                          ; preds = %loop.head203
+  br i1 false, label %then207, label %else208
 
-then195:                                          ; preds = %else194
-  store i32 3, i32* %array_bound192, align 4
-  br label %ifcont199
+then207:                                          ; preds = %else206
+  store i32 3, i32* %array_bound204, align 4
+  br label %ifcont211
 
-else196:                                          ; preds = %else194
-  br i1 false, label %then197, label %else198
+else208:                                          ; preds = %else206
+  br i1 false, label %then209, label %else210
 
-then197:                                          ; preds = %else196
-  store i32 3, i32* %array_bound192, align 4
-  br label %ifcont199
+then209:                                          ; preds = %else208
+  store i32 3, i32* %array_bound204, align 4
+  br label %ifcont211
 
-else198:                                          ; preds = %else196
-  br label %ifcont199
+else210:                                          ; preds = %else208
+  br label %ifcont211
 
-ifcont199:                                        ; preds = %else198, %then197, %then195, %then193
-  %323 = load i32, i32* %array_bound192, align 4
+ifcont211:                                        ; preds = %else210, %then209, %then207, %then205
+  %323 = load i32, i32* %array_bound204, align 4
   %324 = icmp sle i32 %322, %323
-  br i1 %324, label %loop.body200, label %loop.end239
+  br i1 %324, label %loop.body212, label %loop.end251
 
-loop.body200:                                     ; preds = %ifcont199
-  %325 = load i32, i32* %__1_k, align 4
+loop.body212:                                     ; preds = %ifcont211
+  %325 = load i32, i32* %__1_k1, align 4
   %326 = add i32 %325, 1
-  store i32 %326, i32* %__1_k, align 4
-  br i1 false, label %then202, label %else203
+  store i32 %326, i32* %__1_k1, align 4
+  br i1 false, label %then214, label %else215
 
-then202:                                          ; preds = %loop.body200
-  store i32 1, i32* %array_bound201, align 4
-  br label %ifcont208
+then214:                                          ; preds = %loop.body212
+  store i32 1, i32* %array_bound213, align 4
+  br label %ifcont220
 
-else203:                                          ; preds = %loop.body200
-  br i1 true, label %then204, label %else205
+else215:                                          ; preds = %loop.body212
+  br i1 true, label %then216, label %else217
 
-then204:                                          ; preds = %else203
-  store i32 1, i32* %array_bound201, align 4
-  br label %ifcont208
+then216:                                          ; preds = %else215
+  store i32 1, i32* %array_bound213, align 4
+  br label %ifcont220
 
-else205:                                          ; preds = %else203
-  br i1 false, label %then206, label %else207
+else217:                                          ; preds = %else215
+  br i1 false, label %then218, label %else219
 
-then206:                                          ; preds = %else205
-  store i32 1, i32* %array_bound201, align 4
-  br label %ifcont208
+then218:                                          ; preds = %else217
+  store i32 1, i32* %array_bound213, align 4
+  br label %ifcont220
 
-else207:                                          ; preds = %else205
-  br label %ifcont208
+else219:                                          ; preds = %else217
+  br label %ifcont220
 
-ifcont208:                                        ; preds = %else207, %then206, %then204, %then202
-  %327 = load i32, i32* %array_bound201, align 4
+ifcont220:                                        ; preds = %else219, %then218, %then216, %then214
+  %327 = load i32, i32* %array_bound213, align 4
   %328 = sub i32 %327, 1
-  store i32 %328, i32* %__2_k, align 4
-  br label %loop.head209
+  store i32 %328, i32* %__2_k4, align 4
+  br label %loop.head221
 
-loop.head209:                                     ; preds = %loop.end237, %ifcont208
-  %329 = load i32, i32* %__2_k, align 4
+loop.head221:                                     ; preds = %loop.end249, %ifcont220
+  %329 = load i32, i32* %__2_k4, align 4
   %330 = add i32 %329, 1
-  br i1 false, label %then211, label %else212
+  br i1 false, label %then223, label %else224
 
-then211:                                          ; preds = %loop.head209
-  store i32 3, i32* %array_bound210, align 4
-  br label %ifcont217
+then223:                                          ; preds = %loop.head221
+  store i32 3, i32* %array_bound222, align 4
+  br label %ifcont229
 
-else212:                                          ; preds = %loop.head209
-  br i1 true, label %then213, label %else214
+else224:                                          ; preds = %loop.head221
+  br i1 true, label %then225, label %else226
 
-then213:                                          ; preds = %else212
-  store i32 3, i32* %array_bound210, align 4
-  br label %ifcont217
+then225:                                          ; preds = %else224
+  store i32 3, i32* %array_bound222, align 4
+  br label %ifcont229
 
-else214:                                          ; preds = %else212
-  br i1 false, label %then215, label %else216
+else226:                                          ; preds = %else224
+  br i1 false, label %then227, label %else228
 
-then215:                                          ; preds = %else214
-  store i32 3, i32* %array_bound210, align 4
-  br label %ifcont217
+then227:                                          ; preds = %else226
+  store i32 3, i32* %array_bound222, align 4
+  br label %ifcont229
 
-else216:                                          ; preds = %else214
-  br label %ifcont217
+else228:                                          ; preds = %else226
+  br label %ifcont229
 
-ifcont217:                                        ; preds = %else216, %then215, %then213, %then211
-  %331 = load i32, i32* %array_bound210, align 4
+ifcont229:                                        ; preds = %else228, %then227, %then225, %then223
+  %331 = load i32, i32* %array_bound222, align 4
   %332 = icmp sle i32 %330, %331
-  br i1 %332, label %loop.body218, label %loop.end238
+  br i1 %332, label %loop.body230, label %loop.end250
 
-loop.body218:                                     ; preds = %ifcont217
-  %333 = load i32, i32* %__2_k, align 4
+loop.body230:                                     ; preds = %ifcont229
+  %333 = load i32, i32* %__2_k4, align 4
   %334 = add i32 %333, 1
-  store i32 %334, i32* %__2_k, align 4
-  br i1 false, label %then220, label %else221
+  store i32 %334, i32* %__2_k4, align 4
+  br i1 false, label %then232, label %else233
 
-then220:                                          ; preds = %loop.body218
-  store i32 1, i32* %array_bound219, align 4
-  br label %ifcont226
+then232:                                          ; preds = %loop.body230
+  store i32 1, i32* %array_bound231, align 4
+  br label %ifcont238
 
-else221:                                          ; preds = %loop.body218
-  br i1 false, label %then222, label %else223
+else233:                                          ; preds = %loop.body230
+  br i1 false, label %then234, label %else235
 
-then222:                                          ; preds = %else221
-  store i32 1, i32* %array_bound219, align 4
-  br label %ifcont226
+then234:                                          ; preds = %else233
+  store i32 1, i32* %array_bound231, align 4
+  br label %ifcont238
 
-else223:                                          ; preds = %else221
-  br i1 true, label %then224, label %else225
+else235:                                          ; preds = %else233
+  br i1 true, label %then236, label %else237
 
-then224:                                          ; preds = %else223
-  store i32 1, i32* %array_bound219, align 4
-  br label %ifcont226
+then236:                                          ; preds = %else235
+  store i32 1, i32* %array_bound231, align 4
+  br label %ifcont238
 
-else225:                                          ; preds = %else223
-  br label %ifcont226
+else237:                                          ; preds = %else235
+  br label %ifcont238
 
-ifcont226:                                        ; preds = %else225, %then224, %then222, %then220
-  %335 = load i32, i32* %array_bound219, align 4
+ifcont238:                                        ; preds = %else237, %then236, %then234, %then232
+  %335 = load i32, i32* %array_bound231, align 4
   %336 = sub i32 %335, 1
-  store i32 %336, i32* %__3_k, align 4
-  br label %loop.head227
+  store i32 %336, i32* %__3_k7, align 4
+  br label %loop.head239
 
-loop.head227:                                     ; preds = %loop.body236, %ifcont226
-  %337 = load i32, i32* %__3_k, align 4
+loop.head239:                                     ; preds = %loop.body248, %ifcont238
+  %337 = load i32, i32* %__3_k7, align 4
   %338 = add i32 %337, 1
-  br i1 false, label %then229, label %else230
+  br i1 false, label %then241, label %else242
 
-then229:                                          ; preds = %loop.head227
-  store i32 3, i32* %array_bound228, align 4
-  br label %ifcont235
+then241:                                          ; preds = %loop.head239
+  store i32 3, i32* %array_bound240, align 4
+  br label %ifcont247
 
-else230:                                          ; preds = %loop.head227
-  br i1 false, label %then231, label %else232
+else242:                                          ; preds = %loop.head239
+  br i1 false, label %then243, label %else244
 
-then231:                                          ; preds = %else230
-  store i32 3, i32* %array_bound228, align 4
-  br label %ifcont235
+then243:                                          ; preds = %else242
+  store i32 3, i32* %array_bound240, align 4
+  br label %ifcont247
 
-else232:                                          ; preds = %else230
-  br i1 true, label %then233, label %else234
+else244:                                          ; preds = %else242
+  br i1 true, label %then245, label %else246
 
-then233:                                          ; preds = %else232
-  store i32 3, i32* %array_bound228, align 4
-  br label %ifcont235
+then245:                                          ; preds = %else244
+  store i32 3, i32* %array_bound240, align 4
+  br label %ifcont247
 
-else234:                                          ; preds = %else232
-  br label %ifcont235
+else246:                                          ; preds = %else244
+  br label %ifcont247
 
-ifcont235:                                        ; preds = %else234, %then233, %then231, %then229
-  %339 = load i32, i32* %array_bound228, align 4
+ifcont247:                                        ; preds = %else246, %then245, %then243, %then241
+  %339 = load i32, i32* %array_bound240, align 4
   %340 = icmp sle i32 %338, %339
-  br i1 %340, label %loop.body236, label %loop.end237
+  br i1 %340, label %loop.body248, label %loop.end249
 
-loop.body236:                                     ; preds = %ifcont235
-  %341 = load i32, i32* %__3_k, align 4
+loop.body248:                                     ; preds = %ifcont247
+  %341 = load i32, i32* %__3_k7, align 4
   %342 = add i32 %341, 1
-  store i32 %342, i32* %__3_k, align 4
-  %343 = load i32, i32* %__1_k, align 4
-  %344 = load i32, i32* %__2_k, align 4
-  %345 = load i32, i32* %__3_k, align 4
+  store i32 %342, i32* %__3_k7, align 4
+  %343 = load i32, i32* %__1_k1, align 4
+  %344 = load i32, i32* %__2_k4, align 4
+  %345 = load i32, i32* %__3_k7, align 4
   %346 = sub i32 %343, 1
   %347 = mul i32 1, %346
   %348 = add i32 0, %347
@@ -1237,22 +1249,22 @@ loop.body236:                                     ; preds = %ifcont235
   %355 = getelementptr [27 x i32], [27 x i32]* %a, i32 0, i32 %354
   %356 = load i32, i32* %355, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i32 %356, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
-  br label %loop.head227
+  br label %loop.head239
 
-loop.end237:                                      ; preds = %ifcont235
+loop.end249:                                      ; preds = %ifcont247
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  br label %loop.head209
+  br label %loop.head221
 
-loop.end238:                                      ; preds = %ifcont217
+loop.end250:                                      ; preds = %ifcont229
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
-  br label %loop.head191
+  br label %loop.head203
 
-loop.end239:                                      ; preds = %ifcont199
+loop.end251:                                      ; preds = %ifcont211
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %loop.end239
+return:                                           ; preds = %loop.end251
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_08_func-85e526b.json
+++ b/tests/reference/llvm-arrays_08_func-85e526b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_08_func-85e526b.stdout",
-    "stdout_hash": "42ec262d1b57aa024b132d64d8a8663cfca7416d9440fb315cf2e9ee",
+    "stdout_hash": "9200a0da40e4387cf0227db952db2a34240e547632142a8ea1a19723",
     "stderr": "llvm-arrays_08_func-85e526b.stderr",
     "stderr_hash": "d70481e5625f20fa12d3e8bdad4a5dfa6912ac62ade8fc840a5da64b",
     "returncode": 0

--- a/tests/reference/llvm-arrays_08_func-85e526b.stdout
+++ b/tests/reference/llvm-arrays_08_func-85e526b.stdout
@@ -10,6 +10,83 @@ source_filename = "LFortran"
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value8 = alloca i32, align 4
+  %call_arg_value7 = alloca i32, align 4
+  %call_arg_value6 = alloca i32, align 4
+  %call_arg_value5 = alloca i32, align 4
+  %call_arg_value4 = alloca i32, align 4
+  %call_arg_value3 = alloca i32, align 4
+  %call_arg_value2 = alloca i32, align 4
+  %call_arg_value = alloca i32, align 4
+  %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %r = alloca i1, align 1
+  %x = alloca [10 x i32], align 4
+  %y = alloca [10 x i32], align 4
+  store i32 0, i32* %i1, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.body, %.entry
+  %2 = load i32, i32* %i1, align 4
+  %3 = add i32 %2, 1
+  %4 = icmp sle i32 %3, 10
+  br i1 %4, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %loop.head
+  %5 = load i32, i32* %i1, align 4
+  %6 = add i32 %5, 1
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %i1, align 4
+  %8 = sub i32 %7, 1
+  %9 = mul i32 1, %8
+  %10 = add i32 0, %9
+  %11 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 %10
+  %12 = load i32, i32* %i1, align 4
+  store i32 %12, i32* %11, align 4
+  br label %loop.head
+
+loop.end:                                         ; preds = %loop.head
+  %13 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 0
+  store i32 1, i32* %call_arg_value, align 4
+  store i32 10, i32* %call_arg_value2, align 4
+  %14 = getelementptr [10 x i32], [10 x i32]* %y, i32 0, i32 0
+  store i32 1, i32* %call_arg_value3, align 4
+  store i32 10, i32* %call_arg_value4, align 4
+  call void @copy_from_to_integer____0_integer____1(i32* %13, i32* %call_arg_value, i32* %call_arg_value2, i32* %14, i32* %call_arg_value3, i32* %call_arg_value4)
+  %15 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 0
+  store i32 1, i32* %call_arg_value5, align 4
+  store i32 10, i32* %call_arg_value6, align 4
+  %16 = getelementptr [10 x i32], [10 x i32]* %y, i32 0, i32 0
+  store i32 1, i32* %call_arg_value7, align 4
+  store i32 10, i32* %call_arg_value8, align 4
+  %17 = call i1 @verify_integer____0_integer____1(i32* %15, i32* %call_arg_value5, i32* %call_arg_value6, i32* %16, i32* %call_arg_value7, i32* %call_arg_value8)
+  store i1 %17, i1* %r, align 1
+  %18 = load i1, i1* %r, align 1
+  %19 = icmp eq i1 %18, false
+  %20 = select i1 %19, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  %21 = load i1, i1* %r, align 1
+  %22 = xor i1 %21, true
+  br i1 %22, label %then, label %else
+
+then:                                             ; preds = %loop.end
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %loop.end
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
+  ret i32 0
+}
+
 define void @copy_from_to_integer____0_integer____1(i32* %a, i32* %__1a, i32* %__2a, i32* %b, i32* %__1b, i32* %__2b) {
 .entry:
   %i = alloca i32, align 4
@@ -106,82 +183,6 @@ loop.end:                                         ; preds = %loop.head
 return:                                           ; preds = %loop.end
   %29 = load i1, i1* %r, align 1
   ret i1 %29
-}
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value7 = alloca i32, align 4
-  %call_arg_value6 = alloca i32, align 4
-  %call_arg_value5 = alloca i32, align 4
-  %call_arg_value4 = alloca i32, align 4
-  %call_arg_value3 = alloca i32, align 4
-  %call_arg_value2 = alloca i32, align 4
-  %call_arg_value1 = alloca i32, align 4
-  %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i = alloca i32, align 4
-  %r = alloca i1, align 1
-  %x = alloca [10 x i32], align 4
-  %y = alloca [10 x i32], align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 10
-  br i1 %4, label %loop.body, label %loop.end
-
-loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
-  %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %i, align 4
-  %8 = sub i32 %7, 1
-  %9 = mul i32 1, %8
-  %10 = add i32 0, %9
-  %11 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 %10
-  %12 = load i32, i32* %i, align 4
-  store i32 %12, i32* %11, align 4
-  br label %loop.head
-
-loop.end:                                         ; preds = %loop.head
-  %13 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 0
-  store i32 1, i32* %call_arg_value, align 4
-  store i32 10, i32* %call_arg_value1, align 4
-  %14 = getelementptr [10 x i32], [10 x i32]* %y, i32 0, i32 0
-  store i32 1, i32* %call_arg_value2, align 4
-  store i32 10, i32* %call_arg_value3, align 4
-  call void @copy_from_to_integer____0_integer____1(i32* %13, i32* %call_arg_value, i32* %call_arg_value1, i32* %14, i32* %call_arg_value2, i32* %call_arg_value3)
-  %15 = getelementptr [10 x i32], [10 x i32]* %x, i32 0, i32 0
-  store i32 1, i32* %call_arg_value4, align 4
-  store i32 10, i32* %call_arg_value5, align 4
-  %16 = getelementptr [10 x i32], [10 x i32]* %y, i32 0, i32 0
-  store i32 1, i32* %call_arg_value6, align 4
-  store i32 10, i32* %call_arg_value7, align 4
-  %17 = call i1 @verify_integer____0_integer____1(i32* %15, i32* %call_arg_value4, i32* %call_arg_value5, i32* %16, i32* %call_arg_value6, i32* %call_arg_value7)
-  store i1 %17, i1* %r, align 1
-  %18 = load i1, i1* %r, align 1
-  %19 = icmp eq i1 %18, false
-  %20 = select i1 %19, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %21 = load i1, i1* %r, align 1
-  %22 = xor i1 %21, true
-  br i1 %22, label %then, label %else
-
-then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-else:                                             ; preds = %loop.end
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  br label %return
-
-return:                                           ; preds = %ifcont
-  ret i32 0
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-arrays_13-8ff7d44.json
+++ b/tests/reference/llvm-arrays_13-8ff7d44.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_13-8ff7d44.stdout",
-    "stdout_hash": "51cf76f7f8b6cfa2613bf5d46309fe3ab2324211db500a354939102f",
+    "stdout_hash": "e168cf7227ea62123a152c5d50410dd3325b790e06ed32a337d48def",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_13-8ff7d44.stdout
+++ b/tests/reference/llvm-arrays_13-8ff7d44.stdout
@@ -18,6 +18,289 @@ source_filename = "LFortran"
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %array_descriptor4 = alloca %array, align 8
+  %array_descriptor = alloca %array.0, align 8
+  %u = alloca i32, align 4
+  %v = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i = alloca %array.0*, align 8
+  store %array.0* null, %array.0** %i, align 8
+  %arr_desc = alloca %array.0, align 8
+  %2 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 2
+  %3 = alloca i32, align 4
+  store i32 1, i32* %3, align 4
+  %4 = load i32, i32* %3, align 4
+  %5 = alloca %dimension_descriptor, i32 %4, align 8
+  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
+  %6 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 4
+  store i32 1, i32* %6, align 4
+  %7 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 0
+  store i32* null, i32** %7, align 8
+  store %array.0* %arr_desc, %array.0** %i, align 8
+  %iv = alloca [2 x i32], align 4
+  %r = alloca %array*, align 8
+  store %array* null, %array** %r, align 8
+  %arr_desc1 = alloca %array, align 8
+  %8 = getelementptr %array, %array* %arr_desc1, i32 0, i32 2
+  %9 = alloca i32, align 4
+  store i32 2, i32* %9, align 4
+  %10 = load i32, i32* %9, align 4
+  %11 = alloca %dimension_descriptor, i32 %10, align 8
+  store %dimension_descriptor* %11, %dimension_descriptor** %8, align 8
+  %12 = getelementptr %array, %array* %arr_desc1, i32 0, i32 4
+  store i32 2, i32* %12, align 4
+  %13 = getelementptr %array, %array* %arr_desc1, i32 0, i32 0
+  store float* null, float** %13, align 8
+  store %array* %arr_desc1, %array** %r, align 8
+  %rv = alloca [6 x float], align 4
+  %u2 = alloca i32, align 4
+  %v3 = alloca i32, align 4
+  %14 = getelementptr [2 x i32], [2 x i32]* %iv, i32 0, i32 0
+  %15 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 0
+  store i32* %14, i32** %15, align 8
+  %16 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 1
+  store i32 0, i32* %16, align 4
+  %17 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 2
+  %18 = alloca %dimension_descriptor, align 8
+  store %dimension_descriptor* %18, %dimension_descriptor** %17, align 8
+  %19 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 4
+  store i32 1, i32* %19, align 4
+  %20 = load %dimension_descriptor*, %dimension_descriptor** %17, align 8
+  %21 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 0
+  %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 0
+  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 1
+  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 2
+  store i32 1, i32* %22, align 4
+  store i32 1, i32* %23, align 4
+  store i32 2, i32* %24, align 4
+  store %array.0* %array_descriptor, %array.0** %i, align 8
+  %25 = getelementptr [6 x float], [6 x float]* %rv, i32 0, i32 0
+  %26 = getelementptr %array, %array* %array_descriptor4, i32 0, i32 0
+  store float* %25, float** %26, align 8
+  %27 = getelementptr %array, %array* %array_descriptor4, i32 0, i32 1
+  store i32 0, i32* %27, align 4
+  %28 = getelementptr %array, %array* %array_descriptor4, i32 0, i32 2
+  %29 = alloca %dimension_descriptor, i32 2, align 8
+  store %dimension_descriptor* %29, %dimension_descriptor** %28, align 8
+  %30 = getelementptr %array, %array* %array_descriptor4, i32 0, i32 4
+  store i32 2, i32* %30, align 4
+  %31 = load %dimension_descriptor*, %dimension_descriptor** %28, align 8
+  %32 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 0
+  %33 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 0
+  %34 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 1
+  %35 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 2
+  store i32 1, i32* %33, align 4
+  store i32 1, i32* %34, align 4
+  store i32 2, i32* %35, align 4
+  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 1
+  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
+  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
+  store i32 2, i32* %37, align 4
+  store i32 1, i32* %38, align 4
+  store i32 3, i32* %39, align 4
+  store %array* %array_descriptor4, %array** %r, align 8
+  %40 = load %array.0*, %array.0** %i, align 8
+  %41 = getelementptr %array.0, %array.0* %40, i32 0, i32 2
+  %42 = load %dimension_descriptor*, %dimension_descriptor** %41, align 8
+  %43 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 0
+  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 1
+  %45 = load i32, i32* %44, align 4
+  %46 = sub i32 1, %45
+  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 0
+  %48 = load i32, i32* %47, align 4
+  %49 = mul i32 %48, %46
+  %50 = add i32 0, %49
+  %51 = getelementptr %array.0, %array.0* %40, i32 0, i32 1
+  %52 = load i32, i32* %51, align 4
+  %53 = add i32 %50, %52
+  %54 = getelementptr %array.0, %array.0* %40, i32 0, i32 0
+  %55 = load i32*, i32** %54, align 8
+  %56 = getelementptr inbounds i32, i32* %55, i32 %53
+  store i32 1, i32* %56, align 4
+  %57 = load %array.0*, %array.0** %i, align 8
+  %58 = getelementptr %array.0, %array.0* %57, i32 0, i32 2
+  %59 = load %dimension_descriptor*, %dimension_descriptor** %58, align 8
+  %60 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %59, i32 0
+  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 1
+  %62 = load i32, i32* %61, align 4
+  %63 = sub i32 1, %62
+  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 0
+  %65 = load i32, i32* %64, align 4
+  %66 = mul i32 %65, %63
+  %67 = add i32 0, %66
+  %68 = getelementptr %array.0, %array.0* %57, i32 0, i32 1
+  %69 = load i32, i32* %68, align 4
+  %70 = add i32 %67, %69
+  %71 = getelementptr %array.0, %array.0* %57, i32 0, i32 0
+  %72 = load i32*, i32** %71, align 8
+  %73 = getelementptr inbounds i32, i32* %72, i32 %70
+  %74 = load i32, i32* %73, align 4
+  %75 = icmp ne i32 %74, 1
+  br i1 %75, label %then, label %else
+
+then:                                             ; preds = %.entry
+  %76 = load %array.0*, %array.0** %i, align 8
+  %77 = getelementptr %array.0, %array.0* %76, i32 0, i32 2
+  %78 = load %dimension_descriptor*, %dimension_descriptor** %77, align 8
+  %79 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %78, i32 0
+  %80 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 1
+  %81 = load i32, i32* %80, align 4
+  %82 = sub i32 2, %81
+  %83 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 0
+  %84 = load i32, i32* %83, align 4
+  %85 = mul i32 %84, %82
+  %86 = add i32 0, %85
+  %87 = getelementptr %array.0, %array.0* %76, i32 0, i32 1
+  %88 = load i32, i32* %87, align 4
+  %89 = add i32 %86, %88
+  %90 = getelementptr %array.0, %array.0* %76, i32 0, i32 0
+  %91 = load i32*, i32** %90, align 8
+  %92 = getelementptr inbounds i32, i32* %91, i32 %89
+  store i32 3, i32* %92, align 4
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  %93 = load %array.0*, %array.0** %i, align 8
+  %94 = getelementptr %array.0, %array.0* %93, i32 0, i32 2
+  %95 = load %dimension_descriptor*, %dimension_descriptor** %94, align 8
+  %96 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %95, i32 0
+  %97 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 1
+  %98 = load i32, i32* %97, align 4
+  %99 = sub i32 2, %98
+  %100 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 0
+  %101 = load i32, i32* %100, align 4
+  %102 = mul i32 %101, %99
+  %103 = add i32 0, %102
+  %104 = getelementptr %array.0, %array.0* %93, i32 0, i32 1
+  %105 = load i32, i32* %104, align 4
+  %106 = add i32 %103, %105
+  %107 = getelementptr %array.0, %array.0* %93, i32 0, i32 0
+  %108 = load i32*, i32** %107, align 8
+  %109 = getelementptr inbounds i32, i32* %108, i32 %106
+  store i32 7, i32* %109, align 4
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %110 = getelementptr [2 x i32], [2 x i32]* %iv, i32 0, i32 0
+  %111 = load i32, i32* %110, align 4
+  %112 = icmp ne i32 %111, 1
+  br i1 %112, label %then5, label %else6
+
+then5:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont7
+
+else6:                                            ; preds = %ifcont
+  br label %ifcont7
+
+ifcont7:                                          ; preds = %else6, %then5
+  %113 = getelementptr [2 x i32], [2 x i32]* %iv, i32 0, i32 1
+  %114 = load i32, i32* %113, align 4
+  %115 = icmp ne i32 %114, 7
+  br i1 %115, label %then8, label %else9
+
+then8:                                            ; preds = %ifcont7
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont10
+
+else9:                                            ; preds = %ifcont7
+  br label %ifcont10
+
+ifcont10:                                         ; preds = %else9, %then8
+  %116 = load %array*, %array** %r, align 8
+  %117 = getelementptr %array, %array* %116, i32 0, i32 2
+  %118 = load %dimension_descriptor*, %dimension_descriptor** %117, align 8
+  %119 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %118, i32 0
+  %120 = getelementptr %dimension_descriptor, %dimension_descriptor* %119, i32 0, i32 1
+  %121 = load i32, i32* %120, align 4
+  %122 = sub i32 %121, 1
+  store i32 %122, i32* %u2, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.end, %ifcont10
+  %123 = load i32, i32* %u2, align 4
+  %124 = add i32 %123, 1
+  %125 = load %array*, %array** %r, align 8
+  %126 = getelementptr %array, %array* %125, i32 0, i32 2
+  %127 = load %dimension_descriptor*, %dimension_descriptor** %126, align 8
+  %128 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %127, i32 0
+  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 1
+  %130 = load i32, i32* %129, align 4
+  %131 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 2
+  %132 = load i32, i32* %131, align 4
+  %133 = add i32 %132, %130
+  %134 = sub i32 %133, 1
+  %135 = icmp sle i32 %124, %134
+  br i1 %135, label %loop.body, label %loop.end13
+
+loop.body:                                        ; preds = %loop.head
+  %136 = load i32, i32* %u2, align 4
+  %137 = add i32 %136, 1
+  store i32 %137, i32* %u2, align 4
+  %138 = load %array*, %array** %r, align 8
+  %139 = getelementptr %array, %array* %138, i32 0, i32 2
+  %140 = load %dimension_descriptor*, %dimension_descriptor** %139, align 8
+  %141 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %140, i32 1
+  %142 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 1
+  %143 = load i32, i32* %142, align 4
+  %144 = sub i32 %143, 1
+  store i32 %144, i32* %v3, align 4
+  br label %loop.head11
+
+loop.head11:                                      ; preds = %loop.body12, %loop.body
+  %145 = load i32, i32* %v3, align 4
+  %146 = add i32 %145, 1
+  %147 = load %array*, %array** %r, align 8
+  %148 = getelementptr %array, %array* %147, i32 0, i32 2
+  %149 = load %dimension_descriptor*, %dimension_descriptor** %148, align 8
+  %150 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %149, i32 1
+  %151 = getelementptr %dimension_descriptor, %dimension_descriptor* %150, i32 0, i32 1
+  %152 = load i32, i32* %151, align 4
+  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %150, i32 0, i32 2
+  %154 = load i32, i32* %153, align 4
+  %155 = add i32 %154, %152
+  %156 = sub i32 %155, 1
+  %157 = icmp sle i32 %146, %156
+  br i1 %157, label %loop.body12, label %loop.end
+
+loop.body12:                                      ; preds = %loop.head11
+  %158 = load i32, i32* %v3, align 4
+  %159 = add i32 %158, 1
+  store i32 %159, i32* %v3, align 4
+  %160 = load i32, i32* %u2, align 4
+  %161 = load i32, i32* %v3, align 4
+  %162 = sub i32 %160, 1
+  %163 = mul i32 1, %162
+  %164 = add i32 0, %163
+  %165 = sub i32 %161, 1
+  %166 = mul i32 2, %165
+  %167 = add i32 %164, %166
+  %168 = getelementptr [6 x float], [6 x float]* %rv, i32 0, i32 %167
+  %169 = load i32, i32* %u2, align 4
+  %170 = load i32, i32* %v3, align 4
+  %171 = mul i32 %169, %170
+  %172 = sitofp i32 %171 to float
+  store float %172, float* %168, align 4
+  br label %loop.head11
+
+loop.end:                                         ; preds = %loop.head11
+  br label %loop.head
+
+loop.end13:                                       ; preds = %loop.head
+  call void @check_real(%array** %r)
+  %173 = load %array*, %array** %r, align 8
+  call void @check_real_without_pointer(%array* %173)
+  br label %return
+
+return:                                           ; preds = %loop.end13
+  ret i32 0
+}
+
 define void @check_real(%array** %r) {
 .entry:
   %u = alloca i32, align 4
@@ -256,286 +539,5 @@ return:                                           ; preds = %loop.end3
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %array_descriptor2 = alloca %array, align 8
-  %array_descriptor = alloca %array.0, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i = alloca %array.0*, align 8
-  store %array.0* null, %array.0** %i, align 8
-  %arr_desc = alloca %array.0, align 8
-  %2 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 2
-  %3 = alloca i32, align 4
-  store i32 1, i32* %3, align 4
-  %4 = load i32, i32* %3, align 4
-  %5 = alloca %dimension_descriptor, i32 %4, align 8
-  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
-  %6 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 4
-  store i32 1, i32* %6, align 4
-  %7 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %7, align 8
-  store %array.0* %arr_desc, %array.0** %i, align 8
-  %iv = alloca [2 x i32], align 4
-  %r = alloca %array*, align 8
-  store %array* null, %array** %r, align 8
-  %arr_desc1 = alloca %array, align 8
-  %8 = getelementptr %array, %array* %arr_desc1, i32 0, i32 2
-  %9 = alloca i32, align 4
-  store i32 2, i32* %9, align 4
-  %10 = load i32, i32* %9, align 4
-  %11 = alloca %dimension_descriptor, i32 %10, align 8
-  store %dimension_descriptor* %11, %dimension_descriptor** %8, align 8
-  %12 = getelementptr %array, %array* %arr_desc1, i32 0, i32 4
-  store i32 2, i32* %12, align 4
-  %13 = getelementptr %array, %array* %arr_desc1, i32 0, i32 0
-  store float* null, float** %13, align 8
-  store %array* %arr_desc1, %array** %r, align 8
-  %rv = alloca [6 x float], align 4
-  %u = alloca i32, align 4
-  %v = alloca i32, align 4
-  %14 = getelementptr [2 x i32], [2 x i32]* %iv, i32 0, i32 0
-  %15 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 0
-  store i32* %14, i32** %15, align 8
-  %16 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 1
-  store i32 0, i32* %16, align 4
-  %17 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 2
-  %18 = alloca %dimension_descriptor, align 8
-  store %dimension_descriptor* %18, %dimension_descriptor** %17, align 8
-  %19 = getelementptr %array.0, %array.0* %array_descriptor, i32 0, i32 4
-  store i32 1, i32* %19, align 4
-  %20 = load %dimension_descriptor*, %dimension_descriptor** %17, align 8
-  %21 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %20, i32 0
-  %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 0
-  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 1
-  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %21, i32 0, i32 2
-  store i32 1, i32* %22, align 4
-  store i32 1, i32* %23, align 4
-  store i32 2, i32* %24, align 4
-  store %array.0* %array_descriptor, %array.0** %i, align 8
-  %25 = getelementptr [6 x float], [6 x float]* %rv, i32 0, i32 0
-  %26 = getelementptr %array, %array* %array_descriptor2, i32 0, i32 0
-  store float* %25, float** %26, align 8
-  %27 = getelementptr %array, %array* %array_descriptor2, i32 0, i32 1
-  store i32 0, i32* %27, align 4
-  %28 = getelementptr %array, %array* %array_descriptor2, i32 0, i32 2
-  %29 = alloca %dimension_descriptor, i32 2, align 8
-  store %dimension_descriptor* %29, %dimension_descriptor** %28, align 8
-  %30 = getelementptr %array, %array* %array_descriptor2, i32 0, i32 4
-  store i32 2, i32* %30, align 4
-  %31 = load %dimension_descriptor*, %dimension_descriptor** %28, align 8
-  %32 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 0
-  %33 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 0
-  %34 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 1
-  %35 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 2
-  store i32 1, i32* %33, align 4
-  store i32 1, i32* %34, align 4
-  store i32 2, i32* %35, align 4
-  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 1
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
-  store i32 2, i32* %37, align 4
-  store i32 1, i32* %38, align 4
-  store i32 3, i32* %39, align 4
-  store %array* %array_descriptor2, %array** %r, align 8
-  %40 = load %array.0*, %array.0** %i, align 8
-  %41 = getelementptr %array.0, %array.0* %40, i32 0, i32 2
-  %42 = load %dimension_descriptor*, %dimension_descriptor** %41, align 8
-  %43 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 0
-  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 1
-  %45 = load i32, i32* %44, align 4
-  %46 = sub i32 1, %45
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 0
-  %48 = load i32, i32* %47, align 4
-  %49 = mul i32 %48, %46
-  %50 = add i32 0, %49
-  %51 = getelementptr %array.0, %array.0* %40, i32 0, i32 1
-  %52 = load i32, i32* %51, align 4
-  %53 = add i32 %50, %52
-  %54 = getelementptr %array.0, %array.0* %40, i32 0, i32 0
-  %55 = load i32*, i32** %54, align 8
-  %56 = getelementptr inbounds i32, i32* %55, i32 %53
-  store i32 1, i32* %56, align 4
-  %57 = load %array.0*, %array.0** %i, align 8
-  %58 = getelementptr %array.0, %array.0* %57, i32 0, i32 2
-  %59 = load %dimension_descriptor*, %dimension_descriptor** %58, align 8
-  %60 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %59, i32 0
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 1
-  %62 = load i32, i32* %61, align 4
-  %63 = sub i32 1, %62
-  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 0
-  %65 = load i32, i32* %64, align 4
-  %66 = mul i32 %65, %63
-  %67 = add i32 0, %66
-  %68 = getelementptr %array.0, %array.0* %57, i32 0, i32 1
-  %69 = load i32, i32* %68, align 4
-  %70 = add i32 %67, %69
-  %71 = getelementptr %array.0, %array.0* %57, i32 0, i32 0
-  %72 = load i32*, i32** %71, align 8
-  %73 = getelementptr inbounds i32, i32* %72, i32 %70
-  %74 = load i32, i32* %73, align 4
-  %75 = icmp ne i32 %74, 1
-  br i1 %75, label %then, label %else
-
-then:                                             ; preds = %.entry
-  %76 = load %array.0*, %array.0** %i, align 8
-  %77 = getelementptr %array.0, %array.0* %76, i32 0, i32 2
-  %78 = load %dimension_descriptor*, %dimension_descriptor** %77, align 8
-  %79 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %78, i32 0
-  %80 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 1
-  %81 = load i32, i32* %80, align 4
-  %82 = sub i32 2, %81
-  %83 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 0
-  %84 = load i32, i32* %83, align 4
-  %85 = mul i32 %84, %82
-  %86 = add i32 0, %85
-  %87 = getelementptr %array.0, %array.0* %76, i32 0, i32 1
-  %88 = load i32, i32* %87, align 4
-  %89 = add i32 %86, %88
-  %90 = getelementptr %array.0, %array.0* %76, i32 0, i32 0
-  %91 = load i32*, i32** %90, align 8
-  %92 = getelementptr inbounds i32, i32* %91, i32 %89
-  store i32 3, i32* %92, align 4
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  %93 = load %array.0*, %array.0** %i, align 8
-  %94 = getelementptr %array.0, %array.0* %93, i32 0, i32 2
-  %95 = load %dimension_descriptor*, %dimension_descriptor** %94, align 8
-  %96 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %95, i32 0
-  %97 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 1
-  %98 = load i32, i32* %97, align 4
-  %99 = sub i32 2, %98
-  %100 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 0
-  %101 = load i32, i32* %100, align 4
-  %102 = mul i32 %101, %99
-  %103 = add i32 0, %102
-  %104 = getelementptr %array.0, %array.0* %93, i32 0, i32 1
-  %105 = load i32, i32* %104, align 4
-  %106 = add i32 %103, %105
-  %107 = getelementptr %array.0, %array.0* %93, i32 0, i32 0
-  %108 = load i32*, i32** %107, align 8
-  %109 = getelementptr inbounds i32, i32* %108, i32 %106
-  store i32 7, i32* %109, align 4
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %110 = getelementptr [2 x i32], [2 x i32]* %iv, i32 0, i32 0
-  %111 = load i32, i32* %110, align 4
-  %112 = icmp ne i32 %111, 1
-  br i1 %112, label %then3, label %else4
-
-then3:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont5
-
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
-
-ifcont5:                                          ; preds = %else4, %then3
-  %113 = getelementptr [2 x i32], [2 x i32]* %iv, i32 0, i32 1
-  %114 = load i32, i32* %113, align 4
-  %115 = icmp ne i32 %114, 7
-  br i1 %115, label %then6, label %else7
-
-then6:                                            ; preds = %ifcont5
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont8
-
-else7:                                            ; preds = %ifcont5
-  br label %ifcont8
-
-ifcont8:                                          ; preds = %else7, %then6
-  %116 = load %array*, %array** %r, align 8
-  %117 = getelementptr %array, %array* %116, i32 0, i32 2
-  %118 = load %dimension_descriptor*, %dimension_descriptor** %117, align 8
-  %119 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %118, i32 0
-  %120 = getelementptr %dimension_descriptor, %dimension_descriptor* %119, i32 0, i32 1
-  %121 = load i32, i32* %120, align 4
-  %122 = sub i32 %121, 1
-  store i32 %122, i32* %u, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.end, %ifcont8
-  %123 = load i32, i32* %u, align 4
-  %124 = add i32 %123, 1
-  %125 = load %array*, %array** %r, align 8
-  %126 = getelementptr %array, %array* %125, i32 0, i32 2
-  %127 = load %dimension_descriptor*, %dimension_descriptor** %126, align 8
-  %128 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %127, i32 0
-  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 1
-  %130 = load i32, i32* %129, align 4
-  %131 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 2
-  %132 = load i32, i32* %131, align 4
-  %133 = add i32 %132, %130
-  %134 = sub i32 %133, 1
-  %135 = icmp sle i32 %124, %134
-  br i1 %135, label %loop.body, label %loop.end11
-
-loop.body:                                        ; preds = %loop.head
-  %136 = load i32, i32* %u, align 4
-  %137 = add i32 %136, 1
-  store i32 %137, i32* %u, align 4
-  %138 = load %array*, %array** %r, align 8
-  %139 = getelementptr %array, %array* %138, i32 0, i32 2
-  %140 = load %dimension_descriptor*, %dimension_descriptor** %139, align 8
-  %141 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %140, i32 1
-  %142 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 1
-  %143 = load i32, i32* %142, align 4
-  %144 = sub i32 %143, 1
-  store i32 %144, i32* %v, align 4
-  br label %loop.head9
-
-loop.head9:                                       ; preds = %loop.body10, %loop.body
-  %145 = load i32, i32* %v, align 4
-  %146 = add i32 %145, 1
-  %147 = load %array*, %array** %r, align 8
-  %148 = getelementptr %array, %array* %147, i32 0, i32 2
-  %149 = load %dimension_descriptor*, %dimension_descriptor** %148, align 8
-  %150 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %149, i32 1
-  %151 = getelementptr %dimension_descriptor, %dimension_descriptor* %150, i32 0, i32 1
-  %152 = load i32, i32* %151, align 4
-  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %150, i32 0, i32 2
-  %154 = load i32, i32* %153, align 4
-  %155 = add i32 %154, %152
-  %156 = sub i32 %155, 1
-  %157 = icmp sle i32 %146, %156
-  br i1 %157, label %loop.body10, label %loop.end
-
-loop.body10:                                      ; preds = %loop.head9
-  %158 = load i32, i32* %v, align 4
-  %159 = add i32 %158, 1
-  store i32 %159, i32* %v, align 4
-  %160 = load i32, i32* %u, align 4
-  %161 = load i32, i32* %v, align 4
-  %162 = sub i32 %160, 1
-  %163 = mul i32 1, %162
-  %164 = add i32 0, %163
-  %165 = sub i32 %161, 1
-  %166 = mul i32 2, %165
-  %167 = add i32 %164, %166
-  %168 = getelementptr [6 x float], [6 x float]* %rv, i32 0, i32 %167
-  %169 = load i32, i32* %u, align 4
-  %170 = load i32, i32* %v, align 4
-  %171 = mul i32 %169, %170
-  %172 = sitofp i32 %171 to float
-  store float %172, float* %168, align 4
-  br label %loop.head9
-
-loop.end:                                         ; preds = %loop.head9
-  br label %loop.head
-
-loop.end11:                                       ; preds = %loop.head
-  call void @check_real(%array** %r)
-  %173 = load %array*, %array** %r, align 8
-  call void @check_real_without_pointer(%array* %173)
-  br label %return
-
-return:                                           ; preds = %loop.end11
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-arrays_25-5b87ac7.json
+++ b/tests/reference/llvm-arrays_25-5b87ac7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_25-5b87ac7.stdout",
-    "stdout_hash": "ee7d758f21fc0ab7dc303a4e7ce4d8ec668169b09099ffe15306e7d1",
+    "stdout_hash": "d6b04a2f77b090eca999f344f2faa1f8220d6686a1642d002b3a7385",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_25-5b87ac7.stdout
+++ b/tests/reference/llvm-arrays_25-5b87ac7.stdout
@@ -21,65 +21,15 @@ source_filename = "LFortran"
 @13 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @14 = private unnamed_addr constant [3 x i8] c"%s\00", align 1
 
-define void @decode_integer____0(i32* %idx, i32* %__1idx, i32* %__2idx) {
-.entry:
-  %0 = load i32, i32* %__1idx, align 4
-  %1 = load i32, i32* %__2idx, align 4
-  %2 = sub i32 4, %0
-  %3 = mul i32 1, %2
-  %4 = add i32 0, %3
-  %5 = mul i32 1, %1
-  %6 = getelementptr inbounds i32, i32* %idx, i32 %4
-  %7 = load i32, i32* %6, align 4
-  %8 = icmp ne i32 %7, 0
-  br i1 %8, label %then, label %else
-
-then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %9 = load i32, i32* %__1idx, align 4
-  %10 = load i32, i32* %__2idx, align 4
-  %11 = sub i32 5, %9
-  %12 = mul i32 1, %11
-  %13 = add i32 0, %12
-  %14 = mul i32 1, %10
-  %15 = getelementptr inbounds i32, i32* %idx, i32 %13
-  %16 = load i32, i32* %15, align 4
-  %17 = icmp ne i32 %16, 5
-  br i1 %17, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
-  br label %return
-
-return:                                           ; preds = %ifcont3
-  ret void
-}
-
-declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @exit(i32)
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value4 = alloca i32, align 4
+  %call_arg_value6 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__1_k = alloca i32, align 4
   %__1_t = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_k1 = alloca i32, align 4
+  %__1_t2 = alloca i32, align 4
   %m = alloca %model_t, align 8
   %2 = getelementptr %model_t, %model_t* %m, i32 0, i32 0
   store %array* null, %array** %2, align 8
@@ -145,11 +95,11 @@ ifcont:                                           ; preds = %else, %then
   %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
   %38 = load i32, i32* %37, align 4
   %39 = sub i32 %38, 1
-  store i32 %39, i32* %__1_t, align 4
+  store i32 %39, i32* %__1_t2, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %ifcont
-  %40 = load i32, i32* %__1_t, align 4
+  %40 = load i32, i32* %__1_t2, align 4
   %41 = add i32 %40, 1
   %42 = getelementptr %model_t, %model_t* %m, i32 0, i32 0
   %43 = load %array*, %array** %42, align 8
@@ -166,11 +116,11 @@ loop.head:                                        ; preds = %loop.body, %ifcont
   br i1 %53, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %54 = load i32, i32* %__1_t, align 4
+  %54 = load i32, i32* %__1_t2, align 4
   %55 = add i32 %54, 1
-  store i32 %55, i32* %__1_t, align 4
+  store i32 %55, i32* %__1_t2, align 4
   %56 = getelementptr %model_t, %model_t* %m, i32 0, i32 0
-  %57 = load i32, i32* %__1_t, align 4
+  %57 = load i32, i32* %__1_t2, align 4
   %58 = load %array*, %array** %56, align 8
   %59 = getelementptr %array, %array* %58, i32 0, i32 2
   %60 = load %dimension_descriptor*, %dimension_descriptor** %59, align 8
@@ -219,11 +169,11 @@ loop.end:                                         ; preds = %loop.head
   %98 = getelementptr %dimension_descriptor, %dimension_descriptor* %97, i32 0, i32 1
   %99 = load i32, i32* %98, align 4
   %100 = sub i32 %99, 1
-  store i32 %100, i32* %__1_k, align 4
-  br label %loop.head1
+  store i32 %100, i32* %__1_k1, align 4
+  br label %loop.head3
 
-loop.head1:                                       ; preds = %loop.body2, %loop.end
-  %101 = load i32, i32* %__1_k, align 4
+loop.head3:                                       ; preds = %loop.body4, %loop.end
+  %101 = load i32, i32* %__1_k1, align 4
   %102 = add i32 %101, 1
   %103 = getelementptr %model_t, %model_t* %m, i32 0, i32 0
   %104 = load %array*, %array** %103, align 8
@@ -237,14 +187,14 @@ loop.head1:                                       ; preds = %loop.body2, %loop.e
   %112 = add i32 %111, %109
   %113 = sub i32 %112, 1
   %114 = icmp sle i32 %102, %113
-  br i1 %114, label %loop.body2, label %loop.end3
+  br i1 %114, label %loop.body4, label %loop.end5
 
-loop.body2:                                       ; preds = %loop.head1
-  %115 = load i32, i32* %__1_k, align 4
+loop.body4:                                       ; preds = %loop.head3
+  %115 = load i32, i32* %__1_k1, align 4
   %116 = add i32 %115, 1
-  store i32 %116, i32* %__1_k, align 4
+  store i32 %116, i32* %__1_k1, align 4
   %117 = getelementptr %model_t, %model_t* %m, i32 0, i32 0
-  %118 = load i32, i32* %__1_k, align 4
+  %118 = load i32, i32* %__1_k1, align 4
   %119 = load %array*, %array** %117, align 8
   %120 = getelementptr %array, %array* %119, i32 0, i32 2
   %121 = load %dimension_descriptor*, %dimension_descriptor** %120, align 8
@@ -264,9 +214,9 @@ loop.body2:                                       ; preds = %loop.head1
   %135 = getelementptr inbounds i32, i32* %134, i32 %132
   %136 = load i32, i32* %135, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i32 %136, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  br label %loop.head1
+  br label %loop.head3
 
-loop.end3:                                        ; preds = %loop.head1
+loop.end5:                                        ; preds = %loop.head3
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   %137 = getelementptr %model_t, %model_t* %m, i32 0, i32 0
@@ -291,13 +241,65 @@ loop.end3:                                        ; preds = %loop.head1
   %155 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 0
   %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 2
   %157 = load i32, i32* %156, align 4
-  store i32 %157, i32* %call_arg_value4, align 4
-  call void @decode_integer____0(i32* %143, i32* %call_arg_value, i32* %call_arg_value4)
+  store i32 %157, i32* %call_arg_value6, align 4
+  call void @decode_integer____0(i32* %143, i32* %call_arg_value, i32* %call_arg_value6)
   br label %return
 
-return:                                           ; preds = %loop.end3
+return:                                           ; preds = %loop.end5
   ret i32 0
 }
+
+define void @decode_integer____0(i32* %idx, i32* %__1idx, i32* %__2idx) {
+.entry:
+  %0 = load i32, i32* %__1idx, align 4
+  %1 = load i32, i32* %__2idx, align 4
+  %2 = sub i32 4, %0
+  %3 = mul i32 1, %2
+  %4 = add i32 0, %3
+  %5 = mul i32 1, %1
+  %6 = getelementptr inbounds i32, i32* %idx, i32 %4
+  %7 = load i32, i32* %6, align 4
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %then, label %else
+
+then:                                             ; preds = %.entry
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %9 = load i32, i32* %__1idx, align 4
+  %10 = load i32, i32* %__2idx, align 4
+  %11 = sub i32 5, %9
+  %12 = mul i32 1, %11
+  %13 = add i32 0, %12
+  %14 = mul i32 1, %10
+  %15 = getelementptr inbounds i32, i32* %idx, i32 %13
+  %16 = load i32, i32* %15, align 4
+  %17 = icmp ne i32 %16, 5
+  br i1 %17, label %then1, label %else2
+
+then1:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont3
+
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
+
+ifcont3:                                          ; preds = %else2, %then1
+  br label %return
+
+return:                                           ; preds = %ifcont3
+  ret void
+}
+
+declare void @_lcompilers_print_error(i8*, ...)
+
+declare void @exit(i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-arrays_op_1-636d572.json
+++ b/tests/reference/llvm-arrays_op_1-636d572.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_1-636d572.stdout",
-    "stdout_hash": "6aada93e260d07eb367be463c13e0a9962b561f513581247c29852d6",
+    "stdout_hash": "0da881850043ffbe4c200883775edaf902af35a5b6bf21b08b51a4b6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_1-636d572.stdout
+++ b/tests/reference/llvm-arrays_op_1-636d572.stdout
@@ -73,69 +73,75 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %array_bound307 = alloca i32, align 4
-  %array_bound302 = alloca i32, align 4
-  %array_bound298 = alloca i32, align 4
+  %array_bound313 = alloca i32, align 4
+  %array_bound308 = alloca i32, align 4
+  %array_bound304 = alloca i32, align 4
+  %array_bound300 = alloca i32, align 4
   %array_bound294 = alloca i32, align 4
-  %array_bound288 = alloca i32, align 4
-  %array_bound283 = alloca i32, align 4
+  %array_bound289 = alloca i32, align 4
+  %array_bound285 = alloca i32, align 4
   %array_bound279 = alloca i32, align 4
-  %array_bound273 = alloca i32, align 4
-  %array_bound268 = alloca i32, align 4
+  %array_bound274 = alloca i32, align 4
+  %array_bound270 = alloca i32, align 4
   %array_bound264 = alloca i32, align 4
-  %array_bound258 = alloca i32, align 4
-  %array_bound253 = alloca i32, align 4
-  %array_bound249 = alloca i32, align 4
-  %array_bound245 = alloca i32, align 4
-  %array_bound227 = alloca i32, align 4
-  %array_bound222 = alloca i32, align 4
-  %array_bound218 = alloca i32, align 4
+  %array_bound259 = alloca i32, align 4
+  %array_bound255 = alloca i32, align 4
+  %array_bound251 = alloca i32, align 4
+  %array_bound233 = alloca i32, align 4
+  %array_bound228 = alloca i32, align 4
+  %array_bound224 = alloca i32, align 4
+  %array_bound220 = alloca i32, align 4
   %array_bound214 = alloca i32, align 4
-  %array_bound208 = alloca i32, align 4
-  %array_bound203 = alloca i32, align 4
+  %array_bound209 = alloca i32, align 4
+  %array_bound205 = alloca i32, align 4
   %array_bound199 = alloca i32, align 4
-  %array_bound193 = alloca i32, align 4
-  %array_bound188 = alloca i32, align 4
-  %array_bound184 = alloca i32, align 4
-  %array_bound180 = alloca i32, align 4
-  %array_bound162 = alloca i32, align 4
-  %array_bound157 = alloca i32, align 4
-  %array_bound153 = alloca i32, align 4
+  %array_bound194 = alloca i32, align 4
+  %array_bound190 = alloca i32, align 4
+  %array_bound186 = alloca i32, align 4
+  %array_bound168 = alloca i32, align 4
+  %array_bound163 = alloca i32, align 4
+  %array_bound159 = alloca i32, align 4
+  %array_bound155 = alloca i32, align 4
   %array_bound149 = alloca i32, align 4
-  %array_bound143 = alloca i32, align 4
-  %array_bound138 = alloca i32, align 4
-  %array_bound134 = alloca i32, align 4
+  %array_bound144 = alloca i32, align 4
+  %array_bound140 = alloca i32, align 4
+  %array_bound136 = alloca i32, align 4
   %array_bound130 = alloca i32, align 4
-  %array_bound124 = alloca i32, align 4
-  %array_bound119 = alloca i32, align 4
+  %array_bound125 = alloca i32, align 4
+  %array_bound121 = alloca i32, align 4
   %array_bound115 = alloca i32, align 4
-  %array_bound109 = alloca i32, align 4
-  %array_bound104 = alloca i32, align 4
-  %array_bound100 = alloca i32, align 4
-  %array_bound82 = alloca i32, align 4
-  %array_bound77 = alloca i32, align 4
-  %array_bound73 = alloca i32, align 4
+  %array_bound110 = alloca i32, align 4
+  %array_bound106 = alloca i32, align 4
+  %array_bound88 = alloca i32, align 4
+  %array_bound83 = alloca i32, align 4
+  %array_bound79 = alloca i32, align 4
+  %array_bound75 = alloca i32, align 4
   %array_bound69 = alloca i32, align 4
-  %array_bound63 = alloca i32, align 4
-  %array_bound58 = alloca i32, align 4
+  %array_bound64 = alloca i32, align 4
+  %array_bound60 = alloca i32, align 4
   %array_bound54 = alloca i32, align 4
-  %array_bound48 = alloca i32, align 4
-  %array_bound43 = alloca i32, align 4
-  %array_bound39 = alloca i32, align 4
+  %array_bound49 = alloca i32, align 4
+  %array_bound45 = alloca i32, align 4
+  %array_bound41 = alloca i32, align 4
   %array_bound35 = alloca i32, align 4
-  %array_bound29 = alloca i32, align 4
-  %array_bound24 = alloca i32, align 4
-  %array_bound20 = alloca i32, align 4
+  %array_bound30 = alloca i32, align 4
+  %array_bound26 = alloca i32, align 4
+  %array_bound22 = alloca i32, align 4
   %array_bound16 = alloca i32, align 4
-  %array_bound10 = alloca i32, align 4
-  %array_bound5 = alloca i32, align 4
-  %array_bound1 = alloca i32, align 4
+  %array_bound11 = alloca i32, align 4
+  %array_bound7 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__1_k = alloca i32, align 4
   %__1_t = alloca i32, align 4
   %__1_u = alloca i32, align 4
   %__1_v = alloca i32, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_k1 = alloca i32, align 4
+  %__1_t2 = alloca i32, align 4
+  %__1_u3 = alloca i32, align 4
+  %__1_v4 = alloca i32, align 4
   %__libasr__created__var__0__array_constructor_ = alloca [4 x i32], align 4
   %__libasr__created__var__0__integer_bin_op_res = alloca [4 x i32], align 4
   %__libasr__created__var__1__array_constructor_ = alloca [4 x i32], align 4
@@ -153,9 +159,9 @@ define i32 @main(i32 %0, i8** %1) {
   %b = alloca [4 x i32], align 4
   %c = alloca [4 x float], align 4
   %d = alloca [4 x float], align 4
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  %i5 = alloca i32, align 4
+  %j6 = alloca i32, align 4
+  store i32 0, i32* %i5, align 4
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry
@@ -167,132 +173,132 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %then
   %2 = load i32, i32* %array_bound, align 4
-  store i32 %2, i32* %__1_k, align 4
-  %3 = load i32, i32* %__1_k, align 4
+  store i32 %2, i32* %__1_k1, align 4
+  %3 = load i32, i32* %__1_k1, align 4
   %4 = sub i32 %3, 1
   %5 = mul i32 1, %4
   %6 = add i32 0, %5
   %7 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__0__array_constructor_, i32 0, i32 %6
-  %8 = load i32, i32* %i, align 4
+  %8 = load i32, i32* %i5, align 4
   %9 = add i32 %8, 1
   store i32 %9, i32* %7, align 4
-  %10 = load i32, i32* %__1_k, align 4
+  %10 = load i32, i32* %__1_k1, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %__1_k, align 4
-  store i32 0, i32* %j, align 4
+  store i32 %11, i32* %__1_k1, align 4
+  store i32 0, i32* %j6, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %ifcont
-  %12 = load i32, i32* %j, align 4
+  %12 = load i32, i32* %j6, align 4
   %13 = add i32 %12, 1
-  %14 = load i32, i32* %i, align 4
+  %14 = load i32, i32* %i5, align 4
   %15 = add i32 %14, 3
   %16 = icmp sle i32 %13, %15
   br i1 %16, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %17 = load i32, i32* %j, align 4
+  %17 = load i32, i32* %j6, align 4
   %18 = add i32 %17, 1
-  store i32 %18, i32* %j, align 4
-  %19 = load i32, i32* %__1_k, align 4
+  store i32 %18, i32* %j6, align 4
+  %19 = load i32, i32* %__1_k1, align 4
   %20 = sub i32 %19, 1
   %21 = mul i32 1, %20
   %22 = add i32 0, %21
   %23 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__0__array_constructor_, i32 0, i32 %22
-  %24 = load i32, i32* %i, align 4
-  %25 = load i32, i32* %j, align 4
+  %24 = load i32, i32* %i5, align 4
+  %25 = load i32, i32* %j6, align 4
   %26 = add i32 %24, %25
   store i32 %26, i32* %23, align 4
-  %27 = load i32, i32* %__1_k, align 4
+  %27 = load i32, i32* %__1_k1, align 4
   %28 = add i32 %27, 1
-  store i32 %28, i32* %__1_k, align 4
+  store i32 %28, i32* %__1_k1, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 true, label %then2, label %else3
+  br i1 true, label %then8, label %else9
 
-then2:                                            ; preds = %loop.end
-  store i32 1, i32* %array_bound1, align 4
-  br label %ifcont4
+then8:                                            ; preds = %loop.end
+  store i32 1, i32* %array_bound7, align 4
+  br label %ifcont10
 
-else3:                                            ; preds = %loop.end
-  br label %ifcont4
+else9:                                            ; preds = %loop.end
+  br label %ifcont10
 
-ifcont4:                                          ; preds = %else3, %then2
-  %29 = load i32, i32* %array_bound1, align 4
-  store i32 %29, i32* %__1_v, align 4
-  br i1 true, label %then6, label %else7
+ifcont10:                                         ; preds = %else9, %then8
+  %29 = load i32, i32* %array_bound7, align 4
+  store i32 %29, i32* %__1_v4, align 4
+  br i1 true, label %then12, label %else13
 
-then6:                                            ; preds = %ifcont4
-  store i32 1, i32* %array_bound5, align 4
-  br label %ifcont8
+then12:                                           ; preds = %ifcont10
+  store i32 1, i32* %array_bound11, align 4
+  br label %ifcont14
 
-else7:                                            ; preds = %ifcont4
-  br label %ifcont8
+else13:                                           ; preds = %ifcont10
+  br label %ifcont14
 
-ifcont8:                                          ; preds = %else7, %then6
-  %30 = load i32, i32* %array_bound5, align 4
+ifcont14:                                         ; preds = %else13, %then12
+  %30 = load i32, i32* %array_bound11, align 4
   %31 = sub i32 %30, 1
-  store i32 %31, i32* %__1_t, align 4
-  br label %loop.head9
+  store i32 %31, i32* %__1_t2, align 4
+  br label %loop.head15
 
-loop.head9:                                       ; preds = %loop.body14, %ifcont8
-  %32 = load i32, i32* %__1_t, align 4
+loop.head15:                                      ; preds = %loop.body20, %ifcont14
+  %32 = load i32, i32* %__1_t2, align 4
   %33 = add i32 %32, 1
-  br i1 true, label %then11, label %else12
+  br i1 true, label %then17, label %else18
 
-then11:                                           ; preds = %loop.head9
-  store i32 4, i32* %array_bound10, align 4
-  br label %ifcont13
+then17:                                           ; preds = %loop.head15
+  store i32 4, i32* %array_bound16, align 4
+  br label %ifcont19
 
-else12:                                           ; preds = %loop.head9
-  br label %ifcont13
+else18:                                           ; preds = %loop.head15
+  br label %ifcont19
 
-ifcont13:                                         ; preds = %else12, %then11
-  %34 = load i32, i32* %array_bound10, align 4
+ifcont19:                                         ; preds = %else18, %then17
+  %34 = load i32, i32* %array_bound16, align 4
   %35 = icmp sle i32 %33, %34
-  br i1 %35, label %loop.body14, label %loop.end15
+  br i1 %35, label %loop.body20, label %loop.end21
 
-loop.body14:                                      ; preds = %ifcont13
-  %36 = load i32, i32* %__1_t, align 4
+loop.body20:                                      ; preds = %ifcont19
+  %36 = load i32, i32* %__1_t2, align 4
   %37 = add i32 %36, 1
-  store i32 %37, i32* %__1_t, align 4
-  %38 = load i32, i32* %__1_t, align 4
+  store i32 %37, i32* %__1_t2, align 4
+  %38 = load i32, i32* %__1_t2, align 4
   %39 = sub i32 %38, 1
   %40 = mul i32 1, %39
   %41 = add i32 0, %40
   %42 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %41
-  %43 = load i32, i32* %__1_v, align 4
+  %43 = load i32, i32* %__1_v4, align 4
   %44 = sub i32 %43, 1
   %45 = mul i32 1, %44
   %46 = add i32 0, %45
   %47 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__0__array_constructor_, i32 0, i32 %46
   %48 = load i32, i32* %47, align 4
   store i32 %48, i32* %42, align 4
-  %49 = load i32, i32* %__1_v, align 4
+  %49 = load i32, i32* %__1_v4, align 4
   %50 = add i32 %49, 1
-  store i32 %50, i32* %__1_v, align 4
-  br label %loop.head9
+  store i32 %50, i32* %__1_v4, align 4
+  br label %loop.head15
 
-loop.end15:                                       ; preds = %ifcont13
-  br i1 true, label %then17, label %else18
+loop.end21:                                       ; preds = %ifcont19
+  br i1 true, label %then23, label %else24
 
-then17:                                           ; preds = %loop.end15
-  store i32 1, i32* %array_bound16, align 4
-  br label %ifcont19
+then23:                                           ; preds = %loop.end21
+  store i32 1, i32* %array_bound22, align 4
+  br label %ifcont25
 
-else18:                                           ; preds = %loop.end15
-  br label %ifcont19
+else24:                                           ; preds = %loop.end21
+  br label %ifcont25
 
-ifcont19:                                         ; preds = %else18, %then17
-  %51 = load i32, i32* %array_bound16, align 4
-  store i32 %51, i32* %__1_k, align 4
-  %52 = load i32, i32* %__1_k, align 4
+ifcont25:                                         ; preds = %else24, %then23
+  %51 = load i32, i32* %array_bound22, align 4
+  store i32 %51, i32* %__1_k1, align 4
+  %52 = load i32, i32* %__1_k1, align 4
   %53 = sub i32 %52, 1
   %54 = mul i32 1, %53
   %55 = add i32 0, %54
   %56 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %55
-  %57 = load i32, i32* %i, align 4
+  %57 = load i32, i32* %i5, align 4
   %58 = add i32 %57, 1
   %59 = sub i32 %58, 1
   %60 = mul i32 1, %59
@@ -301,15 +307,15 @@ ifcont19:                                         ; preds = %else18, %then17
   %63 = load i32, i32* %62, align 4
   %64 = mul i32 4, %63
   store i32 %64, i32* %56, align 4
-  %65 = load i32, i32* %__1_k, align 4
+  %65 = load i32, i32* %__1_k1, align 4
   %66 = add i32 %65, 1
-  store i32 %66, i32* %__1_k, align 4
-  %67 = load i32, i32* %__1_k, align 4
+  store i32 %66, i32* %__1_k1, align 4
+  %67 = load i32, i32* %__1_k1, align 4
   %68 = sub i32 %67, 1
   %69 = mul i32 1, %68
   %70 = add i32 0, %69
   %71 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %70
-  %72 = load i32, i32* %i, align 4
+  %72 = load i32, i32* %i5, align 4
   %73 = add i32 %72, 2
   %74 = sub i32 %73, 1
   %75 = mul i32 1, %74
@@ -318,15 +324,15 @@ ifcont19:                                         ; preds = %else18, %then17
   %78 = load i32, i32* %77, align 4
   %79 = mul i32 5, %78
   store i32 %79, i32* %71, align 4
-  %80 = load i32, i32* %__1_k, align 4
+  %80 = load i32, i32* %__1_k1, align 4
   %81 = add i32 %80, 1
-  store i32 %81, i32* %__1_k, align 4
-  %82 = load i32, i32* %__1_k, align 4
+  store i32 %81, i32* %__1_k1, align 4
+  %82 = load i32, i32* %__1_k1, align 4
   %83 = sub i32 %82, 1
   %84 = mul i32 1, %83
   %85 = add i32 0, %84
   %86 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %85
-  %87 = load i32, i32* %i, align 4
+  %87 = load i32, i32* %i5, align 4
   %88 = add i32 %87, 3
   %89 = sub i32 %88, 1
   %90 = mul i32 1, %89
@@ -335,15 +341,15 @@ ifcont19:                                         ; preds = %else18, %then17
   %93 = load i32, i32* %92, align 4
   %94 = mul i32 6, %93
   store i32 %94, i32* %86, align 4
-  %95 = load i32, i32* %__1_k, align 4
+  %95 = load i32, i32* %__1_k1, align 4
   %96 = add i32 %95, 1
-  store i32 %96, i32* %__1_k, align 4
-  %97 = load i32, i32* %__1_k, align 4
+  store i32 %96, i32* %__1_k1, align 4
+  %97 = load i32, i32* %__1_k1, align 4
   %98 = sub i32 %97, 1
   %99 = mul i32 1, %98
   %100 = add i32 0, %99
   %101 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %100
-  %102 = load i32, i32* %i, align 4
+  %102 = load i32, i32* %i5, align 4
   %103 = add i32 %102, 4
   %104 = sub i32 %103, 1
   %105 = mul i32 1, %104
@@ -352,92 +358,92 @@ ifcont19:                                         ; preds = %else18, %then17
   %108 = load i32, i32* %107, align 4
   %109 = mul i32 7, %108
   store i32 %109, i32* %101, align 4
-  %110 = load i32, i32* %__1_k, align 4
+  %110 = load i32, i32* %__1_k1, align 4
   %111 = add i32 %110, 1
-  store i32 %111, i32* %__1_k, align 4
-  br i1 true, label %then21, label %else22
+  store i32 %111, i32* %__1_k1, align 4
+  br i1 true, label %then27, label %else28
 
-then21:                                           ; preds = %ifcont19
-  store i32 1, i32* %array_bound20, align 4
-  br label %ifcont23
+then27:                                           ; preds = %ifcont25
+  store i32 1, i32* %array_bound26, align 4
+  br label %ifcont29
 
-else22:                                           ; preds = %ifcont19
-  br label %ifcont23
+else28:                                           ; preds = %ifcont25
+  br label %ifcont29
 
-ifcont23:                                         ; preds = %else22, %then21
-  %112 = load i32, i32* %array_bound20, align 4
-  store i32 %112, i32* %__1_v, align 4
-  br i1 true, label %then25, label %else26
+ifcont29:                                         ; preds = %else28, %then27
+  %112 = load i32, i32* %array_bound26, align 4
+  store i32 %112, i32* %__1_v4, align 4
+  br i1 true, label %then31, label %else32
 
-then25:                                           ; preds = %ifcont23
-  store i32 1, i32* %array_bound24, align 4
-  br label %ifcont27
+then31:                                           ; preds = %ifcont29
+  store i32 1, i32* %array_bound30, align 4
+  br label %ifcont33
 
-else26:                                           ; preds = %ifcont23
-  br label %ifcont27
+else32:                                           ; preds = %ifcont29
+  br label %ifcont33
 
-ifcont27:                                         ; preds = %else26, %then25
-  %113 = load i32, i32* %array_bound24, align 4
+ifcont33:                                         ; preds = %else32, %then31
+  %113 = load i32, i32* %array_bound30, align 4
   %114 = sub i32 %113, 1
-  store i32 %114, i32* %__1_t, align 4
-  br label %loop.head28
+  store i32 %114, i32* %__1_t2, align 4
+  br label %loop.head34
 
-loop.head28:                                      ; preds = %loop.body33, %ifcont27
-  %115 = load i32, i32* %__1_t, align 4
+loop.head34:                                      ; preds = %loop.body39, %ifcont33
+  %115 = load i32, i32* %__1_t2, align 4
   %116 = add i32 %115, 1
-  br i1 true, label %then30, label %else31
+  br i1 true, label %then36, label %else37
 
-then30:                                           ; preds = %loop.head28
-  store i32 4, i32* %array_bound29, align 4
-  br label %ifcont32
+then36:                                           ; preds = %loop.head34
+  store i32 4, i32* %array_bound35, align 4
+  br label %ifcont38
 
-else31:                                           ; preds = %loop.head28
-  br label %ifcont32
+else37:                                           ; preds = %loop.head34
+  br label %ifcont38
 
-ifcont32:                                         ; preds = %else31, %then30
-  %117 = load i32, i32* %array_bound29, align 4
+ifcont38:                                         ; preds = %else37, %then36
+  %117 = load i32, i32* %array_bound35, align 4
   %118 = icmp sle i32 %116, %117
-  br i1 %118, label %loop.body33, label %loop.end34
+  br i1 %118, label %loop.body39, label %loop.end40
 
-loop.body33:                                      ; preds = %ifcont32
-  %119 = load i32, i32* %__1_t, align 4
+loop.body39:                                      ; preds = %ifcont38
+  %119 = load i32, i32* %__1_t2, align 4
   %120 = add i32 %119, 1
-  store i32 %120, i32* %__1_t, align 4
-  %121 = load i32, i32* %__1_t, align 4
+  store i32 %120, i32* %__1_t2, align 4
+  %121 = load i32, i32* %__1_t2, align 4
   %122 = sub i32 %121, 1
   %123 = mul i32 1, %122
   %124 = add i32 0, %123
   %125 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %124
-  %126 = load i32, i32* %__1_v, align 4
+  %126 = load i32, i32* %__1_v4, align 4
   %127 = sub i32 %126, 1
   %128 = mul i32 1, %127
   %129 = add i32 0, %128
   %130 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__1__array_constructor_, i32 0, i32 %129
   %131 = load i32, i32* %130, align 4
   store i32 %131, i32* %125, align 4
-  %132 = load i32, i32* %__1_v, align 4
+  %132 = load i32, i32* %__1_v4, align 4
   %133 = add i32 %132, 1
-  store i32 %133, i32* %__1_v, align 4
-  br label %loop.head28
+  store i32 %133, i32* %__1_v4, align 4
+  br label %loop.head34
 
-loop.end34:                                       ; preds = %ifcont32
+loop.end40:                                       ; preds = %ifcont38
   %134 = getelementptr [4 x float], [4 x float]* %c, i32 0, i32 0
-  %135 = load i32, i32* %i, align 4
+  %135 = load i32, i32* %i5, align 4
   %136 = add i32 %135, 1
   %137 = sitofp i32 %136 to float
   store float %137, float* %134, align 4
   %138 = getelementptr [4 x float], [4 x float]* %c, i32 0, i32 1
-  %139 = load i32, i32* %i, align 4
+  %139 = load i32, i32* %i5, align 4
   %140 = mul i32 %139, 1
   %141 = sitofp i32 %140 to float
   store float %141, float* %138, align 4
   %142 = getelementptr [4 x float], [4 x float]* %c, i32 0, i32 2
-  %143 = load i32, i32* %i, align 4
+  %143 = load i32, i32* %i5, align 4
   %144 = mul i32 %143, 2
   %145 = sitofp i32 %144 to float
   store float %145, float* %142, align 4
   %146 = getelementptr [4 x float], [4 x float]* %c, i32 0, i32 3
-  %147 = load i32, i32* %i, align 4
+  %147 = load i32, i32* %i5, align 4
   %148 = mul i32 %147, 3
   %149 = sitofp i32 %148 to float
   store float %149, float* %146, align 4
@@ -472,78 +478,78 @@ loop.end34:                                       ; preds = %ifcont32
   %176 = load float, float* %175, align 4
   %177 = fpext float %176 to double
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([33 x i8], [33 x i8]* @8, i32 0, i32 0), double %168, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), double %171, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), double %174, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), double %177, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  br i1 true, label %then36, label %else37
+  br i1 true, label %then42, label %else43
 
-then36:                                           ; preds = %loop.end34
-  store i32 1, i32* %array_bound35, align 4
-  br label %ifcont38
+then42:                                           ; preds = %loop.end40
+  store i32 1, i32* %array_bound41, align 4
+  br label %ifcont44
 
-else37:                                           ; preds = %loop.end34
-  br label %ifcont38
+else43:                                           ; preds = %loop.end40
+  br label %ifcont44
 
-ifcont38:                                         ; preds = %else37, %then36
-  %178 = load i32, i32* %array_bound35, align 4
-  store i32 %178, i32* %__1_v, align 4
-  br i1 true, label %then40, label %else41
+ifcont44:                                         ; preds = %else43, %then42
+  %178 = load i32, i32* %array_bound41, align 4
+  store i32 %178, i32* %__1_v4, align 4
+  br i1 true, label %then46, label %else47
 
-then40:                                           ; preds = %ifcont38
-  store i32 1, i32* %array_bound39, align 4
-  br label %ifcont42
+then46:                                           ; preds = %ifcont44
+  store i32 1, i32* %array_bound45, align 4
+  br label %ifcont48
 
-else41:                                           ; preds = %ifcont38
-  br label %ifcont42
+else47:                                           ; preds = %ifcont44
+  br label %ifcont48
 
-ifcont42:                                         ; preds = %else41, %then40
-  %179 = load i32, i32* %array_bound39, align 4
-  store i32 %179, i32* %__1_u, align 4
-  br i1 true, label %then44, label %else45
+ifcont48:                                         ; preds = %else47, %then46
+  %179 = load i32, i32* %array_bound45, align 4
+  store i32 %179, i32* %__1_u3, align 4
+  br i1 true, label %then50, label %else51
 
-then44:                                           ; preds = %ifcont42
-  store i32 1, i32* %array_bound43, align 4
-  br label %ifcont46
+then50:                                           ; preds = %ifcont48
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont52
 
-else45:                                           ; preds = %ifcont42
-  br label %ifcont46
+else51:                                           ; preds = %ifcont48
+  br label %ifcont52
 
-ifcont46:                                         ; preds = %else45, %then44
-  %180 = load i32, i32* %array_bound43, align 4
+ifcont52:                                         ; preds = %else51, %then50
+  %180 = load i32, i32* %array_bound49, align 4
   %181 = sub i32 %180, 1
-  store i32 %181, i32* %__1_t, align 4
-  br label %loop.head47
+  store i32 %181, i32* %__1_t2, align 4
+  br label %loop.head53
 
-loop.head47:                                      ; preds = %loop.body52, %ifcont46
-  %182 = load i32, i32* %__1_t, align 4
+loop.head53:                                      ; preds = %loop.body58, %ifcont52
+  %182 = load i32, i32* %__1_t2, align 4
   %183 = add i32 %182, 1
-  br i1 true, label %then49, label %else50
+  br i1 true, label %then55, label %else56
 
-then49:                                           ; preds = %loop.head47
-  store i32 4, i32* %array_bound48, align 4
-  br label %ifcont51
+then55:                                           ; preds = %loop.head53
+  store i32 4, i32* %array_bound54, align 4
+  br label %ifcont57
 
-else50:                                           ; preds = %loop.head47
-  br label %ifcont51
+else56:                                           ; preds = %loop.head53
+  br label %ifcont57
 
-ifcont51:                                         ; preds = %else50, %then49
-  %184 = load i32, i32* %array_bound48, align 4
+ifcont57:                                         ; preds = %else56, %then55
+  %184 = load i32, i32* %array_bound54, align 4
   %185 = icmp sle i32 %183, %184
-  br i1 %185, label %loop.body52, label %loop.end53
+  br i1 %185, label %loop.body58, label %loop.end59
 
-loop.body52:                                      ; preds = %ifcont51
-  %186 = load i32, i32* %__1_t, align 4
+loop.body58:                                      ; preds = %ifcont57
+  %186 = load i32, i32* %__1_t2, align 4
   %187 = add i32 %186, 1
-  store i32 %187, i32* %__1_t, align 4
-  %188 = load i32, i32* %__1_t, align 4
+  store i32 %187, i32* %__1_t2, align 4
+  %188 = load i32, i32* %__1_t2, align 4
   %189 = sub i32 %188, 1
   %190 = mul i32 1, %189
   %191 = add i32 0, %190
   %192 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__0__integer_bin_op_res, i32 0, i32 %191
-  %193 = load i32, i32* %__1_v, align 4
+  %193 = load i32, i32* %__1_v4, align 4
   %194 = sub i32 %193, 1
   %195 = mul i32 1, %194
   %196 = add i32 0, %195
   %197 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %196
   %198 = load i32, i32* %197, align 4
-  %199 = load i32, i32* %__1_u, align 4
+  %199 = load i32, i32* %__1_u3, align 4
   %200 = sub i32 %199, 1
   %201 = mul i32 1, %200
   %202 = add i32 0, %201
@@ -551,69 +557,69 @@ loop.body52:                                      ; preds = %ifcont51
   %204 = load i32, i32* %203, align 4
   %205 = add i32 %198, %204
   store i32 %205, i32* %192, align 4
-  %206 = load i32, i32* %__1_v, align 4
+  %206 = load i32, i32* %__1_v4, align 4
   %207 = add i32 %206, 1
-  store i32 %207, i32* %__1_v, align 4
-  %208 = load i32, i32* %__1_u, align 4
+  store i32 %207, i32* %__1_v4, align 4
+  %208 = load i32, i32* %__1_u3, align 4
   %209 = add i32 %208, 1
-  store i32 %209, i32* %__1_u, align 4
-  br label %loop.head47
+  store i32 %209, i32* %__1_u3, align 4
+  br label %loop.head53
 
-loop.end53:                                       ; preds = %ifcont51
-  br i1 true, label %then55, label %else56
+loop.end59:                                       ; preds = %ifcont57
+  br i1 true, label %then61, label %else62
 
-then55:                                           ; preds = %loop.end53
-  store i32 1, i32* %array_bound54, align 4
-  br label %ifcont57
+then61:                                           ; preds = %loop.end59
+  store i32 1, i32* %array_bound60, align 4
+  br label %ifcont63
 
-else56:                                           ; preds = %loop.end53
-  br label %ifcont57
+else62:                                           ; preds = %loop.end59
+  br label %ifcont63
 
-ifcont57:                                         ; preds = %else56, %then55
-  %210 = load i32, i32* %array_bound54, align 4
-  store i32 %210, i32* %__1_v, align 4
-  br i1 true, label %then59, label %else60
+ifcont63:                                         ; preds = %else62, %then61
+  %210 = load i32, i32* %array_bound60, align 4
+  store i32 %210, i32* %__1_v4, align 4
+  br i1 true, label %then65, label %else66
 
-then59:                                           ; preds = %ifcont57
-  store i32 1, i32* %array_bound58, align 4
-  br label %ifcont61
+then65:                                           ; preds = %ifcont63
+  store i32 1, i32* %array_bound64, align 4
+  br label %ifcont67
 
-else60:                                           ; preds = %ifcont57
-  br label %ifcont61
+else66:                                           ; preds = %ifcont63
+  br label %ifcont67
 
-ifcont61:                                         ; preds = %else60, %then59
-  %211 = load i32, i32* %array_bound58, align 4
+ifcont67:                                         ; preds = %else66, %then65
+  %211 = load i32, i32* %array_bound64, align 4
   %212 = sub i32 %211, 1
-  store i32 %212, i32* %__1_t, align 4
-  br label %loop.head62
+  store i32 %212, i32* %__1_t2, align 4
+  br label %loop.head68
 
-loop.head62:                                      ; preds = %loop.body67, %ifcont61
-  %213 = load i32, i32* %__1_t, align 4
+loop.head68:                                      ; preds = %loop.body73, %ifcont67
+  %213 = load i32, i32* %__1_t2, align 4
   %214 = add i32 %213, 1
-  br i1 true, label %then64, label %else65
+  br i1 true, label %then70, label %else71
 
-then64:                                           ; preds = %loop.head62
-  store i32 4, i32* %array_bound63, align 4
-  br label %ifcont66
+then70:                                           ; preds = %loop.head68
+  store i32 4, i32* %array_bound69, align 4
+  br label %ifcont72
 
-else65:                                           ; preds = %loop.head62
-  br label %ifcont66
+else71:                                           ; preds = %loop.head68
+  br label %ifcont72
 
-ifcont66:                                         ; preds = %else65, %then64
-  %215 = load i32, i32* %array_bound63, align 4
+ifcont72:                                         ; preds = %else71, %then70
+  %215 = load i32, i32* %array_bound69, align 4
   %216 = icmp sle i32 %214, %215
-  br i1 %216, label %loop.body67, label %loop.end68
+  br i1 %216, label %loop.body73, label %loop.end74
 
-loop.body67:                                      ; preds = %ifcont66
-  %217 = load i32, i32* %__1_t, align 4
+loop.body73:                                      ; preds = %ifcont72
+  %217 = load i32, i32* %__1_t2, align 4
   %218 = add i32 %217, 1
-  store i32 %218, i32* %__1_t, align 4
-  %219 = load i32, i32* %__1_t, align 4
+  store i32 %218, i32* %__1_t2, align 4
+  %219 = load i32, i32* %__1_t2, align 4
   %220 = sub i32 %219, 1
   %221 = mul i32 1, %220
   %222 = add i32 0, %221
   %223 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__1__implicit_cast_res, i32 0, i32 %222
-  %224 = load i32, i32* %__1_v, align 4
+  %224 = load i32, i32* %__1_v4, align 4
   %225 = sub i32 %224, 1
   %226 = mul i32 1, %225
   %227 = add i32 0, %226
@@ -621,84 +627,84 @@ loop.body67:                                      ; preds = %ifcont66
   %229 = load i32, i32* %228, align 4
   %230 = sitofp i32 %229 to float
   store float %230, float* %223, align 4
-  %231 = load i32, i32* %__1_v, align 4
+  %231 = load i32, i32* %__1_v4, align 4
   %232 = add i32 %231, 1
-  store i32 %232, i32* %__1_v, align 4
-  br label %loop.head62
+  store i32 %232, i32* %__1_v4, align 4
+  br label %loop.head68
 
-loop.end68:                                       ; preds = %ifcont66
-  br i1 true, label %then70, label %else71
+loop.end74:                                       ; preds = %ifcont72
+  br i1 true, label %then76, label %else77
 
-then70:                                           ; preds = %loop.end68
-  store i32 1, i32* %array_bound69, align 4
-  br label %ifcont72
+then76:                                           ; preds = %loop.end74
+  store i32 1, i32* %array_bound75, align 4
+  br label %ifcont78
 
-else71:                                           ; preds = %loop.end68
-  br label %ifcont72
+else77:                                           ; preds = %loop.end74
+  br label %ifcont78
 
-ifcont72:                                         ; preds = %else71, %then70
-  %233 = load i32, i32* %array_bound69, align 4
-  store i32 %233, i32* %__1_v, align 4
-  br i1 true, label %then74, label %else75
+ifcont78:                                         ; preds = %else77, %then76
+  %233 = load i32, i32* %array_bound75, align 4
+  store i32 %233, i32* %__1_v4, align 4
+  br i1 true, label %then80, label %else81
 
-then74:                                           ; preds = %ifcont72
-  store i32 1, i32* %array_bound73, align 4
-  br label %ifcont76
+then80:                                           ; preds = %ifcont78
+  store i32 1, i32* %array_bound79, align 4
+  br label %ifcont82
 
-else75:                                           ; preds = %ifcont72
-  br label %ifcont76
+else81:                                           ; preds = %ifcont78
+  br label %ifcont82
 
-ifcont76:                                         ; preds = %else75, %then74
-  %234 = load i32, i32* %array_bound73, align 4
-  store i32 %234, i32* %__1_u, align 4
-  br i1 true, label %then78, label %else79
+ifcont82:                                         ; preds = %else81, %then80
+  %234 = load i32, i32* %array_bound79, align 4
+  store i32 %234, i32* %__1_u3, align 4
+  br i1 true, label %then84, label %else85
 
-then78:                                           ; preds = %ifcont76
-  store i32 1, i32* %array_bound77, align 4
-  br label %ifcont80
+then84:                                           ; preds = %ifcont82
+  store i32 1, i32* %array_bound83, align 4
+  br label %ifcont86
 
-else79:                                           ; preds = %ifcont76
-  br label %ifcont80
+else85:                                           ; preds = %ifcont82
+  br label %ifcont86
 
-ifcont80:                                         ; preds = %else79, %then78
-  %235 = load i32, i32* %array_bound77, align 4
+ifcont86:                                         ; preds = %else85, %then84
+  %235 = load i32, i32* %array_bound83, align 4
   %236 = sub i32 %235, 1
-  store i32 %236, i32* %__1_t, align 4
-  br label %loop.head81
+  store i32 %236, i32* %__1_t2, align 4
+  br label %loop.head87
 
-loop.head81:                                      ; preds = %loop.body86, %ifcont80
-  %237 = load i32, i32* %__1_t, align 4
+loop.head87:                                      ; preds = %loop.body92, %ifcont86
+  %237 = load i32, i32* %__1_t2, align 4
   %238 = add i32 %237, 1
-  br i1 true, label %then83, label %else84
+  br i1 true, label %then89, label %else90
 
-then83:                                           ; preds = %loop.head81
-  store i32 4, i32* %array_bound82, align 4
-  br label %ifcont85
+then89:                                           ; preds = %loop.head87
+  store i32 4, i32* %array_bound88, align 4
+  br label %ifcont91
 
-else84:                                           ; preds = %loop.head81
-  br label %ifcont85
+else90:                                           ; preds = %loop.head87
+  br label %ifcont91
 
-ifcont85:                                         ; preds = %else84, %then83
-  %239 = load i32, i32* %array_bound82, align 4
+ifcont91:                                         ; preds = %else90, %then89
+  %239 = load i32, i32* %array_bound88, align 4
   %240 = icmp sle i32 %238, %239
-  br i1 %240, label %loop.body86, label %loop.end87
+  br i1 %240, label %loop.body92, label %loop.end93
 
-loop.body86:                                      ; preds = %ifcont85
-  %241 = load i32, i32* %__1_t, align 4
+loop.body92:                                      ; preds = %ifcont91
+  %241 = load i32, i32* %__1_t2, align 4
   %242 = add i32 %241, 1
-  store i32 %242, i32* %__1_t, align 4
-  %243 = load i32, i32* %__1_t, align 4
+  store i32 %242, i32* %__1_t2, align 4
+  %243 = load i32, i32* %__1_t2, align 4
   %244 = sub i32 %243, 1
   %245 = mul i32 1, %244
   %246 = add i32 0, %245
   %247 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 %246
-  %248 = load i32, i32* %__1_v, align 4
+  %248 = load i32, i32* %__1_v4, align 4
   %249 = sub i32 %248, 1
   %250 = mul i32 1, %249
   %251 = add i32 0, %250
   %252 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__1__implicit_cast_res, i32 0, i32 %251
   %253 = load float, float* %252, align 4
-  %254 = load i32, i32* %__1_u, align 4
+  %254 = load i32, i32* %__1_u3, align 4
   %255 = sub i32 %254, 1
   %256 = mul i32 1, %255
   %257 = add i32 0, %256
@@ -706,15 +712,15 @@ loop.body86:                                      ; preds = %ifcont85
   %259 = load float, float* %258, align 4
   %260 = fadd float %253, %259
   store float %260, float* %247, align 4
-  %261 = load i32, i32* %__1_v, align 4
+  %261 = load i32, i32* %__1_v4, align 4
   %262 = add i32 %261, 1
-  store i32 %262, i32* %__1_v, align 4
-  %263 = load i32, i32* %__1_u, align 4
+  store i32 %262, i32* %__1_v4, align 4
+  %263 = load i32, i32* %__1_u3, align 4
   %264 = add i32 %263, 1
-  store i32 %264, i32* %__1_u, align 4
-  br label %loop.head81
+  store i32 %264, i32* %__1_u3, align 4
+  br label %loop.head87
 
-loop.end87:                                       ; preds = %ifcont85
+loop.end93:                                       ; preds = %ifcont91
   %265 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %266 = load float, float* %265, align 4
   %267 = fpext float %266 to double
@@ -731,52 +737,24 @@ loop.end87:                                       ; preds = %ifcont85
   %277 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %278 = load float, float* %277, align 4
   %279 = fcmp one float %278, 6.000000e+00
-  br i1 %279, label %then88, label %else89
+  br i1 %279, label %then94, label %else95
 
-then88:                                           ; preds = %loop.end87
+then94:                                           ; preds = %loop.end93
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont90
-
-else89:                                           ; preds = %loop.end87
-  br label %ifcont90
-
-ifcont90:                                         ; preds = %else89, %then88
-  %280 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
-  %281 = load float, float* %280, align 4
-  %282 = fcmp one float %281, 6.000000e+00
-  br i1 %282, label %then91, label %else92
-
-then91:                                           ; preds = %ifcont90
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont93
-
-else92:                                           ; preds = %ifcont90
-  br label %ifcont93
-
-ifcont93:                                         ; preds = %else92, %then91
-  %283 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
-  %284 = load float, float* %283, align 4
-  %285 = fcmp one float %284, 1.400000e+01
-  br i1 %285, label %then94, label %else95
-
-then94:                                           ; preds = %ifcont93
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont96
 
-else95:                                           ; preds = %ifcont93
+else95:                                           ; preds = %loop.end93
   br label %ifcont96
 
 ifcont96:                                         ; preds = %else95, %then94
-  %286 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
-  %287 = load float, float* %286, align 4
-  %288 = fcmp one float %287, 2.400000e+01
-  br i1 %288, label %then97, label %else98
+  %280 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
+  %281 = load float, float* %280, align 4
+  %282 = fcmp one float %281, 6.000000e+00
+  br i1 %282, label %then97, label %else98
 
 then97:                                           ; preds = %ifcont96
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont99
 
@@ -784,60 +762,88 @@ else98:                                           ; preds = %ifcont96
   br label %ifcont99
 
 ifcont99:                                         ; preds = %else98, %then97
-  br i1 true, label %then101, label %else102
+  %283 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
+  %284 = load float, float* %283, align 4
+  %285 = fcmp one float %284, 1.400000e+01
+  br i1 %285, label %then100, label %else101
 
-then101:                                          ; preds = %ifcont99
-  store i32 1, i32* %array_bound100, align 4
-  br label %ifcont103
+then100:                                          ; preds = %ifcont99
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont102
 
-else102:                                          ; preds = %ifcont99
-  br label %ifcont103
+else101:                                          ; preds = %ifcont99
+  br label %ifcont102
 
-ifcont103:                                        ; preds = %else102, %then101
-  %289 = load i32, i32* %array_bound100, align 4
-  store i32 %289, i32* %__1_v, align 4
-  br i1 true, label %then105, label %else106
+ifcont102:                                        ; preds = %else101, %then100
+  %286 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
+  %287 = load float, float* %286, align 4
+  %288 = fcmp one float %287, 2.400000e+01
+  br i1 %288, label %then103, label %else104
 
-then105:                                          ; preds = %ifcont103
-  store i32 1, i32* %array_bound104, align 4
-  br label %ifcont107
+then103:                                          ; preds = %ifcont102
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont105
 
-else106:                                          ; preds = %ifcont103
-  br label %ifcont107
+else104:                                          ; preds = %ifcont102
+  br label %ifcont105
 
-ifcont107:                                        ; preds = %else106, %then105
-  %290 = load i32, i32* %array_bound104, align 4
+ifcont105:                                        ; preds = %else104, %then103
+  br i1 true, label %then107, label %else108
+
+then107:                                          ; preds = %ifcont105
+  store i32 1, i32* %array_bound106, align 4
+  br label %ifcont109
+
+else108:                                          ; preds = %ifcont105
+  br label %ifcont109
+
+ifcont109:                                        ; preds = %else108, %then107
+  %289 = load i32, i32* %array_bound106, align 4
+  store i32 %289, i32* %__1_v4, align 4
+  br i1 true, label %then111, label %else112
+
+then111:                                          ; preds = %ifcont109
+  store i32 1, i32* %array_bound110, align 4
+  br label %ifcont113
+
+else112:                                          ; preds = %ifcont109
+  br label %ifcont113
+
+ifcont113:                                        ; preds = %else112, %then111
+  %290 = load i32, i32* %array_bound110, align 4
   %291 = sub i32 %290, 1
-  store i32 %291, i32* %__1_t, align 4
-  br label %loop.head108
+  store i32 %291, i32* %__1_t2, align 4
+  br label %loop.head114
 
-loop.head108:                                     ; preds = %loop.body113, %ifcont107
-  %292 = load i32, i32* %__1_t, align 4
+loop.head114:                                     ; preds = %loop.body119, %ifcont113
+  %292 = load i32, i32* %__1_t2, align 4
   %293 = add i32 %292, 1
-  br i1 true, label %then110, label %else111
+  br i1 true, label %then116, label %else117
 
-then110:                                          ; preds = %loop.head108
-  store i32 4, i32* %array_bound109, align 4
-  br label %ifcont112
+then116:                                          ; preds = %loop.head114
+  store i32 4, i32* %array_bound115, align 4
+  br label %ifcont118
 
-else111:                                          ; preds = %loop.head108
-  br label %ifcont112
+else117:                                          ; preds = %loop.head114
+  br label %ifcont118
 
-ifcont112:                                        ; preds = %else111, %then110
-  %294 = load i32, i32* %array_bound109, align 4
+ifcont118:                                        ; preds = %else117, %then116
+  %294 = load i32, i32* %array_bound115, align 4
   %295 = icmp sle i32 %293, %294
-  br i1 %295, label %loop.body113, label %loop.end114
+  br i1 %295, label %loop.body119, label %loop.end120
 
-loop.body113:                                     ; preds = %ifcont112
-  %296 = load i32, i32* %__1_t, align 4
+loop.body119:                                     ; preds = %ifcont118
+  %296 = load i32, i32* %__1_t2, align 4
   %297 = add i32 %296, 1
-  store i32 %297, i32* %__1_t, align 4
-  %298 = load i32, i32* %__1_t, align 4
+  store i32 %297, i32* %__1_t2, align 4
+  %298 = load i32, i32* %__1_t2, align 4
   %299 = sub i32 %298, 1
   %300 = mul i32 1, %299
   %301 = add i32 0, %300
   %302 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__2__implicit_cast_res, i32 0, i32 %301
-  %303 = load i32, i32* %__1_v, align 4
+  %303 = load i32, i32* %__1_v4, align 4
   %304 = sub i32 %303, 1
   %305 = mul i32 1, %304
   %306 = add i32 0, %305
@@ -845,66 +851,66 @@ loop.body113:                                     ; preds = %ifcont112
   %308 = load i32, i32* %307, align 4
   %309 = sitofp i32 %308 to float
   store float %309, float* %302, align 4
-  %310 = load i32, i32* %__1_v, align 4
+  %310 = load i32, i32* %__1_v4, align 4
   %311 = add i32 %310, 1
-  store i32 %311, i32* %__1_v, align 4
-  br label %loop.head108
+  store i32 %311, i32* %__1_v4, align 4
+  br label %loop.head114
 
-loop.end114:                                      ; preds = %ifcont112
-  br i1 true, label %then116, label %else117
+loop.end120:                                      ; preds = %ifcont118
+  br i1 true, label %then122, label %else123
 
-then116:                                          ; preds = %loop.end114
-  store i32 1, i32* %array_bound115, align 4
-  br label %ifcont118
+then122:                                          ; preds = %loop.end120
+  store i32 1, i32* %array_bound121, align 4
+  br label %ifcont124
 
-else117:                                          ; preds = %loop.end114
-  br label %ifcont118
+else123:                                          ; preds = %loop.end120
+  br label %ifcont124
 
-ifcont118:                                        ; preds = %else117, %then116
-  %312 = load i32, i32* %array_bound115, align 4
-  store i32 %312, i32* %__1_v, align 4
-  br i1 true, label %then120, label %else121
+ifcont124:                                        ; preds = %else123, %then122
+  %312 = load i32, i32* %array_bound121, align 4
+  store i32 %312, i32* %__1_v4, align 4
+  br i1 true, label %then126, label %else127
 
-then120:                                          ; preds = %ifcont118
-  store i32 1, i32* %array_bound119, align 4
-  br label %ifcont122
+then126:                                          ; preds = %ifcont124
+  store i32 1, i32* %array_bound125, align 4
+  br label %ifcont128
 
-else121:                                          ; preds = %ifcont118
-  br label %ifcont122
+else127:                                          ; preds = %ifcont124
+  br label %ifcont128
 
-ifcont122:                                        ; preds = %else121, %then120
-  %313 = load i32, i32* %array_bound119, align 4
+ifcont128:                                        ; preds = %else127, %then126
+  %313 = load i32, i32* %array_bound125, align 4
   %314 = sub i32 %313, 1
-  store i32 %314, i32* %__1_t, align 4
-  br label %loop.head123
+  store i32 %314, i32* %__1_t2, align 4
+  br label %loop.head129
 
-loop.head123:                                     ; preds = %loop.body128, %ifcont122
-  %315 = load i32, i32* %__1_t, align 4
+loop.head129:                                     ; preds = %loop.body134, %ifcont128
+  %315 = load i32, i32* %__1_t2, align 4
   %316 = add i32 %315, 1
-  br i1 true, label %then125, label %else126
+  br i1 true, label %then131, label %else132
 
-then125:                                          ; preds = %loop.head123
-  store i32 4, i32* %array_bound124, align 4
-  br label %ifcont127
+then131:                                          ; preds = %loop.head129
+  store i32 4, i32* %array_bound130, align 4
+  br label %ifcont133
 
-else126:                                          ; preds = %loop.head123
-  br label %ifcont127
+else132:                                          ; preds = %loop.head129
+  br label %ifcont133
 
-ifcont127:                                        ; preds = %else126, %then125
-  %317 = load i32, i32* %array_bound124, align 4
+ifcont133:                                        ; preds = %else132, %then131
+  %317 = load i32, i32* %array_bound130, align 4
   %318 = icmp sle i32 %316, %317
-  br i1 %318, label %loop.body128, label %loop.end129
+  br i1 %318, label %loop.body134, label %loop.end135
 
-loop.body128:                                     ; preds = %ifcont127
-  %319 = load i32, i32* %__1_t, align 4
+loop.body134:                                     ; preds = %ifcont133
+  %319 = load i32, i32* %__1_t2, align 4
   %320 = add i32 %319, 1
-  store i32 %320, i32* %__1_t, align 4
-  %321 = load i32, i32* %__1_t, align 4
+  store i32 %320, i32* %__1_t2, align 4
+  %321 = load i32, i32* %__1_t2, align 4
   %322 = sub i32 %321, 1
   %323 = mul i32 1, %322
   %324 = add i32 0, %323
   %325 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__3__implicit_cast_res, i32 0, i32 %324
-  %326 = load i32, i32* %__1_v, align 4
+  %326 = load i32, i32* %__1_v4, align 4
   %327 = sub i32 %326, 1
   %328 = mul i32 1, %327
   %329 = add i32 0, %328
@@ -912,84 +918,84 @@ loop.body128:                                     ; preds = %ifcont127
   %331 = load i32, i32* %330, align 4
   %332 = sitofp i32 %331 to float
   store float %332, float* %325, align 4
-  %333 = load i32, i32* %__1_v, align 4
+  %333 = load i32, i32* %__1_v4, align 4
   %334 = add i32 %333, 1
-  store i32 %334, i32* %__1_v, align 4
-  br label %loop.head123
+  store i32 %334, i32* %__1_v4, align 4
+  br label %loop.head129
 
-loop.end129:                                      ; preds = %ifcont127
-  br i1 true, label %then131, label %else132
+loop.end135:                                      ; preds = %ifcont133
+  br i1 true, label %then137, label %else138
 
-then131:                                          ; preds = %loop.end129
-  store i32 1, i32* %array_bound130, align 4
-  br label %ifcont133
+then137:                                          ; preds = %loop.end135
+  store i32 1, i32* %array_bound136, align 4
+  br label %ifcont139
 
-else132:                                          ; preds = %loop.end129
-  br label %ifcont133
+else138:                                          ; preds = %loop.end135
+  br label %ifcont139
 
-ifcont133:                                        ; preds = %else132, %then131
-  %335 = load i32, i32* %array_bound130, align 4
-  store i32 %335, i32* %__1_v, align 4
-  br i1 true, label %then135, label %else136
+ifcont139:                                        ; preds = %else138, %then137
+  %335 = load i32, i32* %array_bound136, align 4
+  store i32 %335, i32* %__1_v4, align 4
+  br i1 true, label %then141, label %else142
 
-then135:                                          ; preds = %ifcont133
-  store i32 1, i32* %array_bound134, align 4
-  br label %ifcont137
+then141:                                          ; preds = %ifcont139
+  store i32 1, i32* %array_bound140, align 4
+  br label %ifcont143
 
-else136:                                          ; preds = %ifcont133
-  br label %ifcont137
+else142:                                          ; preds = %ifcont139
+  br label %ifcont143
 
-ifcont137:                                        ; preds = %else136, %then135
-  %336 = load i32, i32* %array_bound134, align 4
-  store i32 %336, i32* %__1_u, align 4
-  br i1 true, label %then139, label %else140
+ifcont143:                                        ; preds = %else142, %then141
+  %336 = load i32, i32* %array_bound140, align 4
+  store i32 %336, i32* %__1_u3, align 4
+  br i1 true, label %then145, label %else146
 
-then139:                                          ; preds = %ifcont137
-  store i32 1, i32* %array_bound138, align 4
-  br label %ifcont141
+then145:                                          ; preds = %ifcont143
+  store i32 1, i32* %array_bound144, align 4
+  br label %ifcont147
 
-else140:                                          ; preds = %ifcont137
-  br label %ifcont141
+else146:                                          ; preds = %ifcont143
+  br label %ifcont147
 
-ifcont141:                                        ; preds = %else140, %then139
-  %337 = load i32, i32* %array_bound138, align 4
+ifcont147:                                        ; preds = %else146, %then145
+  %337 = load i32, i32* %array_bound144, align 4
   %338 = sub i32 %337, 1
-  store i32 %338, i32* %__1_t, align 4
-  br label %loop.head142
+  store i32 %338, i32* %__1_t2, align 4
+  br label %loop.head148
 
-loop.head142:                                     ; preds = %loop.body147, %ifcont141
-  %339 = load i32, i32* %__1_t, align 4
+loop.head148:                                     ; preds = %loop.body153, %ifcont147
+  %339 = load i32, i32* %__1_t2, align 4
   %340 = add i32 %339, 1
-  br i1 true, label %then144, label %else145
+  br i1 true, label %then150, label %else151
 
-then144:                                          ; preds = %loop.head142
-  store i32 4, i32* %array_bound143, align 4
-  br label %ifcont146
+then150:                                          ; preds = %loop.head148
+  store i32 4, i32* %array_bound149, align 4
+  br label %ifcont152
 
-else145:                                          ; preds = %loop.head142
-  br label %ifcont146
+else151:                                          ; preds = %loop.head148
+  br label %ifcont152
 
-ifcont146:                                        ; preds = %else145, %then144
-  %341 = load i32, i32* %array_bound143, align 4
+ifcont152:                                        ; preds = %else151, %then150
+  %341 = load i32, i32* %array_bound149, align 4
   %342 = icmp sle i32 %340, %341
-  br i1 %342, label %loop.body147, label %loop.end148
+  br i1 %342, label %loop.body153, label %loop.end154
 
-loop.body147:                                     ; preds = %ifcont146
-  %343 = load i32, i32* %__1_t, align 4
+loop.body153:                                     ; preds = %ifcont152
+  %343 = load i32, i32* %__1_t2, align 4
   %344 = add i32 %343, 1
-  store i32 %344, i32* %__1_t, align 4
-  %345 = load i32, i32* %__1_t, align 4
+  store i32 %344, i32* %__1_t2, align 4
+  %345 = load i32, i32* %__1_t2, align 4
   %346 = sub i32 %345, 1
   %347 = mul i32 1, %346
   %348 = add i32 0, %347
   %349 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__4__real_bin_op_res, i32 0, i32 %348
-  %350 = load i32, i32* %__1_v, align 4
+  %350 = load i32, i32* %__1_v4, align 4
   %351 = sub i32 %350, 1
   %352 = mul i32 1, %351
   %353 = add i32 0, %352
   %354 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__3__implicit_cast_res, i32 0, i32 %353
   %355 = load float, float* %354, align 4
-  %356 = load i32, i32* %__1_u, align 4
+  %356 = load i32, i32* %__1_u3, align 4
   %357 = sub i32 %356, 1
   %358 = mul i32 1, %357
   %359 = add i32 0, %358
@@ -997,87 +1003,87 @@ loop.body147:                                     ; preds = %ifcont146
   %361 = load float, float* %360, align 4
   %362 = fmul float %355, %361
   store float %362, float* %349, align 4
-  %363 = load i32, i32* %__1_v, align 4
+  %363 = load i32, i32* %__1_v4, align 4
   %364 = add i32 %363, 1
-  store i32 %364, i32* %__1_v, align 4
-  %365 = load i32, i32* %__1_u, align 4
+  store i32 %364, i32* %__1_v4, align 4
+  %365 = load i32, i32* %__1_u3, align 4
   %366 = add i32 %365, 1
-  store i32 %366, i32* %__1_u, align 4
-  br label %loop.head142
+  store i32 %366, i32* %__1_u3, align 4
+  br label %loop.head148
 
-loop.end148:                                      ; preds = %ifcont146
-  br i1 true, label %then150, label %else151
+loop.end154:                                      ; preds = %ifcont152
+  br i1 true, label %then156, label %else157
 
-then150:                                          ; preds = %loop.end148
-  store i32 1, i32* %array_bound149, align 4
-  br label %ifcont152
+then156:                                          ; preds = %loop.end154
+  store i32 1, i32* %array_bound155, align 4
+  br label %ifcont158
 
-else151:                                          ; preds = %loop.end148
-  br label %ifcont152
+else157:                                          ; preds = %loop.end154
+  br label %ifcont158
 
-ifcont152:                                        ; preds = %else151, %then150
-  %367 = load i32, i32* %array_bound149, align 4
-  store i32 %367, i32* %__1_v, align 4
-  br i1 true, label %then154, label %else155
+ifcont158:                                        ; preds = %else157, %then156
+  %367 = load i32, i32* %array_bound155, align 4
+  store i32 %367, i32* %__1_v4, align 4
+  br i1 true, label %then160, label %else161
 
-then154:                                          ; preds = %ifcont152
-  store i32 1, i32* %array_bound153, align 4
-  br label %ifcont156
+then160:                                          ; preds = %ifcont158
+  store i32 1, i32* %array_bound159, align 4
+  br label %ifcont162
 
-else155:                                          ; preds = %ifcont152
-  br label %ifcont156
+else161:                                          ; preds = %ifcont158
+  br label %ifcont162
 
-ifcont156:                                        ; preds = %else155, %then154
-  %368 = load i32, i32* %array_bound153, align 4
-  store i32 %368, i32* %__1_u, align 4
-  br i1 true, label %then158, label %else159
+ifcont162:                                        ; preds = %else161, %then160
+  %368 = load i32, i32* %array_bound159, align 4
+  store i32 %368, i32* %__1_u3, align 4
+  br i1 true, label %then164, label %else165
 
-then158:                                          ; preds = %ifcont156
-  store i32 1, i32* %array_bound157, align 4
-  br label %ifcont160
+then164:                                          ; preds = %ifcont162
+  store i32 1, i32* %array_bound163, align 4
+  br label %ifcont166
 
-else159:                                          ; preds = %ifcont156
-  br label %ifcont160
+else165:                                          ; preds = %ifcont162
+  br label %ifcont166
 
-ifcont160:                                        ; preds = %else159, %then158
-  %369 = load i32, i32* %array_bound157, align 4
+ifcont166:                                        ; preds = %else165, %then164
+  %369 = load i32, i32* %array_bound163, align 4
   %370 = sub i32 %369, 1
-  store i32 %370, i32* %__1_t, align 4
-  br label %loop.head161
+  store i32 %370, i32* %__1_t2, align 4
+  br label %loop.head167
 
-loop.head161:                                     ; preds = %loop.body166, %ifcont160
-  %371 = load i32, i32* %__1_t, align 4
+loop.head167:                                     ; preds = %loop.body172, %ifcont166
+  %371 = load i32, i32* %__1_t2, align 4
   %372 = add i32 %371, 1
-  br i1 true, label %then163, label %else164
+  br i1 true, label %then169, label %else170
 
-then163:                                          ; preds = %loop.head161
-  store i32 4, i32* %array_bound162, align 4
-  br label %ifcont165
+then169:                                          ; preds = %loop.head167
+  store i32 4, i32* %array_bound168, align 4
+  br label %ifcont171
 
-else164:                                          ; preds = %loop.head161
-  br label %ifcont165
+else170:                                          ; preds = %loop.head167
+  br label %ifcont171
 
-ifcont165:                                        ; preds = %else164, %then163
-  %373 = load i32, i32* %array_bound162, align 4
+ifcont171:                                        ; preds = %else170, %then169
+  %373 = load i32, i32* %array_bound168, align 4
   %374 = icmp sle i32 %372, %373
-  br i1 %374, label %loop.body166, label %loop.end167
+  br i1 %374, label %loop.body172, label %loop.end173
 
-loop.body166:                                     ; preds = %ifcont165
-  %375 = load i32, i32* %__1_t, align 4
+loop.body172:                                     ; preds = %ifcont171
+  %375 = load i32, i32* %__1_t2, align 4
   %376 = add i32 %375, 1
-  store i32 %376, i32* %__1_t, align 4
-  %377 = load i32, i32* %__1_t, align 4
+  store i32 %376, i32* %__1_t2, align 4
+  %377 = load i32, i32* %__1_t2, align 4
   %378 = sub i32 %377, 1
   %379 = mul i32 1, %378
   %380 = add i32 0, %379
   %381 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 %380
-  %382 = load i32, i32* %__1_v, align 4
+  %382 = load i32, i32* %__1_v4, align 4
   %383 = sub i32 %382, 1
   %384 = mul i32 1, %383
   %385 = add i32 0, %384
   %386 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__2__implicit_cast_res, i32 0, i32 %385
   %387 = load float, float* %386, align 4
-  %388 = load i32, i32* %__1_u, align 4
+  %388 = load i32, i32* %__1_u3, align 4
   %389 = sub i32 %388, 1
   %390 = mul i32 1, %389
   %391 = add i32 0, %390
@@ -1085,15 +1091,15 @@ loop.body166:                                     ; preds = %ifcont165
   %393 = load float, float* %392, align 4
   %394 = fsub float %387, %393
   store float %394, float* %381, align 4
-  %395 = load i32, i32* %__1_v, align 4
+  %395 = load i32, i32* %__1_v4, align 4
   %396 = add i32 %395, 1
-  store i32 %396, i32* %__1_v, align 4
-  %397 = load i32, i32* %__1_u, align 4
+  store i32 %396, i32* %__1_v4, align 4
+  %397 = load i32, i32* %__1_u3, align 4
   %398 = add i32 %397, 1
-  store i32 %398, i32* %__1_u, align 4
-  br label %loop.head161
+  store i32 %398, i32* %__1_u3, align 4
+  br label %loop.head167
 
-loop.end167:                                      ; preds = %ifcont165
+loop.end173:                                      ; preds = %ifcont171
   %399 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %400 = load float, float* %399, align 4
   %401 = fpext float %400 to double
@@ -1110,52 +1116,24 @@ loop.end167:                                      ; preds = %ifcont165
   %411 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %412 = load float, float* %411, align 4
   %413 = fcmp one float %412, -3.000000e+00
-  br i1 %413, label %then168, label %else169
+  br i1 %413, label %then174, label %else175
 
-then168:                                          ; preds = %loop.end167
+then174:                                          ; preds = %loop.end173
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont170
-
-else169:                                          ; preds = %loop.end167
-  br label %ifcont170
-
-ifcont170:                                        ; preds = %else169, %then168
-  %414 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
-  %415 = load float, float* %414, align 4
-  %416 = fcmp one float %415, 1.000000e+00
-  br i1 %416, label %then171, label %else172
-
-then171:                                          ; preds = %ifcont170
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont173
-
-else172:                                          ; preds = %ifcont170
-  br label %ifcont173
-
-ifcont173:                                        ; preds = %else172, %then171
-  %417 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
-  %418 = load float, float* %417, align 4
-  %419 = fcmp one float %418, 2.000000e+00
-  br i1 %419, label %then174, label %else175
-
-then174:                                          ; preds = %ifcont173
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont176
 
-else175:                                          ; preds = %ifcont173
+else175:                                          ; preds = %loop.end173
   br label %ifcont176
 
 ifcont176:                                        ; preds = %else175, %then174
-  %420 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
-  %421 = load float, float* %420, align 4
-  %422 = fcmp one float %421, 3.000000e+00
-  br i1 %422, label %then177, label %else178
+  %414 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
+  %415 = load float, float* %414, align 4
+  %416 = fcmp one float %415, 1.000000e+00
+  br i1 %416, label %then177, label %else178
 
 then177:                                          ; preds = %ifcont176
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont179
 
@@ -1163,78 +1141,106 @@ else178:                                          ; preds = %ifcont176
   br label %ifcont179
 
 ifcont179:                                        ; preds = %else178, %then177
-  br i1 true, label %then181, label %else182
+  %417 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
+  %418 = load float, float* %417, align 4
+  %419 = fcmp one float %418, 2.000000e+00
+  br i1 %419, label %then180, label %else181
 
-then181:                                          ; preds = %ifcont179
-  store i32 1, i32* %array_bound180, align 4
-  br label %ifcont183
+then180:                                          ; preds = %ifcont179
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont182
 
-else182:                                          ; preds = %ifcont179
-  br label %ifcont183
+else181:                                          ; preds = %ifcont179
+  br label %ifcont182
 
-ifcont183:                                        ; preds = %else182, %then181
-  %423 = load i32, i32* %array_bound180, align 4
-  store i32 %423, i32* %__1_v, align 4
-  br i1 true, label %then185, label %else186
+ifcont182:                                        ; preds = %else181, %then180
+  %420 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
+  %421 = load float, float* %420, align 4
+  %422 = fcmp one float %421, 3.000000e+00
+  br i1 %422, label %then183, label %else184
 
-then185:                                          ; preds = %ifcont183
-  store i32 1, i32* %array_bound184, align 4
-  br label %ifcont187
+then183:                                          ; preds = %ifcont182
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont185
 
-else186:                                          ; preds = %ifcont183
-  br label %ifcont187
+else184:                                          ; preds = %ifcont182
+  br label %ifcont185
 
-ifcont187:                                        ; preds = %else186, %then185
-  %424 = load i32, i32* %array_bound184, align 4
-  store i32 %424, i32* %__1_u, align 4
-  br i1 true, label %then189, label %else190
+ifcont185:                                        ; preds = %else184, %then183
+  br i1 true, label %then187, label %else188
 
-then189:                                          ; preds = %ifcont187
-  store i32 1, i32* %array_bound188, align 4
-  br label %ifcont191
+then187:                                          ; preds = %ifcont185
+  store i32 1, i32* %array_bound186, align 4
+  br label %ifcont189
 
-else190:                                          ; preds = %ifcont187
-  br label %ifcont191
+else188:                                          ; preds = %ifcont185
+  br label %ifcont189
 
-ifcont191:                                        ; preds = %else190, %then189
-  %425 = load i32, i32* %array_bound188, align 4
+ifcont189:                                        ; preds = %else188, %then187
+  %423 = load i32, i32* %array_bound186, align 4
+  store i32 %423, i32* %__1_v4, align 4
+  br i1 true, label %then191, label %else192
+
+then191:                                          ; preds = %ifcont189
+  store i32 1, i32* %array_bound190, align 4
+  br label %ifcont193
+
+else192:                                          ; preds = %ifcont189
+  br label %ifcont193
+
+ifcont193:                                        ; preds = %else192, %then191
+  %424 = load i32, i32* %array_bound190, align 4
+  store i32 %424, i32* %__1_u3, align 4
+  br i1 true, label %then195, label %else196
+
+then195:                                          ; preds = %ifcont193
+  store i32 1, i32* %array_bound194, align 4
+  br label %ifcont197
+
+else196:                                          ; preds = %ifcont193
+  br label %ifcont197
+
+ifcont197:                                        ; preds = %else196, %then195
+  %425 = load i32, i32* %array_bound194, align 4
   %426 = sub i32 %425, 1
-  store i32 %426, i32* %__1_t, align 4
-  br label %loop.head192
+  store i32 %426, i32* %__1_t2, align 4
+  br label %loop.head198
 
-loop.head192:                                     ; preds = %loop.body197, %ifcont191
-  %427 = load i32, i32* %__1_t, align 4
+loop.head198:                                     ; preds = %loop.body203, %ifcont197
+  %427 = load i32, i32* %__1_t2, align 4
   %428 = add i32 %427, 1
-  br i1 true, label %then194, label %else195
+  br i1 true, label %then200, label %else201
 
-then194:                                          ; preds = %loop.head192
-  store i32 4, i32* %array_bound193, align 4
-  br label %ifcont196
+then200:                                          ; preds = %loop.head198
+  store i32 4, i32* %array_bound199, align 4
+  br label %ifcont202
 
-else195:                                          ; preds = %loop.head192
-  br label %ifcont196
+else201:                                          ; preds = %loop.head198
+  br label %ifcont202
 
-ifcont196:                                        ; preds = %else195, %then194
-  %429 = load i32, i32* %array_bound193, align 4
+ifcont202:                                        ; preds = %else201, %then200
+  %429 = load i32, i32* %array_bound199, align 4
   %430 = icmp sle i32 %428, %429
-  br i1 %430, label %loop.body197, label %loop.end198
+  br i1 %430, label %loop.body203, label %loop.end204
 
-loop.body197:                                     ; preds = %ifcont196
-  %431 = load i32, i32* %__1_t, align 4
+loop.body203:                                     ; preds = %ifcont202
+  %431 = load i32, i32* %__1_t2, align 4
   %432 = add i32 %431, 1
-  store i32 %432, i32* %__1_t, align 4
-  %433 = load i32, i32* %__1_t, align 4
+  store i32 %432, i32* %__1_t2, align 4
+  %433 = load i32, i32* %__1_t2, align 4
   %434 = sub i32 %433, 1
   %435 = mul i32 1, %434
   %436 = add i32 0, %435
   %437 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__5__integer_bin_op_res, i32 0, i32 %436
-  %438 = load i32, i32* %__1_v, align 4
+  %438 = load i32, i32* %__1_v4, align 4
   %439 = sub i32 %438, 1
   %440 = mul i32 1, %439
   %441 = add i32 0, %440
   %442 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %441
   %443 = load i32, i32* %442, align 4
-  %444 = load i32, i32* %__1_u, align 4
+  %444 = load i32, i32* %__1_u3, align 4
   %445 = sub i32 %444, 1
   %446 = mul i32 1, %445
   %447 = add i32 0, %446
@@ -1242,69 +1248,69 @@ loop.body197:                                     ; preds = %ifcont196
   %449 = load i32, i32* %448, align 4
   %450 = mul i32 %443, %449
   store i32 %450, i32* %437, align 4
-  %451 = load i32, i32* %__1_v, align 4
+  %451 = load i32, i32* %__1_v4, align 4
   %452 = add i32 %451, 1
-  store i32 %452, i32* %__1_v, align 4
-  %453 = load i32, i32* %__1_u, align 4
+  store i32 %452, i32* %__1_v4, align 4
+  %453 = load i32, i32* %__1_u3, align 4
   %454 = add i32 %453, 1
-  store i32 %454, i32* %__1_u, align 4
-  br label %loop.head192
+  store i32 %454, i32* %__1_u3, align 4
+  br label %loop.head198
 
-loop.end198:                                      ; preds = %ifcont196
-  br i1 true, label %then200, label %else201
+loop.end204:                                      ; preds = %ifcont202
+  br i1 true, label %then206, label %else207
 
-then200:                                          ; preds = %loop.end198
-  store i32 1, i32* %array_bound199, align 4
-  br label %ifcont202
+then206:                                          ; preds = %loop.end204
+  store i32 1, i32* %array_bound205, align 4
+  br label %ifcont208
 
-else201:                                          ; preds = %loop.end198
-  br label %ifcont202
+else207:                                          ; preds = %loop.end204
+  br label %ifcont208
 
-ifcont202:                                        ; preds = %else201, %then200
-  %455 = load i32, i32* %array_bound199, align 4
-  store i32 %455, i32* %__1_v, align 4
-  br i1 true, label %then204, label %else205
+ifcont208:                                        ; preds = %else207, %then206
+  %455 = load i32, i32* %array_bound205, align 4
+  store i32 %455, i32* %__1_v4, align 4
+  br i1 true, label %then210, label %else211
 
-then204:                                          ; preds = %ifcont202
-  store i32 1, i32* %array_bound203, align 4
-  br label %ifcont206
+then210:                                          ; preds = %ifcont208
+  store i32 1, i32* %array_bound209, align 4
+  br label %ifcont212
 
-else205:                                          ; preds = %ifcont202
-  br label %ifcont206
+else211:                                          ; preds = %ifcont208
+  br label %ifcont212
 
-ifcont206:                                        ; preds = %else205, %then204
-  %456 = load i32, i32* %array_bound203, align 4
+ifcont212:                                        ; preds = %else211, %then210
+  %456 = load i32, i32* %array_bound209, align 4
   %457 = sub i32 %456, 1
-  store i32 %457, i32* %__1_t, align 4
-  br label %loop.head207
+  store i32 %457, i32* %__1_t2, align 4
+  br label %loop.head213
 
-loop.head207:                                     ; preds = %loop.body212, %ifcont206
-  %458 = load i32, i32* %__1_t, align 4
+loop.head213:                                     ; preds = %loop.body218, %ifcont212
+  %458 = load i32, i32* %__1_t2, align 4
   %459 = add i32 %458, 1
-  br i1 true, label %then209, label %else210
+  br i1 true, label %then215, label %else216
 
-then209:                                          ; preds = %loop.head207
-  store i32 4, i32* %array_bound208, align 4
-  br label %ifcont211
+then215:                                          ; preds = %loop.head213
+  store i32 4, i32* %array_bound214, align 4
+  br label %ifcont217
 
-else210:                                          ; preds = %loop.head207
-  br label %ifcont211
+else216:                                          ; preds = %loop.head213
+  br label %ifcont217
 
-ifcont211:                                        ; preds = %else210, %then209
-  %460 = load i32, i32* %array_bound208, align 4
+ifcont217:                                        ; preds = %else216, %then215
+  %460 = load i32, i32* %array_bound214, align 4
   %461 = icmp sle i32 %459, %460
-  br i1 %461, label %loop.body212, label %loop.end213
+  br i1 %461, label %loop.body218, label %loop.end219
 
-loop.body212:                                     ; preds = %ifcont211
-  %462 = load i32, i32* %__1_t, align 4
+loop.body218:                                     ; preds = %ifcont217
+  %462 = load i32, i32* %__1_t2, align 4
   %463 = add i32 %462, 1
-  store i32 %463, i32* %__1_t, align 4
-  %464 = load i32, i32* %__1_t, align 4
+  store i32 %463, i32* %__1_t2, align 4
+  %464 = load i32, i32* %__1_t2, align 4
   %465 = sub i32 %464, 1
   %466 = mul i32 1, %465
   %467 = add i32 0, %466
   %468 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__6__implicit_cast_res, i32 0, i32 %467
-  %469 = load i32, i32* %__1_v, align 4
+  %469 = load i32, i32* %__1_v4, align 4
   %470 = sub i32 %469, 1
   %471 = mul i32 1, %470
   %472 = add i32 0, %471
@@ -1312,84 +1318,84 @@ loop.body212:                                     ; preds = %ifcont211
   %474 = load i32, i32* %473, align 4
   %475 = sitofp i32 %474 to float
   store float %475, float* %468, align 4
-  %476 = load i32, i32* %__1_v, align 4
+  %476 = load i32, i32* %__1_v4, align 4
   %477 = add i32 %476, 1
-  store i32 %477, i32* %__1_v, align 4
-  br label %loop.head207
+  store i32 %477, i32* %__1_v4, align 4
+  br label %loop.head213
 
-loop.end213:                                      ; preds = %ifcont211
-  br i1 true, label %then215, label %else216
+loop.end219:                                      ; preds = %ifcont217
+  br i1 true, label %then221, label %else222
 
-then215:                                          ; preds = %loop.end213
-  store i32 1, i32* %array_bound214, align 4
-  br label %ifcont217
+then221:                                          ; preds = %loop.end219
+  store i32 1, i32* %array_bound220, align 4
+  br label %ifcont223
 
-else216:                                          ; preds = %loop.end213
-  br label %ifcont217
+else222:                                          ; preds = %loop.end219
+  br label %ifcont223
 
-ifcont217:                                        ; preds = %else216, %then215
-  %478 = load i32, i32* %array_bound214, align 4
-  store i32 %478, i32* %__1_v, align 4
-  br i1 true, label %then219, label %else220
+ifcont223:                                        ; preds = %else222, %then221
+  %478 = load i32, i32* %array_bound220, align 4
+  store i32 %478, i32* %__1_v4, align 4
+  br i1 true, label %then225, label %else226
 
-then219:                                          ; preds = %ifcont217
-  store i32 1, i32* %array_bound218, align 4
-  br label %ifcont221
+then225:                                          ; preds = %ifcont223
+  store i32 1, i32* %array_bound224, align 4
+  br label %ifcont227
 
-else220:                                          ; preds = %ifcont217
-  br label %ifcont221
+else226:                                          ; preds = %ifcont223
+  br label %ifcont227
 
-ifcont221:                                        ; preds = %else220, %then219
-  %479 = load i32, i32* %array_bound218, align 4
-  store i32 %479, i32* %__1_u, align 4
-  br i1 true, label %then223, label %else224
+ifcont227:                                        ; preds = %else226, %then225
+  %479 = load i32, i32* %array_bound224, align 4
+  store i32 %479, i32* %__1_u3, align 4
+  br i1 true, label %then229, label %else230
 
-then223:                                          ; preds = %ifcont221
-  store i32 1, i32* %array_bound222, align 4
-  br label %ifcont225
+then229:                                          ; preds = %ifcont227
+  store i32 1, i32* %array_bound228, align 4
+  br label %ifcont231
 
-else224:                                          ; preds = %ifcont221
-  br label %ifcont225
+else230:                                          ; preds = %ifcont227
+  br label %ifcont231
 
-ifcont225:                                        ; preds = %else224, %then223
-  %480 = load i32, i32* %array_bound222, align 4
+ifcont231:                                        ; preds = %else230, %then229
+  %480 = load i32, i32* %array_bound228, align 4
   %481 = sub i32 %480, 1
-  store i32 %481, i32* %__1_t, align 4
-  br label %loop.head226
+  store i32 %481, i32* %__1_t2, align 4
+  br label %loop.head232
 
-loop.head226:                                     ; preds = %loop.body231, %ifcont225
-  %482 = load i32, i32* %__1_t, align 4
+loop.head232:                                     ; preds = %loop.body237, %ifcont231
+  %482 = load i32, i32* %__1_t2, align 4
   %483 = add i32 %482, 1
-  br i1 true, label %then228, label %else229
+  br i1 true, label %then234, label %else235
 
-then228:                                          ; preds = %loop.head226
-  store i32 4, i32* %array_bound227, align 4
-  br label %ifcont230
+then234:                                          ; preds = %loop.head232
+  store i32 4, i32* %array_bound233, align 4
+  br label %ifcont236
 
-else229:                                          ; preds = %loop.head226
-  br label %ifcont230
+else235:                                          ; preds = %loop.head232
+  br label %ifcont236
 
-ifcont230:                                        ; preds = %else229, %then228
-  %484 = load i32, i32* %array_bound227, align 4
+ifcont236:                                        ; preds = %else235, %then234
+  %484 = load i32, i32* %array_bound233, align 4
   %485 = icmp sle i32 %483, %484
-  br i1 %485, label %loop.body231, label %loop.end232
+  br i1 %485, label %loop.body237, label %loop.end238
 
-loop.body231:                                     ; preds = %ifcont230
-  %486 = load i32, i32* %__1_t, align 4
+loop.body237:                                     ; preds = %ifcont236
+  %486 = load i32, i32* %__1_t2, align 4
   %487 = add i32 %486, 1
-  store i32 %487, i32* %__1_t, align 4
-  %488 = load i32, i32* %__1_t, align 4
+  store i32 %487, i32* %__1_t2, align 4
+  %488 = load i32, i32* %__1_t2, align 4
   %489 = sub i32 %488, 1
   %490 = mul i32 1, %489
   %491 = add i32 0, %490
   %492 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 %491
-  %493 = load i32, i32* %__1_v, align 4
+  %493 = load i32, i32* %__1_v4, align 4
   %494 = sub i32 %493, 1
   %495 = mul i32 1, %494
   %496 = add i32 0, %495
   %497 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__6__implicit_cast_res, i32 0, i32 %496
   %498 = load float, float* %497, align 4
-  %499 = load i32, i32* %__1_u, align 4
+  %499 = load i32, i32* %__1_u3, align 4
   %500 = sub i32 %499, 1
   %501 = mul i32 1, %500
   %502 = add i32 0, %501
@@ -1397,15 +1403,15 @@ loop.body231:                                     ; preds = %ifcont230
   %504 = load float, float* %503, align 4
   %505 = fmul float %498, %504
   store float %505, float* %492, align 4
-  %506 = load i32, i32* %__1_v, align 4
+  %506 = load i32, i32* %__1_v4, align 4
   %507 = add i32 %506, 1
-  store i32 %507, i32* %__1_v, align 4
-  %508 = load i32, i32* %__1_u, align 4
+  store i32 %507, i32* %__1_v4, align 4
+  %508 = load i32, i32* %__1_u3, align 4
   %509 = add i32 %508, 1
-  store i32 %509, i32* %__1_u, align 4
-  br label %loop.head226
+  store i32 %509, i32* %__1_u3, align 4
+  br label %loop.head232
 
-loop.end232:                                      ; preds = %ifcont230
+loop.end238:                                      ; preds = %ifcont236
   %510 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %511 = load float, float* %510, align 4
   %512 = fpext float %511 to double
@@ -1422,52 +1428,24 @@ loop.end232:                                      ; preds = %ifcont230
   %522 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %523 = load float, float* %522, align 4
   %524 = fcmp one float %523, 4.000000e+00
-  br i1 %524, label %then233, label %else234
+  br i1 %524, label %then239, label %else240
 
-then233:                                          ; preds = %loop.end232
+then239:                                          ; preds = %loop.end238
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont235
-
-else234:                                          ; preds = %loop.end232
-  br label %ifcont235
-
-ifcont235:                                        ; preds = %else234, %then233
-  %525 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
-  %526 = load float, float* %525, align 4
-  %527 = fcmp one float %526, 0.000000e+00
-  br i1 %527, label %then236, label %else237
-
-then236:                                          ; preds = %ifcont235
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont238
-
-else237:                                          ; preds = %ifcont235
-  br label %ifcont238
-
-ifcont238:                                        ; preds = %else237, %then236
-  %528 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
-  %529 = load float, float* %528, align 4
-  %530 = fcmp one float %529, 0.000000e+00
-  br i1 %530, label %then239, label %else240
-
-then239:                                          ; preds = %ifcont238
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @48, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont241
 
-else240:                                          ; preds = %ifcont238
+else240:                                          ; preds = %loop.end238
   br label %ifcont241
 
 ifcont241:                                        ; preds = %else240, %then239
-  %531 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
-  %532 = load float, float* %531, align 4
-  %533 = fcmp one float %532, 0.000000e+00
-  br i1 %533, label %then242, label %else243
+  %525 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
+  %526 = load float, float* %525, align 4
+  %527 = fcmp one float %526, 0.000000e+00
+  br i1 %527, label %then242, label %else243
 
 then242:                                          ; preds = %ifcont241
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont244
 
@@ -1475,78 +1453,106 @@ else243:                                          ; preds = %ifcont241
   br label %ifcont244
 
 ifcont244:                                        ; preds = %else243, %then242
-  br i1 true, label %then246, label %else247
+  %528 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
+  %529 = load float, float* %528, align 4
+  %530 = fcmp one float %529, 0.000000e+00
+  br i1 %530, label %then245, label %else246
 
-then246:                                          ; preds = %ifcont244
-  store i32 1, i32* %array_bound245, align 4
-  br label %ifcont248
+then245:                                          ; preds = %ifcont244
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @48, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont247
 
-else247:                                          ; preds = %ifcont244
-  br label %ifcont248
+else246:                                          ; preds = %ifcont244
+  br label %ifcont247
 
-ifcont248:                                        ; preds = %else247, %then246
-  %534 = load i32, i32* %array_bound245, align 4
-  store i32 %534, i32* %__1_v, align 4
-  br i1 true, label %then250, label %else251
+ifcont247:                                        ; preds = %else246, %then245
+  %531 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
+  %532 = load float, float* %531, align 4
+  %533 = fcmp one float %532, 0.000000e+00
+  br i1 %533, label %then248, label %else249
 
-then250:                                          ; preds = %ifcont248
-  store i32 1, i32* %array_bound249, align 4
-  br label %ifcont252
+then248:                                          ; preds = %ifcont247
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont250
 
-else251:                                          ; preds = %ifcont248
-  br label %ifcont252
+else249:                                          ; preds = %ifcont247
+  br label %ifcont250
 
-ifcont252:                                        ; preds = %else251, %then250
-  %535 = load i32, i32* %array_bound249, align 4
-  store i32 %535, i32* %__1_u, align 4
-  br i1 true, label %then254, label %else255
+ifcont250:                                        ; preds = %else249, %then248
+  br i1 true, label %then252, label %else253
 
-then254:                                          ; preds = %ifcont252
-  store i32 1, i32* %array_bound253, align 4
-  br label %ifcont256
+then252:                                          ; preds = %ifcont250
+  store i32 1, i32* %array_bound251, align 4
+  br label %ifcont254
 
-else255:                                          ; preds = %ifcont252
-  br label %ifcont256
+else253:                                          ; preds = %ifcont250
+  br label %ifcont254
 
-ifcont256:                                        ; preds = %else255, %then254
-  %536 = load i32, i32* %array_bound253, align 4
+ifcont254:                                        ; preds = %else253, %then252
+  %534 = load i32, i32* %array_bound251, align 4
+  store i32 %534, i32* %__1_v4, align 4
+  br i1 true, label %then256, label %else257
+
+then256:                                          ; preds = %ifcont254
+  store i32 1, i32* %array_bound255, align 4
+  br label %ifcont258
+
+else257:                                          ; preds = %ifcont254
+  br label %ifcont258
+
+ifcont258:                                        ; preds = %else257, %then256
+  %535 = load i32, i32* %array_bound255, align 4
+  store i32 %535, i32* %__1_u3, align 4
+  br i1 true, label %then260, label %else261
+
+then260:                                          ; preds = %ifcont258
+  store i32 1, i32* %array_bound259, align 4
+  br label %ifcont262
+
+else261:                                          ; preds = %ifcont258
+  br label %ifcont262
+
+ifcont262:                                        ; preds = %else261, %then260
+  %536 = load i32, i32* %array_bound259, align 4
   %537 = sub i32 %536, 1
-  store i32 %537, i32* %__1_t, align 4
-  br label %loop.head257
+  store i32 %537, i32* %__1_t2, align 4
+  br label %loop.head263
 
-loop.head257:                                     ; preds = %loop.body262, %ifcont256
-  %538 = load i32, i32* %__1_t, align 4
+loop.head263:                                     ; preds = %loop.body268, %ifcont262
+  %538 = load i32, i32* %__1_t2, align 4
   %539 = add i32 %538, 1
-  br i1 true, label %then259, label %else260
+  br i1 true, label %then265, label %else266
 
-then259:                                          ; preds = %loop.head257
-  store i32 4, i32* %array_bound258, align 4
-  br label %ifcont261
+then265:                                          ; preds = %loop.head263
+  store i32 4, i32* %array_bound264, align 4
+  br label %ifcont267
 
-else260:                                          ; preds = %loop.head257
-  br label %ifcont261
+else266:                                          ; preds = %loop.head263
+  br label %ifcont267
 
-ifcont261:                                        ; preds = %else260, %then259
-  %540 = load i32, i32* %array_bound258, align 4
+ifcont267:                                        ; preds = %else266, %then265
+  %540 = load i32, i32* %array_bound264, align 4
   %541 = icmp sle i32 %539, %540
-  br i1 %541, label %loop.body262, label %loop.end263
+  br i1 %541, label %loop.body268, label %loop.end269
 
-loop.body262:                                     ; preds = %ifcont261
-  %542 = load i32, i32* %__1_t, align 4
+loop.body268:                                     ; preds = %ifcont267
+  %542 = load i32, i32* %__1_t2, align 4
   %543 = add i32 %542, 1
-  store i32 %543, i32* %__1_t, align 4
-  %544 = load i32, i32* %__1_t, align 4
+  store i32 %543, i32* %__1_t2, align 4
+  %544 = load i32, i32* %__1_t2, align 4
   %545 = sub i32 %544, 1
   %546 = mul i32 1, %545
   %547 = add i32 0, %546
   %548 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__7__integer_bin_op_res, i32 0, i32 %547
-  %549 = load i32, i32* %__1_v, align 4
+  %549 = load i32, i32* %__1_v4, align 4
   %550 = sub i32 %549, 1
   %551 = mul i32 1, %550
   %552 = add i32 0, %551
   %553 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %552
   %554 = load i32, i32* %553, align 4
-  %555 = load i32, i32* %__1_u, align 4
+  %555 = load i32, i32* %__1_u3, align 4
   %556 = sub i32 %555, 1
   %557 = mul i32 1, %556
   %558 = add i32 0, %557
@@ -1554,69 +1560,69 @@ loop.body262:                                     ; preds = %ifcont261
   %560 = load i32, i32* %559, align 4
   %561 = mul i32 %554, %560
   store i32 %561, i32* %548, align 4
-  %562 = load i32, i32* %__1_v, align 4
+  %562 = load i32, i32* %__1_v4, align 4
   %563 = add i32 %562, 1
-  store i32 %563, i32* %__1_v, align 4
-  %564 = load i32, i32* %__1_u, align 4
+  store i32 %563, i32* %__1_v4, align 4
+  %564 = load i32, i32* %__1_u3, align 4
   %565 = add i32 %564, 1
-  store i32 %565, i32* %__1_u, align 4
-  br label %loop.head257
+  store i32 %565, i32* %__1_u3, align 4
+  br label %loop.head263
 
-loop.end263:                                      ; preds = %ifcont261
-  br i1 true, label %then265, label %else266
+loop.end269:                                      ; preds = %ifcont267
+  br i1 true, label %then271, label %else272
 
-then265:                                          ; preds = %loop.end263
-  store i32 1, i32* %array_bound264, align 4
-  br label %ifcont267
+then271:                                          ; preds = %loop.end269
+  store i32 1, i32* %array_bound270, align 4
+  br label %ifcont273
 
-else266:                                          ; preds = %loop.end263
-  br label %ifcont267
+else272:                                          ; preds = %loop.end269
+  br label %ifcont273
 
-ifcont267:                                        ; preds = %else266, %then265
-  %566 = load i32, i32* %array_bound264, align 4
-  store i32 %566, i32* %__1_v, align 4
-  br i1 true, label %then269, label %else270
+ifcont273:                                        ; preds = %else272, %then271
+  %566 = load i32, i32* %array_bound270, align 4
+  store i32 %566, i32* %__1_v4, align 4
+  br i1 true, label %then275, label %else276
 
-then269:                                          ; preds = %ifcont267
-  store i32 1, i32* %array_bound268, align 4
-  br label %ifcont271
+then275:                                          ; preds = %ifcont273
+  store i32 1, i32* %array_bound274, align 4
+  br label %ifcont277
 
-else270:                                          ; preds = %ifcont267
-  br label %ifcont271
+else276:                                          ; preds = %ifcont273
+  br label %ifcont277
 
-ifcont271:                                        ; preds = %else270, %then269
-  %567 = load i32, i32* %array_bound268, align 4
+ifcont277:                                        ; preds = %else276, %then275
+  %567 = load i32, i32* %array_bound274, align 4
   %568 = sub i32 %567, 1
-  store i32 %568, i32* %__1_t, align 4
-  br label %loop.head272
+  store i32 %568, i32* %__1_t2, align 4
+  br label %loop.head278
 
-loop.head272:                                     ; preds = %loop.body277, %ifcont271
-  %569 = load i32, i32* %__1_t, align 4
+loop.head278:                                     ; preds = %loop.body283, %ifcont277
+  %569 = load i32, i32* %__1_t2, align 4
   %570 = add i32 %569, 1
-  br i1 true, label %then274, label %else275
+  br i1 true, label %then280, label %else281
 
-then274:                                          ; preds = %loop.head272
-  store i32 4, i32* %array_bound273, align 4
-  br label %ifcont276
+then280:                                          ; preds = %loop.head278
+  store i32 4, i32* %array_bound279, align 4
+  br label %ifcont282
 
-else275:                                          ; preds = %loop.head272
-  br label %ifcont276
+else281:                                          ; preds = %loop.head278
+  br label %ifcont282
 
-ifcont276:                                        ; preds = %else275, %then274
-  %571 = load i32, i32* %array_bound273, align 4
+ifcont282:                                        ; preds = %else281, %then280
+  %571 = load i32, i32* %array_bound279, align 4
   %572 = icmp sle i32 %570, %571
-  br i1 %572, label %loop.body277, label %loop.end278
+  br i1 %572, label %loop.body283, label %loop.end284
 
-loop.body277:                                     ; preds = %ifcont276
-  %573 = load i32, i32* %__1_t, align 4
+loop.body283:                                     ; preds = %ifcont282
+  %573 = load i32, i32* %__1_t2, align 4
   %574 = add i32 %573, 1
-  store i32 %574, i32* %__1_t, align 4
-  %575 = load i32, i32* %__1_t, align 4
+  store i32 %574, i32* %__1_t2, align 4
+  %575 = load i32, i32* %__1_t2, align 4
   %576 = sub i32 %575, 1
   %577 = mul i32 1, %576
   %578 = add i32 0, %577
   %579 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__8__implicit_cast_res, i32 0, i32 %578
-  %580 = load i32, i32* %__1_v, align 4
+  %580 = load i32, i32* %__1_v4, align 4
   %581 = sub i32 %580, 1
   %582 = mul i32 1, %581
   %583 = add i32 0, %582
@@ -1624,67 +1630,67 @@ loop.body277:                                     ; preds = %ifcont276
   %585 = load i32, i32* %584, align 4
   %586 = sitofp i32 %585 to float
   store float %586, float* %579, align 4
-  %587 = load i32, i32* %__1_v, align 4
+  %587 = load i32, i32* %__1_v4, align 4
   %588 = add i32 %587, 1
-  store i32 %588, i32* %__1_v, align 4
-  br label %loop.head272
+  store i32 %588, i32* %__1_v4, align 4
+  br label %loop.head278
 
-loop.end278:                                      ; preds = %ifcont276
+loop.end284:                                      ; preds = %ifcont282
   store float 1.000000e+00, float* %__libasr_created_scalar_auxiliary_variable, align 4
-  br i1 true, label %then280, label %else281
+  br i1 true, label %then286, label %else287
 
-then280:                                          ; preds = %loop.end278
-  store i32 1, i32* %array_bound279, align 4
-  br label %ifcont282
+then286:                                          ; preds = %loop.end284
+  store i32 1, i32* %array_bound285, align 4
+  br label %ifcont288
 
-else281:                                          ; preds = %loop.end278
-  br label %ifcont282
+else287:                                          ; preds = %loop.end284
+  br label %ifcont288
 
-ifcont282:                                        ; preds = %else281, %then280
-  %589 = load i32, i32* %array_bound279, align 4
-  store i32 %589, i32* %__1_v, align 4
-  br i1 true, label %then284, label %else285
+ifcont288:                                        ; preds = %else287, %then286
+  %589 = load i32, i32* %array_bound285, align 4
+  store i32 %589, i32* %__1_v4, align 4
+  br i1 true, label %then290, label %else291
 
-then284:                                          ; preds = %ifcont282
-  store i32 1, i32* %array_bound283, align 4
-  br label %ifcont286
+then290:                                          ; preds = %ifcont288
+  store i32 1, i32* %array_bound289, align 4
+  br label %ifcont292
 
-else285:                                          ; preds = %ifcont282
-  br label %ifcont286
+else291:                                          ; preds = %ifcont288
+  br label %ifcont292
 
-ifcont286:                                        ; preds = %else285, %then284
-  %590 = load i32, i32* %array_bound283, align 4
+ifcont292:                                        ; preds = %else291, %then290
+  %590 = load i32, i32* %array_bound289, align 4
   %591 = sub i32 %590, 1
-  store i32 %591, i32* %__1_t, align 4
-  br label %loop.head287
+  store i32 %591, i32* %__1_t2, align 4
+  br label %loop.head293
 
-loop.head287:                                     ; preds = %loop.body292, %ifcont286
-  %592 = load i32, i32* %__1_t, align 4
+loop.head293:                                     ; preds = %loop.body298, %ifcont292
+  %592 = load i32, i32* %__1_t2, align 4
   %593 = add i32 %592, 1
-  br i1 true, label %then289, label %else290
+  br i1 true, label %then295, label %else296
 
-then289:                                          ; preds = %loop.head287
-  store i32 4, i32* %array_bound288, align 4
-  br label %ifcont291
+then295:                                          ; preds = %loop.head293
+  store i32 4, i32* %array_bound294, align 4
+  br label %ifcont297
 
-else290:                                          ; preds = %loop.head287
-  br label %ifcont291
+else296:                                          ; preds = %loop.head293
+  br label %ifcont297
 
-ifcont291:                                        ; preds = %else290, %then289
-  %594 = load i32, i32* %array_bound288, align 4
+ifcont297:                                        ; preds = %else296, %then295
+  %594 = load i32, i32* %array_bound294, align 4
   %595 = icmp sle i32 %593, %594
-  br i1 %595, label %loop.body292, label %loop.end293
+  br i1 %595, label %loop.body298, label %loop.end299
 
-loop.body292:                                     ; preds = %ifcont291
-  %596 = load i32, i32* %__1_t, align 4
+loop.body298:                                     ; preds = %ifcont297
+  %596 = load i32, i32* %__1_t2, align 4
   %597 = add i32 %596, 1
-  store i32 %597, i32* %__1_t, align 4
-  %598 = load i32, i32* %__1_t, align 4
+  store i32 %597, i32* %__1_t2, align 4
+  %598 = load i32, i32* %__1_t2, align 4
   %599 = sub i32 %598, 1
   %600 = mul i32 1, %599
   %601 = add i32 0, %600
   %602 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__9__real_bin_op_res, i32 0, i32 %601
-  %603 = load i32, i32* %__1_v, align 4
+  %603 = load i32, i32* %__1_v4, align 4
   %604 = sub i32 %603, 1
   %605 = mul i32 1, %604
   %606 = add i32 0, %605
@@ -1693,84 +1699,84 @@ loop.body292:                                     ; preds = %ifcont291
   %609 = load float, float* %__libasr_created_scalar_auxiliary_variable, align 4
   %610 = fadd float %608, %609
   store float %610, float* %602, align 4
-  %611 = load i32, i32* %__1_v, align 4
+  %611 = load i32, i32* %__1_v4, align 4
   %612 = add i32 %611, 1
-  store i32 %612, i32* %__1_v, align 4
-  br label %loop.head287
+  store i32 %612, i32* %__1_v4, align 4
+  br label %loop.head293
 
-loop.end293:                                      ; preds = %ifcont291
-  br i1 true, label %then295, label %else296
+loop.end299:                                      ; preds = %ifcont297
+  br i1 true, label %then301, label %else302
 
-then295:                                          ; preds = %loop.end293
-  store i32 1, i32* %array_bound294, align 4
-  br label %ifcont297
+then301:                                          ; preds = %loop.end299
+  store i32 1, i32* %array_bound300, align 4
+  br label %ifcont303
 
-else296:                                          ; preds = %loop.end293
-  br label %ifcont297
+else302:                                          ; preds = %loop.end299
+  br label %ifcont303
 
-ifcont297:                                        ; preds = %else296, %then295
-  %613 = load i32, i32* %array_bound294, align 4
-  store i32 %613, i32* %__1_v, align 4
-  br i1 true, label %then299, label %else300
+ifcont303:                                        ; preds = %else302, %then301
+  %613 = load i32, i32* %array_bound300, align 4
+  store i32 %613, i32* %__1_v4, align 4
+  br i1 true, label %then305, label %else306
 
-then299:                                          ; preds = %ifcont297
-  store i32 1, i32* %array_bound298, align 4
-  br label %ifcont301
+then305:                                          ; preds = %ifcont303
+  store i32 1, i32* %array_bound304, align 4
+  br label %ifcont307
 
-else300:                                          ; preds = %ifcont297
-  br label %ifcont301
+else306:                                          ; preds = %ifcont303
+  br label %ifcont307
 
-ifcont301:                                        ; preds = %else300, %then299
-  %614 = load i32, i32* %array_bound298, align 4
-  store i32 %614, i32* %__1_u, align 4
-  br i1 true, label %then303, label %else304
+ifcont307:                                        ; preds = %else306, %then305
+  %614 = load i32, i32* %array_bound304, align 4
+  store i32 %614, i32* %__1_u3, align 4
+  br i1 true, label %then309, label %else310
 
-then303:                                          ; preds = %ifcont301
-  store i32 1, i32* %array_bound302, align 4
-  br label %ifcont305
+then309:                                          ; preds = %ifcont307
+  store i32 1, i32* %array_bound308, align 4
+  br label %ifcont311
 
-else304:                                          ; preds = %ifcont301
-  br label %ifcont305
+else310:                                          ; preds = %ifcont307
+  br label %ifcont311
 
-ifcont305:                                        ; preds = %else304, %then303
-  %615 = load i32, i32* %array_bound302, align 4
+ifcont311:                                        ; preds = %else310, %then309
+  %615 = load i32, i32* %array_bound308, align 4
   %616 = sub i32 %615, 1
-  store i32 %616, i32* %__1_t, align 4
-  br label %loop.head306
+  store i32 %616, i32* %__1_t2, align 4
+  br label %loop.head312
 
-loop.head306:                                     ; preds = %loop.body311, %ifcont305
-  %617 = load i32, i32* %__1_t, align 4
+loop.head312:                                     ; preds = %loop.body317, %ifcont311
+  %617 = load i32, i32* %__1_t2, align 4
   %618 = add i32 %617, 1
-  br i1 true, label %then308, label %else309
+  br i1 true, label %then314, label %else315
 
-then308:                                          ; preds = %loop.head306
-  store i32 4, i32* %array_bound307, align 4
-  br label %ifcont310
+then314:                                          ; preds = %loop.head312
+  store i32 4, i32* %array_bound313, align 4
+  br label %ifcont316
 
-else309:                                          ; preds = %loop.head306
-  br label %ifcont310
+else315:                                          ; preds = %loop.head312
+  br label %ifcont316
 
-ifcont310:                                        ; preds = %else309, %then308
-  %619 = load i32, i32* %array_bound307, align 4
+ifcont316:                                        ; preds = %else315, %then314
+  %619 = load i32, i32* %array_bound313, align 4
   %620 = icmp sle i32 %618, %619
-  br i1 %620, label %loop.body311, label %loop.end312
+  br i1 %620, label %loop.body317, label %loop.end318
 
-loop.body311:                                     ; preds = %ifcont310
-  %621 = load i32, i32* %__1_t, align 4
+loop.body317:                                     ; preds = %ifcont316
+  %621 = load i32, i32* %__1_t2, align 4
   %622 = add i32 %621, 1
-  store i32 %622, i32* %__1_t, align 4
-  %623 = load i32, i32* %__1_t, align 4
+  store i32 %622, i32* %__1_t2, align 4
+  %623 = load i32, i32* %__1_t2, align 4
   %624 = sub i32 %623, 1
   %625 = mul i32 1, %624
   %626 = add i32 0, %625
   %627 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 %626
-  %628 = load i32, i32* %__1_v, align 4
+  %628 = load i32, i32* %__1_v4, align 4
   %629 = sub i32 %628, 1
   %630 = mul i32 1, %629
   %631 = add i32 0, %630
   %632 = getelementptr [4 x float], [4 x float]* %__libasr__created__var__8__implicit_cast_res, i32 0, i32 %631
   %633 = load float, float* %632, align 4
-  %634 = load i32, i32* %__1_u, align 4
+  %634 = load i32, i32* %__1_u3, align 4
   %635 = sub i32 %634, 1
   %636 = mul i32 1, %635
   %637 = add i32 0, %636
@@ -1778,15 +1784,15 @@ loop.body311:                                     ; preds = %ifcont310
   %639 = load float, float* %638, align 4
   %640 = fdiv float %633, %639
   store float %640, float* %627, align 4
-  %641 = load i32, i32* %__1_v, align 4
+  %641 = load i32, i32* %__1_v4, align 4
   %642 = add i32 %641, 1
-  store i32 %642, i32* %__1_v, align 4
-  %643 = load i32, i32* %__1_u, align 4
+  store i32 %642, i32* %__1_v4, align 4
+  %643 = load i32, i32* %__1_u3, align 4
   %644 = add i32 %643, 1
-  store i32 %644, i32* %__1_u, align 4
-  br label %loop.head306
+  store i32 %644, i32* %__1_u3, align 4
+  br label %loop.head312
 
-loop.end312:                                      ; preds = %ifcont310
+loop.end318:                                      ; preds = %ifcont316
   %645 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %646 = load float, float* %645, align 4
   %647 = fpext float %646 to double
@@ -1803,52 +1809,24 @@ loop.end312:                                      ; preds = %ifcont310
   %657 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 0
   %658 = load float, float* %657, align 4
   %659 = fcmp one float %658, 2.000000e+00
-  br i1 %659, label %then313, label %else314
+  br i1 %659, label %then319, label %else320
 
-then313:                                          ; preds = %loop.end312
+then319:                                          ; preds = %loop.end318
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont315
-
-else314:                                          ; preds = %loop.end312
-  br label %ifcont315
-
-ifcont315:                                        ; preds = %else314, %then313
-  %660 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
-  %661 = load float, float* %660, align 4
-  %662 = fcmp one float %661, 5.000000e+00
-  br i1 %662, label %then316, label %else317
-
-then316:                                          ; preds = %ifcont315
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @60, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont318
-
-else317:                                          ; preds = %ifcont315
-  br label %ifcont318
-
-ifcont318:                                        ; preds = %else317, %then316
-  %663 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
-  %664 = load float, float* %663, align 4
-  %665 = fcmp one float %664, 2.400000e+01
-  br i1 %665, label %then319, label %else320
-
-then319:                                          ; preds = %ifcont318
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont321
 
-else320:                                          ; preds = %ifcont318
+else320:                                          ; preds = %loop.end318
   br label %ifcont321
 
 ifcont321:                                        ; preds = %else320, %then319
-  %666 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
-  %667 = load float, float* %666, align 4
-  %668 = fcmp one float %667, 6.300000e+01
-  br i1 %668, label %then322, label %else323
+  %660 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 1
+  %661 = load float, float* %660, align 4
+  %662 = fcmp one float %661, 5.000000e+00
+  br i1 %662, label %then322, label %else323
 
 then322:                                          ; preds = %ifcont321
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @60, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont324
 
@@ -1856,9 +1834,37 @@ else323:                                          ; preds = %ifcont321
   br label %ifcont324
 
 ifcont324:                                        ; preds = %else323, %then322
+  %663 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 2
+  %664 = load float, float* %663, align 4
+  %665 = fcmp one float %664, 2.400000e+01
+  br i1 %665, label %then325, label %else326
+
+then325:                                          ; preds = %ifcont324
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont327
+
+else326:                                          ; preds = %ifcont324
+  br label %ifcont327
+
+ifcont327:                                        ; preds = %else326, %then325
+  %666 = getelementptr [4 x float], [4 x float]* %d, i32 0, i32 3
+  %667 = load float, float* %666, align 4
+  %668 = fcmp one float %667, 6.300000e+01
+  br i1 %668, label %then328, label %else329
+
+then328:                                          ; preds = %ifcont327
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont330
+
+else329:                                          ; preds = %ifcont327
+  br label %ifcont330
+
+ifcont330:                                        ; preds = %else329, %then328
   br label %return
 
-return:                                           ; preds = %ifcont324
+return:                                           ; preds = %ifcont330
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_2-c36ad8d.json
+++ b/tests/reference/llvm-arrays_op_2-c36ad8d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_2-c36ad8d.stdout",
-    "stdout_hash": "e242a9b979c752bb120f54b40792ce5832cc46f8bdafcaa4727d4028",
+    "stdout_hash": "c52e61978867e3cbcf060600563557fc696b9c19d99a9e35c4342932",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_2-c36ad8d.stdout
+++ b/tests/reference/llvm-arrays_op_2-c36ad8d.stdout
@@ -70,55 +70,54 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %array_bound447 = alloca i32, align 4
-  %array_bound438 = alloca i32, align 4
-  %array_bound430 = alloca i32, align 4
-  %array_bound422 = alloca i32, align 4
-  %array_bound413 = alloca i32, align 4
-  %array_bound404 = alloca i32, align 4
-  %array_bound396 = alloca i32, align 4
-  %array_bound388 = alloca i32, align 4
-  %array_bound379 = alloca i32, align 4
-  %array_bound370 = alloca i32, align 4
-  %array_bound362 = alloca i32, align 4
-  %array_bound354 = alloca i32, align 4
-  %array_bound330 = alloca i32, align 4
-  %array_bound321 = alloca i32, align 4
-  %array_bound313 = alloca i32, align 4
-  %array_bound305 = alloca i32, align 4
-  %array_bound296 = alloca i32, align 4
-  %array_bound287 = alloca i32, align 4
-  %array_bound279 = alloca i32, align 4
-  %array_bound271 = alloca i32, align 4
-  %array_bound262 = alloca i32, align 4
-  %array_bound253 = alloca i32, align 4
-  %array_bound245 = alloca i32, align 4
-  %array_bound237 = alloca i32, align 4
-  %array_bound213 = alloca i32, align 4
-  %array_bound204 = alloca i32, align 4
-  %array_bound196 = alloca i32, align 4
-  %array_bound188 = alloca i32, align 4
-  %array_bound179 = alloca i32, align 4
-  %array_bound170 = alloca i32, align 4
-  %array_bound162 = alloca i32, align 4
-  %array_bound154 = alloca i32, align 4
-  %array_bound145 = alloca i32, align 4
-  %array_bound136 = alloca i32, align 4
-  %array_bound128 = alloca i32, align 4
-  %array_bound120 = alloca i32, align 4
-  %array_bound96 = alloca i32, align 4
-  %array_bound87 = alloca i32, align 4
-  %array_bound79 = alloca i32, align 4
-  %array_bound71 = alloca i32, align 4
-  %array_bound62 = alloca i32, align 4
-  %array_bound53 = alloca i32, align 4
-  %array_bound45 = alloca i32, align 4
-  %array_bound37 = alloca i32, align 4
-  %array_bound28 = alloca i32, align 4
-  %array_bound19 = alloca i32, align 4
-  %array_bound11 = alloca i32, align 4
+  %array_bound459 = alloca i32, align 4
+  %array_bound450 = alloca i32, align 4
+  %array_bound442 = alloca i32, align 4
+  %array_bound434 = alloca i32, align 4
+  %array_bound425 = alloca i32, align 4
+  %array_bound416 = alloca i32, align 4
+  %array_bound408 = alloca i32, align 4
+  %array_bound400 = alloca i32, align 4
+  %array_bound391 = alloca i32, align 4
+  %array_bound382 = alloca i32, align 4
+  %array_bound374 = alloca i32, align 4
+  %array_bound366 = alloca i32, align 4
+  %array_bound342 = alloca i32, align 4
+  %array_bound333 = alloca i32, align 4
+  %array_bound325 = alloca i32, align 4
+  %array_bound317 = alloca i32, align 4
+  %array_bound308 = alloca i32, align 4
+  %array_bound299 = alloca i32, align 4
+  %array_bound291 = alloca i32, align 4
+  %array_bound283 = alloca i32, align 4
+  %array_bound274 = alloca i32, align 4
+  %array_bound265 = alloca i32, align 4
+  %array_bound257 = alloca i32, align 4
+  %array_bound249 = alloca i32, align 4
+  %array_bound225 = alloca i32, align 4
+  %array_bound216 = alloca i32, align 4
+  %array_bound208 = alloca i32, align 4
+  %array_bound200 = alloca i32, align 4
+  %array_bound191 = alloca i32, align 4
+  %array_bound182 = alloca i32, align 4
+  %array_bound174 = alloca i32, align 4
+  %array_bound166 = alloca i32, align 4
+  %array_bound157 = alloca i32, align 4
+  %array_bound148 = alloca i32, align 4
+  %array_bound140 = alloca i32, align 4
+  %array_bound132 = alloca i32, align 4
+  %array_bound108 = alloca i32, align 4
+  %array_bound99 = alloca i32, align 4
+  %array_bound91 = alloca i32, align 4
+  %array_bound83 = alloca i32, align 4
+  %array_bound74 = alloca i32, align 4
+  %array_bound65 = alloca i32, align 4
+  %array_bound57 = alloca i32, align 4
+  %array_bound49 = alloca i32, align 4
+  %array_bound40 = alloca i32, align 4
+  %array_bound31 = alloca i32, align 4
+  %array_bound23 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__1_t = alloca i32, align 4
   %__1_u = alloca i32, align 4
   %__1_v = alloca i32, align 4
@@ -128,54 +127,67 @@ define i32 @main(i32 %0, i8** %1) {
   %__3_t = alloca i32, align 4
   %__3_u = alloca i32, align 4
   %__3_v = alloca i32, align 4
-  %a = alloca [4 x i32], align 4
-  %b = alloca [4 x i32], align 4
-  %c = alloca [4 x i32], align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   %k = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_t1 = alloca i32, align 4
+  %__1_u2 = alloca i32, align 4
+  %__1_v3 = alloca i32, align 4
+  %__2_t4 = alloca i32, align 4
+  %__2_u5 = alloca i32, align 4
+  %__2_v6 = alloca i32, align 4
+  %__3_t7 = alloca i32, align 4
+  %__3_u8 = alloca i32, align 4
+  %__3_v9 = alloca i32, align 4
+  %a = alloca [4 x i32], align 4
+  %b = alloca [4 x i32], align 4
+  %c = alloca [4 x i32], align 4
+  %i10 = alloca i32, align 4
+  %j11 = alloca i32, align 4
+  %k12 = alloca i32, align 4
+  store i32 0, i32* %i10, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %loop.end5, %.entry
-  %2 = load i32, i32* %i, align 4
+loop.head:                                        ; preds = %loop.end17, %.entry
+  %2 = load i32, i32* %i10, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 2
-  br i1 %4, label %loop.body, label %loop.end6
+  br i1 %4, label %loop.body, label %loop.end18
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i10, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head1
+  store i32 %6, i32* %i10, align 4
+  store i32 0, i32* %j11, align 4
+  br label %loop.head13
 
-loop.head1:                                       ; preds = %loop.end, %loop.body
-  %7 = load i32, i32* %j, align 4
+loop.head13:                                      ; preds = %loop.end, %loop.body
+  %7 = load i32, i32* %j11, align 4
   %8 = add i32 %7, 1
   %9 = icmp sle i32 %8, 2
-  br i1 %9, label %loop.body2, label %loop.end5
+  br i1 %9, label %loop.body14, label %loop.end17
 
-loop.body2:                                       ; preds = %loop.head1
-  %10 = load i32, i32* %j, align 4
+loop.body14:                                      ; preds = %loop.head13
+  %10 = load i32, i32* %j11, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %j, align 4
-  store i32 0, i32* %k, align 4
-  br label %loop.head3
+  store i32 %11, i32* %j11, align 4
+  store i32 0, i32* %k12, align 4
+  br label %loop.head15
 
-loop.head3:                                       ; preds = %loop.body4, %loop.body2
-  %12 = load i32, i32* %k, align 4
+loop.head15:                                      ; preds = %loop.body16, %loop.body14
+  %12 = load i32, i32* %k12, align 4
   %13 = add i32 %12, 1
   %14 = icmp sle i32 %13, 1
-  br i1 %14, label %loop.body4, label %loop.end
+  br i1 %14, label %loop.body16, label %loop.end
 
-loop.body4:                                       ; preds = %loop.head3
-  %15 = load i32, i32* %k, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %15 = load i32, i32* %k12, align 4
   %16 = add i32 %15, 1
-  store i32 %16, i32* %k, align 4
-  %17 = load i32, i32* %i, align 4
-  %18 = load i32, i32* %j, align 4
-  %19 = load i32, i32* %k, align 4
+  store i32 %16, i32* %k12, align 4
+  %17 = load i32, i32* %i10, align 4
+  %18 = load i32, i32* %j11, align 4
+  %19 = load i32, i32* %k12, align 4
   %20 = sub i32 %17, 1
   %21 = mul i32 1, %20
   %22 = add i32 0, %21
@@ -186,13 +198,13 @@ loop.body4:                                       ; preds = %loop.head3
   %27 = mul i32 4, %26
   %28 = add i32 %25, %27
   %29 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %28
-  %30 = load i32, i32* %i, align 4
-  %31 = load i32, i32* %i, align 4
+  %30 = load i32, i32* %i10, align 4
+  %31 = load i32, i32* %i10, align 4
   %32 = mul i32 %30, %31
   store i32 %32, i32* %29, align 4
-  %33 = load i32, i32* %i, align 4
-  %34 = load i32, i32* %j, align 4
-  %35 = load i32, i32* %k, align 4
+  %33 = load i32, i32* %i10, align 4
+  %34 = load i32, i32* %j11, align 4
+  %35 = load i32, i32* %k12, align 4
   %36 = sub i32 %33, 1
   %37 = mul i32 1, %36
   %38 = add i32 0, %37
@@ -203,20 +215,20 @@ loop.body4:                                       ; preds = %loop.head3
   %43 = mul i32 4, %42
   %44 = add i32 %41, %43
   %45 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %44
-  %46 = load i32, i32* %j, align 4
-  %47 = load i32, i32* %j, align 4
+  %46 = load i32, i32* %j11, align 4
+  %47 = load i32, i32* %j11, align 4
   %48 = mul i32 %46, %47
   store i32 %48, i32* %45, align 4
-  br label %loop.head3
+  br label %loop.head15
 
-loop.end:                                         ; preds = %loop.head3
-  br label %loop.head1
+loop.end:                                         ; preds = %loop.head15
+  br label %loop.head13
 
-loop.end5:                                        ; preds = %loop.head1
+loop.end17:                                       ; preds = %loop.head13
   br label %loop.head
 
-loop.end6:                                        ; preds = %loop.head
-  store i32 0, i32* %i, align 4
+loop.end18:                                       ; preds = %loop.head
+  store i32 0, i32* %i10, align 4
   %49 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 0
   %50 = load i32, i32* %49, align 4
   %51 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 2
@@ -237,355 +249,355 @@ loop.end6:                                        ; preds = %loop.head
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @5, i32 0, i32 0), i32 %58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %60, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   br i1 true, label %then, label %else
 
-then:                                             ; preds = %loop.end6
+then:                                             ; preds = %loop.end18
   store i32 1, i32* %array_bound, align 4
   br label %ifcont
 
-else:                                             ; preds = %loop.end6
-  br i1 false, label %then7, label %else8
+else:                                             ; preds = %loop.end18
+  br i1 false, label %then19, label %else20
 
-then7:                                            ; preds = %else
+then19:                                           ; preds = %else
   store i32 1, i32* %array_bound, align 4
   br label %ifcont
 
-else8:                                            ; preds = %else
-  br i1 false, label %then9, label %else10
+else20:                                           ; preds = %else
+  br i1 false, label %then21, label %else22
 
-then9:                                            ; preds = %else8
+then21:                                           ; preds = %else20
   store i32 1, i32* %array_bound, align 4
   br label %ifcont
 
-else10:                                           ; preds = %else8
+else22:                                           ; preds = %else20
   br label %ifcont
 
-ifcont:                                           ; preds = %else10, %then9, %then7, %then
+ifcont:                                           ; preds = %else22, %then21, %then19, %then
   %65 = load i32, i32* %array_bound, align 4
-  store i32 %65, i32* %__1_v, align 4
-  br i1 true, label %then12, label %else13
+  store i32 %65, i32* %__1_v3, align 4
+  br i1 true, label %then24, label %else25
 
-then12:                                           ; preds = %ifcont
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont18
+then24:                                           ; preds = %ifcont
+  store i32 1, i32* %array_bound23, align 4
+  br label %ifcont30
 
-else13:                                           ; preds = %ifcont
-  br i1 false, label %then14, label %else15
+else25:                                           ; preds = %ifcont
+  br i1 false, label %then26, label %else27
 
-then14:                                           ; preds = %else13
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont18
+then26:                                           ; preds = %else25
+  store i32 1, i32* %array_bound23, align 4
+  br label %ifcont30
 
-else15:                                           ; preds = %else13
-  br i1 false, label %then16, label %else17
+else27:                                           ; preds = %else25
+  br i1 false, label %then28, label %else29
 
-then16:                                           ; preds = %else15
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont18
+then28:                                           ; preds = %else27
+  store i32 1, i32* %array_bound23, align 4
+  br label %ifcont30
 
-else17:                                           ; preds = %else15
-  br label %ifcont18
+else29:                                           ; preds = %else27
+  br label %ifcont30
 
-ifcont18:                                         ; preds = %else17, %then16, %then14, %then12
-  %66 = load i32, i32* %array_bound11, align 4
-  store i32 %66, i32* %__1_u, align 4
-  br i1 true, label %then20, label %else21
+ifcont30:                                         ; preds = %else29, %then28, %then26, %then24
+  %66 = load i32, i32* %array_bound23, align 4
+  store i32 %66, i32* %__1_u2, align 4
+  br i1 true, label %then32, label %else33
 
-then20:                                           ; preds = %ifcont18
-  store i32 1, i32* %array_bound19, align 4
-  br label %ifcont26
+then32:                                           ; preds = %ifcont30
+  store i32 1, i32* %array_bound31, align 4
+  br label %ifcont38
 
-else21:                                           ; preds = %ifcont18
-  br i1 false, label %then22, label %else23
+else33:                                           ; preds = %ifcont30
+  br i1 false, label %then34, label %else35
 
-then22:                                           ; preds = %else21
-  store i32 1, i32* %array_bound19, align 4
-  br label %ifcont26
+then34:                                           ; preds = %else33
+  store i32 1, i32* %array_bound31, align 4
+  br label %ifcont38
 
-else23:                                           ; preds = %else21
-  br i1 false, label %then24, label %else25
+else35:                                           ; preds = %else33
+  br i1 false, label %then36, label %else37
 
-then24:                                           ; preds = %else23
-  store i32 1, i32* %array_bound19, align 4
-  br label %ifcont26
+then36:                                           ; preds = %else35
+  store i32 1, i32* %array_bound31, align 4
+  br label %ifcont38
 
-else25:                                           ; preds = %else23
-  br label %ifcont26
+else37:                                           ; preds = %else35
+  br label %ifcont38
 
-ifcont26:                                         ; preds = %else25, %then24, %then22, %then20
-  %67 = load i32, i32* %array_bound19, align 4
+ifcont38:                                         ; preds = %else37, %then36, %then34, %then32
+  %67 = load i32, i32* %array_bound31, align 4
   %68 = sub i32 %67, 1
-  store i32 %68, i32* %__1_t, align 4
-  br label %loop.head27
+  store i32 %68, i32* %__1_t1, align 4
+  br label %loop.head39
 
-loop.head27:                                      ; preds = %loop.end106, %ifcont26
-  %69 = load i32, i32* %__1_t, align 4
+loop.head39:                                      ; preds = %loop.end118, %ifcont38
+  %69 = load i32, i32* %__1_t1, align 4
   %70 = add i32 %69, 1
-  br i1 true, label %then29, label %else30
+  br i1 true, label %then41, label %else42
 
-then29:                                           ; preds = %loop.head27
-  store i32 2, i32* %array_bound28, align 4
-  br label %ifcont35
+then41:                                           ; preds = %loop.head39
+  store i32 2, i32* %array_bound40, align 4
+  br label %ifcont47
 
-else30:                                           ; preds = %loop.head27
-  br i1 false, label %then31, label %else32
+else42:                                           ; preds = %loop.head39
+  br i1 false, label %then43, label %else44
 
-then31:                                           ; preds = %else30
-  store i32 2, i32* %array_bound28, align 4
-  br label %ifcont35
+then43:                                           ; preds = %else42
+  store i32 2, i32* %array_bound40, align 4
+  br label %ifcont47
 
-else32:                                           ; preds = %else30
-  br i1 false, label %then33, label %else34
+else44:                                           ; preds = %else42
+  br i1 false, label %then45, label %else46
 
-then33:                                           ; preds = %else32
-  store i32 1, i32* %array_bound28, align 4
-  br label %ifcont35
+then45:                                           ; preds = %else44
+  store i32 1, i32* %array_bound40, align 4
+  br label %ifcont47
 
-else34:                                           ; preds = %else32
-  br label %ifcont35
+else46:                                           ; preds = %else44
+  br label %ifcont47
 
-ifcont35:                                         ; preds = %else34, %then33, %then31, %then29
-  %71 = load i32, i32* %array_bound28, align 4
+ifcont47:                                         ; preds = %else46, %then45, %then43, %then41
+  %71 = load i32, i32* %array_bound40, align 4
   %72 = icmp sle i32 %70, %71
-  br i1 %72, label %loop.body36, label %loop.end107
+  br i1 %72, label %loop.body48, label %loop.end119
 
-loop.body36:                                      ; preds = %ifcont35
-  %73 = load i32, i32* %__1_t, align 4
+loop.body48:                                      ; preds = %ifcont47
+  %73 = load i32, i32* %__1_t1, align 4
   %74 = add i32 %73, 1
-  store i32 %74, i32* %__1_t, align 4
-  br i1 true, label %then38, label %else39
+  store i32 %74, i32* %__1_t1, align 4
+  br i1 true, label %then50, label %else51
 
-then38:                                           ; preds = %loop.body36
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont44
+then50:                                           ; preds = %loop.body48
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont56
 
-else39:                                           ; preds = %loop.body36
-  br i1 false, label %then40, label %else41
+else51:                                           ; preds = %loop.body48
+  br i1 false, label %then52, label %else53
 
-then40:                                           ; preds = %else39
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont44
+then52:                                           ; preds = %else51
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont56
 
-else41:                                           ; preds = %else39
-  br i1 false, label %then42, label %else43
-
-then42:                                           ; preds = %else41
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont44
-
-else43:                                           ; preds = %else41
-  br label %ifcont44
-
-ifcont44:                                         ; preds = %else43, %then42, %then40, %then38
-  %75 = load i32, i32* %array_bound37, align 4
-  store i32 %75, i32* %__2_v, align 4
-  br i1 true, label %then46, label %else47
-
-then46:                                           ; preds = %ifcont44
-  store i32 1, i32* %array_bound45, align 4
-  br label %ifcont52
-
-else47:                                           ; preds = %ifcont44
-  br i1 false, label %then48, label %else49
-
-then48:                                           ; preds = %else47
-  store i32 1, i32* %array_bound45, align 4
-  br label %ifcont52
-
-else49:                                           ; preds = %else47
-  br i1 false, label %then50, label %else51
-
-then50:                                           ; preds = %else49
-  store i32 1, i32* %array_bound45, align 4
-  br label %ifcont52
-
-else51:                                           ; preds = %else49
-  br label %ifcont52
-
-ifcont52:                                         ; preds = %else51, %then50, %then48, %then46
-  %76 = load i32, i32* %array_bound45, align 4
-  store i32 %76, i32* %__2_u, align 4
+else53:                                           ; preds = %else51
   br i1 false, label %then54, label %else55
 
-then54:                                           ; preds = %ifcont52
-  store i32 1, i32* %array_bound53, align 4
-  br label %ifcont60
+then54:                                           ; preds = %else53
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont56
 
-else55:                                           ; preds = %ifcont52
-  br i1 true, label %then56, label %else57
+else55:                                           ; preds = %else53
+  br label %ifcont56
 
-then56:                                           ; preds = %else55
-  store i32 1, i32* %array_bound53, align 4
-  br label %ifcont60
+ifcont56:                                         ; preds = %else55, %then54, %then52, %then50
+  %75 = load i32, i32* %array_bound49, align 4
+  store i32 %75, i32* %__2_v6, align 4
+  br i1 true, label %then58, label %else59
 
-else57:                                           ; preds = %else55
-  br i1 false, label %then58, label %else59
+then58:                                           ; preds = %ifcont56
+  store i32 1, i32* %array_bound57, align 4
+  br label %ifcont64
 
-then58:                                           ; preds = %else57
-  store i32 1, i32* %array_bound53, align 4
-  br label %ifcont60
+else59:                                           ; preds = %ifcont56
+  br i1 false, label %then60, label %else61
 
-else59:                                           ; preds = %else57
-  br label %ifcont60
+then60:                                           ; preds = %else59
+  store i32 1, i32* %array_bound57, align 4
+  br label %ifcont64
 
-ifcont60:                                         ; preds = %else59, %then58, %then56, %then54
-  %77 = load i32, i32* %array_bound53, align 4
+else61:                                           ; preds = %else59
+  br i1 false, label %then62, label %else63
+
+then62:                                           ; preds = %else61
+  store i32 1, i32* %array_bound57, align 4
+  br label %ifcont64
+
+else63:                                           ; preds = %else61
+  br label %ifcont64
+
+ifcont64:                                         ; preds = %else63, %then62, %then60, %then58
+  %76 = load i32, i32* %array_bound57, align 4
+  store i32 %76, i32* %__2_u5, align 4
+  br i1 false, label %then66, label %else67
+
+then66:                                           ; preds = %ifcont64
+  store i32 1, i32* %array_bound65, align 4
+  br label %ifcont72
+
+else67:                                           ; preds = %ifcont64
+  br i1 true, label %then68, label %else69
+
+then68:                                           ; preds = %else67
+  store i32 1, i32* %array_bound65, align 4
+  br label %ifcont72
+
+else69:                                           ; preds = %else67
+  br i1 false, label %then70, label %else71
+
+then70:                                           ; preds = %else69
+  store i32 1, i32* %array_bound65, align 4
+  br label %ifcont72
+
+else71:                                           ; preds = %else69
+  br label %ifcont72
+
+ifcont72:                                         ; preds = %else71, %then70, %then68, %then66
+  %77 = load i32, i32* %array_bound65, align 4
   %78 = sub i32 %77, 1
-  store i32 %78, i32* %__2_t, align 4
-  br label %loop.head61
+  store i32 %78, i32* %__2_t4, align 4
+  br label %loop.head73
 
-loop.head61:                                      ; preds = %loop.end105, %ifcont60
-  %79 = load i32, i32* %__2_t, align 4
+loop.head73:                                      ; preds = %loop.end117, %ifcont72
+  %79 = load i32, i32* %__2_t4, align 4
   %80 = add i32 %79, 1
-  br i1 false, label %then63, label %else64
+  br i1 false, label %then75, label %else76
 
-then63:                                           ; preds = %loop.head61
-  store i32 2, i32* %array_bound62, align 4
-  br label %ifcont69
+then75:                                           ; preds = %loop.head73
+  store i32 2, i32* %array_bound74, align 4
+  br label %ifcont81
 
-else64:                                           ; preds = %loop.head61
-  br i1 true, label %then65, label %else66
+else76:                                           ; preds = %loop.head73
+  br i1 true, label %then77, label %else78
 
-then65:                                           ; preds = %else64
-  store i32 2, i32* %array_bound62, align 4
-  br label %ifcont69
+then77:                                           ; preds = %else76
+  store i32 2, i32* %array_bound74, align 4
+  br label %ifcont81
 
-else66:                                           ; preds = %else64
-  br i1 false, label %then67, label %else68
+else78:                                           ; preds = %else76
+  br i1 false, label %then79, label %else80
 
-then67:                                           ; preds = %else66
-  store i32 1, i32* %array_bound62, align 4
-  br label %ifcont69
+then79:                                           ; preds = %else78
+  store i32 1, i32* %array_bound74, align 4
+  br label %ifcont81
 
-else68:                                           ; preds = %else66
-  br label %ifcont69
+else80:                                           ; preds = %else78
+  br label %ifcont81
 
-ifcont69:                                         ; preds = %else68, %then67, %then65, %then63
-  %81 = load i32, i32* %array_bound62, align 4
+ifcont81:                                         ; preds = %else80, %then79, %then77, %then75
+  %81 = load i32, i32* %array_bound74, align 4
   %82 = icmp sle i32 %80, %81
-  br i1 %82, label %loop.body70, label %loop.end106
+  br i1 %82, label %loop.body82, label %loop.end118
 
-loop.body70:                                      ; preds = %ifcont69
-  %83 = load i32, i32* %__2_t, align 4
+loop.body82:                                      ; preds = %ifcont81
+  %83 = load i32, i32* %__2_t4, align 4
   %84 = add i32 %83, 1
-  store i32 %84, i32* %__2_t, align 4
-  br i1 false, label %then72, label %else73
-
-then72:                                           ; preds = %loop.body70
-  store i32 1, i32* %array_bound71, align 4
-  br label %ifcont78
-
-else73:                                           ; preds = %loop.body70
-  br i1 true, label %then74, label %else75
-
-then74:                                           ; preds = %else73
-  store i32 1, i32* %array_bound71, align 4
-  br label %ifcont78
-
-else75:                                           ; preds = %else73
-  br i1 false, label %then76, label %else77
-
-then76:                                           ; preds = %else75
-  store i32 1, i32* %array_bound71, align 4
-  br label %ifcont78
-
-else77:                                           ; preds = %else75
-  br label %ifcont78
-
-ifcont78:                                         ; preds = %else77, %then76, %then74, %then72
-  %85 = load i32, i32* %array_bound71, align 4
-  store i32 %85, i32* %__3_v, align 4
-  br i1 false, label %then80, label %else81
-
-then80:                                           ; preds = %ifcont78
-  store i32 1, i32* %array_bound79, align 4
-  br label %ifcont86
-
-else81:                                           ; preds = %ifcont78
-  br i1 true, label %then82, label %else83
-
-then82:                                           ; preds = %else81
-  store i32 1, i32* %array_bound79, align 4
-  br label %ifcont86
-
-else83:                                           ; preds = %else81
+  store i32 %84, i32* %__2_t4, align 4
   br i1 false, label %then84, label %else85
 
-then84:                                           ; preds = %else83
-  store i32 1, i32* %array_bound79, align 4
-  br label %ifcont86
+then84:                                           ; preds = %loop.body82
+  store i32 1, i32* %array_bound83, align 4
+  br label %ifcont90
 
-else85:                                           ; preds = %else83
-  br label %ifcont86
+else85:                                           ; preds = %loop.body82
+  br i1 true, label %then86, label %else87
 
-ifcont86:                                         ; preds = %else85, %then84, %then82, %then80
-  %86 = load i32, i32* %array_bound79, align 4
-  store i32 %86, i32* %__3_u, align 4
+then86:                                           ; preds = %else85
+  store i32 1, i32* %array_bound83, align 4
+  br label %ifcont90
+
+else87:                                           ; preds = %else85
   br i1 false, label %then88, label %else89
 
-then88:                                           ; preds = %ifcont86
-  store i32 1, i32* %array_bound87, align 4
-  br label %ifcont94
+then88:                                           ; preds = %else87
+  store i32 1, i32* %array_bound83, align 4
+  br label %ifcont90
 
-else89:                                           ; preds = %ifcont86
-  br i1 false, label %then90, label %else91
+else89:                                           ; preds = %else87
+  br label %ifcont90
 
-then90:                                           ; preds = %else89
-  store i32 1, i32* %array_bound87, align 4
-  br label %ifcont94
+ifcont90:                                         ; preds = %else89, %then88, %then86, %then84
+  %85 = load i32, i32* %array_bound83, align 4
+  store i32 %85, i32* %__3_v9, align 4
+  br i1 false, label %then92, label %else93
 
-else91:                                           ; preds = %else89
-  br i1 true, label %then92, label %else93
+then92:                                           ; preds = %ifcont90
+  store i32 1, i32* %array_bound91, align 4
+  br label %ifcont98
 
-then92:                                           ; preds = %else91
-  store i32 1, i32* %array_bound87, align 4
-  br label %ifcont94
+else93:                                           ; preds = %ifcont90
+  br i1 true, label %then94, label %else95
 
-else93:                                           ; preds = %else91
-  br label %ifcont94
+then94:                                           ; preds = %else93
+  store i32 1, i32* %array_bound91, align 4
+  br label %ifcont98
 
-ifcont94:                                         ; preds = %else93, %then92, %then90, %then88
-  %87 = load i32, i32* %array_bound87, align 4
+else95:                                           ; preds = %else93
+  br i1 false, label %then96, label %else97
+
+then96:                                           ; preds = %else95
+  store i32 1, i32* %array_bound91, align 4
+  br label %ifcont98
+
+else97:                                           ; preds = %else95
+  br label %ifcont98
+
+ifcont98:                                         ; preds = %else97, %then96, %then94, %then92
+  %86 = load i32, i32* %array_bound91, align 4
+  store i32 %86, i32* %__3_u8, align 4
+  br i1 false, label %then100, label %else101
+
+then100:                                          ; preds = %ifcont98
+  store i32 1, i32* %array_bound99, align 4
+  br label %ifcont106
+
+else101:                                          ; preds = %ifcont98
+  br i1 false, label %then102, label %else103
+
+then102:                                          ; preds = %else101
+  store i32 1, i32* %array_bound99, align 4
+  br label %ifcont106
+
+else103:                                          ; preds = %else101
+  br i1 true, label %then104, label %else105
+
+then104:                                          ; preds = %else103
+  store i32 1, i32* %array_bound99, align 4
+  br label %ifcont106
+
+else105:                                          ; preds = %else103
+  br label %ifcont106
+
+ifcont106:                                        ; preds = %else105, %then104, %then102, %then100
+  %87 = load i32, i32* %array_bound99, align 4
   %88 = sub i32 %87, 1
-  store i32 %88, i32* %__3_t, align 4
-  br label %loop.head95
+  store i32 %88, i32* %__3_t7, align 4
+  br label %loop.head107
 
-loop.head95:                                      ; preds = %loop.body104, %ifcont94
-  %89 = load i32, i32* %__3_t, align 4
+loop.head107:                                     ; preds = %loop.body116, %ifcont106
+  %89 = load i32, i32* %__3_t7, align 4
   %90 = add i32 %89, 1
-  br i1 false, label %then97, label %else98
+  br i1 false, label %then109, label %else110
 
-then97:                                           ; preds = %loop.head95
-  store i32 2, i32* %array_bound96, align 4
-  br label %ifcont103
+then109:                                          ; preds = %loop.head107
+  store i32 2, i32* %array_bound108, align 4
+  br label %ifcont115
 
-else98:                                           ; preds = %loop.head95
-  br i1 false, label %then99, label %else100
+else110:                                          ; preds = %loop.head107
+  br i1 false, label %then111, label %else112
 
-then99:                                           ; preds = %else98
-  store i32 2, i32* %array_bound96, align 4
-  br label %ifcont103
+then111:                                          ; preds = %else110
+  store i32 2, i32* %array_bound108, align 4
+  br label %ifcont115
 
-else100:                                          ; preds = %else98
-  br i1 true, label %then101, label %else102
+else112:                                          ; preds = %else110
+  br i1 true, label %then113, label %else114
 
-then101:                                          ; preds = %else100
-  store i32 1, i32* %array_bound96, align 4
-  br label %ifcont103
+then113:                                          ; preds = %else112
+  store i32 1, i32* %array_bound108, align 4
+  br label %ifcont115
 
-else102:                                          ; preds = %else100
-  br label %ifcont103
+else114:                                          ; preds = %else112
+  br label %ifcont115
 
-ifcont103:                                        ; preds = %else102, %then101, %then99, %then97
-  %91 = load i32, i32* %array_bound96, align 4
+ifcont115:                                        ; preds = %else114, %then113, %then111, %then109
+  %91 = load i32, i32* %array_bound108, align 4
   %92 = icmp sle i32 %90, %91
-  br i1 %92, label %loop.body104, label %loop.end105
+  br i1 %92, label %loop.body116, label %loop.end117
 
-loop.body104:                                     ; preds = %ifcont103
-  %93 = load i32, i32* %__3_t, align 4
+loop.body116:                                     ; preds = %ifcont115
+  %93 = load i32, i32* %__3_t7, align 4
   %94 = add i32 %93, 1
-  store i32 %94, i32* %__3_t, align 4
-  %95 = load i32, i32* %__1_t, align 4
-  %96 = load i32, i32* %__2_t, align 4
-  %97 = load i32, i32* %__3_t, align 4
+  store i32 %94, i32* %__3_t7, align 4
+  %95 = load i32, i32* %__1_t1, align 4
+  %96 = load i32, i32* %__2_t4, align 4
+  %97 = load i32, i32* %__3_t7, align 4
   %98 = sub i32 %95, 1
   %99 = mul i32 1, %98
   %100 = add i32 0, %99
@@ -596,9 +608,9 @@ loop.body104:                                     ; preds = %ifcont103
   %105 = mul i32 4, %104
   %106 = add i32 %103, %105
   %107 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 %106
-  %108 = load i32, i32* %__1_v, align 4
-  %109 = load i32, i32* %__2_v, align 4
-  %110 = load i32, i32* %__3_v, align 4
+  %108 = load i32, i32* %__1_v3, align 4
+  %109 = load i32, i32* %__2_v6, align 4
+  %110 = load i32, i32* %__3_v9, align 4
   %111 = sub i32 %108, 1
   %112 = mul i32 1, %111
   %113 = add i32 0, %112
@@ -610,9 +622,9 @@ loop.body104:                                     ; preds = %ifcont103
   %119 = add i32 %116, %118
   %120 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %119
   %121 = load i32, i32* %120, align 4
-  %122 = load i32, i32* %__1_u, align 4
-  %123 = load i32, i32* %__2_u, align 4
-  %124 = load i32, i32* %__3_u, align 4
+  %122 = load i32, i32* %__1_u2, align 4
+  %123 = load i32, i32* %__2_u5, align 4
+  %124 = load i32, i32* %__3_u8, align 4
   %125 = sub i32 %122, 1
   %126 = mul i32 1, %125
   %127 = add i32 0, %126
@@ -626,33 +638,33 @@ loop.body104:                                     ; preds = %ifcont103
   %135 = load i32, i32* %134, align 4
   %136 = add i32 %121, %135
   store i32 %136, i32* %107, align 4
-  %137 = load i32, i32* %__3_v, align 4
+  %137 = load i32, i32* %__3_v9, align 4
   %138 = add i32 %137, 1
-  store i32 %138, i32* %__3_v, align 4
-  %139 = load i32, i32* %__3_u, align 4
+  store i32 %138, i32* %__3_v9, align 4
+  %139 = load i32, i32* %__3_u8, align 4
   %140 = add i32 %139, 1
-  store i32 %140, i32* %__3_u, align 4
-  br label %loop.head95
+  store i32 %140, i32* %__3_u8, align 4
+  br label %loop.head107
 
-loop.end105:                                      ; preds = %ifcont103
-  %141 = load i32, i32* %__2_v, align 4
+loop.end117:                                      ; preds = %ifcont115
+  %141 = load i32, i32* %__2_v6, align 4
   %142 = add i32 %141, 1
-  store i32 %142, i32* %__2_v, align 4
-  %143 = load i32, i32* %__2_u, align 4
+  store i32 %142, i32* %__2_v6, align 4
+  %143 = load i32, i32* %__2_u5, align 4
   %144 = add i32 %143, 1
-  store i32 %144, i32* %__2_u, align 4
-  br label %loop.head61
+  store i32 %144, i32* %__2_u5, align 4
+  br label %loop.head73
 
-loop.end106:                                      ; preds = %ifcont69
-  %145 = load i32, i32* %__1_v, align 4
+loop.end118:                                      ; preds = %ifcont81
+  %145 = load i32, i32* %__1_v3, align 4
   %146 = add i32 %145, 1
-  store i32 %146, i32* %__1_v, align 4
-  %147 = load i32, i32* %__1_u, align 4
+  store i32 %146, i32* %__1_v3, align 4
+  %147 = load i32, i32* %__1_u2, align 4
   %148 = add i32 %147, 1
-  store i32 %148, i32* %__1_u, align 4
-  br label %loop.head27
+  store i32 %148, i32* %__1_u2, align 4
+  br label %loop.head39
 
-loop.end107:                                      ; preds = %ifcont35
+loop.end119:                                      ; preds = %ifcont47
   %149 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %150 = load i32, i32* %149, align 4
   %151 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
@@ -665,410 +677,410 @@ loop.end107:                                      ; preds = %ifcont35
   %157 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %158 = load i32, i32* %157, align 4
   %159 = icmp ne i32 %158, 2
-  br i1 %159, label %then108, label %else109
+  br i1 %159, label %then120, label %else121
 
-then108:                                          ; preds = %loop.end107
+then120:                                          ; preds = %loop.end119
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont110
+  br label %ifcont122
 
-else109:                                          ; preds = %loop.end107
-  br label %ifcont110
+else121:                                          ; preds = %loop.end119
+  br label %ifcont122
 
-ifcont110:                                        ; preds = %else109, %then108
+ifcont122:                                        ; preds = %else121, %then120
   %160 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
   %161 = load i32, i32* %160, align 4
   %162 = icmp ne i32 %161, 5
-  br i1 %162, label %then111, label %else112
+  br i1 %162, label %then123, label %else124
 
-then111:                                          ; preds = %ifcont110
+then123:                                          ; preds = %ifcont122
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont113
+  br label %ifcont125
 
-else112:                                          ; preds = %ifcont110
-  br label %ifcont113
+else124:                                          ; preds = %ifcont122
+  br label %ifcont125
 
-ifcont113:                                        ; preds = %else112, %then111
+ifcont125:                                        ; preds = %else124, %then123
   %163 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 1
   %164 = load i32, i32* %163, align 4
   %165 = icmp ne i32 %164, 5
-  br i1 %165, label %then114, label %else115
+  br i1 %165, label %then126, label %else127
 
-then114:                                          ; preds = %ifcont113
+then126:                                          ; preds = %ifcont125
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont116
+  br label %ifcont128
 
-else115:                                          ; preds = %ifcont113
-  br label %ifcont116
+else127:                                          ; preds = %ifcont125
+  br label %ifcont128
 
-ifcont116:                                        ; preds = %else115, %then114
+ifcont128:                                        ; preds = %else127, %then126
   %166 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 3
   %167 = load i32, i32* %166, align 4
   %168 = icmp ne i32 %167, 8
-  br i1 %168, label %then117, label %else118
+  br i1 %168, label %then129, label %else130
 
-then117:                                          ; preds = %ifcont116
+then129:                                          ; preds = %ifcont128
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont119
+  br label %ifcont131
 
-else118:                                          ; preds = %ifcont116
-  br label %ifcont119
+else130:                                          ; preds = %ifcont128
+  br label %ifcont131
 
-ifcont119:                                        ; preds = %else118, %then117
-  br i1 true, label %then121, label %else122
+ifcont131:                                        ; preds = %else130, %then129
+  br i1 true, label %then133, label %else134
 
-then121:                                          ; preds = %ifcont119
-  store i32 1, i32* %array_bound120, align 4
-  br label %ifcont127
+then133:                                          ; preds = %ifcont131
+  store i32 1, i32* %array_bound132, align 4
+  br label %ifcont139
 
-else122:                                          ; preds = %ifcont119
-  br i1 false, label %then123, label %else124
+else134:                                          ; preds = %ifcont131
+  br i1 false, label %then135, label %else136
 
-then123:                                          ; preds = %else122
-  store i32 1, i32* %array_bound120, align 4
-  br label %ifcont127
+then135:                                          ; preds = %else134
+  store i32 1, i32* %array_bound132, align 4
+  br label %ifcont139
 
-else124:                                          ; preds = %else122
-  br i1 false, label %then125, label %else126
+else136:                                          ; preds = %else134
+  br i1 false, label %then137, label %else138
 
-then125:                                          ; preds = %else124
-  store i32 1, i32* %array_bound120, align 4
-  br label %ifcont127
+then137:                                          ; preds = %else136
+  store i32 1, i32* %array_bound132, align 4
+  br label %ifcont139
 
-else126:                                          ; preds = %else124
-  br label %ifcont127
+else138:                                          ; preds = %else136
+  br label %ifcont139
 
-ifcont127:                                        ; preds = %else126, %then125, %then123, %then121
-  %169 = load i32, i32* %array_bound120, align 4
-  store i32 %169, i32* %__1_v, align 4
-  br i1 true, label %then129, label %else130
+ifcont139:                                        ; preds = %else138, %then137, %then135, %then133
+  %169 = load i32, i32* %array_bound132, align 4
+  store i32 %169, i32* %__1_v3, align 4
+  br i1 true, label %then141, label %else142
 
-then129:                                          ; preds = %ifcont127
-  store i32 1, i32* %array_bound128, align 4
-  br label %ifcont135
+then141:                                          ; preds = %ifcont139
+  store i32 1, i32* %array_bound140, align 4
+  br label %ifcont147
 
-else130:                                          ; preds = %ifcont127
-  br i1 false, label %then131, label %else132
+else142:                                          ; preds = %ifcont139
+  br i1 false, label %then143, label %else144
 
-then131:                                          ; preds = %else130
-  store i32 1, i32* %array_bound128, align 4
-  br label %ifcont135
+then143:                                          ; preds = %else142
+  store i32 1, i32* %array_bound140, align 4
+  br label %ifcont147
 
-else132:                                          ; preds = %else130
-  br i1 false, label %then133, label %else134
+else144:                                          ; preds = %else142
+  br i1 false, label %then145, label %else146
 
-then133:                                          ; preds = %else132
-  store i32 1, i32* %array_bound128, align 4
-  br label %ifcont135
+then145:                                          ; preds = %else144
+  store i32 1, i32* %array_bound140, align 4
+  br label %ifcont147
 
-else134:                                          ; preds = %else132
-  br label %ifcont135
+else146:                                          ; preds = %else144
+  br label %ifcont147
 
-ifcont135:                                        ; preds = %else134, %then133, %then131, %then129
-  %170 = load i32, i32* %array_bound128, align 4
-  store i32 %170, i32* %__1_u, align 4
-  br i1 true, label %then137, label %else138
+ifcont147:                                        ; preds = %else146, %then145, %then143, %then141
+  %170 = load i32, i32* %array_bound140, align 4
+  store i32 %170, i32* %__1_u2, align 4
+  br i1 true, label %then149, label %else150
 
-then137:                                          ; preds = %ifcont135
-  store i32 1, i32* %array_bound136, align 4
-  br label %ifcont143
+then149:                                          ; preds = %ifcont147
+  store i32 1, i32* %array_bound148, align 4
+  br label %ifcont155
 
-else138:                                          ; preds = %ifcont135
-  br i1 false, label %then139, label %else140
+else150:                                          ; preds = %ifcont147
+  br i1 false, label %then151, label %else152
 
-then139:                                          ; preds = %else138
-  store i32 1, i32* %array_bound136, align 4
-  br label %ifcont143
+then151:                                          ; preds = %else150
+  store i32 1, i32* %array_bound148, align 4
+  br label %ifcont155
 
-else140:                                          ; preds = %else138
-  br i1 false, label %then141, label %else142
+else152:                                          ; preds = %else150
+  br i1 false, label %then153, label %else154
 
-then141:                                          ; preds = %else140
-  store i32 1, i32* %array_bound136, align 4
-  br label %ifcont143
+then153:                                          ; preds = %else152
+  store i32 1, i32* %array_bound148, align 4
+  br label %ifcont155
 
-else142:                                          ; preds = %else140
-  br label %ifcont143
+else154:                                          ; preds = %else152
+  br label %ifcont155
 
-ifcont143:                                        ; preds = %else142, %then141, %then139, %then137
-  %171 = load i32, i32* %array_bound136, align 4
+ifcont155:                                        ; preds = %else154, %then153, %then151, %then149
+  %171 = load i32, i32* %array_bound148, align 4
   %172 = sub i32 %171, 1
-  store i32 %172, i32* %__1_t, align 4
-  br label %loop.head144
+  store i32 %172, i32* %__1_t1, align 4
+  br label %loop.head156
 
-loop.head144:                                     ; preds = %loop.end223, %ifcont143
-  %173 = load i32, i32* %__1_t, align 4
+loop.head156:                                     ; preds = %loop.end235, %ifcont155
+  %173 = load i32, i32* %__1_t1, align 4
   %174 = add i32 %173, 1
-  br i1 true, label %then146, label %else147
+  br i1 true, label %then158, label %else159
 
-then146:                                          ; preds = %loop.head144
-  store i32 2, i32* %array_bound145, align 4
-  br label %ifcont152
+then158:                                          ; preds = %loop.head156
+  store i32 2, i32* %array_bound157, align 4
+  br label %ifcont164
 
-else147:                                          ; preds = %loop.head144
-  br i1 false, label %then148, label %else149
+else159:                                          ; preds = %loop.head156
+  br i1 false, label %then160, label %else161
 
-then148:                                          ; preds = %else147
-  store i32 2, i32* %array_bound145, align 4
-  br label %ifcont152
+then160:                                          ; preds = %else159
+  store i32 2, i32* %array_bound157, align 4
+  br label %ifcont164
 
-else149:                                          ; preds = %else147
-  br i1 false, label %then150, label %else151
+else161:                                          ; preds = %else159
+  br i1 false, label %then162, label %else163
 
-then150:                                          ; preds = %else149
-  store i32 1, i32* %array_bound145, align 4
-  br label %ifcont152
+then162:                                          ; preds = %else161
+  store i32 1, i32* %array_bound157, align 4
+  br label %ifcont164
 
-else151:                                          ; preds = %else149
-  br label %ifcont152
+else163:                                          ; preds = %else161
+  br label %ifcont164
 
-ifcont152:                                        ; preds = %else151, %then150, %then148, %then146
-  %175 = load i32, i32* %array_bound145, align 4
+ifcont164:                                        ; preds = %else163, %then162, %then160, %then158
+  %175 = load i32, i32* %array_bound157, align 4
   %176 = icmp sle i32 %174, %175
-  br i1 %176, label %loop.body153, label %loop.end224
+  br i1 %176, label %loop.body165, label %loop.end236
 
-loop.body153:                                     ; preds = %ifcont152
-  %177 = load i32, i32* %__1_t, align 4
+loop.body165:                                     ; preds = %ifcont164
+  %177 = load i32, i32* %__1_t1, align 4
   %178 = add i32 %177, 1
-  store i32 %178, i32* %__1_t, align 4
-  br i1 true, label %then155, label %else156
+  store i32 %178, i32* %__1_t1, align 4
+  br i1 true, label %then167, label %else168
 
-then155:                                          ; preds = %loop.body153
-  store i32 1, i32* %array_bound154, align 4
-  br label %ifcont161
+then167:                                          ; preds = %loop.body165
+  store i32 1, i32* %array_bound166, align 4
+  br label %ifcont173
 
-else156:                                          ; preds = %loop.body153
-  br i1 false, label %then157, label %else158
+else168:                                          ; preds = %loop.body165
+  br i1 false, label %then169, label %else170
 
-then157:                                          ; preds = %else156
-  store i32 1, i32* %array_bound154, align 4
-  br label %ifcont161
+then169:                                          ; preds = %else168
+  store i32 1, i32* %array_bound166, align 4
+  br label %ifcont173
 
-else158:                                          ; preds = %else156
-  br i1 false, label %then159, label %else160
-
-then159:                                          ; preds = %else158
-  store i32 1, i32* %array_bound154, align 4
-  br label %ifcont161
-
-else160:                                          ; preds = %else158
-  br label %ifcont161
-
-ifcont161:                                        ; preds = %else160, %then159, %then157, %then155
-  %179 = load i32, i32* %array_bound154, align 4
-  store i32 %179, i32* %__2_v, align 4
-  br i1 true, label %then163, label %else164
-
-then163:                                          ; preds = %ifcont161
-  store i32 1, i32* %array_bound162, align 4
-  br label %ifcont169
-
-else164:                                          ; preds = %ifcont161
-  br i1 false, label %then165, label %else166
-
-then165:                                          ; preds = %else164
-  store i32 1, i32* %array_bound162, align 4
-  br label %ifcont169
-
-else166:                                          ; preds = %else164
-  br i1 false, label %then167, label %else168
-
-then167:                                          ; preds = %else166
-  store i32 1, i32* %array_bound162, align 4
-  br label %ifcont169
-
-else168:                                          ; preds = %else166
-  br label %ifcont169
-
-ifcont169:                                        ; preds = %else168, %then167, %then165, %then163
-  %180 = load i32, i32* %array_bound162, align 4
-  store i32 %180, i32* %__2_u, align 4
+else170:                                          ; preds = %else168
   br i1 false, label %then171, label %else172
 
-then171:                                          ; preds = %ifcont169
-  store i32 1, i32* %array_bound170, align 4
-  br label %ifcont177
+then171:                                          ; preds = %else170
+  store i32 1, i32* %array_bound166, align 4
+  br label %ifcont173
 
-else172:                                          ; preds = %ifcont169
-  br i1 true, label %then173, label %else174
+else172:                                          ; preds = %else170
+  br label %ifcont173
 
-then173:                                          ; preds = %else172
-  store i32 1, i32* %array_bound170, align 4
-  br label %ifcont177
+ifcont173:                                        ; preds = %else172, %then171, %then169, %then167
+  %179 = load i32, i32* %array_bound166, align 4
+  store i32 %179, i32* %__2_v6, align 4
+  br i1 true, label %then175, label %else176
 
-else174:                                          ; preds = %else172
-  br i1 false, label %then175, label %else176
+then175:                                          ; preds = %ifcont173
+  store i32 1, i32* %array_bound174, align 4
+  br label %ifcont181
 
-then175:                                          ; preds = %else174
-  store i32 1, i32* %array_bound170, align 4
-  br label %ifcont177
+else176:                                          ; preds = %ifcont173
+  br i1 false, label %then177, label %else178
 
-else176:                                          ; preds = %else174
-  br label %ifcont177
+then177:                                          ; preds = %else176
+  store i32 1, i32* %array_bound174, align 4
+  br label %ifcont181
 
-ifcont177:                                        ; preds = %else176, %then175, %then173, %then171
-  %181 = load i32, i32* %array_bound170, align 4
+else178:                                          ; preds = %else176
+  br i1 false, label %then179, label %else180
+
+then179:                                          ; preds = %else178
+  store i32 1, i32* %array_bound174, align 4
+  br label %ifcont181
+
+else180:                                          ; preds = %else178
+  br label %ifcont181
+
+ifcont181:                                        ; preds = %else180, %then179, %then177, %then175
+  %180 = load i32, i32* %array_bound174, align 4
+  store i32 %180, i32* %__2_u5, align 4
+  br i1 false, label %then183, label %else184
+
+then183:                                          ; preds = %ifcont181
+  store i32 1, i32* %array_bound182, align 4
+  br label %ifcont189
+
+else184:                                          ; preds = %ifcont181
+  br i1 true, label %then185, label %else186
+
+then185:                                          ; preds = %else184
+  store i32 1, i32* %array_bound182, align 4
+  br label %ifcont189
+
+else186:                                          ; preds = %else184
+  br i1 false, label %then187, label %else188
+
+then187:                                          ; preds = %else186
+  store i32 1, i32* %array_bound182, align 4
+  br label %ifcont189
+
+else188:                                          ; preds = %else186
+  br label %ifcont189
+
+ifcont189:                                        ; preds = %else188, %then187, %then185, %then183
+  %181 = load i32, i32* %array_bound182, align 4
   %182 = sub i32 %181, 1
-  store i32 %182, i32* %__2_t, align 4
-  br label %loop.head178
+  store i32 %182, i32* %__2_t4, align 4
+  br label %loop.head190
 
-loop.head178:                                     ; preds = %loop.end222, %ifcont177
-  %183 = load i32, i32* %__2_t, align 4
+loop.head190:                                     ; preds = %loop.end234, %ifcont189
+  %183 = load i32, i32* %__2_t4, align 4
   %184 = add i32 %183, 1
-  br i1 false, label %then180, label %else181
+  br i1 false, label %then192, label %else193
 
-then180:                                          ; preds = %loop.head178
-  store i32 2, i32* %array_bound179, align 4
-  br label %ifcont186
+then192:                                          ; preds = %loop.head190
+  store i32 2, i32* %array_bound191, align 4
+  br label %ifcont198
 
-else181:                                          ; preds = %loop.head178
-  br i1 true, label %then182, label %else183
+else193:                                          ; preds = %loop.head190
+  br i1 true, label %then194, label %else195
 
-then182:                                          ; preds = %else181
-  store i32 2, i32* %array_bound179, align 4
-  br label %ifcont186
+then194:                                          ; preds = %else193
+  store i32 2, i32* %array_bound191, align 4
+  br label %ifcont198
 
-else183:                                          ; preds = %else181
-  br i1 false, label %then184, label %else185
+else195:                                          ; preds = %else193
+  br i1 false, label %then196, label %else197
 
-then184:                                          ; preds = %else183
-  store i32 1, i32* %array_bound179, align 4
-  br label %ifcont186
+then196:                                          ; preds = %else195
+  store i32 1, i32* %array_bound191, align 4
+  br label %ifcont198
 
-else185:                                          ; preds = %else183
-  br label %ifcont186
+else197:                                          ; preds = %else195
+  br label %ifcont198
 
-ifcont186:                                        ; preds = %else185, %then184, %then182, %then180
-  %185 = load i32, i32* %array_bound179, align 4
+ifcont198:                                        ; preds = %else197, %then196, %then194, %then192
+  %185 = load i32, i32* %array_bound191, align 4
   %186 = icmp sle i32 %184, %185
-  br i1 %186, label %loop.body187, label %loop.end223
+  br i1 %186, label %loop.body199, label %loop.end235
 
-loop.body187:                                     ; preds = %ifcont186
-  %187 = load i32, i32* %__2_t, align 4
+loop.body199:                                     ; preds = %ifcont198
+  %187 = load i32, i32* %__2_t4, align 4
   %188 = add i32 %187, 1
-  store i32 %188, i32* %__2_t, align 4
-  br i1 false, label %then189, label %else190
-
-then189:                                          ; preds = %loop.body187
-  store i32 1, i32* %array_bound188, align 4
-  br label %ifcont195
-
-else190:                                          ; preds = %loop.body187
-  br i1 true, label %then191, label %else192
-
-then191:                                          ; preds = %else190
-  store i32 1, i32* %array_bound188, align 4
-  br label %ifcont195
-
-else192:                                          ; preds = %else190
-  br i1 false, label %then193, label %else194
-
-then193:                                          ; preds = %else192
-  store i32 1, i32* %array_bound188, align 4
-  br label %ifcont195
-
-else194:                                          ; preds = %else192
-  br label %ifcont195
-
-ifcont195:                                        ; preds = %else194, %then193, %then191, %then189
-  %189 = load i32, i32* %array_bound188, align 4
-  store i32 %189, i32* %__3_v, align 4
-  br i1 false, label %then197, label %else198
-
-then197:                                          ; preds = %ifcont195
-  store i32 1, i32* %array_bound196, align 4
-  br label %ifcont203
-
-else198:                                          ; preds = %ifcont195
-  br i1 true, label %then199, label %else200
-
-then199:                                          ; preds = %else198
-  store i32 1, i32* %array_bound196, align 4
-  br label %ifcont203
-
-else200:                                          ; preds = %else198
+  store i32 %188, i32* %__2_t4, align 4
   br i1 false, label %then201, label %else202
 
-then201:                                          ; preds = %else200
-  store i32 1, i32* %array_bound196, align 4
-  br label %ifcont203
+then201:                                          ; preds = %loop.body199
+  store i32 1, i32* %array_bound200, align 4
+  br label %ifcont207
 
-else202:                                          ; preds = %else200
-  br label %ifcont203
+else202:                                          ; preds = %loop.body199
+  br i1 true, label %then203, label %else204
 
-ifcont203:                                        ; preds = %else202, %then201, %then199, %then197
-  %190 = load i32, i32* %array_bound196, align 4
-  store i32 %190, i32* %__3_u, align 4
+then203:                                          ; preds = %else202
+  store i32 1, i32* %array_bound200, align 4
+  br label %ifcont207
+
+else204:                                          ; preds = %else202
   br i1 false, label %then205, label %else206
 
-then205:                                          ; preds = %ifcont203
-  store i32 1, i32* %array_bound204, align 4
-  br label %ifcont211
+then205:                                          ; preds = %else204
+  store i32 1, i32* %array_bound200, align 4
+  br label %ifcont207
 
-else206:                                          ; preds = %ifcont203
-  br i1 false, label %then207, label %else208
+else206:                                          ; preds = %else204
+  br label %ifcont207
 
-then207:                                          ; preds = %else206
-  store i32 1, i32* %array_bound204, align 4
-  br label %ifcont211
+ifcont207:                                        ; preds = %else206, %then205, %then203, %then201
+  %189 = load i32, i32* %array_bound200, align 4
+  store i32 %189, i32* %__3_v9, align 4
+  br i1 false, label %then209, label %else210
 
-else208:                                          ; preds = %else206
-  br i1 true, label %then209, label %else210
+then209:                                          ; preds = %ifcont207
+  store i32 1, i32* %array_bound208, align 4
+  br label %ifcont215
 
-then209:                                          ; preds = %else208
-  store i32 1, i32* %array_bound204, align 4
-  br label %ifcont211
+else210:                                          ; preds = %ifcont207
+  br i1 true, label %then211, label %else212
 
-else210:                                          ; preds = %else208
-  br label %ifcont211
+then211:                                          ; preds = %else210
+  store i32 1, i32* %array_bound208, align 4
+  br label %ifcont215
 
-ifcont211:                                        ; preds = %else210, %then209, %then207, %then205
-  %191 = load i32, i32* %array_bound204, align 4
+else212:                                          ; preds = %else210
+  br i1 false, label %then213, label %else214
+
+then213:                                          ; preds = %else212
+  store i32 1, i32* %array_bound208, align 4
+  br label %ifcont215
+
+else214:                                          ; preds = %else212
+  br label %ifcont215
+
+ifcont215:                                        ; preds = %else214, %then213, %then211, %then209
+  %190 = load i32, i32* %array_bound208, align 4
+  store i32 %190, i32* %__3_u8, align 4
+  br i1 false, label %then217, label %else218
+
+then217:                                          ; preds = %ifcont215
+  store i32 1, i32* %array_bound216, align 4
+  br label %ifcont223
+
+else218:                                          ; preds = %ifcont215
+  br i1 false, label %then219, label %else220
+
+then219:                                          ; preds = %else218
+  store i32 1, i32* %array_bound216, align 4
+  br label %ifcont223
+
+else220:                                          ; preds = %else218
+  br i1 true, label %then221, label %else222
+
+then221:                                          ; preds = %else220
+  store i32 1, i32* %array_bound216, align 4
+  br label %ifcont223
+
+else222:                                          ; preds = %else220
+  br label %ifcont223
+
+ifcont223:                                        ; preds = %else222, %then221, %then219, %then217
+  %191 = load i32, i32* %array_bound216, align 4
   %192 = sub i32 %191, 1
-  store i32 %192, i32* %__3_t, align 4
-  br label %loop.head212
+  store i32 %192, i32* %__3_t7, align 4
+  br label %loop.head224
 
-loop.head212:                                     ; preds = %loop.body221, %ifcont211
-  %193 = load i32, i32* %__3_t, align 4
+loop.head224:                                     ; preds = %loop.body233, %ifcont223
+  %193 = load i32, i32* %__3_t7, align 4
   %194 = add i32 %193, 1
-  br i1 false, label %then214, label %else215
+  br i1 false, label %then226, label %else227
 
-then214:                                          ; preds = %loop.head212
-  store i32 2, i32* %array_bound213, align 4
-  br label %ifcont220
+then226:                                          ; preds = %loop.head224
+  store i32 2, i32* %array_bound225, align 4
+  br label %ifcont232
 
-else215:                                          ; preds = %loop.head212
-  br i1 false, label %then216, label %else217
+else227:                                          ; preds = %loop.head224
+  br i1 false, label %then228, label %else229
 
-then216:                                          ; preds = %else215
-  store i32 2, i32* %array_bound213, align 4
-  br label %ifcont220
+then228:                                          ; preds = %else227
+  store i32 2, i32* %array_bound225, align 4
+  br label %ifcont232
 
-else217:                                          ; preds = %else215
-  br i1 true, label %then218, label %else219
+else229:                                          ; preds = %else227
+  br i1 true, label %then230, label %else231
 
-then218:                                          ; preds = %else217
-  store i32 1, i32* %array_bound213, align 4
-  br label %ifcont220
+then230:                                          ; preds = %else229
+  store i32 1, i32* %array_bound225, align 4
+  br label %ifcont232
 
-else219:                                          ; preds = %else217
-  br label %ifcont220
+else231:                                          ; preds = %else229
+  br label %ifcont232
 
-ifcont220:                                        ; preds = %else219, %then218, %then216, %then214
-  %195 = load i32, i32* %array_bound213, align 4
+ifcont232:                                        ; preds = %else231, %then230, %then228, %then226
+  %195 = load i32, i32* %array_bound225, align 4
   %196 = icmp sle i32 %194, %195
-  br i1 %196, label %loop.body221, label %loop.end222
+  br i1 %196, label %loop.body233, label %loop.end234
 
-loop.body221:                                     ; preds = %ifcont220
-  %197 = load i32, i32* %__3_t, align 4
+loop.body233:                                     ; preds = %ifcont232
+  %197 = load i32, i32* %__3_t7, align 4
   %198 = add i32 %197, 1
-  store i32 %198, i32* %__3_t, align 4
-  %199 = load i32, i32* %__1_t, align 4
-  %200 = load i32, i32* %__2_t, align 4
-  %201 = load i32, i32* %__3_t, align 4
+  store i32 %198, i32* %__3_t7, align 4
+  %199 = load i32, i32* %__1_t1, align 4
+  %200 = load i32, i32* %__2_t4, align 4
+  %201 = load i32, i32* %__3_t7, align 4
   %202 = sub i32 %199, 1
   %203 = mul i32 1, %202
   %204 = add i32 0, %203
@@ -1079,9 +1091,9 @@ loop.body221:                                     ; preds = %ifcont220
   %209 = mul i32 4, %208
   %210 = add i32 %207, %209
   %211 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 %210
-  %212 = load i32, i32* %__1_v, align 4
-  %213 = load i32, i32* %__2_v, align 4
-  %214 = load i32, i32* %__3_v, align 4
+  %212 = load i32, i32* %__1_v3, align 4
+  %213 = load i32, i32* %__2_v6, align 4
+  %214 = load i32, i32* %__3_v9, align 4
   %215 = sub i32 %212, 1
   %216 = mul i32 1, %215
   %217 = add i32 0, %216
@@ -1093,9 +1105,9 @@ loop.body221:                                     ; preds = %ifcont220
   %223 = add i32 %220, %222
   %224 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %223
   %225 = load i32, i32* %224, align 4
-  %226 = load i32, i32* %__1_u, align 4
-  %227 = load i32, i32* %__2_u, align 4
-  %228 = load i32, i32* %__3_u, align 4
+  %226 = load i32, i32* %__1_u2, align 4
+  %227 = load i32, i32* %__2_u5, align 4
+  %228 = load i32, i32* %__3_u8, align 4
   %229 = sub i32 %226, 1
   %230 = mul i32 1, %229
   %231 = add i32 0, %230
@@ -1109,33 +1121,33 @@ loop.body221:                                     ; preds = %ifcont220
   %239 = load i32, i32* %238, align 4
   %240 = sub i32 %225, %239
   store i32 %240, i32* %211, align 4
-  %241 = load i32, i32* %__3_v, align 4
+  %241 = load i32, i32* %__3_v9, align 4
   %242 = add i32 %241, 1
-  store i32 %242, i32* %__3_v, align 4
-  %243 = load i32, i32* %__3_u, align 4
+  store i32 %242, i32* %__3_v9, align 4
+  %243 = load i32, i32* %__3_u8, align 4
   %244 = add i32 %243, 1
-  store i32 %244, i32* %__3_u, align 4
-  br label %loop.head212
+  store i32 %244, i32* %__3_u8, align 4
+  br label %loop.head224
 
-loop.end222:                                      ; preds = %ifcont220
-  %245 = load i32, i32* %__2_v, align 4
+loop.end234:                                      ; preds = %ifcont232
+  %245 = load i32, i32* %__2_v6, align 4
   %246 = add i32 %245, 1
-  store i32 %246, i32* %__2_v, align 4
-  %247 = load i32, i32* %__2_u, align 4
+  store i32 %246, i32* %__2_v6, align 4
+  %247 = load i32, i32* %__2_u5, align 4
   %248 = add i32 %247, 1
-  store i32 %248, i32* %__2_u, align 4
-  br label %loop.head178
+  store i32 %248, i32* %__2_u5, align 4
+  br label %loop.head190
 
-loop.end223:                                      ; preds = %ifcont186
-  %249 = load i32, i32* %__1_v, align 4
+loop.end235:                                      ; preds = %ifcont198
+  %249 = load i32, i32* %__1_v3, align 4
   %250 = add i32 %249, 1
-  store i32 %250, i32* %__1_v, align 4
-  %251 = load i32, i32* %__1_u, align 4
+  store i32 %250, i32* %__1_v3, align 4
+  %251 = load i32, i32* %__1_u2, align 4
   %252 = add i32 %251, 1
-  store i32 %252, i32* %__1_u, align 4
-  br label %loop.head144
+  store i32 %252, i32* %__1_u2, align 4
+  br label %loop.head156
 
-loop.end224:                                      ; preds = %ifcont152
+loop.end236:                                      ; preds = %ifcont164
   %253 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %254 = load i32, i32* %253, align 4
   %255 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
@@ -1148,410 +1160,410 @@ loop.end224:                                      ; preds = %ifcont152
   %261 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %262 = load i32, i32* %261, align 4
   %263 = icmp ne i32 %262, 0
-  br i1 %263, label %then225, label %else226
+  br i1 %263, label %then237, label %else238
 
-then225:                                          ; preds = %loop.end224
+then237:                                          ; preds = %loop.end236
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont227
+  br label %ifcont239
 
-else226:                                          ; preds = %loop.end224
-  br label %ifcont227
+else238:                                          ; preds = %loop.end236
+  br label %ifcont239
 
-ifcont227:                                        ; preds = %else226, %then225
+ifcont239:                                        ; preds = %else238, %then237
   %264 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
   %265 = load i32, i32* %264, align 4
   %266 = icmp ne i32 %265, -3
-  br i1 %266, label %then228, label %else229
+  br i1 %266, label %then240, label %else241
 
-then228:                                          ; preds = %ifcont227
+then240:                                          ; preds = %ifcont239
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont230
+  br label %ifcont242
 
-else229:                                          ; preds = %ifcont227
-  br label %ifcont230
+else241:                                          ; preds = %ifcont239
+  br label %ifcont242
 
-ifcont230:                                        ; preds = %else229, %then228
+ifcont242:                                        ; preds = %else241, %then240
   %267 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 1
   %268 = load i32, i32* %267, align 4
   %269 = icmp ne i32 %268, 3
-  br i1 %269, label %then231, label %else232
+  br i1 %269, label %then243, label %else244
 
-then231:                                          ; preds = %ifcont230
+then243:                                          ; preds = %ifcont242
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont233
+  br label %ifcont245
 
-else232:                                          ; preds = %ifcont230
-  br label %ifcont233
+else244:                                          ; preds = %ifcont242
+  br label %ifcont245
 
-ifcont233:                                        ; preds = %else232, %then231
+ifcont245:                                        ; preds = %else244, %then243
   %270 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 3
   %271 = load i32, i32* %270, align 4
   %272 = icmp ne i32 %271, 0
-  br i1 %272, label %then234, label %else235
+  br i1 %272, label %then246, label %else247
 
-then234:                                          ; preds = %ifcont233
+then246:                                          ; preds = %ifcont245
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont236
+  br label %ifcont248
 
-else235:                                          ; preds = %ifcont233
-  br label %ifcont236
+else247:                                          ; preds = %ifcont245
+  br label %ifcont248
 
-ifcont236:                                        ; preds = %else235, %then234
-  br i1 true, label %then238, label %else239
+ifcont248:                                        ; preds = %else247, %then246
+  br i1 true, label %then250, label %else251
 
-then238:                                          ; preds = %ifcont236
-  store i32 1, i32* %array_bound237, align 4
-  br label %ifcont244
+then250:                                          ; preds = %ifcont248
+  store i32 1, i32* %array_bound249, align 4
+  br label %ifcont256
 
-else239:                                          ; preds = %ifcont236
-  br i1 false, label %then240, label %else241
+else251:                                          ; preds = %ifcont248
+  br i1 false, label %then252, label %else253
 
-then240:                                          ; preds = %else239
-  store i32 1, i32* %array_bound237, align 4
-  br label %ifcont244
+then252:                                          ; preds = %else251
+  store i32 1, i32* %array_bound249, align 4
+  br label %ifcont256
 
-else241:                                          ; preds = %else239
-  br i1 false, label %then242, label %else243
+else253:                                          ; preds = %else251
+  br i1 false, label %then254, label %else255
 
-then242:                                          ; preds = %else241
-  store i32 1, i32* %array_bound237, align 4
-  br label %ifcont244
+then254:                                          ; preds = %else253
+  store i32 1, i32* %array_bound249, align 4
+  br label %ifcont256
 
-else243:                                          ; preds = %else241
-  br label %ifcont244
+else255:                                          ; preds = %else253
+  br label %ifcont256
 
-ifcont244:                                        ; preds = %else243, %then242, %then240, %then238
-  %273 = load i32, i32* %array_bound237, align 4
-  store i32 %273, i32* %__1_v, align 4
-  br i1 true, label %then246, label %else247
+ifcont256:                                        ; preds = %else255, %then254, %then252, %then250
+  %273 = load i32, i32* %array_bound249, align 4
+  store i32 %273, i32* %__1_v3, align 4
+  br i1 true, label %then258, label %else259
 
-then246:                                          ; preds = %ifcont244
-  store i32 1, i32* %array_bound245, align 4
-  br label %ifcont252
+then258:                                          ; preds = %ifcont256
+  store i32 1, i32* %array_bound257, align 4
+  br label %ifcont264
 
-else247:                                          ; preds = %ifcont244
-  br i1 false, label %then248, label %else249
+else259:                                          ; preds = %ifcont256
+  br i1 false, label %then260, label %else261
 
-then248:                                          ; preds = %else247
-  store i32 1, i32* %array_bound245, align 4
-  br label %ifcont252
+then260:                                          ; preds = %else259
+  store i32 1, i32* %array_bound257, align 4
+  br label %ifcont264
 
-else249:                                          ; preds = %else247
-  br i1 false, label %then250, label %else251
+else261:                                          ; preds = %else259
+  br i1 false, label %then262, label %else263
 
-then250:                                          ; preds = %else249
-  store i32 1, i32* %array_bound245, align 4
-  br label %ifcont252
+then262:                                          ; preds = %else261
+  store i32 1, i32* %array_bound257, align 4
+  br label %ifcont264
 
-else251:                                          ; preds = %else249
-  br label %ifcont252
+else263:                                          ; preds = %else261
+  br label %ifcont264
 
-ifcont252:                                        ; preds = %else251, %then250, %then248, %then246
-  %274 = load i32, i32* %array_bound245, align 4
-  store i32 %274, i32* %__1_u, align 4
-  br i1 true, label %then254, label %else255
+ifcont264:                                        ; preds = %else263, %then262, %then260, %then258
+  %274 = load i32, i32* %array_bound257, align 4
+  store i32 %274, i32* %__1_u2, align 4
+  br i1 true, label %then266, label %else267
 
-then254:                                          ; preds = %ifcont252
-  store i32 1, i32* %array_bound253, align 4
-  br label %ifcont260
+then266:                                          ; preds = %ifcont264
+  store i32 1, i32* %array_bound265, align 4
+  br label %ifcont272
 
-else255:                                          ; preds = %ifcont252
-  br i1 false, label %then256, label %else257
+else267:                                          ; preds = %ifcont264
+  br i1 false, label %then268, label %else269
 
-then256:                                          ; preds = %else255
-  store i32 1, i32* %array_bound253, align 4
-  br label %ifcont260
+then268:                                          ; preds = %else267
+  store i32 1, i32* %array_bound265, align 4
+  br label %ifcont272
 
-else257:                                          ; preds = %else255
-  br i1 false, label %then258, label %else259
+else269:                                          ; preds = %else267
+  br i1 false, label %then270, label %else271
 
-then258:                                          ; preds = %else257
-  store i32 1, i32* %array_bound253, align 4
-  br label %ifcont260
+then270:                                          ; preds = %else269
+  store i32 1, i32* %array_bound265, align 4
+  br label %ifcont272
 
-else259:                                          ; preds = %else257
-  br label %ifcont260
+else271:                                          ; preds = %else269
+  br label %ifcont272
 
-ifcont260:                                        ; preds = %else259, %then258, %then256, %then254
-  %275 = load i32, i32* %array_bound253, align 4
+ifcont272:                                        ; preds = %else271, %then270, %then268, %then266
+  %275 = load i32, i32* %array_bound265, align 4
   %276 = sub i32 %275, 1
-  store i32 %276, i32* %__1_t, align 4
-  br label %loop.head261
+  store i32 %276, i32* %__1_t1, align 4
+  br label %loop.head273
 
-loop.head261:                                     ; preds = %loop.end340, %ifcont260
-  %277 = load i32, i32* %__1_t, align 4
+loop.head273:                                     ; preds = %loop.end352, %ifcont272
+  %277 = load i32, i32* %__1_t1, align 4
   %278 = add i32 %277, 1
-  br i1 true, label %then263, label %else264
+  br i1 true, label %then275, label %else276
 
-then263:                                          ; preds = %loop.head261
-  store i32 2, i32* %array_bound262, align 4
-  br label %ifcont269
+then275:                                          ; preds = %loop.head273
+  store i32 2, i32* %array_bound274, align 4
+  br label %ifcont281
 
-else264:                                          ; preds = %loop.head261
-  br i1 false, label %then265, label %else266
+else276:                                          ; preds = %loop.head273
+  br i1 false, label %then277, label %else278
 
-then265:                                          ; preds = %else264
-  store i32 2, i32* %array_bound262, align 4
-  br label %ifcont269
+then277:                                          ; preds = %else276
+  store i32 2, i32* %array_bound274, align 4
+  br label %ifcont281
 
-else266:                                          ; preds = %else264
-  br i1 false, label %then267, label %else268
+else278:                                          ; preds = %else276
+  br i1 false, label %then279, label %else280
 
-then267:                                          ; preds = %else266
-  store i32 1, i32* %array_bound262, align 4
-  br label %ifcont269
+then279:                                          ; preds = %else278
+  store i32 1, i32* %array_bound274, align 4
+  br label %ifcont281
 
-else268:                                          ; preds = %else266
-  br label %ifcont269
+else280:                                          ; preds = %else278
+  br label %ifcont281
 
-ifcont269:                                        ; preds = %else268, %then267, %then265, %then263
-  %279 = load i32, i32* %array_bound262, align 4
+ifcont281:                                        ; preds = %else280, %then279, %then277, %then275
+  %279 = load i32, i32* %array_bound274, align 4
   %280 = icmp sle i32 %278, %279
-  br i1 %280, label %loop.body270, label %loop.end341
+  br i1 %280, label %loop.body282, label %loop.end353
 
-loop.body270:                                     ; preds = %ifcont269
-  %281 = load i32, i32* %__1_t, align 4
+loop.body282:                                     ; preds = %ifcont281
+  %281 = load i32, i32* %__1_t1, align 4
   %282 = add i32 %281, 1
-  store i32 %282, i32* %__1_t, align 4
-  br i1 true, label %then272, label %else273
+  store i32 %282, i32* %__1_t1, align 4
+  br i1 true, label %then284, label %else285
 
-then272:                                          ; preds = %loop.body270
-  store i32 1, i32* %array_bound271, align 4
-  br label %ifcont278
+then284:                                          ; preds = %loop.body282
+  store i32 1, i32* %array_bound283, align 4
+  br label %ifcont290
 
-else273:                                          ; preds = %loop.body270
-  br i1 false, label %then274, label %else275
+else285:                                          ; preds = %loop.body282
+  br i1 false, label %then286, label %else287
 
-then274:                                          ; preds = %else273
-  store i32 1, i32* %array_bound271, align 4
-  br label %ifcont278
+then286:                                          ; preds = %else285
+  store i32 1, i32* %array_bound283, align 4
+  br label %ifcont290
 
-else275:                                          ; preds = %else273
-  br i1 false, label %then276, label %else277
-
-then276:                                          ; preds = %else275
-  store i32 1, i32* %array_bound271, align 4
-  br label %ifcont278
-
-else277:                                          ; preds = %else275
-  br label %ifcont278
-
-ifcont278:                                        ; preds = %else277, %then276, %then274, %then272
-  %283 = load i32, i32* %array_bound271, align 4
-  store i32 %283, i32* %__2_v, align 4
-  br i1 true, label %then280, label %else281
-
-then280:                                          ; preds = %ifcont278
-  store i32 1, i32* %array_bound279, align 4
-  br label %ifcont286
-
-else281:                                          ; preds = %ifcont278
-  br i1 false, label %then282, label %else283
-
-then282:                                          ; preds = %else281
-  store i32 1, i32* %array_bound279, align 4
-  br label %ifcont286
-
-else283:                                          ; preds = %else281
-  br i1 false, label %then284, label %else285
-
-then284:                                          ; preds = %else283
-  store i32 1, i32* %array_bound279, align 4
-  br label %ifcont286
-
-else285:                                          ; preds = %else283
-  br label %ifcont286
-
-ifcont286:                                        ; preds = %else285, %then284, %then282, %then280
-  %284 = load i32, i32* %array_bound279, align 4
-  store i32 %284, i32* %__2_u, align 4
+else287:                                          ; preds = %else285
   br i1 false, label %then288, label %else289
 
-then288:                                          ; preds = %ifcont286
-  store i32 1, i32* %array_bound287, align 4
-  br label %ifcont294
+then288:                                          ; preds = %else287
+  store i32 1, i32* %array_bound283, align 4
+  br label %ifcont290
 
-else289:                                          ; preds = %ifcont286
-  br i1 true, label %then290, label %else291
+else289:                                          ; preds = %else287
+  br label %ifcont290
 
-then290:                                          ; preds = %else289
-  store i32 1, i32* %array_bound287, align 4
-  br label %ifcont294
+ifcont290:                                        ; preds = %else289, %then288, %then286, %then284
+  %283 = load i32, i32* %array_bound283, align 4
+  store i32 %283, i32* %__2_v6, align 4
+  br i1 true, label %then292, label %else293
 
-else291:                                          ; preds = %else289
-  br i1 false, label %then292, label %else293
+then292:                                          ; preds = %ifcont290
+  store i32 1, i32* %array_bound291, align 4
+  br label %ifcont298
 
-then292:                                          ; preds = %else291
-  store i32 1, i32* %array_bound287, align 4
-  br label %ifcont294
+else293:                                          ; preds = %ifcont290
+  br i1 false, label %then294, label %else295
 
-else293:                                          ; preds = %else291
-  br label %ifcont294
+then294:                                          ; preds = %else293
+  store i32 1, i32* %array_bound291, align 4
+  br label %ifcont298
 
-ifcont294:                                        ; preds = %else293, %then292, %then290, %then288
-  %285 = load i32, i32* %array_bound287, align 4
+else295:                                          ; preds = %else293
+  br i1 false, label %then296, label %else297
+
+then296:                                          ; preds = %else295
+  store i32 1, i32* %array_bound291, align 4
+  br label %ifcont298
+
+else297:                                          ; preds = %else295
+  br label %ifcont298
+
+ifcont298:                                        ; preds = %else297, %then296, %then294, %then292
+  %284 = load i32, i32* %array_bound291, align 4
+  store i32 %284, i32* %__2_u5, align 4
+  br i1 false, label %then300, label %else301
+
+then300:                                          ; preds = %ifcont298
+  store i32 1, i32* %array_bound299, align 4
+  br label %ifcont306
+
+else301:                                          ; preds = %ifcont298
+  br i1 true, label %then302, label %else303
+
+then302:                                          ; preds = %else301
+  store i32 1, i32* %array_bound299, align 4
+  br label %ifcont306
+
+else303:                                          ; preds = %else301
+  br i1 false, label %then304, label %else305
+
+then304:                                          ; preds = %else303
+  store i32 1, i32* %array_bound299, align 4
+  br label %ifcont306
+
+else305:                                          ; preds = %else303
+  br label %ifcont306
+
+ifcont306:                                        ; preds = %else305, %then304, %then302, %then300
+  %285 = load i32, i32* %array_bound299, align 4
   %286 = sub i32 %285, 1
-  store i32 %286, i32* %__2_t, align 4
-  br label %loop.head295
+  store i32 %286, i32* %__2_t4, align 4
+  br label %loop.head307
 
-loop.head295:                                     ; preds = %loop.end339, %ifcont294
-  %287 = load i32, i32* %__2_t, align 4
+loop.head307:                                     ; preds = %loop.end351, %ifcont306
+  %287 = load i32, i32* %__2_t4, align 4
   %288 = add i32 %287, 1
-  br i1 false, label %then297, label %else298
+  br i1 false, label %then309, label %else310
 
-then297:                                          ; preds = %loop.head295
-  store i32 2, i32* %array_bound296, align 4
-  br label %ifcont303
+then309:                                          ; preds = %loop.head307
+  store i32 2, i32* %array_bound308, align 4
+  br label %ifcont315
 
-else298:                                          ; preds = %loop.head295
-  br i1 true, label %then299, label %else300
+else310:                                          ; preds = %loop.head307
+  br i1 true, label %then311, label %else312
 
-then299:                                          ; preds = %else298
-  store i32 2, i32* %array_bound296, align 4
-  br label %ifcont303
+then311:                                          ; preds = %else310
+  store i32 2, i32* %array_bound308, align 4
+  br label %ifcont315
 
-else300:                                          ; preds = %else298
-  br i1 false, label %then301, label %else302
+else312:                                          ; preds = %else310
+  br i1 false, label %then313, label %else314
 
-then301:                                          ; preds = %else300
-  store i32 1, i32* %array_bound296, align 4
-  br label %ifcont303
+then313:                                          ; preds = %else312
+  store i32 1, i32* %array_bound308, align 4
+  br label %ifcont315
 
-else302:                                          ; preds = %else300
-  br label %ifcont303
+else314:                                          ; preds = %else312
+  br label %ifcont315
 
-ifcont303:                                        ; preds = %else302, %then301, %then299, %then297
-  %289 = load i32, i32* %array_bound296, align 4
+ifcont315:                                        ; preds = %else314, %then313, %then311, %then309
+  %289 = load i32, i32* %array_bound308, align 4
   %290 = icmp sle i32 %288, %289
-  br i1 %290, label %loop.body304, label %loop.end340
+  br i1 %290, label %loop.body316, label %loop.end352
 
-loop.body304:                                     ; preds = %ifcont303
-  %291 = load i32, i32* %__2_t, align 4
+loop.body316:                                     ; preds = %ifcont315
+  %291 = load i32, i32* %__2_t4, align 4
   %292 = add i32 %291, 1
-  store i32 %292, i32* %__2_t, align 4
-  br i1 false, label %then306, label %else307
-
-then306:                                          ; preds = %loop.body304
-  store i32 1, i32* %array_bound305, align 4
-  br label %ifcont312
-
-else307:                                          ; preds = %loop.body304
-  br i1 true, label %then308, label %else309
-
-then308:                                          ; preds = %else307
-  store i32 1, i32* %array_bound305, align 4
-  br label %ifcont312
-
-else309:                                          ; preds = %else307
-  br i1 false, label %then310, label %else311
-
-then310:                                          ; preds = %else309
-  store i32 1, i32* %array_bound305, align 4
-  br label %ifcont312
-
-else311:                                          ; preds = %else309
-  br label %ifcont312
-
-ifcont312:                                        ; preds = %else311, %then310, %then308, %then306
-  %293 = load i32, i32* %array_bound305, align 4
-  store i32 %293, i32* %__3_v, align 4
-  br i1 false, label %then314, label %else315
-
-then314:                                          ; preds = %ifcont312
-  store i32 1, i32* %array_bound313, align 4
-  br label %ifcont320
-
-else315:                                          ; preds = %ifcont312
-  br i1 true, label %then316, label %else317
-
-then316:                                          ; preds = %else315
-  store i32 1, i32* %array_bound313, align 4
-  br label %ifcont320
-
-else317:                                          ; preds = %else315
+  store i32 %292, i32* %__2_t4, align 4
   br i1 false, label %then318, label %else319
 
-then318:                                          ; preds = %else317
-  store i32 1, i32* %array_bound313, align 4
-  br label %ifcont320
+then318:                                          ; preds = %loop.body316
+  store i32 1, i32* %array_bound317, align 4
+  br label %ifcont324
 
-else319:                                          ; preds = %else317
-  br label %ifcont320
+else319:                                          ; preds = %loop.body316
+  br i1 true, label %then320, label %else321
 
-ifcont320:                                        ; preds = %else319, %then318, %then316, %then314
-  %294 = load i32, i32* %array_bound313, align 4
-  store i32 %294, i32* %__3_u, align 4
+then320:                                          ; preds = %else319
+  store i32 1, i32* %array_bound317, align 4
+  br label %ifcont324
+
+else321:                                          ; preds = %else319
   br i1 false, label %then322, label %else323
 
-then322:                                          ; preds = %ifcont320
-  store i32 1, i32* %array_bound321, align 4
-  br label %ifcont328
+then322:                                          ; preds = %else321
+  store i32 1, i32* %array_bound317, align 4
+  br label %ifcont324
 
-else323:                                          ; preds = %ifcont320
-  br i1 false, label %then324, label %else325
+else323:                                          ; preds = %else321
+  br label %ifcont324
 
-then324:                                          ; preds = %else323
-  store i32 1, i32* %array_bound321, align 4
-  br label %ifcont328
+ifcont324:                                        ; preds = %else323, %then322, %then320, %then318
+  %293 = load i32, i32* %array_bound317, align 4
+  store i32 %293, i32* %__3_v9, align 4
+  br i1 false, label %then326, label %else327
 
-else325:                                          ; preds = %else323
-  br i1 true, label %then326, label %else327
+then326:                                          ; preds = %ifcont324
+  store i32 1, i32* %array_bound325, align 4
+  br label %ifcont332
 
-then326:                                          ; preds = %else325
-  store i32 1, i32* %array_bound321, align 4
-  br label %ifcont328
+else327:                                          ; preds = %ifcont324
+  br i1 true, label %then328, label %else329
 
-else327:                                          ; preds = %else325
-  br label %ifcont328
+then328:                                          ; preds = %else327
+  store i32 1, i32* %array_bound325, align 4
+  br label %ifcont332
 
-ifcont328:                                        ; preds = %else327, %then326, %then324, %then322
-  %295 = load i32, i32* %array_bound321, align 4
+else329:                                          ; preds = %else327
+  br i1 false, label %then330, label %else331
+
+then330:                                          ; preds = %else329
+  store i32 1, i32* %array_bound325, align 4
+  br label %ifcont332
+
+else331:                                          ; preds = %else329
+  br label %ifcont332
+
+ifcont332:                                        ; preds = %else331, %then330, %then328, %then326
+  %294 = load i32, i32* %array_bound325, align 4
+  store i32 %294, i32* %__3_u8, align 4
+  br i1 false, label %then334, label %else335
+
+then334:                                          ; preds = %ifcont332
+  store i32 1, i32* %array_bound333, align 4
+  br label %ifcont340
+
+else335:                                          ; preds = %ifcont332
+  br i1 false, label %then336, label %else337
+
+then336:                                          ; preds = %else335
+  store i32 1, i32* %array_bound333, align 4
+  br label %ifcont340
+
+else337:                                          ; preds = %else335
+  br i1 true, label %then338, label %else339
+
+then338:                                          ; preds = %else337
+  store i32 1, i32* %array_bound333, align 4
+  br label %ifcont340
+
+else339:                                          ; preds = %else337
+  br label %ifcont340
+
+ifcont340:                                        ; preds = %else339, %then338, %then336, %then334
+  %295 = load i32, i32* %array_bound333, align 4
   %296 = sub i32 %295, 1
-  store i32 %296, i32* %__3_t, align 4
-  br label %loop.head329
+  store i32 %296, i32* %__3_t7, align 4
+  br label %loop.head341
 
-loop.head329:                                     ; preds = %loop.body338, %ifcont328
-  %297 = load i32, i32* %__3_t, align 4
+loop.head341:                                     ; preds = %loop.body350, %ifcont340
+  %297 = load i32, i32* %__3_t7, align 4
   %298 = add i32 %297, 1
-  br i1 false, label %then331, label %else332
+  br i1 false, label %then343, label %else344
 
-then331:                                          ; preds = %loop.head329
-  store i32 2, i32* %array_bound330, align 4
-  br label %ifcont337
+then343:                                          ; preds = %loop.head341
+  store i32 2, i32* %array_bound342, align 4
+  br label %ifcont349
 
-else332:                                          ; preds = %loop.head329
-  br i1 false, label %then333, label %else334
+else344:                                          ; preds = %loop.head341
+  br i1 false, label %then345, label %else346
 
-then333:                                          ; preds = %else332
-  store i32 2, i32* %array_bound330, align 4
-  br label %ifcont337
+then345:                                          ; preds = %else344
+  store i32 2, i32* %array_bound342, align 4
+  br label %ifcont349
 
-else334:                                          ; preds = %else332
-  br i1 true, label %then335, label %else336
+else346:                                          ; preds = %else344
+  br i1 true, label %then347, label %else348
 
-then335:                                          ; preds = %else334
-  store i32 1, i32* %array_bound330, align 4
-  br label %ifcont337
+then347:                                          ; preds = %else346
+  store i32 1, i32* %array_bound342, align 4
+  br label %ifcont349
 
-else336:                                          ; preds = %else334
-  br label %ifcont337
+else348:                                          ; preds = %else346
+  br label %ifcont349
 
-ifcont337:                                        ; preds = %else336, %then335, %then333, %then331
-  %299 = load i32, i32* %array_bound330, align 4
+ifcont349:                                        ; preds = %else348, %then347, %then345, %then343
+  %299 = load i32, i32* %array_bound342, align 4
   %300 = icmp sle i32 %298, %299
-  br i1 %300, label %loop.body338, label %loop.end339
+  br i1 %300, label %loop.body350, label %loop.end351
 
-loop.body338:                                     ; preds = %ifcont337
-  %301 = load i32, i32* %__3_t, align 4
+loop.body350:                                     ; preds = %ifcont349
+  %301 = load i32, i32* %__3_t7, align 4
   %302 = add i32 %301, 1
-  store i32 %302, i32* %__3_t, align 4
-  %303 = load i32, i32* %__1_t, align 4
-  %304 = load i32, i32* %__2_t, align 4
-  %305 = load i32, i32* %__3_t, align 4
+  store i32 %302, i32* %__3_t7, align 4
+  %303 = load i32, i32* %__1_t1, align 4
+  %304 = load i32, i32* %__2_t4, align 4
+  %305 = load i32, i32* %__3_t7, align 4
   %306 = sub i32 %303, 1
   %307 = mul i32 1, %306
   %308 = add i32 0, %307
@@ -1562,9 +1574,9 @@ loop.body338:                                     ; preds = %ifcont337
   %313 = mul i32 4, %312
   %314 = add i32 %311, %313
   %315 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 %314
-  %316 = load i32, i32* %__1_v, align 4
-  %317 = load i32, i32* %__2_v, align 4
-  %318 = load i32, i32* %__3_v, align 4
+  %316 = load i32, i32* %__1_v3, align 4
+  %317 = load i32, i32* %__2_v6, align 4
+  %318 = load i32, i32* %__3_v9, align 4
   %319 = sub i32 %316, 1
   %320 = mul i32 1, %319
   %321 = add i32 0, %320
@@ -1576,9 +1588,9 @@ loop.body338:                                     ; preds = %ifcont337
   %327 = add i32 %324, %326
   %328 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %327
   %329 = load i32, i32* %328, align 4
-  %330 = load i32, i32* %__1_u, align 4
-  %331 = load i32, i32* %__2_u, align 4
-  %332 = load i32, i32* %__3_u, align 4
+  %330 = load i32, i32* %__1_u2, align 4
+  %331 = load i32, i32* %__2_u5, align 4
+  %332 = load i32, i32* %__3_u8, align 4
   %333 = sub i32 %330, 1
   %334 = mul i32 1, %333
   %335 = add i32 0, %334
@@ -1592,33 +1604,33 @@ loop.body338:                                     ; preds = %ifcont337
   %343 = load i32, i32* %342, align 4
   %344 = mul i32 %329, %343
   store i32 %344, i32* %315, align 4
-  %345 = load i32, i32* %__3_v, align 4
+  %345 = load i32, i32* %__3_v9, align 4
   %346 = add i32 %345, 1
-  store i32 %346, i32* %__3_v, align 4
-  %347 = load i32, i32* %__3_u, align 4
+  store i32 %346, i32* %__3_v9, align 4
+  %347 = load i32, i32* %__3_u8, align 4
   %348 = add i32 %347, 1
-  store i32 %348, i32* %__3_u, align 4
-  br label %loop.head329
+  store i32 %348, i32* %__3_u8, align 4
+  br label %loop.head341
 
-loop.end339:                                      ; preds = %ifcont337
-  %349 = load i32, i32* %__2_v, align 4
+loop.end351:                                      ; preds = %ifcont349
+  %349 = load i32, i32* %__2_v6, align 4
   %350 = add i32 %349, 1
-  store i32 %350, i32* %__2_v, align 4
-  %351 = load i32, i32* %__2_u, align 4
+  store i32 %350, i32* %__2_v6, align 4
+  %351 = load i32, i32* %__2_u5, align 4
   %352 = add i32 %351, 1
-  store i32 %352, i32* %__2_u, align 4
-  br label %loop.head295
+  store i32 %352, i32* %__2_u5, align 4
+  br label %loop.head307
 
-loop.end340:                                      ; preds = %ifcont303
-  %353 = load i32, i32* %__1_v, align 4
+loop.end352:                                      ; preds = %ifcont315
+  %353 = load i32, i32* %__1_v3, align 4
   %354 = add i32 %353, 1
-  store i32 %354, i32* %__1_v, align 4
-  %355 = load i32, i32* %__1_u, align 4
+  store i32 %354, i32* %__1_v3, align 4
+  %355 = load i32, i32* %__1_u2, align 4
   %356 = add i32 %355, 1
-  store i32 %356, i32* %__1_u, align 4
-  br label %loop.head261
+  store i32 %356, i32* %__1_u2, align 4
+  br label %loop.head273
 
-loop.end341:                                      ; preds = %ifcont269
+loop.end353:                                      ; preds = %ifcont281
   %357 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %358 = load i32, i32* %357, align 4
   %359 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
@@ -1631,410 +1643,410 @@ loop.end341:                                      ; preds = %ifcont269
   %365 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %366 = load i32, i32* %365, align 4
   %367 = icmp ne i32 %366, 1
-  br i1 %367, label %then342, label %else343
+  br i1 %367, label %then354, label %else355
 
-then342:                                          ; preds = %loop.end341
+then354:                                          ; preds = %loop.end353
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont344
+  br label %ifcont356
 
-else343:                                          ; preds = %loop.end341
-  br label %ifcont344
+else355:                                          ; preds = %loop.end353
+  br label %ifcont356
 
-ifcont344:                                        ; preds = %else343, %then342
+ifcont356:                                        ; preds = %else355, %then354
   %368 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
   %369 = load i32, i32* %368, align 4
   %370 = icmp ne i32 %369, 4
-  br i1 %370, label %then345, label %else346
+  br i1 %370, label %then357, label %else358
 
-then345:                                          ; preds = %ifcont344
+then357:                                          ; preds = %ifcont356
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont347
+  br label %ifcont359
 
-else346:                                          ; preds = %ifcont344
-  br label %ifcont347
+else358:                                          ; preds = %ifcont356
+  br label %ifcont359
 
-ifcont347:                                        ; preds = %else346, %then345
+ifcont359:                                        ; preds = %else358, %then357
   %371 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 1
   %372 = load i32, i32* %371, align 4
   %373 = icmp ne i32 %372, 4
-  br i1 %373, label %then348, label %else349
+  br i1 %373, label %then360, label %else361
 
-then348:                                          ; preds = %ifcont347
+then360:                                          ; preds = %ifcont359
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont350
+  br label %ifcont362
 
-else349:                                          ; preds = %ifcont347
-  br label %ifcont350
+else361:                                          ; preds = %ifcont359
+  br label %ifcont362
 
-ifcont350:                                        ; preds = %else349, %then348
+ifcont362:                                        ; preds = %else361, %then360
   %374 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 3
   %375 = load i32, i32* %374, align 4
   %376 = icmp ne i32 %375, 16
-  br i1 %376, label %then351, label %else352
+  br i1 %376, label %then363, label %else364
 
-then351:                                          ; preds = %ifcont350
+then363:                                          ; preds = %ifcont362
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @48, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont353
+  br label %ifcont365
 
-else352:                                          ; preds = %ifcont350
-  br label %ifcont353
+else364:                                          ; preds = %ifcont362
+  br label %ifcont365
 
-ifcont353:                                        ; preds = %else352, %then351
-  br i1 true, label %then355, label %else356
+ifcont365:                                        ; preds = %else364, %then363
+  br i1 true, label %then367, label %else368
 
-then355:                                          ; preds = %ifcont353
-  store i32 1, i32* %array_bound354, align 4
-  br label %ifcont361
+then367:                                          ; preds = %ifcont365
+  store i32 1, i32* %array_bound366, align 4
+  br label %ifcont373
 
-else356:                                          ; preds = %ifcont353
-  br i1 false, label %then357, label %else358
+else368:                                          ; preds = %ifcont365
+  br i1 false, label %then369, label %else370
 
-then357:                                          ; preds = %else356
-  store i32 1, i32* %array_bound354, align 4
-  br label %ifcont361
+then369:                                          ; preds = %else368
+  store i32 1, i32* %array_bound366, align 4
+  br label %ifcont373
 
-else358:                                          ; preds = %else356
-  br i1 false, label %then359, label %else360
+else370:                                          ; preds = %else368
+  br i1 false, label %then371, label %else372
 
-then359:                                          ; preds = %else358
-  store i32 1, i32* %array_bound354, align 4
-  br label %ifcont361
+then371:                                          ; preds = %else370
+  store i32 1, i32* %array_bound366, align 4
+  br label %ifcont373
 
-else360:                                          ; preds = %else358
-  br label %ifcont361
+else372:                                          ; preds = %else370
+  br label %ifcont373
 
-ifcont361:                                        ; preds = %else360, %then359, %then357, %then355
-  %377 = load i32, i32* %array_bound354, align 4
-  store i32 %377, i32* %__1_v, align 4
-  br i1 true, label %then363, label %else364
+ifcont373:                                        ; preds = %else372, %then371, %then369, %then367
+  %377 = load i32, i32* %array_bound366, align 4
+  store i32 %377, i32* %__1_v3, align 4
+  br i1 true, label %then375, label %else376
 
-then363:                                          ; preds = %ifcont361
-  store i32 1, i32* %array_bound362, align 4
-  br label %ifcont369
+then375:                                          ; preds = %ifcont373
+  store i32 1, i32* %array_bound374, align 4
+  br label %ifcont381
 
-else364:                                          ; preds = %ifcont361
-  br i1 false, label %then365, label %else366
+else376:                                          ; preds = %ifcont373
+  br i1 false, label %then377, label %else378
 
-then365:                                          ; preds = %else364
-  store i32 1, i32* %array_bound362, align 4
-  br label %ifcont369
+then377:                                          ; preds = %else376
+  store i32 1, i32* %array_bound374, align 4
+  br label %ifcont381
 
-else366:                                          ; preds = %else364
-  br i1 false, label %then367, label %else368
+else378:                                          ; preds = %else376
+  br i1 false, label %then379, label %else380
 
-then367:                                          ; preds = %else366
-  store i32 1, i32* %array_bound362, align 4
-  br label %ifcont369
+then379:                                          ; preds = %else378
+  store i32 1, i32* %array_bound374, align 4
+  br label %ifcont381
 
-else368:                                          ; preds = %else366
-  br label %ifcont369
+else380:                                          ; preds = %else378
+  br label %ifcont381
 
-ifcont369:                                        ; preds = %else368, %then367, %then365, %then363
-  %378 = load i32, i32* %array_bound362, align 4
-  store i32 %378, i32* %__1_u, align 4
-  br i1 true, label %then371, label %else372
+ifcont381:                                        ; preds = %else380, %then379, %then377, %then375
+  %378 = load i32, i32* %array_bound374, align 4
+  store i32 %378, i32* %__1_u2, align 4
+  br i1 true, label %then383, label %else384
 
-then371:                                          ; preds = %ifcont369
-  store i32 1, i32* %array_bound370, align 4
-  br label %ifcont377
+then383:                                          ; preds = %ifcont381
+  store i32 1, i32* %array_bound382, align 4
+  br label %ifcont389
 
-else372:                                          ; preds = %ifcont369
-  br i1 false, label %then373, label %else374
+else384:                                          ; preds = %ifcont381
+  br i1 false, label %then385, label %else386
 
-then373:                                          ; preds = %else372
-  store i32 1, i32* %array_bound370, align 4
-  br label %ifcont377
+then385:                                          ; preds = %else384
+  store i32 1, i32* %array_bound382, align 4
+  br label %ifcont389
 
-else374:                                          ; preds = %else372
-  br i1 false, label %then375, label %else376
+else386:                                          ; preds = %else384
+  br i1 false, label %then387, label %else388
 
-then375:                                          ; preds = %else374
-  store i32 1, i32* %array_bound370, align 4
-  br label %ifcont377
+then387:                                          ; preds = %else386
+  store i32 1, i32* %array_bound382, align 4
+  br label %ifcont389
 
-else376:                                          ; preds = %else374
-  br label %ifcont377
+else388:                                          ; preds = %else386
+  br label %ifcont389
 
-ifcont377:                                        ; preds = %else376, %then375, %then373, %then371
-  %379 = load i32, i32* %array_bound370, align 4
+ifcont389:                                        ; preds = %else388, %then387, %then385, %then383
+  %379 = load i32, i32* %array_bound382, align 4
   %380 = sub i32 %379, 1
-  store i32 %380, i32* %__1_t, align 4
-  br label %loop.head378
+  store i32 %380, i32* %__1_t1, align 4
+  br label %loop.head390
 
-loop.head378:                                     ; preds = %loop.end457, %ifcont377
-  %381 = load i32, i32* %__1_t, align 4
+loop.head390:                                     ; preds = %loop.end469, %ifcont389
+  %381 = load i32, i32* %__1_t1, align 4
   %382 = add i32 %381, 1
-  br i1 true, label %then380, label %else381
+  br i1 true, label %then392, label %else393
 
-then380:                                          ; preds = %loop.head378
-  store i32 2, i32* %array_bound379, align 4
-  br label %ifcont386
+then392:                                          ; preds = %loop.head390
+  store i32 2, i32* %array_bound391, align 4
+  br label %ifcont398
 
-else381:                                          ; preds = %loop.head378
-  br i1 false, label %then382, label %else383
+else393:                                          ; preds = %loop.head390
+  br i1 false, label %then394, label %else395
 
-then382:                                          ; preds = %else381
-  store i32 2, i32* %array_bound379, align 4
-  br label %ifcont386
+then394:                                          ; preds = %else393
+  store i32 2, i32* %array_bound391, align 4
+  br label %ifcont398
 
-else383:                                          ; preds = %else381
-  br i1 false, label %then384, label %else385
+else395:                                          ; preds = %else393
+  br i1 false, label %then396, label %else397
 
-then384:                                          ; preds = %else383
-  store i32 1, i32* %array_bound379, align 4
-  br label %ifcont386
+then396:                                          ; preds = %else395
+  store i32 1, i32* %array_bound391, align 4
+  br label %ifcont398
 
-else385:                                          ; preds = %else383
-  br label %ifcont386
+else397:                                          ; preds = %else395
+  br label %ifcont398
 
-ifcont386:                                        ; preds = %else385, %then384, %then382, %then380
-  %383 = load i32, i32* %array_bound379, align 4
+ifcont398:                                        ; preds = %else397, %then396, %then394, %then392
+  %383 = load i32, i32* %array_bound391, align 4
   %384 = icmp sle i32 %382, %383
-  br i1 %384, label %loop.body387, label %loop.end458
+  br i1 %384, label %loop.body399, label %loop.end470
 
-loop.body387:                                     ; preds = %ifcont386
-  %385 = load i32, i32* %__1_t, align 4
+loop.body399:                                     ; preds = %ifcont398
+  %385 = load i32, i32* %__1_t1, align 4
   %386 = add i32 %385, 1
-  store i32 %386, i32* %__1_t, align 4
-  br i1 true, label %then389, label %else390
+  store i32 %386, i32* %__1_t1, align 4
+  br i1 true, label %then401, label %else402
 
-then389:                                          ; preds = %loop.body387
-  store i32 1, i32* %array_bound388, align 4
-  br label %ifcont395
+then401:                                          ; preds = %loop.body399
+  store i32 1, i32* %array_bound400, align 4
+  br label %ifcont407
 
-else390:                                          ; preds = %loop.body387
-  br i1 false, label %then391, label %else392
+else402:                                          ; preds = %loop.body399
+  br i1 false, label %then403, label %else404
 
-then391:                                          ; preds = %else390
-  store i32 1, i32* %array_bound388, align 4
-  br label %ifcont395
+then403:                                          ; preds = %else402
+  store i32 1, i32* %array_bound400, align 4
+  br label %ifcont407
 
-else392:                                          ; preds = %else390
-  br i1 false, label %then393, label %else394
-
-then393:                                          ; preds = %else392
-  store i32 1, i32* %array_bound388, align 4
-  br label %ifcont395
-
-else394:                                          ; preds = %else392
-  br label %ifcont395
-
-ifcont395:                                        ; preds = %else394, %then393, %then391, %then389
-  %387 = load i32, i32* %array_bound388, align 4
-  store i32 %387, i32* %__2_v, align 4
-  br i1 true, label %then397, label %else398
-
-then397:                                          ; preds = %ifcont395
-  store i32 1, i32* %array_bound396, align 4
-  br label %ifcont403
-
-else398:                                          ; preds = %ifcont395
-  br i1 false, label %then399, label %else400
-
-then399:                                          ; preds = %else398
-  store i32 1, i32* %array_bound396, align 4
-  br label %ifcont403
-
-else400:                                          ; preds = %else398
-  br i1 false, label %then401, label %else402
-
-then401:                                          ; preds = %else400
-  store i32 1, i32* %array_bound396, align 4
-  br label %ifcont403
-
-else402:                                          ; preds = %else400
-  br label %ifcont403
-
-ifcont403:                                        ; preds = %else402, %then401, %then399, %then397
-  %388 = load i32, i32* %array_bound396, align 4
-  store i32 %388, i32* %__2_u, align 4
+else404:                                          ; preds = %else402
   br i1 false, label %then405, label %else406
 
-then405:                                          ; preds = %ifcont403
-  store i32 1, i32* %array_bound404, align 4
-  br label %ifcont411
+then405:                                          ; preds = %else404
+  store i32 1, i32* %array_bound400, align 4
+  br label %ifcont407
 
-else406:                                          ; preds = %ifcont403
-  br i1 true, label %then407, label %else408
+else406:                                          ; preds = %else404
+  br label %ifcont407
 
-then407:                                          ; preds = %else406
-  store i32 1, i32* %array_bound404, align 4
-  br label %ifcont411
+ifcont407:                                        ; preds = %else406, %then405, %then403, %then401
+  %387 = load i32, i32* %array_bound400, align 4
+  store i32 %387, i32* %__2_v6, align 4
+  br i1 true, label %then409, label %else410
 
-else408:                                          ; preds = %else406
-  br i1 false, label %then409, label %else410
+then409:                                          ; preds = %ifcont407
+  store i32 1, i32* %array_bound408, align 4
+  br label %ifcont415
 
-then409:                                          ; preds = %else408
-  store i32 1, i32* %array_bound404, align 4
-  br label %ifcont411
+else410:                                          ; preds = %ifcont407
+  br i1 false, label %then411, label %else412
 
-else410:                                          ; preds = %else408
-  br label %ifcont411
+then411:                                          ; preds = %else410
+  store i32 1, i32* %array_bound408, align 4
+  br label %ifcont415
 
-ifcont411:                                        ; preds = %else410, %then409, %then407, %then405
-  %389 = load i32, i32* %array_bound404, align 4
+else412:                                          ; preds = %else410
+  br i1 false, label %then413, label %else414
+
+then413:                                          ; preds = %else412
+  store i32 1, i32* %array_bound408, align 4
+  br label %ifcont415
+
+else414:                                          ; preds = %else412
+  br label %ifcont415
+
+ifcont415:                                        ; preds = %else414, %then413, %then411, %then409
+  %388 = load i32, i32* %array_bound408, align 4
+  store i32 %388, i32* %__2_u5, align 4
+  br i1 false, label %then417, label %else418
+
+then417:                                          ; preds = %ifcont415
+  store i32 1, i32* %array_bound416, align 4
+  br label %ifcont423
+
+else418:                                          ; preds = %ifcont415
+  br i1 true, label %then419, label %else420
+
+then419:                                          ; preds = %else418
+  store i32 1, i32* %array_bound416, align 4
+  br label %ifcont423
+
+else420:                                          ; preds = %else418
+  br i1 false, label %then421, label %else422
+
+then421:                                          ; preds = %else420
+  store i32 1, i32* %array_bound416, align 4
+  br label %ifcont423
+
+else422:                                          ; preds = %else420
+  br label %ifcont423
+
+ifcont423:                                        ; preds = %else422, %then421, %then419, %then417
+  %389 = load i32, i32* %array_bound416, align 4
   %390 = sub i32 %389, 1
-  store i32 %390, i32* %__2_t, align 4
-  br label %loop.head412
+  store i32 %390, i32* %__2_t4, align 4
+  br label %loop.head424
 
-loop.head412:                                     ; preds = %loop.end456, %ifcont411
-  %391 = load i32, i32* %__2_t, align 4
+loop.head424:                                     ; preds = %loop.end468, %ifcont423
+  %391 = load i32, i32* %__2_t4, align 4
   %392 = add i32 %391, 1
-  br i1 false, label %then414, label %else415
+  br i1 false, label %then426, label %else427
 
-then414:                                          ; preds = %loop.head412
-  store i32 2, i32* %array_bound413, align 4
-  br label %ifcont420
+then426:                                          ; preds = %loop.head424
+  store i32 2, i32* %array_bound425, align 4
+  br label %ifcont432
 
-else415:                                          ; preds = %loop.head412
-  br i1 true, label %then416, label %else417
+else427:                                          ; preds = %loop.head424
+  br i1 true, label %then428, label %else429
 
-then416:                                          ; preds = %else415
-  store i32 2, i32* %array_bound413, align 4
-  br label %ifcont420
+then428:                                          ; preds = %else427
+  store i32 2, i32* %array_bound425, align 4
+  br label %ifcont432
 
-else417:                                          ; preds = %else415
-  br i1 false, label %then418, label %else419
+else429:                                          ; preds = %else427
+  br i1 false, label %then430, label %else431
 
-then418:                                          ; preds = %else417
-  store i32 1, i32* %array_bound413, align 4
-  br label %ifcont420
+then430:                                          ; preds = %else429
+  store i32 1, i32* %array_bound425, align 4
+  br label %ifcont432
 
-else419:                                          ; preds = %else417
-  br label %ifcont420
+else431:                                          ; preds = %else429
+  br label %ifcont432
 
-ifcont420:                                        ; preds = %else419, %then418, %then416, %then414
-  %393 = load i32, i32* %array_bound413, align 4
+ifcont432:                                        ; preds = %else431, %then430, %then428, %then426
+  %393 = load i32, i32* %array_bound425, align 4
   %394 = icmp sle i32 %392, %393
-  br i1 %394, label %loop.body421, label %loop.end457
+  br i1 %394, label %loop.body433, label %loop.end469
 
-loop.body421:                                     ; preds = %ifcont420
-  %395 = load i32, i32* %__2_t, align 4
+loop.body433:                                     ; preds = %ifcont432
+  %395 = load i32, i32* %__2_t4, align 4
   %396 = add i32 %395, 1
-  store i32 %396, i32* %__2_t, align 4
-  br i1 false, label %then423, label %else424
-
-then423:                                          ; preds = %loop.body421
-  store i32 1, i32* %array_bound422, align 4
-  br label %ifcont429
-
-else424:                                          ; preds = %loop.body421
-  br i1 true, label %then425, label %else426
-
-then425:                                          ; preds = %else424
-  store i32 1, i32* %array_bound422, align 4
-  br label %ifcont429
-
-else426:                                          ; preds = %else424
-  br i1 false, label %then427, label %else428
-
-then427:                                          ; preds = %else426
-  store i32 1, i32* %array_bound422, align 4
-  br label %ifcont429
-
-else428:                                          ; preds = %else426
-  br label %ifcont429
-
-ifcont429:                                        ; preds = %else428, %then427, %then425, %then423
-  %397 = load i32, i32* %array_bound422, align 4
-  store i32 %397, i32* %__3_v, align 4
-  br i1 false, label %then431, label %else432
-
-then431:                                          ; preds = %ifcont429
-  store i32 1, i32* %array_bound430, align 4
-  br label %ifcont437
-
-else432:                                          ; preds = %ifcont429
-  br i1 true, label %then433, label %else434
-
-then433:                                          ; preds = %else432
-  store i32 1, i32* %array_bound430, align 4
-  br label %ifcont437
-
-else434:                                          ; preds = %else432
+  store i32 %396, i32* %__2_t4, align 4
   br i1 false, label %then435, label %else436
 
-then435:                                          ; preds = %else434
-  store i32 1, i32* %array_bound430, align 4
-  br label %ifcont437
+then435:                                          ; preds = %loop.body433
+  store i32 1, i32* %array_bound434, align 4
+  br label %ifcont441
 
-else436:                                          ; preds = %else434
-  br label %ifcont437
+else436:                                          ; preds = %loop.body433
+  br i1 true, label %then437, label %else438
 
-ifcont437:                                        ; preds = %else436, %then435, %then433, %then431
-  %398 = load i32, i32* %array_bound430, align 4
-  store i32 %398, i32* %__3_u, align 4
+then437:                                          ; preds = %else436
+  store i32 1, i32* %array_bound434, align 4
+  br label %ifcont441
+
+else438:                                          ; preds = %else436
   br i1 false, label %then439, label %else440
 
-then439:                                          ; preds = %ifcont437
-  store i32 1, i32* %array_bound438, align 4
-  br label %ifcont445
+then439:                                          ; preds = %else438
+  store i32 1, i32* %array_bound434, align 4
+  br label %ifcont441
 
-else440:                                          ; preds = %ifcont437
-  br i1 false, label %then441, label %else442
+else440:                                          ; preds = %else438
+  br label %ifcont441
 
-then441:                                          ; preds = %else440
-  store i32 1, i32* %array_bound438, align 4
-  br label %ifcont445
+ifcont441:                                        ; preds = %else440, %then439, %then437, %then435
+  %397 = load i32, i32* %array_bound434, align 4
+  store i32 %397, i32* %__3_v9, align 4
+  br i1 false, label %then443, label %else444
 
-else442:                                          ; preds = %else440
-  br i1 true, label %then443, label %else444
+then443:                                          ; preds = %ifcont441
+  store i32 1, i32* %array_bound442, align 4
+  br label %ifcont449
 
-then443:                                          ; preds = %else442
-  store i32 1, i32* %array_bound438, align 4
-  br label %ifcont445
+else444:                                          ; preds = %ifcont441
+  br i1 true, label %then445, label %else446
 
-else444:                                          ; preds = %else442
-  br label %ifcont445
+then445:                                          ; preds = %else444
+  store i32 1, i32* %array_bound442, align 4
+  br label %ifcont449
 
-ifcont445:                                        ; preds = %else444, %then443, %then441, %then439
-  %399 = load i32, i32* %array_bound438, align 4
+else446:                                          ; preds = %else444
+  br i1 false, label %then447, label %else448
+
+then447:                                          ; preds = %else446
+  store i32 1, i32* %array_bound442, align 4
+  br label %ifcont449
+
+else448:                                          ; preds = %else446
+  br label %ifcont449
+
+ifcont449:                                        ; preds = %else448, %then447, %then445, %then443
+  %398 = load i32, i32* %array_bound442, align 4
+  store i32 %398, i32* %__3_u8, align 4
+  br i1 false, label %then451, label %else452
+
+then451:                                          ; preds = %ifcont449
+  store i32 1, i32* %array_bound450, align 4
+  br label %ifcont457
+
+else452:                                          ; preds = %ifcont449
+  br i1 false, label %then453, label %else454
+
+then453:                                          ; preds = %else452
+  store i32 1, i32* %array_bound450, align 4
+  br label %ifcont457
+
+else454:                                          ; preds = %else452
+  br i1 true, label %then455, label %else456
+
+then455:                                          ; preds = %else454
+  store i32 1, i32* %array_bound450, align 4
+  br label %ifcont457
+
+else456:                                          ; preds = %else454
+  br label %ifcont457
+
+ifcont457:                                        ; preds = %else456, %then455, %then453, %then451
+  %399 = load i32, i32* %array_bound450, align 4
   %400 = sub i32 %399, 1
-  store i32 %400, i32* %__3_t, align 4
-  br label %loop.head446
+  store i32 %400, i32* %__3_t7, align 4
+  br label %loop.head458
 
-loop.head446:                                     ; preds = %loop.body455, %ifcont445
-  %401 = load i32, i32* %__3_t, align 4
+loop.head458:                                     ; preds = %loop.body467, %ifcont457
+  %401 = load i32, i32* %__3_t7, align 4
   %402 = add i32 %401, 1
-  br i1 false, label %then448, label %else449
+  br i1 false, label %then460, label %else461
 
-then448:                                          ; preds = %loop.head446
-  store i32 2, i32* %array_bound447, align 4
-  br label %ifcont454
+then460:                                          ; preds = %loop.head458
+  store i32 2, i32* %array_bound459, align 4
+  br label %ifcont466
 
-else449:                                          ; preds = %loop.head446
-  br i1 false, label %then450, label %else451
+else461:                                          ; preds = %loop.head458
+  br i1 false, label %then462, label %else463
 
-then450:                                          ; preds = %else449
-  store i32 2, i32* %array_bound447, align 4
-  br label %ifcont454
+then462:                                          ; preds = %else461
+  store i32 2, i32* %array_bound459, align 4
+  br label %ifcont466
 
-else451:                                          ; preds = %else449
-  br i1 true, label %then452, label %else453
+else463:                                          ; preds = %else461
+  br i1 true, label %then464, label %else465
 
-then452:                                          ; preds = %else451
-  store i32 1, i32* %array_bound447, align 4
-  br label %ifcont454
+then464:                                          ; preds = %else463
+  store i32 1, i32* %array_bound459, align 4
+  br label %ifcont466
 
-else453:                                          ; preds = %else451
-  br label %ifcont454
+else465:                                          ; preds = %else463
+  br label %ifcont466
 
-ifcont454:                                        ; preds = %else453, %then452, %then450, %then448
-  %403 = load i32, i32* %array_bound447, align 4
+ifcont466:                                        ; preds = %else465, %then464, %then462, %then460
+  %403 = load i32, i32* %array_bound459, align 4
   %404 = icmp sle i32 %402, %403
-  br i1 %404, label %loop.body455, label %loop.end456
+  br i1 %404, label %loop.body467, label %loop.end468
 
-loop.body455:                                     ; preds = %ifcont454
-  %405 = load i32, i32* %__3_t, align 4
+loop.body467:                                     ; preds = %ifcont466
+  %405 = load i32, i32* %__3_t7, align 4
   %406 = add i32 %405, 1
-  store i32 %406, i32* %__3_t, align 4
-  %407 = load i32, i32* %__1_t, align 4
-  %408 = load i32, i32* %__2_t, align 4
-  %409 = load i32, i32* %__3_t, align 4
+  store i32 %406, i32* %__3_t7, align 4
+  %407 = load i32, i32* %__1_t1, align 4
+  %408 = load i32, i32* %__2_t4, align 4
+  %409 = load i32, i32* %__3_t7, align 4
   %410 = sub i32 %407, 1
   %411 = mul i32 1, %410
   %412 = add i32 0, %411
@@ -2045,9 +2057,9 @@ loop.body455:                                     ; preds = %ifcont454
   %417 = mul i32 4, %416
   %418 = add i32 %415, %417
   %419 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 %418
-  %420 = load i32, i32* %__1_v, align 4
-  %421 = load i32, i32* %__2_v, align 4
-  %422 = load i32, i32* %__3_v, align 4
+  %420 = load i32, i32* %__1_v3, align 4
+  %421 = load i32, i32* %__2_v6, align 4
+  %422 = load i32, i32* %__3_v9, align 4
   %423 = sub i32 %420, 1
   %424 = mul i32 1, %423
   %425 = add i32 0, %424
@@ -2059,9 +2071,9 @@ loop.body455:                                     ; preds = %ifcont454
   %431 = add i32 %428, %430
   %432 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %431
   %433 = load i32, i32* %432, align 4
-  %434 = load i32, i32* %__1_u, align 4
-  %435 = load i32, i32* %__2_u, align 4
-  %436 = load i32, i32* %__3_u, align 4
+  %434 = load i32, i32* %__1_u2, align 4
+  %435 = load i32, i32* %__2_u5, align 4
+  %436 = load i32, i32* %__3_u8, align 4
   %437 = sub i32 %434, 1
   %438 = mul i32 1, %437
   %439 = add i32 0, %438
@@ -2075,33 +2087,33 @@ loop.body455:                                     ; preds = %ifcont454
   %447 = load i32, i32* %446, align 4
   %448 = sdiv i32 %433, %447
   store i32 %448, i32* %419, align 4
-  %449 = load i32, i32* %__3_v, align 4
+  %449 = load i32, i32* %__3_v9, align 4
   %450 = add i32 %449, 1
-  store i32 %450, i32* %__3_v, align 4
-  %451 = load i32, i32* %__3_u, align 4
+  store i32 %450, i32* %__3_v9, align 4
+  %451 = load i32, i32* %__3_u8, align 4
   %452 = add i32 %451, 1
-  store i32 %452, i32* %__3_u, align 4
-  br label %loop.head446
+  store i32 %452, i32* %__3_u8, align 4
+  br label %loop.head458
 
-loop.end456:                                      ; preds = %ifcont454
-  %453 = load i32, i32* %__2_v, align 4
+loop.end468:                                      ; preds = %ifcont466
+  %453 = load i32, i32* %__2_v6, align 4
   %454 = add i32 %453, 1
-  store i32 %454, i32* %__2_v, align 4
-  %455 = load i32, i32* %__2_u, align 4
+  store i32 %454, i32* %__2_v6, align 4
+  %455 = load i32, i32* %__2_u5, align 4
   %456 = add i32 %455, 1
-  store i32 %456, i32* %__2_u, align 4
-  br label %loop.head412
+  store i32 %456, i32* %__2_u5, align 4
+  br label %loop.head424
 
-loop.end457:                                      ; preds = %ifcont420
-  %457 = load i32, i32* %__1_v, align 4
+loop.end469:                                      ; preds = %ifcont432
+  %457 = load i32, i32* %__1_v3, align 4
   %458 = add i32 %457, 1
-  store i32 %458, i32* %__1_v, align 4
-  %459 = load i32, i32* %__1_u, align 4
+  store i32 %458, i32* %__1_v3, align 4
+  %459 = load i32, i32* %__1_u2, align 4
   %460 = add i32 %459, 1
-  store i32 %460, i32* %__1_u, align 4
-  br label %loop.head378
+  store i32 %460, i32* %__1_u2, align 4
+  br label %loop.head390
 
-loop.end458:                                      ; preds = %ifcont386
+loop.end470:                                      ; preds = %ifcont398
   %461 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %462 = load i32, i32* %461, align 4
   %463 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
@@ -2114,62 +2126,62 @@ loop.end458:                                      ; preds = %ifcont386
   %469 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 0
   %470 = load i32, i32* %469, align 4
   %471 = icmp ne i32 %470, 1
-  br i1 %471, label %then459, label %else460
+  br i1 %471, label %then471, label %else472
 
-then459:                                          ; preds = %loop.end458
+then471:                                          ; preds = %loop.end470
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @56, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @54, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @55, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont461
+  br label %ifcont473
 
-else460:                                          ; preds = %loop.end458
-  br label %ifcont461
+else472:                                          ; preds = %loop.end470
+  br label %ifcont473
 
-ifcont461:                                        ; preds = %else460, %then459
+ifcont473:                                        ; preds = %else472, %then471
   %472 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 2
   %473 = load i32, i32* %472, align 4
   %474 = icmp ne i32 %473, 4
-  br i1 %474, label %then462, label %else463
+  br i1 %474, label %then474, label %else475
 
-then462:                                          ; preds = %ifcont461
+then474:                                          ; preds = %ifcont473
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont464
+  br label %ifcont476
 
-else463:                                          ; preds = %ifcont461
-  br label %ifcont464
+else475:                                          ; preds = %ifcont473
+  br label %ifcont476
 
-ifcont464:                                        ; preds = %else463, %then462
+ifcont476:                                        ; preds = %else475, %then474
   %475 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 1
   %476 = load i32, i32* %475, align 4
   %477 = icmp ne i32 %476, 0
-  br i1 %477, label %then465, label %else466
+  br i1 %477, label %then477, label %else478
 
-then465:                                          ; preds = %ifcont464
+then477:                                          ; preds = %ifcont476
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @60, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont467
+  br label %ifcont479
 
-else466:                                          ; preds = %ifcont464
-  br label %ifcont467
+else478:                                          ; preds = %ifcont476
+  br label %ifcont479
 
-ifcont467:                                        ; preds = %else466, %then465
+ifcont479:                                        ; preds = %else478, %then477
   %478 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i32 3
   %479 = load i32, i32* %478, align 4
   %480 = icmp ne i32 %479, 1
-  br i1 %480, label %then468, label %else469
+  br i1 %480, label %then480, label %else481
 
-then468:                                          ; preds = %ifcont467
+then480:                                          ; preds = %ifcont479
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont470
+  br label %ifcont482
 
-else469:                                          ; preds = %ifcont467
-  br label %ifcont470
+else481:                                          ; preds = %ifcont479
+  br label %ifcont482
 
-ifcont470:                                        ; preds = %else469, %then468
+ifcont482:                                        ; preds = %else481, %then480
   br label %return
 
-return:                                           ; preds = %ifcont470
+return:                                           ; preds = %ifcont482
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "2cc9d2723213b4a93d82b8ddd235d6db7939656da215f273a0740bd8",
+    "stdout_hash": "418ffd3de78b6007559518058064b78d3c3d92cd768ba36c6214dbc5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -4,6 +4,9 @@ source_filename = "LFortran"
 %array = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
 
+@array_op_3.dim1 = internal global i32 0
+@array_op_3.dim2 = internal global i32 0
+@array_op_3.dim3 = internal global i32 0
 @0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -16,9 +19,1659 @@ source_filename = "LFortran"
 @9 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
-@array_op_3.dim1 = internal global i32 0
-@array_op_3.dim2 = internal global i32 0
-@array_op_3.dim3 = internal global i32 0
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value67 = alloca i32, align 4
+  %call_arg_value57 = alloca i32, align 4
+  %call_arg_value47 = alloca i32, align 4
+  %call_arg_value37 = alloca i32, align 4
+  %call_arg_value25 = alloca i32, align 4
+  %call_arg_value = alloca i32, align 4
+  %__1_t = alloca i32, align 4
+  %__1_u = alloca i32, align 4
+  %__1_v = alloca i32, align 4
+  %__2_t = alloca i32, align 4
+  %__2_u = alloca i32, align 4
+  %__2_v = alloca i32, align 4
+  %__3_t = alloca i32, align 4
+  %__3_u = alloca i32, align 4
+  %__3_v = alloca i32, align 4
+  store i32 10, i32* @array_op_3.dim1, align 4
+  store i32 100, i32* @array_op_3.dim2, align 4
+  store i32 1, i32* @array_op_3.dim3, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  %k = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_t1 = alloca i32, align 4
+  %__1_u2 = alloca i32, align 4
+  %__1_v3 = alloca i32, align 4
+  %__2_t4 = alloca i32, align 4
+  %__2_u5 = alloca i32, align 4
+  %__2_v6 = alloca i32, align 4
+  %__3_t7 = alloca i32, align 4
+  %__3_u8 = alloca i32, align 4
+  %__3_v9 = alloca i32, align 4
+  %a = alloca %array*, align 8
+  store %array* null, %array** %a, align 8
+  %arr_desc = alloca %array, align 8
+  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %3 = alloca i32, align 4
+  store i32 3, i32* %3, align 4
+  %4 = load i32, i32* %3, align 4
+  %5 = alloca %dimension_descriptor, i32 %4, align 8
+  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
+  %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
+  store i32 3, i32* %6, align 4
+  %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
+  store i1* null, i1** %7, align 8
+  store %array* %arr_desc, %array** %a, align 8
+  %b = alloca %array*, align 8
+  store %array* null, %array** %b, align 8
+  %arr_desc10 = alloca %array, align 8
+  %8 = getelementptr %array, %array* %arr_desc10, i32 0, i32 2
+  %9 = alloca i32, align 4
+  store i32 3, i32* %9, align 4
+  %10 = load i32, i32* %9, align 4
+  %11 = alloca %dimension_descriptor, i32 %10, align 8
+  store %dimension_descriptor* %11, %dimension_descriptor** %8, align 8
+  %12 = getelementptr %array, %array* %arr_desc10, i32 0, i32 4
+  store i32 3, i32* %12, align 4
+  %13 = getelementptr %array, %array* %arr_desc10, i32 0, i32 0
+  store i1* null, i1** %13, align 8
+  store %array* %arr_desc10, %array** %b, align 8
+  %c = alloca %array*, align 8
+  store %array* null, %array** %c, align 8
+  %arr_desc11 = alloca %array, align 8
+  %14 = getelementptr %array, %array* %arr_desc11, i32 0, i32 2
+  %15 = alloca i32, align 4
+  store i32 3, i32* %15, align 4
+  %16 = load i32, i32* %15, align 4
+  %17 = alloca %dimension_descriptor, i32 %16, align 8
+  store %dimension_descriptor* %17, %dimension_descriptor** %14, align 8
+  %18 = getelementptr %array, %array* %arr_desc11, i32 0, i32 4
+  store i32 3, i32* %18, align 4
+  %19 = getelementptr %array, %array* %arr_desc11, i32 0, i32 0
+  store i1* null, i1** %19, align 8
+  store %array* %arr_desc11, %array** %c, align 8
+  store i32 10, i32* @array_op_3.dim1, align 4
+  store i32 100, i32* @array_op_3.dim2, align 4
+  store i32 1, i32* @array_op_3.dim3, align 4
+  %i12 = alloca i32, align 4
+  %j13 = alloca i32, align 4
+  %k14 = alloca i32, align 4
+  %20 = load %array*, %array** %a, align 8
+  %21 = ptrtoint %array* %20 to i32
+  %22 = icmp eq i32 %21, 0
+  br i1 %22, label %then, label %else
+
+then:                                             ; preds = %.entry
+  %23 = alloca %array, align 8
+  %24 = getelementptr %array, %array* %23, i32 0, i32 2
+  %25 = alloca i32, align 4
+  store i32 3, i32* %25, align 4
+  %26 = load i32, i32* %25, align 4
+  %27 = alloca %dimension_descriptor, i32 %26, align 8
+  store %dimension_descriptor* %27, %dimension_descriptor** %24, align 8
+  %28 = getelementptr %array, %array* %23, i32 0, i32 4
+  store i32 3, i32* %28, align 4
+  store %array* %23, %array** %a, align 8
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %29 = load i32, i32* @array_op_3.dim1, align 4
+  %30 = load i32, i32* @array_op_3.dim2, align 4
+  %31 = load i32, i32* @array_op_3.dim3, align 4
+  %32 = load %array*, %array** %a, align 8
+  %33 = getelementptr %array, %array* %32, i32 0, i32 1
+  store i32 0, i32* %33, align 4
+  %34 = getelementptr %array, %array* %32, i32 0, i32 2
+  %35 = load %dimension_descriptor*, %dimension_descriptor** %34, align 8
+  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 0
+  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
+  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
+  store i32 1, i32* %37, align 4
+  store i32 1, i32* %38, align 4
+  store i32 %29, i32* %39, align 4
+  %40 = mul i32 1, %29
+  %41 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 1
+  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 0
+  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 1
+  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 2
+  store i32 %40, i32* %42, align 4
+  store i32 1, i32* %43, align 4
+  store i32 %30, i32* %44, align 4
+  %45 = mul i32 %40, %30
+  %46 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 2
+  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 0
+  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 1
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 2
+  store i32 %45, i32* %47, align 4
+  store i32 1, i32* %48, align 4
+  store i32 %31, i32* %49, align 4
+  %50 = mul i32 %45, %31
+  %51 = getelementptr %array, %array* %32, i32 0, i32 0
+  %52 = alloca i32, align 4
+  %53 = mul i32 %50, 1
+  store i32 %53, i32* %52, align 4
+  %54 = load i32, i32* %52, align 4
+  %55 = call i8* @_lfortran_malloc(i32 %54)
+  %56 = bitcast i8* %55 to i1*
+  store i1* %56, i1** %51, align 8
+  %57 = load %array*, %array** %b, align 8
+  %58 = ptrtoint %array* %57 to i32
+  %59 = icmp eq i32 %58, 0
+  br i1 %59, label %then15, label %else16
+
+then15:                                           ; preds = %ifcont
+  %60 = alloca %array, align 8
+  %61 = getelementptr %array, %array* %60, i32 0, i32 2
+  %62 = alloca i32, align 4
+  store i32 3, i32* %62, align 4
+  %63 = load i32, i32* %62, align 4
+  %64 = alloca %dimension_descriptor, i32 %63, align 8
+  store %dimension_descriptor* %64, %dimension_descriptor** %61, align 8
+  %65 = getelementptr %array, %array* %60, i32 0, i32 4
+  store i32 3, i32* %65, align 4
+  store %array* %60, %array** %b, align 8
+  br label %ifcont17
+
+else16:                                           ; preds = %ifcont
+  br label %ifcont17
+
+ifcont17:                                         ; preds = %else16, %then15
+  %66 = load i32, i32* @array_op_3.dim1, align 4
+  %67 = load i32, i32* @array_op_3.dim2, align 4
+  %68 = load i32, i32* @array_op_3.dim3, align 4
+  %69 = load %array*, %array** %b, align 8
+  %70 = getelementptr %array, %array* %69, i32 0, i32 1
+  store i32 0, i32* %70, align 4
+  %71 = getelementptr %array, %array* %69, i32 0, i32 2
+  %72 = load %dimension_descriptor*, %dimension_descriptor** %71, align 8
+  %73 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %72, i32 0
+  %74 = getelementptr %dimension_descriptor, %dimension_descriptor* %73, i32 0, i32 0
+  %75 = getelementptr %dimension_descriptor, %dimension_descriptor* %73, i32 0, i32 1
+  %76 = getelementptr %dimension_descriptor, %dimension_descriptor* %73, i32 0, i32 2
+  store i32 1, i32* %74, align 4
+  store i32 1, i32* %75, align 4
+  store i32 %66, i32* %76, align 4
+  %77 = mul i32 1, %66
+  %78 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %72, i32 1
+  %79 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 0
+  %80 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 1
+  %81 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 2
+  store i32 %77, i32* %79, align 4
+  store i32 1, i32* %80, align 4
+  store i32 %67, i32* %81, align 4
+  %82 = mul i32 %77, %67
+  %83 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %72, i32 2
+  %84 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 0
+  %85 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 1
+  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 2
+  store i32 %82, i32* %84, align 4
+  store i32 1, i32* %85, align 4
+  store i32 %68, i32* %86, align 4
+  %87 = mul i32 %82, %68
+  %88 = getelementptr %array, %array* %69, i32 0, i32 0
+  %89 = alloca i32, align 4
+  %90 = mul i32 %87, 1
+  store i32 %90, i32* %89, align 4
+  %91 = load i32, i32* %89, align 4
+  %92 = call i8* @_lfortran_malloc(i32 %91)
+  %93 = bitcast i8* %92 to i1*
+  store i1* %93, i1** %88, align 8
+  %94 = load %array*, %array** %c, align 8
+  %95 = ptrtoint %array* %94 to i32
+  %96 = icmp eq i32 %95, 0
+  br i1 %96, label %then18, label %else19
+
+then18:                                           ; preds = %ifcont17
+  %97 = alloca %array, align 8
+  %98 = getelementptr %array, %array* %97, i32 0, i32 2
+  %99 = alloca i32, align 4
+  store i32 3, i32* %99, align 4
+  %100 = load i32, i32* %99, align 4
+  %101 = alloca %dimension_descriptor, i32 %100, align 8
+  store %dimension_descriptor* %101, %dimension_descriptor** %98, align 8
+  %102 = getelementptr %array, %array* %97, i32 0, i32 4
+  store i32 3, i32* %102, align 4
+  store %array* %97, %array** %c, align 8
+  br label %ifcont20
+
+else19:                                           ; preds = %ifcont17
+  br label %ifcont20
+
+ifcont20:                                         ; preds = %else19, %then18
+  %103 = load i32, i32* @array_op_3.dim1, align 4
+  %104 = load i32, i32* @array_op_3.dim2, align 4
+  %105 = load i32, i32* @array_op_3.dim3, align 4
+  %106 = load %array*, %array** %c, align 8
+  %107 = getelementptr %array, %array* %106, i32 0, i32 1
+  store i32 0, i32* %107, align 4
+  %108 = getelementptr %array, %array* %106, i32 0, i32 2
+  %109 = load %dimension_descriptor*, %dimension_descriptor** %108, align 8
+  %110 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 0
+  %111 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 0
+  %112 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 1
+  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 2
+  store i32 1, i32* %111, align 4
+  store i32 1, i32* %112, align 4
+  store i32 %103, i32* %113, align 4
+  %114 = mul i32 1, %103
+  %115 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 1
+  %116 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 0
+  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 1
+  %118 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 2
+  store i32 %114, i32* %116, align 4
+  store i32 1, i32* %117, align 4
+  store i32 %104, i32* %118, align 4
+  %119 = mul i32 %114, %104
+  %120 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 2
+  %121 = getelementptr %dimension_descriptor, %dimension_descriptor* %120, i32 0, i32 0
+  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %120, i32 0, i32 1
+  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %120, i32 0, i32 2
+  store i32 %119, i32* %121, align 4
+  store i32 1, i32* %122, align 4
+  store i32 %105, i32* %123, align 4
+  %124 = mul i32 %119, %105
+  %125 = getelementptr %array, %array* %106, i32 0, i32 0
+  %126 = alloca i32, align 4
+  %127 = mul i32 %124, 1
+  store i32 %127, i32* %126, align 4
+  %128 = load i32, i32* %126, align 4
+  %129 = call i8* @_lfortran_malloc(i32 %128)
+  %130 = bitcast i8* %129 to i1*
+  store i1* %130, i1** %125, align 8
+  store i32 0, i32* %i12, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.end26, %ifcont20
+  %131 = load i32, i32* %i12, align 4
+  %132 = add i32 %131, 1
+  %133 = load i32, i32* @array_op_3.dim1, align 4
+  %134 = icmp sle i32 %132, %133
+  br i1 %134, label %loop.body, label %loop.end27
+
+loop.body:                                        ; preds = %loop.head
+  %135 = load i32, i32* %i12, align 4
+  %136 = add i32 %135, 1
+  store i32 %136, i32* %i12, align 4
+  store i32 0, i32* %j13, align 4
+  br label %loop.head21
+
+loop.head21:                                      ; preds = %loop.end, %loop.body
+  %137 = load i32, i32* %j13, align 4
+  %138 = add i32 %137, 1
+  %139 = load i32, i32* @array_op_3.dim2, align 4
+  %140 = icmp sle i32 %138, %139
+  br i1 %140, label %loop.body22, label %loop.end26
+
+loop.body22:                                      ; preds = %loop.head21
+  %141 = load i32, i32* %j13, align 4
+  %142 = add i32 %141, 1
+  store i32 %142, i32* %j13, align 4
+  store i32 0, i32* %k14, align 4
+  br label %loop.head23
+
+loop.head23:                                      ; preds = %loop.body24, %loop.body22
+  %143 = load i32, i32* %k14, align 4
+  %144 = add i32 %143, 1
+  %145 = load i32, i32* @array_op_3.dim3, align 4
+  %146 = icmp sle i32 %144, %145
+  br i1 %146, label %loop.body24, label %loop.end
+
+loop.body24:                                      ; preds = %loop.head23
+  %147 = load i32, i32* %k14, align 4
+  %148 = add i32 %147, 1
+  store i32 %148, i32* %k14, align 4
+  %149 = load i32, i32* %i12, align 4
+  %150 = load i32, i32* %j13, align 4
+  %151 = load i32, i32* %k14, align 4
+  %152 = load %array*, %array** %a, align 8
+  %153 = getelementptr %array, %array* %152, i32 0, i32 2
+  %154 = load %dimension_descriptor*, %dimension_descriptor** %153, align 8
+  %155 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 0
+  %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 1
+  %157 = load i32, i32* %156, align 4
+  %158 = sub i32 %149, %157
+  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 0
+  %160 = load i32, i32* %159, align 4
+  %161 = mul i32 %160, %158
+  %162 = add i32 0, %161
+  %163 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 1
+  %164 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 1
+  %165 = load i32, i32* %164, align 4
+  %166 = sub i32 %150, %165
+  %167 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 0
+  %168 = load i32, i32* %167, align 4
+  %169 = mul i32 %168, %166
+  %170 = add i32 %162, %169
+  %171 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 2
+  %172 = getelementptr %dimension_descriptor, %dimension_descriptor* %171, i32 0, i32 1
+  %173 = load i32, i32* %172, align 4
+  %174 = sub i32 %151, %173
+  %175 = getelementptr %dimension_descriptor, %dimension_descriptor* %171, i32 0, i32 0
+  %176 = load i32, i32* %175, align 4
+  %177 = mul i32 %176, %174
+  %178 = add i32 %170, %177
+  %179 = getelementptr %array, %array* %152, i32 0, i32 1
+  %180 = load i32, i32* %179, align 4
+  %181 = add i32 %178, %180
+  %182 = getelementptr %array, %array* %152, i32 0, i32 0
+  %183 = load i1*, i1** %182, align 8
+  %184 = getelementptr inbounds i1, i1* %183, i32 %181
+  %185 = load i32, i32* %i12, align 4
+  %186 = load i32, i32* %j13, align 4
+  %187 = add i32 %185, %186
+  %188 = load i32, i32* %k14, align 4
+  %189 = add i32 %187, %188
+  store i32 %189, i32* %call_arg_value, align 4
+  %190 = call i1 @modulo2(i32* %call_arg_value)
+  store i1 %190, i1* %184, align 1
+  %191 = load i32, i32* %i12, align 4
+  %192 = load i32, i32* %j13, align 4
+  %193 = load i32, i32* %k14, align 4
+  %194 = load %array*, %array** %b, align 8
+  %195 = getelementptr %array, %array* %194, i32 0, i32 2
+  %196 = load %dimension_descriptor*, %dimension_descriptor** %195, align 8
+  %197 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %196, i32 0
+  %198 = getelementptr %dimension_descriptor, %dimension_descriptor* %197, i32 0, i32 1
+  %199 = load i32, i32* %198, align 4
+  %200 = sub i32 %191, %199
+  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %197, i32 0, i32 0
+  %202 = load i32, i32* %201, align 4
+  %203 = mul i32 %202, %200
+  %204 = add i32 0, %203
+  %205 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %196, i32 1
+  %206 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 1
+  %207 = load i32, i32* %206, align 4
+  %208 = sub i32 %192, %207
+  %209 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 0
+  %210 = load i32, i32* %209, align 4
+  %211 = mul i32 %210, %208
+  %212 = add i32 %204, %211
+  %213 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %196, i32 2
+  %214 = getelementptr %dimension_descriptor, %dimension_descriptor* %213, i32 0, i32 1
+  %215 = load i32, i32* %214, align 4
+  %216 = sub i32 %193, %215
+  %217 = getelementptr %dimension_descriptor, %dimension_descriptor* %213, i32 0, i32 0
+  %218 = load i32, i32* %217, align 4
+  %219 = mul i32 %218, %216
+  %220 = add i32 %212, %219
+  %221 = getelementptr %array, %array* %194, i32 0, i32 1
+  %222 = load i32, i32* %221, align 4
+  %223 = add i32 %220, %222
+  %224 = getelementptr %array, %array* %194, i32 0, i32 0
+  %225 = load i1*, i1** %224, align 8
+  %226 = getelementptr inbounds i1, i1* %225, i32 %223
+  %227 = load i32, i32* %i12, align 4
+  %228 = load i32, i32* %j13, align 4
+  %229 = mul i32 %227, %228
+  %230 = load i32, i32* %j13, align 4
+  %231 = load i32, i32* %k14, align 4
+  %232 = mul i32 %230, %231
+  %233 = add i32 %229, %232
+  %234 = load i32, i32* %k14, align 4
+  %235 = load i32, i32* %j13, align 4
+  %236 = mul i32 %234, %235
+  %237 = add i32 %233, %236
+  store i32 %237, i32* %call_arg_value25, align 4
+  %238 = call i1 @modulo2(i32* %call_arg_value25)
+  store i1 %238, i1* %226, align 1
+  br label %loop.head23
+
+loop.end:                                         ; preds = %loop.head23
+  br label %loop.head21
+
+loop.end26:                                       ; preds = %loop.head21
+  br label %loop.head
+
+loop.end27:                                       ; preds = %loop.head
+  %239 = load %array*, %array** %a, align 8
+  %240 = getelementptr %array, %array* %239, i32 0, i32 2
+  %241 = load %dimension_descriptor*, %dimension_descriptor** %240, align 8
+  %242 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %241, i32 0
+  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %242, i32 0, i32 1
+  %244 = load i32, i32* %243, align 4
+  store i32 %244, i32* %__1_v3, align 4
+  %245 = load %array*, %array** %b, align 8
+  %246 = getelementptr %array, %array* %245, i32 0, i32 2
+  %247 = load %dimension_descriptor*, %dimension_descriptor** %246, align 8
+  %248 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %247, i32 0
+  %249 = getelementptr %dimension_descriptor, %dimension_descriptor* %248, i32 0, i32 1
+  %250 = load i32, i32* %249, align 4
+  store i32 %250, i32* %__1_u2, align 4
+  %251 = load %array*, %array** %c, align 8
+  %252 = getelementptr %array, %array* %251, i32 0, i32 2
+  %253 = load %dimension_descriptor*, %dimension_descriptor** %252, align 8
+  %254 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %253, i32 0
+  %255 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 1
+  %256 = load i32, i32* %255, align 4
+  %257 = sub i32 %256, 1
+  store i32 %257, i32* %__1_t1, align 4
+  br label %loop.head28
+
+loop.head28:                                      ; preds = %loop.end35, %loop.end27
+  %258 = load i32, i32* %__1_t1, align 4
+  %259 = add i32 %258, 1
+  %260 = load %array*, %array** %c, align 8
+  %261 = getelementptr %array, %array* %260, i32 0, i32 2
+  %262 = load %dimension_descriptor*, %dimension_descriptor** %261, align 8
+  %263 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %262, i32 0
+  %264 = getelementptr %dimension_descriptor, %dimension_descriptor* %263, i32 0, i32 1
+  %265 = load i32, i32* %264, align 4
+  %266 = getelementptr %dimension_descriptor, %dimension_descriptor* %263, i32 0, i32 2
+  %267 = load i32, i32* %266, align 4
+  %268 = add i32 %267, %265
+  %269 = sub i32 %268, 1
+  %270 = icmp sle i32 %259, %269
+  br i1 %270, label %loop.body29, label %loop.end36
+
+loop.body29:                                      ; preds = %loop.head28
+  %271 = load i32, i32* %__1_t1, align 4
+  %272 = add i32 %271, 1
+  store i32 %272, i32* %__1_t1, align 4
+  %273 = load %array*, %array** %a, align 8
+  %274 = getelementptr %array, %array* %273, i32 0, i32 2
+  %275 = load %dimension_descriptor*, %dimension_descriptor** %274, align 8
+  %276 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %275, i32 0
+  %277 = getelementptr %dimension_descriptor, %dimension_descriptor* %276, i32 0, i32 1
+  %278 = load i32, i32* %277, align 4
+  store i32 %278, i32* %__2_v6, align 4
+  %279 = load %array*, %array** %b, align 8
+  %280 = getelementptr %array, %array* %279, i32 0, i32 2
+  %281 = load %dimension_descriptor*, %dimension_descriptor** %280, align 8
+  %282 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %281, i32 0
+  %283 = getelementptr %dimension_descriptor, %dimension_descriptor* %282, i32 0, i32 1
+  %284 = load i32, i32* %283, align 4
+  store i32 %284, i32* %__2_u5, align 4
+  %285 = load %array*, %array** %c, align 8
+  %286 = getelementptr %array, %array* %285, i32 0, i32 2
+  %287 = load %dimension_descriptor*, %dimension_descriptor** %286, align 8
+  %288 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %287, i32 1
+  %289 = getelementptr %dimension_descriptor, %dimension_descriptor* %288, i32 0, i32 1
+  %290 = load i32, i32* %289, align 4
+  %291 = sub i32 %290, 1
+  store i32 %291, i32* %__2_t4, align 4
+  br label %loop.head30
+
+loop.head30:                                      ; preds = %loop.end34, %loop.body29
+  %292 = load i32, i32* %__2_t4, align 4
+  %293 = add i32 %292, 1
+  %294 = load %array*, %array** %c, align 8
+  %295 = getelementptr %array, %array* %294, i32 0, i32 2
+  %296 = load %dimension_descriptor*, %dimension_descriptor** %295, align 8
+  %297 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %296, i32 1
+  %298 = getelementptr %dimension_descriptor, %dimension_descriptor* %297, i32 0, i32 1
+  %299 = load i32, i32* %298, align 4
+  %300 = getelementptr %dimension_descriptor, %dimension_descriptor* %297, i32 0, i32 2
+  %301 = load i32, i32* %300, align 4
+  %302 = add i32 %301, %299
+  %303 = sub i32 %302, 1
+  %304 = icmp sle i32 %293, %303
+  br i1 %304, label %loop.body31, label %loop.end35
+
+loop.body31:                                      ; preds = %loop.head30
+  %305 = load i32, i32* %__2_t4, align 4
+  %306 = add i32 %305, 1
+  store i32 %306, i32* %__2_t4, align 4
+  %307 = load %array*, %array** %a, align 8
+  %308 = getelementptr %array, %array* %307, i32 0, i32 2
+  %309 = load %dimension_descriptor*, %dimension_descriptor** %308, align 8
+  %310 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %309, i32 1
+  %311 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 1
+  %312 = load i32, i32* %311, align 4
+  store i32 %312, i32* %__3_v9, align 4
+  %313 = load %array*, %array** %b, align 8
+  %314 = getelementptr %array, %array* %313, i32 0, i32 2
+  %315 = load %dimension_descriptor*, %dimension_descriptor** %314, align 8
+  %316 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %315, i32 1
+  %317 = getelementptr %dimension_descriptor, %dimension_descriptor* %316, i32 0, i32 1
+  %318 = load i32, i32* %317, align 4
+  store i32 %318, i32* %__3_u8, align 4
+  %319 = load %array*, %array** %c, align 8
+  %320 = getelementptr %array, %array* %319, i32 0, i32 2
+  %321 = load %dimension_descriptor*, %dimension_descriptor** %320, align 8
+  %322 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %321, i32 2
+  %323 = getelementptr %dimension_descriptor, %dimension_descriptor* %322, i32 0, i32 1
+  %324 = load i32, i32* %323, align 4
+  %325 = sub i32 %324, 1
+  store i32 %325, i32* %__3_t7, align 4
+  br label %loop.head32
+
+loop.head32:                                      ; preds = %loop.body33, %loop.body31
+  %326 = load i32, i32* %__3_t7, align 4
+  %327 = add i32 %326, 1
+  %328 = load %array*, %array** %c, align 8
+  %329 = getelementptr %array, %array* %328, i32 0, i32 2
+  %330 = load %dimension_descriptor*, %dimension_descriptor** %329, align 8
+  %331 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %330, i32 2
+  %332 = getelementptr %dimension_descriptor, %dimension_descriptor* %331, i32 0, i32 1
+  %333 = load i32, i32* %332, align 4
+  %334 = getelementptr %dimension_descriptor, %dimension_descriptor* %331, i32 0, i32 2
+  %335 = load i32, i32* %334, align 4
+  %336 = add i32 %335, %333
+  %337 = sub i32 %336, 1
+  %338 = icmp sle i32 %327, %337
+  br i1 %338, label %loop.body33, label %loop.end34
+
+loop.body33:                                      ; preds = %loop.head32
+  %339 = load i32, i32* %__3_t7, align 4
+  %340 = add i32 %339, 1
+  store i32 %340, i32* %__3_t7, align 4
+  %341 = load i32, i32* %__1_t1, align 4
+  %342 = load i32, i32* %__2_t4, align 4
+  %343 = load i32, i32* %__3_t7, align 4
+  %344 = load %array*, %array** %c, align 8
+  %345 = getelementptr %array, %array* %344, i32 0, i32 2
+  %346 = load %dimension_descriptor*, %dimension_descriptor** %345, align 8
+  %347 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %346, i32 0
+  %348 = getelementptr %dimension_descriptor, %dimension_descriptor* %347, i32 0, i32 1
+  %349 = load i32, i32* %348, align 4
+  %350 = sub i32 %341, %349
+  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %347, i32 0, i32 0
+  %352 = load i32, i32* %351, align 4
+  %353 = mul i32 %352, %350
+  %354 = add i32 0, %353
+  %355 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %346, i32 1
+  %356 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 1
+  %357 = load i32, i32* %356, align 4
+  %358 = sub i32 %342, %357
+  %359 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 0
+  %360 = load i32, i32* %359, align 4
+  %361 = mul i32 %360, %358
+  %362 = add i32 %354, %361
+  %363 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %346, i32 2
+  %364 = getelementptr %dimension_descriptor, %dimension_descriptor* %363, i32 0, i32 1
+  %365 = load i32, i32* %364, align 4
+  %366 = sub i32 %343, %365
+  %367 = getelementptr %dimension_descriptor, %dimension_descriptor* %363, i32 0, i32 0
+  %368 = load i32, i32* %367, align 4
+  %369 = mul i32 %368, %366
+  %370 = add i32 %362, %369
+  %371 = getelementptr %array, %array* %344, i32 0, i32 1
+  %372 = load i32, i32* %371, align 4
+  %373 = add i32 %370, %372
+  %374 = getelementptr %array, %array* %344, i32 0, i32 0
+  %375 = load i1*, i1** %374, align 8
+  %376 = getelementptr inbounds i1, i1* %375, i32 %373
+  %377 = load i32, i32* %__1_v3, align 4
+  %378 = load i32, i32* %__2_v6, align 4
+  %379 = load i32, i32* %__3_v9, align 4
+  %380 = load %array*, %array** %a, align 8
+  %381 = getelementptr %array, %array* %380, i32 0, i32 2
+  %382 = load %dimension_descriptor*, %dimension_descriptor** %381, align 8
+  %383 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %382, i32 0
+  %384 = getelementptr %dimension_descriptor, %dimension_descriptor* %383, i32 0, i32 1
+  %385 = load i32, i32* %384, align 4
+  %386 = sub i32 %377, %385
+  %387 = getelementptr %dimension_descriptor, %dimension_descriptor* %383, i32 0, i32 0
+  %388 = load i32, i32* %387, align 4
+  %389 = mul i32 %388, %386
+  %390 = add i32 0, %389
+  %391 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %382, i32 1
+  %392 = getelementptr %dimension_descriptor, %dimension_descriptor* %391, i32 0, i32 1
+  %393 = load i32, i32* %392, align 4
+  %394 = sub i32 %378, %393
+  %395 = getelementptr %dimension_descriptor, %dimension_descriptor* %391, i32 0, i32 0
+  %396 = load i32, i32* %395, align 4
+  %397 = mul i32 %396, %394
+  %398 = add i32 %390, %397
+  %399 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %382, i32 2
+  %400 = getelementptr %dimension_descriptor, %dimension_descriptor* %399, i32 0, i32 1
+  %401 = load i32, i32* %400, align 4
+  %402 = sub i32 %379, %401
+  %403 = getelementptr %dimension_descriptor, %dimension_descriptor* %399, i32 0, i32 0
+  %404 = load i32, i32* %403, align 4
+  %405 = mul i32 %404, %402
+  %406 = add i32 %398, %405
+  %407 = getelementptr %array, %array* %380, i32 0, i32 1
+  %408 = load i32, i32* %407, align 4
+  %409 = add i32 %406, %408
+  %410 = getelementptr %array, %array* %380, i32 0, i32 0
+  %411 = load i1*, i1** %410, align 8
+  %412 = getelementptr inbounds i1, i1* %411, i32 %409
+  %413 = load i1, i1* %412, align 1
+  %414 = load i32, i32* %__1_u2, align 4
+  %415 = load i32, i32* %__2_u5, align 4
+  %416 = load i32, i32* %__3_u8, align 4
+  %417 = load %array*, %array** %b, align 8
+  %418 = getelementptr %array, %array* %417, i32 0, i32 2
+  %419 = load %dimension_descriptor*, %dimension_descriptor** %418, align 8
+  %420 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 0
+  %421 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 1
+  %422 = load i32, i32* %421, align 4
+  %423 = sub i32 %414, %422
+  %424 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 0
+  %425 = load i32, i32* %424, align 4
+  %426 = mul i32 %425, %423
+  %427 = add i32 0, %426
+  %428 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 1
+  %429 = getelementptr %dimension_descriptor, %dimension_descriptor* %428, i32 0, i32 1
+  %430 = load i32, i32* %429, align 4
+  %431 = sub i32 %415, %430
+  %432 = getelementptr %dimension_descriptor, %dimension_descriptor* %428, i32 0, i32 0
+  %433 = load i32, i32* %432, align 4
+  %434 = mul i32 %433, %431
+  %435 = add i32 %427, %434
+  %436 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 2
+  %437 = getelementptr %dimension_descriptor, %dimension_descriptor* %436, i32 0, i32 1
+  %438 = load i32, i32* %437, align 4
+  %439 = sub i32 %416, %438
+  %440 = getelementptr %dimension_descriptor, %dimension_descriptor* %436, i32 0, i32 0
+  %441 = load i32, i32* %440, align 4
+  %442 = mul i32 %441, %439
+  %443 = add i32 %435, %442
+  %444 = getelementptr %array, %array* %417, i32 0, i32 1
+  %445 = load i32, i32* %444, align 4
+  %446 = add i32 %443, %445
+  %447 = getelementptr %array, %array* %417, i32 0, i32 0
+  %448 = load i1*, i1** %447, align 8
+  %449 = getelementptr inbounds i1, i1* %448, i32 %446
+  %450 = load i1, i1* %449, align 1
+  %451 = icmp eq i1 %413, false
+  %452 = select i1 %451, i1 %413, i1 %450
+  store i1 %452, i1* %376, align 1
+  %453 = load i32, i32* %__3_v9, align 4
+  %454 = add i32 %453, 1
+  store i32 %454, i32* %__3_v9, align 4
+  %455 = load i32, i32* %__3_u8, align 4
+  %456 = add i32 %455, 1
+  store i32 %456, i32* %__3_u8, align 4
+  br label %loop.head32
+
+loop.end34:                                       ; preds = %loop.head32
+  %457 = load i32, i32* %__2_v6, align 4
+  %458 = add i32 %457, 1
+  store i32 %458, i32* %__2_v6, align 4
+  %459 = load i32, i32* %__2_u5, align 4
+  %460 = add i32 %459, 1
+  store i32 %460, i32* %__2_u5, align 4
+  br label %loop.head30
+
+loop.end35:                                       ; preds = %loop.head30
+  %461 = load i32, i32* %__1_v3, align 4
+  %462 = add i32 %461, 1
+  store i32 %462, i32* %__1_v3, align 4
+  %463 = load i32, i32* %__1_u2, align 4
+  %464 = add i32 %463, 1
+  store i32 %464, i32* %__1_u2, align 4
+  br label %loop.head28
+
+loop.end36:                                       ; preds = %loop.head28
+  store i32 0, i32* %call_arg_value37, align 4
+  call void @verify(%array** %c, i32* %call_arg_value37)
+  %465 = load %array*, %array** %a, align 8
+  %466 = getelementptr %array, %array* %465, i32 0, i32 2
+  %467 = load %dimension_descriptor*, %dimension_descriptor** %466, align 8
+  %468 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %467, i32 0
+  %469 = getelementptr %dimension_descriptor, %dimension_descriptor* %468, i32 0, i32 1
+  %470 = load i32, i32* %469, align 4
+  store i32 %470, i32* %__1_v3, align 4
+  %471 = load %array*, %array** %b, align 8
+  %472 = getelementptr %array, %array* %471, i32 0, i32 2
+  %473 = load %dimension_descriptor*, %dimension_descriptor** %472, align 8
+  %474 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %473, i32 0
+  %475 = getelementptr %dimension_descriptor, %dimension_descriptor* %474, i32 0, i32 1
+  %476 = load i32, i32* %475, align 4
+  store i32 %476, i32* %__1_u2, align 4
+  %477 = load %array*, %array** %c, align 8
+  %478 = getelementptr %array, %array* %477, i32 0, i32 2
+  %479 = load %dimension_descriptor*, %dimension_descriptor** %478, align 8
+  %480 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %479, i32 0
+  %481 = getelementptr %dimension_descriptor, %dimension_descriptor* %480, i32 0, i32 1
+  %482 = load i32, i32* %481, align 4
+  %483 = sub i32 %482, 1
+  store i32 %483, i32* %__1_t1, align 4
+  br label %loop.head38
+
+loop.head38:                                      ; preds = %loop.end45, %loop.end36
+  %484 = load i32, i32* %__1_t1, align 4
+  %485 = add i32 %484, 1
+  %486 = load %array*, %array** %c, align 8
+  %487 = getelementptr %array, %array* %486, i32 0, i32 2
+  %488 = load %dimension_descriptor*, %dimension_descriptor** %487, align 8
+  %489 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %488, i32 0
+  %490 = getelementptr %dimension_descriptor, %dimension_descriptor* %489, i32 0, i32 1
+  %491 = load i32, i32* %490, align 4
+  %492 = getelementptr %dimension_descriptor, %dimension_descriptor* %489, i32 0, i32 2
+  %493 = load i32, i32* %492, align 4
+  %494 = add i32 %493, %491
+  %495 = sub i32 %494, 1
+  %496 = icmp sle i32 %485, %495
+  br i1 %496, label %loop.body39, label %loop.end46
+
+loop.body39:                                      ; preds = %loop.head38
+  %497 = load i32, i32* %__1_t1, align 4
+  %498 = add i32 %497, 1
+  store i32 %498, i32* %__1_t1, align 4
+  %499 = load %array*, %array** %a, align 8
+  %500 = getelementptr %array, %array* %499, i32 0, i32 2
+  %501 = load %dimension_descriptor*, %dimension_descriptor** %500, align 8
+  %502 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %501, i32 0
+  %503 = getelementptr %dimension_descriptor, %dimension_descriptor* %502, i32 0, i32 1
+  %504 = load i32, i32* %503, align 4
+  store i32 %504, i32* %__2_v6, align 4
+  %505 = load %array*, %array** %b, align 8
+  %506 = getelementptr %array, %array* %505, i32 0, i32 2
+  %507 = load %dimension_descriptor*, %dimension_descriptor** %506, align 8
+  %508 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %507, i32 0
+  %509 = getelementptr %dimension_descriptor, %dimension_descriptor* %508, i32 0, i32 1
+  %510 = load i32, i32* %509, align 4
+  store i32 %510, i32* %__2_u5, align 4
+  %511 = load %array*, %array** %c, align 8
+  %512 = getelementptr %array, %array* %511, i32 0, i32 2
+  %513 = load %dimension_descriptor*, %dimension_descriptor** %512, align 8
+  %514 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %513, i32 1
+  %515 = getelementptr %dimension_descriptor, %dimension_descriptor* %514, i32 0, i32 1
+  %516 = load i32, i32* %515, align 4
+  %517 = sub i32 %516, 1
+  store i32 %517, i32* %__2_t4, align 4
+  br label %loop.head40
+
+loop.head40:                                      ; preds = %loop.end44, %loop.body39
+  %518 = load i32, i32* %__2_t4, align 4
+  %519 = add i32 %518, 1
+  %520 = load %array*, %array** %c, align 8
+  %521 = getelementptr %array, %array* %520, i32 0, i32 2
+  %522 = load %dimension_descriptor*, %dimension_descriptor** %521, align 8
+  %523 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %522, i32 1
+  %524 = getelementptr %dimension_descriptor, %dimension_descriptor* %523, i32 0, i32 1
+  %525 = load i32, i32* %524, align 4
+  %526 = getelementptr %dimension_descriptor, %dimension_descriptor* %523, i32 0, i32 2
+  %527 = load i32, i32* %526, align 4
+  %528 = add i32 %527, %525
+  %529 = sub i32 %528, 1
+  %530 = icmp sle i32 %519, %529
+  br i1 %530, label %loop.body41, label %loop.end45
+
+loop.body41:                                      ; preds = %loop.head40
+  %531 = load i32, i32* %__2_t4, align 4
+  %532 = add i32 %531, 1
+  store i32 %532, i32* %__2_t4, align 4
+  %533 = load %array*, %array** %a, align 8
+  %534 = getelementptr %array, %array* %533, i32 0, i32 2
+  %535 = load %dimension_descriptor*, %dimension_descriptor** %534, align 8
+  %536 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %535, i32 1
+  %537 = getelementptr %dimension_descriptor, %dimension_descriptor* %536, i32 0, i32 1
+  %538 = load i32, i32* %537, align 4
+  store i32 %538, i32* %__3_v9, align 4
+  %539 = load %array*, %array** %b, align 8
+  %540 = getelementptr %array, %array* %539, i32 0, i32 2
+  %541 = load %dimension_descriptor*, %dimension_descriptor** %540, align 8
+  %542 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %541, i32 1
+  %543 = getelementptr %dimension_descriptor, %dimension_descriptor* %542, i32 0, i32 1
+  %544 = load i32, i32* %543, align 4
+  store i32 %544, i32* %__3_u8, align 4
+  %545 = load %array*, %array** %c, align 8
+  %546 = getelementptr %array, %array* %545, i32 0, i32 2
+  %547 = load %dimension_descriptor*, %dimension_descriptor** %546, align 8
+  %548 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %547, i32 2
+  %549 = getelementptr %dimension_descriptor, %dimension_descriptor* %548, i32 0, i32 1
+  %550 = load i32, i32* %549, align 4
+  %551 = sub i32 %550, 1
+  store i32 %551, i32* %__3_t7, align 4
+  br label %loop.head42
+
+loop.head42:                                      ; preds = %loop.body43, %loop.body41
+  %552 = load i32, i32* %__3_t7, align 4
+  %553 = add i32 %552, 1
+  %554 = load %array*, %array** %c, align 8
+  %555 = getelementptr %array, %array* %554, i32 0, i32 2
+  %556 = load %dimension_descriptor*, %dimension_descriptor** %555, align 8
+  %557 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 2
+  %558 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 1
+  %559 = load i32, i32* %558, align 4
+  %560 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 2
+  %561 = load i32, i32* %560, align 4
+  %562 = add i32 %561, %559
+  %563 = sub i32 %562, 1
+  %564 = icmp sle i32 %553, %563
+  br i1 %564, label %loop.body43, label %loop.end44
+
+loop.body43:                                      ; preds = %loop.head42
+  %565 = load i32, i32* %__3_t7, align 4
+  %566 = add i32 %565, 1
+  store i32 %566, i32* %__3_t7, align 4
+  %567 = load i32, i32* %__1_t1, align 4
+  %568 = load i32, i32* %__2_t4, align 4
+  %569 = load i32, i32* %__3_t7, align 4
+  %570 = load %array*, %array** %c, align 8
+  %571 = getelementptr %array, %array* %570, i32 0, i32 2
+  %572 = load %dimension_descriptor*, %dimension_descriptor** %571, align 8
+  %573 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %572, i32 0
+  %574 = getelementptr %dimension_descriptor, %dimension_descriptor* %573, i32 0, i32 1
+  %575 = load i32, i32* %574, align 4
+  %576 = sub i32 %567, %575
+  %577 = getelementptr %dimension_descriptor, %dimension_descriptor* %573, i32 0, i32 0
+  %578 = load i32, i32* %577, align 4
+  %579 = mul i32 %578, %576
+  %580 = add i32 0, %579
+  %581 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %572, i32 1
+  %582 = getelementptr %dimension_descriptor, %dimension_descriptor* %581, i32 0, i32 1
+  %583 = load i32, i32* %582, align 4
+  %584 = sub i32 %568, %583
+  %585 = getelementptr %dimension_descriptor, %dimension_descriptor* %581, i32 0, i32 0
+  %586 = load i32, i32* %585, align 4
+  %587 = mul i32 %586, %584
+  %588 = add i32 %580, %587
+  %589 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %572, i32 2
+  %590 = getelementptr %dimension_descriptor, %dimension_descriptor* %589, i32 0, i32 1
+  %591 = load i32, i32* %590, align 4
+  %592 = sub i32 %569, %591
+  %593 = getelementptr %dimension_descriptor, %dimension_descriptor* %589, i32 0, i32 0
+  %594 = load i32, i32* %593, align 4
+  %595 = mul i32 %594, %592
+  %596 = add i32 %588, %595
+  %597 = getelementptr %array, %array* %570, i32 0, i32 1
+  %598 = load i32, i32* %597, align 4
+  %599 = add i32 %596, %598
+  %600 = getelementptr %array, %array* %570, i32 0, i32 0
+  %601 = load i1*, i1** %600, align 8
+  %602 = getelementptr inbounds i1, i1* %601, i32 %599
+  %603 = load i32, i32* %__1_v3, align 4
+  %604 = load i32, i32* %__2_v6, align 4
+  %605 = load i32, i32* %__3_v9, align 4
+  %606 = load %array*, %array** %a, align 8
+  %607 = getelementptr %array, %array* %606, i32 0, i32 2
+  %608 = load %dimension_descriptor*, %dimension_descriptor** %607, align 8
+  %609 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %608, i32 0
+  %610 = getelementptr %dimension_descriptor, %dimension_descriptor* %609, i32 0, i32 1
+  %611 = load i32, i32* %610, align 4
+  %612 = sub i32 %603, %611
+  %613 = getelementptr %dimension_descriptor, %dimension_descriptor* %609, i32 0, i32 0
+  %614 = load i32, i32* %613, align 4
+  %615 = mul i32 %614, %612
+  %616 = add i32 0, %615
+  %617 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %608, i32 1
+  %618 = getelementptr %dimension_descriptor, %dimension_descriptor* %617, i32 0, i32 1
+  %619 = load i32, i32* %618, align 4
+  %620 = sub i32 %604, %619
+  %621 = getelementptr %dimension_descriptor, %dimension_descriptor* %617, i32 0, i32 0
+  %622 = load i32, i32* %621, align 4
+  %623 = mul i32 %622, %620
+  %624 = add i32 %616, %623
+  %625 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %608, i32 2
+  %626 = getelementptr %dimension_descriptor, %dimension_descriptor* %625, i32 0, i32 1
+  %627 = load i32, i32* %626, align 4
+  %628 = sub i32 %605, %627
+  %629 = getelementptr %dimension_descriptor, %dimension_descriptor* %625, i32 0, i32 0
+  %630 = load i32, i32* %629, align 4
+  %631 = mul i32 %630, %628
+  %632 = add i32 %624, %631
+  %633 = getelementptr %array, %array* %606, i32 0, i32 1
+  %634 = load i32, i32* %633, align 4
+  %635 = add i32 %632, %634
+  %636 = getelementptr %array, %array* %606, i32 0, i32 0
+  %637 = load i1*, i1** %636, align 8
+  %638 = getelementptr inbounds i1, i1* %637, i32 %635
+  %639 = load i1, i1* %638, align 1
+  %640 = load i32, i32* %__1_u2, align 4
+  %641 = load i32, i32* %__2_u5, align 4
+  %642 = load i32, i32* %__3_u8, align 4
+  %643 = load %array*, %array** %b, align 8
+  %644 = getelementptr %array, %array* %643, i32 0, i32 2
+  %645 = load %dimension_descriptor*, %dimension_descriptor** %644, align 8
+  %646 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %645, i32 0
+  %647 = getelementptr %dimension_descriptor, %dimension_descriptor* %646, i32 0, i32 1
+  %648 = load i32, i32* %647, align 4
+  %649 = sub i32 %640, %648
+  %650 = getelementptr %dimension_descriptor, %dimension_descriptor* %646, i32 0, i32 0
+  %651 = load i32, i32* %650, align 4
+  %652 = mul i32 %651, %649
+  %653 = add i32 0, %652
+  %654 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %645, i32 1
+  %655 = getelementptr %dimension_descriptor, %dimension_descriptor* %654, i32 0, i32 1
+  %656 = load i32, i32* %655, align 4
+  %657 = sub i32 %641, %656
+  %658 = getelementptr %dimension_descriptor, %dimension_descriptor* %654, i32 0, i32 0
+  %659 = load i32, i32* %658, align 4
+  %660 = mul i32 %659, %657
+  %661 = add i32 %653, %660
+  %662 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %645, i32 2
+  %663 = getelementptr %dimension_descriptor, %dimension_descriptor* %662, i32 0, i32 1
+  %664 = load i32, i32* %663, align 4
+  %665 = sub i32 %642, %664
+  %666 = getelementptr %dimension_descriptor, %dimension_descriptor* %662, i32 0, i32 0
+  %667 = load i32, i32* %666, align 4
+  %668 = mul i32 %667, %665
+  %669 = add i32 %661, %668
+  %670 = getelementptr %array, %array* %643, i32 0, i32 1
+  %671 = load i32, i32* %670, align 4
+  %672 = add i32 %669, %671
+  %673 = getelementptr %array, %array* %643, i32 0, i32 0
+  %674 = load i1*, i1** %673, align 8
+  %675 = getelementptr inbounds i1, i1* %674, i32 %672
+  %676 = load i1, i1* %675, align 1
+  %677 = icmp eq i1 %639, false
+  %678 = select i1 %677, i1 %676, i1 %639
+  store i1 %678, i1* %602, align 1
+  %679 = load i32, i32* %__3_v9, align 4
+  %680 = add i32 %679, 1
+  store i32 %680, i32* %__3_v9, align 4
+  %681 = load i32, i32* %__3_u8, align 4
+  %682 = add i32 %681, 1
+  store i32 %682, i32* %__3_u8, align 4
+  br label %loop.head42
+
+loop.end44:                                       ; preds = %loop.head42
+  %683 = load i32, i32* %__2_v6, align 4
+  %684 = add i32 %683, 1
+  store i32 %684, i32* %__2_v6, align 4
+  %685 = load i32, i32* %__2_u5, align 4
+  %686 = add i32 %685, 1
+  store i32 %686, i32* %__2_u5, align 4
+  br label %loop.head40
+
+loop.end45:                                       ; preds = %loop.head40
+  %687 = load i32, i32* %__1_v3, align 4
+  %688 = add i32 %687, 1
+  store i32 %688, i32* %__1_v3, align 4
+  %689 = load i32, i32* %__1_u2, align 4
+  %690 = add i32 %689, 1
+  store i32 %690, i32* %__1_u2, align 4
+  br label %loop.head38
+
+loop.end46:                                       ; preds = %loop.head38
+  store i32 1, i32* %call_arg_value47, align 4
+  call void @verify(%array** %c, i32* %call_arg_value47)
+  %691 = load %array*, %array** %a, align 8
+  %692 = getelementptr %array, %array* %691, i32 0, i32 2
+  %693 = load %dimension_descriptor*, %dimension_descriptor** %692, align 8
+  %694 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %693, i32 0
+  %695 = getelementptr %dimension_descriptor, %dimension_descriptor* %694, i32 0, i32 1
+  %696 = load i32, i32* %695, align 4
+  store i32 %696, i32* %__1_v3, align 4
+  %697 = load %array*, %array** %b, align 8
+  %698 = getelementptr %array, %array* %697, i32 0, i32 2
+  %699 = load %dimension_descriptor*, %dimension_descriptor** %698, align 8
+  %700 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %699, i32 0
+  %701 = getelementptr %dimension_descriptor, %dimension_descriptor* %700, i32 0, i32 1
+  %702 = load i32, i32* %701, align 4
+  store i32 %702, i32* %__1_u2, align 4
+  %703 = load %array*, %array** %c, align 8
+  %704 = getelementptr %array, %array* %703, i32 0, i32 2
+  %705 = load %dimension_descriptor*, %dimension_descriptor** %704, align 8
+  %706 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %705, i32 0
+  %707 = getelementptr %dimension_descriptor, %dimension_descriptor* %706, i32 0, i32 1
+  %708 = load i32, i32* %707, align 4
+  %709 = sub i32 %708, 1
+  store i32 %709, i32* %__1_t1, align 4
+  br label %loop.head48
+
+loop.head48:                                      ; preds = %loop.end55, %loop.end46
+  %710 = load i32, i32* %__1_t1, align 4
+  %711 = add i32 %710, 1
+  %712 = load %array*, %array** %c, align 8
+  %713 = getelementptr %array, %array* %712, i32 0, i32 2
+  %714 = load %dimension_descriptor*, %dimension_descriptor** %713, align 8
+  %715 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %714, i32 0
+  %716 = getelementptr %dimension_descriptor, %dimension_descriptor* %715, i32 0, i32 1
+  %717 = load i32, i32* %716, align 4
+  %718 = getelementptr %dimension_descriptor, %dimension_descriptor* %715, i32 0, i32 2
+  %719 = load i32, i32* %718, align 4
+  %720 = add i32 %719, %717
+  %721 = sub i32 %720, 1
+  %722 = icmp sle i32 %711, %721
+  br i1 %722, label %loop.body49, label %loop.end56
+
+loop.body49:                                      ; preds = %loop.head48
+  %723 = load i32, i32* %__1_t1, align 4
+  %724 = add i32 %723, 1
+  store i32 %724, i32* %__1_t1, align 4
+  %725 = load %array*, %array** %a, align 8
+  %726 = getelementptr %array, %array* %725, i32 0, i32 2
+  %727 = load %dimension_descriptor*, %dimension_descriptor** %726, align 8
+  %728 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %727, i32 0
+  %729 = getelementptr %dimension_descriptor, %dimension_descriptor* %728, i32 0, i32 1
+  %730 = load i32, i32* %729, align 4
+  store i32 %730, i32* %__2_v6, align 4
+  %731 = load %array*, %array** %b, align 8
+  %732 = getelementptr %array, %array* %731, i32 0, i32 2
+  %733 = load %dimension_descriptor*, %dimension_descriptor** %732, align 8
+  %734 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %733, i32 0
+  %735 = getelementptr %dimension_descriptor, %dimension_descriptor* %734, i32 0, i32 1
+  %736 = load i32, i32* %735, align 4
+  store i32 %736, i32* %__2_u5, align 4
+  %737 = load %array*, %array** %c, align 8
+  %738 = getelementptr %array, %array* %737, i32 0, i32 2
+  %739 = load %dimension_descriptor*, %dimension_descriptor** %738, align 8
+  %740 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %739, i32 1
+  %741 = getelementptr %dimension_descriptor, %dimension_descriptor* %740, i32 0, i32 1
+  %742 = load i32, i32* %741, align 4
+  %743 = sub i32 %742, 1
+  store i32 %743, i32* %__2_t4, align 4
+  br label %loop.head50
+
+loop.head50:                                      ; preds = %loop.end54, %loop.body49
+  %744 = load i32, i32* %__2_t4, align 4
+  %745 = add i32 %744, 1
+  %746 = load %array*, %array** %c, align 8
+  %747 = getelementptr %array, %array* %746, i32 0, i32 2
+  %748 = load %dimension_descriptor*, %dimension_descriptor** %747, align 8
+  %749 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %748, i32 1
+  %750 = getelementptr %dimension_descriptor, %dimension_descriptor* %749, i32 0, i32 1
+  %751 = load i32, i32* %750, align 4
+  %752 = getelementptr %dimension_descriptor, %dimension_descriptor* %749, i32 0, i32 2
+  %753 = load i32, i32* %752, align 4
+  %754 = add i32 %753, %751
+  %755 = sub i32 %754, 1
+  %756 = icmp sle i32 %745, %755
+  br i1 %756, label %loop.body51, label %loop.end55
+
+loop.body51:                                      ; preds = %loop.head50
+  %757 = load i32, i32* %__2_t4, align 4
+  %758 = add i32 %757, 1
+  store i32 %758, i32* %__2_t4, align 4
+  %759 = load %array*, %array** %a, align 8
+  %760 = getelementptr %array, %array* %759, i32 0, i32 2
+  %761 = load %dimension_descriptor*, %dimension_descriptor** %760, align 8
+  %762 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %761, i32 1
+  %763 = getelementptr %dimension_descriptor, %dimension_descriptor* %762, i32 0, i32 1
+  %764 = load i32, i32* %763, align 4
+  store i32 %764, i32* %__3_v9, align 4
+  %765 = load %array*, %array** %b, align 8
+  %766 = getelementptr %array, %array* %765, i32 0, i32 2
+  %767 = load %dimension_descriptor*, %dimension_descriptor** %766, align 8
+  %768 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %767, i32 1
+  %769 = getelementptr %dimension_descriptor, %dimension_descriptor* %768, i32 0, i32 1
+  %770 = load i32, i32* %769, align 4
+  store i32 %770, i32* %__3_u8, align 4
+  %771 = load %array*, %array** %c, align 8
+  %772 = getelementptr %array, %array* %771, i32 0, i32 2
+  %773 = load %dimension_descriptor*, %dimension_descriptor** %772, align 8
+  %774 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %773, i32 2
+  %775 = getelementptr %dimension_descriptor, %dimension_descriptor* %774, i32 0, i32 1
+  %776 = load i32, i32* %775, align 4
+  %777 = sub i32 %776, 1
+  store i32 %777, i32* %__3_t7, align 4
+  br label %loop.head52
+
+loop.head52:                                      ; preds = %loop.body53, %loop.body51
+  %778 = load i32, i32* %__3_t7, align 4
+  %779 = add i32 %778, 1
+  %780 = load %array*, %array** %c, align 8
+  %781 = getelementptr %array, %array* %780, i32 0, i32 2
+  %782 = load %dimension_descriptor*, %dimension_descriptor** %781, align 8
+  %783 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %782, i32 2
+  %784 = getelementptr %dimension_descriptor, %dimension_descriptor* %783, i32 0, i32 1
+  %785 = load i32, i32* %784, align 4
+  %786 = getelementptr %dimension_descriptor, %dimension_descriptor* %783, i32 0, i32 2
+  %787 = load i32, i32* %786, align 4
+  %788 = add i32 %787, %785
+  %789 = sub i32 %788, 1
+  %790 = icmp sle i32 %779, %789
+  br i1 %790, label %loop.body53, label %loop.end54
+
+loop.body53:                                      ; preds = %loop.head52
+  %791 = load i32, i32* %__3_t7, align 4
+  %792 = add i32 %791, 1
+  store i32 %792, i32* %__3_t7, align 4
+  %793 = load i32, i32* %__1_t1, align 4
+  %794 = load i32, i32* %__2_t4, align 4
+  %795 = load i32, i32* %__3_t7, align 4
+  %796 = load %array*, %array** %c, align 8
+  %797 = getelementptr %array, %array* %796, i32 0, i32 2
+  %798 = load %dimension_descriptor*, %dimension_descriptor** %797, align 8
+  %799 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %798, i32 0
+  %800 = getelementptr %dimension_descriptor, %dimension_descriptor* %799, i32 0, i32 1
+  %801 = load i32, i32* %800, align 4
+  %802 = sub i32 %793, %801
+  %803 = getelementptr %dimension_descriptor, %dimension_descriptor* %799, i32 0, i32 0
+  %804 = load i32, i32* %803, align 4
+  %805 = mul i32 %804, %802
+  %806 = add i32 0, %805
+  %807 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %798, i32 1
+  %808 = getelementptr %dimension_descriptor, %dimension_descriptor* %807, i32 0, i32 1
+  %809 = load i32, i32* %808, align 4
+  %810 = sub i32 %794, %809
+  %811 = getelementptr %dimension_descriptor, %dimension_descriptor* %807, i32 0, i32 0
+  %812 = load i32, i32* %811, align 4
+  %813 = mul i32 %812, %810
+  %814 = add i32 %806, %813
+  %815 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %798, i32 2
+  %816 = getelementptr %dimension_descriptor, %dimension_descriptor* %815, i32 0, i32 1
+  %817 = load i32, i32* %816, align 4
+  %818 = sub i32 %795, %817
+  %819 = getelementptr %dimension_descriptor, %dimension_descriptor* %815, i32 0, i32 0
+  %820 = load i32, i32* %819, align 4
+  %821 = mul i32 %820, %818
+  %822 = add i32 %814, %821
+  %823 = getelementptr %array, %array* %796, i32 0, i32 1
+  %824 = load i32, i32* %823, align 4
+  %825 = add i32 %822, %824
+  %826 = getelementptr %array, %array* %796, i32 0, i32 0
+  %827 = load i1*, i1** %826, align 8
+  %828 = getelementptr inbounds i1, i1* %827, i32 %825
+  %829 = load i32, i32* %__1_v3, align 4
+  %830 = load i32, i32* %__2_v6, align 4
+  %831 = load i32, i32* %__3_v9, align 4
+  %832 = load %array*, %array** %a, align 8
+  %833 = getelementptr %array, %array* %832, i32 0, i32 2
+  %834 = load %dimension_descriptor*, %dimension_descriptor** %833, align 8
+  %835 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %834, i32 0
+  %836 = getelementptr %dimension_descriptor, %dimension_descriptor* %835, i32 0, i32 1
+  %837 = load i32, i32* %836, align 4
+  %838 = sub i32 %829, %837
+  %839 = getelementptr %dimension_descriptor, %dimension_descriptor* %835, i32 0, i32 0
+  %840 = load i32, i32* %839, align 4
+  %841 = mul i32 %840, %838
+  %842 = add i32 0, %841
+  %843 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %834, i32 1
+  %844 = getelementptr %dimension_descriptor, %dimension_descriptor* %843, i32 0, i32 1
+  %845 = load i32, i32* %844, align 4
+  %846 = sub i32 %830, %845
+  %847 = getelementptr %dimension_descriptor, %dimension_descriptor* %843, i32 0, i32 0
+  %848 = load i32, i32* %847, align 4
+  %849 = mul i32 %848, %846
+  %850 = add i32 %842, %849
+  %851 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %834, i32 2
+  %852 = getelementptr %dimension_descriptor, %dimension_descriptor* %851, i32 0, i32 1
+  %853 = load i32, i32* %852, align 4
+  %854 = sub i32 %831, %853
+  %855 = getelementptr %dimension_descriptor, %dimension_descriptor* %851, i32 0, i32 0
+  %856 = load i32, i32* %855, align 4
+  %857 = mul i32 %856, %854
+  %858 = add i32 %850, %857
+  %859 = getelementptr %array, %array* %832, i32 0, i32 1
+  %860 = load i32, i32* %859, align 4
+  %861 = add i32 %858, %860
+  %862 = getelementptr %array, %array* %832, i32 0, i32 0
+  %863 = load i1*, i1** %862, align 8
+  %864 = getelementptr inbounds i1, i1* %863, i32 %861
+  %865 = load i1, i1* %864, align 1
+  %866 = load i32, i32* %__1_u2, align 4
+  %867 = load i32, i32* %__2_u5, align 4
+  %868 = load i32, i32* %__3_u8, align 4
+  %869 = load %array*, %array** %b, align 8
+  %870 = getelementptr %array, %array* %869, i32 0, i32 2
+  %871 = load %dimension_descriptor*, %dimension_descriptor** %870, align 8
+  %872 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %871, i32 0
+  %873 = getelementptr %dimension_descriptor, %dimension_descriptor* %872, i32 0, i32 1
+  %874 = load i32, i32* %873, align 4
+  %875 = sub i32 %866, %874
+  %876 = getelementptr %dimension_descriptor, %dimension_descriptor* %872, i32 0, i32 0
+  %877 = load i32, i32* %876, align 4
+  %878 = mul i32 %877, %875
+  %879 = add i32 0, %878
+  %880 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %871, i32 1
+  %881 = getelementptr %dimension_descriptor, %dimension_descriptor* %880, i32 0, i32 1
+  %882 = load i32, i32* %881, align 4
+  %883 = sub i32 %867, %882
+  %884 = getelementptr %dimension_descriptor, %dimension_descriptor* %880, i32 0, i32 0
+  %885 = load i32, i32* %884, align 4
+  %886 = mul i32 %885, %883
+  %887 = add i32 %879, %886
+  %888 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %871, i32 2
+  %889 = getelementptr %dimension_descriptor, %dimension_descriptor* %888, i32 0, i32 1
+  %890 = load i32, i32* %889, align 4
+  %891 = sub i32 %868, %890
+  %892 = getelementptr %dimension_descriptor, %dimension_descriptor* %888, i32 0, i32 0
+  %893 = load i32, i32* %892, align 4
+  %894 = mul i32 %893, %891
+  %895 = add i32 %887, %894
+  %896 = getelementptr %array, %array* %869, i32 0, i32 1
+  %897 = load i32, i32* %896, align 4
+  %898 = add i32 %895, %897
+  %899 = getelementptr %array, %array* %869, i32 0, i32 0
+  %900 = load i1*, i1** %899, align 8
+  %901 = getelementptr inbounds i1, i1* %900, i32 %898
+  %902 = load i1, i1* %901, align 1
+  %903 = icmp eq i1 %865, false
+  %904 = xor i1 %865, %902
+  %905 = xor i1 %904, true
+  store i1 %905, i1* %828, align 1
+  %906 = load i32, i32* %__3_v9, align 4
+  %907 = add i32 %906, 1
+  store i32 %907, i32* %__3_v9, align 4
+  %908 = load i32, i32* %__3_u8, align 4
+  %909 = add i32 %908, 1
+  store i32 %909, i32* %__3_u8, align 4
+  br label %loop.head52
+
+loop.end54:                                       ; preds = %loop.head52
+  %910 = load i32, i32* %__2_v6, align 4
+  %911 = add i32 %910, 1
+  store i32 %911, i32* %__2_v6, align 4
+  %912 = load i32, i32* %__2_u5, align 4
+  %913 = add i32 %912, 1
+  store i32 %913, i32* %__2_u5, align 4
+  br label %loop.head50
+
+loop.end55:                                       ; preds = %loop.head50
+  %914 = load i32, i32* %__1_v3, align 4
+  %915 = add i32 %914, 1
+  store i32 %915, i32* %__1_v3, align 4
+  %916 = load i32, i32* %__1_u2, align 4
+  %917 = add i32 %916, 1
+  store i32 %917, i32* %__1_u2, align 4
+  br label %loop.head48
+
+loop.end56:                                       ; preds = %loop.head48
+  store i32 2, i32* %call_arg_value57, align 4
+  call void @verify(%array** %c, i32* %call_arg_value57)
+  %918 = load %array*, %array** %b, align 8
+  %919 = getelementptr %array, %array* %918, i32 0, i32 2
+  %920 = load %dimension_descriptor*, %dimension_descriptor** %919, align 8
+  %921 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %920, i32 0
+  %922 = getelementptr %dimension_descriptor, %dimension_descriptor* %921, i32 0, i32 1
+  %923 = load i32, i32* %922, align 4
+  store i32 %923, i32* %__1_v3, align 4
+  %924 = load %array*, %array** %a, align 8
+  %925 = getelementptr %array, %array* %924, i32 0, i32 2
+  %926 = load %dimension_descriptor*, %dimension_descriptor** %925, align 8
+  %927 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %926, i32 0
+  %928 = getelementptr %dimension_descriptor, %dimension_descriptor* %927, i32 0, i32 1
+  %929 = load i32, i32* %928, align 4
+  store i32 %929, i32* %__1_u2, align 4
+  %930 = load %array*, %array** %c, align 8
+  %931 = getelementptr %array, %array* %930, i32 0, i32 2
+  %932 = load %dimension_descriptor*, %dimension_descriptor** %931, align 8
+  %933 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %932, i32 0
+  %934 = getelementptr %dimension_descriptor, %dimension_descriptor* %933, i32 0, i32 1
+  %935 = load i32, i32* %934, align 4
+  %936 = sub i32 %935, 1
+  store i32 %936, i32* %__1_t1, align 4
+  br label %loop.head58
+
+loop.head58:                                      ; preds = %loop.end65, %loop.end56
+  %937 = load i32, i32* %__1_t1, align 4
+  %938 = add i32 %937, 1
+  %939 = load %array*, %array** %c, align 8
+  %940 = getelementptr %array, %array* %939, i32 0, i32 2
+  %941 = load %dimension_descriptor*, %dimension_descriptor** %940, align 8
+  %942 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %941, i32 0
+  %943 = getelementptr %dimension_descriptor, %dimension_descriptor* %942, i32 0, i32 1
+  %944 = load i32, i32* %943, align 4
+  %945 = getelementptr %dimension_descriptor, %dimension_descriptor* %942, i32 0, i32 2
+  %946 = load i32, i32* %945, align 4
+  %947 = add i32 %946, %944
+  %948 = sub i32 %947, 1
+  %949 = icmp sle i32 %938, %948
+  br i1 %949, label %loop.body59, label %loop.end66
+
+loop.body59:                                      ; preds = %loop.head58
+  %950 = load i32, i32* %__1_t1, align 4
+  %951 = add i32 %950, 1
+  store i32 %951, i32* %__1_t1, align 4
+  %952 = load %array*, %array** %b, align 8
+  %953 = getelementptr %array, %array* %952, i32 0, i32 2
+  %954 = load %dimension_descriptor*, %dimension_descriptor** %953, align 8
+  %955 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %954, i32 0
+  %956 = getelementptr %dimension_descriptor, %dimension_descriptor* %955, i32 0, i32 1
+  %957 = load i32, i32* %956, align 4
+  store i32 %957, i32* %__2_v6, align 4
+  %958 = load %array*, %array** %a, align 8
+  %959 = getelementptr %array, %array* %958, i32 0, i32 2
+  %960 = load %dimension_descriptor*, %dimension_descriptor** %959, align 8
+  %961 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %960, i32 0
+  %962 = getelementptr %dimension_descriptor, %dimension_descriptor* %961, i32 0, i32 1
+  %963 = load i32, i32* %962, align 4
+  store i32 %963, i32* %__2_u5, align 4
+  %964 = load %array*, %array** %c, align 8
+  %965 = getelementptr %array, %array* %964, i32 0, i32 2
+  %966 = load %dimension_descriptor*, %dimension_descriptor** %965, align 8
+  %967 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %966, i32 1
+  %968 = getelementptr %dimension_descriptor, %dimension_descriptor* %967, i32 0, i32 1
+  %969 = load i32, i32* %968, align 4
+  %970 = sub i32 %969, 1
+  store i32 %970, i32* %__2_t4, align 4
+  br label %loop.head60
+
+loop.head60:                                      ; preds = %loop.end64, %loop.body59
+  %971 = load i32, i32* %__2_t4, align 4
+  %972 = add i32 %971, 1
+  %973 = load %array*, %array** %c, align 8
+  %974 = getelementptr %array, %array* %973, i32 0, i32 2
+  %975 = load %dimension_descriptor*, %dimension_descriptor** %974, align 8
+  %976 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %975, i32 1
+  %977 = getelementptr %dimension_descriptor, %dimension_descriptor* %976, i32 0, i32 1
+  %978 = load i32, i32* %977, align 4
+  %979 = getelementptr %dimension_descriptor, %dimension_descriptor* %976, i32 0, i32 2
+  %980 = load i32, i32* %979, align 4
+  %981 = add i32 %980, %978
+  %982 = sub i32 %981, 1
+  %983 = icmp sle i32 %972, %982
+  br i1 %983, label %loop.body61, label %loop.end65
+
+loop.body61:                                      ; preds = %loop.head60
+  %984 = load i32, i32* %__2_t4, align 4
+  %985 = add i32 %984, 1
+  store i32 %985, i32* %__2_t4, align 4
+  %986 = load %array*, %array** %b, align 8
+  %987 = getelementptr %array, %array* %986, i32 0, i32 2
+  %988 = load %dimension_descriptor*, %dimension_descriptor** %987, align 8
+  %989 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %988, i32 1
+  %990 = getelementptr %dimension_descriptor, %dimension_descriptor* %989, i32 0, i32 1
+  %991 = load i32, i32* %990, align 4
+  store i32 %991, i32* %__3_v9, align 4
+  %992 = load %array*, %array** %a, align 8
+  %993 = getelementptr %array, %array* %992, i32 0, i32 2
+  %994 = load %dimension_descriptor*, %dimension_descriptor** %993, align 8
+  %995 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %994, i32 1
+  %996 = getelementptr %dimension_descriptor, %dimension_descriptor* %995, i32 0, i32 1
+  %997 = load i32, i32* %996, align 4
+  store i32 %997, i32* %__3_u8, align 4
+  %998 = load %array*, %array** %c, align 8
+  %999 = getelementptr %array, %array* %998, i32 0, i32 2
+  %1000 = load %dimension_descriptor*, %dimension_descriptor** %999, align 8
+  %1001 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1000, i32 2
+  %1002 = getelementptr %dimension_descriptor, %dimension_descriptor* %1001, i32 0, i32 1
+  %1003 = load i32, i32* %1002, align 4
+  %1004 = sub i32 %1003, 1
+  store i32 %1004, i32* %__3_t7, align 4
+  br label %loop.head62
+
+loop.head62:                                      ; preds = %loop.body63, %loop.body61
+  %1005 = load i32, i32* %__3_t7, align 4
+  %1006 = add i32 %1005, 1
+  %1007 = load %array*, %array** %c, align 8
+  %1008 = getelementptr %array, %array* %1007, i32 0, i32 2
+  %1009 = load %dimension_descriptor*, %dimension_descriptor** %1008, align 8
+  %1010 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1009, i32 2
+  %1011 = getelementptr %dimension_descriptor, %dimension_descriptor* %1010, i32 0, i32 1
+  %1012 = load i32, i32* %1011, align 4
+  %1013 = getelementptr %dimension_descriptor, %dimension_descriptor* %1010, i32 0, i32 2
+  %1014 = load i32, i32* %1013, align 4
+  %1015 = add i32 %1014, %1012
+  %1016 = sub i32 %1015, 1
+  %1017 = icmp sle i32 %1006, %1016
+  br i1 %1017, label %loop.body63, label %loop.end64
+
+loop.body63:                                      ; preds = %loop.head62
+  %1018 = load i32, i32* %__3_t7, align 4
+  %1019 = add i32 %1018, 1
+  store i32 %1019, i32* %__3_t7, align 4
+  %1020 = load i32, i32* %__1_t1, align 4
+  %1021 = load i32, i32* %__2_t4, align 4
+  %1022 = load i32, i32* %__3_t7, align 4
+  %1023 = load %array*, %array** %c, align 8
+  %1024 = getelementptr %array, %array* %1023, i32 0, i32 2
+  %1025 = load %dimension_descriptor*, %dimension_descriptor** %1024, align 8
+  %1026 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1025, i32 0
+  %1027 = getelementptr %dimension_descriptor, %dimension_descriptor* %1026, i32 0, i32 1
+  %1028 = load i32, i32* %1027, align 4
+  %1029 = sub i32 %1020, %1028
+  %1030 = getelementptr %dimension_descriptor, %dimension_descriptor* %1026, i32 0, i32 0
+  %1031 = load i32, i32* %1030, align 4
+  %1032 = mul i32 %1031, %1029
+  %1033 = add i32 0, %1032
+  %1034 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1025, i32 1
+  %1035 = getelementptr %dimension_descriptor, %dimension_descriptor* %1034, i32 0, i32 1
+  %1036 = load i32, i32* %1035, align 4
+  %1037 = sub i32 %1021, %1036
+  %1038 = getelementptr %dimension_descriptor, %dimension_descriptor* %1034, i32 0, i32 0
+  %1039 = load i32, i32* %1038, align 4
+  %1040 = mul i32 %1039, %1037
+  %1041 = add i32 %1033, %1040
+  %1042 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1025, i32 2
+  %1043 = getelementptr %dimension_descriptor, %dimension_descriptor* %1042, i32 0, i32 1
+  %1044 = load i32, i32* %1043, align 4
+  %1045 = sub i32 %1022, %1044
+  %1046 = getelementptr %dimension_descriptor, %dimension_descriptor* %1042, i32 0, i32 0
+  %1047 = load i32, i32* %1046, align 4
+  %1048 = mul i32 %1047, %1045
+  %1049 = add i32 %1041, %1048
+  %1050 = getelementptr %array, %array* %1023, i32 0, i32 1
+  %1051 = load i32, i32* %1050, align 4
+  %1052 = add i32 %1049, %1051
+  %1053 = getelementptr %array, %array* %1023, i32 0, i32 0
+  %1054 = load i1*, i1** %1053, align 8
+  %1055 = getelementptr inbounds i1, i1* %1054, i32 %1052
+  %1056 = load i32, i32* %__1_v3, align 4
+  %1057 = load i32, i32* %__2_v6, align 4
+  %1058 = load i32, i32* %__3_v9, align 4
+  %1059 = load %array*, %array** %b, align 8
+  %1060 = getelementptr %array, %array* %1059, i32 0, i32 2
+  %1061 = load %dimension_descriptor*, %dimension_descriptor** %1060, align 8
+  %1062 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1061, i32 0
+  %1063 = getelementptr %dimension_descriptor, %dimension_descriptor* %1062, i32 0, i32 1
+  %1064 = load i32, i32* %1063, align 4
+  %1065 = sub i32 %1056, %1064
+  %1066 = getelementptr %dimension_descriptor, %dimension_descriptor* %1062, i32 0, i32 0
+  %1067 = load i32, i32* %1066, align 4
+  %1068 = mul i32 %1067, %1065
+  %1069 = add i32 0, %1068
+  %1070 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1061, i32 1
+  %1071 = getelementptr %dimension_descriptor, %dimension_descriptor* %1070, i32 0, i32 1
+  %1072 = load i32, i32* %1071, align 4
+  %1073 = sub i32 %1057, %1072
+  %1074 = getelementptr %dimension_descriptor, %dimension_descriptor* %1070, i32 0, i32 0
+  %1075 = load i32, i32* %1074, align 4
+  %1076 = mul i32 %1075, %1073
+  %1077 = add i32 %1069, %1076
+  %1078 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1061, i32 2
+  %1079 = getelementptr %dimension_descriptor, %dimension_descriptor* %1078, i32 0, i32 1
+  %1080 = load i32, i32* %1079, align 4
+  %1081 = sub i32 %1058, %1080
+  %1082 = getelementptr %dimension_descriptor, %dimension_descriptor* %1078, i32 0, i32 0
+  %1083 = load i32, i32* %1082, align 4
+  %1084 = mul i32 %1083, %1081
+  %1085 = add i32 %1077, %1084
+  %1086 = getelementptr %array, %array* %1059, i32 0, i32 1
+  %1087 = load i32, i32* %1086, align 4
+  %1088 = add i32 %1085, %1087
+  %1089 = getelementptr %array, %array* %1059, i32 0, i32 0
+  %1090 = load i1*, i1** %1089, align 8
+  %1091 = getelementptr inbounds i1, i1* %1090, i32 %1088
+  %1092 = load i1, i1* %1091, align 1
+  %1093 = load i32, i32* %__1_u2, align 4
+  %1094 = load i32, i32* %__2_u5, align 4
+  %1095 = load i32, i32* %__3_u8, align 4
+  %1096 = load %array*, %array** %a, align 8
+  %1097 = getelementptr %array, %array* %1096, i32 0, i32 2
+  %1098 = load %dimension_descriptor*, %dimension_descriptor** %1097, align 8
+  %1099 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1098, i32 0
+  %1100 = getelementptr %dimension_descriptor, %dimension_descriptor* %1099, i32 0, i32 1
+  %1101 = load i32, i32* %1100, align 4
+  %1102 = sub i32 %1093, %1101
+  %1103 = getelementptr %dimension_descriptor, %dimension_descriptor* %1099, i32 0, i32 0
+  %1104 = load i32, i32* %1103, align 4
+  %1105 = mul i32 %1104, %1102
+  %1106 = add i32 0, %1105
+  %1107 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1098, i32 1
+  %1108 = getelementptr %dimension_descriptor, %dimension_descriptor* %1107, i32 0, i32 1
+  %1109 = load i32, i32* %1108, align 4
+  %1110 = sub i32 %1094, %1109
+  %1111 = getelementptr %dimension_descriptor, %dimension_descriptor* %1107, i32 0, i32 0
+  %1112 = load i32, i32* %1111, align 4
+  %1113 = mul i32 %1112, %1110
+  %1114 = add i32 %1106, %1113
+  %1115 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1098, i32 2
+  %1116 = getelementptr %dimension_descriptor, %dimension_descriptor* %1115, i32 0, i32 1
+  %1117 = load i32, i32* %1116, align 4
+  %1118 = sub i32 %1095, %1117
+  %1119 = getelementptr %dimension_descriptor, %dimension_descriptor* %1115, i32 0, i32 0
+  %1120 = load i32, i32* %1119, align 4
+  %1121 = mul i32 %1120, %1118
+  %1122 = add i32 %1114, %1121
+  %1123 = getelementptr %array, %array* %1096, i32 0, i32 1
+  %1124 = load i32, i32* %1123, align 4
+  %1125 = add i32 %1122, %1124
+  %1126 = getelementptr %array, %array* %1096, i32 0, i32 0
+  %1127 = load i1*, i1** %1126, align 8
+  %1128 = getelementptr inbounds i1, i1* %1127, i32 %1125
+  %1129 = load i1, i1* %1128, align 1
+  %1130 = icmp eq i1 %1092, false
+  %1131 = xor i1 %1092, %1129
+  store i1 %1131, i1* %1055, align 1
+  %1132 = load i32, i32* %__3_v9, align 4
+  %1133 = add i32 %1132, 1
+  store i32 %1133, i32* %__3_v9, align 4
+  %1134 = load i32, i32* %__3_u8, align 4
+  %1135 = add i32 %1134, 1
+  store i32 %1135, i32* %__3_u8, align 4
+  br label %loop.head62
+
+loop.end64:                                       ; preds = %loop.head62
+  %1136 = load i32, i32* %__2_v6, align 4
+  %1137 = add i32 %1136, 1
+  store i32 %1137, i32* %__2_v6, align 4
+  %1138 = load i32, i32* %__2_u5, align 4
+  %1139 = add i32 %1138, 1
+  store i32 %1139, i32* %__2_u5, align 4
+  br label %loop.head60
+
+loop.end65:                                       ; preds = %loop.head60
+  %1140 = load i32, i32* %__1_v3, align 4
+  %1141 = add i32 %1140, 1
+  store i32 %1141, i32* %__1_v3, align 4
+  %1142 = load i32, i32* %__1_u2, align 4
+  %1143 = add i32 %1142, 1
+  store i32 %1143, i32* %__1_u2, align 4
+  br label %loop.head58
+
+loop.end66:                                       ; preds = %loop.head58
+  store i32 3, i32* %call_arg_value67, align 4
+  call void @verify(%array** %c, i32* %call_arg_value67)
+  %1144 = load %array*, %array** %a, align 8
+  %1145 = getelementptr %array, %array* %1144, i32 0, i32 0
+  %1146 = load i1*, i1** %1145, align 8
+  %1147 = ptrtoint i1* %1146 to i64
+  %1148 = icmp ne i64 %1147, 0
+  br i1 %1148, label %then68, label %else69
+
+then68:                                           ; preds = %loop.end66
+  %1149 = getelementptr %array, %array* %1144, i32 0, i32 0
+  %1150 = load i1*, i1** %1149, align 8
+  %1151 = alloca i8*, align 8
+  %1152 = bitcast i1* %1150 to i8*
+  store i8* %1152, i8** %1151, align 8
+  %1153 = load i8*, i8** %1151, align 8
+  call void @_lfortran_free(i8* %1153)
+  %1154 = getelementptr %array, %array* %1144, i32 0, i32 0
+  store i1* null, i1** %1154, align 8
+  br label %ifcont70
+
+else69:                                           ; preds = %loop.end66
+  br label %ifcont70
+
+ifcont70:                                         ; preds = %else69, %then68
+  %1155 = load %array*, %array** %b, align 8
+  %1156 = getelementptr %array, %array* %1155, i32 0, i32 0
+  %1157 = load i1*, i1** %1156, align 8
+  %1158 = ptrtoint i1* %1157 to i64
+  %1159 = icmp ne i64 %1158, 0
+  br i1 %1159, label %then71, label %else72
+
+then71:                                           ; preds = %ifcont70
+  %1160 = getelementptr %array, %array* %1155, i32 0, i32 0
+  %1161 = load i1*, i1** %1160, align 8
+  %1162 = alloca i8*, align 8
+  %1163 = bitcast i1* %1161 to i8*
+  store i8* %1163, i8** %1162, align 8
+  %1164 = load i8*, i8** %1162, align 8
+  call void @_lfortran_free(i8* %1164)
+  %1165 = getelementptr %array, %array* %1155, i32 0, i32 0
+  store i1* null, i1** %1165, align 8
+  br label %ifcont73
+
+else72:                                           ; preds = %ifcont70
+  br label %ifcont73
+
+ifcont73:                                         ; preds = %else72, %then71
+  %1166 = load %array*, %array** %c, align 8
+  %1167 = getelementptr %array, %array* %1166, i32 0, i32 0
+  %1168 = load i1*, i1** %1167, align 8
+  %1169 = ptrtoint i1* %1168 to i64
+  %1170 = icmp ne i64 %1169, 0
+  br i1 %1170, label %then74, label %else75
+
+then74:                                           ; preds = %ifcont73
+  %1171 = getelementptr %array, %array* %1166, i32 0, i32 0
+  %1172 = load i1*, i1** %1171, align 8
+  %1173 = alloca i8*, align 8
+  %1174 = bitcast i1* %1172 to i8*
+  store i8* %1174, i8** %1173, align 8
+  %1175 = load i8*, i8** %1173, align 8
+  call void @_lfortran_free(i8* %1175)
+  %1176 = getelementptr %array, %array* %1166, i32 0, i32 0
+  store i1* null, i1** %1176, align 8
+  br label %ifcont76
+
+else75:                                           ; preds = %ifcont73
+  br label %ifcont76
+
+ifcont76:                                         ; preds = %else75, %then74
+  %1177 = load %array*, %array** %a, align 8
+  %1178 = getelementptr %array, %array* %1177, i32 0, i32 0
+  %1179 = load i1*, i1** %1178, align 8
+  %1180 = ptrtoint i1* %1179 to i64
+  %1181 = icmp ne i64 %1180, 0
+  br i1 %1181, label %then77, label %else78
+
+then77:                                           ; preds = %ifcont76
+  %1182 = getelementptr %array, %array* %1177, i32 0, i32 0
+  %1183 = load i1*, i1** %1182, align 8
+  %1184 = alloca i8*, align 8
+  %1185 = bitcast i1* %1183 to i8*
+  store i8* %1185, i8** %1184, align 8
+  %1186 = load i8*, i8** %1184, align 8
+  call void @_lfortran_free(i8* %1186)
+  %1187 = getelementptr %array, %array* %1177, i32 0, i32 0
+  store i1* null, i1** %1187, align 8
+  br label %ifcont79
+
+else78:                                           ; preds = %ifcont76
+  br label %ifcont79
+
+ifcont79:                                         ; preds = %else78, %then77
+  %1188 = load %array*, %array** %b, align 8
+  %1189 = getelementptr %array, %array* %1188, i32 0, i32 0
+  %1190 = load i1*, i1** %1189, align 8
+  %1191 = ptrtoint i1* %1190 to i64
+  %1192 = icmp ne i64 %1191, 0
+  br i1 %1192, label %then80, label %else81
+
+then80:                                           ; preds = %ifcont79
+  %1193 = getelementptr %array, %array* %1188, i32 0, i32 0
+  %1194 = load i1*, i1** %1193, align 8
+  %1195 = alloca i8*, align 8
+  %1196 = bitcast i1* %1194 to i8*
+  store i8* %1196, i8** %1195, align 8
+  %1197 = load i8*, i8** %1195, align 8
+  call void @_lfortran_free(i8* %1197)
+  %1198 = getelementptr %array, %array* %1188, i32 0, i32 0
+  store i1* null, i1** %1198, align 8
+  br label %ifcont82
+
+else81:                                           ; preds = %ifcont79
+  br label %ifcont82
+
+ifcont82:                                         ; preds = %else81, %then80
+  %1199 = load %array*, %array** %c, align 8
+  %1200 = getelementptr %array, %array* %1199, i32 0, i32 0
+  %1201 = load i1*, i1** %1200, align 8
+  %1202 = ptrtoint i1* %1201 to i64
+  %1203 = icmp ne i64 %1202, 0
+  br i1 %1203, label %then83, label %else84
+
+then83:                                           ; preds = %ifcont82
+  %1204 = getelementptr %array, %array* %1199, i32 0, i32 0
+  %1205 = load i1*, i1** %1204, align 8
+  %1206 = alloca i8*, align 8
+  %1207 = bitcast i1* %1205 to i8*
+  store i8* %1207, i8** %1206, align 8
+  %1208 = load i8*, i8** %1206, align 8
+  call void @_lfortran_free(i8* %1208)
+  %1209 = getelementptr %array, %array* %1199, i32 0, i32 0
+  store i1* null, i1** %1209, align 8
+  br label %ifcont85
+
+else84:                                           ; preds = %ifcont82
+  br label %ifcont85
+
+ifcont85:                                         ; preds = %else84, %then83
+  br label %return
+
+return:                                           ; preds = %ifcont85
+  ret i32 0
+}
 
 define i1 @modulo2(i32* %x) {
 .entry:
@@ -437,1644 +2090,6 @@ return:                                           ; preds = %loop.end28
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value55 = alloca i32, align 4
-  %call_arg_value45 = alloca i32, align 4
-  %call_arg_value35 = alloca i32, align 4
-  %call_arg_value25 = alloca i32, align 4
-  %call_arg_value13 = alloca i32, align 4
-  %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__1_t = alloca i32, align 4
-  %__1_u = alloca i32, align 4
-  %__1_v = alloca i32, align 4
-  %__2_t = alloca i32, align 4
-  %__2_u = alloca i32, align 4
-  %__2_v = alloca i32, align 4
-  %__3_t = alloca i32, align 4
-  %__3_u = alloca i32, align 4
-  %__3_v = alloca i32, align 4
-  %a = alloca %array*, align 8
-  store %array* null, %array** %a, align 8
-  %arr_desc = alloca %array, align 8
-  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %3 = alloca i32, align 4
-  store i32 3, i32* %3, align 4
-  %4 = load i32, i32* %3, align 4
-  %5 = alloca %dimension_descriptor, i32 %4, align 8
-  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
-  %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
-  store i32 3, i32* %6, align 4
-  %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
-  store i1* null, i1** %7, align 8
-  store %array* %arr_desc, %array** %a, align 8
-  %b = alloca %array*, align 8
-  store %array* null, %array** %b, align 8
-  %arr_desc1 = alloca %array, align 8
-  %8 = getelementptr %array, %array* %arr_desc1, i32 0, i32 2
-  %9 = alloca i32, align 4
-  store i32 3, i32* %9, align 4
-  %10 = load i32, i32* %9, align 4
-  %11 = alloca %dimension_descriptor, i32 %10, align 8
-  store %dimension_descriptor* %11, %dimension_descriptor** %8, align 8
-  %12 = getelementptr %array, %array* %arr_desc1, i32 0, i32 4
-  store i32 3, i32* %12, align 4
-  %13 = getelementptr %array, %array* %arr_desc1, i32 0, i32 0
-  store i1* null, i1** %13, align 8
-  store %array* %arr_desc1, %array** %b, align 8
-  %c = alloca %array*, align 8
-  store %array* null, %array** %c, align 8
-  %arr_desc2 = alloca %array, align 8
-  %14 = getelementptr %array, %array* %arr_desc2, i32 0, i32 2
-  %15 = alloca i32, align 4
-  store i32 3, i32* %15, align 4
-  %16 = load i32, i32* %15, align 4
-  %17 = alloca %dimension_descriptor, i32 %16, align 8
-  store %dimension_descriptor* %17, %dimension_descriptor** %14, align 8
-  %18 = getelementptr %array, %array* %arr_desc2, i32 0, i32 4
-  store i32 3, i32* %18, align 4
-  %19 = getelementptr %array, %array* %arr_desc2, i32 0, i32 0
-  store i1* null, i1** %19, align 8
-  store %array* %arr_desc2, %array** %c, align 8
-  store i32 10, i32* @array_op_3.dim1, align 4
-  store i32 100, i32* @array_op_3.dim2, align 4
-  store i32 1, i32* @array_op_3.dim3, align 4
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  %k = alloca i32, align 4
-  %20 = load %array*, %array** %a, align 8
-  %21 = ptrtoint %array* %20 to i32
-  %22 = icmp eq i32 %21, 0
-  br i1 %22, label %then, label %else
-
-then:                                             ; preds = %.entry
-  %23 = alloca %array, align 8
-  %24 = getelementptr %array, %array* %23, i32 0, i32 2
-  %25 = alloca i32, align 4
-  store i32 3, i32* %25, align 4
-  %26 = load i32, i32* %25, align 4
-  %27 = alloca %dimension_descriptor, i32 %26, align 8
-  store %dimension_descriptor* %27, %dimension_descriptor** %24, align 8
-  %28 = getelementptr %array, %array* %23, i32 0, i32 4
-  store i32 3, i32* %28, align 4
-  store %array* %23, %array** %a, align 8
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %29 = load i32, i32* @array_op_3.dim1, align 4
-  %30 = load i32, i32* @array_op_3.dim2, align 4
-  %31 = load i32, i32* @array_op_3.dim3, align 4
-  %32 = load %array*, %array** %a, align 8
-  %33 = getelementptr %array, %array* %32, i32 0, i32 1
-  store i32 0, i32* %33, align 4
-  %34 = getelementptr %array, %array* %32, i32 0, i32 2
-  %35 = load %dimension_descriptor*, %dimension_descriptor** %34, align 8
-  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 0
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
-  store i32 1, i32* %37, align 4
-  store i32 1, i32* %38, align 4
-  store i32 %29, i32* %39, align 4
-  %40 = mul i32 1, %29
-  %41 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 1
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 0
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 1
-  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 2
-  store i32 %40, i32* %42, align 4
-  store i32 1, i32* %43, align 4
-  store i32 %30, i32* %44, align 4
-  %45 = mul i32 %40, %30
-  %46 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 2
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 0
-  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 1
-  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 2
-  store i32 %45, i32* %47, align 4
-  store i32 1, i32* %48, align 4
-  store i32 %31, i32* %49, align 4
-  %50 = mul i32 %45, %31
-  %51 = getelementptr %array, %array* %32, i32 0, i32 0
-  %52 = alloca i32, align 4
-  %53 = mul i32 %50, 1
-  store i32 %53, i32* %52, align 4
-  %54 = load i32, i32* %52, align 4
-  %55 = call i8* @_lfortran_malloc(i32 %54)
-  %56 = bitcast i8* %55 to i1*
-  store i1* %56, i1** %51, align 8
-  %57 = load %array*, %array** %b, align 8
-  %58 = ptrtoint %array* %57 to i32
-  %59 = icmp eq i32 %58, 0
-  br i1 %59, label %then3, label %else4
-
-then3:                                            ; preds = %ifcont
-  %60 = alloca %array, align 8
-  %61 = getelementptr %array, %array* %60, i32 0, i32 2
-  %62 = alloca i32, align 4
-  store i32 3, i32* %62, align 4
-  %63 = load i32, i32* %62, align 4
-  %64 = alloca %dimension_descriptor, i32 %63, align 8
-  store %dimension_descriptor* %64, %dimension_descriptor** %61, align 8
-  %65 = getelementptr %array, %array* %60, i32 0, i32 4
-  store i32 3, i32* %65, align 4
-  store %array* %60, %array** %b, align 8
-  br label %ifcont5
-
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
-
-ifcont5:                                          ; preds = %else4, %then3
-  %66 = load i32, i32* @array_op_3.dim1, align 4
-  %67 = load i32, i32* @array_op_3.dim2, align 4
-  %68 = load i32, i32* @array_op_3.dim3, align 4
-  %69 = load %array*, %array** %b, align 8
-  %70 = getelementptr %array, %array* %69, i32 0, i32 1
-  store i32 0, i32* %70, align 4
-  %71 = getelementptr %array, %array* %69, i32 0, i32 2
-  %72 = load %dimension_descriptor*, %dimension_descriptor** %71, align 8
-  %73 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %72, i32 0
-  %74 = getelementptr %dimension_descriptor, %dimension_descriptor* %73, i32 0, i32 0
-  %75 = getelementptr %dimension_descriptor, %dimension_descriptor* %73, i32 0, i32 1
-  %76 = getelementptr %dimension_descriptor, %dimension_descriptor* %73, i32 0, i32 2
-  store i32 1, i32* %74, align 4
-  store i32 1, i32* %75, align 4
-  store i32 %66, i32* %76, align 4
-  %77 = mul i32 1, %66
-  %78 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %72, i32 1
-  %79 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 0
-  %80 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 1
-  %81 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 2
-  store i32 %77, i32* %79, align 4
-  store i32 1, i32* %80, align 4
-  store i32 %67, i32* %81, align 4
-  %82 = mul i32 %77, %67
-  %83 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %72, i32 2
-  %84 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 0
-  %85 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 1
-  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 2
-  store i32 %82, i32* %84, align 4
-  store i32 1, i32* %85, align 4
-  store i32 %68, i32* %86, align 4
-  %87 = mul i32 %82, %68
-  %88 = getelementptr %array, %array* %69, i32 0, i32 0
-  %89 = alloca i32, align 4
-  %90 = mul i32 %87, 1
-  store i32 %90, i32* %89, align 4
-  %91 = load i32, i32* %89, align 4
-  %92 = call i8* @_lfortran_malloc(i32 %91)
-  %93 = bitcast i8* %92 to i1*
-  store i1* %93, i1** %88, align 8
-  %94 = load %array*, %array** %c, align 8
-  %95 = ptrtoint %array* %94 to i32
-  %96 = icmp eq i32 %95, 0
-  br i1 %96, label %then6, label %else7
-
-then6:                                            ; preds = %ifcont5
-  %97 = alloca %array, align 8
-  %98 = getelementptr %array, %array* %97, i32 0, i32 2
-  %99 = alloca i32, align 4
-  store i32 3, i32* %99, align 4
-  %100 = load i32, i32* %99, align 4
-  %101 = alloca %dimension_descriptor, i32 %100, align 8
-  store %dimension_descriptor* %101, %dimension_descriptor** %98, align 8
-  %102 = getelementptr %array, %array* %97, i32 0, i32 4
-  store i32 3, i32* %102, align 4
-  store %array* %97, %array** %c, align 8
-  br label %ifcont8
-
-else7:                                            ; preds = %ifcont5
-  br label %ifcont8
-
-ifcont8:                                          ; preds = %else7, %then6
-  %103 = load i32, i32* @array_op_3.dim1, align 4
-  %104 = load i32, i32* @array_op_3.dim2, align 4
-  %105 = load i32, i32* @array_op_3.dim3, align 4
-  %106 = load %array*, %array** %c, align 8
-  %107 = getelementptr %array, %array* %106, i32 0, i32 1
-  store i32 0, i32* %107, align 4
-  %108 = getelementptr %array, %array* %106, i32 0, i32 2
-  %109 = load %dimension_descriptor*, %dimension_descriptor** %108, align 8
-  %110 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 0
-  %111 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 0
-  %112 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 1
-  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 2
-  store i32 1, i32* %111, align 4
-  store i32 1, i32* %112, align 4
-  store i32 %103, i32* %113, align 4
-  %114 = mul i32 1, %103
-  %115 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 1
-  %116 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 0
-  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 1
-  %118 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 2
-  store i32 %114, i32* %116, align 4
-  store i32 1, i32* %117, align 4
-  store i32 %104, i32* %118, align 4
-  %119 = mul i32 %114, %104
-  %120 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 2
-  %121 = getelementptr %dimension_descriptor, %dimension_descriptor* %120, i32 0, i32 0
-  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %120, i32 0, i32 1
-  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %120, i32 0, i32 2
-  store i32 %119, i32* %121, align 4
-  store i32 1, i32* %122, align 4
-  store i32 %105, i32* %123, align 4
-  %124 = mul i32 %119, %105
-  %125 = getelementptr %array, %array* %106, i32 0, i32 0
-  %126 = alloca i32, align 4
-  %127 = mul i32 %124, 1
-  store i32 %127, i32* %126, align 4
-  %128 = load i32, i32* %126, align 4
-  %129 = call i8* @_lfortran_malloc(i32 %128)
-  %130 = bitcast i8* %129 to i1*
-  store i1* %130, i1** %125, align 8
-  store i32 0, i32* %i, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.end14, %ifcont8
-  %131 = load i32, i32* %i, align 4
-  %132 = add i32 %131, 1
-  %133 = load i32, i32* @array_op_3.dim1, align 4
-  %134 = icmp sle i32 %132, %133
-  br i1 %134, label %loop.body, label %loop.end15
-
-loop.body:                                        ; preds = %loop.head
-  %135 = load i32, i32* %i, align 4
-  %136 = add i32 %135, 1
-  store i32 %136, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head9
-
-loop.head9:                                       ; preds = %loop.end, %loop.body
-  %137 = load i32, i32* %j, align 4
-  %138 = add i32 %137, 1
-  %139 = load i32, i32* @array_op_3.dim2, align 4
-  %140 = icmp sle i32 %138, %139
-  br i1 %140, label %loop.body10, label %loop.end14
-
-loop.body10:                                      ; preds = %loop.head9
-  %141 = load i32, i32* %j, align 4
-  %142 = add i32 %141, 1
-  store i32 %142, i32* %j, align 4
-  store i32 0, i32* %k, align 4
-  br label %loop.head11
-
-loop.head11:                                      ; preds = %loop.body12, %loop.body10
-  %143 = load i32, i32* %k, align 4
-  %144 = add i32 %143, 1
-  %145 = load i32, i32* @array_op_3.dim3, align 4
-  %146 = icmp sle i32 %144, %145
-  br i1 %146, label %loop.body12, label %loop.end
-
-loop.body12:                                      ; preds = %loop.head11
-  %147 = load i32, i32* %k, align 4
-  %148 = add i32 %147, 1
-  store i32 %148, i32* %k, align 4
-  %149 = load i32, i32* %i, align 4
-  %150 = load i32, i32* %j, align 4
-  %151 = load i32, i32* %k, align 4
-  %152 = load %array*, %array** %a, align 8
-  %153 = getelementptr %array, %array* %152, i32 0, i32 2
-  %154 = load %dimension_descriptor*, %dimension_descriptor** %153, align 8
-  %155 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 0
-  %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 1
-  %157 = load i32, i32* %156, align 4
-  %158 = sub i32 %149, %157
-  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 0
-  %160 = load i32, i32* %159, align 4
-  %161 = mul i32 %160, %158
-  %162 = add i32 0, %161
-  %163 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 1
-  %164 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 1
-  %165 = load i32, i32* %164, align 4
-  %166 = sub i32 %150, %165
-  %167 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 0
-  %168 = load i32, i32* %167, align 4
-  %169 = mul i32 %168, %166
-  %170 = add i32 %162, %169
-  %171 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %154, i32 2
-  %172 = getelementptr %dimension_descriptor, %dimension_descriptor* %171, i32 0, i32 1
-  %173 = load i32, i32* %172, align 4
-  %174 = sub i32 %151, %173
-  %175 = getelementptr %dimension_descriptor, %dimension_descriptor* %171, i32 0, i32 0
-  %176 = load i32, i32* %175, align 4
-  %177 = mul i32 %176, %174
-  %178 = add i32 %170, %177
-  %179 = getelementptr %array, %array* %152, i32 0, i32 1
-  %180 = load i32, i32* %179, align 4
-  %181 = add i32 %178, %180
-  %182 = getelementptr %array, %array* %152, i32 0, i32 0
-  %183 = load i1*, i1** %182, align 8
-  %184 = getelementptr inbounds i1, i1* %183, i32 %181
-  %185 = load i32, i32* %i, align 4
-  %186 = load i32, i32* %j, align 4
-  %187 = add i32 %185, %186
-  %188 = load i32, i32* %k, align 4
-  %189 = add i32 %187, %188
-  store i32 %189, i32* %call_arg_value, align 4
-  %190 = call i1 @modulo2(i32* %call_arg_value)
-  store i1 %190, i1* %184, align 1
-  %191 = load i32, i32* %i, align 4
-  %192 = load i32, i32* %j, align 4
-  %193 = load i32, i32* %k, align 4
-  %194 = load %array*, %array** %b, align 8
-  %195 = getelementptr %array, %array* %194, i32 0, i32 2
-  %196 = load %dimension_descriptor*, %dimension_descriptor** %195, align 8
-  %197 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %196, i32 0
-  %198 = getelementptr %dimension_descriptor, %dimension_descriptor* %197, i32 0, i32 1
-  %199 = load i32, i32* %198, align 4
-  %200 = sub i32 %191, %199
-  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %197, i32 0, i32 0
-  %202 = load i32, i32* %201, align 4
-  %203 = mul i32 %202, %200
-  %204 = add i32 0, %203
-  %205 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %196, i32 1
-  %206 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 1
-  %207 = load i32, i32* %206, align 4
-  %208 = sub i32 %192, %207
-  %209 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 0
-  %210 = load i32, i32* %209, align 4
-  %211 = mul i32 %210, %208
-  %212 = add i32 %204, %211
-  %213 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %196, i32 2
-  %214 = getelementptr %dimension_descriptor, %dimension_descriptor* %213, i32 0, i32 1
-  %215 = load i32, i32* %214, align 4
-  %216 = sub i32 %193, %215
-  %217 = getelementptr %dimension_descriptor, %dimension_descriptor* %213, i32 0, i32 0
-  %218 = load i32, i32* %217, align 4
-  %219 = mul i32 %218, %216
-  %220 = add i32 %212, %219
-  %221 = getelementptr %array, %array* %194, i32 0, i32 1
-  %222 = load i32, i32* %221, align 4
-  %223 = add i32 %220, %222
-  %224 = getelementptr %array, %array* %194, i32 0, i32 0
-  %225 = load i1*, i1** %224, align 8
-  %226 = getelementptr inbounds i1, i1* %225, i32 %223
-  %227 = load i32, i32* %i, align 4
-  %228 = load i32, i32* %j, align 4
-  %229 = mul i32 %227, %228
-  %230 = load i32, i32* %j, align 4
-  %231 = load i32, i32* %k, align 4
-  %232 = mul i32 %230, %231
-  %233 = add i32 %229, %232
-  %234 = load i32, i32* %k, align 4
-  %235 = load i32, i32* %j, align 4
-  %236 = mul i32 %234, %235
-  %237 = add i32 %233, %236
-  store i32 %237, i32* %call_arg_value13, align 4
-  %238 = call i1 @modulo2(i32* %call_arg_value13)
-  store i1 %238, i1* %226, align 1
-  br label %loop.head11
-
-loop.end:                                         ; preds = %loop.head11
-  br label %loop.head9
-
-loop.end14:                                       ; preds = %loop.head9
-  br label %loop.head
-
-loop.end15:                                       ; preds = %loop.head
-  %239 = load %array*, %array** %a, align 8
-  %240 = getelementptr %array, %array* %239, i32 0, i32 2
-  %241 = load %dimension_descriptor*, %dimension_descriptor** %240, align 8
-  %242 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %241, i32 0
-  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %242, i32 0, i32 1
-  %244 = load i32, i32* %243, align 4
-  store i32 %244, i32* %__1_v, align 4
-  %245 = load %array*, %array** %b, align 8
-  %246 = getelementptr %array, %array* %245, i32 0, i32 2
-  %247 = load %dimension_descriptor*, %dimension_descriptor** %246, align 8
-  %248 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %247, i32 0
-  %249 = getelementptr %dimension_descriptor, %dimension_descriptor* %248, i32 0, i32 1
-  %250 = load i32, i32* %249, align 4
-  store i32 %250, i32* %__1_u, align 4
-  %251 = load %array*, %array** %c, align 8
-  %252 = getelementptr %array, %array* %251, i32 0, i32 2
-  %253 = load %dimension_descriptor*, %dimension_descriptor** %252, align 8
-  %254 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %253, i32 0
-  %255 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 1
-  %256 = load i32, i32* %255, align 4
-  %257 = sub i32 %256, 1
-  store i32 %257, i32* %__1_t, align 4
-  br label %loop.head16
-
-loop.head16:                                      ; preds = %loop.end23, %loop.end15
-  %258 = load i32, i32* %__1_t, align 4
-  %259 = add i32 %258, 1
-  %260 = load %array*, %array** %c, align 8
-  %261 = getelementptr %array, %array* %260, i32 0, i32 2
-  %262 = load %dimension_descriptor*, %dimension_descriptor** %261, align 8
-  %263 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %262, i32 0
-  %264 = getelementptr %dimension_descriptor, %dimension_descriptor* %263, i32 0, i32 1
-  %265 = load i32, i32* %264, align 4
-  %266 = getelementptr %dimension_descriptor, %dimension_descriptor* %263, i32 0, i32 2
-  %267 = load i32, i32* %266, align 4
-  %268 = add i32 %267, %265
-  %269 = sub i32 %268, 1
-  %270 = icmp sle i32 %259, %269
-  br i1 %270, label %loop.body17, label %loop.end24
-
-loop.body17:                                      ; preds = %loop.head16
-  %271 = load i32, i32* %__1_t, align 4
-  %272 = add i32 %271, 1
-  store i32 %272, i32* %__1_t, align 4
-  %273 = load %array*, %array** %a, align 8
-  %274 = getelementptr %array, %array* %273, i32 0, i32 2
-  %275 = load %dimension_descriptor*, %dimension_descriptor** %274, align 8
-  %276 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %275, i32 0
-  %277 = getelementptr %dimension_descriptor, %dimension_descriptor* %276, i32 0, i32 1
-  %278 = load i32, i32* %277, align 4
-  store i32 %278, i32* %__2_v, align 4
-  %279 = load %array*, %array** %b, align 8
-  %280 = getelementptr %array, %array* %279, i32 0, i32 2
-  %281 = load %dimension_descriptor*, %dimension_descriptor** %280, align 8
-  %282 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %281, i32 0
-  %283 = getelementptr %dimension_descriptor, %dimension_descriptor* %282, i32 0, i32 1
-  %284 = load i32, i32* %283, align 4
-  store i32 %284, i32* %__2_u, align 4
-  %285 = load %array*, %array** %c, align 8
-  %286 = getelementptr %array, %array* %285, i32 0, i32 2
-  %287 = load %dimension_descriptor*, %dimension_descriptor** %286, align 8
-  %288 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %287, i32 1
-  %289 = getelementptr %dimension_descriptor, %dimension_descriptor* %288, i32 0, i32 1
-  %290 = load i32, i32* %289, align 4
-  %291 = sub i32 %290, 1
-  store i32 %291, i32* %__2_t, align 4
-  br label %loop.head18
-
-loop.head18:                                      ; preds = %loop.end22, %loop.body17
-  %292 = load i32, i32* %__2_t, align 4
-  %293 = add i32 %292, 1
-  %294 = load %array*, %array** %c, align 8
-  %295 = getelementptr %array, %array* %294, i32 0, i32 2
-  %296 = load %dimension_descriptor*, %dimension_descriptor** %295, align 8
-  %297 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %296, i32 1
-  %298 = getelementptr %dimension_descriptor, %dimension_descriptor* %297, i32 0, i32 1
-  %299 = load i32, i32* %298, align 4
-  %300 = getelementptr %dimension_descriptor, %dimension_descriptor* %297, i32 0, i32 2
-  %301 = load i32, i32* %300, align 4
-  %302 = add i32 %301, %299
-  %303 = sub i32 %302, 1
-  %304 = icmp sle i32 %293, %303
-  br i1 %304, label %loop.body19, label %loop.end23
-
-loop.body19:                                      ; preds = %loop.head18
-  %305 = load i32, i32* %__2_t, align 4
-  %306 = add i32 %305, 1
-  store i32 %306, i32* %__2_t, align 4
-  %307 = load %array*, %array** %a, align 8
-  %308 = getelementptr %array, %array* %307, i32 0, i32 2
-  %309 = load %dimension_descriptor*, %dimension_descriptor** %308, align 8
-  %310 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %309, i32 1
-  %311 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 1
-  %312 = load i32, i32* %311, align 4
-  store i32 %312, i32* %__3_v, align 4
-  %313 = load %array*, %array** %b, align 8
-  %314 = getelementptr %array, %array* %313, i32 0, i32 2
-  %315 = load %dimension_descriptor*, %dimension_descriptor** %314, align 8
-  %316 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %315, i32 1
-  %317 = getelementptr %dimension_descriptor, %dimension_descriptor* %316, i32 0, i32 1
-  %318 = load i32, i32* %317, align 4
-  store i32 %318, i32* %__3_u, align 4
-  %319 = load %array*, %array** %c, align 8
-  %320 = getelementptr %array, %array* %319, i32 0, i32 2
-  %321 = load %dimension_descriptor*, %dimension_descriptor** %320, align 8
-  %322 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %321, i32 2
-  %323 = getelementptr %dimension_descriptor, %dimension_descriptor* %322, i32 0, i32 1
-  %324 = load i32, i32* %323, align 4
-  %325 = sub i32 %324, 1
-  store i32 %325, i32* %__3_t, align 4
-  br label %loop.head20
-
-loop.head20:                                      ; preds = %loop.body21, %loop.body19
-  %326 = load i32, i32* %__3_t, align 4
-  %327 = add i32 %326, 1
-  %328 = load %array*, %array** %c, align 8
-  %329 = getelementptr %array, %array* %328, i32 0, i32 2
-  %330 = load %dimension_descriptor*, %dimension_descriptor** %329, align 8
-  %331 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %330, i32 2
-  %332 = getelementptr %dimension_descriptor, %dimension_descriptor* %331, i32 0, i32 1
-  %333 = load i32, i32* %332, align 4
-  %334 = getelementptr %dimension_descriptor, %dimension_descriptor* %331, i32 0, i32 2
-  %335 = load i32, i32* %334, align 4
-  %336 = add i32 %335, %333
-  %337 = sub i32 %336, 1
-  %338 = icmp sle i32 %327, %337
-  br i1 %338, label %loop.body21, label %loop.end22
-
-loop.body21:                                      ; preds = %loop.head20
-  %339 = load i32, i32* %__3_t, align 4
-  %340 = add i32 %339, 1
-  store i32 %340, i32* %__3_t, align 4
-  %341 = load i32, i32* %__1_t, align 4
-  %342 = load i32, i32* %__2_t, align 4
-  %343 = load i32, i32* %__3_t, align 4
-  %344 = load %array*, %array** %c, align 8
-  %345 = getelementptr %array, %array* %344, i32 0, i32 2
-  %346 = load %dimension_descriptor*, %dimension_descriptor** %345, align 8
-  %347 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %346, i32 0
-  %348 = getelementptr %dimension_descriptor, %dimension_descriptor* %347, i32 0, i32 1
-  %349 = load i32, i32* %348, align 4
-  %350 = sub i32 %341, %349
-  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %347, i32 0, i32 0
-  %352 = load i32, i32* %351, align 4
-  %353 = mul i32 %352, %350
-  %354 = add i32 0, %353
-  %355 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %346, i32 1
-  %356 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 1
-  %357 = load i32, i32* %356, align 4
-  %358 = sub i32 %342, %357
-  %359 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 0
-  %360 = load i32, i32* %359, align 4
-  %361 = mul i32 %360, %358
-  %362 = add i32 %354, %361
-  %363 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %346, i32 2
-  %364 = getelementptr %dimension_descriptor, %dimension_descriptor* %363, i32 0, i32 1
-  %365 = load i32, i32* %364, align 4
-  %366 = sub i32 %343, %365
-  %367 = getelementptr %dimension_descriptor, %dimension_descriptor* %363, i32 0, i32 0
-  %368 = load i32, i32* %367, align 4
-  %369 = mul i32 %368, %366
-  %370 = add i32 %362, %369
-  %371 = getelementptr %array, %array* %344, i32 0, i32 1
-  %372 = load i32, i32* %371, align 4
-  %373 = add i32 %370, %372
-  %374 = getelementptr %array, %array* %344, i32 0, i32 0
-  %375 = load i1*, i1** %374, align 8
-  %376 = getelementptr inbounds i1, i1* %375, i32 %373
-  %377 = load i32, i32* %__1_v, align 4
-  %378 = load i32, i32* %__2_v, align 4
-  %379 = load i32, i32* %__3_v, align 4
-  %380 = load %array*, %array** %a, align 8
-  %381 = getelementptr %array, %array* %380, i32 0, i32 2
-  %382 = load %dimension_descriptor*, %dimension_descriptor** %381, align 8
-  %383 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %382, i32 0
-  %384 = getelementptr %dimension_descriptor, %dimension_descriptor* %383, i32 0, i32 1
-  %385 = load i32, i32* %384, align 4
-  %386 = sub i32 %377, %385
-  %387 = getelementptr %dimension_descriptor, %dimension_descriptor* %383, i32 0, i32 0
-  %388 = load i32, i32* %387, align 4
-  %389 = mul i32 %388, %386
-  %390 = add i32 0, %389
-  %391 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %382, i32 1
-  %392 = getelementptr %dimension_descriptor, %dimension_descriptor* %391, i32 0, i32 1
-  %393 = load i32, i32* %392, align 4
-  %394 = sub i32 %378, %393
-  %395 = getelementptr %dimension_descriptor, %dimension_descriptor* %391, i32 0, i32 0
-  %396 = load i32, i32* %395, align 4
-  %397 = mul i32 %396, %394
-  %398 = add i32 %390, %397
-  %399 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %382, i32 2
-  %400 = getelementptr %dimension_descriptor, %dimension_descriptor* %399, i32 0, i32 1
-  %401 = load i32, i32* %400, align 4
-  %402 = sub i32 %379, %401
-  %403 = getelementptr %dimension_descriptor, %dimension_descriptor* %399, i32 0, i32 0
-  %404 = load i32, i32* %403, align 4
-  %405 = mul i32 %404, %402
-  %406 = add i32 %398, %405
-  %407 = getelementptr %array, %array* %380, i32 0, i32 1
-  %408 = load i32, i32* %407, align 4
-  %409 = add i32 %406, %408
-  %410 = getelementptr %array, %array* %380, i32 0, i32 0
-  %411 = load i1*, i1** %410, align 8
-  %412 = getelementptr inbounds i1, i1* %411, i32 %409
-  %413 = load i1, i1* %412, align 1
-  %414 = load i32, i32* %__1_u, align 4
-  %415 = load i32, i32* %__2_u, align 4
-  %416 = load i32, i32* %__3_u, align 4
-  %417 = load %array*, %array** %b, align 8
-  %418 = getelementptr %array, %array* %417, i32 0, i32 2
-  %419 = load %dimension_descriptor*, %dimension_descriptor** %418, align 8
-  %420 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 0
-  %421 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 1
-  %422 = load i32, i32* %421, align 4
-  %423 = sub i32 %414, %422
-  %424 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 0
-  %425 = load i32, i32* %424, align 4
-  %426 = mul i32 %425, %423
-  %427 = add i32 0, %426
-  %428 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 1
-  %429 = getelementptr %dimension_descriptor, %dimension_descriptor* %428, i32 0, i32 1
-  %430 = load i32, i32* %429, align 4
-  %431 = sub i32 %415, %430
-  %432 = getelementptr %dimension_descriptor, %dimension_descriptor* %428, i32 0, i32 0
-  %433 = load i32, i32* %432, align 4
-  %434 = mul i32 %433, %431
-  %435 = add i32 %427, %434
-  %436 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 2
-  %437 = getelementptr %dimension_descriptor, %dimension_descriptor* %436, i32 0, i32 1
-  %438 = load i32, i32* %437, align 4
-  %439 = sub i32 %416, %438
-  %440 = getelementptr %dimension_descriptor, %dimension_descriptor* %436, i32 0, i32 0
-  %441 = load i32, i32* %440, align 4
-  %442 = mul i32 %441, %439
-  %443 = add i32 %435, %442
-  %444 = getelementptr %array, %array* %417, i32 0, i32 1
-  %445 = load i32, i32* %444, align 4
-  %446 = add i32 %443, %445
-  %447 = getelementptr %array, %array* %417, i32 0, i32 0
-  %448 = load i1*, i1** %447, align 8
-  %449 = getelementptr inbounds i1, i1* %448, i32 %446
-  %450 = load i1, i1* %449, align 1
-  %451 = icmp eq i1 %413, false
-  %452 = select i1 %451, i1 %413, i1 %450
-  store i1 %452, i1* %376, align 1
-  %453 = load i32, i32* %__3_v, align 4
-  %454 = add i32 %453, 1
-  store i32 %454, i32* %__3_v, align 4
-  %455 = load i32, i32* %__3_u, align 4
-  %456 = add i32 %455, 1
-  store i32 %456, i32* %__3_u, align 4
-  br label %loop.head20
-
-loop.end22:                                       ; preds = %loop.head20
-  %457 = load i32, i32* %__2_v, align 4
-  %458 = add i32 %457, 1
-  store i32 %458, i32* %__2_v, align 4
-  %459 = load i32, i32* %__2_u, align 4
-  %460 = add i32 %459, 1
-  store i32 %460, i32* %__2_u, align 4
-  br label %loop.head18
-
-loop.end23:                                       ; preds = %loop.head18
-  %461 = load i32, i32* %__1_v, align 4
-  %462 = add i32 %461, 1
-  store i32 %462, i32* %__1_v, align 4
-  %463 = load i32, i32* %__1_u, align 4
-  %464 = add i32 %463, 1
-  store i32 %464, i32* %__1_u, align 4
-  br label %loop.head16
-
-loop.end24:                                       ; preds = %loop.head16
-  store i32 0, i32* %call_arg_value25, align 4
-  call void @verify(%array** %c, i32* %call_arg_value25)
-  %465 = load %array*, %array** %a, align 8
-  %466 = getelementptr %array, %array* %465, i32 0, i32 2
-  %467 = load %dimension_descriptor*, %dimension_descriptor** %466, align 8
-  %468 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %467, i32 0
-  %469 = getelementptr %dimension_descriptor, %dimension_descriptor* %468, i32 0, i32 1
-  %470 = load i32, i32* %469, align 4
-  store i32 %470, i32* %__1_v, align 4
-  %471 = load %array*, %array** %b, align 8
-  %472 = getelementptr %array, %array* %471, i32 0, i32 2
-  %473 = load %dimension_descriptor*, %dimension_descriptor** %472, align 8
-  %474 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %473, i32 0
-  %475 = getelementptr %dimension_descriptor, %dimension_descriptor* %474, i32 0, i32 1
-  %476 = load i32, i32* %475, align 4
-  store i32 %476, i32* %__1_u, align 4
-  %477 = load %array*, %array** %c, align 8
-  %478 = getelementptr %array, %array* %477, i32 0, i32 2
-  %479 = load %dimension_descriptor*, %dimension_descriptor** %478, align 8
-  %480 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %479, i32 0
-  %481 = getelementptr %dimension_descriptor, %dimension_descriptor* %480, i32 0, i32 1
-  %482 = load i32, i32* %481, align 4
-  %483 = sub i32 %482, 1
-  store i32 %483, i32* %__1_t, align 4
-  br label %loop.head26
-
-loop.head26:                                      ; preds = %loop.end33, %loop.end24
-  %484 = load i32, i32* %__1_t, align 4
-  %485 = add i32 %484, 1
-  %486 = load %array*, %array** %c, align 8
-  %487 = getelementptr %array, %array* %486, i32 0, i32 2
-  %488 = load %dimension_descriptor*, %dimension_descriptor** %487, align 8
-  %489 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %488, i32 0
-  %490 = getelementptr %dimension_descriptor, %dimension_descriptor* %489, i32 0, i32 1
-  %491 = load i32, i32* %490, align 4
-  %492 = getelementptr %dimension_descriptor, %dimension_descriptor* %489, i32 0, i32 2
-  %493 = load i32, i32* %492, align 4
-  %494 = add i32 %493, %491
-  %495 = sub i32 %494, 1
-  %496 = icmp sle i32 %485, %495
-  br i1 %496, label %loop.body27, label %loop.end34
-
-loop.body27:                                      ; preds = %loop.head26
-  %497 = load i32, i32* %__1_t, align 4
-  %498 = add i32 %497, 1
-  store i32 %498, i32* %__1_t, align 4
-  %499 = load %array*, %array** %a, align 8
-  %500 = getelementptr %array, %array* %499, i32 0, i32 2
-  %501 = load %dimension_descriptor*, %dimension_descriptor** %500, align 8
-  %502 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %501, i32 0
-  %503 = getelementptr %dimension_descriptor, %dimension_descriptor* %502, i32 0, i32 1
-  %504 = load i32, i32* %503, align 4
-  store i32 %504, i32* %__2_v, align 4
-  %505 = load %array*, %array** %b, align 8
-  %506 = getelementptr %array, %array* %505, i32 0, i32 2
-  %507 = load %dimension_descriptor*, %dimension_descriptor** %506, align 8
-  %508 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %507, i32 0
-  %509 = getelementptr %dimension_descriptor, %dimension_descriptor* %508, i32 0, i32 1
-  %510 = load i32, i32* %509, align 4
-  store i32 %510, i32* %__2_u, align 4
-  %511 = load %array*, %array** %c, align 8
-  %512 = getelementptr %array, %array* %511, i32 0, i32 2
-  %513 = load %dimension_descriptor*, %dimension_descriptor** %512, align 8
-  %514 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %513, i32 1
-  %515 = getelementptr %dimension_descriptor, %dimension_descriptor* %514, i32 0, i32 1
-  %516 = load i32, i32* %515, align 4
-  %517 = sub i32 %516, 1
-  store i32 %517, i32* %__2_t, align 4
-  br label %loop.head28
-
-loop.head28:                                      ; preds = %loop.end32, %loop.body27
-  %518 = load i32, i32* %__2_t, align 4
-  %519 = add i32 %518, 1
-  %520 = load %array*, %array** %c, align 8
-  %521 = getelementptr %array, %array* %520, i32 0, i32 2
-  %522 = load %dimension_descriptor*, %dimension_descriptor** %521, align 8
-  %523 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %522, i32 1
-  %524 = getelementptr %dimension_descriptor, %dimension_descriptor* %523, i32 0, i32 1
-  %525 = load i32, i32* %524, align 4
-  %526 = getelementptr %dimension_descriptor, %dimension_descriptor* %523, i32 0, i32 2
-  %527 = load i32, i32* %526, align 4
-  %528 = add i32 %527, %525
-  %529 = sub i32 %528, 1
-  %530 = icmp sle i32 %519, %529
-  br i1 %530, label %loop.body29, label %loop.end33
-
-loop.body29:                                      ; preds = %loop.head28
-  %531 = load i32, i32* %__2_t, align 4
-  %532 = add i32 %531, 1
-  store i32 %532, i32* %__2_t, align 4
-  %533 = load %array*, %array** %a, align 8
-  %534 = getelementptr %array, %array* %533, i32 0, i32 2
-  %535 = load %dimension_descriptor*, %dimension_descriptor** %534, align 8
-  %536 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %535, i32 1
-  %537 = getelementptr %dimension_descriptor, %dimension_descriptor* %536, i32 0, i32 1
-  %538 = load i32, i32* %537, align 4
-  store i32 %538, i32* %__3_v, align 4
-  %539 = load %array*, %array** %b, align 8
-  %540 = getelementptr %array, %array* %539, i32 0, i32 2
-  %541 = load %dimension_descriptor*, %dimension_descriptor** %540, align 8
-  %542 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %541, i32 1
-  %543 = getelementptr %dimension_descriptor, %dimension_descriptor* %542, i32 0, i32 1
-  %544 = load i32, i32* %543, align 4
-  store i32 %544, i32* %__3_u, align 4
-  %545 = load %array*, %array** %c, align 8
-  %546 = getelementptr %array, %array* %545, i32 0, i32 2
-  %547 = load %dimension_descriptor*, %dimension_descriptor** %546, align 8
-  %548 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %547, i32 2
-  %549 = getelementptr %dimension_descriptor, %dimension_descriptor* %548, i32 0, i32 1
-  %550 = load i32, i32* %549, align 4
-  %551 = sub i32 %550, 1
-  store i32 %551, i32* %__3_t, align 4
-  br label %loop.head30
-
-loop.head30:                                      ; preds = %loop.body31, %loop.body29
-  %552 = load i32, i32* %__3_t, align 4
-  %553 = add i32 %552, 1
-  %554 = load %array*, %array** %c, align 8
-  %555 = getelementptr %array, %array* %554, i32 0, i32 2
-  %556 = load %dimension_descriptor*, %dimension_descriptor** %555, align 8
-  %557 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 2
-  %558 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 1
-  %559 = load i32, i32* %558, align 4
-  %560 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 2
-  %561 = load i32, i32* %560, align 4
-  %562 = add i32 %561, %559
-  %563 = sub i32 %562, 1
-  %564 = icmp sle i32 %553, %563
-  br i1 %564, label %loop.body31, label %loop.end32
-
-loop.body31:                                      ; preds = %loop.head30
-  %565 = load i32, i32* %__3_t, align 4
-  %566 = add i32 %565, 1
-  store i32 %566, i32* %__3_t, align 4
-  %567 = load i32, i32* %__1_t, align 4
-  %568 = load i32, i32* %__2_t, align 4
-  %569 = load i32, i32* %__3_t, align 4
-  %570 = load %array*, %array** %c, align 8
-  %571 = getelementptr %array, %array* %570, i32 0, i32 2
-  %572 = load %dimension_descriptor*, %dimension_descriptor** %571, align 8
-  %573 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %572, i32 0
-  %574 = getelementptr %dimension_descriptor, %dimension_descriptor* %573, i32 0, i32 1
-  %575 = load i32, i32* %574, align 4
-  %576 = sub i32 %567, %575
-  %577 = getelementptr %dimension_descriptor, %dimension_descriptor* %573, i32 0, i32 0
-  %578 = load i32, i32* %577, align 4
-  %579 = mul i32 %578, %576
-  %580 = add i32 0, %579
-  %581 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %572, i32 1
-  %582 = getelementptr %dimension_descriptor, %dimension_descriptor* %581, i32 0, i32 1
-  %583 = load i32, i32* %582, align 4
-  %584 = sub i32 %568, %583
-  %585 = getelementptr %dimension_descriptor, %dimension_descriptor* %581, i32 0, i32 0
-  %586 = load i32, i32* %585, align 4
-  %587 = mul i32 %586, %584
-  %588 = add i32 %580, %587
-  %589 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %572, i32 2
-  %590 = getelementptr %dimension_descriptor, %dimension_descriptor* %589, i32 0, i32 1
-  %591 = load i32, i32* %590, align 4
-  %592 = sub i32 %569, %591
-  %593 = getelementptr %dimension_descriptor, %dimension_descriptor* %589, i32 0, i32 0
-  %594 = load i32, i32* %593, align 4
-  %595 = mul i32 %594, %592
-  %596 = add i32 %588, %595
-  %597 = getelementptr %array, %array* %570, i32 0, i32 1
-  %598 = load i32, i32* %597, align 4
-  %599 = add i32 %596, %598
-  %600 = getelementptr %array, %array* %570, i32 0, i32 0
-  %601 = load i1*, i1** %600, align 8
-  %602 = getelementptr inbounds i1, i1* %601, i32 %599
-  %603 = load i32, i32* %__1_v, align 4
-  %604 = load i32, i32* %__2_v, align 4
-  %605 = load i32, i32* %__3_v, align 4
-  %606 = load %array*, %array** %a, align 8
-  %607 = getelementptr %array, %array* %606, i32 0, i32 2
-  %608 = load %dimension_descriptor*, %dimension_descriptor** %607, align 8
-  %609 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %608, i32 0
-  %610 = getelementptr %dimension_descriptor, %dimension_descriptor* %609, i32 0, i32 1
-  %611 = load i32, i32* %610, align 4
-  %612 = sub i32 %603, %611
-  %613 = getelementptr %dimension_descriptor, %dimension_descriptor* %609, i32 0, i32 0
-  %614 = load i32, i32* %613, align 4
-  %615 = mul i32 %614, %612
-  %616 = add i32 0, %615
-  %617 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %608, i32 1
-  %618 = getelementptr %dimension_descriptor, %dimension_descriptor* %617, i32 0, i32 1
-  %619 = load i32, i32* %618, align 4
-  %620 = sub i32 %604, %619
-  %621 = getelementptr %dimension_descriptor, %dimension_descriptor* %617, i32 0, i32 0
-  %622 = load i32, i32* %621, align 4
-  %623 = mul i32 %622, %620
-  %624 = add i32 %616, %623
-  %625 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %608, i32 2
-  %626 = getelementptr %dimension_descriptor, %dimension_descriptor* %625, i32 0, i32 1
-  %627 = load i32, i32* %626, align 4
-  %628 = sub i32 %605, %627
-  %629 = getelementptr %dimension_descriptor, %dimension_descriptor* %625, i32 0, i32 0
-  %630 = load i32, i32* %629, align 4
-  %631 = mul i32 %630, %628
-  %632 = add i32 %624, %631
-  %633 = getelementptr %array, %array* %606, i32 0, i32 1
-  %634 = load i32, i32* %633, align 4
-  %635 = add i32 %632, %634
-  %636 = getelementptr %array, %array* %606, i32 0, i32 0
-  %637 = load i1*, i1** %636, align 8
-  %638 = getelementptr inbounds i1, i1* %637, i32 %635
-  %639 = load i1, i1* %638, align 1
-  %640 = load i32, i32* %__1_u, align 4
-  %641 = load i32, i32* %__2_u, align 4
-  %642 = load i32, i32* %__3_u, align 4
-  %643 = load %array*, %array** %b, align 8
-  %644 = getelementptr %array, %array* %643, i32 0, i32 2
-  %645 = load %dimension_descriptor*, %dimension_descriptor** %644, align 8
-  %646 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %645, i32 0
-  %647 = getelementptr %dimension_descriptor, %dimension_descriptor* %646, i32 0, i32 1
-  %648 = load i32, i32* %647, align 4
-  %649 = sub i32 %640, %648
-  %650 = getelementptr %dimension_descriptor, %dimension_descriptor* %646, i32 0, i32 0
-  %651 = load i32, i32* %650, align 4
-  %652 = mul i32 %651, %649
-  %653 = add i32 0, %652
-  %654 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %645, i32 1
-  %655 = getelementptr %dimension_descriptor, %dimension_descriptor* %654, i32 0, i32 1
-  %656 = load i32, i32* %655, align 4
-  %657 = sub i32 %641, %656
-  %658 = getelementptr %dimension_descriptor, %dimension_descriptor* %654, i32 0, i32 0
-  %659 = load i32, i32* %658, align 4
-  %660 = mul i32 %659, %657
-  %661 = add i32 %653, %660
-  %662 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %645, i32 2
-  %663 = getelementptr %dimension_descriptor, %dimension_descriptor* %662, i32 0, i32 1
-  %664 = load i32, i32* %663, align 4
-  %665 = sub i32 %642, %664
-  %666 = getelementptr %dimension_descriptor, %dimension_descriptor* %662, i32 0, i32 0
-  %667 = load i32, i32* %666, align 4
-  %668 = mul i32 %667, %665
-  %669 = add i32 %661, %668
-  %670 = getelementptr %array, %array* %643, i32 0, i32 1
-  %671 = load i32, i32* %670, align 4
-  %672 = add i32 %669, %671
-  %673 = getelementptr %array, %array* %643, i32 0, i32 0
-  %674 = load i1*, i1** %673, align 8
-  %675 = getelementptr inbounds i1, i1* %674, i32 %672
-  %676 = load i1, i1* %675, align 1
-  %677 = icmp eq i1 %639, false
-  %678 = select i1 %677, i1 %676, i1 %639
-  store i1 %678, i1* %602, align 1
-  %679 = load i32, i32* %__3_v, align 4
-  %680 = add i32 %679, 1
-  store i32 %680, i32* %__3_v, align 4
-  %681 = load i32, i32* %__3_u, align 4
-  %682 = add i32 %681, 1
-  store i32 %682, i32* %__3_u, align 4
-  br label %loop.head30
-
-loop.end32:                                       ; preds = %loop.head30
-  %683 = load i32, i32* %__2_v, align 4
-  %684 = add i32 %683, 1
-  store i32 %684, i32* %__2_v, align 4
-  %685 = load i32, i32* %__2_u, align 4
-  %686 = add i32 %685, 1
-  store i32 %686, i32* %__2_u, align 4
-  br label %loop.head28
-
-loop.end33:                                       ; preds = %loop.head28
-  %687 = load i32, i32* %__1_v, align 4
-  %688 = add i32 %687, 1
-  store i32 %688, i32* %__1_v, align 4
-  %689 = load i32, i32* %__1_u, align 4
-  %690 = add i32 %689, 1
-  store i32 %690, i32* %__1_u, align 4
-  br label %loop.head26
-
-loop.end34:                                       ; preds = %loop.head26
-  store i32 1, i32* %call_arg_value35, align 4
-  call void @verify(%array** %c, i32* %call_arg_value35)
-  %691 = load %array*, %array** %a, align 8
-  %692 = getelementptr %array, %array* %691, i32 0, i32 2
-  %693 = load %dimension_descriptor*, %dimension_descriptor** %692, align 8
-  %694 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %693, i32 0
-  %695 = getelementptr %dimension_descriptor, %dimension_descriptor* %694, i32 0, i32 1
-  %696 = load i32, i32* %695, align 4
-  store i32 %696, i32* %__1_v, align 4
-  %697 = load %array*, %array** %b, align 8
-  %698 = getelementptr %array, %array* %697, i32 0, i32 2
-  %699 = load %dimension_descriptor*, %dimension_descriptor** %698, align 8
-  %700 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %699, i32 0
-  %701 = getelementptr %dimension_descriptor, %dimension_descriptor* %700, i32 0, i32 1
-  %702 = load i32, i32* %701, align 4
-  store i32 %702, i32* %__1_u, align 4
-  %703 = load %array*, %array** %c, align 8
-  %704 = getelementptr %array, %array* %703, i32 0, i32 2
-  %705 = load %dimension_descriptor*, %dimension_descriptor** %704, align 8
-  %706 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %705, i32 0
-  %707 = getelementptr %dimension_descriptor, %dimension_descriptor* %706, i32 0, i32 1
-  %708 = load i32, i32* %707, align 4
-  %709 = sub i32 %708, 1
-  store i32 %709, i32* %__1_t, align 4
-  br label %loop.head36
-
-loop.head36:                                      ; preds = %loop.end43, %loop.end34
-  %710 = load i32, i32* %__1_t, align 4
-  %711 = add i32 %710, 1
-  %712 = load %array*, %array** %c, align 8
-  %713 = getelementptr %array, %array* %712, i32 0, i32 2
-  %714 = load %dimension_descriptor*, %dimension_descriptor** %713, align 8
-  %715 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %714, i32 0
-  %716 = getelementptr %dimension_descriptor, %dimension_descriptor* %715, i32 0, i32 1
-  %717 = load i32, i32* %716, align 4
-  %718 = getelementptr %dimension_descriptor, %dimension_descriptor* %715, i32 0, i32 2
-  %719 = load i32, i32* %718, align 4
-  %720 = add i32 %719, %717
-  %721 = sub i32 %720, 1
-  %722 = icmp sle i32 %711, %721
-  br i1 %722, label %loop.body37, label %loop.end44
-
-loop.body37:                                      ; preds = %loop.head36
-  %723 = load i32, i32* %__1_t, align 4
-  %724 = add i32 %723, 1
-  store i32 %724, i32* %__1_t, align 4
-  %725 = load %array*, %array** %a, align 8
-  %726 = getelementptr %array, %array* %725, i32 0, i32 2
-  %727 = load %dimension_descriptor*, %dimension_descriptor** %726, align 8
-  %728 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %727, i32 0
-  %729 = getelementptr %dimension_descriptor, %dimension_descriptor* %728, i32 0, i32 1
-  %730 = load i32, i32* %729, align 4
-  store i32 %730, i32* %__2_v, align 4
-  %731 = load %array*, %array** %b, align 8
-  %732 = getelementptr %array, %array* %731, i32 0, i32 2
-  %733 = load %dimension_descriptor*, %dimension_descriptor** %732, align 8
-  %734 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %733, i32 0
-  %735 = getelementptr %dimension_descriptor, %dimension_descriptor* %734, i32 0, i32 1
-  %736 = load i32, i32* %735, align 4
-  store i32 %736, i32* %__2_u, align 4
-  %737 = load %array*, %array** %c, align 8
-  %738 = getelementptr %array, %array* %737, i32 0, i32 2
-  %739 = load %dimension_descriptor*, %dimension_descriptor** %738, align 8
-  %740 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %739, i32 1
-  %741 = getelementptr %dimension_descriptor, %dimension_descriptor* %740, i32 0, i32 1
-  %742 = load i32, i32* %741, align 4
-  %743 = sub i32 %742, 1
-  store i32 %743, i32* %__2_t, align 4
-  br label %loop.head38
-
-loop.head38:                                      ; preds = %loop.end42, %loop.body37
-  %744 = load i32, i32* %__2_t, align 4
-  %745 = add i32 %744, 1
-  %746 = load %array*, %array** %c, align 8
-  %747 = getelementptr %array, %array* %746, i32 0, i32 2
-  %748 = load %dimension_descriptor*, %dimension_descriptor** %747, align 8
-  %749 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %748, i32 1
-  %750 = getelementptr %dimension_descriptor, %dimension_descriptor* %749, i32 0, i32 1
-  %751 = load i32, i32* %750, align 4
-  %752 = getelementptr %dimension_descriptor, %dimension_descriptor* %749, i32 0, i32 2
-  %753 = load i32, i32* %752, align 4
-  %754 = add i32 %753, %751
-  %755 = sub i32 %754, 1
-  %756 = icmp sle i32 %745, %755
-  br i1 %756, label %loop.body39, label %loop.end43
-
-loop.body39:                                      ; preds = %loop.head38
-  %757 = load i32, i32* %__2_t, align 4
-  %758 = add i32 %757, 1
-  store i32 %758, i32* %__2_t, align 4
-  %759 = load %array*, %array** %a, align 8
-  %760 = getelementptr %array, %array* %759, i32 0, i32 2
-  %761 = load %dimension_descriptor*, %dimension_descriptor** %760, align 8
-  %762 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %761, i32 1
-  %763 = getelementptr %dimension_descriptor, %dimension_descriptor* %762, i32 0, i32 1
-  %764 = load i32, i32* %763, align 4
-  store i32 %764, i32* %__3_v, align 4
-  %765 = load %array*, %array** %b, align 8
-  %766 = getelementptr %array, %array* %765, i32 0, i32 2
-  %767 = load %dimension_descriptor*, %dimension_descriptor** %766, align 8
-  %768 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %767, i32 1
-  %769 = getelementptr %dimension_descriptor, %dimension_descriptor* %768, i32 0, i32 1
-  %770 = load i32, i32* %769, align 4
-  store i32 %770, i32* %__3_u, align 4
-  %771 = load %array*, %array** %c, align 8
-  %772 = getelementptr %array, %array* %771, i32 0, i32 2
-  %773 = load %dimension_descriptor*, %dimension_descriptor** %772, align 8
-  %774 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %773, i32 2
-  %775 = getelementptr %dimension_descriptor, %dimension_descriptor* %774, i32 0, i32 1
-  %776 = load i32, i32* %775, align 4
-  %777 = sub i32 %776, 1
-  store i32 %777, i32* %__3_t, align 4
-  br label %loop.head40
-
-loop.head40:                                      ; preds = %loop.body41, %loop.body39
-  %778 = load i32, i32* %__3_t, align 4
-  %779 = add i32 %778, 1
-  %780 = load %array*, %array** %c, align 8
-  %781 = getelementptr %array, %array* %780, i32 0, i32 2
-  %782 = load %dimension_descriptor*, %dimension_descriptor** %781, align 8
-  %783 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %782, i32 2
-  %784 = getelementptr %dimension_descriptor, %dimension_descriptor* %783, i32 0, i32 1
-  %785 = load i32, i32* %784, align 4
-  %786 = getelementptr %dimension_descriptor, %dimension_descriptor* %783, i32 0, i32 2
-  %787 = load i32, i32* %786, align 4
-  %788 = add i32 %787, %785
-  %789 = sub i32 %788, 1
-  %790 = icmp sle i32 %779, %789
-  br i1 %790, label %loop.body41, label %loop.end42
-
-loop.body41:                                      ; preds = %loop.head40
-  %791 = load i32, i32* %__3_t, align 4
-  %792 = add i32 %791, 1
-  store i32 %792, i32* %__3_t, align 4
-  %793 = load i32, i32* %__1_t, align 4
-  %794 = load i32, i32* %__2_t, align 4
-  %795 = load i32, i32* %__3_t, align 4
-  %796 = load %array*, %array** %c, align 8
-  %797 = getelementptr %array, %array* %796, i32 0, i32 2
-  %798 = load %dimension_descriptor*, %dimension_descriptor** %797, align 8
-  %799 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %798, i32 0
-  %800 = getelementptr %dimension_descriptor, %dimension_descriptor* %799, i32 0, i32 1
-  %801 = load i32, i32* %800, align 4
-  %802 = sub i32 %793, %801
-  %803 = getelementptr %dimension_descriptor, %dimension_descriptor* %799, i32 0, i32 0
-  %804 = load i32, i32* %803, align 4
-  %805 = mul i32 %804, %802
-  %806 = add i32 0, %805
-  %807 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %798, i32 1
-  %808 = getelementptr %dimension_descriptor, %dimension_descriptor* %807, i32 0, i32 1
-  %809 = load i32, i32* %808, align 4
-  %810 = sub i32 %794, %809
-  %811 = getelementptr %dimension_descriptor, %dimension_descriptor* %807, i32 0, i32 0
-  %812 = load i32, i32* %811, align 4
-  %813 = mul i32 %812, %810
-  %814 = add i32 %806, %813
-  %815 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %798, i32 2
-  %816 = getelementptr %dimension_descriptor, %dimension_descriptor* %815, i32 0, i32 1
-  %817 = load i32, i32* %816, align 4
-  %818 = sub i32 %795, %817
-  %819 = getelementptr %dimension_descriptor, %dimension_descriptor* %815, i32 0, i32 0
-  %820 = load i32, i32* %819, align 4
-  %821 = mul i32 %820, %818
-  %822 = add i32 %814, %821
-  %823 = getelementptr %array, %array* %796, i32 0, i32 1
-  %824 = load i32, i32* %823, align 4
-  %825 = add i32 %822, %824
-  %826 = getelementptr %array, %array* %796, i32 0, i32 0
-  %827 = load i1*, i1** %826, align 8
-  %828 = getelementptr inbounds i1, i1* %827, i32 %825
-  %829 = load i32, i32* %__1_v, align 4
-  %830 = load i32, i32* %__2_v, align 4
-  %831 = load i32, i32* %__3_v, align 4
-  %832 = load %array*, %array** %a, align 8
-  %833 = getelementptr %array, %array* %832, i32 0, i32 2
-  %834 = load %dimension_descriptor*, %dimension_descriptor** %833, align 8
-  %835 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %834, i32 0
-  %836 = getelementptr %dimension_descriptor, %dimension_descriptor* %835, i32 0, i32 1
-  %837 = load i32, i32* %836, align 4
-  %838 = sub i32 %829, %837
-  %839 = getelementptr %dimension_descriptor, %dimension_descriptor* %835, i32 0, i32 0
-  %840 = load i32, i32* %839, align 4
-  %841 = mul i32 %840, %838
-  %842 = add i32 0, %841
-  %843 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %834, i32 1
-  %844 = getelementptr %dimension_descriptor, %dimension_descriptor* %843, i32 0, i32 1
-  %845 = load i32, i32* %844, align 4
-  %846 = sub i32 %830, %845
-  %847 = getelementptr %dimension_descriptor, %dimension_descriptor* %843, i32 0, i32 0
-  %848 = load i32, i32* %847, align 4
-  %849 = mul i32 %848, %846
-  %850 = add i32 %842, %849
-  %851 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %834, i32 2
-  %852 = getelementptr %dimension_descriptor, %dimension_descriptor* %851, i32 0, i32 1
-  %853 = load i32, i32* %852, align 4
-  %854 = sub i32 %831, %853
-  %855 = getelementptr %dimension_descriptor, %dimension_descriptor* %851, i32 0, i32 0
-  %856 = load i32, i32* %855, align 4
-  %857 = mul i32 %856, %854
-  %858 = add i32 %850, %857
-  %859 = getelementptr %array, %array* %832, i32 0, i32 1
-  %860 = load i32, i32* %859, align 4
-  %861 = add i32 %858, %860
-  %862 = getelementptr %array, %array* %832, i32 0, i32 0
-  %863 = load i1*, i1** %862, align 8
-  %864 = getelementptr inbounds i1, i1* %863, i32 %861
-  %865 = load i1, i1* %864, align 1
-  %866 = load i32, i32* %__1_u, align 4
-  %867 = load i32, i32* %__2_u, align 4
-  %868 = load i32, i32* %__3_u, align 4
-  %869 = load %array*, %array** %b, align 8
-  %870 = getelementptr %array, %array* %869, i32 0, i32 2
-  %871 = load %dimension_descriptor*, %dimension_descriptor** %870, align 8
-  %872 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %871, i32 0
-  %873 = getelementptr %dimension_descriptor, %dimension_descriptor* %872, i32 0, i32 1
-  %874 = load i32, i32* %873, align 4
-  %875 = sub i32 %866, %874
-  %876 = getelementptr %dimension_descriptor, %dimension_descriptor* %872, i32 0, i32 0
-  %877 = load i32, i32* %876, align 4
-  %878 = mul i32 %877, %875
-  %879 = add i32 0, %878
-  %880 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %871, i32 1
-  %881 = getelementptr %dimension_descriptor, %dimension_descriptor* %880, i32 0, i32 1
-  %882 = load i32, i32* %881, align 4
-  %883 = sub i32 %867, %882
-  %884 = getelementptr %dimension_descriptor, %dimension_descriptor* %880, i32 0, i32 0
-  %885 = load i32, i32* %884, align 4
-  %886 = mul i32 %885, %883
-  %887 = add i32 %879, %886
-  %888 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %871, i32 2
-  %889 = getelementptr %dimension_descriptor, %dimension_descriptor* %888, i32 0, i32 1
-  %890 = load i32, i32* %889, align 4
-  %891 = sub i32 %868, %890
-  %892 = getelementptr %dimension_descriptor, %dimension_descriptor* %888, i32 0, i32 0
-  %893 = load i32, i32* %892, align 4
-  %894 = mul i32 %893, %891
-  %895 = add i32 %887, %894
-  %896 = getelementptr %array, %array* %869, i32 0, i32 1
-  %897 = load i32, i32* %896, align 4
-  %898 = add i32 %895, %897
-  %899 = getelementptr %array, %array* %869, i32 0, i32 0
-  %900 = load i1*, i1** %899, align 8
-  %901 = getelementptr inbounds i1, i1* %900, i32 %898
-  %902 = load i1, i1* %901, align 1
-  %903 = icmp eq i1 %865, false
-  %904 = xor i1 %865, %902
-  %905 = xor i1 %904, true
-  store i1 %905, i1* %828, align 1
-  %906 = load i32, i32* %__3_v, align 4
-  %907 = add i32 %906, 1
-  store i32 %907, i32* %__3_v, align 4
-  %908 = load i32, i32* %__3_u, align 4
-  %909 = add i32 %908, 1
-  store i32 %909, i32* %__3_u, align 4
-  br label %loop.head40
-
-loop.end42:                                       ; preds = %loop.head40
-  %910 = load i32, i32* %__2_v, align 4
-  %911 = add i32 %910, 1
-  store i32 %911, i32* %__2_v, align 4
-  %912 = load i32, i32* %__2_u, align 4
-  %913 = add i32 %912, 1
-  store i32 %913, i32* %__2_u, align 4
-  br label %loop.head38
-
-loop.end43:                                       ; preds = %loop.head38
-  %914 = load i32, i32* %__1_v, align 4
-  %915 = add i32 %914, 1
-  store i32 %915, i32* %__1_v, align 4
-  %916 = load i32, i32* %__1_u, align 4
-  %917 = add i32 %916, 1
-  store i32 %917, i32* %__1_u, align 4
-  br label %loop.head36
-
-loop.end44:                                       ; preds = %loop.head36
-  store i32 2, i32* %call_arg_value45, align 4
-  call void @verify(%array** %c, i32* %call_arg_value45)
-  %918 = load %array*, %array** %b, align 8
-  %919 = getelementptr %array, %array* %918, i32 0, i32 2
-  %920 = load %dimension_descriptor*, %dimension_descriptor** %919, align 8
-  %921 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %920, i32 0
-  %922 = getelementptr %dimension_descriptor, %dimension_descriptor* %921, i32 0, i32 1
-  %923 = load i32, i32* %922, align 4
-  store i32 %923, i32* %__1_v, align 4
-  %924 = load %array*, %array** %a, align 8
-  %925 = getelementptr %array, %array* %924, i32 0, i32 2
-  %926 = load %dimension_descriptor*, %dimension_descriptor** %925, align 8
-  %927 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %926, i32 0
-  %928 = getelementptr %dimension_descriptor, %dimension_descriptor* %927, i32 0, i32 1
-  %929 = load i32, i32* %928, align 4
-  store i32 %929, i32* %__1_u, align 4
-  %930 = load %array*, %array** %c, align 8
-  %931 = getelementptr %array, %array* %930, i32 0, i32 2
-  %932 = load %dimension_descriptor*, %dimension_descriptor** %931, align 8
-  %933 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %932, i32 0
-  %934 = getelementptr %dimension_descriptor, %dimension_descriptor* %933, i32 0, i32 1
-  %935 = load i32, i32* %934, align 4
-  %936 = sub i32 %935, 1
-  store i32 %936, i32* %__1_t, align 4
-  br label %loop.head46
-
-loop.head46:                                      ; preds = %loop.end53, %loop.end44
-  %937 = load i32, i32* %__1_t, align 4
-  %938 = add i32 %937, 1
-  %939 = load %array*, %array** %c, align 8
-  %940 = getelementptr %array, %array* %939, i32 0, i32 2
-  %941 = load %dimension_descriptor*, %dimension_descriptor** %940, align 8
-  %942 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %941, i32 0
-  %943 = getelementptr %dimension_descriptor, %dimension_descriptor* %942, i32 0, i32 1
-  %944 = load i32, i32* %943, align 4
-  %945 = getelementptr %dimension_descriptor, %dimension_descriptor* %942, i32 0, i32 2
-  %946 = load i32, i32* %945, align 4
-  %947 = add i32 %946, %944
-  %948 = sub i32 %947, 1
-  %949 = icmp sle i32 %938, %948
-  br i1 %949, label %loop.body47, label %loop.end54
-
-loop.body47:                                      ; preds = %loop.head46
-  %950 = load i32, i32* %__1_t, align 4
-  %951 = add i32 %950, 1
-  store i32 %951, i32* %__1_t, align 4
-  %952 = load %array*, %array** %b, align 8
-  %953 = getelementptr %array, %array* %952, i32 0, i32 2
-  %954 = load %dimension_descriptor*, %dimension_descriptor** %953, align 8
-  %955 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %954, i32 0
-  %956 = getelementptr %dimension_descriptor, %dimension_descriptor* %955, i32 0, i32 1
-  %957 = load i32, i32* %956, align 4
-  store i32 %957, i32* %__2_v, align 4
-  %958 = load %array*, %array** %a, align 8
-  %959 = getelementptr %array, %array* %958, i32 0, i32 2
-  %960 = load %dimension_descriptor*, %dimension_descriptor** %959, align 8
-  %961 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %960, i32 0
-  %962 = getelementptr %dimension_descriptor, %dimension_descriptor* %961, i32 0, i32 1
-  %963 = load i32, i32* %962, align 4
-  store i32 %963, i32* %__2_u, align 4
-  %964 = load %array*, %array** %c, align 8
-  %965 = getelementptr %array, %array* %964, i32 0, i32 2
-  %966 = load %dimension_descriptor*, %dimension_descriptor** %965, align 8
-  %967 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %966, i32 1
-  %968 = getelementptr %dimension_descriptor, %dimension_descriptor* %967, i32 0, i32 1
-  %969 = load i32, i32* %968, align 4
-  %970 = sub i32 %969, 1
-  store i32 %970, i32* %__2_t, align 4
-  br label %loop.head48
-
-loop.head48:                                      ; preds = %loop.end52, %loop.body47
-  %971 = load i32, i32* %__2_t, align 4
-  %972 = add i32 %971, 1
-  %973 = load %array*, %array** %c, align 8
-  %974 = getelementptr %array, %array* %973, i32 0, i32 2
-  %975 = load %dimension_descriptor*, %dimension_descriptor** %974, align 8
-  %976 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %975, i32 1
-  %977 = getelementptr %dimension_descriptor, %dimension_descriptor* %976, i32 0, i32 1
-  %978 = load i32, i32* %977, align 4
-  %979 = getelementptr %dimension_descriptor, %dimension_descriptor* %976, i32 0, i32 2
-  %980 = load i32, i32* %979, align 4
-  %981 = add i32 %980, %978
-  %982 = sub i32 %981, 1
-  %983 = icmp sle i32 %972, %982
-  br i1 %983, label %loop.body49, label %loop.end53
-
-loop.body49:                                      ; preds = %loop.head48
-  %984 = load i32, i32* %__2_t, align 4
-  %985 = add i32 %984, 1
-  store i32 %985, i32* %__2_t, align 4
-  %986 = load %array*, %array** %b, align 8
-  %987 = getelementptr %array, %array* %986, i32 0, i32 2
-  %988 = load %dimension_descriptor*, %dimension_descriptor** %987, align 8
-  %989 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %988, i32 1
-  %990 = getelementptr %dimension_descriptor, %dimension_descriptor* %989, i32 0, i32 1
-  %991 = load i32, i32* %990, align 4
-  store i32 %991, i32* %__3_v, align 4
-  %992 = load %array*, %array** %a, align 8
-  %993 = getelementptr %array, %array* %992, i32 0, i32 2
-  %994 = load %dimension_descriptor*, %dimension_descriptor** %993, align 8
-  %995 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %994, i32 1
-  %996 = getelementptr %dimension_descriptor, %dimension_descriptor* %995, i32 0, i32 1
-  %997 = load i32, i32* %996, align 4
-  store i32 %997, i32* %__3_u, align 4
-  %998 = load %array*, %array** %c, align 8
-  %999 = getelementptr %array, %array* %998, i32 0, i32 2
-  %1000 = load %dimension_descriptor*, %dimension_descriptor** %999, align 8
-  %1001 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1000, i32 2
-  %1002 = getelementptr %dimension_descriptor, %dimension_descriptor* %1001, i32 0, i32 1
-  %1003 = load i32, i32* %1002, align 4
-  %1004 = sub i32 %1003, 1
-  store i32 %1004, i32* %__3_t, align 4
-  br label %loop.head50
-
-loop.head50:                                      ; preds = %loop.body51, %loop.body49
-  %1005 = load i32, i32* %__3_t, align 4
-  %1006 = add i32 %1005, 1
-  %1007 = load %array*, %array** %c, align 8
-  %1008 = getelementptr %array, %array* %1007, i32 0, i32 2
-  %1009 = load %dimension_descriptor*, %dimension_descriptor** %1008, align 8
-  %1010 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1009, i32 2
-  %1011 = getelementptr %dimension_descriptor, %dimension_descriptor* %1010, i32 0, i32 1
-  %1012 = load i32, i32* %1011, align 4
-  %1013 = getelementptr %dimension_descriptor, %dimension_descriptor* %1010, i32 0, i32 2
-  %1014 = load i32, i32* %1013, align 4
-  %1015 = add i32 %1014, %1012
-  %1016 = sub i32 %1015, 1
-  %1017 = icmp sle i32 %1006, %1016
-  br i1 %1017, label %loop.body51, label %loop.end52
-
-loop.body51:                                      ; preds = %loop.head50
-  %1018 = load i32, i32* %__3_t, align 4
-  %1019 = add i32 %1018, 1
-  store i32 %1019, i32* %__3_t, align 4
-  %1020 = load i32, i32* %__1_t, align 4
-  %1021 = load i32, i32* %__2_t, align 4
-  %1022 = load i32, i32* %__3_t, align 4
-  %1023 = load %array*, %array** %c, align 8
-  %1024 = getelementptr %array, %array* %1023, i32 0, i32 2
-  %1025 = load %dimension_descriptor*, %dimension_descriptor** %1024, align 8
-  %1026 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1025, i32 0
-  %1027 = getelementptr %dimension_descriptor, %dimension_descriptor* %1026, i32 0, i32 1
-  %1028 = load i32, i32* %1027, align 4
-  %1029 = sub i32 %1020, %1028
-  %1030 = getelementptr %dimension_descriptor, %dimension_descriptor* %1026, i32 0, i32 0
-  %1031 = load i32, i32* %1030, align 4
-  %1032 = mul i32 %1031, %1029
-  %1033 = add i32 0, %1032
-  %1034 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1025, i32 1
-  %1035 = getelementptr %dimension_descriptor, %dimension_descriptor* %1034, i32 0, i32 1
-  %1036 = load i32, i32* %1035, align 4
-  %1037 = sub i32 %1021, %1036
-  %1038 = getelementptr %dimension_descriptor, %dimension_descriptor* %1034, i32 0, i32 0
-  %1039 = load i32, i32* %1038, align 4
-  %1040 = mul i32 %1039, %1037
-  %1041 = add i32 %1033, %1040
-  %1042 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1025, i32 2
-  %1043 = getelementptr %dimension_descriptor, %dimension_descriptor* %1042, i32 0, i32 1
-  %1044 = load i32, i32* %1043, align 4
-  %1045 = sub i32 %1022, %1044
-  %1046 = getelementptr %dimension_descriptor, %dimension_descriptor* %1042, i32 0, i32 0
-  %1047 = load i32, i32* %1046, align 4
-  %1048 = mul i32 %1047, %1045
-  %1049 = add i32 %1041, %1048
-  %1050 = getelementptr %array, %array* %1023, i32 0, i32 1
-  %1051 = load i32, i32* %1050, align 4
-  %1052 = add i32 %1049, %1051
-  %1053 = getelementptr %array, %array* %1023, i32 0, i32 0
-  %1054 = load i1*, i1** %1053, align 8
-  %1055 = getelementptr inbounds i1, i1* %1054, i32 %1052
-  %1056 = load i32, i32* %__1_v, align 4
-  %1057 = load i32, i32* %__2_v, align 4
-  %1058 = load i32, i32* %__3_v, align 4
-  %1059 = load %array*, %array** %b, align 8
-  %1060 = getelementptr %array, %array* %1059, i32 0, i32 2
-  %1061 = load %dimension_descriptor*, %dimension_descriptor** %1060, align 8
-  %1062 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1061, i32 0
-  %1063 = getelementptr %dimension_descriptor, %dimension_descriptor* %1062, i32 0, i32 1
-  %1064 = load i32, i32* %1063, align 4
-  %1065 = sub i32 %1056, %1064
-  %1066 = getelementptr %dimension_descriptor, %dimension_descriptor* %1062, i32 0, i32 0
-  %1067 = load i32, i32* %1066, align 4
-  %1068 = mul i32 %1067, %1065
-  %1069 = add i32 0, %1068
-  %1070 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1061, i32 1
-  %1071 = getelementptr %dimension_descriptor, %dimension_descriptor* %1070, i32 0, i32 1
-  %1072 = load i32, i32* %1071, align 4
-  %1073 = sub i32 %1057, %1072
-  %1074 = getelementptr %dimension_descriptor, %dimension_descriptor* %1070, i32 0, i32 0
-  %1075 = load i32, i32* %1074, align 4
-  %1076 = mul i32 %1075, %1073
-  %1077 = add i32 %1069, %1076
-  %1078 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1061, i32 2
-  %1079 = getelementptr %dimension_descriptor, %dimension_descriptor* %1078, i32 0, i32 1
-  %1080 = load i32, i32* %1079, align 4
-  %1081 = sub i32 %1058, %1080
-  %1082 = getelementptr %dimension_descriptor, %dimension_descriptor* %1078, i32 0, i32 0
-  %1083 = load i32, i32* %1082, align 4
-  %1084 = mul i32 %1083, %1081
-  %1085 = add i32 %1077, %1084
-  %1086 = getelementptr %array, %array* %1059, i32 0, i32 1
-  %1087 = load i32, i32* %1086, align 4
-  %1088 = add i32 %1085, %1087
-  %1089 = getelementptr %array, %array* %1059, i32 0, i32 0
-  %1090 = load i1*, i1** %1089, align 8
-  %1091 = getelementptr inbounds i1, i1* %1090, i32 %1088
-  %1092 = load i1, i1* %1091, align 1
-  %1093 = load i32, i32* %__1_u, align 4
-  %1094 = load i32, i32* %__2_u, align 4
-  %1095 = load i32, i32* %__3_u, align 4
-  %1096 = load %array*, %array** %a, align 8
-  %1097 = getelementptr %array, %array* %1096, i32 0, i32 2
-  %1098 = load %dimension_descriptor*, %dimension_descriptor** %1097, align 8
-  %1099 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1098, i32 0
-  %1100 = getelementptr %dimension_descriptor, %dimension_descriptor* %1099, i32 0, i32 1
-  %1101 = load i32, i32* %1100, align 4
-  %1102 = sub i32 %1093, %1101
-  %1103 = getelementptr %dimension_descriptor, %dimension_descriptor* %1099, i32 0, i32 0
-  %1104 = load i32, i32* %1103, align 4
-  %1105 = mul i32 %1104, %1102
-  %1106 = add i32 0, %1105
-  %1107 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1098, i32 1
-  %1108 = getelementptr %dimension_descriptor, %dimension_descriptor* %1107, i32 0, i32 1
-  %1109 = load i32, i32* %1108, align 4
-  %1110 = sub i32 %1094, %1109
-  %1111 = getelementptr %dimension_descriptor, %dimension_descriptor* %1107, i32 0, i32 0
-  %1112 = load i32, i32* %1111, align 4
-  %1113 = mul i32 %1112, %1110
-  %1114 = add i32 %1106, %1113
-  %1115 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %1098, i32 2
-  %1116 = getelementptr %dimension_descriptor, %dimension_descriptor* %1115, i32 0, i32 1
-  %1117 = load i32, i32* %1116, align 4
-  %1118 = sub i32 %1095, %1117
-  %1119 = getelementptr %dimension_descriptor, %dimension_descriptor* %1115, i32 0, i32 0
-  %1120 = load i32, i32* %1119, align 4
-  %1121 = mul i32 %1120, %1118
-  %1122 = add i32 %1114, %1121
-  %1123 = getelementptr %array, %array* %1096, i32 0, i32 1
-  %1124 = load i32, i32* %1123, align 4
-  %1125 = add i32 %1122, %1124
-  %1126 = getelementptr %array, %array* %1096, i32 0, i32 0
-  %1127 = load i1*, i1** %1126, align 8
-  %1128 = getelementptr inbounds i1, i1* %1127, i32 %1125
-  %1129 = load i1, i1* %1128, align 1
-  %1130 = icmp eq i1 %1092, false
-  %1131 = xor i1 %1092, %1129
-  store i1 %1131, i1* %1055, align 1
-  %1132 = load i32, i32* %__3_v, align 4
-  %1133 = add i32 %1132, 1
-  store i32 %1133, i32* %__3_v, align 4
-  %1134 = load i32, i32* %__3_u, align 4
-  %1135 = add i32 %1134, 1
-  store i32 %1135, i32* %__3_u, align 4
-  br label %loop.head50
-
-loop.end52:                                       ; preds = %loop.head50
-  %1136 = load i32, i32* %__2_v, align 4
-  %1137 = add i32 %1136, 1
-  store i32 %1137, i32* %__2_v, align 4
-  %1138 = load i32, i32* %__2_u, align 4
-  %1139 = add i32 %1138, 1
-  store i32 %1139, i32* %__2_u, align 4
-  br label %loop.head48
-
-loop.end53:                                       ; preds = %loop.head48
-  %1140 = load i32, i32* %__1_v, align 4
-  %1141 = add i32 %1140, 1
-  store i32 %1141, i32* %__1_v, align 4
-  %1142 = load i32, i32* %__1_u, align 4
-  %1143 = add i32 %1142, 1
-  store i32 %1143, i32* %__1_u, align 4
-  br label %loop.head46
-
-loop.end54:                                       ; preds = %loop.head46
-  store i32 3, i32* %call_arg_value55, align 4
-  call void @verify(%array** %c, i32* %call_arg_value55)
-  %1144 = load %array*, %array** %a, align 8
-  %1145 = getelementptr %array, %array* %1144, i32 0, i32 0
-  %1146 = load i1*, i1** %1145, align 8
-  %1147 = ptrtoint i1* %1146 to i64
-  %1148 = icmp ne i64 %1147, 0
-  br i1 %1148, label %then56, label %else57
-
-then56:                                           ; preds = %loop.end54
-  %1149 = getelementptr %array, %array* %1144, i32 0, i32 0
-  %1150 = load i1*, i1** %1149, align 8
-  %1151 = alloca i8*, align 8
-  %1152 = bitcast i1* %1150 to i8*
-  store i8* %1152, i8** %1151, align 8
-  %1153 = load i8*, i8** %1151, align 8
-  call void @_lfortran_free(i8* %1153)
-  %1154 = getelementptr %array, %array* %1144, i32 0, i32 0
-  store i1* null, i1** %1154, align 8
-  br label %ifcont58
-
-else57:                                           ; preds = %loop.end54
-  br label %ifcont58
-
-ifcont58:                                         ; preds = %else57, %then56
-  %1155 = load %array*, %array** %b, align 8
-  %1156 = getelementptr %array, %array* %1155, i32 0, i32 0
-  %1157 = load i1*, i1** %1156, align 8
-  %1158 = ptrtoint i1* %1157 to i64
-  %1159 = icmp ne i64 %1158, 0
-  br i1 %1159, label %then59, label %else60
-
-then59:                                           ; preds = %ifcont58
-  %1160 = getelementptr %array, %array* %1155, i32 0, i32 0
-  %1161 = load i1*, i1** %1160, align 8
-  %1162 = alloca i8*, align 8
-  %1163 = bitcast i1* %1161 to i8*
-  store i8* %1163, i8** %1162, align 8
-  %1164 = load i8*, i8** %1162, align 8
-  call void @_lfortran_free(i8* %1164)
-  %1165 = getelementptr %array, %array* %1155, i32 0, i32 0
-  store i1* null, i1** %1165, align 8
-  br label %ifcont61
-
-else60:                                           ; preds = %ifcont58
-  br label %ifcont61
-
-ifcont61:                                         ; preds = %else60, %then59
-  %1166 = load %array*, %array** %c, align 8
-  %1167 = getelementptr %array, %array* %1166, i32 0, i32 0
-  %1168 = load i1*, i1** %1167, align 8
-  %1169 = ptrtoint i1* %1168 to i64
-  %1170 = icmp ne i64 %1169, 0
-  br i1 %1170, label %then62, label %else63
-
-then62:                                           ; preds = %ifcont61
-  %1171 = getelementptr %array, %array* %1166, i32 0, i32 0
-  %1172 = load i1*, i1** %1171, align 8
-  %1173 = alloca i8*, align 8
-  %1174 = bitcast i1* %1172 to i8*
-  store i8* %1174, i8** %1173, align 8
-  %1175 = load i8*, i8** %1173, align 8
-  call void @_lfortran_free(i8* %1175)
-  %1176 = getelementptr %array, %array* %1166, i32 0, i32 0
-  store i1* null, i1** %1176, align 8
-  br label %ifcont64
-
-else63:                                           ; preds = %ifcont61
-  br label %ifcont64
-
-ifcont64:                                         ; preds = %else63, %then62
-  %1177 = load %array*, %array** %a, align 8
-  %1178 = getelementptr %array, %array* %1177, i32 0, i32 0
-  %1179 = load i1*, i1** %1178, align 8
-  %1180 = ptrtoint i1* %1179 to i64
-  %1181 = icmp ne i64 %1180, 0
-  br i1 %1181, label %then65, label %else66
-
-then65:                                           ; preds = %ifcont64
-  %1182 = getelementptr %array, %array* %1177, i32 0, i32 0
-  %1183 = load i1*, i1** %1182, align 8
-  %1184 = alloca i8*, align 8
-  %1185 = bitcast i1* %1183 to i8*
-  store i8* %1185, i8** %1184, align 8
-  %1186 = load i8*, i8** %1184, align 8
-  call void @_lfortran_free(i8* %1186)
-  %1187 = getelementptr %array, %array* %1177, i32 0, i32 0
-  store i1* null, i1** %1187, align 8
-  br label %ifcont67
-
-else66:                                           ; preds = %ifcont64
-  br label %ifcont67
-
-ifcont67:                                         ; preds = %else66, %then65
-  %1188 = load %array*, %array** %b, align 8
-  %1189 = getelementptr %array, %array* %1188, i32 0, i32 0
-  %1190 = load i1*, i1** %1189, align 8
-  %1191 = ptrtoint i1* %1190 to i64
-  %1192 = icmp ne i64 %1191, 0
-  br i1 %1192, label %then68, label %else69
-
-then68:                                           ; preds = %ifcont67
-  %1193 = getelementptr %array, %array* %1188, i32 0, i32 0
-  %1194 = load i1*, i1** %1193, align 8
-  %1195 = alloca i8*, align 8
-  %1196 = bitcast i1* %1194 to i8*
-  store i8* %1196, i8** %1195, align 8
-  %1197 = load i8*, i8** %1195, align 8
-  call void @_lfortran_free(i8* %1197)
-  %1198 = getelementptr %array, %array* %1188, i32 0, i32 0
-  store i1* null, i1** %1198, align 8
-  br label %ifcont70
-
-else69:                                           ; preds = %ifcont67
-  br label %ifcont70
-
-ifcont70:                                         ; preds = %else69, %then68
-  %1199 = load %array*, %array** %c, align 8
-  %1200 = getelementptr %array, %array* %1199, i32 0, i32 0
-  %1201 = load i1*, i1** %1200, align 8
-  %1202 = ptrtoint i1* %1201 to i64
-  %1203 = icmp ne i64 %1202, 0
-  br i1 %1203, label %then71, label %else72
-
-then71:                                           ; preds = %ifcont70
-  %1204 = getelementptr %array, %array* %1199, i32 0, i32 0
-  %1205 = load i1*, i1** %1204, align 8
-  %1206 = alloca i8*, align 8
-  %1207 = bitcast i1* %1205 to i8*
-  store i8* %1207, i8** %1206, align 8
-  %1208 = load i8*, i8** %1206, align 8
-  call void @_lfortran_free(i8* %1208)
-  %1209 = getelementptr %array, %array* %1199, i32 0, i32 0
-  store i1* null, i1** %1209, align 8
-  br label %ifcont73
-
-else72:                                           ; preds = %ifcont70
-  br label %ifcont73
-
-ifcont73:                                         ; preds = %else72, %then71
-  br label %return
-
-return:                                           ; preds = %ifcont73
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-arrays_op_5-8426b5a.json
+++ b/tests/reference/llvm-arrays_op_5-8426b5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_5-8426b5a.stdout",
-    "stdout_hash": "e01d72dc1cb6c217715d5a7a558d6fd807f9ccf9c8e9c964c74e956b",
+    "stdout_hash": "9305d756748441ed7f103308176559b98447ee4e28606186a4ca74dd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_5-8426b5a.stdout
+++ b/tests/reference/llvm-arrays_op_5-8426b5a.stdout
@@ -10,6 +10,3702 @@ source_filename = "LFortran"
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value885 = alloca i32, align 4
+  %call_arg_value884 = alloca i32, align 4
+  %call_arg_value883 = alloca i32, align 4
+  %call_arg_value882 = alloca i32, align 4
+  %call_arg_value881 = alloca i32, align 4
+  %call_arg_value880 = alloca i32, align 4
+  %call_arg_value879 = alloca i32, align 4
+  %array_bound867 = alloca i32, align 4
+  %array_bound858 = alloca i32, align 4
+  %array_bound850 = alloca i32, align 4
+  %array_bound842 = alloca i32, align 4
+  %array_bound833 = alloca i32, align 4
+  %array_bound824 = alloca i32, align 4
+  %array_bound816 = alloca i32, align 4
+  %array_bound808 = alloca i32, align 4
+  %array_bound799 = alloca i32, align 4
+  %array_bound790 = alloca i32, align 4
+  %array_bound782 = alloca i32, align 4
+  %array_bound774 = alloca i32, align 4
+  %array_bound762 = alloca i32, align 4
+  %array_bound753 = alloca i32, align 4
+  %array_bound745 = alloca i32, align 4
+  %array_bound736 = alloca i32, align 4
+  %array_bound727 = alloca i32, align 4
+  %array_bound719 = alloca i32, align 4
+  %array_bound710 = alloca i32, align 4
+  %array_bound701 = alloca i32, align 4
+  %array_bound693 = alloca i32, align 4
+  %array_bound681 = alloca i32, align 4
+  %array_bound672 = alloca i32, align 4
+  %array_bound664 = alloca i32, align 4
+  %array_bound655 = alloca i32, align 4
+  %array_bound646 = alloca i32, align 4
+  %array_bound638 = alloca i32, align 4
+  %array_bound629 = alloca i32, align 4
+  %array_bound620 = alloca i32, align 4
+  %array_bound612 = alloca i32, align 4
+  %array_bound600 = alloca i32, align 4
+  %array_bound591 = alloca i32, align 4
+  %array_bound583 = alloca i32, align 4
+  %array_bound574 = alloca i32, align 4
+  %array_bound565 = alloca i32, align 4
+  %array_bound557 = alloca i32, align 4
+  %array_bound548 = alloca i32, align 4
+  %array_bound539 = alloca i32, align 4
+  %array_bound531 = alloca i32, align 4
+  %array_bound519 = alloca i32, align 4
+  %array_bound510 = alloca i32, align 4
+  %array_bound502 = alloca i32, align 4
+  %array_bound493 = alloca i32, align 4
+  %array_bound484 = alloca i32, align 4
+  %array_bound476 = alloca i32, align 4
+  %array_bound467 = alloca i32, align 4
+  %array_bound458 = alloca i32, align 4
+  %array_bound450 = alloca i32, align 4
+  %array_bound438 = alloca i32, align 4
+  %array_bound429 = alloca i32, align 4
+  %array_bound421 = alloca i32, align 4
+  %array_bound412 = alloca i32, align 4
+  %array_bound403 = alloca i32, align 4
+  %array_bound395 = alloca i32, align 4
+  %array_bound386 = alloca i32, align 4
+  %array_bound377 = alloca i32, align 4
+  %array_bound369 = alloca i32, align 4
+  %call_arg_value368 = alloca i32, align 4
+  %call_arg_value367 = alloca i32, align 4
+  %call_arg_value366 = alloca i32, align 4
+  %call_arg_value365 = alloca i32, align 4
+  %call_arg_value364 = alloca i32, align 4
+  %call_arg_value363 = alloca i32, align 4
+  %call_arg_value = alloca i32, align 4
+  %array_bound351 = alloca i32, align 4
+  %array_bound342 = alloca i32, align 4
+  %array_bound334 = alloca i32, align 4
+  %array_bound326 = alloca i32, align 4
+  %array_bound317 = alloca i32, align 4
+  %array_bound308 = alloca i32, align 4
+  %array_bound300 = alloca i32, align 4
+  %array_bound292 = alloca i32, align 4
+  %array_bound283 = alloca i32, align 4
+  %array_bound274 = alloca i32, align 4
+  %array_bound266 = alloca i32, align 4
+  %array_bound258 = alloca i32, align 4
+  %array_bound246 = alloca i32, align 4
+  %array_bound237 = alloca i32, align 4
+  %array_bound229 = alloca i32, align 4
+  %array_bound220 = alloca i32, align 4
+  %array_bound211 = alloca i32, align 4
+  %array_bound203 = alloca i32, align 4
+  %array_bound194 = alloca i32, align 4
+  %array_bound185 = alloca i32, align 4
+  %array_bound177 = alloca i32, align 4
+  %array_bound165 = alloca i32, align 4
+  %array_bound156 = alloca i32, align 4
+  %array_bound148 = alloca i32, align 4
+  %array_bound139 = alloca i32, align 4
+  %array_bound130 = alloca i32, align 4
+  %array_bound122 = alloca i32, align 4
+  %array_bound113 = alloca i32, align 4
+  %array_bound104 = alloca i32, align 4
+  %array_bound96 = alloca i32, align 4
+  %array_bound84 = alloca i32, align 4
+  %array_bound75 = alloca i32, align 4
+  %array_bound67 = alloca i32, align 4
+  %array_bound58 = alloca i32, align 4
+  %array_bound49 = alloca i32, align 4
+  %array_bound41 = alloca i32, align 4
+  %array_bound32 = alloca i32, align 4
+  %array_bound23 = alloca i32, align 4
+  %array_bound = alloca i32, align 4
+  %__1_t = alloca i32, align 4
+  %__1_u = alloca i32, align 4
+  %__1_v = alloca i32, align 4
+  %__2_t = alloca i32, align 4
+  %__2_u = alloca i32, align 4
+  %__2_v = alloca i32, align 4
+  %__3_t = alloca i32, align 4
+  %__3_u = alloca i32, align 4
+  %__3_v = alloca i32, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  %k = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_t1 = alloca i32, align 4
+  %__1_u2 = alloca i32, align 4
+  %__1_v3 = alloca i32, align 4
+  %__2_t4 = alloca i32, align 4
+  %__2_u5 = alloca i32, align 4
+  %__2_v6 = alloca i32, align 4
+  %__3_t7 = alloca i32, align 4
+  %__3_u8 = alloca i32, align 4
+  %__3_v9 = alloca i32, align 4
+  %__libasr__created__var__0__implicit_cast_res = alloca [4 x %complex_4], align 8
+  %__libasr__created__var__1__implicit_cast_res = alloca [4 x %complex_4], align 8
+  %__libasr__created__var__2__complex_bin_op_res = alloca [4 x %complex_4], align 8
+  %__libasr__created__var__3__integer_unary_op_res = alloca [4 x i32], align 4
+  %__libasr__created__var__4__implicit_cast_res = alloca [4 x %complex_4], align 8
+  %__libasr__created__var__5__integer_unary_op_res = alloca [4 x i32], align 4
+  %__libasr__created__var__6__implicit_cast_res = alloca [4 x %complex_4], align 8
+  %__libasr__created__var__7__complex_bin_op_res = alloca [4 x %complex_4], align 8
+  %__libasr_created_scalar_auxiliary_variable = alloca %complex_4, align 8
+  %__libasr_created_scalar_auxiliary_variable1 = alloca %complex_4, align 8
+  %a = alloca [4 x i32], align 4
+  %b = alloca [4 x i32], align 4
+  %c = alloca [4 x %complex_4], align 8
+  %i10 = alloca i32, align 4
+  %j11 = alloca i32, align 4
+  %k12 = alloca i32, align 4
+  store i32 0, i32* %i10, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.end17, %.entry
+  %2 = load i32, i32* %i10, align 4
+  %3 = add i32 %2, 1
+  %4 = icmp sle i32 %3, 2
+  br i1 %4, label %loop.body, label %loop.end18
+
+loop.body:                                        ; preds = %loop.head
+  %5 = load i32, i32* %i10, align 4
+  %6 = add i32 %5, 1
+  store i32 %6, i32* %i10, align 4
+  store i32 0, i32* %j11, align 4
+  br label %loop.head13
+
+loop.head13:                                      ; preds = %loop.end, %loop.body
+  %7 = load i32, i32* %j11, align 4
+  %8 = add i32 %7, 1
+  %9 = icmp sle i32 %8, 2
+  br i1 %9, label %loop.body14, label %loop.end17
+
+loop.body14:                                      ; preds = %loop.head13
+  %10 = load i32, i32* %j11, align 4
+  %11 = add i32 %10, 1
+  store i32 %11, i32* %j11, align 4
+  store i32 0, i32* %k12, align 4
+  br label %loop.head15
+
+loop.head15:                                      ; preds = %loop.body16, %loop.body14
+  %12 = load i32, i32* %k12, align 4
+  %13 = add i32 %12, 1
+  %14 = icmp sle i32 %13, 1
+  br i1 %14, label %loop.body16, label %loop.end
+
+loop.body16:                                      ; preds = %loop.head15
+  %15 = load i32, i32* %k12, align 4
+  %16 = add i32 %15, 1
+  store i32 %16, i32* %k12, align 4
+  %17 = load i32, i32* %i10, align 4
+  %18 = load i32, i32* %j11, align 4
+  %19 = load i32, i32* %k12, align 4
+  %20 = sub i32 %17, 1
+  %21 = mul i32 1, %20
+  %22 = add i32 0, %21
+  %23 = sub i32 %18, 1
+  %24 = mul i32 2, %23
+  %25 = add i32 %22, %24
+  %26 = sub i32 %19, 1
+  %27 = mul i32 4, %26
+  %28 = add i32 %25, %27
+  %29 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %28
+  %30 = load i32, i32* %i10, align 4
+  %31 = load i32, i32* %j11, align 4
+  %32 = add i32 %30, %31
+  %33 = load i32, i32* %k12, align 4
+  %34 = add i32 %32, %33
+  store i32 %34, i32* %29, align 4
+  %35 = load i32, i32* %i10, align 4
+  %36 = load i32, i32* %j11, align 4
+  %37 = load i32, i32* %k12, align 4
+  %38 = sub i32 %35, 1
+  %39 = mul i32 1, %38
+  %40 = add i32 0, %39
+  %41 = sub i32 %36, 1
+  %42 = mul i32 2, %41
+  %43 = add i32 %40, %42
+  %44 = sub i32 %37, 1
+  %45 = mul i32 4, %44
+  %46 = add i32 %43, %45
+  %47 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %46
+  %48 = load i32, i32* %i10, align 4
+  %49 = load i32, i32* %j11, align 4
+  %50 = mul i32 %48, %49
+  %51 = load i32, i32* %k12, align 4
+  %52 = mul i32 %50, %51
+  store i32 %52, i32* %47, align 4
+  br label %loop.head15
+
+loop.end:                                         ; preds = %loop.head15
+  br label %loop.head13
+
+loop.end17:                                       ; preds = %loop.head13
+  br label %loop.head
+
+loop.end18:                                       ; preds = %loop.head
+  br i1 true, label %then, label %else
+
+then:                                             ; preds = %loop.end18
+  store i32 1, i32* %array_bound, align 4
+  br label %ifcont
+
+else:                                             ; preds = %loop.end18
+  br i1 false, label %then19, label %else20
+
+then19:                                           ; preds = %else
+  store i32 1, i32* %array_bound, align 4
+  br label %ifcont
+
+else20:                                           ; preds = %else
+  br i1 false, label %then21, label %else22
+
+then21:                                           ; preds = %else20
+  store i32 1, i32* %array_bound, align 4
+  br label %ifcont
+
+else22:                                           ; preds = %else20
+  br label %ifcont
+
+ifcont:                                           ; preds = %else22, %then21, %then19, %then
+  %53 = load i32, i32* %array_bound, align 4
+  store i32 %53, i32* %__1_v3, align 4
+  br i1 true, label %then24, label %else25
+
+then24:                                           ; preds = %ifcont
+  store i32 1, i32* %array_bound23, align 4
+  br label %ifcont30
+
+else25:                                           ; preds = %ifcont
+  br i1 false, label %then26, label %else27
+
+then26:                                           ; preds = %else25
+  store i32 1, i32* %array_bound23, align 4
+  br label %ifcont30
+
+else27:                                           ; preds = %else25
+  br i1 false, label %then28, label %else29
+
+then28:                                           ; preds = %else27
+  store i32 1, i32* %array_bound23, align 4
+  br label %ifcont30
+
+else29:                                           ; preds = %else27
+  br label %ifcont30
+
+ifcont30:                                         ; preds = %else29, %then28, %then26, %then24
+  %54 = load i32, i32* %array_bound23, align 4
+  %55 = sub i32 %54, 1
+  store i32 %55, i32* %__1_t1, align 4
+  br label %loop.head31
+
+loop.head31:                                      ; preds = %loop.end94, %ifcont30
+  %56 = load i32, i32* %__1_t1, align 4
+  %57 = add i32 %56, 1
+  br i1 true, label %then33, label %else34
+
+then33:                                           ; preds = %loop.head31
+  store i32 2, i32* %array_bound32, align 4
+  br label %ifcont39
+
+else34:                                           ; preds = %loop.head31
+  br i1 false, label %then35, label %else36
+
+then35:                                           ; preds = %else34
+  store i32 2, i32* %array_bound32, align 4
+  br label %ifcont39
+
+else36:                                           ; preds = %else34
+  br i1 false, label %then37, label %else38
+
+then37:                                           ; preds = %else36
+  store i32 1, i32* %array_bound32, align 4
+  br label %ifcont39
+
+else38:                                           ; preds = %else36
+  br label %ifcont39
+
+ifcont39:                                         ; preds = %else38, %then37, %then35, %then33
+  %58 = load i32, i32* %array_bound32, align 4
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %loop.body40, label %loop.end95
+
+loop.body40:                                      ; preds = %ifcont39
+  %60 = load i32, i32* %__1_t1, align 4
+  %61 = add i32 %60, 1
+  store i32 %61, i32* %__1_t1, align 4
+  br i1 true, label %then42, label %else43
+
+then42:                                           ; preds = %loop.body40
+  store i32 1, i32* %array_bound41, align 4
+  br label %ifcont48
+
+else43:                                           ; preds = %loop.body40
+  br i1 false, label %then44, label %else45
+
+then44:                                           ; preds = %else43
+  store i32 1, i32* %array_bound41, align 4
+  br label %ifcont48
+
+else45:                                           ; preds = %else43
+  br i1 false, label %then46, label %else47
+
+then46:                                           ; preds = %else45
+  store i32 1, i32* %array_bound41, align 4
+  br label %ifcont48
+
+else47:                                           ; preds = %else45
+  br label %ifcont48
+
+ifcont48:                                         ; preds = %else47, %then46, %then44, %then42
+  %62 = load i32, i32* %array_bound41, align 4
+  store i32 %62, i32* %__2_v6, align 4
+  br i1 false, label %then50, label %else51
+
+then50:                                           ; preds = %ifcont48
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont56
+
+else51:                                           ; preds = %ifcont48
+  br i1 true, label %then52, label %else53
+
+then52:                                           ; preds = %else51
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont56
+
+else53:                                           ; preds = %else51
+  br i1 false, label %then54, label %else55
+
+then54:                                           ; preds = %else53
+  store i32 1, i32* %array_bound49, align 4
+  br label %ifcont56
+
+else55:                                           ; preds = %else53
+  br label %ifcont56
+
+ifcont56:                                         ; preds = %else55, %then54, %then52, %then50
+  %63 = load i32, i32* %array_bound49, align 4
+  %64 = sub i32 %63, 1
+  store i32 %64, i32* %__2_t4, align 4
+  br label %loop.head57
+
+loop.head57:                                      ; preds = %loop.end93, %ifcont56
+  %65 = load i32, i32* %__2_t4, align 4
+  %66 = add i32 %65, 1
+  br i1 false, label %then59, label %else60
+
+then59:                                           ; preds = %loop.head57
+  store i32 2, i32* %array_bound58, align 4
+  br label %ifcont65
+
+else60:                                           ; preds = %loop.head57
+  br i1 true, label %then61, label %else62
+
+then61:                                           ; preds = %else60
+  store i32 2, i32* %array_bound58, align 4
+  br label %ifcont65
+
+else62:                                           ; preds = %else60
+  br i1 false, label %then63, label %else64
+
+then63:                                           ; preds = %else62
+  store i32 1, i32* %array_bound58, align 4
+  br label %ifcont65
+
+else64:                                           ; preds = %else62
+  br label %ifcont65
+
+ifcont65:                                         ; preds = %else64, %then63, %then61, %then59
+  %67 = load i32, i32* %array_bound58, align 4
+  %68 = icmp sle i32 %66, %67
+  br i1 %68, label %loop.body66, label %loop.end94
+
+loop.body66:                                      ; preds = %ifcont65
+  %69 = load i32, i32* %__2_t4, align 4
+  %70 = add i32 %69, 1
+  store i32 %70, i32* %__2_t4, align 4
+  br i1 false, label %then68, label %else69
+
+then68:                                           ; preds = %loop.body66
+  store i32 1, i32* %array_bound67, align 4
+  br label %ifcont74
+
+else69:                                           ; preds = %loop.body66
+  br i1 true, label %then70, label %else71
+
+then70:                                           ; preds = %else69
+  store i32 1, i32* %array_bound67, align 4
+  br label %ifcont74
+
+else71:                                           ; preds = %else69
+  br i1 false, label %then72, label %else73
+
+then72:                                           ; preds = %else71
+  store i32 1, i32* %array_bound67, align 4
+  br label %ifcont74
+
+else73:                                           ; preds = %else71
+  br label %ifcont74
+
+ifcont74:                                         ; preds = %else73, %then72, %then70, %then68
+  %71 = load i32, i32* %array_bound67, align 4
+  store i32 %71, i32* %__3_v9, align 4
+  br i1 false, label %then76, label %else77
+
+then76:                                           ; preds = %ifcont74
+  store i32 1, i32* %array_bound75, align 4
+  br label %ifcont82
+
+else77:                                           ; preds = %ifcont74
+  br i1 false, label %then78, label %else79
+
+then78:                                           ; preds = %else77
+  store i32 1, i32* %array_bound75, align 4
+  br label %ifcont82
+
+else79:                                           ; preds = %else77
+  br i1 true, label %then80, label %else81
+
+then80:                                           ; preds = %else79
+  store i32 1, i32* %array_bound75, align 4
+  br label %ifcont82
+
+else81:                                           ; preds = %else79
+  br label %ifcont82
+
+ifcont82:                                         ; preds = %else81, %then80, %then78, %then76
+  %72 = load i32, i32* %array_bound75, align 4
+  %73 = sub i32 %72, 1
+  store i32 %73, i32* %__3_t7, align 4
+  br label %loop.head83
+
+loop.head83:                                      ; preds = %loop.body92, %ifcont82
+  %74 = load i32, i32* %__3_t7, align 4
+  %75 = add i32 %74, 1
+  br i1 false, label %then85, label %else86
+
+then85:                                           ; preds = %loop.head83
+  store i32 2, i32* %array_bound84, align 4
+  br label %ifcont91
+
+else86:                                           ; preds = %loop.head83
+  br i1 false, label %then87, label %else88
+
+then87:                                           ; preds = %else86
+  store i32 2, i32* %array_bound84, align 4
+  br label %ifcont91
+
+else88:                                           ; preds = %else86
+  br i1 true, label %then89, label %else90
+
+then89:                                           ; preds = %else88
+  store i32 1, i32* %array_bound84, align 4
+  br label %ifcont91
+
+else90:                                           ; preds = %else88
+  br label %ifcont91
+
+ifcont91:                                         ; preds = %else90, %then89, %then87, %then85
+  %76 = load i32, i32* %array_bound84, align 4
+  %77 = icmp sle i32 %75, %76
+  br i1 %77, label %loop.body92, label %loop.end93
+
+loop.body92:                                      ; preds = %ifcont91
+  %78 = load i32, i32* %__3_t7, align 4
+  %79 = add i32 %78, 1
+  store i32 %79, i32* %__3_t7, align 4
+  %80 = load i32, i32* %__1_t1, align 4
+  %81 = load i32, i32* %__2_t4, align 4
+  %82 = load i32, i32* %__3_t7, align 4
+  %83 = sub i32 %80, 1
+  %84 = mul i32 1, %83
+  %85 = add i32 0, %84
+  %86 = sub i32 %81, 1
+  %87 = mul i32 2, %86
+  %88 = add i32 %85, %87
+  %89 = sub i32 %82, 1
+  %90 = mul i32 4, %89
+  %91 = add i32 %88, %90
+  %92 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__0__implicit_cast_res, i32 0, i32 %91
+  %93 = load i32, i32* %__1_v3, align 4
+  %94 = load i32, i32* %__2_v6, align 4
+  %95 = load i32, i32* %__3_v9, align 4
+  %96 = sub i32 %93, 1
+  %97 = mul i32 1, %96
+  %98 = add i32 0, %97
+  %99 = sub i32 %94, 1
+  %100 = mul i32 2, %99
+  %101 = add i32 %98, %100
+  %102 = sub i32 %95, 1
+  %103 = mul i32 4, %102
+  %104 = add i32 %101, %103
+  %105 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %104
+  %106 = load i32, i32* %105, align 4
+  %107 = sitofp i32 %106 to float
+  %108 = alloca %complex_4, align 8
+  %109 = getelementptr %complex_4, %complex_4* %108, i32 0, i32 0
+  %110 = getelementptr %complex_4, %complex_4* %108, i32 0, i32 1
+  store float %107, float* %109, align 4
+  store float 0.000000e+00, float* %110, align 4
+  %111 = load %complex_4, %complex_4* %108, align 4
+  store %complex_4 %111, %complex_4* %92, align 4
+  %112 = load i32, i32* %__3_v9, align 4
+  %113 = add i32 %112, 1
+  store i32 %113, i32* %__3_v9, align 4
+  br label %loop.head83
+
+loop.end93:                                       ; preds = %ifcont91
+  %114 = load i32, i32* %__2_v6, align 4
+  %115 = add i32 %114, 1
+  store i32 %115, i32* %__2_v6, align 4
+  br label %loop.head57
+
+loop.end94:                                       ; preds = %ifcont65
+  %116 = load i32, i32* %__1_v3, align 4
+  %117 = add i32 %116, 1
+  store i32 %117, i32* %__1_v3, align 4
+  br label %loop.head31
+
+loop.end95:                                       ; preds = %ifcont39
+  br i1 true, label %then97, label %else98
+
+then97:                                           ; preds = %loop.end95
+  store i32 1, i32* %array_bound96, align 4
+  br label %ifcont103
+
+else98:                                           ; preds = %loop.end95
+  br i1 false, label %then99, label %else100
+
+then99:                                           ; preds = %else98
+  store i32 1, i32* %array_bound96, align 4
+  br label %ifcont103
+
+else100:                                          ; preds = %else98
+  br i1 false, label %then101, label %else102
+
+then101:                                          ; preds = %else100
+  store i32 1, i32* %array_bound96, align 4
+  br label %ifcont103
+
+else102:                                          ; preds = %else100
+  br label %ifcont103
+
+ifcont103:                                        ; preds = %else102, %then101, %then99, %then97
+  %118 = load i32, i32* %array_bound96, align 4
+  store i32 %118, i32* %__1_v3, align 4
+  br i1 true, label %then105, label %else106
+
+then105:                                          ; preds = %ifcont103
+  store i32 1, i32* %array_bound104, align 4
+  br label %ifcont111
+
+else106:                                          ; preds = %ifcont103
+  br i1 false, label %then107, label %else108
+
+then107:                                          ; preds = %else106
+  store i32 1, i32* %array_bound104, align 4
+  br label %ifcont111
+
+else108:                                          ; preds = %else106
+  br i1 false, label %then109, label %else110
+
+then109:                                          ; preds = %else108
+  store i32 1, i32* %array_bound104, align 4
+  br label %ifcont111
+
+else110:                                          ; preds = %else108
+  br label %ifcont111
+
+ifcont111:                                        ; preds = %else110, %then109, %then107, %then105
+  %119 = load i32, i32* %array_bound104, align 4
+  %120 = sub i32 %119, 1
+  store i32 %120, i32* %__1_t1, align 4
+  br label %loop.head112
+
+loop.head112:                                     ; preds = %loop.end175, %ifcont111
+  %121 = load i32, i32* %__1_t1, align 4
+  %122 = add i32 %121, 1
+  br i1 true, label %then114, label %else115
+
+then114:                                          ; preds = %loop.head112
+  store i32 2, i32* %array_bound113, align 4
+  br label %ifcont120
+
+else115:                                          ; preds = %loop.head112
+  br i1 false, label %then116, label %else117
+
+then116:                                          ; preds = %else115
+  store i32 2, i32* %array_bound113, align 4
+  br label %ifcont120
+
+else117:                                          ; preds = %else115
+  br i1 false, label %then118, label %else119
+
+then118:                                          ; preds = %else117
+  store i32 1, i32* %array_bound113, align 4
+  br label %ifcont120
+
+else119:                                          ; preds = %else117
+  br label %ifcont120
+
+ifcont120:                                        ; preds = %else119, %then118, %then116, %then114
+  %123 = load i32, i32* %array_bound113, align 4
+  %124 = icmp sle i32 %122, %123
+  br i1 %124, label %loop.body121, label %loop.end176
+
+loop.body121:                                     ; preds = %ifcont120
+  %125 = load i32, i32* %__1_t1, align 4
+  %126 = add i32 %125, 1
+  store i32 %126, i32* %__1_t1, align 4
+  br i1 true, label %then123, label %else124
+
+then123:                                          ; preds = %loop.body121
+  store i32 1, i32* %array_bound122, align 4
+  br label %ifcont129
+
+else124:                                          ; preds = %loop.body121
+  br i1 false, label %then125, label %else126
+
+then125:                                          ; preds = %else124
+  store i32 1, i32* %array_bound122, align 4
+  br label %ifcont129
+
+else126:                                          ; preds = %else124
+  br i1 false, label %then127, label %else128
+
+then127:                                          ; preds = %else126
+  store i32 1, i32* %array_bound122, align 4
+  br label %ifcont129
+
+else128:                                          ; preds = %else126
+  br label %ifcont129
+
+ifcont129:                                        ; preds = %else128, %then127, %then125, %then123
+  %127 = load i32, i32* %array_bound122, align 4
+  store i32 %127, i32* %__2_v6, align 4
+  br i1 false, label %then131, label %else132
+
+then131:                                          ; preds = %ifcont129
+  store i32 1, i32* %array_bound130, align 4
+  br label %ifcont137
+
+else132:                                          ; preds = %ifcont129
+  br i1 true, label %then133, label %else134
+
+then133:                                          ; preds = %else132
+  store i32 1, i32* %array_bound130, align 4
+  br label %ifcont137
+
+else134:                                          ; preds = %else132
+  br i1 false, label %then135, label %else136
+
+then135:                                          ; preds = %else134
+  store i32 1, i32* %array_bound130, align 4
+  br label %ifcont137
+
+else136:                                          ; preds = %else134
+  br label %ifcont137
+
+ifcont137:                                        ; preds = %else136, %then135, %then133, %then131
+  %128 = load i32, i32* %array_bound130, align 4
+  %129 = sub i32 %128, 1
+  store i32 %129, i32* %__2_t4, align 4
+  br label %loop.head138
+
+loop.head138:                                     ; preds = %loop.end174, %ifcont137
+  %130 = load i32, i32* %__2_t4, align 4
+  %131 = add i32 %130, 1
+  br i1 false, label %then140, label %else141
+
+then140:                                          ; preds = %loop.head138
+  store i32 2, i32* %array_bound139, align 4
+  br label %ifcont146
+
+else141:                                          ; preds = %loop.head138
+  br i1 true, label %then142, label %else143
+
+then142:                                          ; preds = %else141
+  store i32 2, i32* %array_bound139, align 4
+  br label %ifcont146
+
+else143:                                          ; preds = %else141
+  br i1 false, label %then144, label %else145
+
+then144:                                          ; preds = %else143
+  store i32 1, i32* %array_bound139, align 4
+  br label %ifcont146
+
+else145:                                          ; preds = %else143
+  br label %ifcont146
+
+ifcont146:                                        ; preds = %else145, %then144, %then142, %then140
+  %132 = load i32, i32* %array_bound139, align 4
+  %133 = icmp sle i32 %131, %132
+  br i1 %133, label %loop.body147, label %loop.end175
+
+loop.body147:                                     ; preds = %ifcont146
+  %134 = load i32, i32* %__2_t4, align 4
+  %135 = add i32 %134, 1
+  store i32 %135, i32* %__2_t4, align 4
+  br i1 false, label %then149, label %else150
+
+then149:                                          ; preds = %loop.body147
+  store i32 1, i32* %array_bound148, align 4
+  br label %ifcont155
+
+else150:                                          ; preds = %loop.body147
+  br i1 true, label %then151, label %else152
+
+then151:                                          ; preds = %else150
+  store i32 1, i32* %array_bound148, align 4
+  br label %ifcont155
+
+else152:                                          ; preds = %else150
+  br i1 false, label %then153, label %else154
+
+then153:                                          ; preds = %else152
+  store i32 1, i32* %array_bound148, align 4
+  br label %ifcont155
+
+else154:                                          ; preds = %else152
+  br label %ifcont155
+
+ifcont155:                                        ; preds = %else154, %then153, %then151, %then149
+  %136 = load i32, i32* %array_bound148, align 4
+  store i32 %136, i32* %__3_v9, align 4
+  br i1 false, label %then157, label %else158
+
+then157:                                          ; preds = %ifcont155
+  store i32 1, i32* %array_bound156, align 4
+  br label %ifcont163
+
+else158:                                          ; preds = %ifcont155
+  br i1 false, label %then159, label %else160
+
+then159:                                          ; preds = %else158
+  store i32 1, i32* %array_bound156, align 4
+  br label %ifcont163
+
+else160:                                          ; preds = %else158
+  br i1 true, label %then161, label %else162
+
+then161:                                          ; preds = %else160
+  store i32 1, i32* %array_bound156, align 4
+  br label %ifcont163
+
+else162:                                          ; preds = %else160
+  br label %ifcont163
+
+ifcont163:                                        ; preds = %else162, %then161, %then159, %then157
+  %137 = load i32, i32* %array_bound156, align 4
+  %138 = sub i32 %137, 1
+  store i32 %138, i32* %__3_t7, align 4
+  br label %loop.head164
+
+loop.head164:                                     ; preds = %loop.body173, %ifcont163
+  %139 = load i32, i32* %__3_t7, align 4
+  %140 = add i32 %139, 1
+  br i1 false, label %then166, label %else167
+
+then166:                                          ; preds = %loop.head164
+  store i32 2, i32* %array_bound165, align 4
+  br label %ifcont172
+
+else167:                                          ; preds = %loop.head164
+  br i1 false, label %then168, label %else169
+
+then168:                                          ; preds = %else167
+  store i32 2, i32* %array_bound165, align 4
+  br label %ifcont172
+
+else169:                                          ; preds = %else167
+  br i1 true, label %then170, label %else171
+
+then170:                                          ; preds = %else169
+  store i32 1, i32* %array_bound165, align 4
+  br label %ifcont172
+
+else171:                                          ; preds = %else169
+  br label %ifcont172
+
+ifcont172:                                        ; preds = %else171, %then170, %then168, %then166
+  %141 = load i32, i32* %array_bound165, align 4
+  %142 = icmp sle i32 %140, %141
+  br i1 %142, label %loop.body173, label %loop.end174
+
+loop.body173:                                     ; preds = %ifcont172
+  %143 = load i32, i32* %__3_t7, align 4
+  %144 = add i32 %143, 1
+  store i32 %144, i32* %__3_t7, align 4
+  %145 = load i32, i32* %__1_t1, align 4
+  %146 = load i32, i32* %__2_t4, align 4
+  %147 = load i32, i32* %__3_t7, align 4
+  %148 = sub i32 %145, 1
+  %149 = mul i32 1, %148
+  %150 = add i32 0, %149
+  %151 = sub i32 %146, 1
+  %152 = mul i32 2, %151
+  %153 = add i32 %150, %152
+  %154 = sub i32 %147, 1
+  %155 = mul i32 4, %154
+  %156 = add i32 %153, %155
+  %157 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__1__implicit_cast_res, i32 0, i32 %156
+  %158 = load i32, i32* %__1_v3, align 4
+  %159 = load i32, i32* %__2_v6, align 4
+  %160 = load i32, i32* %__3_v9, align 4
+  %161 = sub i32 %158, 1
+  %162 = mul i32 1, %161
+  %163 = add i32 0, %162
+  %164 = sub i32 %159, 1
+  %165 = mul i32 2, %164
+  %166 = add i32 %163, %165
+  %167 = sub i32 %160, 1
+  %168 = mul i32 4, %167
+  %169 = add i32 %166, %168
+  %170 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %169
+  %171 = load i32, i32* %170, align 4
+  %172 = sitofp i32 %171 to float
+  %173 = alloca %complex_4, align 8
+  %174 = getelementptr %complex_4, %complex_4* %173, i32 0, i32 0
+  %175 = getelementptr %complex_4, %complex_4* %173, i32 0, i32 1
+  store float %172, float* %174, align 4
+  store float 0.000000e+00, float* %175, align 4
+  %176 = load %complex_4, %complex_4* %173, align 4
+  store %complex_4 %176, %complex_4* %157, align 4
+  %177 = load i32, i32* %__3_v9, align 4
+  %178 = add i32 %177, 1
+  store i32 %178, i32* %__3_v9, align 4
+  br label %loop.head164
+
+loop.end174:                                      ; preds = %ifcont172
+  %179 = load i32, i32* %__2_v6, align 4
+  %180 = add i32 %179, 1
+  store i32 %180, i32* %__2_v6, align 4
+  br label %loop.head138
+
+loop.end175:                                      ; preds = %ifcont146
+  %181 = load i32, i32* %__1_v3, align 4
+  %182 = add i32 %181, 1
+  store i32 %182, i32* %__1_v3, align 4
+  br label %loop.head112
+
+loop.end176:                                      ; preds = %ifcont120
+  %183 = alloca %complex_4, align 8
+  %184 = getelementptr %complex_4, %complex_4* %183, i32 0, i32 0
+  %185 = getelementptr %complex_4, %complex_4* %183, i32 0, i32 1
+  store float 0.000000e+00, float* %184, align 4
+  store float 1.000000e+00, float* %185, align 4
+  %186 = load %complex_4, %complex_4* %183, align 4
+  store %complex_4 %186, %complex_4* %__libasr_created_scalar_auxiliary_variable, align 4
+  br i1 true, label %then178, label %else179
+
+then178:                                          ; preds = %loop.end176
+  store i32 1, i32* %array_bound177, align 4
+  br label %ifcont184
+
+else179:                                          ; preds = %loop.end176
+  br i1 false, label %then180, label %else181
+
+then180:                                          ; preds = %else179
+  store i32 1, i32* %array_bound177, align 4
+  br label %ifcont184
+
+else181:                                          ; preds = %else179
+  br i1 false, label %then182, label %else183
+
+then182:                                          ; preds = %else181
+  store i32 1, i32* %array_bound177, align 4
+  br label %ifcont184
+
+else183:                                          ; preds = %else181
+  br label %ifcont184
+
+ifcont184:                                        ; preds = %else183, %then182, %then180, %then178
+  %187 = load i32, i32* %array_bound177, align 4
+  store i32 %187, i32* %__1_v3, align 4
+  br i1 true, label %then186, label %else187
+
+then186:                                          ; preds = %ifcont184
+  store i32 1, i32* %array_bound185, align 4
+  br label %ifcont192
+
+else187:                                          ; preds = %ifcont184
+  br i1 false, label %then188, label %else189
+
+then188:                                          ; preds = %else187
+  store i32 1, i32* %array_bound185, align 4
+  br label %ifcont192
+
+else189:                                          ; preds = %else187
+  br i1 false, label %then190, label %else191
+
+then190:                                          ; preds = %else189
+  store i32 1, i32* %array_bound185, align 4
+  br label %ifcont192
+
+else191:                                          ; preds = %else189
+  br label %ifcont192
+
+ifcont192:                                        ; preds = %else191, %then190, %then188, %then186
+  %188 = load i32, i32* %array_bound185, align 4
+  %189 = sub i32 %188, 1
+  store i32 %189, i32* %__1_t1, align 4
+  br label %loop.head193
+
+loop.head193:                                     ; preds = %loop.end256, %ifcont192
+  %190 = load i32, i32* %__1_t1, align 4
+  %191 = add i32 %190, 1
+  br i1 true, label %then195, label %else196
+
+then195:                                          ; preds = %loop.head193
+  store i32 2, i32* %array_bound194, align 4
+  br label %ifcont201
+
+else196:                                          ; preds = %loop.head193
+  br i1 false, label %then197, label %else198
+
+then197:                                          ; preds = %else196
+  store i32 2, i32* %array_bound194, align 4
+  br label %ifcont201
+
+else198:                                          ; preds = %else196
+  br i1 false, label %then199, label %else200
+
+then199:                                          ; preds = %else198
+  store i32 1, i32* %array_bound194, align 4
+  br label %ifcont201
+
+else200:                                          ; preds = %else198
+  br label %ifcont201
+
+ifcont201:                                        ; preds = %else200, %then199, %then197, %then195
+  %192 = load i32, i32* %array_bound194, align 4
+  %193 = icmp sle i32 %191, %192
+  br i1 %193, label %loop.body202, label %loop.end257
+
+loop.body202:                                     ; preds = %ifcont201
+  %194 = load i32, i32* %__1_t1, align 4
+  %195 = add i32 %194, 1
+  store i32 %195, i32* %__1_t1, align 4
+  br i1 false, label %then204, label %else205
+
+then204:                                          ; preds = %loop.body202
+  store i32 1, i32* %array_bound203, align 4
+  br label %ifcont210
+
+else205:                                          ; preds = %loop.body202
+  br i1 true, label %then206, label %else207
+
+then206:                                          ; preds = %else205
+  store i32 1, i32* %array_bound203, align 4
+  br label %ifcont210
+
+else207:                                          ; preds = %else205
+  br i1 false, label %then208, label %else209
+
+then208:                                          ; preds = %else207
+  store i32 1, i32* %array_bound203, align 4
+  br label %ifcont210
+
+else209:                                          ; preds = %else207
+  br label %ifcont210
+
+ifcont210:                                        ; preds = %else209, %then208, %then206, %then204
+  %196 = load i32, i32* %array_bound203, align 4
+  store i32 %196, i32* %__2_v6, align 4
+  br i1 false, label %then212, label %else213
+
+then212:                                          ; preds = %ifcont210
+  store i32 1, i32* %array_bound211, align 4
+  br label %ifcont218
+
+else213:                                          ; preds = %ifcont210
+  br i1 true, label %then214, label %else215
+
+then214:                                          ; preds = %else213
+  store i32 1, i32* %array_bound211, align 4
+  br label %ifcont218
+
+else215:                                          ; preds = %else213
+  br i1 false, label %then216, label %else217
+
+then216:                                          ; preds = %else215
+  store i32 1, i32* %array_bound211, align 4
+  br label %ifcont218
+
+else217:                                          ; preds = %else215
+  br label %ifcont218
+
+ifcont218:                                        ; preds = %else217, %then216, %then214, %then212
+  %197 = load i32, i32* %array_bound211, align 4
+  %198 = sub i32 %197, 1
+  store i32 %198, i32* %__2_t4, align 4
+  br label %loop.head219
+
+loop.head219:                                     ; preds = %loop.end255, %ifcont218
+  %199 = load i32, i32* %__2_t4, align 4
+  %200 = add i32 %199, 1
+  br i1 false, label %then221, label %else222
+
+then221:                                          ; preds = %loop.head219
+  store i32 2, i32* %array_bound220, align 4
+  br label %ifcont227
+
+else222:                                          ; preds = %loop.head219
+  br i1 true, label %then223, label %else224
+
+then223:                                          ; preds = %else222
+  store i32 2, i32* %array_bound220, align 4
+  br label %ifcont227
+
+else224:                                          ; preds = %else222
+  br i1 false, label %then225, label %else226
+
+then225:                                          ; preds = %else224
+  store i32 1, i32* %array_bound220, align 4
+  br label %ifcont227
+
+else226:                                          ; preds = %else224
+  br label %ifcont227
+
+ifcont227:                                        ; preds = %else226, %then225, %then223, %then221
+  %201 = load i32, i32* %array_bound220, align 4
+  %202 = icmp sle i32 %200, %201
+  br i1 %202, label %loop.body228, label %loop.end256
+
+loop.body228:                                     ; preds = %ifcont227
+  %203 = load i32, i32* %__2_t4, align 4
+  %204 = add i32 %203, 1
+  store i32 %204, i32* %__2_t4, align 4
+  br i1 false, label %then230, label %else231
+
+then230:                                          ; preds = %loop.body228
+  store i32 1, i32* %array_bound229, align 4
+  br label %ifcont236
+
+else231:                                          ; preds = %loop.body228
+  br i1 false, label %then232, label %else233
+
+then232:                                          ; preds = %else231
+  store i32 1, i32* %array_bound229, align 4
+  br label %ifcont236
+
+else233:                                          ; preds = %else231
+  br i1 true, label %then234, label %else235
+
+then234:                                          ; preds = %else233
+  store i32 1, i32* %array_bound229, align 4
+  br label %ifcont236
+
+else235:                                          ; preds = %else233
+  br label %ifcont236
+
+ifcont236:                                        ; preds = %else235, %then234, %then232, %then230
+  %205 = load i32, i32* %array_bound229, align 4
+  store i32 %205, i32* %__3_v9, align 4
+  br i1 false, label %then238, label %else239
+
+then238:                                          ; preds = %ifcont236
+  store i32 1, i32* %array_bound237, align 4
+  br label %ifcont244
+
+else239:                                          ; preds = %ifcont236
+  br i1 false, label %then240, label %else241
+
+then240:                                          ; preds = %else239
+  store i32 1, i32* %array_bound237, align 4
+  br label %ifcont244
+
+else241:                                          ; preds = %else239
+  br i1 true, label %then242, label %else243
+
+then242:                                          ; preds = %else241
+  store i32 1, i32* %array_bound237, align 4
+  br label %ifcont244
+
+else243:                                          ; preds = %else241
+  br label %ifcont244
+
+ifcont244:                                        ; preds = %else243, %then242, %then240, %then238
+  %206 = load i32, i32* %array_bound237, align 4
+  %207 = sub i32 %206, 1
+  store i32 %207, i32* %__3_t7, align 4
+  br label %loop.head245
+
+loop.head245:                                     ; preds = %loop.body254, %ifcont244
+  %208 = load i32, i32* %__3_t7, align 4
+  %209 = add i32 %208, 1
+  br i1 false, label %then247, label %else248
+
+then247:                                          ; preds = %loop.head245
+  store i32 2, i32* %array_bound246, align 4
+  br label %ifcont253
+
+else248:                                          ; preds = %loop.head245
+  br i1 false, label %then249, label %else250
+
+then249:                                          ; preds = %else248
+  store i32 2, i32* %array_bound246, align 4
+  br label %ifcont253
+
+else250:                                          ; preds = %else248
+  br i1 true, label %then251, label %else252
+
+then251:                                          ; preds = %else250
+  store i32 1, i32* %array_bound246, align 4
+  br label %ifcont253
+
+else252:                                          ; preds = %else250
+  br label %ifcont253
+
+ifcont253:                                        ; preds = %else252, %then251, %then249, %then247
+  %210 = load i32, i32* %array_bound246, align 4
+  %211 = icmp sle i32 %209, %210
+  br i1 %211, label %loop.body254, label %loop.end255
+
+loop.body254:                                     ; preds = %ifcont253
+  %212 = load i32, i32* %__3_t7, align 4
+  %213 = add i32 %212, 1
+  store i32 %213, i32* %__3_t7, align 4
+  %214 = load i32, i32* %__1_t1, align 4
+  %215 = load i32, i32* %__2_t4, align 4
+  %216 = load i32, i32* %__3_t7, align 4
+  %217 = sub i32 %214, 1
+  %218 = mul i32 1, %217
+  %219 = add i32 0, %218
+  %220 = sub i32 %215, 1
+  %221 = mul i32 2, %220
+  %222 = add i32 %219, %221
+  %223 = sub i32 %216, 1
+  %224 = mul i32 4, %223
+  %225 = add i32 %222, %224
+  %226 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__2__complex_bin_op_res, i32 0, i32 %225
+  %227 = load %complex_4, %complex_4* %__libasr_created_scalar_auxiliary_variable, align 4
+  %228 = load i32, i32* %__1_v3, align 4
+  %229 = load i32, i32* %__2_v6, align 4
+  %230 = load i32, i32* %__3_v9, align 4
+  %231 = sub i32 %228, 1
+  %232 = mul i32 1, %231
+  %233 = add i32 0, %232
+  %234 = sub i32 %229, 1
+  %235 = mul i32 2, %234
+  %236 = add i32 %233, %235
+  %237 = sub i32 %230, 1
+  %238 = mul i32 4, %237
+  %239 = add i32 %236, %238
+  %240 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__1__implicit_cast_res, i32 0, i32 %239
+  %241 = load %complex_4, %complex_4* %240, align 4
+  %242 = alloca %complex_4, align 8
+  store %complex_4 %227, %complex_4* %242, align 4
+  %243 = alloca %complex_4, align 8
+  store %complex_4 %241, %complex_4* %243, align 4
+  %244 = alloca %complex_4, align 8
+  call void @_lfortran_complex_mul_32(%complex_4* %242, %complex_4* %243, %complex_4* %244)
+  %245 = load %complex_4, %complex_4* %244, align 4
+  store %complex_4 %245, %complex_4* %226, align 4
+  %246 = load i32, i32* %__3_v9, align 4
+  %247 = add i32 %246, 1
+  store i32 %247, i32* %__3_v9, align 4
+  br label %loop.head245
+
+loop.end255:                                      ; preds = %ifcont253
+  %248 = load i32, i32* %__2_v6, align 4
+  %249 = add i32 %248, 1
+  store i32 %249, i32* %__2_v6, align 4
+  br label %loop.head219
+
+loop.end256:                                      ; preds = %ifcont227
+  %250 = load i32, i32* %__1_v3, align 4
+  %251 = add i32 %250, 1
+  store i32 %251, i32* %__1_v3, align 4
+  br label %loop.head193
+
+loop.end257:                                      ; preds = %ifcont201
+  br i1 true, label %then259, label %else260
+
+then259:                                          ; preds = %loop.end257
+  store i32 1, i32* %array_bound258, align 4
+  br label %ifcont265
+
+else260:                                          ; preds = %loop.end257
+  br i1 false, label %then261, label %else262
+
+then261:                                          ; preds = %else260
+  store i32 1, i32* %array_bound258, align 4
+  br label %ifcont265
+
+else262:                                          ; preds = %else260
+  br i1 false, label %then263, label %else264
+
+then263:                                          ; preds = %else262
+  store i32 1, i32* %array_bound258, align 4
+  br label %ifcont265
+
+else264:                                          ; preds = %else262
+  br label %ifcont265
+
+ifcont265:                                        ; preds = %else264, %then263, %then261, %then259
+  %252 = load i32, i32* %array_bound258, align 4
+  store i32 %252, i32* %__1_v3, align 4
+  br i1 true, label %then267, label %else268
+
+then267:                                          ; preds = %ifcont265
+  store i32 1, i32* %array_bound266, align 4
+  br label %ifcont273
+
+else268:                                          ; preds = %ifcont265
+  br i1 false, label %then269, label %else270
+
+then269:                                          ; preds = %else268
+  store i32 1, i32* %array_bound266, align 4
+  br label %ifcont273
+
+else270:                                          ; preds = %else268
+  br i1 false, label %then271, label %else272
+
+then271:                                          ; preds = %else270
+  store i32 1, i32* %array_bound266, align 4
+  br label %ifcont273
+
+else272:                                          ; preds = %else270
+  br label %ifcont273
+
+ifcont273:                                        ; preds = %else272, %then271, %then269, %then267
+  %253 = load i32, i32* %array_bound266, align 4
+  store i32 %253, i32* %__1_u2, align 4
+  br i1 true, label %then275, label %else276
+
+then275:                                          ; preds = %ifcont273
+  store i32 1, i32* %array_bound274, align 4
+  br label %ifcont281
+
+else276:                                          ; preds = %ifcont273
+  br i1 false, label %then277, label %else278
+
+then277:                                          ; preds = %else276
+  store i32 1, i32* %array_bound274, align 4
+  br label %ifcont281
+
+else278:                                          ; preds = %else276
+  br i1 false, label %then279, label %else280
+
+then279:                                          ; preds = %else278
+  store i32 1, i32* %array_bound274, align 4
+  br label %ifcont281
+
+else280:                                          ; preds = %else278
+  br label %ifcont281
+
+ifcont281:                                        ; preds = %else280, %then279, %then277, %then275
+  %254 = load i32, i32* %array_bound274, align 4
+  %255 = sub i32 %254, 1
+  store i32 %255, i32* %__1_t1, align 4
+  br label %loop.head282
+
+loop.head282:                                     ; preds = %loop.end361, %ifcont281
+  %256 = load i32, i32* %__1_t1, align 4
+  %257 = add i32 %256, 1
+  br i1 true, label %then284, label %else285
+
+then284:                                          ; preds = %loop.head282
+  store i32 2, i32* %array_bound283, align 4
+  br label %ifcont290
+
+else285:                                          ; preds = %loop.head282
+  br i1 false, label %then286, label %else287
+
+then286:                                          ; preds = %else285
+  store i32 2, i32* %array_bound283, align 4
+  br label %ifcont290
+
+else287:                                          ; preds = %else285
+  br i1 false, label %then288, label %else289
+
+then288:                                          ; preds = %else287
+  store i32 1, i32* %array_bound283, align 4
+  br label %ifcont290
+
+else289:                                          ; preds = %else287
+  br label %ifcont290
+
+ifcont290:                                        ; preds = %else289, %then288, %then286, %then284
+  %258 = load i32, i32* %array_bound283, align 4
+  %259 = icmp sle i32 %257, %258
+  br i1 %259, label %loop.body291, label %loop.end362
+
+loop.body291:                                     ; preds = %ifcont290
+  %260 = load i32, i32* %__1_t1, align 4
+  %261 = add i32 %260, 1
+  store i32 %261, i32* %__1_t1, align 4
+  br i1 true, label %then293, label %else294
+
+then293:                                          ; preds = %loop.body291
+  store i32 1, i32* %array_bound292, align 4
+  br label %ifcont299
+
+else294:                                          ; preds = %loop.body291
+  br i1 false, label %then295, label %else296
+
+then295:                                          ; preds = %else294
+  store i32 1, i32* %array_bound292, align 4
+  br label %ifcont299
+
+else296:                                          ; preds = %else294
+  br i1 false, label %then297, label %else298
+
+then297:                                          ; preds = %else296
+  store i32 1, i32* %array_bound292, align 4
+  br label %ifcont299
+
+else298:                                          ; preds = %else296
+  br label %ifcont299
+
+ifcont299:                                        ; preds = %else298, %then297, %then295, %then293
+  %262 = load i32, i32* %array_bound292, align 4
+  store i32 %262, i32* %__2_v6, align 4
+  br i1 true, label %then301, label %else302
+
+then301:                                          ; preds = %ifcont299
+  store i32 1, i32* %array_bound300, align 4
+  br label %ifcont307
+
+else302:                                          ; preds = %ifcont299
+  br i1 false, label %then303, label %else304
+
+then303:                                          ; preds = %else302
+  store i32 1, i32* %array_bound300, align 4
+  br label %ifcont307
+
+else304:                                          ; preds = %else302
+  br i1 false, label %then305, label %else306
+
+then305:                                          ; preds = %else304
+  store i32 1, i32* %array_bound300, align 4
+  br label %ifcont307
+
+else306:                                          ; preds = %else304
+  br label %ifcont307
+
+ifcont307:                                        ; preds = %else306, %then305, %then303, %then301
+  %263 = load i32, i32* %array_bound300, align 4
+  store i32 %263, i32* %__2_u5, align 4
+  br i1 false, label %then309, label %else310
+
+then309:                                          ; preds = %ifcont307
+  store i32 1, i32* %array_bound308, align 4
+  br label %ifcont315
+
+else310:                                          ; preds = %ifcont307
+  br i1 true, label %then311, label %else312
+
+then311:                                          ; preds = %else310
+  store i32 1, i32* %array_bound308, align 4
+  br label %ifcont315
+
+else312:                                          ; preds = %else310
+  br i1 false, label %then313, label %else314
+
+then313:                                          ; preds = %else312
+  store i32 1, i32* %array_bound308, align 4
+  br label %ifcont315
+
+else314:                                          ; preds = %else312
+  br label %ifcont315
+
+ifcont315:                                        ; preds = %else314, %then313, %then311, %then309
+  %264 = load i32, i32* %array_bound308, align 4
+  %265 = sub i32 %264, 1
+  store i32 %265, i32* %__2_t4, align 4
+  br label %loop.head316
+
+loop.head316:                                     ; preds = %loop.end360, %ifcont315
+  %266 = load i32, i32* %__2_t4, align 4
+  %267 = add i32 %266, 1
+  br i1 false, label %then318, label %else319
+
+then318:                                          ; preds = %loop.head316
+  store i32 2, i32* %array_bound317, align 4
+  br label %ifcont324
+
+else319:                                          ; preds = %loop.head316
+  br i1 true, label %then320, label %else321
+
+then320:                                          ; preds = %else319
+  store i32 2, i32* %array_bound317, align 4
+  br label %ifcont324
+
+else321:                                          ; preds = %else319
+  br i1 false, label %then322, label %else323
+
+then322:                                          ; preds = %else321
+  store i32 1, i32* %array_bound317, align 4
+  br label %ifcont324
+
+else323:                                          ; preds = %else321
+  br label %ifcont324
+
+ifcont324:                                        ; preds = %else323, %then322, %then320, %then318
+  %268 = load i32, i32* %array_bound317, align 4
+  %269 = icmp sle i32 %267, %268
+  br i1 %269, label %loop.body325, label %loop.end361
+
+loop.body325:                                     ; preds = %ifcont324
+  %270 = load i32, i32* %__2_t4, align 4
+  %271 = add i32 %270, 1
+  store i32 %271, i32* %__2_t4, align 4
+  br i1 false, label %then327, label %else328
+
+then327:                                          ; preds = %loop.body325
+  store i32 1, i32* %array_bound326, align 4
+  br label %ifcont333
+
+else328:                                          ; preds = %loop.body325
+  br i1 true, label %then329, label %else330
+
+then329:                                          ; preds = %else328
+  store i32 1, i32* %array_bound326, align 4
+  br label %ifcont333
+
+else330:                                          ; preds = %else328
+  br i1 false, label %then331, label %else332
+
+then331:                                          ; preds = %else330
+  store i32 1, i32* %array_bound326, align 4
+  br label %ifcont333
+
+else332:                                          ; preds = %else330
+  br label %ifcont333
+
+ifcont333:                                        ; preds = %else332, %then331, %then329, %then327
+  %272 = load i32, i32* %array_bound326, align 4
+  store i32 %272, i32* %__3_v9, align 4
+  br i1 false, label %then335, label %else336
+
+then335:                                          ; preds = %ifcont333
+  store i32 1, i32* %array_bound334, align 4
+  br label %ifcont341
+
+else336:                                          ; preds = %ifcont333
+  br i1 true, label %then337, label %else338
+
+then337:                                          ; preds = %else336
+  store i32 1, i32* %array_bound334, align 4
+  br label %ifcont341
+
+else338:                                          ; preds = %else336
+  br i1 false, label %then339, label %else340
+
+then339:                                          ; preds = %else338
+  store i32 1, i32* %array_bound334, align 4
+  br label %ifcont341
+
+else340:                                          ; preds = %else338
+  br label %ifcont341
+
+ifcont341:                                        ; preds = %else340, %then339, %then337, %then335
+  %273 = load i32, i32* %array_bound334, align 4
+  store i32 %273, i32* %__3_u8, align 4
+  br i1 false, label %then343, label %else344
+
+then343:                                          ; preds = %ifcont341
+  store i32 1, i32* %array_bound342, align 4
+  br label %ifcont349
+
+else344:                                          ; preds = %ifcont341
+  br i1 false, label %then345, label %else346
+
+then345:                                          ; preds = %else344
+  store i32 1, i32* %array_bound342, align 4
+  br label %ifcont349
+
+else346:                                          ; preds = %else344
+  br i1 true, label %then347, label %else348
+
+then347:                                          ; preds = %else346
+  store i32 1, i32* %array_bound342, align 4
+  br label %ifcont349
+
+else348:                                          ; preds = %else346
+  br label %ifcont349
+
+ifcont349:                                        ; preds = %else348, %then347, %then345, %then343
+  %274 = load i32, i32* %array_bound342, align 4
+  %275 = sub i32 %274, 1
+  store i32 %275, i32* %__3_t7, align 4
+  br label %loop.head350
+
+loop.head350:                                     ; preds = %loop.body359, %ifcont349
+  %276 = load i32, i32* %__3_t7, align 4
+  %277 = add i32 %276, 1
+  br i1 false, label %then352, label %else353
+
+then352:                                          ; preds = %loop.head350
+  store i32 2, i32* %array_bound351, align 4
+  br label %ifcont358
+
+else353:                                          ; preds = %loop.head350
+  br i1 false, label %then354, label %else355
+
+then354:                                          ; preds = %else353
+  store i32 2, i32* %array_bound351, align 4
+  br label %ifcont358
+
+else355:                                          ; preds = %else353
+  br i1 true, label %then356, label %else357
+
+then356:                                          ; preds = %else355
+  store i32 1, i32* %array_bound351, align 4
+  br label %ifcont358
+
+else357:                                          ; preds = %else355
+  br label %ifcont358
+
+ifcont358:                                        ; preds = %else357, %then356, %then354, %then352
+  %278 = load i32, i32* %array_bound351, align 4
+  %279 = icmp sle i32 %277, %278
+  br i1 %279, label %loop.body359, label %loop.end360
+
+loop.body359:                                     ; preds = %ifcont358
+  %280 = load i32, i32* %__3_t7, align 4
+  %281 = add i32 %280, 1
+  store i32 %281, i32* %__3_t7, align 4
+  %282 = load i32, i32* %__1_t1, align 4
+  %283 = load i32, i32* %__2_t4, align 4
+  %284 = load i32, i32* %__3_t7, align 4
+  %285 = sub i32 %282, 1
+  %286 = mul i32 1, %285
+  %287 = add i32 0, %286
+  %288 = sub i32 %283, 1
+  %289 = mul i32 2, %288
+  %290 = add i32 %287, %289
+  %291 = sub i32 %284, 1
+  %292 = mul i32 4, %291
+  %293 = add i32 %290, %292
+  %294 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 %293
+  %295 = load i32, i32* %__1_v3, align 4
+  %296 = load i32, i32* %__2_v6, align 4
+  %297 = load i32, i32* %__3_v9, align 4
+  %298 = sub i32 %295, 1
+  %299 = mul i32 1, %298
+  %300 = add i32 0, %299
+  %301 = sub i32 %296, 1
+  %302 = mul i32 2, %301
+  %303 = add i32 %300, %302
+  %304 = sub i32 %297, 1
+  %305 = mul i32 4, %304
+  %306 = add i32 %303, %305
+  %307 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__0__implicit_cast_res, i32 0, i32 %306
+  %308 = load %complex_4, %complex_4* %307, align 4
+  %309 = load i32, i32* %__1_u2, align 4
+  %310 = load i32, i32* %__2_u5, align 4
+  %311 = load i32, i32* %__3_u8, align 4
+  %312 = sub i32 %309, 1
+  %313 = mul i32 1, %312
+  %314 = add i32 0, %313
+  %315 = sub i32 %310, 1
+  %316 = mul i32 2, %315
+  %317 = add i32 %314, %316
+  %318 = sub i32 %311, 1
+  %319 = mul i32 4, %318
+  %320 = add i32 %317, %319
+  %321 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__2__complex_bin_op_res, i32 0, i32 %320
+  %322 = load %complex_4, %complex_4* %321, align 4
+  %323 = alloca %complex_4, align 8
+  store %complex_4 %308, %complex_4* %323, align 4
+  %324 = alloca %complex_4, align 8
+  store %complex_4 %322, %complex_4* %324, align 4
+  %325 = alloca %complex_4, align 8
+  call void @_lfortran_complex_add_32(%complex_4* %323, %complex_4* %324, %complex_4* %325)
+  %326 = load %complex_4, %complex_4* %325, align 4
+  store %complex_4 %326, %complex_4* %294, align 4
+  %327 = load i32, i32* %__3_v9, align 4
+  %328 = add i32 %327, 1
+  store i32 %328, i32* %__3_v9, align 4
+  %329 = load i32, i32* %__3_u8, align 4
+  %330 = add i32 %329, 1
+  store i32 %330, i32* %__3_u8, align 4
+  br label %loop.head350
+
+loop.end360:                                      ; preds = %ifcont358
+  %331 = load i32, i32* %__2_v6, align 4
+  %332 = add i32 %331, 1
+  store i32 %332, i32* %__2_v6, align 4
+  %333 = load i32, i32* %__2_u5, align 4
+  %334 = add i32 %333, 1
+  store i32 %334, i32* %__2_u5, align 4
+  br label %loop.head316
+
+loop.end361:                                      ; preds = %ifcont324
+  %335 = load i32, i32* %__1_v3, align 4
+  %336 = add i32 %335, 1
+  store i32 %336, i32* %__1_v3, align 4
+  %337 = load i32, i32* %__1_u2, align 4
+  %338 = add i32 %337, 1
+  store i32 %338, i32* %__1_u2, align 4
+  br label %loop.head282
+
+loop.end362:                                      ; preds = %ifcont290
+  %339 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 0
+  store i32 1, i32* %call_arg_value, align 4
+  store i32 2, i32* %call_arg_value363, align 4
+  store i32 1, i32* %call_arg_value364, align 4
+  store i32 2, i32* %call_arg_value365, align 4
+  store i32 1, i32* %call_arg_value366, align 4
+  store i32 1, i32* %call_arg_value367, align 4
+  store i32 0, i32* %call_arg_value368, align 4
+  call void @check_complex__________0(%complex_4* %339, i32* %call_arg_value, i32* %call_arg_value363, i32* %call_arg_value364, i32* %call_arg_value365, i32* %call_arg_value366, i32* %call_arg_value367, i32* %call_arg_value368)
+  br i1 true, label %then370, label %else371
+
+then370:                                          ; preds = %loop.end362
+  store i32 1, i32* %array_bound369, align 4
+  br label %ifcont376
+
+else371:                                          ; preds = %loop.end362
+  br i1 false, label %then372, label %else373
+
+then372:                                          ; preds = %else371
+  store i32 1, i32* %array_bound369, align 4
+  br label %ifcont376
+
+else373:                                          ; preds = %else371
+  br i1 false, label %then374, label %else375
+
+then374:                                          ; preds = %else373
+  store i32 1, i32* %array_bound369, align 4
+  br label %ifcont376
+
+else375:                                          ; preds = %else373
+  br label %ifcont376
+
+ifcont376:                                        ; preds = %else375, %then374, %then372, %then370
+  %340 = load i32, i32* %array_bound369, align 4
+  store i32 %340, i32* %__1_v3, align 4
+  br i1 true, label %then378, label %else379
+
+then378:                                          ; preds = %ifcont376
+  store i32 1, i32* %array_bound377, align 4
+  br label %ifcont384
+
+else379:                                          ; preds = %ifcont376
+  br i1 false, label %then380, label %else381
+
+then380:                                          ; preds = %else379
+  store i32 1, i32* %array_bound377, align 4
+  br label %ifcont384
+
+else381:                                          ; preds = %else379
+  br i1 false, label %then382, label %else383
+
+then382:                                          ; preds = %else381
+  store i32 1, i32* %array_bound377, align 4
+  br label %ifcont384
+
+else383:                                          ; preds = %else381
+  br label %ifcont384
+
+ifcont384:                                        ; preds = %else383, %then382, %then380, %then378
+  %341 = load i32, i32* %array_bound377, align 4
+  %342 = sub i32 %341, 1
+  store i32 %342, i32* %__1_t1, align 4
+  br label %loop.head385
+
+loop.head385:                                     ; preds = %loop.end448, %ifcont384
+  %343 = load i32, i32* %__1_t1, align 4
+  %344 = add i32 %343, 1
+  br i1 true, label %then387, label %else388
+
+then387:                                          ; preds = %loop.head385
+  store i32 2, i32* %array_bound386, align 4
+  br label %ifcont393
+
+else388:                                          ; preds = %loop.head385
+  br i1 false, label %then389, label %else390
+
+then389:                                          ; preds = %else388
+  store i32 2, i32* %array_bound386, align 4
+  br label %ifcont393
+
+else390:                                          ; preds = %else388
+  br i1 false, label %then391, label %else392
+
+then391:                                          ; preds = %else390
+  store i32 1, i32* %array_bound386, align 4
+  br label %ifcont393
+
+else392:                                          ; preds = %else390
+  br label %ifcont393
+
+ifcont393:                                        ; preds = %else392, %then391, %then389, %then387
+  %345 = load i32, i32* %array_bound386, align 4
+  %346 = icmp sle i32 %344, %345
+  br i1 %346, label %loop.body394, label %loop.end449
+
+loop.body394:                                     ; preds = %ifcont393
+  %347 = load i32, i32* %__1_t1, align 4
+  %348 = add i32 %347, 1
+  store i32 %348, i32* %__1_t1, align 4
+  br i1 true, label %then396, label %else397
+
+then396:                                          ; preds = %loop.body394
+  store i32 1, i32* %array_bound395, align 4
+  br label %ifcont402
+
+else397:                                          ; preds = %loop.body394
+  br i1 false, label %then398, label %else399
+
+then398:                                          ; preds = %else397
+  store i32 1, i32* %array_bound395, align 4
+  br label %ifcont402
+
+else399:                                          ; preds = %else397
+  br i1 false, label %then400, label %else401
+
+then400:                                          ; preds = %else399
+  store i32 1, i32* %array_bound395, align 4
+  br label %ifcont402
+
+else401:                                          ; preds = %else399
+  br label %ifcont402
+
+ifcont402:                                        ; preds = %else401, %then400, %then398, %then396
+  %349 = load i32, i32* %array_bound395, align 4
+  store i32 %349, i32* %__2_v6, align 4
+  br i1 false, label %then404, label %else405
+
+then404:                                          ; preds = %ifcont402
+  store i32 1, i32* %array_bound403, align 4
+  br label %ifcont410
+
+else405:                                          ; preds = %ifcont402
+  br i1 true, label %then406, label %else407
+
+then406:                                          ; preds = %else405
+  store i32 1, i32* %array_bound403, align 4
+  br label %ifcont410
+
+else407:                                          ; preds = %else405
+  br i1 false, label %then408, label %else409
+
+then408:                                          ; preds = %else407
+  store i32 1, i32* %array_bound403, align 4
+  br label %ifcont410
+
+else409:                                          ; preds = %else407
+  br label %ifcont410
+
+ifcont410:                                        ; preds = %else409, %then408, %then406, %then404
+  %350 = load i32, i32* %array_bound403, align 4
+  %351 = sub i32 %350, 1
+  store i32 %351, i32* %__2_t4, align 4
+  br label %loop.head411
+
+loop.head411:                                     ; preds = %loop.end447, %ifcont410
+  %352 = load i32, i32* %__2_t4, align 4
+  %353 = add i32 %352, 1
+  br i1 false, label %then413, label %else414
+
+then413:                                          ; preds = %loop.head411
+  store i32 2, i32* %array_bound412, align 4
+  br label %ifcont419
+
+else414:                                          ; preds = %loop.head411
+  br i1 true, label %then415, label %else416
+
+then415:                                          ; preds = %else414
+  store i32 2, i32* %array_bound412, align 4
+  br label %ifcont419
+
+else416:                                          ; preds = %else414
+  br i1 false, label %then417, label %else418
+
+then417:                                          ; preds = %else416
+  store i32 1, i32* %array_bound412, align 4
+  br label %ifcont419
+
+else418:                                          ; preds = %else416
+  br label %ifcont419
+
+ifcont419:                                        ; preds = %else418, %then417, %then415, %then413
+  %354 = load i32, i32* %array_bound412, align 4
+  %355 = icmp sle i32 %353, %354
+  br i1 %355, label %loop.body420, label %loop.end448
+
+loop.body420:                                     ; preds = %ifcont419
+  %356 = load i32, i32* %__2_t4, align 4
+  %357 = add i32 %356, 1
+  store i32 %357, i32* %__2_t4, align 4
+  br i1 false, label %then422, label %else423
+
+then422:                                          ; preds = %loop.body420
+  store i32 1, i32* %array_bound421, align 4
+  br label %ifcont428
+
+else423:                                          ; preds = %loop.body420
+  br i1 true, label %then424, label %else425
+
+then424:                                          ; preds = %else423
+  store i32 1, i32* %array_bound421, align 4
+  br label %ifcont428
+
+else425:                                          ; preds = %else423
+  br i1 false, label %then426, label %else427
+
+then426:                                          ; preds = %else425
+  store i32 1, i32* %array_bound421, align 4
+  br label %ifcont428
+
+else427:                                          ; preds = %else425
+  br label %ifcont428
+
+ifcont428:                                        ; preds = %else427, %then426, %then424, %then422
+  %358 = load i32, i32* %array_bound421, align 4
+  store i32 %358, i32* %__3_v9, align 4
+  br i1 false, label %then430, label %else431
+
+then430:                                          ; preds = %ifcont428
+  store i32 1, i32* %array_bound429, align 4
+  br label %ifcont436
+
+else431:                                          ; preds = %ifcont428
+  br i1 false, label %then432, label %else433
+
+then432:                                          ; preds = %else431
+  store i32 1, i32* %array_bound429, align 4
+  br label %ifcont436
+
+else433:                                          ; preds = %else431
+  br i1 true, label %then434, label %else435
+
+then434:                                          ; preds = %else433
+  store i32 1, i32* %array_bound429, align 4
+  br label %ifcont436
+
+else435:                                          ; preds = %else433
+  br label %ifcont436
+
+ifcont436:                                        ; preds = %else435, %then434, %then432, %then430
+  %359 = load i32, i32* %array_bound429, align 4
+  %360 = sub i32 %359, 1
+  store i32 %360, i32* %__3_t7, align 4
+  br label %loop.head437
+
+loop.head437:                                     ; preds = %loop.body446, %ifcont436
+  %361 = load i32, i32* %__3_t7, align 4
+  %362 = add i32 %361, 1
+  br i1 false, label %then439, label %else440
+
+then439:                                          ; preds = %loop.head437
+  store i32 2, i32* %array_bound438, align 4
+  br label %ifcont445
+
+else440:                                          ; preds = %loop.head437
+  br i1 false, label %then441, label %else442
+
+then441:                                          ; preds = %else440
+  store i32 2, i32* %array_bound438, align 4
+  br label %ifcont445
+
+else442:                                          ; preds = %else440
+  br i1 true, label %then443, label %else444
+
+then443:                                          ; preds = %else442
+  store i32 1, i32* %array_bound438, align 4
+  br label %ifcont445
+
+else444:                                          ; preds = %else442
+  br label %ifcont445
+
+ifcont445:                                        ; preds = %else444, %then443, %then441, %then439
+  %363 = load i32, i32* %array_bound438, align 4
+  %364 = icmp sle i32 %362, %363
+  br i1 %364, label %loop.body446, label %loop.end447
+
+loop.body446:                                     ; preds = %ifcont445
+  %365 = load i32, i32* %__3_t7, align 4
+  %366 = add i32 %365, 1
+  store i32 %366, i32* %__3_t7, align 4
+  %367 = load i32, i32* %__1_t1, align 4
+  %368 = load i32, i32* %__2_t4, align 4
+  %369 = load i32, i32* %__3_t7, align 4
+  %370 = sub i32 %367, 1
+  %371 = mul i32 1, %370
+  %372 = add i32 0, %371
+  %373 = sub i32 %368, 1
+  %374 = mul i32 2, %373
+  %375 = add i32 %372, %374
+  %376 = sub i32 %369, 1
+  %377 = mul i32 4, %376
+  %378 = add i32 %375, %377
+  %379 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__3__integer_unary_op_res, i32 0, i32 %378
+  %380 = load i32, i32* %__1_v3, align 4
+  %381 = load i32, i32* %__2_v6, align 4
+  %382 = load i32, i32* %__3_v9, align 4
+  %383 = sub i32 %380, 1
+  %384 = mul i32 1, %383
+  %385 = add i32 0, %384
+  %386 = sub i32 %381, 1
+  %387 = mul i32 2, %386
+  %388 = add i32 %385, %387
+  %389 = sub i32 %382, 1
+  %390 = mul i32 4, %389
+  %391 = add i32 %388, %390
+  %392 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %391
+  %393 = load i32, i32* %392, align 4
+  %394 = sub i32 0, %393
+  store i32 %394, i32* %379, align 4
+  %395 = load i32, i32* %__3_v9, align 4
+  %396 = add i32 %395, 1
+  store i32 %396, i32* %__3_v9, align 4
+  br label %loop.head437
+
+loop.end447:                                      ; preds = %ifcont445
+  %397 = load i32, i32* %__2_v6, align 4
+  %398 = add i32 %397, 1
+  store i32 %398, i32* %__2_v6, align 4
+  br label %loop.head411
+
+loop.end448:                                      ; preds = %ifcont419
+  %399 = load i32, i32* %__1_v3, align 4
+  %400 = add i32 %399, 1
+  store i32 %400, i32* %__1_v3, align 4
+  br label %loop.head385
+
+loop.end449:                                      ; preds = %ifcont393
+  br i1 true, label %then451, label %else452
+
+then451:                                          ; preds = %loop.end449
+  store i32 1, i32* %array_bound450, align 4
+  br label %ifcont457
+
+else452:                                          ; preds = %loop.end449
+  br i1 false, label %then453, label %else454
+
+then453:                                          ; preds = %else452
+  store i32 1, i32* %array_bound450, align 4
+  br label %ifcont457
+
+else454:                                          ; preds = %else452
+  br i1 false, label %then455, label %else456
+
+then455:                                          ; preds = %else454
+  store i32 1, i32* %array_bound450, align 4
+  br label %ifcont457
+
+else456:                                          ; preds = %else454
+  br label %ifcont457
+
+ifcont457:                                        ; preds = %else456, %then455, %then453, %then451
+  %401 = load i32, i32* %array_bound450, align 4
+  store i32 %401, i32* %__1_v3, align 4
+  br i1 true, label %then459, label %else460
+
+then459:                                          ; preds = %ifcont457
+  store i32 1, i32* %array_bound458, align 4
+  br label %ifcont465
+
+else460:                                          ; preds = %ifcont457
+  br i1 false, label %then461, label %else462
+
+then461:                                          ; preds = %else460
+  store i32 1, i32* %array_bound458, align 4
+  br label %ifcont465
+
+else462:                                          ; preds = %else460
+  br i1 false, label %then463, label %else464
+
+then463:                                          ; preds = %else462
+  store i32 1, i32* %array_bound458, align 4
+  br label %ifcont465
+
+else464:                                          ; preds = %else462
+  br label %ifcont465
+
+ifcont465:                                        ; preds = %else464, %then463, %then461, %then459
+  %402 = load i32, i32* %array_bound458, align 4
+  %403 = sub i32 %402, 1
+  store i32 %403, i32* %__1_t1, align 4
+  br label %loop.head466
+
+loop.head466:                                     ; preds = %loop.end529, %ifcont465
+  %404 = load i32, i32* %__1_t1, align 4
+  %405 = add i32 %404, 1
+  br i1 true, label %then468, label %else469
+
+then468:                                          ; preds = %loop.head466
+  store i32 2, i32* %array_bound467, align 4
+  br label %ifcont474
+
+else469:                                          ; preds = %loop.head466
+  br i1 false, label %then470, label %else471
+
+then470:                                          ; preds = %else469
+  store i32 2, i32* %array_bound467, align 4
+  br label %ifcont474
+
+else471:                                          ; preds = %else469
+  br i1 false, label %then472, label %else473
+
+then472:                                          ; preds = %else471
+  store i32 1, i32* %array_bound467, align 4
+  br label %ifcont474
+
+else473:                                          ; preds = %else471
+  br label %ifcont474
+
+ifcont474:                                        ; preds = %else473, %then472, %then470, %then468
+  %406 = load i32, i32* %array_bound467, align 4
+  %407 = icmp sle i32 %405, %406
+  br i1 %407, label %loop.body475, label %loop.end530
+
+loop.body475:                                     ; preds = %ifcont474
+  %408 = load i32, i32* %__1_t1, align 4
+  %409 = add i32 %408, 1
+  store i32 %409, i32* %__1_t1, align 4
+  br i1 true, label %then477, label %else478
+
+then477:                                          ; preds = %loop.body475
+  store i32 1, i32* %array_bound476, align 4
+  br label %ifcont483
+
+else478:                                          ; preds = %loop.body475
+  br i1 false, label %then479, label %else480
+
+then479:                                          ; preds = %else478
+  store i32 1, i32* %array_bound476, align 4
+  br label %ifcont483
+
+else480:                                          ; preds = %else478
+  br i1 false, label %then481, label %else482
+
+then481:                                          ; preds = %else480
+  store i32 1, i32* %array_bound476, align 4
+  br label %ifcont483
+
+else482:                                          ; preds = %else480
+  br label %ifcont483
+
+ifcont483:                                        ; preds = %else482, %then481, %then479, %then477
+  %410 = load i32, i32* %array_bound476, align 4
+  store i32 %410, i32* %__2_v6, align 4
+  br i1 false, label %then485, label %else486
+
+then485:                                          ; preds = %ifcont483
+  store i32 1, i32* %array_bound484, align 4
+  br label %ifcont491
+
+else486:                                          ; preds = %ifcont483
+  br i1 true, label %then487, label %else488
+
+then487:                                          ; preds = %else486
+  store i32 1, i32* %array_bound484, align 4
+  br label %ifcont491
+
+else488:                                          ; preds = %else486
+  br i1 false, label %then489, label %else490
+
+then489:                                          ; preds = %else488
+  store i32 1, i32* %array_bound484, align 4
+  br label %ifcont491
+
+else490:                                          ; preds = %else488
+  br label %ifcont491
+
+ifcont491:                                        ; preds = %else490, %then489, %then487, %then485
+  %411 = load i32, i32* %array_bound484, align 4
+  %412 = sub i32 %411, 1
+  store i32 %412, i32* %__2_t4, align 4
+  br label %loop.head492
+
+loop.head492:                                     ; preds = %loop.end528, %ifcont491
+  %413 = load i32, i32* %__2_t4, align 4
+  %414 = add i32 %413, 1
+  br i1 false, label %then494, label %else495
+
+then494:                                          ; preds = %loop.head492
+  store i32 2, i32* %array_bound493, align 4
+  br label %ifcont500
+
+else495:                                          ; preds = %loop.head492
+  br i1 true, label %then496, label %else497
+
+then496:                                          ; preds = %else495
+  store i32 2, i32* %array_bound493, align 4
+  br label %ifcont500
+
+else497:                                          ; preds = %else495
+  br i1 false, label %then498, label %else499
+
+then498:                                          ; preds = %else497
+  store i32 1, i32* %array_bound493, align 4
+  br label %ifcont500
+
+else499:                                          ; preds = %else497
+  br label %ifcont500
+
+ifcont500:                                        ; preds = %else499, %then498, %then496, %then494
+  %415 = load i32, i32* %array_bound493, align 4
+  %416 = icmp sle i32 %414, %415
+  br i1 %416, label %loop.body501, label %loop.end529
+
+loop.body501:                                     ; preds = %ifcont500
+  %417 = load i32, i32* %__2_t4, align 4
+  %418 = add i32 %417, 1
+  store i32 %418, i32* %__2_t4, align 4
+  br i1 false, label %then503, label %else504
+
+then503:                                          ; preds = %loop.body501
+  store i32 1, i32* %array_bound502, align 4
+  br label %ifcont509
+
+else504:                                          ; preds = %loop.body501
+  br i1 true, label %then505, label %else506
+
+then505:                                          ; preds = %else504
+  store i32 1, i32* %array_bound502, align 4
+  br label %ifcont509
+
+else506:                                          ; preds = %else504
+  br i1 false, label %then507, label %else508
+
+then507:                                          ; preds = %else506
+  store i32 1, i32* %array_bound502, align 4
+  br label %ifcont509
+
+else508:                                          ; preds = %else506
+  br label %ifcont509
+
+ifcont509:                                        ; preds = %else508, %then507, %then505, %then503
+  %419 = load i32, i32* %array_bound502, align 4
+  store i32 %419, i32* %__3_v9, align 4
+  br i1 false, label %then511, label %else512
+
+then511:                                          ; preds = %ifcont509
+  store i32 1, i32* %array_bound510, align 4
+  br label %ifcont517
+
+else512:                                          ; preds = %ifcont509
+  br i1 false, label %then513, label %else514
+
+then513:                                          ; preds = %else512
+  store i32 1, i32* %array_bound510, align 4
+  br label %ifcont517
+
+else514:                                          ; preds = %else512
+  br i1 true, label %then515, label %else516
+
+then515:                                          ; preds = %else514
+  store i32 1, i32* %array_bound510, align 4
+  br label %ifcont517
+
+else516:                                          ; preds = %else514
+  br label %ifcont517
+
+ifcont517:                                        ; preds = %else516, %then515, %then513, %then511
+  %420 = load i32, i32* %array_bound510, align 4
+  %421 = sub i32 %420, 1
+  store i32 %421, i32* %__3_t7, align 4
+  br label %loop.head518
+
+loop.head518:                                     ; preds = %loop.body527, %ifcont517
+  %422 = load i32, i32* %__3_t7, align 4
+  %423 = add i32 %422, 1
+  br i1 false, label %then520, label %else521
+
+then520:                                          ; preds = %loop.head518
+  store i32 2, i32* %array_bound519, align 4
+  br label %ifcont526
+
+else521:                                          ; preds = %loop.head518
+  br i1 false, label %then522, label %else523
+
+then522:                                          ; preds = %else521
+  store i32 2, i32* %array_bound519, align 4
+  br label %ifcont526
+
+else523:                                          ; preds = %else521
+  br i1 true, label %then524, label %else525
+
+then524:                                          ; preds = %else523
+  store i32 1, i32* %array_bound519, align 4
+  br label %ifcont526
+
+else525:                                          ; preds = %else523
+  br label %ifcont526
+
+ifcont526:                                        ; preds = %else525, %then524, %then522, %then520
+  %424 = load i32, i32* %array_bound519, align 4
+  %425 = icmp sle i32 %423, %424
+  br i1 %425, label %loop.body527, label %loop.end528
+
+loop.body527:                                     ; preds = %ifcont526
+  %426 = load i32, i32* %__3_t7, align 4
+  %427 = add i32 %426, 1
+  store i32 %427, i32* %__3_t7, align 4
+  %428 = load i32, i32* %__1_t1, align 4
+  %429 = load i32, i32* %__2_t4, align 4
+  %430 = load i32, i32* %__3_t7, align 4
+  %431 = sub i32 %428, 1
+  %432 = mul i32 1, %431
+  %433 = add i32 0, %432
+  %434 = sub i32 %429, 1
+  %435 = mul i32 2, %434
+  %436 = add i32 %433, %435
+  %437 = sub i32 %430, 1
+  %438 = mul i32 4, %437
+  %439 = add i32 %436, %438
+  %440 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__4__implicit_cast_res, i32 0, i32 %439
+  %441 = load i32, i32* %__1_v3, align 4
+  %442 = load i32, i32* %__2_v6, align 4
+  %443 = load i32, i32* %__3_v9, align 4
+  %444 = sub i32 %441, 1
+  %445 = mul i32 1, %444
+  %446 = add i32 0, %445
+  %447 = sub i32 %442, 1
+  %448 = mul i32 2, %447
+  %449 = add i32 %446, %448
+  %450 = sub i32 %443, 1
+  %451 = mul i32 4, %450
+  %452 = add i32 %449, %451
+  %453 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__3__integer_unary_op_res, i32 0, i32 %452
+  %454 = load i32, i32* %453, align 4
+  %455 = sitofp i32 %454 to float
+  %456 = alloca %complex_4, align 8
+  %457 = getelementptr %complex_4, %complex_4* %456, i32 0, i32 0
+  %458 = getelementptr %complex_4, %complex_4* %456, i32 0, i32 1
+  store float %455, float* %457, align 4
+  store float 0.000000e+00, float* %458, align 4
+  %459 = load %complex_4, %complex_4* %456, align 4
+  store %complex_4 %459, %complex_4* %440, align 4
+  %460 = load i32, i32* %__3_v9, align 4
+  %461 = add i32 %460, 1
+  store i32 %461, i32* %__3_v9, align 4
+  br label %loop.head518
+
+loop.end528:                                      ; preds = %ifcont526
+  %462 = load i32, i32* %__2_v6, align 4
+  %463 = add i32 %462, 1
+  store i32 %463, i32* %__2_v6, align 4
+  br label %loop.head492
+
+loop.end529:                                      ; preds = %ifcont500
+  %464 = load i32, i32* %__1_v3, align 4
+  %465 = add i32 %464, 1
+  store i32 %465, i32* %__1_v3, align 4
+  br label %loop.head466
+
+loop.end530:                                      ; preds = %ifcont474
+  br i1 true, label %then532, label %else533
+
+then532:                                          ; preds = %loop.end530
+  store i32 1, i32* %array_bound531, align 4
+  br label %ifcont538
+
+else533:                                          ; preds = %loop.end530
+  br i1 false, label %then534, label %else535
+
+then534:                                          ; preds = %else533
+  store i32 1, i32* %array_bound531, align 4
+  br label %ifcont538
+
+else535:                                          ; preds = %else533
+  br i1 false, label %then536, label %else537
+
+then536:                                          ; preds = %else535
+  store i32 1, i32* %array_bound531, align 4
+  br label %ifcont538
+
+else537:                                          ; preds = %else535
+  br label %ifcont538
+
+ifcont538:                                        ; preds = %else537, %then536, %then534, %then532
+  %466 = load i32, i32* %array_bound531, align 4
+  store i32 %466, i32* %__1_v3, align 4
+  br i1 true, label %then540, label %else541
+
+then540:                                          ; preds = %ifcont538
+  store i32 1, i32* %array_bound539, align 4
+  br label %ifcont546
+
+else541:                                          ; preds = %ifcont538
+  br i1 false, label %then542, label %else543
+
+then542:                                          ; preds = %else541
+  store i32 1, i32* %array_bound539, align 4
+  br label %ifcont546
+
+else543:                                          ; preds = %else541
+  br i1 false, label %then544, label %else545
+
+then544:                                          ; preds = %else543
+  store i32 1, i32* %array_bound539, align 4
+  br label %ifcont546
+
+else545:                                          ; preds = %else543
+  br label %ifcont546
+
+ifcont546:                                        ; preds = %else545, %then544, %then542, %then540
+  %467 = load i32, i32* %array_bound539, align 4
+  %468 = sub i32 %467, 1
+  store i32 %468, i32* %__1_t1, align 4
+  br label %loop.head547
+
+loop.head547:                                     ; preds = %loop.end610, %ifcont546
+  %469 = load i32, i32* %__1_t1, align 4
+  %470 = add i32 %469, 1
+  br i1 true, label %then549, label %else550
+
+then549:                                          ; preds = %loop.head547
+  store i32 2, i32* %array_bound548, align 4
+  br label %ifcont555
+
+else550:                                          ; preds = %loop.head547
+  br i1 false, label %then551, label %else552
+
+then551:                                          ; preds = %else550
+  store i32 2, i32* %array_bound548, align 4
+  br label %ifcont555
+
+else552:                                          ; preds = %else550
+  br i1 false, label %then553, label %else554
+
+then553:                                          ; preds = %else552
+  store i32 1, i32* %array_bound548, align 4
+  br label %ifcont555
+
+else554:                                          ; preds = %else552
+  br label %ifcont555
+
+ifcont555:                                        ; preds = %else554, %then553, %then551, %then549
+  %471 = load i32, i32* %array_bound548, align 4
+  %472 = icmp sle i32 %470, %471
+  br i1 %472, label %loop.body556, label %loop.end611
+
+loop.body556:                                     ; preds = %ifcont555
+  %473 = load i32, i32* %__1_t1, align 4
+  %474 = add i32 %473, 1
+  store i32 %474, i32* %__1_t1, align 4
+  br i1 true, label %then558, label %else559
+
+then558:                                          ; preds = %loop.body556
+  store i32 1, i32* %array_bound557, align 4
+  br label %ifcont564
+
+else559:                                          ; preds = %loop.body556
+  br i1 false, label %then560, label %else561
+
+then560:                                          ; preds = %else559
+  store i32 1, i32* %array_bound557, align 4
+  br label %ifcont564
+
+else561:                                          ; preds = %else559
+  br i1 false, label %then562, label %else563
+
+then562:                                          ; preds = %else561
+  store i32 1, i32* %array_bound557, align 4
+  br label %ifcont564
+
+else563:                                          ; preds = %else561
+  br label %ifcont564
+
+ifcont564:                                        ; preds = %else563, %then562, %then560, %then558
+  %475 = load i32, i32* %array_bound557, align 4
+  store i32 %475, i32* %__2_v6, align 4
+  br i1 false, label %then566, label %else567
+
+then566:                                          ; preds = %ifcont564
+  store i32 1, i32* %array_bound565, align 4
+  br label %ifcont572
+
+else567:                                          ; preds = %ifcont564
+  br i1 true, label %then568, label %else569
+
+then568:                                          ; preds = %else567
+  store i32 1, i32* %array_bound565, align 4
+  br label %ifcont572
+
+else569:                                          ; preds = %else567
+  br i1 false, label %then570, label %else571
+
+then570:                                          ; preds = %else569
+  store i32 1, i32* %array_bound565, align 4
+  br label %ifcont572
+
+else571:                                          ; preds = %else569
+  br label %ifcont572
+
+ifcont572:                                        ; preds = %else571, %then570, %then568, %then566
+  %476 = load i32, i32* %array_bound565, align 4
+  %477 = sub i32 %476, 1
+  store i32 %477, i32* %__2_t4, align 4
+  br label %loop.head573
+
+loop.head573:                                     ; preds = %loop.end609, %ifcont572
+  %478 = load i32, i32* %__2_t4, align 4
+  %479 = add i32 %478, 1
+  br i1 false, label %then575, label %else576
+
+then575:                                          ; preds = %loop.head573
+  store i32 2, i32* %array_bound574, align 4
+  br label %ifcont581
+
+else576:                                          ; preds = %loop.head573
+  br i1 true, label %then577, label %else578
+
+then577:                                          ; preds = %else576
+  store i32 2, i32* %array_bound574, align 4
+  br label %ifcont581
+
+else578:                                          ; preds = %else576
+  br i1 false, label %then579, label %else580
+
+then579:                                          ; preds = %else578
+  store i32 1, i32* %array_bound574, align 4
+  br label %ifcont581
+
+else580:                                          ; preds = %else578
+  br label %ifcont581
+
+ifcont581:                                        ; preds = %else580, %then579, %then577, %then575
+  %480 = load i32, i32* %array_bound574, align 4
+  %481 = icmp sle i32 %479, %480
+  br i1 %481, label %loop.body582, label %loop.end610
+
+loop.body582:                                     ; preds = %ifcont581
+  %482 = load i32, i32* %__2_t4, align 4
+  %483 = add i32 %482, 1
+  store i32 %483, i32* %__2_t4, align 4
+  br i1 false, label %then584, label %else585
+
+then584:                                          ; preds = %loop.body582
+  store i32 1, i32* %array_bound583, align 4
+  br label %ifcont590
+
+else585:                                          ; preds = %loop.body582
+  br i1 true, label %then586, label %else587
+
+then586:                                          ; preds = %else585
+  store i32 1, i32* %array_bound583, align 4
+  br label %ifcont590
+
+else587:                                          ; preds = %else585
+  br i1 false, label %then588, label %else589
+
+then588:                                          ; preds = %else587
+  store i32 1, i32* %array_bound583, align 4
+  br label %ifcont590
+
+else589:                                          ; preds = %else587
+  br label %ifcont590
+
+ifcont590:                                        ; preds = %else589, %then588, %then586, %then584
+  %484 = load i32, i32* %array_bound583, align 4
+  store i32 %484, i32* %__3_v9, align 4
+  br i1 false, label %then592, label %else593
+
+then592:                                          ; preds = %ifcont590
+  store i32 1, i32* %array_bound591, align 4
+  br label %ifcont598
+
+else593:                                          ; preds = %ifcont590
+  br i1 false, label %then594, label %else595
+
+then594:                                          ; preds = %else593
+  store i32 1, i32* %array_bound591, align 4
+  br label %ifcont598
+
+else595:                                          ; preds = %else593
+  br i1 true, label %then596, label %else597
+
+then596:                                          ; preds = %else595
+  store i32 1, i32* %array_bound591, align 4
+  br label %ifcont598
+
+else597:                                          ; preds = %else595
+  br label %ifcont598
+
+ifcont598:                                        ; preds = %else597, %then596, %then594, %then592
+  %485 = load i32, i32* %array_bound591, align 4
+  %486 = sub i32 %485, 1
+  store i32 %486, i32* %__3_t7, align 4
+  br label %loop.head599
+
+loop.head599:                                     ; preds = %loop.body608, %ifcont598
+  %487 = load i32, i32* %__3_t7, align 4
+  %488 = add i32 %487, 1
+  br i1 false, label %then601, label %else602
+
+then601:                                          ; preds = %loop.head599
+  store i32 2, i32* %array_bound600, align 4
+  br label %ifcont607
+
+else602:                                          ; preds = %loop.head599
+  br i1 false, label %then603, label %else604
+
+then603:                                          ; preds = %else602
+  store i32 2, i32* %array_bound600, align 4
+  br label %ifcont607
+
+else604:                                          ; preds = %else602
+  br i1 true, label %then605, label %else606
+
+then605:                                          ; preds = %else604
+  store i32 1, i32* %array_bound600, align 4
+  br label %ifcont607
+
+else606:                                          ; preds = %else604
+  br label %ifcont607
+
+ifcont607:                                        ; preds = %else606, %then605, %then603, %then601
+  %489 = load i32, i32* %array_bound600, align 4
+  %490 = icmp sle i32 %488, %489
+  br i1 %490, label %loop.body608, label %loop.end609
+
+loop.body608:                                     ; preds = %ifcont607
+  %491 = load i32, i32* %__3_t7, align 4
+  %492 = add i32 %491, 1
+  store i32 %492, i32* %__3_t7, align 4
+  %493 = load i32, i32* %__1_t1, align 4
+  %494 = load i32, i32* %__2_t4, align 4
+  %495 = load i32, i32* %__3_t7, align 4
+  %496 = sub i32 %493, 1
+  %497 = mul i32 1, %496
+  %498 = add i32 0, %497
+  %499 = sub i32 %494, 1
+  %500 = mul i32 2, %499
+  %501 = add i32 %498, %500
+  %502 = sub i32 %495, 1
+  %503 = mul i32 4, %502
+  %504 = add i32 %501, %503
+  %505 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__5__integer_unary_op_res, i32 0, i32 %504
+  %506 = load i32, i32* %__1_v3, align 4
+  %507 = load i32, i32* %__2_v6, align 4
+  %508 = load i32, i32* %__3_v9, align 4
+  %509 = sub i32 %506, 1
+  %510 = mul i32 1, %509
+  %511 = add i32 0, %510
+  %512 = sub i32 %507, 1
+  %513 = mul i32 2, %512
+  %514 = add i32 %511, %513
+  %515 = sub i32 %508, 1
+  %516 = mul i32 4, %515
+  %517 = add i32 %514, %516
+  %518 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %517
+  %519 = load i32, i32* %518, align 4
+  %520 = sub i32 0, %519
+  store i32 %520, i32* %505, align 4
+  %521 = load i32, i32* %__3_v9, align 4
+  %522 = add i32 %521, 1
+  store i32 %522, i32* %__3_v9, align 4
+  br label %loop.head599
+
+loop.end609:                                      ; preds = %ifcont607
+  %523 = load i32, i32* %__2_v6, align 4
+  %524 = add i32 %523, 1
+  store i32 %524, i32* %__2_v6, align 4
+  br label %loop.head573
+
+loop.end610:                                      ; preds = %ifcont581
+  %525 = load i32, i32* %__1_v3, align 4
+  %526 = add i32 %525, 1
+  store i32 %526, i32* %__1_v3, align 4
+  br label %loop.head547
+
+loop.end611:                                      ; preds = %ifcont555
+  br i1 true, label %then613, label %else614
+
+then613:                                          ; preds = %loop.end611
+  store i32 1, i32* %array_bound612, align 4
+  br label %ifcont619
+
+else614:                                          ; preds = %loop.end611
+  br i1 false, label %then615, label %else616
+
+then615:                                          ; preds = %else614
+  store i32 1, i32* %array_bound612, align 4
+  br label %ifcont619
+
+else616:                                          ; preds = %else614
+  br i1 false, label %then617, label %else618
+
+then617:                                          ; preds = %else616
+  store i32 1, i32* %array_bound612, align 4
+  br label %ifcont619
+
+else618:                                          ; preds = %else616
+  br label %ifcont619
+
+ifcont619:                                        ; preds = %else618, %then617, %then615, %then613
+  %527 = load i32, i32* %array_bound612, align 4
+  store i32 %527, i32* %__1_v3, align 4
+  br i1 true, label %then621, label %else622
+
+then621:                                          ; preds = %ifcont619
+  store i32 1, i32* %array_bound620, align 4
+  br label %ifcont627
+
+else622:                                          ; preds = %ifcont619
+  br i1 false, label %then623, label %else624
+
+then623:                                          ; preds = %else622
+  store i32 1, i32* %array_bound620, align 4
+  br label %ifcont627
+
+else624:                                          ; preds = %else622
+  br i1 false, label %then625, label %else626
+
+then625:                                          ; preds = %else624
+  store i32 1, i32* %array_bound620, align 4
+  br label %ifcont627
+
+else626:                                          ; preds = %else624
+  br label %ifcont627
+
+ifcont627:                                        ; preds = %else626, %then625, %then623, %then621
+  %528 = load i32, i32* %array_bound620, align 4
+  %529 = sub i32 %528, 1
+  store i32 %529, i32* %__1_t1, align 4
+  br label %loop.head628
+
+loop.head628:                                     ; preds = %loop.end691, %ifcont627
+  %530 = load i32, i32* %__1_t1, align 4
+  %531 = add i32 %530, 1
+  br i1 true, label %then630, label %else631
+
+then630:                                          ; preds = %loop.head628
+  store i32 2, i32* %array_bound629, align 4
+  br label %ifcont636
+
+else631:                                          ; preds = %loop.head628
+  br i1 false, label %then632, label %else633
+
+then632:                                          ; preds = %else631
+  store i32 2, i32* %array_bound629, align 4
+  br label %ifcont636
+
+else633:                                          ; preds = %else631
+  br i1 false, label %then634, label %else635
+
+then634:                                          ; preds = %else633
+  store i32 1, i32* %array_bound629, align 4
+  br label %ifcont636
+
+else635:                                          ; preds = %else633
+  br label %ifcont636
+
+ifcont636:                                        ; preds = %else635, %then634, %then632, %then630
+  %532 = load i32, i32* %array_bound629, align 4
+  %533 = icmp sle i32 %531, %532
+  br i1 %533, label %loop.body637, label %loop.end692
+
+loop.body637:                                     ; preds = %ifcont636
+  %534 = load i32, i32* %__1_t1, align 4
+  %535 = add i32 %534, 1
+  store i32 %535, i32* %__1_t1, align 4
+  br i1 true, label %then639, label %else640
+
+then639:                                          ; preds = %loop.body637
+  store i32 1, i32* %array_bound638, align 4
+  br label %ifcont645
+
+else640:                                          ; preds = %loop.body637
+  br i1 false, label %then641, label %else642
+
+then641:                                          ; preds = %else640
+  store i32 1, i32* %array_bound638, align 4
+  br label %ifcont645
+
+else642:                                          ; preds = %else640
+  br i1 false, label %then643, label %else644
+
+then643:                                          ; preds = %else642
+  store i32 1, i32* %array_bound638, align 4
+  br label %ifcont645
+
+else644:                                          ; preds = %else642
+  br label %ifcont645
+
+ifcont645:                                        ; preds = %else644, %then643, %then641, %then639
+  %536 = load i32, i32* %array_bound638, align 4
+  store i32 %536, i32* %__2_v6, align 4
+  br i1 false, label %then647, label %else648
+
+then647:                                          ; preds = %ifcont645
+  store i32 1, i32* %array_bound646, align 4
+  br label %ifcont653
+
+else648:                                          ; preds = %ifcont645
+  br i1 true, label %then649, label %else650
+
+then649:                                          ; preds = %else648
+  store i32 1, i32* %array_bound646, align 4
+  br label %ifcont653
+
+else650:                                          ; preds = %else648
+  br i1 false, label %then651, label %else652
+
+then651:                                          ; preds = %else650
+  store i32 1, i32* %array_bound646, align 4
+  br label %ifcont653
+
+else652:                                          ; preds = %else650
+  br label %ifcont653
+
+ifcont653:                                        ; preds = %else652, %then651, %then649, %then647
+  %537 = load i32, i32* %array_bound646, align 4
+  %538 = sub i32 %537, 1
+  store i32 %538, i32* %__2_t4, align 4
+  br label %loop.head654
+
+loop.head654:                                     ; preds = %loop.end690, %ifcont653
+  %539 = load i32, i32* %__2_t4, align 4
+  %540 = add i32 %539, 1
+  br i1 false, label %then656, label %else657
+
+then656:                                          ; preds = %loop.head654
+  store i32 2, i32* %array_bound655, align 4
+  br label %ifcont662
+
+else657:                                          ; preds = %loop.head654
+  br i1 true, label %then658, label %else659
+
+then658:                                          ; preds = %else657
+  store i32 2, i32* %array_bound655, align 4
+  br label %ifcont662
+
+else659:                                          ; preds = %else657
+  br i1 false, label %then660, label %else661
+
+then660:                                          ; preds = %else659
+  store i32 1, i32* %array_bound655, align 4
+  br label %ifcont662
+
+else661:                                          ; preds = %else659
+  br label %ifcont662
+
+ifcont662:                                        ; preds = %else661, %then660, %then658, %then656
+  %541 = load i32, i32* %array_bound655, align 4
+  %542 = icmp sle i32 %540, %541
+  br i1 %542, label %loop.body663, label %loop.end691
+
+loop.body663:                                     ; preds = %ifcont662
+  %543 = load i32, i32* %__2_t4, align 4
+  %544 = add i32 %543, 1
+  store i32 %544, i32* %__2_t4, align 4
+  br i1 false, label %then665, label %else666
+
+then665:                                          ; preds = %loop.body663
+  store i32 1, i32* %array_bound664, align 4
+  br label %ifcont671
+
+else666:                                          ; preds = %loop.body663
+  br i1 true, label %then667, label %else668
+
+then667:                                          ; preds = %else666
+  store i32 1, i32* %array_bound664, align 4
+  br label %ifcont671
+
+else668:                                          ; preds = %else666
+  br i1 false, label %then669, label %else670
+
+then669:                                          ; preds = %else668
+  store i32 1, i32* %array_bound664, align 4
+  br label %ifcont671
+
+else670:                                          ; preds = %else668
+  br label %ifcont671
+
+ifcont671:                                        ; preds = %else670, %then669, %then667, %then665
+  %545 = load i32, i32* %array_bound664, align 4
+  store i32 %545, i32* %__3_v9, align 4
+  br i1 false, label %then673, label %else674
+
+then673:                                          ; preds = %ifcont671
+  store i32 1, i32* %array_bound672, align 4
+  br label %ifcont679
+
+else674:                                          ; preds = %ifcont671
+  br i1 false, label %then675, label %else676
+
+then675:                                          ; preds = %else674
+  store i32 1, i32* %array_bound672, align 4
+  br label %ifcont679
+
+else676:                                          ; preds = %else674
+  br i1 true, label %then677, label %else678
+
+then677:                                          ; preds = %else676
+  store i32 1, i32* %array_bound672, align 4
+  br label %ifcont679
+
+else678:                                          ; preds = %else676
+  br label %ifcont679
+
+ifcont679:                                        ; preds = %else678, %then677, %then675, %then673
+  %546 = load i32, i32* %array_bound672, align 4
+  %547 = sub i32 %546, 1
+  store i32 %547, i32* %__3_t7, align 4
+  br label %loop.head680
+
+loop.head680:                                     ; preds = %loop.body689, %ifcont679
+  %548 = load i32, i32* %__3_t7, align 4
+  %549 = add i32 %548, 1
+  br i1 false, label %then682, label %else683
+
+then682:                                          ; preds = %loop.head680
+  store i32 2, i32* %array_bound681, align 4
+  br label %ifcont688
+
+else683:                                          ; preds = %loop.head680
+  br i1 false, label %then684, label %else685
+
+then684:                                          ; preds = %else683
+  store i32 2, i32* %array_bound681, align 4
+  br label %ifcont688
+
+else685:                                          ; preds = %else683
+  br i1 true, label %then686, label %else687
+
+then686:                                          ; preds = %else685
+  store i32 1, i32* %array_bound681, align 4
+  br label %ifcont688
+
+else687:                                          ; preds = %else685
+  br label %ifcont688
+
+ifcont688:                                        ; preds = %else687, %then686, %then684, %then682
+  %550 = load i32, i32* %array_bound681, align 4
+  %551 = icmp sle i32 %549, %550
+  br i1 %551, label %loop.body689, label %loop.end690
+
+loop.body689:                                     ; preds = %ifcont688
+  %552 = load i32, i32* %__3_t7, align 4
+  %553 = add i32 %552, 1
+  store i32 %553, i32* %__3_t7, align 4
+  %554 = load i32, i32* %__1_t1, align 4
+  %555 = load i32, i32* %__2_t4, align 4
+  %556 = load i32, i32* %__3_t7, align 4
+  %557 = sub i32 %554, 1
+  %558 = mul i32 1, %557
+  %559 = add i32 0, %558
+  %560 = sub i32 %555, 1
+  %561 = mul i32 2, %560
+  %562 = add i32 %559, %561
+  %563 = sub i32 %556, 1
+  %564 = mul i32 4, %563
+  %565 = add i32 %562, %564
+  %566 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__6__implicit_cast_res, i32 0, i32 %565
+  %567 = load i32, i32* %__1_v3, align 4
+  %568 = load i32, i32* %__2_v6, align 4
+  %569 = load i32, i32* %__3_v9, align 4
+  %570 = sub i32 %567, 1
+  %571 = mul i32 1, %570
+  %572 = add i32 0, %571
+  %573 = sub i32 %568, 1
+  %574 = mul i32 2, %573
+  %575 = add i32 %572, %574
+  %576 = sub i32 %569, 1
+  %577 = mul i32 4, %576
+  %578 = add i32 %575, %577
+  %579 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__5__integer_unary_op_res, i32 0, i32 %578
+  %580 = load i32, i32* %579, align 4
+  %581 = sitofp i32 %580 to float
+  %582 = alloca %complex_4, align 8
+  %583 = getelementptr %complex_4, %complex_4* %582, i32 0, i32 0
+  %584 = getelementptr %complex_4, %complex_4* %582, i32 0, i32 1
+  store float %581, float* %583, align 4
+  store float 0.000000e+00, float* %584, align 4
+  %585 = load %complex_4, %complex_4* %582, align 4
+  store %complex_4 %585, %complex_4* %566, align 4
+  %586 = load i32, i32* %__3_v9, align 4
+  %587 = add i32 %586, 1
+  store i32 %587, i32* %__3_v9, align 4
+  br label %loop.head680
+
+loop.end690:                                      ; preds = %ifcont688
+  %588 = load i32, i32* %__2_v6, align 4
+  %589 = add i32 %588, 1
+  store i32 %589, i32* %__2_v6, align 4
+  br label %loop.head654
+
+loop.end691:                                      ; preds = %ifcont662
+  %590 = load i32, i32* %__1_v3, align 4
+  %591 = add i32 %590, 1
+  store i32 %591, i32* %__1_v3, align 4
+  br label %loop.head628
+
+loop.end692:                                      ; preds = %ifcont636
+  %592 = alloca %complex_4, align 8
+  %593 = getelementptr %complex_4, %complex_4* %592, i32 0, i32 0
+  %594 = getelementptr %complex_4, %complex_4* %592, i32 0, i32 1
+  store float 0.000000e+00, float* %593, align 4
+  store float 1.000000e+00, float* %594, align 4
+  %595 = load %complex_4, %complex_4* %592, align 4
+  store %complex_4 %595, %complex_4* %__libasr_created_scalar_auxiliary_variable1, align 4
+  br i1 true, label %then694, label %else695
+
+then694:                                          ; preds = %loop.end692
+  store i32 1, i32* %array_bound693, align 4
+  br label %ifcont700
+
+else695:                                          ; preds = %loop.end692
+  br i1 false, label %then696, label %else697
+
+then696:                                          ; preds = %else695
+  store i32 1, i32* %array_bound693, align 4
+  br label %ifcont700
+
+else697:                                          ; preds = %else695
+  br i1 false, label %then698, label %else699
+
+then698:                                          ; preds = %else697
+  store i32 1, i32* %array_bound693, align 4
+  br label %ifcont700
+
+else699:                                          ; preds = %else697
+  br label %ifcont700
+
+ifcont700:                                        ; preds = %else699, %then698, %then696, %then694
+  %596 = load i32, i32* %array_bound693, align 4
+  store i32 %596, i32* %__1_v3, align 4
+  br i1 true, label %then702, label %else703
+
+then702:                                          ; preds = %ifcont700
+  store i32 1, i32* %array_bound701, align 4
+  br label %ifcont708
+
+else703:                                          ; preds = %ifcont700
+  br i1 false, label %then704, label %else705
+
+then704:                                          ; preds = %else703
+  store i32 1, i32* %array_bound701, align 4
+  br label %ifcont708
+
+else705:                                          ; preds = %else703
+  br i1 false, label %then706, label %else707
+
+then706:                                          ; preds = %else705
+  store i32 1, i32* %array_bound701, align 4
+  br label %ifcont708
+
+else707:                                          ; preds = %else705
+  br label %ifcont708
+
+ifcont708:                                        ; preds = %else707, %then706, %then704, %then702
+  %597 = load i32, i32* %array_bound701, align 4
+  %598 = sub i32 %597, 1
+  store i32 %598, i32* %__1_t1, align 4
+  br label %loop.head709
+
+loop.head709:                                     ; preds = %loop.end772, %ifcont708
+  %599 = load i32, i32* %__1_t1, align 4
+  %600 = add i32 %599, 1
+  br i1 true, label %then711, label %else712
+
+then711:                                          ; preds = %loop.head709
+  store i32 2, i32* %array_bound710, align 4
+  br label %ifcont717
+
+else712:                                          ; preds = %loop.head709
+  br i1 false, label %then713, label %else714
+
+then713:                                          ; preds = %else712
+  store i32 2, i32* %array_bound710, align 4
+  br label %ifcont717
+
+else714:                                          ; preds = %else712
+  br i1 false, label %then715, label %else716
+
+then715:                                          ; preds = %else714
+  store i32 1, i32* %array_bound710, align 4
+  br label %ifcont717
+
+else716:                                          ; preds = %else714
+  br label %ifcont717
+
+ifcont717:                                        ; preds = %else716, %then715, %then713, %then711
+  %601 = load i32, i32* %array_bound710, align 4
+  %602 = icmp sle i32 %600, %601
+  br i1 %602, label %loop.body718, label %loop.end773
+
+loop.body718:                                     ; preds = %ifcont717
+  %603 = load i32, i32* %__1_t1, align 4
+  %604 = add i32 %603, 1
+  store i32 %604, i32* %__1_t1, align 4
+  br i1 false, label %then720, label %else721
+
+then720:                                          ; preds = %loop.body718
+  store i32 1, i32* %array_bound719, align 4
+  br label %ifcont726
+
+else721:                                          ; preds = %loop.body718
+  br i1 true, label %then722, label %else723
+
+then722:                                          ; preds = %else721
+  store i32 1, i32* %array_bound719, align 4
+  br label %ifcont726
+
+else723:                                          ; preds = %else721
+  br i1 false, label %then724, label %else725
+
+then724:                                          ; preds = %else723
+  store i32 1, i32* %array_bound719, align 4
+  br label %ifcont726
+
+else725:                                          ; preds = %else723
+  br label %ifcont726
+
+ifcont726:                                        ; preds = %else725, %then724, %then722, %then720
+  %605 = load i32, i32* %array_bound719, align 4
+  store i32 %605, i32* %__2_v6, align 4
+  br i1 false, label %then728, label %else729
+
+then728:                                          ; preds = %ifcont726
+  store i32 1, i32* %array_bound727, align 4
+  br label %ifcont734
+
+else729:                                          ; preds = %ifcont726
+  br i1 true, label %then730, label %else731
+
+then730:                                          ; preds = %else729
+  store i32 1, i32* %array_bound727, align 4
+  br label %ifcont734
+
+else731:                                          ; preds = %else729
+  br i1 false, label %then732, label %else733
+
+then732:                                          ; preds = %else731
+  store i32 1, i32* %array_bound727, align 4
+  br label %ifcont734
+
+else733:                                          ; preds = %else731
+  br label %ifcont734
+
+ifcont734:                                        ; preds = %else733, %then732, %then730, %then728
+  %606 = load i32, i32* %array_bound727, align 4
+  %607 = sub i32 %606, 1
+  store i32 %607, i32* %__2_t4, align 4
+  br label %loop.head735
+
+loop.head735:                                     ; preds = %loop.end771, %ifcont734
+  %608 = load i32, i32* %__2_t4, align 4
+  %609 = add i32 %608, 1
+  br i1 false, label %then737, label %else738
+
+then737:                                          ; preds = %loop.head735
+  store i32 2, i32* %array_bound736, align 4
+  br label %ifcont743
+
+else738:                                          ; preds = %loop.head735
+  br i1 true, label %then739, label %else740
+
+then739:                                          ; preds = %else738
+  store i32 2, i32* %array_bound736, align 4
+  br label %ifcont743
+
+else740:                                          ; preds = %else738
+  br i1 false, label %then741, label %else742
+
+then741:                                          ; preds = %else740
+  store i32 1, i32* %array_bound736, align 4
+  br label %ifcont743
+
+else742:                                          ; preds = %else740
+  br label %ifcont743
+
+ifcont743:                                        ; preds = %else742, %then741, %then739, %then737
+  %610 = load i32, i32* %array_bound736, align 4
+  %611 = icmp sle i32 %609, %610
+  br i1 %611, label %loop.body744, label %loop.end772
+
+loop.body744:                                     ; preds = %ifcont743
+  %612 = load i32, i32* %__2_t4, align 4
+  %613 = add i32 %612, 1
+  store i32 %613, i32* %__2_t4, align 4
+  br i1 false, label %then746, label %else747
+
+then746:                                          ; preds = %loop.body744
+  store i32 1, i32* %array_bound745, align 4
+  br label %ifcont752
+
+else747:                                          ; preds = %loop.body744
+  br i1 false, label %then748, label %else749
+
+then748:                                          ; preds = %else747
+  store i32 1, i32* %array_bound745, align 4
+  br label %ifcont752
+
+else749:                                          ; preds = %else747
+  br i1 true, label %then750, label %else751
+
+then750:                                          ; preds = %else749
+  store i32 1, i32* %array_bound745, align 4
+  br label %ifcont752
+
+else751:                                          ; preds = %else749
+  br label %ifcont752
+
+ifcont752:                                        ; preds = %else751, %then750, %then748, %then746
+  %614 = load i32, i32* %array_bound745, align 4
+  store i32 %614, i32* %__3_v9, align 4
+  br i1 false, label %then754, label %else755
+
+then754:                                          ; preds = %ifcont752
+  store i32 1, i32* %array_bound753, align 4
+  br label %ifcont760
+
+else755:                                          ; preds = %ifcont752
+  br i1 false, label %then756, label %else757
+
+then756:                                          ; preds = %else755
+  store i32 1, i32* %array_bound753, align 4
+  br label %ifcont760
+
+else757:                                          ; preds = %else755
+  br i1 true, label %then758, label %else759
+
+then758:                                          ; preds = %else757
+  store i32 1, i32* %array_bound753, align 4
+  br label %ifcont760
+
+else759:                                          ; preds = %else757
+  br label %ifcont760
+
+ifcont760:                                        ; preds = %else759, %then758, %then756, %then754
+  %615 = load i32, i32* %array_bound753, align 4
+  %616 = sub i32 %615, 1
+  store i32 %616, i32* %__3_t7, align 4
+  br label %loop.head761
+
+loop.head761:                                     ; preds = %loop.body770, %ifcont760
+  %617 = load i32, i32* %__3_t7, align 4
+  %618 = add i32 %617, 1
+  br i1 false, label %then763, label %else764
+
+then763:                                          ; preds = %loop.head761
+  store i32 2, i32* %array_bound762, align 4
+  br label %ifcont769
+
+else764:                                          ; preds = %loop.head761
+  br i1 false, label %then765, label %else766
+
+then765:                                          ; preds = %else764
+  store i32 2, i32* %array_bound762, align 4
+  br label %ifcont769
+
+else766:                                          ; preds = %else764
+  br i1 true, label %then767, label %else768
+
+then767:                                          ; preds = %else766
+  store i32 1, i32* %array_bound762, align 4
+  br label %ifcont769
+
+else768:                                          ; preds = %else766
+  br label %ifcont769
+
+ifcont769:                                        ; preds = %else768, %then767, %then765, %then763
+  %619 = load i32, i32* %array_bound762, align 4
+  %620 = icmp sle i32 %618, %619
+  br i1 %620, label %loop.body770, label %loop.end771
+
+loop.body770:                                     ; preds = %ifcont769
+  %621 = load i32, i32* %__3_t7, align 4
+  %622 = add i32 %621, 1
+  store i32 %622, i32* %__3_t7, align 4
+  %623 = load i32, i32* %__1_t1, align 4
+  %624 = load i32, i32* %__2_t4, align 4
+  %625 = load i32, i32* %__3_t7, align 4
+  %626 = sub i32 %623, 1
+  %627 = mul i32 1, %626
+  %628 = add i32 0, %627
+  %629 = sub i32 %624, 1
+  %630 = mul i32 2, %629
+  %631 = add i32 %628, %630
+  %632 = sub i32 %625, 1
+  %633 = mul i32 4, %632
+  %634 = add i32 %631, %633
+  %635 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__7__complex_bin_op_res, i32 0, i32 %634
+  %636 = load %complex_4, %complex_4* %__libasr_created_scalar_auxiliary_variable1, align 4
+  %637 = load i32, i32* %__1_v3, align 4
+  %638 = load i32, i32* %__2_v6, align 4
+  %639 = load i32, i32* %__3_v9, align 4
+  %640 = sub i32 %637, 1
+  %641 = mul i32 1, %640
+  %642 = add i32 0, %641
+  %643 = sub i32 %638, 1
+  %644 = mul i32 2, %643
+  %645 = add i32 %642, %644
+  %646 = sub i32 %639, 1
+  %647 = mul i32 4, %646
+  %648 = add i32 %645, %647
+  %649 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__6__implicit_cast_res, i32 0, i32 %648
+  %650 = load %complex_4, %complex_4* %649, align 4
+  %651 = alloca %complex_4, align 8
+  store %complex_4 %636, %complex_4* %651, align 4
+  %652 = alloca %complex_4, align 8
+  store %complex_4 %650, %complex_4* %652, align 4
+  %653 = alloca %complex_4, align 8
+  call void @_lfortran_complex_mul_32(%complex_4* %651, %complex_4* %652, %complex_4* %653)
+  %654 = load %complex_4, %complex_4* %653, align 4
+  store %complex_4 %654, %complex_4* %635, align 4
+  %655 = load i32, i32* %__3_v9, align 4
+  %656 = add i32 %655, 1
+  store i32 %656, i32* %__3_v9, align 4
+  br label %loop.head761
+
+loop.end771:                                      ; preds = %ifcont769
+  %657 = load i32, i32* %__2_v6, align 4
+  %658 = add i32 %657, 1
+  store i32 %658, i32* %__2_v6, align 4
+  br label %loop.head735
+
+loop.end772:                                      ; preds = %ifcont743
+  %659 = load i32, i32* %__1_v3, align 4
+  %660 = add i32 %659, 1
+  store i32 %660, i32* %__1_v3, align 4
+  br label %loop.head709
+
+loop.end773:                                      ; preds = %ifcont717
+  br i1 true, label %then775, label %else776
+
+then775:                                          ; preds = %loop.end773
+  store i32 1, i32* %array_bound774, align 4
+  br label %ifcont781
+
+else776:                                          ; preds = %loop.end773
+  br i1 false, label %then777, label %else778
+
+then777:                                          ; preds = %else776
+  store i32 1, i32* %array_bound774, align 4
+  br label %ifcont781
+
+else778:                                          ; preds = %else776
+  br i1 false, label %then779, label %else780
+
+then779:                                          ; preds = %else778
+  store i32 1, i32* %array_bound774, align 4
+  br label %ifcont781
+
+else780:                                          ; preds = %else778
+  br label %ifcont781
+
+ifcont781:                                        ; preds = %else780, %then779, %then777, %then775
+  %661 = load i32, i32* %array_bound774, align 4
+  store i32 %661, i32* %__1_v3, align 4
+  br i1 true, label %then783, label %else784
+
+then783:                                          ; preds = %ifcont781
+  store i32 1, i32* %array_bound782, align 4
+  br label %ifcont789
+
+else784:                                          ; preds = %ifcont781
+  br i1 false, label %then785, label %else786
+
+then785:                                          ; preds = %else784
+  store i32 1, i32* %array_bound782, align 4
+  br label %ifcont789
+
+else786:                                          ; preds = %else784
+  br i1 false, label %then787, label %else788
+
+then787:                                          ; preds = %else786
+  store i32 1, i32* %array_bound782, align 4
+  br label %ifcont789
+
+else788:                                          ; preds = %else786
+  br label %ifcont789
+
+ifcont789:                                        ; preds = %else788, %then787, %then785, %then783
+  %662 = load i32, i32* %array_bound782, align 4
+  store i32 %662, i32* %__1_u2, align 4
+  br i1 true, label %then791, label %else792
+
+then791:                                          ; preds = %ifcont789
+  store i32 1, i32* %array_bound790, align 4
+  br label %ifcont797
+
+else792:                                          ; preds = %ifcont789
+  br i1 false, label %then793, label %else794
+
+then793:                                          ; preds = %else792
+  store i32 1, i32* %array_bound790, align 4
+  br label %ifcont797
+
+else794:                                          ; preds = %else792
+  br i1 false, label %then795, label %else796
+
+then795:                                          ; preds = %else794
+  store i32 1, i32* %array_bound790, align 4
+  br label %ifcont797
+
+else796:                                          ; preds = %else794
+  br label %ifcont797
+
+ifcont797:                                        ; preds = %else796, %then795, %then793, %then791
+  %663 = load i32, i32* %array_bound790, align 4
+  %664 = sub i32 %663, 1
+  store i32 %664, i32* %__1_t1, align 4
+  br label %loop.head798
+
+loop.head798:                                     ; preds = %loop.end877, %ifcont797
+  %665 = load i32, i32* %__1_t1, align 4
+  %666 = add i32 %665, 1
+  br i1 true, label %then800, label %else801
+
+then800:                                          ; preds = %loop.head798
+  store i32 2, i32* %array_bound799, align 4
+  br label %ifcont806
+
+else801:                                          ; preds = %loop.head798
+  br i1 false, label %then802, label %else803
+
+then802:                                          ; preds = %else801
+  store i32 2, i32* %array_bound799, align 4
+  br label %ifcont806
+
+else803:                                          ; preds = %else801
+  br i1 false, label %then804, label %else805
+
+then804:                                          ; preds = %else803
+  store i32 1, i32* %array_bound799, align 4
+  br label %ifcont806
+
+else805:                                          ; preds = %else803
+  br label %ifcont806
+
+ifcont806:                                        ; preds = %else805, %then804, %then802, %then800
+  %667 = load i32, i32* %array_bound799, align 4
+  %668 = icmp sle i32 %666, %667
+  br i1 %668, label %loop.body807, label %loop.end878
+
+loop.body807:                                     ; preds = %ifcont806
+  %669 = load i32, i32* %__1_t1, align 4
+  %670 = add i32 %669, 1
+  store i32 %670, i32* %__1_t1, align 4
+  br i1 true, label %then809, label %else810
+
+then809:                                          ; preds = %loop.body807
+  store i32 1, i32* %array_bound808, align 4
+  br label %ifcont815
+
+else810:                                          ; preds = %loop.body807
+  br i1 false, label %then811, label %else812
+
+then811:                                          ; preds = %else810
+  store i32 1, i32* %array_bound808, align 4
+  br label %ifcont815
+
+else812:                                          ; preds = %else810
+  br i1 false, label %then813, label %else814
+
+then813:                                          ; preds = %else812
+  store i32 1, i32* %array_bound808, align 4
+  br label %ifcont815
+
+else814:                                          ; preds = %else812
+  br label %ifcont815
+
+ifcont815:                                        ; preds = %else814, %then813, %then811, %then809
+  %671 = load i32, i32* %array_bound808, align 4
+  store i32 %671, i32* %__2_v6, align 4
+  br i1 true, label %then817, label %else818
+
+then817:                                          ; preds = %ifcont815
+  store i32 1, i32* %array_bound816, align 4
+  br label %ifcont823
+
+else818:                                          ; preds = %ifcont815
+  br i1 false, label %then819, label %else820
+
+then819:                                          ; preds = %else818
+  store i32 1, i32* %array_bound816, align 4
+  br label %ifcont823
+
+else820:                                          ; preds = %else818
+  br i1 false, label %then821, label %else822
+
+then821:                                          ; preds = %else820
+  store i32 1, i32* %array_bound816, align 4
+  br label %ifcont823
+
+else822:                                          ; preds = %else820
+  br label %ifcont823
+
+ifcont823:                                        ; preds = %else822, %then821, %then819, %then817
+  %672 = load i32, i32* %array_bound816, align 4
+  store i32 %672, i32* %__2_u5, align 4
+  br i1 false, label %then825, label %else826
+
+then825:                                          ; preds = %ifcont823
+  store i32 1, i32* %array_bound824, align 4
+  br label %ifcont831
+
+else826:                                          ; preds = %ifcont823
+  br i1 true, label %then827, label %else828
+
+then827:                                          ; preds = %else826
+  store i32 1, i32* %array_bound824, align 4
+  br label %ifcont831
+
+else828:                                          ; preds = %else826
+  br i1 false, label %then829, label %else830
+
+then829:                                          ; preds = %else828
+  store i32 1, i32* %array_bound824, align 4
+  br label %ifcont831
+
+else830:                                          ; preds = %else828
+  br label %ifcont831
+
+ifcont831:                                        ; preds = %else830, %then829, %then827, %then825
+  %673 = load i32, i32* %array_bound824, align 4
+  %674 = sub i32 %673, 1
+  store i32 %674, i32* %__2_t4, align 4
+  br label %loop.head832
+
+loop.head832:                                     ; preds = %loop.end876, %ifcont831
+  %675 = load i32, i32* %__2_t4, align 4
+  %676 = add i32 %675, 1
+  br i1 false, label %then834, label %else835
+
+then834:                                          ; preds = %loop.head832
+  store i32 2, i32* %array_bound833, align 4
+  br label %ifcont840
+
+else835:                                          ; preds = %loop.head832
+  br i1 true, label %then836, label %else837
+
+then836:                                          ; preds = %else835
+  store i32 2, i32* %array_bound833, align 4
+  br label %ifcont840
+
+else837:                                          ; preds = %else835
+  br i1 false, label %then838, label %else839
+
+then838:                                          ; preds = %else837
+  store i32 1, i32* %array_bound833, align 4
+  br label %ifcont840
+
+else839:                                          ; preds = %else837
+  br label %ifcont840
+
+ifcont840:                                        ; preds = %else839, %then838, %then836, %then834
+  %677 = load i32, i32* %array_bound833, align 4
+  %678 = icmp sle i32 %676, %677
+  br i1 %678, label %loop.body841, label %loop.end877
+
+loop.body841:                                     ; preds = %ifcont840
+  %679 = load i32, i32* %__2_t4, align 4
+  %680 = add i32 %679, 1
+  store i32 %680, i32* %__2_t4, align 4
+  br i1 false, label %then843, label %else844
+
+then843:                                          ; preds = %loop.body841
+  store i32 1, i32* %array_bound842, align 4
+  br label %ifcont849
+
+else844:                                          ; preds = %loop.body841
+  br i1 true, label %then845, label %else846
+
+then845:                                          ; preds = %else844
+  store i32 1, i32* %array_bound842, align 4
+  br label %ifcont849
+
+else846:                                          ; preds = %else844
+  br i1 false, label %then847, label %else848
+
+then847:                                          ; preds = %else846
+  store i32 1, i32* %array_bound842, align 4
+  br label %ifcont849
+
+else848:                                          ; preds = %else846
+  br label %ifcont849
+
+ifcont849:                                        ; preds = %else848, %then847, %then845, %then843
+  %681 = load i32, i32* %array_bound842, align 4
+  store i32 %681, i32* %__3_v9, align 4
+  br i1 false, label %then851, label %else852
+
+then851:                                          ; preds = %ifcont849
+  store i32 1, i32* %array_bound850, align 4
+  br label %ifcont857
+
+else852:                                          ; preds = %ifcont849
+  br i1 true, label %then853, label %else854
+
+then853:                                          ; preds = %else852
+  store i32 1, i32* %array_bound850, align 4
+  br label %ifcont857
+
+else854:                                          ; preds = %else852
+  br i1 false, label %then855, label %else856
+
+then855:                                          ; preds = %else854
+  store i32 1, i32* %array_bound850, align 4
+  br label %ifcont857
+
+else856:                                          ; preds = %else854
+  br label %ifcont857
+
+ifcont857:                                        ; preds = %else856, %then855, %then853, %then851
+  %682 = load i32, i32* %array_bound850, align 4
+  store i32 %682, i32* %__3_u8, align 4
+  br i1 false, label %then859, label %else860
+
+then859:                                          ; preds = %ifcont857
+  store i32 1, i32* %array_bound858, align 4
+  br label %ifcont865
+
+else860:                                          ; preds = %ifcont857
+  br i1 false, label %then861, label %else862
+
+then861:                                          ; preds = %else860
+  store i32 1, i32* %array_bound858, align 4
+  br label %ifcont865
+
+else862:                                          ; preds = %else860
+  br i1 true, label %then863, label %else864
+
+then863:                                          ; preds = %else862
+  store i32 1, i32* %array_bound858, align 4
+  br label %ifcont865
+
+else864:                                          ; preds = %else862
+  br label %ifcont865
+
+ifcont865:                                        ; preds = %else864, %then863, %then861, %then859
+  %683 = load i32, i32* %array_bound858, align 4
+  %684 = sub i32 %683, 1
+  store i32 %684, i32* %__3_t7, align 4
+  br label %loop.head866
+
+loop.head866:                                     ; preds = %loop.body875, %ifcont865
+  %685 = load i32, i32* %__3_t7, align 4
+  %686 = add i32 %685, 1
+  br i1 false, label %then868, label %else869
+
+then868:                                          ; preds = %loop.head866
+  store i32 2, i32* %array_bound867, align 4
+  br label %ifcont874
+
+else869:                                          ; preds = %loop.head866
+  br i1 false, label %then870, label %else871
+
+then870:                                          ; preds = %else869
+  store i32 2, i32* %array_bound867, align 4
+  br label %ifcont874
+
+else871:                                          ; preds = %else869
+  br i1 true, label %then872, label %else873
+
+then872:                                          ; preds = %else871
+  store i32 1, i32* %array_bound867, align 4
+  br label %ifcont874
+
+else873:                                          ; preds = %else871
+  br label %ifcont874
+
+ifcont874:                                        ; preds = %else873, %then872, %then870, %then868
+  %687 = load i32, i32* %array_bound867, align 4
+  %688 = icmp sle i32 %686, %687
+  br i1 %688, label %loop.body875, label %loop.end876
+
+loop.body875:                                     ; preds = %ifcont874
+  %689 = load i32, i32* %__3_t7, align 4
+  %690 = add i32 %689, 1
+  store i32 %690, i32* %__3_t7, align 4
+  %691 = load i32, i32* %__1_t1, align 4
+  %692 = load i32, i32* %__2_t4, align 4
+  %693 = load i32, i32* %__3_t7, align 4
+  %694 = sub i32 %691, 1
+  %695 = mul i32 1, %694
+  %696 = add i32 0, %695
+  %697 = sub i32 %692, 1
+  %698 = mul i32 2, %697
+  %699 = add i32 %696, %698
+  %700 = sub i32 %693, 1
+  %701 = mul i32 4, %700
+  %702 = add i32 %699, %701
+  %703 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 %702
+  %704 = load i32, i32* %__1_v3, align 4
+  %705 = load i32, i32* %__2_v6, align 4
+  %706 = load i32, i32* %__3_v9, align 4
+  %707 = sub i32 %704, 1
+  %708 = mul i32 1, %707
+  %709 = add i32 0, %708
+  %710 = sub i32 %705, 1
+  %711 = mul i32 2, %710
+  %712 = add i32 %709, %711
+  %713 = sub i32 %706, 1
+  %714 = mul i32 4, %713
+  %715 = add i32 %712, %714
+  %716 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__4__implicit_cast_res, i32 0, i32 %715
+  %717 = load %complex_4, %complex_4* %716, align 4
+  %718 = load i32, i32* %__1_u2, align 4
+  %719 = load i32, i32* %__2_u5, align 4
+  %720 = load i32, i32* %__3_u8, align 4
+  %721 = sub i32 %718, 1
+  %722 = mul i32 1, %721
+  %723 = add i32 0, %722
+  %724 = sub i32 %719, 1
+  %725 = mul i32 2, %724
+  %726 = add i32 %723, %725
+  %727 = sub i32 %720, 1
+  %728 = mul i32 4, %727
+  %729 = add i32 %726, %728
+  %730 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__7__complex_bin_op_res, i32 0, i32 %729
+  %731 = load %complex_4, %complex_4* %730, align 4
+  %732 = alloca %complex_4, align 8
+  store %complex_4 %717, %complex_4* %732, align 4
+  %733 = alloca %complex_4, align 8
+  store %complex_4 %731, %complex_4* %733, align 4
+  %734 = alloca %complex_4, align 8
+  call void @_lfortran_complex_add_32(%complex_4* %732, %complex_4* %733, %complex_4* %734)
+  %735 = load %complex_4, %complex_4* %734, align 4
+  store %complex_4 %735, %complex_4* %703, align 4
+  %736 = load i32, i32* %__3_v9, align 4
+  %737 = add i32 %736, 1
+  store i32 %737, i32* %__3_v9, align 4
+  %738 = load i32, i32* %__3_u8, align 4
+  %739 = add i32 %738, 1
+  store i32 %739, i32* %__3_u8, align 4
+  br label %loop.head866
+
+loop.end876:                                      ; preds = %ifcont874
+  %740 = load i32, i32* %__2_v6, align 4
+  %741 = add i32 %740, 1
+  store i32 %741, i32* %__2_v6, align 4
+  %742 = load i32, i32* %__2_u5, align 4
+  %743 = add i32 %742, 1
+  store i32 %743, i32* %__2_u5, align 4
+  br label %loop.head832
+
+loop.end877:                                      ; preds = %ifcont840
+  %744 = load i32, i32* %__1_v3, align 4
+  %745 = add i32 %744, 1
+  store i32 %745, i32* %__1_v3, align 4
+  %746 = load i32, i32* %__1_u2, align 4
+  %747 = add i32 %746, 1
+  store i32 %747, i32* %__1_u2, align 4
+  br label %loop.head798
+
+loop.end878:                                      ; preds = %ifcont806
+  %748 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 0
+  store i32 1, i32* %call_arg_value879, align 4
+  store i32 2, i32* %call_arg_value880, align 4
+  store i32 1, i32* %call_arg_value881, align 4
+  store i32 2, i32* %call_arg_value882, align 4
+  store i32 1, i32* %call_arg_value883, align 4
+  store i32 1, i32* %call_arg_value884, align 4
+  store i32 1, i32* %call_arg_value885, align 4
+  call void @check_complex__________0(%complex_4* %748, i32* %call_arg_value879, i32* %call_arg_value880, i32* %call_arg_value881, i32* %call_arg_value882, i32* %call_arg_value883, i32* %call_arg_value884, i32* %call_arg_value885)
+  br label %return
+
+return:                                           ; preds = %loop.end878
+  ret i32 0
+}
+
 define void @check_complex__________0(%complex_4* %c, i32* %__1c, i32* %__2c, i32* %__3c, i32* %__4c, i32* %__5c, i32* %__6c, i32* %op_code) {
 .entry:
   %i = alloca i32, align 4
@@ -323,3689 +4019,5 @@ declare void @_lcompilers_print_error(i8*, ...)
 declare void @exit(i32)
 
 declare void @_lfortran_complex_sub_32(%complex_4*, %complex_4*, %complex_4*)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value873 = alloca i32, align 4
-  %call_arg_value872 = alloca i32, align 4
-  %call_arg_value871 = alloca i32, align 4
-  %call_arg_value870 = alloca i32, align 4
-  %call_arg_value869 = alloca i32, align 4
-  %call_arg_value868 = alloca i32, align 4
-  %call_arg_value867 = alloca i32, align 4
-  %array_bound855 = alloca i32, align 4
-  %array_bound846 = alloca i32, align 4
-  %array_bound838 = alloca i32, align 4
-  %array_bound830 = alloca i32, align 4
-  %array_bound821 = alloca i32, align 4
-  %array_bound812 = alloca i32, align 4
-  %array_bound804 = alloca i32, align 4
-  %array_bound796 = alloca i32, align 4
-  %array_bound787 = alloca i32, align 4
-  %array_bound778 = alloca i32, align 4
-  %array_bound770 = alloca i32, align 4
-  %array_bound762 = alloca i32, align 4
-  %array_bound750 = alloca i32, align 4
-  %array_bound741 = alloca i32, align 4
-  %array_bound733 = alloca i32, align 4
-  %array_bound724 = alloca i32, align 4
-  %array_bound715 = alloca i32, align 4
-  %array_bound707 = alloca i32, align 4
-  %array_bound698 = alloca i32, align 4
-  %array_bound689 = alloca i32, align 4
-  %array_bound681 = alloca i32, align 4
-  %array_bound669 = alloca i32, align 4
-  %array_bound660 = alloca i32, align 4
-  %array_bound652 = alloca i32, align 4
-  %array_bound643 = alloca i32, align 4
-  %array_bound634 = alloca i32, align 4
-  %array_bound626 = alloca i32, align 4
-  %array_bound617 = alloca i32, align 4
-  %array_bound608 = alloca i32, align 4
-  %array_bound600 = alloca i32, align 4
-  %array_bound588 = alloca i32, align 4
-  %array_bound579 = alloca i32, align 4
-  %array_bound571 = alloca i32, align 4
-  %array_bound562 = alloca i32, align 4
-  %array_bound553 = alloca i32, align 4
-  %array_bound545 = alloca i32, align 4
-  %array_bound536 = alloca i32, align 4
-  %array_bound527 = alloca i32, align 4
-  %array_bound519 = alloca i32, align 4
-  %array_bound507 = alloca i32, align 4
-  %array_bound498 = alloca i32, align 4
-  %array_bound490 = alloca i32, align 4
-  %array_bound481 = alloca i32, align 4
-  %array_bound472 = alloca i32, align 4
-  %array_bound464 = alloca i32, align 4
-  %array_bound455 = alloca i32, align 4
-  %array_bound446 = alloca i32, align 4
-  %array_bound438 = alloca i32, align 4
-  %array_bound426 = alloca i32, align 4
-  %array_bound417 = alloca i32, align 4
-  %array_bound409 = alloca i32, align 4
-  %array_bound400 = alloca i32, align 4
-  %array_bound391 = alloca i32, align 4
-  %array_bound383 = alloca i32, align 4
-  %array_bound374 = alloca i32, align 4
-  %array_bound365 = alloca i32, align 4
-  %array_bound357 = alloca i32, align 4
-  %call_arg_value356 = alloca i32, align 4
-  %call_arg_value355 = alloca i32, align 4
-  %call_arg_value354 = alloca i32, align 4
-  %call_arg_value353 = alloca i32, align 4
-  %call_arg_value352 = alloca i32, align 4
-  %call_arg_value351 = alloca i32, align 4
-  %call_arg_value = alloca i32, align 4
-  %array_bound339 = alloca i32, align 4
-  %array_bound330 = alloca i32, align 4
-  %array_bound322 = alloca i32, align 4
-  %array_bound314 = alloca i32, align 4
-  %array_bound305 = alloca i32, align 4
-  %array_bound296 = alloca i32, align 4
-  %array_bound288 = alloca i32, align 4
-  %array_bound280 = alloca i32, align 4
-  %array_bound271 = alloca i32, align 4
-  %array_bound262 = alloca i32, align 4
-  %array_bound254 = alloca i32, align 4
-  %array_bound246 = alloca i32, align 4
-  %array_bound234 = alloca i32, align 4
-  %array_bound225 = alloca i32, align 4
-  %array_bound217 = alloca i32, align 4
-  %array_bound208 = alloca i32, align 4
-  %array_bound199 = alloca i32, align 4
-  %array_bound191 = alloca i32, align 4
-  %array_bound182 = alloca i32, align 4
-  %array_bound173 = alloca i32, align 4
-  %array_bound165 = alloca i32, align 4
-  %array_bound153 = alloca i32, align 4
-  %array_bound144 = alloca i32, align 4
-  %array_bound136 = alloca i32, align 4
-  %array_bound127 = alloca i32, align 4
-  %array_bound118 = alloca i32, align 4
-  %array_bound110 = alloca i32, align 4
-  %array_bound101 = alloca i32, align 4
-  %array_bound92 = alloca i32, align 4
-  %array_bound84 = alloca i32, align 4
-  %array_bound72 = alloca i32, align 4
-  %array_bound63 = alloca i32, align 4
-  %array_bound55 = alloca i32, align 4
-  %array_bound46 = alloca i32, align 4
-  %array_bound37 = alloca i32, align 4
-  %array_bound29 = alloca i32, align 4
-  %array_bound20 = alloca i32, align 4
-  %array_bound11 = alloca i32, align 4
-  %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__1_t = alloca i32, align 4
-  %__1_u = alloca i32, align 4
-  %__1_v = alloca i32, align 4
-  %__2_t = alloca i32, align 4
-  %__2_u = alloca i32, align 4
-  %__2_v = alloca i32, align 4
-  %__3_t = alloca i32, align 4
-  %__3_u = alloca i32, align 4
-  %__3_v = alloca i32, align 4
-  %__libasr__created__var__0__implicit_cast_res = alloca [4 x %complex_4], align 8
-  %__libasr__created__var__1__implicit_cast_res = alloca [4 x %complex_4], align 8
-  %__libasr__created__var__2__complex_bin_op_res = alloca [4 x %complex_4], align 8
-  %__libasr__created__var__3__integer_unary_op_res = alloca [4 x i32], align 4
-  %__libasr__created__var__4__implicit_cast_res = alloca [4 x %complex_4], align 8
-  %__libasr__created__var__5__integer_unary_op_res = alloca [4 x i32], align 4
-  %__libasr__created__var__6__implicit_cast_res = alloca [4 x %complex_4], align 8
-  %__libasr__created__var__7__complex_bin_op_res = alloca [4 x %complex_4], align 8
-  %__libasr_created_scalar_auxiliary_variable = alloca %complex_4, align 8
-  %__libasr_created_scalar_auxiliary_variable1 = alloca %complex_4, align 8
-  %a = alloca [4 x i32], align 4
-  %b = alloca [4 x i32], align 4
-  %c = alloca [4 x %complex_4], align 8
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  %k = alloca i32, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.end5, %.entry
-  %2 = load i32, i32* %i, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 2
-  br i1 %4, label %loop.body, label %loop.end6
-
-loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
-  %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head1
-
-loop.head1:                                       ; preds = %loop.end, %loop.body
-  %7 = load i32, i32* %j, align 4
-  %8 = add i32 %7, 1
-  %9 = icmp sle i32 %8, 2
-  br i1 %9, label %loop.body2, label %loop.end5
-
-loop.body2:                                       ; preds = %loop.head1
-  %10 = load i32, i32* %j, align 4
-  %11 = add i32 %10, 1
-  store i32 %11, i32* %j, align 4
-  store i32 0, i32* %k, align 4
-  br label %loop.head3
-
-loop.head3:                                       ; preds = %loop.body4, %loop.body2
-  %12 = load i32, i32* %k, align 4
-  %13 = add i32 %12, 1
-  %14 = icmp sle i32 %13, 1
-  br i1 %14, label %loop.body4, label %loop.end
-
-loop.body4:                                       ; preds = %loop.head3
-  %15 = load i32, i32* %k, align 4
-  %16 = add i32 %15, 1
-  store i32 %16, i32* %k, align 4
-  %17 = load i32, i32* %i, align 4
-  %18 = load i32, i32* %j, align 4
-  %19 = load i32, i32* %k, align 4
-  %20 = sub i32 %17, 1
-  %21 = mul i32 1, %20
-  %22 = add i32 0, %21
-  %23 = sub i32 %18, 1
-  %24 = mul i32 2, %23
-  %25 = add i32 %22, %24
-  %26 = sub i32 %19, 1
-  %27 = mul i32 4, %26
-  %28 = add i32 %25, %27
-  %29 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %28
-  %30 = load i32, i32* %i, align 4
-  %31 = load i32, i32* %j, align 4
-  %32 = add i32 %30, %31
-  %33 = load i32, i32* %k, align 4
-  %34 = add i32 %32, %33
-  store i32 %34, i32* %29, align 4
-  %35 = load i32, i32* %i, align 4
-  %36 = load i32, i32* %j, align 4
-  %37 = load i32, i32* %k, align 4
-  %38 = sub i32 %35, 1
-  %39 = mul i32 1, %38
-  %40 = add i32 0, %39
-  %41 = sub i32 %36, 1
-  %42 = mul i32 2, %41
-  %43 = add i32 %40, %42
-  %44 = sub i32 %37, 1
-  %45 = mul i32 4, %44
-  %46 = add i32 %43, %45
-  %47 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %46
-  %48 = load i32, i32* %i, align 4
-  %49 = load i32, i32* %j, align 4
-  %50 = mul i32 %48, %49
-  %51 = load i32, i32* %k, align 4
-  %52 = mul i32 %50, %51
-  store i32 %52, i32* %47, align 4
-  br label %loop.head3
-
-loop.end:                                         ; preds = %loop.head3
-  br label %loop.head1
-
-loop.end5:                                        ; preds = %loop.head1
-  br label %loop.head
-
-loop.end6:                                        ; preds = %loop.head
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %loop.end6
-  store i32 1, i32* %array_bound, align 4
-  br label %ifcont
-
-else:                                             ; preds = %loop.end6
-  br i1 false, label %then7, label %else8
-
-then7:                                            ; preds = %else
-  store i32 1, i32* %array_bound, align 4
-  br label %ifcont
-
-else8:                                            ; preds = %else
-  br i1 false, label %then9, label %else10
-
-then9:                                            ; preds = %else8
-  store i32 1, i32* %array_bound, align 4
-  br label %ifcont
-
-else10:                                           ; preds = %else8
-  br label %ifcont
-
-ifcont:                                           ; preds = %else10, %then9, %then7, %then
-  %53 = load i32, i32* %array_bound, align 4
-  store i32 %53, i32* %__1_v, align 4
-  br i1 true, label %then12, label %else13
-
-then12:                                           ; preds = %ifcont
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont18
-
-else13:                                           ; preds = %ifcont
-  br i1 false, label %then14, label %else15
-
-then14:                                           ; preds = %else13
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont18
-
-else15:                                           ; preds = %else13
-  br i1 false, label %then16, label %else17
-
-then16:                                           ; preds = %else15
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont18
-
-else17:                                           ; preds = %else15
-  br label %ifcont18
-
-ifcont18:                                         ; preds = %else17, %then16, %then14, %then12
-  %54 = load i32, i32* %array_bound11, align 4
-  %55 = sub i32 %54, 1
-  store i32 %55, i32* %__1_t, align 4
-  br label %loop.head19
-
-loop.head19:                                      ; preds = %loop.end82, %ifcont18
-  %56 = load i32, i32* %__1_t, align 4
-  %57 = add i32 %56, 1
-  br i1 true, label %then21, label %else22
-
-then21:                                           ; preds = %loop.head19
-  store i32 2, i32* %array_bound20, align 4
-  br label %ifcont27
-
-else22:                                           ; preds = %loop.head19
-  br i1 false, label %then23, label %else24
-
-then23:                                           ; preds = %else22
-  store i32 2, i32* %array_bound20, align 4
-  br label %ifcont27
-
-else24:                                           ; preds = %else22
-  br i1 false, label %then25, label %else26
-
-then25:                                           ; preds = %else24
-  store i32 1, i32* %array_bound20, align 4
-  br label %ifcont27
-
-else26:                                           ; preds = %else24
-  br label %ifcont27
-
-ifcont27:                                         ; preds = %else26, %then25, %then23, %then21
-  %58 = load i32, i32* %array_bound20, align 4
-  %59 = icmp sle i32 %57, %58
-  br i1 %59, label %loop.body28, label %loop.end83
-
-loop.body28:                                      ; preds = %ifcont27
-  %60 = load i32, i32* %__1_t, align 4
-  %61 = add i32 %60, 1
-  store i32 %61, i32* %__1_t, align 4
-  br i1 true, label %then30, label %else31
-
-then30:                                           ; preds = %loop.body28
-  store i32 1, i32* %array_bound29, align 4
-  br label %ifcont36
-
-else31:                                           ; preds = %loop.body28
-  br i1 false, label %then32, label %else33
-
-then32:                                           ; preds = %else31
-  store i32 1, i32* %array_bound29, align 4
-  br label %ifcont36
-
-else33:                                           ; preds = %else31
-  br i1 false, label %then34, label %else35
-
-then34:                                           ; preds = %else33
-  store i32 1, i32* %array_bound29, align 4
-  br label %ifcont36
-
-else35:                                           ; preds = %else33
-  br label %ifcont36
-
-ifcont36:                                         ; preds = %else35, %then34, %then32, %then30
-  %62 = load i32, i32* %array_bound29, align 4
-  store i32 %62, i32* %__2_v, align 4
-  br i1 false, label %then38, label %else39
-
-then38:                                           ; preds = %ifcont36
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont44
-
-else39:                                           ; preds = %ifcont36
-  br i1 true, label %then40, label %else41
-
-then40:                                           ; preds = %else39
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont44
-
-else41:                                           ; preds = %else39
-  br i1 false, label %then42, label %else43
-
-then42:                                           ; preds = %else41
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont44
-
-else43:                                           ; preds = %else41
-  br label %ifcont44
-
-ifcont44:                                         ; preds = %else43, %then42, %then40, %then38
-  %63 = load i32, i32* %array_bound37, align 4
-  %64 = sub i32 %63, 1
-  store i32 %64, i32* %__2_t, align 4
-  br label %loop.head45
-
-loop.head45:                                      ; preds = %loop.end81, %ifcont44
-  %65 = load i32, i32* %__2_t, align 4
-  %66 = add i32 %65, 1
-  br i1 false, label %then47, label %else48
-
-then47:                                           ; preds = %loop.head45
-  store i32 2, i32* %array_bound46, align 4
-  br label %ifcont53
-
-else48:                                           ; preds = %loop.head45
-  br i1 true, label %then49, label %else50
-
-then49:                                           ; preds = %else48
-  store i32 2, i32* %array_bound46, align 4
-  br label %ifcont53
-
-else50:                                           ; preds = %else48
-  br i1 false, label %then51, label %else52
-
-then51:                                           ; preds = %else50
-  store i32 1, i32* %array_bound46, align 4
-  br label %ifcont53
-
-else52:                                           ; preds = %else50
-  br label %ifcont53
-
-ifcont53:                                         ; preds = %else52, %then51, %then49, %then47
-  %67 = load i32, i32* %array_bound46, align 4
-  %68 = icmp sle i32 %66, %67
-  br i1 %68, label %loop.body54, label %loop.end82
-
-loop.body54:                                      ; preds = %ifcont53
-  %69 = load i32, i32* %__2_t, align 4
-  %70 = add i32 %69, 1
-  store i32 %70, i32* %__2_t, align 4
-  br i1 false, label %then56, label %else57
-
-then56:                                           ; preds = %loop.body54
-  store i32 1, i32* %array_bound55, align 4
-  br label %ifcont62
-
-else57:                                           ; preds = %loop.body54
-  br i1 true, label %then58, label %else59
-
-then58:                                           ; preds = %else57
-  store i32 1, i32* %array_bound55, align 4
-  br label %ifcont62
-
-else59:                                           ; preds = %else57
-  br i1 false, label %then60, label %else61
-
-then60:                                           ; preds = %else59
-  store i32 1, i32* %array_bound55, align 4
-  br label %ifcont62
-
-else61:                                           ; preds = %else59
-  br label %ifcont62
-
-ifcont62:                                         ; preds = %else61, %then60, %then58, %then56
-  %71 = load i32, i32* %array_bound55, align 4
-  store i32 %71, i32* %__3_v, align 4
-  br i1 false, label %then64, label %else65
-
-then64:                                           ; preds = %ifcont62
-  store i32 1, i32* %array_bound63, align 4
-  br label %ifcont70
-
-else65:                                           ; preds = %ifcont62
-  br i1 false, label %then66, label %else67
-
-then66:                                           ; preds = %else65
-  store i32 1, i32* %array_bound63, align 4
-  br label %ifcont70
-
-else67:                                           ; preds = %else65
-  br i1 true, label %then68, label %else69
-
-then68:                                           ; preds = %else67
-  store i32 1, i32* %array_bound63, align 4
-  br label %ifcont70
-
-else69:                                           ; preds = %else67
-  br label %ifcont70
-
-ifcont70:                                         ; preds = %else69, %then68, %then66, %then64
-  %72 = load i32, i32* %array_bound63, align 4
-  %73 = sub i32 %72, 1
-  store i32 %73, i32* %__3_t, align 4
-  br label %loop.head71
-
-loop.head71:                                      ; preds = %loop.body80, %ifcont70
-  %74 = load i32, i32* %__3_t, align 4
-  %75 = add i32 %74, 1
-  br i1 false, label %then73, label %else74
-
-then73:                                           ; preds = %loop.head71
-  store i32 2, i32* %array_bound72, align 4
-  br label %ifcont79
-
-else74:                                           ; preds = %loop.head71
-  br i1 false, label %then75, label %else76
-
-then75:                                           ; preds = %else74
-  store i32 2, i32* %array_bound72, align 4
-  br label %ifcont79
-
-else76:                                           ; preds = %else74
-  br i1 true, label %then77, label %else78
-
-then77:                                           ; preds = %else76
-  store i32 1, i32* %array_bound72, align 4
-  br label %ifcont79
-
-else78:                                           ; preds = %else76
-  br label %ifcont79
-
-ifcont79:                                         ; preds = %else78, %then77, %then75, %then73
-  %76 = load i32, i32* %array_bound72, align 4
-  %77 = icmp sle i32 %75, %76
-  br i1 %77, label %loop.body80, label %loop.end81
-
-loop.body80:                                      ; preds = %ifcont79
-  %78 = load i32, i32* %__3_t, align 4
-  %79 = add i32 %78, 1
-  store i32 %79, i32* %__3_t, align 4
-  %80 = load i32, i32* %__1_t, align 4
-  %81 = load i32, i32* %__2_t, align 4
-  %82 = load i32, i32* %__3_t, align 4
-  %83 = sub i32 %80, 1
-  %84 = mul i32 1, %83
-  %85 = add i32 0, %84
-  %86 = sub i32 %81, 1
-  %87 = mul i32 2, %86
-  %88 = add i32 %85, %87
-  %89 = sub i32 %82, 1
-  %90 = mul i32 4, %89
-  %91 = add i32 %88, %90
-  %92 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__0__implicit_cast_res, i32 0, i32 %91
-  %93 = load i32, i32* %__1_v, align 4
-  %94 = load i32, i32* %__2_v, align 4
-  %95 = load i32, i32* %__3_v, align 4
-  %96 = sub i32 %93, 1
-  %97 = mul i32 1, %96
-  %98 = add i32 0, %97
-  %99 = sub i32 %94, 1
-  %100 = mul i32 2, %99
-  %101 = add i32 %98, %100
-  %102 = sub i32 %95, 1
-  %103 = mul i32 4, %102
-  %104 = add i32 %101, %103
-  %105 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %104
-  %106 = load i32, i32* %105, align 4
-  %107 = sitofp i32 %106 to float
-  %108 = alloca %complex_4, align 8
-  %109 = getelementptr %complex_4, %complex_4* %108, i32 0, i32 0
-  %110 = getelementptr %complex_4, %complex_4* %108, i32 0, i32 1
-  store float %107, float* %109, align 4
-  store float 0.000000e+00, float* %110, align 4
-  %111 = load %complex_4, %complex_4* %108, align 4
-  store %complex_4 %111, %complex_4* %92, align 4
-  %112 = load i32, i32* %__3_v, align 4
-  %113 = add i32 %112, 1
-  store i32 %113, i32* %__3_v, align 4
-  br label %loop.head71
-
-loop.end81:                                       ; preds = %ifcont79
-  %114 = load i32, i32* %__2_v, align 4
-  %115 = add i32 %114, 1
-  store i32 %115, i32* %__2_v, align 4
-  br label %loop.head45
-
-loop.end82:                                       ; preds = %ifcont53
-  %116 = load i32, i32* %__1_v, align 4
-  %117 = add i32 %116, 1
-  store i32 %117, i32* %__1_v, align 4
-  br label %loop.head19
-
-loop.end83:                                       ; preds = %ifcont27
-  br i1 true, label %then85, label %else86
-
-then85:                                           ; preds = %loop.end83
-  store i32 1, i32* %array_bound84, align 4
-  br label %ifcont91
-
-else86:                                           ; preds = %loop.end83
-  br i1 false, label %then87, label %else88
-
-then87:                                           ; preds = %else86
-  store i32 1, i32* %array_bound84, align 4
-  br label %ifcont91
-
-else88:                                           ; preds = %else86
-  br i1 false, label %then89, label %else90
-
-then89:                                           ; preds = %else88
-  store i32 1, i32* %array_bound84, align 4
-  br label %ifcont91
-
-else90:                                           ; preds = %else88
-  br label %ifcont91
-
-ifcont91:                                         ; preds = %else90, %then89, %then87, %then85
-  %118 = load i32, i32* %array_bound84, align 4
-  store i32 %118, i32* %__1_v, align 4
-  br i1 true, label %then93, label %else94
-
-then93:                                           ; preds = %ifcont91
-  store i32 1, i32* %array_bound92, align 4
-  br label %ifcont99
-
-else94:                                           ; preds = %ifcont91
-  br i1 false, label %then95, label %else96
-
-then95:                                           ; preds = %else94
-  store i32 1, i32* %array_bound92, align 4
-  br label %ifcont99
-
-else96:                                           ; preds = %else94
-  br i1 false, label %then97, label %else98
-
-then97:                                           ; preds = %else96
-  store i32 1, i32* %array_bound92, align 4
-  br label %ifcont99
-
-else98:                                           ; preds = %else96
-  br label %ifcont99
-
-ifcont99:                                         ; preds = %else98, %then97, %then95, %then93
-  %119 = load i32, i32* %array_bound92, align 4
-  %120 = sub i32 %119, 1
-  store i32 %120, i32* %__1_t, align 4
-  br label %loop.head100
-
-loop.head100:                                     ; preds = %loop.end163, %ifcont99
-  %121 = load i32, i32* %__1_t, align 4
-  %122 = add i32 %121, 1
-  br i1 true, label %then102, label %else103
-
-then102:                                          ; preds = %loop.head100
-  store i32 2, i32* %array_bound101, align 4
-  br label %ifcont108
-
-else103:                                          ; preds = %loop.head100
-  br i1 false, label %then104, label %else105
-
-then104:                                          ; preds = %else103
-  store i32 2, i32* %array_bound101, align 4
-  br label %ifcont108
-
-else105:                                          ; preds = %else103
-  br i1 false, label %then106, label %else107
-
-then106:                                          ; preds = %else105
-  store i32 1, i32* %array_bound101, align 4
-  br label %ifcont108
-
-else107:                                          ; preds = %else105
-  br label %ifcont108
-
-ifcont108:                                        ; preds = %else107, %then106, %then104, %then102
-  %123 = load i32, i32* %array_bound101, align 4
-  %124 = icmp sle i32 %122, %123
-  br i1 %124, label %loop.body109, label %loop.end164
-
-loop.body109:                                     ; preds = %ifcont108
-  %125 = load i32, i32* %__1_t, align 4
-  %126 = add i32 %125, 1
-  store i32 %126, i32* %__1_t, align 4
-  br i1 true, label %then111, label %else112
-
-then111:                                          ; preds = %loop.body109
-  store i32 1, i32* %array_bound110, align 4
-  br label %ifcont117
-
-else112:                                          ; preds = %loop.body109
-  br i1 false, label %then113, label %else114
-
-then113:                                          ; preds = %else112
-  store i32 1, i32* %array_bound110, align 4
-  br label %ifcont117
-
-else114:                                          ; preds = %else112
-  br i1 false, label %then115, label %else116
-
-then115:                                          ; preds = %else114
-  store i32 1, i32* %array_bound110, align 4
-  br label %ifcont117
-
-else116:                                          ; preds = %else114
-  br label %ifcont117
-
-ifcont117:                                        ; preds = %else116, %then115, %then113, %then111
-  %127 = load i32, i32* %array_bound110, align 4
-  store i32 %127, i32* %__2_v, align 4
-  br i1 false, label %then119, label %else120
-
-then119:                                          ; preds = %ifcont117
-  store i32 1, i32* %array_bound118, align 4
-  br label %ifcont125
-
-else120:                                          ; preds = %ifcont117
-  br i1 true, label %then121, label %else122
-
-then121:                                          ; preds = %else120
-  store i32 1, i32* %array_bound118, align 4
-  br label %ifcont125
-
-else122:                                          ; preds = %else120
-  br i1 false, label %then123, label %else124
-
-then123:                                          ; preds = %else122
-  store i32 1, i32* %array_bound118, align 4
-  br label %ifcont125
-
-else124:                                          ; preds = %else122
-  br label %ifcont125
-
-ifcont125:                                        ; preds = %else124, %then123, %then121, %then119
-  %128 = load i32, i32* %array_bound118, align 4
-  %129 = sub i32 %128, 1
-  store i32 %129, i32* %__2_t, align 4
-  br label %loop.head126
-
-loop.head126:                                     ; preds = %loop.end162, %ifcont125
-  %130 = load i32, i32* %__2_t, align 4
-  %131 = add i32 %130, 1
-  br i1 false, label %then128, label %else129
-
-then128:                                          ; preds = %loop.head126
-  store i32 2, i32* %array_bound127, align 4
-  br label %ifcont134
-
-else129:                                          ; preds = %loop.head126
-  br i1 true, label %then130, label %else131
-
-then130:                                          ; preds = %else129
-  store i32 2, i32* %array_bound127, align 4
-  br label %ifcont134
-
-else131:                                          ; preds = %else129
-  br i1 false, label %then132, label %else133
-
-then132:                                          ; preds = %else131
-  store i32 1, i32* %array_bound127, align 4
-  br label %ifcont134
-
-else133:                                          ; preds = %else131
-  br label %ifcont134
-
-ifcont134:                                        ; preds = %else133, %then132, %then130, %then128
-  %132 = load i32, i32* %array_bound127, align 4
-  %133 = icmp sle i32 %131, %132
-  br i1 %133, label %loop.body135, label %loop.end163
-
-loop.body135:                                     ; preds = %ifcont134
-  %134 = load i32, i32* %__2_t, align 4
-  %135 = add i32 %134, 1
-  store i32 %135, i32* %__2_t, align 4
-  br i1 false, label %then137, label %else138
-
-then137:                                          ; preds = %loop.body135
-  store i32 1, i32* %array_bound136, align 4
-  br label %ifcont143
-
-else138:                                          ; preds = %loop.body135
-  br i1 true, label %then139, label %else140
-
-then139:                                          ; preds = %else138
-  store i32 1, i32* %array_bound136, align 4
-  br label %ifcont143
-
-else140:                                          ; preds = %else138
-  br i1 false, label %then141, label %else142
-
-then141:                                          ; preds = %else140
-  store i32 1, i32* %array_bound136, align 4
-  br label %ifcont143
-
-else142:                                          ; preds = %else140
-  br label %ifcont143
-
-ifcont143:                                        ; preds = %else142, %then141, %then139, %then137
-  %136 = load i32, i32* %array_bound136, align 4
-  store i32 %136, i32* %__3_v, align 4
-  br i1 false, label %then145, label %else146
-
-then145:                                          ; preds = %ifcont143
-  store i32 1, i32* %array_bound144, align 4
-  br label %ifcont151
-
-else146:                                          ; preds = %ifcont143
-  br i1 false, label %then147, label %else148
-
-then147:                                          ; preds = %else146
-  store i32 1, i32* %array_bound144, align 4
-  br label %ifcont151
-
-else148:                                          ; preds = %else146
-  br i1 true, label %then149, label %else150
-
-then149:                                          ; preds = %else148
-  store i32 1, i32* %array_bound144, align 4
-  br label %ifcont151
-
-else150:                                          ; preds = %else148
-  br label %ifcont151
-
-ifcont151:                                        ; preds = %else150, %then149, %then147, %then145
-  %137 = load i32, i32* %array_bound144, align 4
-  %138 = sub i32 %137, 1
-  store i32 %138, i32* %__3_t, align 4
-  br label %loop.head152
-
-loop.head152:                                     ; preds = %loop.body161, %ifcont151
-  %139 = load i32, i32* %__3_t, align 4
-  %140 = add i32 %139, 1
-  br i1 false, label %then154, label %else155
-
-then154:                                          ; preds = %loop.head152
-  store i32 2, i32* %array_bound153, align 4
-  br label %ifcont160
-
-else155:                                          ; preds = %loop.head152
-  br i1 false, label %then156, label %else157
-
-then156:                                          ; preds = %else155
-  store i32 2, i32* %array_bound153, align 4
-  br label %ifcont160
-
-else157:                                          ; preds = %else155
-  br i1 true, label %then158, label %else159
-
-then158:                                          ; preds = %else157
-  store i32 1, i32* %array_bound153, align 4
-  br label %ifcont160
-
-else159:                                          ; preds = %else157
-  br label %ifcont160
-
-ifcont160:                                        ; preds = %else159, %then158, %then156, %then154
-  %141 = load i32, i32* %array_bound153, align 4
-  %142 = icmp sle i32 %140, %141
-  br i1 %142, label %loop.body161, label %loop.end162
-
-loop.body161:                                     ; preds = %ifcont160
-  %143 = load i32, i32* %__3_t, align 4
-  %144 = add i32 %143, 1
-  store i32 %144, i32* %__3_t, align 4
-  %145 = load i32, i32* %__1_t, align 4
-  %146 = load i32, i32* %__2_t, align 4
-  %147 = load i32, i32* %__3_t, align 4
-  %148 = sub i32 %145, 1
-  %149 = mul i32 1, %148
-  %150 = add i32 0, %149
-  %151 = sub i32 %146, 1
-  %152 = mul i32 2, %151
-  %153 = add i32 %150, %152
-  %154 = sub i32 %147, 1
-  %155 = mul i32 4, %154
-  %156 = add i32 %153, %155
-  %157 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__1__implicit_cast_res, i32 0, i32 %156
-  %158 = load i32, i32* %__1_v, align 4
-  %159 = load i32, i32* %__2_v, align 4
-  %160 = load i32, i32* %__3_v, align 4
-  %161 = sub i32 %158, 1
-  %162 = mul i32 1, %161
-  %163 = add i32 0, %162
-  %164 = sub i32 %159, 1
-  %165 = mul i32 2, %164
-  %166 = add i32 %163, %165
-  %167 = sub i32 %160, 1
-  %168 = mul i32 4, %167
-  %169 = add i32 %166, %168
-  %170 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %169
-  %171 = load i32, i32* %170, align 4
-  %172 = sitofp i32 %171 to float
-  %173 = alloca %complex_4, align 8
-  %174 = getelementptr %complex_4, %complex_4* %173, i32 0, i32 0
-  %175 = getelementptr %complex_4, %complex_4* %173, i32 0, i32 1
-  store float %172, float* %174, align 4
-  store float 0.000000e+00, float* %175, align 4
-  %176 = load %complex_4, %complex_4* %173, align 4
-  store %complex_4 %176, %complex_4* %157, align 4
-  %177 = load i32, i32* %__3_v, align 4
-  %178 = add i32 %177, 1
-  store i32 %178, i32* %__3_v, align 4
-  br label %loop.head152
-
-loop.end162:                                      ; preds = %ifcont160
-  %179 = load i32, i32* %__2_v, align 4
-  %180 = add i32 %179, 1
-  store i32 %180, i32* %__2_v, align 4
-  br label %loop.head126
-
-loop.end163:                                      ; preds = %ifcont134
-  %181 = load i32, i32* %__1_v, align 4
-  %182 = add i32 %181, 1
-  store i32 %182, i32* %__1_v, align 4
-  br label %loop.head100
-
-loop.end164:                                      ; preds = %ifcont108
-  %183 = alloca %complex_4, align 8
-  %184 = getelementptr %complex_4, %complex_4* %183, i32 0, i32 0
-  %185 = getelementptr %complex_4, %complex_4* %183, i32 0, i32 1
-  store float 0.000000e+00, float* %184, align 4
-  store float 1.000000e+00, float* %185, align 4
-  %186 = load %complex_4, %complex_4* %183, align 4
-  store %complex_4 %186, %complex_4* %__libasr_created_scalar_auxiliary_variable, align 4
-  br i1 true, label %then166, label %else167
-
-then166:                                          ; preds = %loop.end164
-  store i32 1, i32* %array_bound165, align 4
-  br label %ifcont172
-
-else167:                                          ; preds = %loop.end164
-  br i1 false, label %then168, label %else169
-
-then168:                                          ; preds = %else167
-  store i32 1, i32* %array_bound165, align 4
-  br label %ifcont172
-
-else169:                                          ; preds = %else167
-  br i1 false, label %then170, label %else171
-
-then170:                                          ; preds = %else169
-  store i32 1, i32* %array_bound165, align 4
-  br label %ifcont172
-
-else171:                                          ; preds = %else169
-  br label %ifcont172
-
-ifcont172:                                        ; preds = %else171, %then170, %then168, %then166
-  %187 = load i32, i32* %array_bound165, align 4
-  store i32 %187, i32* %__1_v, align 4
-  br i1 true, label %then174, label %else175
-
-then174:                                          ; preds = %ifcont172
-  store i32 1, i32* %array_bound173, align 4
-  br label %ifcont180
-
-else175:                                          ; preds = %ifcont172
-  br i1 false, label %then176, label %else177
-
-then176:                                          ; preds = %else175
-  store i32 1, i32* %array_bound173, align 4
-  br label %ifcont180
-
-else177:                                          ; preds = %else175
-  br i1 false, label %then178, label %else179
-
-then178:                                          ; preds = %else177
-  store i32 1, i32* %array_bound173, align 4
-  br label %ifcont180
-
-else179:                                          ; preds = %else177
-  br label %ifcont180
-
-ifcont180:                                        ; preds = %else179, %then178, %then176, %then174
-  %188 = load i32, i32* %array_bound173, align 4
-  %189 = sub i32 %188, 1
-  store i32 %189, i32* %__1_t, align 4
-  br label %loop.head181
-
-loop.head181:                                     ; preds = %loop.end244, %ifcont180
-  %190 = load i32, i32* %__1_t, align 4
-  %191 = add i32 %190, 1
-  br i1 true, label %then183, label %else184
-
-then183:                                          ; preds = %loop.head181
-  store i32 2, i32* %array_bound182, align 4
-  br label %ifcont189
-
-else184:                                          ; preds = %loop.head181
-  br i1 false, label %then185, label %else186
-
-then185:                                          ; preds = %else184
-  store i32 2, i32* %array_bound182, align 4
-  br label %ifcont189
-
-else186:                                          ; preds = %else184
-  br i1 false, label %then187, label %else188
-
-then187:                                          ; preds = %else186
-  store i32 1, i32* %array_bound182, align 4
-  br label %ifcont189
-
-else188:                                          ; preds = %else186
-  br label %ifcont189
-
-ifcont189:                                        ; preds = %else188, %then187, %then185, %then183
-  %192 = load i32, i32* %array_bound182, align 4
-  %193 = icmp sle i32 %191, %192
-  br i1 %193, label %loop.body190, label %loop.end245
-
-loop.body190:                                     ; preds = %ifcont189
-  %194 = load i32, i32* %__1_t, align 4
-  %195 = add i32 %194, 1
-  store i32 %195, i32* %__1_t, align 4
-  br i1 false, label %then192, label %else193
-
-then192:                                          ; preds = %loop.body190
-  store i32 1, i32* %array_bound191, align 4
-  br label %ifcont198
-
-else193:                                          ; preds = %loop.body190
-  br i1 true, label %then194, label %else195
-
-then194:                                          ; preds = %else193
-  store i32 1, i32* %array_bound191, align 4
-  br label %ifcont198
-
-else195:                                          ; preds = %else193
-  br i1 false, label %then196, label %else197
-
-then196:                                          ; preds = %else195
-  store i32 1, i32* %array_bound191, align 4
-  br label %ifcont198
-
-else197:                                          ; preds = %else195
-  br label %ifcont198
-
-ifcont198:                                        ; preds = %else197, %then196, %then194, %then192
-  %196 = load i32, i32* %array_bound191, align 4
-  store i32 %196, i32* %__2_v, align 4
-  br i1 false, label %then200, label %else201
-
-then200:                                          ; preds = %ifcont198
-  store i32 1, i32* %array_bound199, align 4
-  br label %ifcont206
-
-else201:                                          ; preds = %ifcont198
-  br i1 true, label %then202, label %else203
-
-then202:                                          ; preds = %else201
-  store i32 1, i32* %array_bound199, align 4
-  br label %ifcont206
-
-else203:                                          ; preds = %else201
-  br i1 false, label %then204, label %else205
-
-then204:                                          ; preds = %else203
-  store i32 1, i32* %array_bound199, align 4
-  br label %ifcont206
-
-else205:                                          ; preds = %else203
-  br label %ifcont206
-
-ifcont206:                                        ; preds = %else205, %then204, %then202, %then200
-  %197 = load i32, i32* %array_bound199, align 4
-  %198 = sub i32 %197, 1
-  store i32 %198, i32* %__2_t, align 4
-  br label %loop.head207
-
-loop.head207:                                     ; preds = %loop.end243, %ifcont206
-  %199 = load i32, i32* %__2_t, align 4
-  %200 = add i32 %199, 1
-  br i1 false, label %then209, label %else210
-
-then209:                                          ; preds = %loop.head207
-  store i32 2, i32* %array_bound208, align 4
-  br label %ifcont215
-
-else210:                                          ; preds = %loop.head207
-  br i1 true, label %then211, label %else212
-
-then211:                                          ; preds = %else210
-  store i32 2, i32* %array_bound208, align 4
-  br label %ifcont215
-
-else212:                                          ; preds = %else210
-  br i1 false, label %then213, label %else214
-
-then213:                                          ; preds = %else212
-  store i32 1, i32* %array_bound208, align 4
-  br label %ifcont215
-
-else214:                                          ; preds = %else212
-  br label %ifcont215
-
-ifcont215:                                        ; preds = %else214, %then213, %then211, %then209
-  %201 = load i32, i32* %array_bound208, align 4
-  %202 = icmp sle i32 %200, %201
-  br i1 %202, label %loop.body216, label %loop.end244
-
-loop.body216:                                     ; preds = %ifcont215
-  %203 = load i32, i32* %__2_t, align 4
-  %204 = add i32 %203, 1
-  store i32 %204, i32* %__2_t, align 4
-  br i1 false, label %then218, label %else219
-
-then218:                                          ; preds = %loop.body216
-  store i32 1, i32* %array_bound217, align 4
-  br label %ifcont224
-
-else219:                                          ; preds = %loop.body216
-  br i1 false, label %then220, label %else221
-
-then220:                                          ; preds = %else219
-  store i32 1, i32* %array_bound217, align 4
-  br label %ifcont224
-
-else221:                                          ; preds = %else219
-  br i1 true, label %then222, label %else223
-
-then222:                                          ; preds = %else221
-  store i32 1, i32* %array_bound217, align 4
-  br label %ifcont224
-
-else223:                                          ; preds = %else221
-  br label %ifcont224
-
-ifcont224:                                        ; preds = %else223, %then222, %then220, %then218
-  %205 = load i32, i32* %array_bound217, align 4
-  store i32 %205, i32* %__3_v, align 4
-  br i1 false, label %then226, label %else227
-
-then226:                                          ; preds = %ifcont224
-  store i32 1, i32* %array_bound225, align 4
-  br label %ifcont232
-
-else227:                                          ; preds = %ifcont224
-  br i1 false, label %then228, label %else229
-
-then228:                                          ; preds = %else227
-  store i32 1, i32* %array_bound225, align 4
-  br label %ifcont232
-
-else229:                                          ; preds = %else227
-  br i1 true, label %then230, label %else231
-
-then230:                                          ; preds = %else229
-  store i32 1, i32* %array_bound225, align 4
-  br label %ifcont232
-
-else231:                                          ; preds = %else229
-  br label %ifcont232
-
-ifcont232:                                        ; preds = %else231, %then230, %then228, %then226
-  %206 = load i32, i32* %array_bound225, align 4
-  %207 = sub i32 %206, 1
-  store i32 %207, i32* %__3_t, align 4
-  br label %loop.head233
-
-loop.head233:                                     ; preds = %loop.body242, %ifcont232
-  %208 = load i32, i32* %__3_t, align 4
-  %209 = add i32 %208, 1
-  br i1 false, label %then235, label %else236
-
-then235:                                          ; preds = %loop.head233
-  store i32 2, i32* %array_bound234, align 4
-  br label %ifcont241
-
-else236:                                          ; preds = %loop.head233
-  br i1 false, label %then237, label %else238
-
-then237:                                          ; preds = %else236
-  store i32 2, i32* %array_bound234, align 4
-  br label %ifcont241
-
-else238:                                          ; preds = %else236
-  br i1 true, label %then239, label %else240
-
-then239:                                          ; preds = %else238
-  store i32 1, i32* %array_bound234, align 4
-  br label %ifcont241
-
-else240:                                          ; preds = %else238
-  br label %ifcont241
-
-ifcont241:                                        ; preds = %else240, %then239, %then237, %then235
-  %210 = load i32, i32* %array_bound234, align 4
-  %211 = icmp sle i32 %209, %210
-  br i1 %211, label %loop.body242, label %loop.end243
-
-loop.body242:                                     ; preds = %ifcont241
-  %212 = load i32, i32* %__3_t, align 4
-  %213 = add i32 %212, 1
-  store i32 %213, i32* %__3_t, align 4
-  %214 = load i32, i32* %__1_t, align 4
-  %215 = load i32, i32* %__2_t, align 4
-  %216 = load i32, i32* %__3_t, align 4
-  %217 = sub i32 %214, 1
-  %218 = mul i32 1, %217
-  %219 = add i32 0, %218
-  %220 = sub i32 %215, 1
-  %221 = mul i32 2, %220
-  %222 = add i32 %219, %221
-  %223 = sub i32 %216, 1
-  %224 = mul i32 4, %223
-  %225 = add i32 %222, %224
-  %226 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__2__complex_bin_op_res, i32 0, i32 %225
-  %227 = load %complex_4, %complex_4* %__libasr_created_scalar_auxiliary_variable, align 4
-  %228 = load i32, i32* %__1_v, align 4
-  %229 = load i32, i32* %__2_v, align 4
-  %230 = load i32, i32* %__3_v, align 4
-  %231 = sub i32 %228, 1
-  %232 = mul i32 1, %231
-  %233 = add i32 0, %232
-  %234 = sub i32 %229, 1
-  %235 = mul i32 2, %234
-  %236 = add i32 %233, %235
-  %237 = sub i32 %230, 1
-  %238 = mul i32 4, %237
-  %239 = add i32 %236, %238
-  %240 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__1__implicit_cast_res, i32 0, i32 %239
-  %241 = load %complex_4, %complex_4* %240, align 4
-  %242 = alloca %complex_4, align 8
-  store %complex_4 %227, %complex_4* %242, align 4
-  %243 = alloca %complex_4, align 8
-  store %complex_4 %241, %complex_4* %243, align 4
-  %244 = alloca %complex_4, align 8
-  call void @_lfortran_complex_mul_32(%complex_4* %242, %complex_4* %243, %complex_4* %244)
-  %245 = load %complex_4, %complex_4* %244, align 4
-  store %complex_4 %245, %complex_4* %226, align 4
-  %246 = load i32, i32* %__3_v, align 4
-  %247 = add i32 %246, 1
-  store i32 %247, i32* %__3_v, align 4
-  br label %loop.head233
-
-loop.end243:                                      ; preds = %ifcont241
-  %248 = load i32, i32* %__2_v, align 4
-  %249 = add i32 %248, 1
-  store i32 %249, i32* %__2_v, align 4
-  br label %loop.head207
-
-loop.end244:                                      ; preds = %ifcont215
-  %250 = load i32, i32* %__1_v, align 4
-  %251 = add i32 %250, 1
-  store i32 %251, i32* %__1_v, align 4
-  br label %loop.head181
-
-loop.end245:                                      ; preds = %ifcont189
-  br i1 true, label %then247, label %else248
-
-then247:                                          ; preds = %loop.end245
-  store i32 1, i32* %array_bound246, align 4
-  br label %ifcont253
-
-else248:                                          ; preds = %loop.end245
-  br i1 false, label %then249, label %else250
-
-then249:                                          ; preds = %else248
-  store i32 1, i32* %array_bound246, align 4
-  br label %ifcont253
-
-else250:                                          ; preds = %else248
-  br i1 false, label %then251, label %else252
-
-then251:                                          ; preds = %else250
-  store i32 1, i32* %array_bound246, align 4
-  br label %ifcont253
-
-else252:                                          ; preds = %else250
-  br label %ifcont253
-
-ifcont253:                                        ; preds = %else252, %then251, %then249, %then247
-  %252 = load i32, i32* %array_bound246, align 4
-  store i32 %252, i32* %__1_v, align 4
-  br i1 true, label %then255, label %else256
-
-then255:                                          ; preds = %ifcont253
-  store i32 1, i32* %array_bound254, align 4
-  br label %ifcont261
-
-else256:                                          ; preds = %ifcont253
-  br i1 false, label %then257, label %else258
-
-then257:                                          ; preds = %else256
-  store i32 1, i32* %array_bound254, align 4
-  br label %ifcont261
-
-else258:                                          ; preds = %else256
-  br i1 false, label %then259, label %else260
-
-then259:                                          ; preds = %else258
-  store i32 1, i32* %array_bound254, align 4
-  br label %ifcont261
-
-else260:                                          ; preds = %else258
-  br label %ifcont261
-
-ifcont261:                                        ; preds = %else260, %then259, %then257, %then255
-  %253 = load i32, i32* %array_bound254, align 4
-  store i32 %253, i32* %__1_u, align 4
-  br i1 true, label %then263, label %else264
-
-then263:                                          ; preds = %ifcont261
-  store i32 1, i32* %array_bound262, align 4
-  br label %ifcont269
-
-else264:                                          ; preds = %ifcont261
-  br i1 false, label %then265, label %else266
-
-then265:                                          ; preds = %else264
-  store i32 1, i32* %array_bound262, align 4
-  br label %ifcont269
-
-else266:                                          ; preds = %else264
-  br i1 false, label %then267, label %else268
-
-then267:                                          ; preds = %else266
-  store i32 1, i32* %array_bound262, align 4
-  br label %ifcont269
-
-else268:                                          ; preds = %else266
-  br label %ifcont269
-
-ifcont269:                                        ; preds = %else268, %then267, %then265, %then263
-  %254 = load i32, i32* %array_bound262, align 4
-  %255 = sub i32 %254, 1
-  store i32 %255, i32* %__1_t, align 4
-  br label %loop.head270
-
-loop.head270:                                     ; preds = %loop.end349, %ifcont269
-  %256 = load i32, i32* %__1_t, align 4
-  %257 = add i32 %256, 1
-  br i1 true, label %then272, label %else273
-
-then272:                                          ; preds = %loop.head270
-  store i32 2, i32* %array_bound271, align 4
-  br label %ifcont278
-
-else273:                                          ; preds = %loop.head270
-  br i1 false, label %then274, label %else275
-
-then274:                                          ; preds = %else273
-  store i32 2, i32* %array_bound271, align 4
-  br label %ifcont278
-
-else275:                                          ; preds = %else273
-  br i1 false, label %then276, label %else277
-
-then276:                                          ; preds = %else275
-  store i32 1, i32* %array_bound271, align 4
-  br label %ifcont278
-
-else277:                                          ; preds = %else275
-  br label %ifcont278
-
-ifcont278:                                        ; preds = %else277, %then276, %then274, %then272
-  %258 = load i32, i32* %array_bound271, align 4
-  %259 = icmp sle i32 %257, %258
-  br i1 %259, label %loop.body279, label %loop.end350
-
-loop.body279:                                     ; preds = %ifcont278
-  %260 = load i32, i32* %__1_t, align 4
-  %261 = add i32 %260, 1
-  store i32 %261, i32* %__1_t, align 4
-  br i1 true, label %then281, label %else282
-
-then281:                                          ; preds = %loop.body279
-  store i32 1, i32* %array_bound280, align 4
-  br label %ifcont287
-
-else282:                                          ; preds = %loop.body279
-  br i1 false, label %then283, label %else284
-
-then283:                                          ; preds = %else282
-  store i32 1, i32* %array_bound280, align 4
-  br label %ifcont287
-
-else284:                                          ; preds = %else282
-  br i1 false, label %then285, label %else286
-
-then285:                                          ; preds = %else284
-  store i32 1, i32* %array_bound280, align 4
-  br label %ifcont287
-
-else286:                                          ; preds = %else284
-  br label %ifcont287
-
-ifcont287:                                        ; preds = %else286, %then285, %then283, %then281
-  %262 = load i32, i32* %array_bound280, align 4
-  store i32 %262, i32* %__2_v, align 4
-  br i1 true, label %then289, label %else290
-
-then289:                                          ; preds = %ifcont287
-  store i32 1, i32* %array_bound288, align 4
-  br label %ifcont295
-
-else290:                                          ; preds = %ifcont287
-  br i1 false, label %then291, label %else292
-
-then291:                                          ; preds = %else290
-  store i32 1, i32* %array_bound288, align 4
-  br label %ifcont295
-
-else292:                                          ; preds = %else290
-  br i1 false, label %then293, label %else294
-
-then293:                                          ; preds = %else292
-  store i32 1, i32* %array_bound288, align 4
-  br label %ifcont295
-
-else294:                                          ; preds = %else292
-  br label %ifcont295
-
-ifcont295:                                        ; preds = %else294, %then293, %then291, %then289
-  %263 = load i32, i32* %array_bound288, align 4
-  store i32 %263, i32* %__2_u, align 4
-  br i1 false, label %then297, label %else298
-
-then297:                                          ; preds = %ifcont295
-  store i32 1, i32* %array_bound296, align 4
-  br label %ifcont303
-
-else298:                                          ; preds = %ifcont295
-  br i1 true, label %then299, label %else300
-
-then299:                                          ; preds = %else298
-  store i32 1, i32* %array_bound296, align 4
-  br label %ifcont303
-
-else300:                                          ; preds = %else298
-  br i1 false, label %then301, label %else302
-
-then301:                                          ; preds = %else300
-  store i32 1, i32* %array_bound296, align 4
-  br label %ifcont303
-
-else302:                                          ; preds = %else300
-  br label %ifcont303
-
-ifcont303:                                        ; preds = %else302, %then301, %then299, %then297
-  %264 = load i32, i32* %array_bound296, align 4
-  %265 = sub i32 %264, 1
-  store i32 %265, i32* %__2_t, align 4
-  br label %loop.head304
-
-loop.head304:                                     ; preds = %loop.end348, %ifcont303
-  %266 = load i32, i32* %__2_t, align 4
-  %267 = add i32 %266, 1
-  br i1 false, label %then306, label %else307
-
-then306:                                          ; preds = %loop.head304
-  store i32 2, i32* %array_bound305, align 4
-  br label %ifcont312
-
-else307:                                          ; preds = %loop.head304
-  br i1 true, label %then308, label %else309
-
-then308:                                          ; preds = %else307
-  store i32 2, i32* %array_bound305, align 4
-  br label %ifcont312
-
-else309:                                          ; preds = %else307
-  br i1 false, label %then310, label %else311
-
-then310:                                          ; preds = %else309
-  store i32 1, i32* %array_bound305, align 4
-  br label %ifcont312
-
-else311:                                          ; preds = %else309
-  br label %ifcont312
-
-ifcont312:                                        ; preds = %else311, %then310, %then308, %then306
-  %268 = load i32, i32* %array_bound305, align 4
-  %269 = icmp sle i32 %267, %268
-  br i1 %269, label %loop.body313, label %loop.end349
-
-loop.body313:                                     ; preds = %ifcont312
-  %270 = load i32, i32* %__2_t, align 4
-  %271 = add i32 %270, 1
-  store i32 %271, i32* %__2_t, align 4
-  br i1 false, label %then315, label %else316
-
-then315:                                          ; preds = %loop.body313
-  store i32 1, i32* %array_bound314, align 4
-  br label %ifcont321
-
-else316:                                          ; preds = %loop.body313
-  br i1 true, label %then317, label %else318
-
-then317:                                          ; preds = %else316
-  store i32 1, i32* %array_bound314, align 4
-  br label %ifcont321
-
-else318:                                          ; preds = %else316
-  br i1 false, label %then319, label %else320
-
-then319:                                          ; preds = %else318
-  store i32 1, i32* %array_bound314, align 4
-  br label %ifcont321
-
-else320:                                          ; preds = %else318
-  br label %ifcont321
-
-ifcont321:                                        ; preds = %else320, %then319, %then317, %then315
-  %272 = load i32, i32* %array_bound314, align 4
-  store i32 %272, i32* %__3_v, align 4
-  br i1 false, label %then323, label %else324
-
-then323:                                          ; preds = %ifcont321
-  store i32 1, i32* %array_bound322, align 4
-  br label %ifcont329
-
-else324:                                          ; preds = %ifcont321
-  br i1 true, label %then325, label %else326
-
-then325:                                          ; preds = %else324
-  store i32 1, i32* %array_bound322, align 4
-  br label %ifcont329
-
-else326:                                          ; preds = %else324
-  br i1 false, label %then327, label %else328
-
-then327:                                          ; preds = %else326
-  store i32 1, i32* %array_bound322, align 4
-  br label %ifcont329
-
-else328:                                          ; preds = %else326
-  br label %ifcont329
-
-ifcont329:                                        ; preds = %else328, %then327, %then325, %then323
-  %273 = load i32, i32* %array_bound322, align 4
-  store i32 %273, i32* %__3_u, align 4
-  br i1 false, label %then331, label %else332
-
-then331:                                          ; preds = %ifcont329
-  store i32 1, i32* %array_bound330, align 4
-  br label %ifcont337
-
-else332:                                          ; preds = %ifcont329
-  br i1 false, label %then333, label %else334
-
-then333:                                          ; preds = %else332
-  store i32 1, i32* %array_bound330, align 4
-  br label %ifcont337
-
-else334:                                          ; preds = %else332
-  br i1 true, label %then335, label %else336
-
-then335:                                          ; preds = %else334
-  store i32 1, i32* %array_bound330, align 4
-  br label %ifcont337
-
-else336:                                          ; preds = %else334
-  br label %ifcont337
-
-ifcont337:                                        ; preds = %else336, %then335, %then333, %then331
-  %274 = load i32, i32* %array_bound330, align 4
-  %275 = sub i32 %274, 1
-  store i32 %275, i32* %__3_t, align 4
-  br label %loop.head338
-
-loop.head338:                                     ; preds = %loop.body347, %ifcont337
-  %276 = load i32, i32* %__3_t, align 4
-  %277 = add i32 %276, 1
-  br i1 false, label %then340, label %else341
-
-then340:                                          ; preds = %loop.head338
-  store i32 2, i32* %array_bound339, align 4
-  br label %ifcont346
-
-else341:                                          ; preds = %loop.head338
-  br i1 false, label %then342, label %else343
-
-then342:                                          ; preds = %else341
-  store i32 2, i32* %array_bound339, align 4
-  br label %ifcont346
-
-else343:                                          ; preds = %else341
-  br i1 true, label %then344, label %else345
-
-then344:                                          ; preds = %else343
-  store i32 1, i32* %array_bound339, align 4
-  br label %ifcont346
-
-else345:                                          ; preds = %else343
-  br label %ifcont346
-
-ifcont346:                                        ; preds = %else345, %then344, %then342, %then340
-  %278 = load i32, i32* %array_bound339, align 4
-  %279 = icmp sle i32 %277, %278
-  br i1 %279, label %loop.body347, label %loop.end348
-
-loop.body347:                                     ; preds = %ifcont346
-  %280 = load i32, i32* %__3_t, align 4
-  %281 = add i32 %280, 1
-  store i32 %281, i32* %__3_t, align 4
-  %282 = load i32, i32* %__1_t, align 4
-  %283 = load i32, i32* %__2_t, align 4
-  %284 = load i32, i32* %__3_t, align 4
-  %285 = sub i32 %282, 1
-  %286 = mul i32 1, %285
-  %287 = add i32 0, %286
-  %288 = sub i32 %283, 1
-  %289 = mul i32 2, %288
-  %290 = add i32 %287, %289
-  %291 = sub i32 %284, 1
-  %292 = mul i32 4, %291
-  %293 = add i32 %290, %292
-  %294 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 %293
-  %295 = load i32, i32* %__1_v, align 4
-  %296 = load i32, i32* %__2_v, align 4
-  %297 = load i32, i32* %__3_v, align 4
-  %298 = sub i32 %295, 1
-  %299 = mul i32 1, %298
-  %300 = add i32 0, %299
-  %301 = sub i32 %296, 1
-  %302 = mul i32 2, %301
-  %303 = add i32 %300, %302
-  %304 = sub i32 %297, 1
-  %305 = mul i32 4, %304
-  %306 = add i32 %303, %305
-  %307 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__0__implicit_cast_res, i32 0, i32 %306
-  %308 = load %complex_4, %complex_4* %307, align 4
-  %309 = load i32, i32* %__1_u, align 4
-  %310 = load i32, i32* %__2_u, align 4
-  %311 = load i32, i32* %__3_u, align 4
-  %312 = sub i32 %309, 1
-  %313 = mul i32 1, %312
-  %314 = add i32 0, %313
-  %315 = sub i32 %310, 1
-  %316 = mul i32 2, %315
-  %317 = add i32 %314, %316
-  %318 = sub i32 %311, 1
-  %319 = mul i32 4, %318
-  %320 = add i32 %317, %319
-  %321 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__2__complex_bin_op_res, i32 0, i32 %320
-  %322 = load %complex_4, %complex_4* %321, align 4
-  %323 = alloca %complex_4, align 8
-  store %complex_4 %308, %complex_4* %323, align 4
-  %324 = alloca %complex_4, align 8
-  store %complex_4 %322, %complex_4* %324, align 4
-  %325 = alloca %complex_4, align 8
-  call void @_lfortran_complex_add_32(%complex_4* %323, %complex_4* %324, %complex_4* %325)
-  %326 = load %complex_4, %complex_4* %325, align 4
-  store %complex_4 %326, %complex_4* %294, align 4
-  %327 = load i32, i32* %__3_v, align 4
-  %328 = add i32 %327, 1
-  store i32 %328, i32* %__3_v, align 4
-  %329 = load i32, i32* %__3_u, align 4
-  %330 = add i32 %329, 1
-  store i32 %330, i32* %__3_u, align 4
-  br label %loop.head338
-
-loop.end348:                                      ; preds = %ifcont346
-  %331 = load i32, i32* %__2_v, align 4
-  %332 = add i32 %331, 1
-  store i32 %332, i32* %__2_v, align 4
-  %333 = load i32, i32* %__2_u, align 4
-  %334 = add i32 %333, 1
-  store i32 %334, i32* %__2_u, align 4
-  br label %loop.head304
-
-loop.end349:                                      ; preds = %ifcont312
-  %335 = load i32, i32* %__1_v, align 4
-  %336 = add i32 %335, 1
-  store i32 %336, i32* %__1_v, align 4
-  %337 = load i32, i32* %__1_u, align 4
-  %338 = add i32 %337, 1
-  store i32 %338, i32* %__1_u, align 4
-  br label %loop.head270
-
-loop.end350:                                      ; preds = %ifcont278
-  %339 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 0
-  store i32 1, i32* %call_arg_value, align 4
-  store i32 2, i32* %call_arg_value351, align 4
-  store i32 1, i32* %call_arg_value352, align 4
-  store i32 2, i32* %call_arg_value353, align 4
-  store i32 1, i32* %call_arg_value354, align 4
-  store i32 1, i32* %call_arg_value355, align 4
-  store i32 0, i32* %call_arg_value356, align 4
-  call void @check_complex__________0(%complex_4* %339, i32* %call_arg_value, i32* %call_arg_value351, i32* %call_arg_value352, i32* %call_arg_value353, i32* %call_arg_value354, i32* %call_arg_value355, i32* %call_arg_value356)
-  br i1 true, label %then358, label %else359
-
-then358:                                          ; preds = %loop.end350
-  store i32 1, i32* %array_bound357, align 4
-  br label %ifcont364
-
-else359:                                          ; preds = %loop.end350
-  br i1 false, label %then360, label %else361
-
-then360:                                          ; preds = %else359
-  store i32 1, i32* %array_bound357, align 4
-  br label %ifcont364
-
-else361:                                          ; preds = %else359
-  br i1 false, label %then362, label %else363
-
-then362:                                          ; preds = %else361
-  store i32 1, i32* %array_bound357, align 4
-  br label %ifcont364
-
-else363:                                          ; preds = %else361
-  br label %ifcont364
-
-ifcont364:                                        ; preds = %else363, %then362, %then360, %then358
-  %340 = load i32, i32* %array_bound357, align 4
-  store i32 %340, i32* %__1_v, align 4
-  br i1 true, label %then366, label %else367
-
-then366:                                          ; preds = %ifcont364
-  store i32 1, i32* %array_bound365, align 4
-  br label %ifcont372
-
-else367:                                          ; preds = %ifcont364
-  br i1 false, label %then368, label %else369
-
-then368:                                          ; preds = %else367
-  store i32 1, i32* %array_bound365, align 4
-  br label %ifcont372
-
-else369:                                          ; preds = %else367
-  br i1 false, label %then370, label %else371
-
-then370:                                          ; preds = %else369
-  store i32 1, i32* %array_bound365, align 4
-  br label %ifcont372
-
-else371:                                          ; preds = %else369
-  br label %ifcont372
-
-ifcont372:                                        ; preds = %else371, %then370, %then368, %then366
-  %341 = load i32, i32* %array_bound365, align 4
-  %342 = sub i32 %341, 1
-  store i32 %342, i32* %__1_t, align 4
-  br label %loop.head373
-
-loop.head373:                                     ; preds = %loop.end436, %ifcont372
-  %343 = load i32, i32* %__1_t, align 4
-  %344 = add i32 %343, 1
-  br i1 true, label %then375, label %else376
-
-then375:                                          ; preds = %loop.head373
-  store i32 2, i32* %array_bound374, align 4
-  br label %ifcont381
-
-else376:                                          ; preds = %loop.head373
-  br i1 false, label %then377, label %else378
-
-then377:                                          ; preds = %else376
-  store i32 2, i32* %array_bound374, align 4
-  br label %ifcont381
-
-else378:                                          ; preds = %else376
-  br i1 false, label %then379, label %else380
-
-then379:                                          ; preds = %else378
-  store i32 1, i32* %array_bound374, align 4
-  br label %ifcont381
-
-else380:                                          ; preds = %else378
-  br label %ifcont381
-
-ifcont381:                                        ; preds = %else380, %then379, %then377, %then375
-  %345 = load i32, i32* %array_bound374, align 4
-  %346 = icmp sle i32 %344, %345
-  br i1 %346, label %loop.body382, label %loop.end437
-
-loop.body382:                                     ; preds = %ifcont381
-  %347 = load i32, i32* %__1_t, align 4
-  %348 = add i32 %347, 1
-  store i32 %348, i32* %__1_t, align 4
-  br i1 true, label %then384, label %else385
-
-then384:                                          ; preds = %loop.body382
-  store i32 1, i32* %array_bound383, align 4
-  br label %ifcont390
-
-else385:                                          ; preds = %loop.body382
-  br i1 false, label %then386, label %else387
-
-then386:                                          ; preds = %else385
-  store i32 1, i32* %array_bound383, align 4
-  br label %ifcont390
-
-else387:                                          ; preds = %else385
-  br i1 false, label %then388, label %else389
-
-then388:                                          ; preds = %else387
-  store i32 1, i32* %array_bound383, align 4
-  br label %ifcont390
-
-else389:                                          ; preds = %else387
-  br label %ifcont390
-
-ifcont390:                                        ; preds = %else389, %then388, %then386, %then384
-  %349 = load i32, i32* %array_bound383, align 4
-  store i32 %349, i32* %__2_v, align 4
-  br i1 false, label %then392, label %else393
-
-then392:                                          ; preds = %ifcont390
-  store i32 1, i32* %array_bound391, align 4
-  br label %ifcont398
-
-else393:                                          ; preds = %ifcont390
-  br i1 true, label %then394, label %else395
-
-then394:                                          ; preds = %else393
-  store i32 1, i32* %array_bound391, align 4
-  br label %ifcont398
-
-else395:                                          ; preds = %else393
-  br i1 false, label %then396, label %else397
-
-then396:                                          ; preds = %else395
-  store i32 1, i32* %array_bound391, align 4
-  br label %ifcont398
-
-else397:                                          ; preds = %else395
-  br label %ifcont398
-
-ifcont398:                                        ; preds = %else397, %then396, %then394, %then392
-  %350 = load i32, i32* %array_bound391, align 4
-  %351 = sub i32 %350, 1
-  store i32 %351, i32* %__2_t, align 4
-  br label %loop.head399
-
-loop.head399:                                     ; preds = %loop.end435, %ifcont398
-  %352 = load i32, i32* %__2_t, align 4
-  %353 = add i32 %352, 1
-  br i1 false, label %then401, label %else402
-
-then401:                                          ; preds = %loop.head399
-  store i32 2, i32* %array_bound400, align 4
-  br label %ifcont407
-
-else402:                                          ; preds = %loop.head399
-  br i1 true, label %then403, label %else404
-
-then403:                                          ; preds = %else402
-  store i32 2, i32* %array_bound400, align 4
-  br label %ifcont407
-
-else404:                                          ; preds = %else402
-  br i1 false, label %then405, label %else406
-
-then405:                                          ; preds = %else404
-  store i32 1, i32* %array_bound400, align 4
-  br label %ifcont407
-
-else406:                                          ; preds = %else404
-  br label %ifcont407
-
-ifcont407:                                        ; preds = %else406, %then405, %then403, %then401
-  %354 = load i32, i32* %array_bound400, align 4
-  %355 = icmp sle i32 %353, %354
-  br i1 %355, label %loop.body408, label %loop.end436
-
-loop.body408:                                     ; preds = %ifcont407
-  %356 = load i32, i32* %__2_t, align 4
-  %357 = add i32 %356, 1
-  store i32 %357, i32* %__2_t, align 4
-  br i1 false, label %then410, label %else411
-
-then410:                                          ; preds = %loop.body408
-  store i32 1, i32* %array_bound409, align 4
-  br label %ifcont416
-
-else411:                                          ; preds = %loop.body408
-  br i1 true, label %then412, label %else413
-
-then412:                                          ; preds = %else411
-  store i32 1, i32* %array_bound409, align 4
-  br label %ifcont416
-
-else413:                                          ; preds = %else411
-  br i1 false, label %then414, label %else415
-
-then414:                                          ; preds = %else413
-  store i32 1, i32* %array_bound409, align 4
-  br label %ifcont416
-
-else415:                                          ; preds = %else413
-  br label %ifcont416
-
-ifcont416:                                        ; preds = %else415, %then414, %then412, %then410
-  %358 = load i32, i32* %array_bound409, align 4
-  store i32 %358, i32* %__3_v, align 4
-  br i1 false, label %then418, label %else419
-
-then418:                                          ; preds = %ifcont416
-  store i32 1, i32* %array_bound417, align 4
-  br label %ifcont424
-
-else419:                                          ; preds = %ifcont416
-  br i1 false, label %then420, label %else421
-
-then420:                                          ; preds = %else419
-  store i32 1, i32* %array_bound417, align 4
-  br label %ifcont424
-
-else421:                                          ; preds = %else419
-  br i1 true, label %then422, label %else423
-
-then422:                                          ; preds = %else421
-  store i32 1, i32* %array_bound417, align 4
-  br label %ifcont424
-
-else423:                                          ; preds = %else421
-  br label %ifcont424
-
-ifcont424:                                        ; preds = %else423, %then422, %then420, %then418
-  %359 = load i32, i32* %array_bound417, align 4
-  %360 = sub i32 %359, 1
-  store i32 %360, i32* %__3_t, align 4
-  br label %loop.head425
-
-loop.head425:                                     ; preds = %loop.body434, %ifcont424
-  %361 = load i32, i32* %__3_t, align 4
-  %362 = add i32 %361, 1
-  br i1 false, label %then427, label %else428
-
-then427:                                          ; preds = %loop.head425
-  store i32 2, i32* %array_bound426, align 4
-  br label %ifcont433
-
-else428:                                          ; preds = %loop.head425
-  br i1 false, label %then429, label %else430
-
-then429:                                          ; preds = %else428
-  store i32 2, i32* %array_bound426, align 4
-  br label %ifcont433
-
-else430:                                          ; preds = %else428
-  br i1 true, label %then431, label %else432
-
-then431:                                          ; preds = %else430
-  store i32 1, i32* %array_bound426, align 4
-  br label %ifcont433
-
-else432:                                          ; preds = %else430
-  br label %ifcont433
-
-ifcont433:                                        ; preds = %else432, %then431, %then429, %then427
-  %363 = load i32, i32* %array_bound426, align 4
-  %364 = icmp sle i32 %362, %363
-  br i1 %364, label %loop.body434, label %loop.end435
-
-loop.body434:                                     ; preds = %ifcont433
-  %365 = load i32, i32* %__3_t, align 4
-  %366 = add i32 %365, 1
-  store i32 %366, i32* %__3_t, align 4
-  %367 = load i32, i32* %__1_t, align 4
-  %368 = load i32, i32* %__2_t, align 4
-  %369 = load i32, i32* %__3_t, align 4
-  %370 = sub i32 %367, 1
-  %371 = mul i32 1, %370
-  %372 = add i32 0, %371
-  %373 = sub i32 %368, 1
-  %374 = mul i32 2, %373
-  %375 = add i32 %372, %374
-  %376 = sub i32 %369, 1
-  %377 = mul i32 4, %376
-  %378 = add i32 %375, %377
-  %379 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__3__integer_unary_op_res, i32 0, i32 %378
-  %380 = load i32, i32* %__1_v, align 4
-  %381 = load i32, i32* %__2_v, align 4
-  %382 = load i32, i32* %__3_v, align 4
-  %383 = sub i32 %380, 1
-  %384 = mul i32 1, %383
-  %385 = add i32 0, %384
-  %386 = sub i32 %381, 1
-  %387 = mul i32 2, %386
-  %388 = add i32 %385, %387
-  %389 = sub i32 %382, 1
-  %390 = mul i32 4, %389
-  %391 = add i32 %388, %390
-  %392 = getelementptr [4 x i32], [4 x i32]* %a, i32 0, i32 %391
-  %393 = load i32, i32* %392, align 4
-  %394 = sub i32 0, %393
-  store i32 %394, i32* %379, align 4
-  %395 = load i32, i32* %__3_v, align 4
-  %396 = add i32 %395, 1
-  store i32 %396, i32* %__3_v, align 4
-  br label %loop.head425
-
-loop.end435:                                      ; preds = %ifcont433
-  %397 = load i32, i32* %__2_v, align 4
-  %398 = add i32 %397, 1
-  store i32 %398, i32* %__2_v, align 4
-  br label %loop.head399
-
-loop.end436:                                      ; preds = %ifcont407
-  %399 = load i32, i32* %__1_v, align 4
-  %400 = add i32 %399, 1
-  store i32 %400, i32* %__1_v, align 4
-  br label %loop.head373
-
-loop.end437:                                      ; preds = %ifcont381
-  br i1 true, label %then439, label %else440
-
-then439:                                          ; preds = %loop.end437
-  store i32 1, i32* %array_bound438, align 4
-  br label %ifcont445
-
-else440:                                          ; preds = %loop.end437
-  br i1 false, label %then441, label %else442
-
-then441:                                          ; preds = %else440
-  store i32 1, i32* %array_bound438, align 4
-  br label %ifcont445
-
-else442:                                          ; preds = %else440
-  br i1 false, label %then443, label %else444
-
-then443:                                          ; preds = %else442
-  store i32 1, i32* %array_bound438, align 4
-  br label %ifcont445
-
-else444:                                          ; preds = %else442
-  br label %ifcont445
-
-ifcont445:                                        ; preds = %else444, %then443, %then441, %then439
-  %401 = load i32, i32* %array_bound438, align 4
-  store i32 %401, i32* %__1_v, align 4
-  br i1 true, label %then447, label %else448
-
-then447:                                          ; preds = %ifcont445
-  store i32 1, i32* %array_bound446, align 4
-  br label %ifcont453
-
-else448:                                          ; preds = %ifcont445
-  br i1 false, label %then449, label %else450
-
-then449:                                          ; preds = %else448
-  store i32 1, i32* %array_bound446, align 4
-  br label %ifcont453
-
-else450:                                          ; preds = %else448
-  br i1 false, label %then451, label %else452
-
-then451:                                          ; preds = %else450
-  store i32 1, i32* %array_bound446, align 4
-  br label %ifcont453
-
-else452:                                          ; preds = %else450
-  br label %ifcont453
-
-ifcont453:                                        ; preds = %else452, %then451, %then449, %then447
-  %402 = load i32, i32* %array_bound446, align 4
-  %403 = sub i32 %402, 1
-  store i32 %403, i32* %__1_t, align 4
-  br label %loop.head454
-
-loop.head454:                                     ; preds = %loop.end517, %ifcont453
-  %404 = load i32, i32* %__1_t, align 4
-  %405 = add i32 %404, 1
-  br i1 true, label %then456, label %else457
-
-then456:                                          ; preds = %loop.head454
-  store i32 2, i32* %array_bound455, align 4
-  br label %ifcont462
-
-else457:                                          ; preds = %loop.head454
-  br i1 false, label %then458, label %else459
-
-then458:                                          ; preds = %else457
-  store i32 2, i32* %array_bound455, align 4
-  br label %ifcont462
-
-else459:                                          ; preds = %else457
-  br i1 false, label %then460, label %else461
-
-then460:                                          ; preds = %else459
-  store i32 1, i32* %array_bound455, align 4
-  br label %ifcont462
-
-else461:                                          ; preds = %else459
-  br label %ifcont462
-
-ifcont462:                                        ; preds = %else461, %then460, %then458, %then456
-  %406 = load i32, i32* %array_bound455, align 4
-  %407 = icmp sle i32 %405, %406
-  br i1 %407, label %loop.body463, label %loop.end518
-
-loop.body463:                                     ; preds = %ifcont462
-  %408 = load i32, i32* %__1_t, align 4
-  %409 = add i32 %408, 1
-  store i32 %409, i32* %__1_t, align 4
-  br i1 true, label %then465, label %else466
-
-then465:                                          ; preds = %loop.body463
-  store i32 1, i32* %array_bound464, align 4
-  br label %ifcont471
-
-else466:                                          ; preds = %loop.body463
-  br i1 false, label %then467, label %else468
-
-then467:                                          ; preds = %else466
-  store i32 1, i32* %array_bound464, align 4
-  br label %ifcont471
-
-else468:                                          ; preds = %else466
-  br i1 false, label %then469, label %else470
-
-then469:                                          ; preds = %else468
-  store i32 1, i32* %array_bound464, align 4
-  br label %ifcont471
-
-else470:                                          ; preds = %else468
-  br label %ifcont471
-
-ifcont471:                                        ; preds = %else470, %then469, %then467, %then465
-  %410 = load i32, i32* %array_bound464, align 4
-  store i32 %410, i32* %__2_v, align 4
-  br i1 false, label %then473, label %else474
-
-then473:                                          ; preds = %ifcont471
-  store i32 1, i32* %array_bound472, align 4
-  br label %ifcont479
-
-else474:                                          ; preds = %ifcont471
-  br i1 true, label %then475, label %else476
-
-then475:                                          ; preds = %else474
-  store i32 1, i32* %array_bound472, align 4
-  br label %ifcont479
-
-else476:                                          ; preds = %else474
-  br i1 false, label %then477, label %else478
-
-then477:                                          ; preds = %else476
-  store i32 1, i32* %array_bound472, align 4
-  br label %ifcont479
-
-else478:                                          ; preds = %else476
-  br label %ifcont479
-
-ifcont479:                                        ; preds = %else478, %then477, %then475, %then473
-  %411 = load i32, i32* %array_bound472, align 4
-  %412 = sub i32 %411, 1
-  store i32 %412, i32* %__2_t, align 4
-  br label %loop.head480
-
-loop.head480:                                     ; preds = %loop.end516, %ifcont479
-  %413 = load i32, i32* %__2_t, align 4
-  %414 = add i32 %413, 1
-  br i1 false, label %then482, label %else483
-
-then482:                                          ; preds = %loop.head480
-  store i32 2, i32* %array_bound481, align 4
-  br label %ifcont488
-
-else483:                                          ; preds = %loop.head480
-  br i1 true, label %then484, label %else485
-
-then484:                                          ; preds = %else483
-  store i32 2, i32* %array_bound481, align 4
-  br label %ifcont488
-
-else485:                                          ; preds = %else483
-  br i1 false, label %then486, label %else487
-
-then486:                                          ; preds = %else485
-  store i32 1, i32* %array_bound481, align 4
-  br label %ifcont488
-
-else487:                                          ; preds = %else485
-  br label %ifcont488
-
-ifcont488:                                        ; preds = %else487, %then486, %then484, %then482
-  %415 = load i32, i32* %array_bound481, align 4
-  %416 = icmp sle i32 %414, %415
-  br i1 %416, label %loop.body489, label %loop.end517
-
-loop.body489:                                     ; preds = %ifcont488
-  %417 = load i32, i32* %__2_t, align 4
-  %418 = add i32 %417, 1
-  store i32 %418, i32* %__2_t, align 4
-  br i1 false, label %then491, label %else492
-
-then491:                                          ; preds = %loop.body489
-  store i32 1, i32* %array_bound490, align 4
-  br label %ifcont497
-
-else492:                                          ; preds = %loop.body489
-  br i1 true, label %then493, label %else494
-
-then493:                                          ; preds = %else492
-  store i32 1, i32* %array_bound490, align 4
-  br label %ifcont497
-
-else494:                                          ; preds = %else492
-  br i1 false, label %then495, label %else496
-
-then495:                                          ; preds = %else494
-  store i32 1, i32* %array_bound490, align 4
-  br label %ifcont497
-
-else496:                                          ; preds = %else494
-  br label %ifcont497
-
-ifcont497:                                        ; preds = %else496, %then495, %then493, %then491
-  %419 = load i32, i32* %array_bound490, align 4
-  store i32 %419, i32* %__3_v, align 4
-  br i1 false, label %then499, label %else500
-
-then499:                                          ; preds = %ifcont497
-  store i32 1, i32* %array_bound498, align 4
-  br label %ifcont505
-
-else500:                                          ; preds = %ifcont497
-  br i1 false, label %then501, label %else502
-
-then501:                                          ; preds = %else500
-  store i32 1, i32* %array_bound498, align 4
-  br label %ifcont505
-
-else502:                                          ; preds = %else500
-  br i1 true, label %then503, label %else504
-
-then503:                                          ; preds = %else502
-  store i32 1, i32* %array_bound498, align 4
-  br label %ifcont505
-
-else504:                                          ; preds = %else502
-  br label %ifcont505
-
-ifcont505:                                        ; preds = %else504, %then503, %then501, %then499
-  %420 = load i32, i32* %array_bound498, align 4
-  %421 = sub i32 %420, 1
-  store i32 %421, i32* %__3_t, align 4
-  br label %loop.head506
-
-loop.head506:                                     ; preds = %loop.body515, %ifcont505
-  %422 = load i32, i32* %__3_t, align 4
-  %423 = add i32 %422, 1
-  br i1 false, label %then508, label %else509
-
-then508:                                          ; preds = %loop.head506
-  store i32 2, i32* %array_bound507, align 4
-  br label %ifcont514
-
-else509:                                          ; preds = %loop.head506
-  br i1 false, label %then510, label %else511
-
-then510:                                          ; preds = %else509
-  store i32 2, i32* %array_bound507, align 4
-  br label %ifcont514
-
-else511:                                          ; preds = %else509
-  br i1 true, label %then512, label %else513
-
-then512:                                          ; preds = %else511
-  store i32 1, i32* %array_bound507, align 4
-  br label %ifcont514
-
-else513:                                          ; preds = %else511
-  br label %ifcont514
-
-ifcont514:                                        ; preds = %else513, %then512, %then510, %then508
-  %424 = load i32, i32* %array_bound507, align 4
-  %425 = icmp sle i32 %423, %424
-  br i1 %425, label %loop.body515, label %loop.end516
-
-loop.body515:                                     ; preds = %ifcont514
-  %426 = load i32, i32* %__3_t, align 4
-  %427 = add i32 %426, 1
-  store i32 %427, i32* %__3_t, align 4
-  %428 = load i32, i32* %__1_t, align 4
-  %429 = load i32, i32* %__2_t, align 4
-  %430 = load i32, i32* %__3_t, align 4
-  %431 = sub i32 %428, 1
-  %432 = mul i32 1, %431
-  %433 = add i32 0, %432
-  %434 = sub i32 %429, 1
-  %435 = mul i32 2, %434
-  %436 = add i32 %433, %435
-  %437 = sub i32 %430, 1
-  %438 = mul i32 4, %437
-  %439 = add i32 %436, %438
-  %440 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__4__implicit_cast_res, i32 0, i32 %439
-  %441 = load i32, i32* %__1_v, align 4
-  %442 = load i32, i32* %__2_v, align 4
-  %443 = load i32, i32* %__3_v, align 4
-  %444 = sub i32 %441, 1
-  %445 = mul i32 1, %444
-  %446 = add i32 0, %445
-  %447 = sub i32 %442, 1
-  %448 = mul i32 2, %447
-  %449 = add i32 %446, %448
-  %450 = sub i32 %443, 1
-  %451 = mul i32 4, %450
-  %452 = add i32 %449, %451
-  %453 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__3__integer_unary_op_res, i32 0, i32 %452
-  %454 = load i32, i32* %453, align 4
-  %455 = sitofp i32 %454 to float
-  %456 = alloca %complex_4, align 8
-  %457 = getelementptr %complex_4, %complex_4* %456, i32 0, i32 0
-  %458 = getelementptr %complex_4, %complex_4* %456, i32 0, i32 1
-  store float %455, float* %457, align 4
-  store float 0.000000e+00, float* %458, align 4
-  %459 = load %complex_4, %complex_4* %456, align 4
-  store %complex_4 %459, %complex_4* %440, align 4
-  %460 = load i32, i32* %__3_v, align 4
-  %461 = add i32 %460, 1
-  store i32 %461, i32* %__3_v, align 4
-  br label %loop.head506
-
-loop.end516:                                      ; preds = %ifcont514
-  %462 = load i32, i32* %__2_v, align 4
-  %463 = add i32 %462, 1
-  store i32 %463, i32* %__2_v, align 4
-  br label %loop.head480
-
-loop.end517:                                      ; preds = %ifcont488
-  %464 = load i32, i32* %__1_v, align 4
-  %465 = add i32 %464, 1
-  store i32 %465, i32* %__1_v, align 4
-  br label %loop.head454
-
-loop.end518:                                      ; preds = %ifcont462
-  br i1 true, label %then520, label %else521
-
-then520:                                          ; preds = %loop.end518
-  store i32 1, i32* %array_bound519, align 4
-  br label %ifcont526
-
-else521:                                          ; preds = %loop.end518
-  br i1 false, label %then522, label %else523
-
-then522:                                          ; preds = %else521
-  store i32 1, i32* %array_bound519, align 4
-  br label %ifcont526
-
-else523:                                          ; preds = %else521
-  br i1 false, label %then524, label %else525
-
-then524:                                          ; preds = %else523
-  store i32 1, i32* %array_bound519, align 4
-  br label %ifcont526
-
-else525:                                          ; preds = %else523
-  br label %ifcont526
-
-ifcont526:                                        ; preds = %else525, %then524, %then522, %then520
-  %466 = load i32, i32* %array_bound519, align 4
-  store i32 %466, i32* %__1_v, align 4
-  br i1 true, label %then528, label %else529
-
-then528:                                          ; preds = %ifcont526
-  store i32 1, i32* %array_bound527, align 4
-  br label %ifcont534
-
-else529:                                          ; preds = %ifcont526
-  br i1 false, label %then530, label %else531
-
-then530:                                          ; preds = %else529
-  store i32 1, i32* %array_bound527, align 4
-  br label %ifcont534
-
-else531:                                          ; preds = %else529
-  br i1 false, label %then532, label %else533
-
-then532:                                          ; preds = %else531
-  store i32 1, i32* %array_bound527, align 4
-  br label %ifcont534
-
-else533:                                          ; preds = %else531
-  br label %ifcont534
-
-ifcont534:                                        ; preds = %else533, %then532, %then530, %then528
-  %467 = load i32, i32* %array_bound527, align 4
-  %468 = sub i32 %467, 1
-  store i32 %468, i32* %__1_t, align 4
-  br label %loop.head535
-
-loop.head535:                                     ; preds = %loop.end598, %ifcont534
-  %469 = load i32, i32* %__1_t, align 4
-  %470 = add i32 %469, 1
-  br i1 true, label %then537, label %else538
-
-then537:                                          ; preds = %loop.head535
-  store i32 2, i32* %array_bound536, align 4
-  br label %ifcont543
-
-else538:                                          ; preds = %loop.head535
-  br i1 false, label %then539, label %else540
-
-then539:                                          ; preds = %else538
-  store i32 2, i32* %array_bound536, align 4
-  br label %ifcont543
-
-else540:                                          ; preds = %else538
-  br i1 false, label %then541, label %else542
-
-then541:                                          ; preds = %else540
-  store i32 1, i32* %array_bound536, align 4
-  br label %ifcont543
-
-else542:                                          ; preds = %else540
-  br label %ifcont543
-
-ifcont543:                                        ; preds = %else542, %then541, %then539, %then537
-  %471 = load i32, i32* %array_bound536, align 4
-  %472 = icmp sle i32 %470, %471
-  br i1 %472, label %loop.body544, label %loop.end599
-
-loop.body544:                                     ; preds = %ifcont543
-  %473 = load i32, i32* %__1_t, align 4
-  %474 = add i32 %473, 1
-  store i32 %474, i32* %__1_t, align 4
-  br i1 true, label %then546, label %else547
-
-then546:                                          ; preds = %loop.body544
-  store i32 1, i32* %array_bound545, align 4
-  br label %ifcont552
-
-else547:                                          ; preds = %loop.body544
-  br i1 false, label %then548, label %else549
-
-then548:                                          ; preds = %else547
-  store i32 1, i32* %array_bound545, align 4
-  br label %ifcont552
-
-else549:                                          ; preds = %else547
-  br i1 false, label %then550, label %else551
-
-then550:                                          ; preds = %else549
-  store i32 1, i32* %array_bound545, align 4
-  br label %ifcont552
-
-else551:                                          ; preds = %else549
-  br label %ifcont552
-
-ifcont552:                                        ; preds = %else551, %then550, %then548, %then546
-  %475 = load i32, i32* %array_bound545, align 4
-  store i32 %475, i32* %__2_v, align 4
-  br i1 false, label %then554, label %else555
-
-then554:                                          ; preds = %ifcont552
-  store i32 1, i32* %array_bound553, align 4
-  br label %ifcont560
-
-else555:                                          ; preds = %ifcont552
-  br i1 true, label %then556, label %else557
-
-then556:                                          ; preds = %else555
-  store i32 1, i32* %array_bound553, align 4
-  br label %ifcont560
-
-else557:                                          ; preds = %else555
-  br i1 false, label %then558, label %else559
-
-then558:                                          ; preds = %else557
-  store i32 1, i32* %array_bound553, align 4
-  br label %ifcont560
-
-else559:                                          ; preds = %else557
-  br label %ifcont560
-
-ifcont560:                                        ; preds = %else559, %then558, %then556, %then554
-  %476 = load i32, i32* %array_bound553, align 4
-  %477 = sub i32 %476, 1
-  store i32 %477, i32* %__2_t, align 4
-  br label %loop.head561
-
-loop.head561:                                     ; preds = %loop.end597, %ifcont560
-  %478 = load i32, i32* %__2_t, align 4
-  %479 = add i32 %478, 1
-  br i1 false, label %then563, label %else564
-
-then563:                                          ; preds = %loop.head561
-  store i32 2, i32* %array_bound562, align 4
-  br label %ifcont569
-
-else564:                                          ; preds = %loop.head561
-  br i1 true, label %then565, label %else566
-
-then565:                                          ; preds = %else564
-  store i32 2, i32* %array_bound562, align 4
-  br label %ifcont569
-
-else566:                                          ; preds = %else564
-  br i1 false, label %then567, label %else568
-
-then567:                                          ; preds = %else566
-  store i32 1, i32* %array_bound562, align 4
-  br label %ifcont569
-
-else568:                                          ; preds = %else566
-  br label %ifcont569
-
-ifcont569:                                        ; preds = %else568, %then567, %then565, %then563
-  %480 = load i32, i32* %array_bound562, align 4
-  %481 = icmp sle i32 %479, %480
-  br i1 %481, label %loop.body570, label %loop.end598
-
-loop.body570:                                     ; preds = %ifcont569
-  %482 = load i32, i32* %__2_t, align 4
-  %483 = add i32 %482, 1
-  store i32 %483, i32* %__2_t, align 4
-  br i1 false, label %then572, label %else573
-
-then572:                                          ; preds = %loop.body570
-  store i32 1, i32* %array_bound571, align 4
-  br label %ifcont578
-
-else573:                                          ; preds = %loop.body570
-  br i1 true, label %then574, label %else575
-
-then574:                                          ; preds = %else573
-  store i32 1, i32* %array_bound571, align 4
-  br label %ifcont578
-
-else575:                                          ; preds = %else573
-  br i1 false, label %then576, label %else577
-
-then576:                                          ; preds = %else575
-  store i32 1, i32* %array_bound571, align 4
-  br label %ifcont578
-
-else577:                                          ; preds = %else575
-  br label %ifcont578
-
-ifcont578:                                        ; preds = %else577, %then576, %then574, %then572
-  %484 = load i32, i32* %array_bound571, align 4
-  store i32 %484, i32* %__3_v, align 4
-  br i1 false, label %then580, label %else581
-
-then580:                                          ; preds = %ifcont578
-  store i32 1, i32* %array_bound579, align 4
-  br label %ifcont586
-
-else581:                                          ; preds = %ifcont578
-  br i1 false, label %then582, label %else583
-
-then582:                                          ; preds = %else581
-  store i32 1, i32* %array_bound579, align 4
-  br label %ifcont586
-
-else583:                                          ; preds = %else581
-  br i1 true, label %then584, label %else585
-
-then584:                                          ; preds = %else583
-  store i32 1, i32* %array_bound579, align 4
-  br label %ifcont586
-
-else585:                                          ; preds = %else583
-  br label %ifcont586
-
-ifcont586:                                        ; preds = %else585, %then584, %then582, %then580
-  %485 = load i32, i32* %array_bound579, align 4
-  %486 = sub i32 %485, 1
-  store i32 %486, i32* %__3_t, align 4
-  br label %loop.head587
-
-loop.head587:                                     ; preds = %loop.body596, %ifcont586
-  %487 = load i32, i32* %__3_t, align 4
-  %488 = add i32 %487, 1
-  br i1 false, label %then589, label %else590
-
-then589:                                          ; preds = %loop.head587
-  store i32 2, i32* %array_bound588, align 4
-  br label %ifcont595
-
-else590:                                          ; preds = %loop.head587
-  br i1 false, label %then591, label %else592
-
-then591:                                          ; preds = %else590
-  store i32 2, i32* %array_bound588, align 4
-  br label %ifcont595
-
-else592:                                          ; preds = %else590
-  br i1 true, label %then593, label %else594
-
-then593:                                          ; preds = %else592
-  store i32 1, i32* %array_bound588, align 4
-  br label %ifcont595
-
-else594:                                          ; preds = %else592
-  br label %ifcont595
-
-ifcont595:                                        ; preds = %else594, %then593, %then591, %then589
-  %489 = load i32, i32* %array_bound588, align 4
-  %490 = icmp sle i32 %488, %489
-  br i1 %490, label %loop.body596, label %loop.end597
-
-loop.body596:                                     ; preds = %ifcont595
-  %491 = load i32, i32* %__3_t, align 4
-  %492 = add i32 %491, 1
-  store i32 %492, i32* %__3_t, align 4
-  %493 = load i32, i32* %__1_t, align 4
-  %494 = load i32, i32* %__2_t, align 4
-  %495 = load i32, i32* %__3_t, align 4
-  %496 = sub i32 %493, 1
-  %497 = mul i32 1, %496
-  %498 = add i32 0, %497
-  %499 = sub i32 %494, 1
-  %500 = mul i32 2, %499
-  %501 = add i32 %498, %500
-  %502 = sub i32 %495, 1
-  %503 = mul i32 4, %502
-  %504 = add i32 %501, %503
-  %505 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__5__integer_unary_op_res, i32 0, i32 %504
-  %506 = load i32, i32* %__1_v, align 4
-  %507 = load i32, i32* %__2_v, align 4
-  %508 = load i32, i32* %__3_v, align 4
-  %509 = sub i32 %506, 1
-  %510 = mul i32 1, %509
-  %511 = add i32 0, %510
-  %512 = sub i32 %507, 1
-  %513 = mul i32 2, %512
-  %514 = add i32 %511, %513
-  %515 = sub i32 %508, 1
-  %516 = mul i32 4, %515
-  %517 = add i32 %514, %516
-  %518 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %517
-  %519 = load i32, i32* %518, align 4
-  %520 = sub i32 0, %519
-  store i32 %520, i32* %505, align 4
-  %521 = load i32, i32* %__3_v, align 4
-  %522 = add i32 %521, 1
-  store i32 %522, i32* %__3_v, align 4
-  br label %loop.head587
-
-loop.end597:                                      ; preds = %ifcont595
-  %523 = load i32, i32* %__2_v, align 4
-  %524 = add i32 %523, 1
-  store i32 %524, i32* %__2_v, align 4
-  br label %loop.head561
-
-loop.end598:                                      ; preds = %ifcont569
-  %525 = load i32, i32* %__1_v, align 4
-  %526 = add i32 %525, 1
-  store i32 %526, i32* %__1_v, align 4
-  br label %loop.head535
-
-loop.end599:                                      ; preds = %ifcont543
-  br i1 true, label %then601, label %else602
-
-then601:                                          ; preds = %loop.end599
-  store i32 1, i32* %array_bound600, align 4
-  br label %ifcont607
-
-else602:                                          ; preds = %loop.end599
-  br i1 false, label %then603, label %else604
-
-then603:                                          ; preds = %else602
-  store i32 1, i32* %array_bound600, align 4
-  br label %ifcont607
-
-else604:                                          ; preds = %else602
-  br i1 false, label %then605, label %else606
-
-then605:                                          ; preds = %else604
-  store i32 1, i32* %array_bound600, align 4
-  br label %ifcont607
-
-else606:                                          ; preds = %else604
-  br label %ifcont607
-
-ifcont607:                                        ; preds = %else606, %then605, %then603, %then601
-  %527 = load i32, i32* %array_bound600, align 4
-  store i32 %527, i32* %__1_v, align 4
-  br i1 true, label %then609, label %else610
-
-then609:                                          ; preds = %ifcont607
-  store i32 1, i32* %array_bound608, align 4
-  br label %ifcont615
-
-else610:                                          ; preds = %ifcont607
-  br i1 false, label %then611, label %else612
-
-then611:                                          ; preds = %else610
-  store i32 1, i32* %array_bound608, align 4
-  br label %ifcont615
-
-else612:                                          ; preds = %else610
-  br i1 false, label %then613, label %else614
-
-then613:                                          ; preds = %else612
-  store i32 1, i32* %array_bound608, align 4
-  br label %ifcont615
-
-else614:                                          ; preds = %else612
-  br label %ifcont615
-
-ifcont615:                                        ; preds = %else614, %then613, %then611, %then609
-  %528 = load i32, i32* %array_bound608, align 4
-  %529 = sub i32 %528, 1
-  store i32 %529, i32* %__1_t, align 4
-  br label %loop.head616
-
-loop.head616:                                     ; preds = %loop.end679, %ifcont615
-  %530 = load i32, i32* %__1_t, align 4
-  %531 = add i32 %530, 1
-  br i1 true, label %then618, label %else619
-
-then618:                                          ; preds = %loop.head616
-  store i32 2, i32* %array_bound617, align 4
-  br label %ifcont624
-
-else619:                                          ; preds = %loop.head616
-  br i1 false, label %then620, label %else621
-
-then620:                                          ; preds = %else619
-  store i32 2, i32* %array_bound617, align 4
-  br label %ifcont624
-
-else621:                                          ; preds = %else619
-  br i1 false, label %then622, label %else623
-
-then622:                                          ; preds = %else621
-  store i32 1, i32* %array_bound617, align 4
-  br label %ifcont624
-
-else623:                                          ; preds = %else621
-  br label %ifcont624
-
-ifcont624:                                        ; preds = %else623, %then622, %then620, %then618
-  %532 = load i32, i32* %array_bound617, align 4
-  %533 = icmp sle i32 %531, %532
-  br i1 %533, label %loop.body625, label %loop.end680
-
-loop.body625:                                     ; preds = %ifcont624
-  %534 = load i32, i32* %__1_t, align 4
-  %535 = add i32 %534, 1
-  store i32 %535, i32* %__1_t, align 4
-  br i1 true, label %then627, label %else628
-
-then627:                                          ; preds = %loop.body625
-  store i32 1, i32* %array_bound626, align 4
-  br label %ifcont633
-
-else628:                                          ; preds = %loop.body625
-  br i1 false, label %then629, label %else630
-
-then629:                                          ; preds = %else628
-  store i32 1, i32* %array_bound626, align 4
-  br label %ifcont633
-
-else630:                                          ; preds = %else628
-  br i1 false, label %then631, label %else632
-
-then631:                                          ; preds = %else630
-  store i32 1, i32* %array_bound626, align 4
-  br label %ifcont633
-
-else632:                                          ; preds = %else630
-  br label %ifcont633
-
-ifcont633:                                        ; preds = %else632, %then631, %then629, %then627
-  %536 = load i32, i32* %array_bound626, align 4
-  store i32 %536, i32* %__2_v, align 4
-  br i1 false, label %then635, label %else636
-
-then635:                                          ; preds = %ifcont633
-  store i32 1, i32* %array_bound634, align 4
-  br label %ifcont641
-
-else636:                                          ; preds = %ifcont633
-  br i1 true, label %then637, label %else638
-
-then637:                                          ; preds = %else636
-  store i32 1, i32* %array_bound634, align 4
-  br label %ifcont641
-
-else638:                                          ; preds = %else636
-  br i1 false, label %then639, label %else640
-
-then639:                                          ; preds = %else638
-  store i32 1, i32* %array_bound634, align 4
-  br label %ifcont641
-
-else640:                                          ; preds = %else638
-  br label %ifcont641
-
-ifcont641:                                        ; preds = %else640, %then639, %then637, %then635
-  %537 = load i32, i32* %array_bound634, align 4
-  %538 = sub i32 %537, 1
-  store i32 %538, i32* %__2_t, align 4
-  br label %loop.head642
-
-loop.head642:                                     ; preds = %loop.end678, %ifcont641
-  %539 = load i32, i32* %__2_t, align 4
-  %540 = add i32 %539, 1
-  br i1 false, label %then644, label %else645
-
-then644:                                          ; preds = %loop.head642
-  store i32 2, i32* %array_bound643, align 4
-  br label %ifcont650
-
-else645:                                          ; preds = %loop.head642
-  br i1 true, label %then646, label %else647
-
-then646:                                          ; preds = %else645
-  store i32 2, i32* %array_bound643, align 4
-  br label %ifcont650
-
-else647:                                          ; preds = %else645
-  br i1 false, label %then648, label %else649
-
-then648:                                          ; preds = %else647
-  store i32 1, i32* %array_bound643, align 4
-  br label %ifcont650
-
-else649:                                          ; preds = %else647
-  br label %ifcont650
-
-ifcont650:                                        ; preds = %else649, %then648, %then646, %then644
-  %541 = load i32, i32* %array_bound643, align 4
-  %542 = icmp sle i32 %540, %541
-  br i1 %542, label %loop.body651, label %loop.end679
-
-loop.body651:                                     ; preds = %ifcont650
-  %543 = load i32, i32* %__2_t, align 4
-  %544 = add i32 %543, 1
-  store i32 %544, i32* %__2_t, align 4
-  br i1 false, label %then653, label %else654
-
-then653:                                          ; preds = %loop.body651
-  store i32 1, i32* %array_bound652, align 4
-  br label %ifcont659
-
-else654:                                          ; preds = %loop.body651
-  br i1 true, label %then655, label %else656
-
-then655:                                          ; preds = %else654
-  store i32 1, i32* %array_bound652, align 4
-  br label %ifcont659
-
-else656:                                          ; preds = %else654
-  br i1 false, label %then657, label %else658
-
-then657:                                          ; preds = %else656
-  store i32 1, i32* %array_bound652, align 4
-  br label %ifcont659
-
-else658:                                          ; preds = %else656
-  br label %ifcont659
-
-ifcont659:                                        ; preds = %else658, %then657, %then655, %then653
-  %545 = load i32, i32* %array_bound652, align 4
-  store i32 %545, i32* %__3_v, align 4
-  br i1 false, label %then661, label %else662
-
-then661:                                          ; preds = %ifcont659
-  store i32 1, i32* %array_bound660, align 4
-  br label %ifcont667
-
-else662:                                          ; preds = %ifcont659
-  br i1 false, label %then663, label %else664
-
-then663:                                          ; preds = %else662
-  store i32 1, i32* %array_bound660, align 4
-  br label %ifcont667
-
-else664:                                          ; preds = %else662
-  br i1 true, label %then665, label %else666
-
-then665:                                          ; preds = %else664
-  store i32 1, i32* %array_bound660, align 4
-  br label %ifcont667
-
-else666:                                          ; preds = %else664
-  br label %ifcont667
-
-ifcont667:                                        ; preds = %else666, %then665, %then663, %then661
-  %546 = load i32, i32* %array_bound660, align 4
-  %547 = sub i32 %546, 1
-  store i32 %547, i32* %__3_t, align 4
-  br label %loop.head668
-
-loop.head668:                                     ; preds = %loop.body677, %ifcont667
-  %548 = load i32, i32* %__3_t, align 4
-  %549 = add i32 %548, 1
-  br i1 false, label %then670, label %else671
-
-then670:                                          ; preds = %loop.head668
-  store i32 2, i32* %array_bound669, align 4
-  br label %ifcont676
-
-else671:                                          ; preds = %loop.head668
-  br i1 false, label %then672, label %else673
-
-then672:                                          ; preds = %else671
-  store i32 2, i32* %array_bound669, align 4
-  br label %ifcont676
-
-else673:                                          ; preds = %else671
-  br i1 true, label %then674, label %else675
-
-then674:                                          ; preds = %else673
-  store i32 1, i32* %array_bound669, align 4
-  br label %ifcont676
-
-else675:                                          ; preds = %else673
-  br label %ifcont676
-
-ifcont676:                                        ; preds = %else675, %then674, %then672, %then670
-  %550 = load i32, i32* %array_bound669, align 4
-  %551 = icmp sle i32 %549, %550
-  br i1 %551, label %loop.body677, label %loop.end678
-
-loop.body677:                                     ; preds = %ifcont676
-  %552 = load i32, i32* %__3_t, align 4
-  %553 = add i32 %552, 1
-  store i32 %553, i32* %__3_t, align 4
-  %554 = load i32, i32* %__1_t, align 4
-  %555 = load i32, i32* %__2_t, align 4
-  %556 = load i32, i32* %__3_t, align 4
-  %557 = sub i32 %554, 1
-  %558 = mul i32 1, %557
-  %559 = add i32 0, %558
-  %560 = sub i32 %555, 1
-  %561 = mul i32 2, %560
-  %562 = add i32 %559, %561
-  %563 = sub i32 %556, 1
-  %564 = mul i32 4, %563
-  %565 = add i32 %562, %564
-  %566 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__6__implicit_cast_res, i32 0, i32 %565
-  %567 = load i32, i32* %__1_v, align 4
-  %568 = load i32, i32* %__2_v, align 4
-  %569 = load i32, i32* %__3_v, align 4
-  %570 = sub i32 %567, 1
-  %571 = mul i32 1, %570
-  %572 = add i32 0, %571
-  %573 = sub i32 %568, 1
-  %574 = mul i32 2, %573
-  %575 = add i32 %572, %574
-  %576 = sub i32 %569, 1
-  %577 = mul i32 4, %576
-  %578 = add i32 %575, %577
-  %579 = getelementptr [4 x i32], [4 x i32]* %__libasr__created__var__5__integer_unary_op_res, i32 0, i32 %578
-  %580 = load i32, i32* %579, align 4
-  %581 = sitofp i32 %580 to float
-  %582 = alloca %complex_4, align 8
-  %583 = getelementptr %complex_4, %complex_4* %582, i32 0, i32 0
-  %584 = getelementptr %complex_4, %complex_4* %582, i32 0, i32 1
-  store float %581, float* %583, align 4
-  store float 0.000000e+00, float* %584, align 4
-  %585 = load %complex_4, %complex_4* %582, align 4
-  store %complex_4 %585, %complex_4* %566, align 4
-  %586 = load i32, i32* %__3_v, align 4
-  %587 = add i32 %586, 1
-  store i32 %587, i32* %__3_v, align 4
-  br label %loop.head668
-
-loop.end678:                                      ; preds = %ifcont676
-  %588 = load i32, i32* %__2_v, align 4
-  %589 = add i32 %588, 1
-  store i32 %589, i32* %__2_v, align 4
-  br label %loop.head642
-
-loop.end679:                                      ; preds = %ifcont650
-  %590 = load i32, i32* %__1_v, align 4
-  %591 = add i32 %590, 1
-  store i32 %591, i32* %__1_v, align 4
-  br label %loop.head616
-
-loop.end680:                                      ; preds = %ifcont624
-  %592 = alloca %complex_4, align 8
-  %593 = getelementptr %complex_4, %complex_4* %592, i32 0, i32 0
-  %594 = getelementptr %complex_4, %complex_4* %592, i32 0, i32 1
-  store float 0.000000e+00, float* %593, align 4
-  store float 1.000000e+00, float* %594, align 4
-  %595 = load %complex_4, %complex_4* %592, align 4
-  store %complex_4 %595, %complex_4* %__libasr_created_scalar_auxiliary_variable1, align 4
-  br i1 true, label %then682, label %else683
-
-then682:                                          ; preds = %loop.end680
-  store i32 1, i32* %array_bound681, align 4
-  br label %ifcont688
-
-else683:                                          ; preds = %loop.end680
-  br i1 false, label %then684, label %else685
-
-then684:                                          ; preds = %else683
-  store i32 1, i32* %array_bound681, align 4
-  br label %ifcont688
-
-else685:                                          ; preds = %else683
-  br i1 false, label %then686, label %else687
-
-then686:                                          ; preds = %else685
-  store i32 1, i32* %array_bound681, align 4
-  br label %ifcont688
-
-else687:                                          ; preds = %else685
-  br label %ifcont688
-
-ifcont688:                                        ; preds = %else687, %then686, %then684, %then682
-  %596 = load i32, i32* %array_bound681, align 4
-  store i32 %596, i32* %__1_v, align 4
-  br i1 true, label %then690, label %else691
-
-then690:                                          ; preds = %ifcont688
-  store i32 1, i32* %array_bound689, align 4
-  br label %ifcont696
-
-else691:                                          ; preds = %ifcont688
-  br i1 false, label %then692, label %else693
-
-then692:                                          ; preds = %else691
-  store i32 1, i32* %array_bound689, align 4
-  br label %ifcont696
-
-else693:                                          ; preds = %else691
-  br i1 false, label %then694, label %else695
-
-then694:                                          ; preds = %else693
-  store i32 1, i32* %array_bound689, align 4
-  br label %ifcont696
-
-else695:                                          ; preds = %else693
-  br label %ifcont696
-
-ifcont696:                                        ; preds = %else695, %then694, %then692, %then690
-  %597 = load i32, i32* %array_bound689, align 4
-  %598 = sub i32 %597, 1
-  store i32 %598, i32* %__1_t, align 4
-  br label %loop.head697
-
-loop.head697:                                     ; preds = %loop.end760, %ifcont696
-  %599 = load i32, i32* %__1_t, align 4
-  %600 = add i32 %599, 1
-  br i1 true, label %then699, label %else700
-
-then699:                                          ; preds = %loop.head697
-  store i32 2, i32* %array_bound698, align 4
-  br label %ifcont705
-
-else700:                                          ; preds = %loop.head697
-  br i1 false, label %then701, label %else702
-
-then701:                                          ; preds = %else700
-  store i32 2, i32* %array_bound698, align 4
-  br label %ifcont705
-
-else702:                                          ; preds = %else700
-  br i1 false, label %then703, label %else704
-
-then703:                                          ; preds = %else702
-  store i32 1, i32* %array_bound698, align 4
-  br label %ifcont705
-
-else704:                                          ; preds = %else702
-  br label %ifcont705
-
-ifcont705:                                        ; preds = %else704, %then703, %then701, %then699
-  %601 = load i32, i32* %array_bound698, align 4
-  %602 = icmp sle i32 %600, %601
-  br i1 %602, label %loop.body706, label %loop.end761
-
-loop.body706:                                     ; preds = %ifcont705
-  %603 = load i32, i32* %__1_t, align 4
-  %604 = add i32 %603, 1
-  store i32 %604, i32* %__1_t, align 4
-  br i1 false, label %then708, label %else709
-
-then708:                                          ; preds = %loop.body706
-  store i32 1, i32* %array_bound707, align 4
-  br label %ifcont714
-
-else709:                                          ; preds = %loop.body706
-  br i1 true, label %then710, label %else711
-
-then710:                                          ; preds = %else709
-  store i32 1, i32* %array_bound707, align 4
-  br label %ifcont714
-
-else711:                                          ; preds = %else709
-  br i1 false, label %then712, label %else713
-
-then712:                                          ; preds = %else711
-  store i32 1, i32* %array_bound707, align 4
-  br label %ifcont714
-
-else713:                                          ; preds = %else711
-  br label %ifcont714
-
-ifcont714:                                        ; preds = %else713, %then712, %then710, %then708
-  %605 = load i32, i32* %array_bound707, align 4
-  store i32 %605, i32* %__2_v, align 4
-  br i1 false, label %then716, label %else717
-
-then716:                                          ; preds = %ifcont714
-  store i32 1, i32* %array_bound715, align 4
-  br label %ifcont722
-
-else717:                                          ; preds = %ifcont714
-  br i1 true, label %then718, label %else719
-
-then718:                                          ; preds = %else717
-  store i32 1, i32* %array_bound715, align 4
-  br label %ifcont722
-
-else719:                                          ; preds = %else717
-  br i1 false, label %then720, label %else721
-
-then720:                                          ; preds = %else719
-  store i32 1, i32* %array_bound715, align 4
-  br label %ifcont722
-
-else721:                                          ; preds = %else719
-  br label %ifcont722
-
-ifcont722:                                        ; preds = %else721, %then720, %then718, %then716
-  %606 = load i32, i32* %array_bound715, align 4
-  %607 = sub i32 %606, 1
-  store i32 %607, i32* %__2_t, align 4
-  br label %loop.head723
-
-loop.head723:                                     ; preds = %loop.end759, %ifcont722
-  %608 = load i32, i32* %__2_t, align 4
-  %609 = add i32 %608, 1
-  br i1 false, label %then725, label %else726
-
-then725:                                          ; preds = %loop.head723
-  store i32 2, i32* %array_bound724, align 4
-  br label %ifcont731
-
-else726:                                          ; preds = %loop.head723
-  br i1 true, label %then727, label %else728
-
-then727:                                          ; preds = %else726
-  store i32 2, i32* %array_bound724, align 4
-  br label %ifcont731
-
-else728:                                          ; preds = %else726
-  br i1 false, label %then729, label %else730
-
-then729:                                          ; preds = %else728
-  store i32 1, i32* %array_bound724, align 4
-  br label %ifcont731
-
-else730:                                          ; preds = %else728
-  br label %ifcont731
-
-ifcont731:                                        ; preds = %else730, %then729, %then727, %then725
-  %610 = load i32, i32* %array_bound724, align 4
-  %611 = icmp sle i32 %609, %610
-  br i1 %611, label %loop.body732, label %loop.end760
-
-loop.body732:                                     ; preds = %ifcont731
-  %612 = load i32, i32* %__2_t, align 4
-  %613 = add i32 %612, 1
-  store i32 %613, i32* %__2_t, align 4
-  br i1 false, label %then734, label %else735
-
-then734:                                          ; preds = %loop.body732
-  store i32 1, i32* %array_bound733, align 4
-  br label %ifcont740
-
-else735:                                          ; preds = %loop.body732
-  br i1 false, label %then736, label %else737
-
-then736:                                          ; preds = %else735
-  store i32 1, i32* %array_bound733, align 4
-  br label %ifcont740
-
-else737:                                          ; preds = %else735
-  br i1 true, label %then738, label %else739
-
-then738:                                          ; preds = %else737
-  store i32 1, i32* %array_bound733, align 4
-  br label %ifcont740
-
-else739:                                          ; preds = %else737
-  br label %ifcont740
-
-ifcont740:                                        ; preds = %else739, %then738, %then736, %then734
-  %614 = load i32, i32* %array_bound733, align 4
-  store i32 %614, i32* %__3_v, align 4
-  br i1 false, label %then742, label %else743
-
-then742:                                          ; preds = %ifcont740
-  store i32 1, i32* %array_bound741, align 4
-  br label %ifcont748
-
-else743:                                          ; preds = %ifcont740
-  br i1 false, label %then744, label %else745
-
-then744:                                          ; preds = %else743
-  store i32 1, i32* %array_bound741, align 4
-  br label %ifcont748
-
-else745:                                          ; preds = %else743
-  br i1 true, label %then746, label %else747
-
-then746:                                          ; preds = %else745
-  store i32 1, i32* %array_bound741, align 4
-  br label %ifcont748
-
-else747:                                          ; preds = %else745
-  br label %ifcont748
-
-ifcont748:                                        ; preds = %else747, %then746, %then744, %then742
-  %615 = load i32, i32* %array_bound741, align 4
-  %616 = sub i32 %615, 1
-  store i32 %616, i32* %__3_t, align 4
-  br label %loop.head749
-
-loop.head749:                                     ; preds = %loop.body758, %ifcont748
-  %617 = load i32, i32* %__3_t, align 4
-  %618 = add i32 %617, 1
-  br i1 false, label %then751, label %else752
-
-then751:                                          ; preds = %loop.head749
-  store i32 2, i32* %array_bound750, align 4
-  br label %ifcont757
-
-else752:                                          ; preds = %loop.head749
-  br i1 false, label %then753, label %else754
-
-then753:                                          ; preds = %else752
-  store i32 2, i32* %array_bound750, align 4
-  br label %ifcont757
-
-else754:                                          ; preds = %else752
-  br i1 true, label %then755, label %else756
-
-then755:                                          ; preds = %else754
-  store i32 1, i32* %array_bound750, align 4
-  br label %ifcont757
-
-else756:                                          ; preds = %else754
-  br label %ifcont757
-
-ifcont757:                                        ; preds = %else756, %then755, %then753, %then751
-  %619 = load i32, i32* %array_bound750, align 4
-  %620 = icmp sle i32 %618, %619
-  br i1 %620, label %loop.body758, label %loop.end759
-
-loop.body758:                                     ; preds = %ifcont757
-  %621 = load i32, i32* %__3_t, align 4
-  %622 = add i32 %621, 1
-  store i32 %622, i32* %__3_t, align 4
-  %623 = load i32, i32* %__1_t, align 4
-  %624 = load i32, i32* %__2_t, align 4
-  %625 = load i32, i32* %__3_t, align 4
-  %626 = sub i32 %623, 1
-  %627 = mul i32 1, %626
-  %628 = add i32 0, %627
-  %629 = sub i32 %624, 1
-  %630 = mul i32 2, %629
-  %631 = add i32 %628, %630
-  %632 = sub i32 %625, 1
-  %633 = mul i32 4, %632
-  %634 = add i32 %631, %633
-  %635 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__7__complex_bin_op_res, i32 0, i32 %634
-  %636 = load %complex_4, %complex_4* %__libasr_created_scalar_auxiliary_variable1, align 4
-  %637 = load i32, i32* %__1_v, align 4
-  %638 = load i32, i32* %__2_v, align 4
-  %639 = load i32, i32* %__3_v, align 4
-  %640 = sub i32 %637, 1
-  %641 = mul i32 1, %640
-  %642 = add i32 0, %641
-  %643 = sub i32 %638, 1
-  %644 = mul i32 2, %643
-  %645 = add i32 %642, %644
-  %646 = sub i32 %639, 1
-  %647 = mul i32 4, %646
-  %648 = add i32 %645, %647
-  %649 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__6__implicit_cast_res, i32 0, i32 %648
-  %650 = load %complex_4, %complex_4* %649, align 4
-  %651 = alloca %complex_4, align 8
-  store %complex_4 %636, %complex_4* %651, align 4
-  %652 = alloca %complex_4, align 8
-  store %complex_4 %650, %complex_4* %652, align 4
-  %653 = alloca %complex_4, align 8
-  call void @_lfortran_complex_mul_32(%complex_4* %651, %complex_4* %652, %complex_4* %653)
-  %654 = load %complex_4, %complex_4* %653, align 4
-  store %complex_4 %654, %complex_4* %635, align 4
-  %655 = load i32, i32* %__3_v, align 4
-  %656 = add i32 %655, 1
-  store i32 %656, i32* %__3_v, align 4
-  br label %loop.head749
-
-loop.end759:                                      ; preds = %ifcont757
-  %657 = load i32, i32* %__2_v, align 4
-  %658 = add i32 %657, 1
-  store i32 %658, i32* %__2_v, align 4
-  br label %loop.head723
-
-loop.end760:                                      ; preds = %ifcont731
-  %659 = load i32, i32* %__1_v, align 4
-  %660 = add i32 %659, 1
-  store i32 %660, i32* %__1_v, align 4
-  br label %loop.head697
-
-loop.end761:                                      ; preds = %ifcont705
-  br i1 true, label %then763, label %else764
-
-then763:                                          ; preds = %loop.end761
-  store i32 1, i32* %array_bound762, align 4
-  br label %ifcont769
-
-else764:                                          ; preds = %loop.end761
-  br i1 false, label %then765, label %else766
-
-then765:                                          ; preds = %else764
-  store i32 1, i32* %array_bound762, align 4
-  br label %ifcont769
-
-else766:                                          ; preds = %else764
-  br i1 false, label %then767, label %else768
-
-then767:                                          ; preds = %else766
-  store i32 1, i32* %array_bound762, align 4
-  br label %ifcont769
-
-else768:                                          ; preds = %else766
-  br label %ifcont769
-
-ifcont769:                                        ; preds = %else768, %then767, %then765, %then763
-  %661 = load i32, i32* %array_bound762, align 4
-  store i32 %661, i32* %__1_v, align 4
-  br i1 true, label %then771, label %else772
-
-then771:                                          ; preds = %ifcont769
-  store i32 1, i32* %array_bound770, align 4
-  br label %ifcont777
-
-else772:                                          ; preds = %ifcont769
-  br i1 false, label %then773, label %else774
-
-then773:                                          ; preds = %else772
-  store i32 1, i32* %array_bound770, align 4
-  br label %ifcont777
-
-else774:                                          ; preds = %else772
-  br i1 false, label %then775, label %else776
-
-then775:                                          ; preds = %else774
-  store i32 1, i32* %array_bound770, align 4
-  br label %ifcont777
-
-else776:                                          ; preds = %else774
-  br label %ifcont777
-
-ifcont777:                                        ; preds = %else776, %then775, %then773, %then771
-  %662 = load i32, i32* %array_bound770, align 4
-  store i32 %662, i32* %__1_u, align 4
-  br i1 true, label %then779, label %else780
-
-then779:                                          ; preds = %ifcont777
-  store i32 1, i32* %array_bound778, align 4
-  br label %ifcont785
-
-else780:                                          ; preds = %ifcont777
-  br i1 false, label %then781, label %else782
-
-then781:                                          ; preds = %else780
-  store i32 1, i32* %array_bound778, align 4
-  br label %ifcont785
-
-else782:                                          ; preds = %else780
-  br i1 false, label %then783, label %else784
-
-then783:                                          ; preds = %else782
-  store i32 1, i32* %array_bound778, align 4
-  br label %ifcont785
-
-else784:                                          ; preds = %else782
-  br label %ifcont785
-
-ifcont785:                                        ; preds = %else784, %then783, %then781, %then779
-  %663 = load i32, i32* %array_bound778, align 4
-  %664 = sub i32 %663, 1
-  store i32 %664, i32* %__1_t, align 4
-  br label %loop.head786
-
-loop.head786:                                     ; preds = %loop.end865, %ifcont785
-  %665 = load i32, i32* %__1_t, align 4
-  %666 = add i32 %665, 1
-  br i1 true, label %then788, label %else789
-
-then788:                                          ; preds = %loop.head786
-  store i32 2, i32* %array_bound787, align 4
-  br label %ifcont794
-
-else789:                                          ; preds = %loop.head786
-  br i1 false, label %then790, label %else791
-
-then790:                                          ; preds = %else789
-  store i32 2, i32* %array_bound787, align 4
-  br label %ifcont794
-
-else791:                                          ; preds = %else789
-  br i1 false, label %then792, label %else793
-
-then792:                                          ; preds = %else791
-  store i32 1, i32* %array_bound787, align 4
-  br label %ifcont794
-
-else793:                                          ; preds = %else791
-  br label %ifcont794
-
-ifcont794:                                        ; preds = %else793, %then792, %then790, %then788
-  %667 = load i32, i32* %array_bound787, align 4
-  %668 = icmp sle i32 %666, %667
-  br i1 %668, label %loop.body795, label %loop.end866
-
-loop.body795:                                     ; preds = %ifcont794
-  %669 = load i32, i32* %__1_t, align 4
-  %670 = add i32 %669, 1
-  store i32 %670, i32* %__1_t, align 4
-  br i1 true, label %then797, label %else798
-
-then797:                                          ; preds = %loop.body795
-  store i32 1, i32* %array_bound796, align 4
-  br label %ifcont803
-
-else798:                                          ; preds = %loop.body795
-  br i1 false, label %then799, label %else800
-
-then799:                                          ; preds = %else798
-  store i32 1, i32* %array_bound796, align 4
-  br label %ifcont803
-
-else800:                                          ; preds = %else798
-  br i1 false, label %then801, label %else802
-
-then801:                                          ; preds = %else800
-  store i32 1, i32* %array_bound796, align 4
-  br label %ifcont803
-
-else802:                                          ; preds = %else800
-  br label %ifcont803
-
-ifcont803:                                        ; preds = %else802, %then801, %then799, %then797
-  %671 = load i32, i32* %array_bound796, align 4
-  store i32 %671, i32* %__2_v, align 4
-  br i1 true, label %then805, label %else806
-
-then805:                                          ; preds = %ifcont803
-  store i32 1, i32* %array_bound804, align 4
-  br label %ifcont811
-
-else806:                                          ; preds = %ifcont803
-  br i1 false, label %then807, label %else808
-
-then807:                                          ; preds = %else806
-  store i32 1, i32* %array_bound804, align 4
-  br label %ifcont811
-
-else808:                                          ; preds = %else806
-  br i1 false, label %then809, label %else810
-
-then809:                                          ; preds = %else808
-  store i32 1, i32* %array_bound804, align 4
-  br label %ifcont811
-
-else810:                                          ; preds = %else808
-  br label %ifcont811
-
-ifcont811:                                        ; preds = %else810, %then809, %then807, %then805
-  %672 = load i32, i32* %array_bound804, align 4
-  store i32 %672, i32* %__2_u, align 4
-  br i1 false, label %then813, label %else814
-
-then813:                                          ; preds = %ifcont811
-  store i32 1, i32* %array_bound812, align 4
-  br label %ifcont819
-
-else814:                                          ; preds = %ifcont811
-  br i1 true, label %then815, label %else816
-
-then815:                                          ; preds = %else814
-  store i32 1, i32* %array_bound812, align 4
-  br label %ifcont819
-
-else816:                                          ; preds = %else814
-  br i1 false, label %then817, label %else818
-
-then817:                                          ; preds = %else816
-  store i32 1, i32* %array_bound812, align 4
-  br label %ifcont819
-
-else818:                                          ; preds = %else816
-  br label %ifcont819
-
-ifcont819:                                        ; preds = %else818, %then817, %then815, %then813
-  %673 = load i32, i32* %array_bound812, align 4
-  %674 = sub i32 %673, 1
-  store i32 %674, i32* %__2_t, align 4
-  br label %loop.head820
-
-loop.head820:                                     ; preds = %loop.end864, %ifcont819
-  %675 = load i32, i32* %__2_t, align 4
-  %676 = add i32 %675, 1
-  br i1 false, label %then822, label %else823
-
-then822:                                          ; preds = %loop.head820
-  store i32 2, i32* %array_bound821, align 4
-  br label %ifcont828
-
-else823:                                          ; preds = %loop.head820
-  br i1 true, label %then824, label %else825
-
-then824:                                          ; preds = %else823
-  store i32 2, i32* %array_bound821, align 4
-  br label %ifcont828
-
-else825:                                          ; preds = %else823
-  br i1 false, label %then826, label %else827
-
-then826:                                          ; preds = %else825
-  store i32 1, i32* %array_bound821, align 4
-  br label %ifcont828
-
-else827:                                          ; preds = %else825
-  br label %ifcont828
-
-ifcont828:                                        ; preds = %else827, %then826, %then824, %then822
-  %677 = load i32, i32* %array_bound821, align 4
-  %678 = icmp sle i32 %676, %677
-  br i1 %678, label %loop.body829, label %loop.end865
-
-loop.body829:                                     ; preds = %ifcont828
-  %679 = load i32, i32* %__2_t, align 4
-  %680 = add i32 %679, 1
-  store i32 %680, i32* %__2_t, align 4
-  br i1 false, label %then831, label %else832
-
-then831:                                          ; preds = %loop.body829
-  store i32 1, i32* %array_bound830, align 4
-  br label %ifcont837
-
-else832:                                          ; preds = %loop.body829
-  br i1 true, label %then833, label %else834
-
-then833:                                          ; preds = %else832
-  store i32 1, i32* %array_bound830, align 4
-  br label %ifcont837
-
-else834:                                          ; preds = %else832
-  br i1 false, label %then835, label %else836
-
-then835:                                          ; preds = %else834
-  store i32 1, i32* %array_bound830, align 4
-  br label %ifcont837
-
-else836:                                          ; preds = %else834
-  br label %ifcont837
-
-ifcont837:                                        ; preds = %else836, %then835, %then833, %then831
-  %681 = load i32, i32* %array_bound830, align 4
-  store i32 %681, i32* %__3_v, align 4
-  br i1 false, label %then839, label %else840
-
-then839:                                          ; preds = %ifcont837
-  store i32 1, i32* %array_bound838, align 4
-  br label %ifcont845
-
-else840:                                          ; preds = %ifcont837
-  br i1 true, label %then841, label %else842
-
-then841:                                          ; preds = %else840
-  store i32 1, i32* %array_bound838, align 4
-  br label %ifcont845
-
-else842:                                          ; preds = %else840
-  br i1 false, label %then843, label %else844
-
-then843:                                          ; preds = %else842
-  store i32 1, i32* %array_bound838, align 4
-  br label %ifcont845
-
-else844:                                          ; preds = %else842
-  br label %ifcont845
-
-ifcont845:                                        ; preds = %else844, %then843, %then841, %then839
-  %682 = load i32, i32* %array_bound838, align 4
-  store i32 %682, i32* %__3_u, align 4
-  br i1 false, label %then847, label %else848
-
-then847:                                          ; preds = %ifcont845
-  store i32 1, i32* %array_bound846, align 4
-  br label %ifcont853
-
-else848:                                          ; preds = %ifcont845
-  br i1 false, label %then849, label %else850
-
-then849:                                          ; preds = %else848
-  store i32 1, i32* %array_bound846, align 4
-  br label %ifcont853
-
-else850:                                          ; preds = %else848
-  br i1 true, label %then851, label %else852
-
-then851:                                          ; preds = %else850
-  store i32 1, i32* %array_bound846, align 4
-  br label %ifcont853
-
-else852:                                          ; preds = %else850
-  br label %ifcont853
-
-ifcont853:                                        ; preds = %else852, %then851, %then849, %then847
-  %683 = load i32, i32* %array_bound846, align 4
-  %684 = sub i32 %683, 1
-  store i32 %684, i32* %__3_t, align 4
-  br label %loop.head854
-
-loop.head854:                                     ; preds = %loop.body863, %ifcont853
-  %685 = load i32, i32* %__3_t, align 4
-  %686 = add i32 %685, 1
-  br i1 false, label %then856, label %else857
-
-then856:                                          ; preds = %loop.head854
-  store i32 2, i32* %array_bound855, align 4
-  br label %ifcont862
-
-else857:                                          ; preds = %loop.head854
-  br i1 false, label %then858, label %else859
-
-then858:                                          ; preds = %else857
-  store i32 2, i32* %array_bound855, align 4
-  br label %ifcont862
-
-else859:                                          ; preds = %else857
-  br i1 true, label %then860, label %else861
-
-then860:                                          ; preds = %else859
-  store i32 1, i32* %array_bound855, align 4
-  br label %ifcont862
-
-else861:                                          ; preds = %else859
-  br label %ifcont862
-
-ifcont862:                                        ; preds = %else861, %then860, %then858, %then856
-  %687 = load i32, i32* %array_bound855, align 4
-  %688 = icmp sle i32 %686, %687
-  br i1 %688, label %loop.body863, label %loop.end864
-
-loop.body863:                                     ; preds = %ifcont862
-  %689 = load i32, i32* %__3_t, align 4
-  %690 = add i32 %689, 1
-  store i32 %690, i32* %__3_t, align 4
-  %691 = load i32, i32* %__1_t, align 4
-  %692 = load i32, i32* %__2_t, align 4
-  %693 = load i32, i32* %__3_t, align 4
-  %694 = sub i32 %691, 1
-  %695 = mul i32 1, %694
-  %696 = add i32 0, %695
-  %697 = sub i32 %692, 1
-  %698 = mul i32 2, %697
-  %699 = add i32 %696, %698
-  %700 = sub i32 %693, 1
-  %701 = mul i32 4, %700
-  %702 = add i32 %699, %701
-  %703 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 %702
-  %704 = load i32, i32* %__1_v, align 4
-  %705 = load i32, i32* %__2_v, align 4
-  %706 = load i32, i32* %__3_v, align 4
-  %707 = sub i32 %704, 1
-  %708 = mul i32 1, %707
-  %709 = add i32 0, %708
-  %710 = sub i32 %705, 1
-  %711 = mul i32 2, %710
-  %712 = add i32 %709, %711
-  %713 = sub i32 %706, 1
-  %714 = mul i32 4, %713
-  %715 = add i32 %712, %714
-  %716 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__4__implicit_cast_res, i32 0, i32 %715
-  %717 = load %complex_4, %complex_4* %716, align 4
-  %718 = load i32, i32* %__1_u, align 4
-  %719 = load i32, i32* %__2_u, align 4
-  %720 = load i32, i32* %__3_u, align 4
-  %721 = sub i32 %718, 1
-  %722 = mul i32 1, %721
-  %723 = add i32 0, %722
-  %724 = sub i32 %719, 1
-  %725 = mul i32 2, %724
-  %726 = add i32 %723, %725
-  %727 = sub i32 %720, 1
-  %728 = mul i32 4, %727
-  %729 = add i32 %726, %728
-  %730 = getelementptr [4 x %complex_4], [4 x %complex_4]* %__libasr__created__var__7__complex_bin_op_res, i32 0, i32 %729
-  %731 = load %complex_4, %complex_4* %730, align 4
-  %732 = alloca %complex_4, align 8
-  store %complex_4 %717, %complex_4* %732, align 4
-  %733 = alloca %complex_4, align 8
-  store %complex_4 %731, %complex_4* %733, align 4
-  %734 = alloca %complex_4, align 8
-  call void @_lfortran_complex_add_32(%complex_4* %732, %complex_4* %733, %complex_4* %734)
-  %735 = load %complex_4, %complex_4* %734, align 4
-  store %complex_4 %735, %complex_4* %703, align 4
-  %736 = load i32, i32* %__3_v, align 4
-  %737 = add i32 %736, 1
-  store i32 %737, i32* %__3_v, align 4
-  %738 = load i32, i32* %__3_u, align 4
-  %739 = add i32 %738, 1
-  store i32 %739, i32* %__3_u, align 4
-  br label %loop.head854
-
-loop.end864:                                      ; preds = %ifcont862
-  %740 = load i32, i32* %__2_v, align 4
-  %741 = add i32 %740, 1
-  store i32 %741, i32* %__2_v, align 4
-  %742 = load i32, i32* %__2_u, align 4
-  %743 = add i32 %742, 1
-  store i32 %743, i32* %__2_u, align 4
-  br label %loop.head820
-
-loop.end865:                                      ; preds = %ifcont828
-  %744 = load i32, i32* %__1_v, align 4
-  %745 = add i32 %744, 1
-  store i32 %745, i32* %__1_v, align 4
-  %746 = load i32, i32* %__1_u, align 4
-  %747 = add i32 %746, 1
-  store i32 %747, i32* %__1_u, align 4
-  br label %loop.head786
-
-loop.end866:                                      ; preds = %ifcont794
-  %748 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 0
-  store i32 1, i32* %call_arg_value867, align 4
-  store i32 2, i32* %call_arg_value868, align 4
-  store i32 1, i32* %call_arg_value869, align 4
-  store i32 2, i32* %call_arg_value870, align 4
-  store i32 1, i32* %call_arg_value871, align 4
-  store i32 1, i32* %call_arg_value872, align 4
-  store i32 1, i32* %call_arg_value873, align 4
-  call void @check_complex__________0(%complex_4* %748, i32* %call_arg_value867, i32* %call_arg_value868, i32* %call_arg_value869, i32* %call_arg_value870, i32* %call_arg_value871, i32* %call_arg_value872, i32* %call_arg_value873)
-  br label %return
-
-return:                                           ; preds = %loop.end866
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-arrays_op_7-aeeda6d.json
+++ b/tests/reference/llvm-arrays_op_7-aeeda6d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_7-aeeda6d.stdout",
-    "stdout_hash": "9fd1452f767df5d957754555f4172113c8d5dc802eb6573e9e908b2e",
+    "stdout_hash": "4d22fd2353c93894bcd3952d05fa13d06f3b5b6014098d4fd13127f0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_7-aeeda6d.stdout
+++ b/tests/reference/llvm-arrays_op_7-aeeda6d.stdout
@@ -11,6 +11,129 @@ source_filename = "LFortran"
 @7 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @8 = private unnamed_addr constant [3 x i8] c"%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %array_bound15 = alloca i32, align 4
+  %array_bound10 = alloca i32, align 4
+  %call_arg_value9 = alloca i32, align 4
+  %call_arg_value8 = alloca i32, align 4
+  %call_arg_value7 = alloca i32, align 4
+  %call_arg_value = alloca i32, align 4
+  %array_bound3 = alloca i32, align 4
+  %array_bound = alloca i32, align 4
+  %__1_k = alloca i32, align 4
+  %__1_t = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_k1 = alloca i32, align 4
+  %__1_t2 = alloca i32, align 4
+  %x = alloca [3 x i32], align 4
+  %y = alloca [3 x i32], align 4
+  br i1 true, label %then, label %else
+
+then:                                             ; preds = %.entry
+  store i32 1, i32* %array_bound, align 4
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %2 = load i32, i32* %array_bound, align 4
+  %3 = sub i32 %2, 1
+  store i32 %3, i32* %__1_t2, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.body, %ifcont
+  %4 = load i32, i32* %__1_t2, align 4
+  %5 = add i32 %4, 1
+  br i1 true, label %then4, label %else5
+
+then4:                                            ; preds = %loop.head
+  store i32 3, i32* %array_bound3, align 4
+  br label %ifcont6
+
+else5:                                            ; preds = %loop.head
+  br label %ifcont6
+
+ifcont6:                                          ; preds = %else5, %then4
+  %6 = load i32, i32* %array_bound3, align 4
+  %7 = icmp sle i32 %5, %6
+  br i1 %7, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %ifcont6
+  %8 = load i32, i32* %__1_t2, align 4
+  %9 = add i32 %8, 1
+  store i32 %9, i32* %__1_t2, align 4
+  %10 = load i32, i32* %__1_t2, align 4
+  %11 = sub i32 %10, 1
+  %12 = mul i32 1, %11
+  %13 = add i32 0, %12
+  %14 = getelementptr [3 x i32], [3 x i32]* %x, i32 0, i32 %13
+  store i32 3, i32* %14, align 4
+  br label %loop.head
+
+loop.end:                                         ; preds = %ifcont6
+  %15 = getelementptr [3 x i32], [3 x i32]* %x, i32 0, i32 0
+  store i32 1, i32* %call_arg_value, align 4
+  store i32 3, i32* %call_arg_value7, align 4
+  %16 = getelementptr [3 x i32], [3 x i32]* %y, i32 0, i32 0
+  store i32 1, i32* %call_arg_value8, align 4
+  store i32 3, i32* %call_arg_value9, align 4
+  call void @f_integer____0_integer____1(i32* %15, i32* %call_arg_value, i32* %call_arg_value7, i32* %16, i32* %call_arg_value8, i32* %call_arg_value9)
+  br i1 true, label %then11, label %else12
+
+then11:                                           ; preds = %loop.end
+  store i32 1, i32* %array_bound10, align 4
+  br label %ifcont13
+
+else12:                                           ; preds = %loop.end
+  br label %ifcont13
+
+ifcont13:                                         ; preds = %else12, %then11
+  %17 = load i32, i32* %array_bound10, align 4
+  %18 = sub i32 %17, 1
+  store i32 %18, i32* %__1_k1, align 4
+  br label %loop.head14
+
+loop.head14:                                      ; preds = %loop.body19, %ifcont13
+  %19 = load i32, i32* %__1_k1, align 4
+  %20 = add i32 %19, 1
+  br i1 true, label %then16, label %else17
+
+then16:                                           ; preds = %loop.head14
+  store i32 3, i32* %array_bound15, align 4
+  br label %ifcont18
+
+else17:                                           ; preds = %loop.head14
+  br label %ifcont18
+
+ifcont18:                                         ; preds = %else17, %then16
+  %21 = load i32, i32* %array_bound15, align 4
+  %22 = icmp sle i32 %20, %21
+  br i1 %22, label %loop.body19, label %loop.end20
+
+loop.body19:                                      ; preds = %ifcont18
+  %23 = load i32, i32* %__1_k1, align 4
+  %24 = add i32 %23, 1
+  store i32 %24, i32* %__1_k1, align 4
+  %25 = load i32, i32* %__1_k1, align 4
+  %26 = sub i32 %25, 1
+  %27 = mul i32 1, %26
+  %28 = add i32 0, %27
+  %29 = getelementptr [3 x i32], [3 x i32]* %y, i32 0, i32 %28
+  %30 = load i32, i32* %29, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %loop.head14
+
+loop.end20:                                       ; preds = %ifcont18
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %loop.end20
+  ret i32 0
+}
+
 define void @f_integer____0_integer____1(i32* %x, i32* %__1x, i32* %__2x, i32* %y, i32* %__1y, i32* %__2y) {
 .entry:
   %__1_t = alloca i32, align 4
@@ -64,127 +187,6 @@ loop.end:                                         ; preds = %loop.head
 
 return:                                           ; preds = %loop.end
   ret void
-}
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %array_bound13 = alloca i32, align 4
-  %array_bound8 = alloca i32, align 4
-  %call_arg_value7 = alloca i32, align 4
-  %call_arg_value6 = alloca i32, align 4
-  %call_arg_value5 = alloca i32, align 4
-  %call_arg_value = alloca i32, align 4
-  %array_bound1 = alloca i32, align 4
-  %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__1_k = alloca i32, align 4
-  %__1_t = alloca i32, align 4
-  %x = alloca [3 x i32], align 4
-  %y = alloca [3 x i32], align 4
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %.entry
-  store i32 1, i32* %array_bound, align 4
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %2 = load i32, i32* %array_bound, align 4
-  %3 = sub i32 %2, 1
-  store i32 %3, i32* %__1_t, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.body, %ifcont
-  %4 = load i32, i32* %__1_t, align 4
-  %5 = add i32 %4, 1
-  br i1 true, label %then2, label %else3
-
-then2:                                            ; preds = %loop.head
-  store i32 3, i32* %array_bound1, align 4
-  br label %ifcont4
-
-else3:                                            ; preds = %loop.head
-  br label %ifcont4
-
-ifcont4:                                          ; preds = %else3, %then2
-  %6 = load i32, i32* %array_bound1, align 4
-  %7 = icmp sle i32 %5, %6
-  br i1 %7, label %loop.body, label %loop.end
-
-loop.body:                                        ; preds = %ifcont4
-  %8 = load i32, i32* %__1_t, align 4
-  %9 = add i32 %8, 1
-  store i32 %9, i32* %__1_t, align 4
-  %10 = load i32, i32* %__1_t, align 4
-  %11 = sub i32 %10, 1
-  %12 = mul i32 1, %11
-  %13 = add i32 0, %12
-  %14 = getelementptr [3 x i32], [3 x i32]* %x, i32 0, i32 %13
-  store i32 3, i32* %14, align 4
-  br label %loop.head
-
-loop.end:                                         ; preds = %ifcont4
-  %15 = getelementptr [3 x i32], [3 x i32]* %x, i32 0, i32 0
-  store i32 1, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value5, align 4
-  %16 = getelementptr [3 x i32], [3 x i32]* %y, i32 0, i32 0
-  store i32 1, i32* %call_arg_value6, align 4
-  store i32 3, i32* %call_arg_value7, align 4
-  call void @f_integer____0_integer____1(i32* %15, i32* %call_arg_value, i32* %call_arg_value5, i32* %16, i32* %call_arg_value6, i32* %call_arg_value7)
-  br i1 true, label %then9, label %else10
-
-then9:                                            ; preds = %loop.end
-  store i32 1, i32* %array_bound8, align 4
-  br label %ifcont11
-
-else10:                                           ; preds = %loop.end
-  br label %ifcont11
-
-ifcont11:                                         ; preds = %else10, %then9
-  %17 = load i32, i32* %array_bound8, align 4
-  %18 = sub i32 %17, 1
-  store i32 %18, i32* %__1_k, align 4
-  br label %loop.head12
-
-loop.head12:                                      ; preds = %loop.body17, %ifcont11
-  %19 = load i32, i32* %__1_k, align 4
-  %20 = add i32 %19, 1
-  br i1 true, label %then14, label %else15
-
-then14:                                           ; preds = %loop.head12
-  store i32 3, i32* %array_bound13, align 4
-  br label %ifcont16
-
-else15:                                           ; preds = %loop.head12
-  br label %ifcont16
-
-ifcont16:                                         ; preds = %else15, %then14
-  %21 = load i32, i32* %array_bound13, align 4
-  %22 = icmp sle i32 %20, %21
-  br i1 %22, label %loop.body17, label %loop.end18
-
-loop.body17:                                      ; preds = %ifcont16
-  %23 = load i32, i32* %__1_k, align 4
-  %24 = add i32 %23, 1
-  store i32 %24, i32* %__1_k, align 4
-  %25 = load i32, i32* %__1_k, align 4
-  %26 = sub i32 %25, 1
-  %27 = mul i32 1, %26
-  %28 = add i32 0, %27
-  %29 = getelementptr [3 x i32], [3 x i32]* %y, i32 0, i32 %28
-  %30 = load i32, i32* %29, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  br label %loop.head12
-
-loop.end18:                                       ; preds = %ifcont16
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %loop.end18
-  ret i32 0
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "ee93f5f1b33c2dcd2294e01c939ed10182edb4569feea72b154d8fe3",
+    "stdout_hash": "ebbff124e4ee4a36828c485a3044b482e16897559a443ee9ea10e360",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -33,6 +33,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  store i32 2, i32* @associate_02.t1, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "e98fac8a0d3deaa3d0054d9a72786aef1b5212bc4434a25d55150e9d",
+    "stdout_hash": "2bf0ff855e7c4766f371180af0b3fd503d2cdc191fe6d04cc2750352",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -15,8 +15,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  store i32 2, i32* @associate_03.t1, align 4
+  store i32 1, i32* @associate_03.t2, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
   store i32 2, i32* @associate_03.t1, align 4
@@ -43,24 +46,24 @@ ifcont:                                           ; preds = %else, %then
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @5, i32 0, i32 0), i64 %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   %9 = load i32*, i32** %p1, align 8
   %10 = load i32, i32* %9, align 4
-  store i32 %10, i32* %i, align 4
-  %11 = load i32, i32* %i, align 4
+  store i32 %10, i32* %i1, align 4
+  %11 = load i32, i32* %i1, align 4
   %12 = load i32, i32* @associate_03.t2, align 4
   %13 = icmp eq i32 %11, %12
-  br i1 %13, label %then1, label %else2
+  br i1 %13, label %then2, label %else3
 
-then1:                                            ; preds = %ifcont
+then2:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont4
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else3:                                            ; preds = %ifcont
+  br label %ifcont4
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont4:                                          ; preds = %else3, %then2
   br label %return
 
-return:                                           ; preds = %ifcont3
+return:                                           ; preds = %ifcont4
   ret i32 0
 }
 

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "d110d202384cfa05273bd36cd7d4b2cb1b18058dc27589f229677026",
+    "stdout_hash": "2d02debcc109f6e288b0a9266bae8a9d09fe782728208911cae3c420",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -11,12 +11,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  store i32 1, i32* @bindc3.idx, align 4
+  %y = alloca i16, align 2
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 1, i32* @bindc3.idx, align 4
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
   store i16* null, i16** %x, align 8
-  %y = alloca i16, align 2
+  %y1 = alloca i16, align 2
   %2 = load void*, void** %queries, align 8
   %3 = bitcast void* %2 to i16*
   store i16* %3, i16** %x, align 8
@@ -26,11 +28,11 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load void*, void** %queries, align 8
   %8 = ptrtoint void* %7 to i64
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @2, i32 0, i32 0), i64 %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  store i16* %y, i16** %x, align 8
+  store i16* %y1, i16** %x, align 8
   %9 = load i16*, i16** %x, align 8
   %10 = bitcast i16* %9 to void*
   %11 = ptrtoint void* %10 to i64
-  %12 = bitcast i16* %y to void*
+  %12 = bitcast i16* %y1 to void*
   %13 = ptrtoint void* %12 to i64
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @5, i32 0, i32 0), i64 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i64 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   br label %return

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "f75028697d460b8bf7cf6ff56dc9c93f0703cdff32eaa9573fbbe5e6",
+    "stdout_hash": "1fb57f70aa3cabefc6a6e19489d977361861daf69d9e3a549b4300ab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -13,13 +13,19 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %all_ones = alloca i64, align 8
   store i64 -1, i64* %all_ones, align 4
   %all_zeros = alloca i64, align 8
   store i64 0, i64* %all_zeros, align 4
   %block_size = alloca i32, align 4
   store i32 64, i32* %block_size, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %all_ones1 = alloca i64, align 8
+  store i64 -1, i64* %all_ones1, align 4
+  %all_zeros2 = alloca i64, align 8
+  store i64 0, i64* %all_zeros2, align 4
+  %block_size3 = alloca i32, align 4
+  store i32 64, i32* %block_size3, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @5, i32 0, i32 0), i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @8, i32 0, i32 0), i64 -1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "b33b49a2c475878117f4be18143b1bcf9675300a7023f045d84aee7f",
+    "stdout_hash": "e473becf99181563503f04860139a526dea6250be48551f459c01ab4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -7,16 +7,19 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %boz_1 = alloca i32, align 4
   %boz_2 = alloca i32, align 4
   %boz_3 = alloca i32, align 4
-  store i32 93, i32* %boz_1, align 4
-  store i32 1255, i32* %boz_2, align 4
-  store i32 2748, i32* %boz_3, align 4
-  %2 = load i32, i32* %boz_1, align 4
-  %3 = load i32, i32* %boz_2, align 4
-  %4 = load i32, i32* %boz_3, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %boz_11 = alloca i32, align 4
+  %boz_22 = alloca i32, align 4
+  %boz_33 = alloca i32, align 4
+  store i32 93, i32* %boz_11, align 4
+  store i32 1255, i32* %boz_22, align 4
+  store i32 2748, i32* %boz_33, align 4
+  %2 = load i32, i32* %boz_11, align 4
+  %3 = load i32, i32* %boz_22, align 4
+  %4 = load i32, i32* %boz_33, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "07b64d915269a1dabfd563e1400f3c120bf51b71d3421362a580a84b",
+    "stdout_hash": "094f1718d5f3d76d7a07bda663f7fa5fe0b2fb67e3d1a0c5211105c3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -51,6 +51,7 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  store i32 5, i32* @main.x, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 5, i32* @main.x, align 4
   call void @__module_callback_05_px_call1(i32* @main.x)

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "f86f0ac6ffedb5be4d1e60714b462e5b2df51d6fada64004e6a6cacc",
+    "stdout_hash": "a9c8094b3714dc6dfe10d59890ed4089a2030b0b035f00e634410c5d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -34,125 +34,127 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %out = alloca i32, align 4
-  store i32 4, i32* %i, align 4
-  %2 = load i32, i32* %i, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %out2 = alloca i32, align 4
+  store i32 4, i32* %i1, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = icmp eq i32 %2, 1
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 10, i32* %out, align 4
+  store i32 10, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  br label %ifcont9
+  br label %ifcont11
 
 else:                                             ; preds = %.entry
-  %4 = load i32, i32* %i, align 4
+  %4 = load i32, i32* %i1, align 4
   %5 = icmp eq i32 %4, 2
-  br i1 %5, label %then1, label %else2
+  br i1 %5, label %then3, label %else4
 
-then1:                                            ; preds = %else
-  store i32 20, i32* %out, align 4
+then3:                                            ; preds = %else
+  store i32 20, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  br label %ifcont8
+  br label %ifcont10
 
-else2:                                            ; preds = %else
-  %6 = load i32, i32* %i, align 4
+else4:                                            ; preds = %else
+  %6 = load i32, i32* %i1, align 4
   %7 = icmp eq i32 %6, 3
-  br i1 %7, label %then3, label %else4
-
-then3:                                            ; preds = %else2
-  store i32 30, i32* %out, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
-  br label %ifcont7
-
-else4:                                            ; preds = %else2
-  %8 = load i32, i32* %i, align 4
-  %9 = icmp eq i32 %8, 4
-  br i1 %9, label %then5, label %else6
+  br i1 %7, label %then5, label %else6
 
 then5:                                            ; preds = %else4
-  store i32 40, i32* %out, align 4
+  store i32 30, i32* %out2, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  br label %ifcont9
+
+else6:                                            ; preds = %else4
+  %8 = load i32, i32* %i1, align 4
+  %9 = icmp eq i32 %8, 4
+  br i1 %9, label %then7, label %else8
+
+then7:                                            ; preds = %else6
+  store i32 40, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   br label %ifcont
 
-else6:                                            ; preds = %else4
+else8:                                            ; preds = %else6
   br label %ifcont
 
-ifcont:                                           ; preds = %else6, %then5
-  br label %ifcont7
-
-ifcont7:                                          ; preds = %ifcont, %then3
-  br label %ifcont8
-
-ifcont8:                                          ; preds = %ifcont7, %then1
+ifcont:                                           ; preds = %else8, %then7
   br label %ifcont9
 
-ifcont9:                                          ; preds = %ifcont8, %then
-  %10 = load i32, i32* %out, align 4
-  %11 = icmp ne i32 %10, 40
-  br i1 %11, label %then10, label %else11
+ifcont9:                                          ; preds = %ifcont, %then5
+  br label %ifcont10
 
-then10:                                           ; preds = %ifcont9
+ifcont10:                                         ; preds = %ifcont9, %then3
+  br label %ifcont11
+
+ifcont11:                                         ; preds = %ifcont10, %then
+  %10 = load i32, i32* %out2, align 4
+  %11 = icmp ne i32 %10, 40
+  br i1 %11, label %then12, label %else13
+
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @16, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
-  %12 = load i32, i32* %i, align 4
+ifcont14:                                         ; preds = %else13, %then12
+  %12 = load i32, i32* %i1, align 4
   %13 = icmp eq i32 %12, 1
-  br i1 %13, label %then13, label %else14
+  br i1 %13, label %then15, label %else16
 
-then13:                                           ; preds = %ifcont12
-  store i32 11, i32* %out, align 4
+then15:                                           ; preds = %ifcont14
+  store i32 11, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @22, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  br label %ifcont18
+  br label %ifcont20
 
-else14:                                           ; preds = %ifcont12
-  %14 = load i32, i32* %i, align 4
+else16:                                           ; preds = %ifcont14
+  %14 = load i32, i32* %i1, align 4
   %15 = icmp eq i32 %14, 2
-  %16 = load i32, i32* %i, align 4
+  %16 = load i32, i32* %i1, align 4
   %17 = icmp eq i32 %16, 3
   %18 = icmp eq i1 %15, false
   %19 = select i1 %18, i1 %17, i1 %15
-  %20 = load i32, i32* %i, align 4
+  %20 = load i32, i32* %i1, align 4
   %21 = icmp eq i32 %20, 4
   %22 = icmp eq i1 %19, false
   %23 = select i1 %22, i1 %21, i1 %19
-  br i1 %23, label %then15, label %else16
+  br i1 %23, label %then17, label %else18
 
-then15:                                           ; preds = %else14
-  store i32 22, i32* %out, align 4
+then17:                                           ; preds = %else16
+  store i32 22, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
-  br label %ifcont17
+  br label %ifcont19
 
-else16:                                           ; preds = %else14
-  br label %ifcont17
+else18:                                           ; preds = %else16
+  br label %ifcont19
 
-ifcont17:                                         ; preds = %else16, %then15
-  br label %ifcont18
+ifcont19:                                         ; preds = %else18, %then17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %ifcont17, %then13
-  %24 = load i32, i32* %out, align 4
+ifcont20:                                         ; preds = %ifcont19, %then15
+  %24 = load i32, i32* %out2, align 4
   %25 = icmp ne i32 %24, 22
-  br i1 %25, label %then19, label %else20
+  br i1 %25, label %then21, label %else22
 
-then19:                                           ; preds = %ifcont18
+then21:                                           ; preds = %ifcont20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont23
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else22:                                           ; preds = %ifcont20
+  br label %ifcont23
 
-ifcont21:                                         ; preds = %else20, %then19
+ifcont23:                                         ; preds = %else22, %then21
   br label %return
 
-return:                                           ; preds = %ifcont21
+return:                                           ; preds = %ifcont23
   ret i32 0
 }
 

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "438d953ef94e360dbc7852368bd45d17ded8316f8016b937b5e28a7a",
+    "stdout_hash": "2d04087a482f7632797834ccc3adb6b9d64c5fc4b6d7c335b8144bd4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -103,318 +103,320 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %marks = alloca i32, align 4
   %out = alloca i32, align 4
-  store i32 81, i32* %marks, align 4
-  %2 = load i32, i32* %marks, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %marks1 = alloca i32, align 4
+  %out2 = alloca i32, align 4
+  store i32 81, i32* %marks1, align 4
+  %2 = load i32, i32* %marks1, align 4
   %3 = icmp sle i32 91, %2
-  %4 = load i32, i32* %marks, align 4
+  %4 = load i32, i32* %marks1, align 4
   %5 = icmp sle i32 %4, 100
   %6 = icmp eq i1 %3, false
   %7 = select i1 %6, i1 %3, i1 %5
   br i1 %7, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 0, i32* %out, align 4
+  store i32 0, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  br label %ifcont15
+  br label %ifcont17
 
 else:                                             ; preds = %.entry
-  %8 = load i32, i32* %marks, align 4
+  %8 = load i32, i32* %marks1, align 4
   %9 = icmp sle i32 81, %8
-  %10 = load i32, i32* %marks, align 4
+  %10 = load i32, i32* %marks1, align 4
   %11 = icmp sle i32 %10, 90
   %12 = icmp eq i1 %9, false
   %13 = select i1 %12, i1 %9, i1 %11
-  br i1 %13, label %then1, label %else2
+  br i1 %13, label %then3, label %else4
 
-then1:                                            ; preds = %else
-  store i32 1, i32* %out, align 4
+then3:                                            ; preds = %else
+  store i32 1, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  br label %ifcont14
+  br label %ifcont16
 
-else2:                                            ; preds = %else
-  %14 = load i32, i32* %marks, align 4
+else4:                                            ; preds = %else
+  %14 = load i32, i32* %marks1, align 4
   %15 = icmp sle i32 71, %14
-  %16 = load i32, i32* %marks, align 4
+  %16 = load i32, i32* %marks1, align 4
   %17 = icmp sle i32 %16, 80
   %18 = icmp eq i1 %15, false
   %19 = select i1 %18, i1 %15, i1 %17
-  br i1 %19, label %then3, label %else4
+  br i1 %19, label %then5, label %else6
 
-then3:                                            ; preds = %else2
-  store i32 2, i32* %out, align 4
+then5:                                            ; preds = %else4
+  store i32 2, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
-  br label %ifcont13
+  br label %ifcont15
 
-else4:                                            ; preds = %else2
-  %20 = load i32, i32* %marks, align 4
+else6:                                            ; preds = %else4
+  %20 = load i32, i32* %marks1, align 4
   %21 = icmp sle i32 61, %20
-  %22 = load i32, i32* %marks, align 4
+  %22 = load i32, i32* %marks1, align 4
   %23 = icmp sle i32 %22, 70
   %24 = icmp eq i1 %21, false
   %25 = select i1 %24, i1 %21, i1 %23
-  br i1 %25, label %then5, label %else6
+  br i1 %25, label %then7, label %else8
 
-then5:                                            ; preds = %else4
-  store i32 3, i32* %out, align 4
+then7:                                            ; preds = %else6
+  store i32 3, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
-  br label %ifcont12
+  br label %ifcont14
 
-else6:                                            ; preds = %else4
-  %26 = load i32, i32* %marks, align 4
+else8:                                            ; preds = %else6
+  %26 = load i32, i32* %marks1, align 4
   %27 = icmp sle i32 41, %26
-  %28 = load i32, i32* %marks, align 4
+  %28 = load i32, i32* %marks1, align 4
   %29 = icmp sle i32 %28, 60
   %30 = icmp eq i1 %27, false
   %31 = select i1 %30, i1 %27, i1 %29
-  br i1 %31, label %then7, label %else8
-
-then7:                                            ; preds = %else6
-  store i32 4, i32* %out, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
-  br label %ifcont11
-
-else8:                                            ; preds = %else6
-  %32 = load i32, i32* %marks, align 4
-  %33 = icmp sle i32 %32, 40
-  br i1 %33, label %then9, label %else10
+  br i1 %31, label %then9, label %else10
 
 then9:                                            ; preds = %else8
-  store i32 5, i32* %out, align 4
+  store i32 4, i32* %out2, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
+  br label %ifcont13
+
+else10:                                           ; preds = %else8
+  %32 = load i32, i32* %marks1, align 4
+  %33 = icmp sle i32 %32, 40
+  br i1 %33, label %then11, label %else12
+
+then11:                                           ; preds = %else10
+  store i32 5, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([18 x i8], [18 x i8]* @22, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
   br label %ifcont
 
-else10:                                           ; preds = %else8
-  store i32 6, i32* %out, align 4
+else12:                                           ; preds = %else10
+  store i32 6, i32* %out2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   br label %ifcont
 
-ifcont:                                           ; preds = %else10, %then9
-  br label %ifcont11
-
-ifcont11:                                         ; preds = %ifcont, %then7
-  br label %ifcont12
-
-ifcont12:                                         ; preds = %ifcont11, %then5
+ifcont:                                           ; preds = %else12, %then11
   br label %ifcont13
 
-ifcont13:                                         ; preds = %ifcont12, %then3
+ifcont13:                                         ; preds = %ifcont, %then9
   br label %ifcont14
 
-ifcont14:                                         ; preds = %ifcont13, %then1
+ifcont14:                                         ; preds = %ifcont13, %then7
   br label %ifcont15
 
-ifcont15:                                         ; preds = %ifcont14, %then
-  %34 = load i32, i32* %marks, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))
-  %35 = load i32, i32* %out, align 4
-  %36 = icmp ne i32 %35, 1
-  br i1 %36, label %then16, label %else17
+ifcont15:                                         ; preds = %ifcont14, %then5
+  br label %ifcont16
 
-then16:                                           ; preds = %ifcont15
+ifcont16:                                         ; preds = %ifcont15, %then3
+  br label %ifcont17
+
+ifcont17:                                         ; preds = %ifcont16, %then
+  %34 = load i32, i32* %marks1, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))
+  %35 = load i32, i32* %out2, align 4
+  %36 = icmp ne i32 %35, 1
+  br i1 %36, label %then18, label %else19
+
+then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @34, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont20
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else19:                                           ; preds = %ifcont17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %else17, %then16
-  %37 = load i32, i32* %marks, align 4
+ifcont20:                                         ; preds = %else19, %then18
+  %37 = load i32, i32* %marks1, align 4
   %38 = icmp sle i32 91, %37
-  %39 = load i32, i32* %marks, align 4
+  %39 = load i32, i32* %marks1, align 4
   %40 = icmp sle i32 %39, 100
   %41 = icmp eq i1 %38, false
   %42 = select i1 %41, i1 %38, i1 %40
-  br i1 %42, label %then19, label %else20
+  br i1 %42, label %then21, label %else22
 
-then19:                                           ; preds = %ifcont18
+then21:                                           ; preds = %ifcont20
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
-  br label %ifcont36
+  br label %ifcont38
 
-else20:                                           ; preds = %ifcont18
-  %43 = load i32, i32* %marks, align 4
+else22:                                           ; preds = %ifcont20
+  %43 = load i32, i32* %marks1, align 4
   %44 = icmp sle i32 81, %43
-  %45 = load i32, i32* %marks, align 4
+  %45 = load i32, i32* %marks1, align 4
   %46 = icmp sle i32 %45, 90
   %47 = icmp eq i1 %44, false
   %48 = select i1 %47, i1 %44, i1 %46
-  br i1 %48, label %then21, label %else22
+  br i1 %48, label %then23, label %else24
 
-then21:                                           ; preds = %else20
+then23:                                           ; preds = %else22
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  br label %ifcont35
+  br label %ifcont37
 
-else22:                                           ; preds = %else20
-  %49 = load i32, i32* %marks, align 4
+else24:                                           ; preds = %else22
+  %49 = load i32, i32* %marks1, align 4
   %50 = icmp sle i32 71, %49
-  %51 = load i32, i32* %marks, align 4
+  %51 = load i32, i32* %marks1, align 4
   %52 = icmp sle i32 %51, 80
   %53 = icmp eq i1 %50, false
   %54 = select i1 %53, i1 %50, i1 %52
-  br i1 %54, label %then23, label %else24
+  br i1 %54, label %then25, label %else26
 
-then23:                                           ; preds = %else22
+then25:                                           ; preds = %else24
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @46, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0))
-  br label %ifcont34
+  br label %ifcont36
 
-else24:                                           ; preds = %else22
-  %55 = load i32, i32* %marks, align 4
+else26:                                           ; preds = %else24
+  %55 = load i32, i32* %marks1, align 4
   %56 = icmp sle i32 61, %55
-  %57 = load i32, i32* %marks, align 4
+  %57 = load i32, i32* %marks1, align 4
   %58 = icmp sle i32 %57, 70
   %59 = icmp eq i1 %56, false
   %60 = select i1 %59, i1 %56, i1 %58
-  br i1 %60, label %then25, label %else26
+  br i1 %60, label %then27, label %else28
 
-then25:                                           ; preds = %else24
+then27:                                           ; preds = %else26
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
-  br label %ifcont33
+  br label %ifcont35
 
-else26:                                           ; preds = %else24
-  %61 = load i32, i32* %marks, align 4
+else28:                                           ; preds = %else26
+  %61 = load i32, i32* %marks1, align 4
   %62 = icmp sle i32 41, %61
-  %63 = load i32, i32* %marks, align 4
+  %63 = load i32, i32* %marks1, align 4
   %64 = icmp sle i32 %63, 60
   %65 = icmp eq i1 %62, false
   %66 = select i1 %65, i1 %62, i1 %64
-  br i1 %66, label %then27, label %else28
-
-then27:                                           ; preds = %else26
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @54, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
-  br label %ifcont32
-
-else28:                                           ; preds = %else26
-  %67 = load i32, i32* %marks, align 4
-  %68 = icmp sle i32 %67, 40
-  br i1 %68, label %then29, label %else30
+  br i1 %66, label %then29, label %else30
 
 then29:                                           ; preds = %else28
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @58, i32 0, i32 0), i8* getelementptr inbounds ([18 x i8], [18 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0))
-  br label %ifcont31
-
-else30:                                           ; preds = %else28
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0))
-  br label %ifcont31
-
-ifcont31:                                         ; preds = %else30, %then29
-  br label %ifcont32
-
-ifcont32:                                         ; preds = %ifcont31, %then27
-  br label %ifcont33
-
-ifcont33:                                         ; preds = %ifcont32, %then25
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @54, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
   br label %ifcont34
 
-ifcont34:                                         ; preds = %ifcont33, %then23
+else30:                                           ; preds = %else28
+  %67 = load i32, i32* %marks1, align 4
+  %68 = icmp sle i32 %67, 40
+  br i1 %68, label %then31, label %else32
+
+then31:                                           ; preds = %else30
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @58, i32 0, i32 0), i8* getelementptr inbounds ([18 x i8], [18 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0))
+  br label %ifcont33
+
+else32:                                           ; preds = %else30
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0))
+  br label %ifcont33
+
+ifcont33:                                         ; preds = %else32, %then31
+  br label %ifcont34
+
+ifcont34:                                         ; preds = %ifcont33, %then29
   br label %ifcont35
 
-ifcont35:                                         ; preds = %ifcont34, %then21
+ifcont35:                                         ; preds = %ifcont34, %then27
   br label %ifcont36
 
-ifcont36:                                         ; preds = %ifcont35, %then19
-  %69 = load i32, i32* %marks, align 4
+ifcont36:                                         ; preds = %ifcont35, %then25
+  br label %ifcont37
+
+ifcont37:                                         ; preds = %ifcont36, %then23
+  br label %ifcont38
+
+ifcont38:                                         ; preds = %ifcont37, %then21
+  %69 = load i32, i32* %marks1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @63, i32 0, i32 0), i32 %69, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
-  %70 = load i32, i32* %marks, align 4
+  %70 = load i32, i32* %marks1, align 4
   %71 = icmp sle i32 91, %70
-  %72 = load i32, i32* %marks, align 4
+  %72 = load i32, i32* %marks1, align 4
   %73 = icmp sle i32 %72, 100
   %74 = icmp eq i1 %71, false
   %75 = select i1 %74, i1 %71, i1 %73
-  br i1 %75, label %then37, label %else38
+  br i1 %75, label %then39, label %else40
 
-then37:                                           ; preds = %ifcont36
+then39:                                           ; preds = %ifcont38
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @70, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
-  br label %ifcont54
+  br label %ifcont56
 
-else38:                                           ; preds = %ifcont36
-  %76 = load i32, i32* %marks, align 4
+else40:                                           ; preds = %ifcont38
+  %76 = load i32, i32* %marks1, align 4
   %77 = icmp sle i32 81, %76
-  %78 = load i32, i32* %marks, align 4
+  %78 = load i32, i32* %marks1, align 4
   %79 = icmp sle i32 %78, 90
   %80 = icmp eq i1 %77, false
   %81 = select i1 %80, i1 %77, i1 %79
-  br i1 %81, label %then39, label %else40
+  br i1 %81, label %then41, label %else42
 
-then39:                                           ; preds = %else38
+then41:                                           ; preds = %else40
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @74, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0))
-  br label %ifcont53
+  br label %ifcont55
 
-else40:                                           ; preds = %else38
-  %82 = load i32, i32* %marks, align 4
+else42:                                           ; preds = %else40
+  %82 = load i32, i32* %marks1, align 4
   %83 = icmp sle i32 71, %82
-  %84 = load i32, i32* %marks, align 4
+  %84 = load i32, i32* %marks1, align 4
   %85 = icmp sle i32 %84, 80
   %86 = icmp eq i1 %83, false
   %87 = select i1 %86, i1 %83, i1 %85
-  br i1 %87, label %then41, label %else42
+  br i1 %87, label %then43, label %else44
 
-then41:                                           ; preds = %else40
+then43:                                           ; preds = %else42
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @78, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0))
-  br label %ifcont52
+  br label %ifcont54
 
-else42:                                           ; preds = %else40
-  %88 = load i32, i32* %marks, align 4
+else44:                                           ; preds = %else42
+  %88 = load i32, i32* %marks1, align 4
   %89 = icmp sle i32 61, %88
-  %90 = load i32, i32* %marks, align 4
+  %90 = load i32, i32* %marks1, align 4
   %91 = icmp sle i32 %90, 70
   %92 = icmp eq i1 %89, false
   %93 = select i1 %92, i1 %89, i1 %91
-  br i1 %93, label %then43, label %else44
+  br i1 %93, label %then45, label %else46
 
-then43:                                           ; preds = %else42
+then45:                                           ; preds = %else44
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @82, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0))
-  br label %ifcont51
+  br label %ifcont53
 
-else44:                                           ; preds = %else42
-  %94 = load i32, i32* %marks, align 4
+else46:                                           ; preds = %else44
+  %94 = load i32, i32* %marks1, align 4
   %95 = icmp sle i32 41, %94
-  %96 = load i32, i32* %marks, align 4
+  %96 = load i32, i32* %marks1, align 4
   %97 = icmp sle i32 %96, 60
   %98 = icmp eq i1 %95, false
   %99 = select i1 %98, i1 %95, i1 %97
-  br i1 %99, label %then45, label %else46
-
-then45:                                           ; preds = %else44
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @86, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0))
-  br label %ifcont50
-
-else46:                                           ; preds = %else44
-  %100 = load i32, i32* %marks, align 4
-  %101 = icmp sle i32 %100, 40
-  br i1 %101, label %then47, label %else48
+  br i1 %99, label %then47, label %else48
 
 then47:                                           ; preds = %else46
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @90, i32 0, i32 0), i8* getelementptr inbounds ([18 x i8], [18 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0))
-  br label %ifcont49
-
-else48:                                           ; preds = %else46
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @94, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0))
-  br label %ifcont49
-
-ifcont49:                                         ; preds = %else48, %then47
-  br label %ifcont50
-
-ifcont50:                                         ; preds = %ifcont49, %then45
-  br label %ifcont51
-
-ifcont51:                                         ; preds = %ifcont50, %then43
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @86, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0))
   br label %ifcont52
 
-ifcont52:                                         ; preds = %ifcont51, %then41
+else48:                                           ; preds = %else46
+  %100 = load i32, i32* %marks1, align 4
+  %101 = icmp sle i32 %100, 40
+  br i1 %101, label %then49, label %else50
+
+then49:                                           ; preds = %else48
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @90, i32 0, i32 0), i8* getelementptr inbounds ([18 x i8], [18 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0))
+  br label %ifcont51
+
+else50:                                           ; preds = %else48
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @94, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0))
+  br label %ifcont51
+
+ifcont51:                                         ; preds = %else50, %then49
+  br label %ifcont52
+
+ifcont52:                                         ; preds = %ifcont51, %then47
   br label %ifcont53
 
-ifcont53:                                         ; preds = %ifcont52, %then39
+ifcont53:                                         ; preds = %ifcont52, %then45
   br label %ifcont54
 
-ifcont54:                                         ; preds = %ifcont53, %then37
-  %102 = load i32, i32* %marks, align 4
+ifcont54:                                         ; preds = %ifcont53, %then43
+  br label %ifcont55
+
+ifcont55:                                         ; preds = %ifcont54, %then41
+  br label %ifcont56
+
+ifcont56:                                         ; preds = %ifcont55, %then39
+  %102 = load i32, i32* %marks1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @98, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @95, i32 0, i32 0), i32 %102, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %ifcont54
+return:                                           ; preds = %ifcont56
   ret i32 0
 }
 

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "fa6e4f1e2bcab9023b963fb765e1ec92ff1e4b5b28d9421e351addcc",
+    "stdout_hash": "94a160cd0555d73c0d60e49e95cb62ab764ba01ddc56e784ba9d4a63",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -36,75 +36,80 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   store i32 1, i32* %a, align 4
   %b = alloca i32, align 4
   store i32 2, i32* %b, align 4
   %marks = alloca i32, align 4
-  store i32 94, i32* %marks, align 4
-  %2 = load i32, i32* %marks, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a1 = alloca i32, align 4
+  store i32 1, i32* %a1, align 4
+  %b2 = alloca i32, align 4
+  store i32 2, i32* %b2, align 4
+  %marks3 = alloca i32, align 4
+  store i32 94, i32* %marks3, align 4
+  %2 = load i32, i32* %marks3, align 4
   %3 = icmp sle i32 42, %2
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  br label %ifcont3
+  br label %ifcont6
 
 else:                                             ; preds = %.entry
-  %4 = load i32, i32* %marks, align 4
+  %4 = load i32, i32* %marks3, align 4
   %5 = icmp sle i32 %4, 38
-  br i1 %5, label %then1, label %else2
+  br i1 %5, label %then4, label %else5
 
-then1:                                            ; preds = %else
+then4:                                            ; preds = %else
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
   br label %ifcont
 
-else2:                                            ; preds = %else
+else5:                                            ; preds = %else
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
   br label %ifcont
 
-ifcont:                                           ; preds = %else2, %then1
-  br label %ifcont3
+ifcont:                                           ; preds = %else5, %then4
+  br label %ifcont6
 
-ifcont3:                                          ; preds = %ifcont, %then
-  %6 = load i32, i32* %marks, align 4
+ifcont6:                                          ; preds = %ifcont, %then
+  %6 = load i32, i32* %marks3, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
-  store i32 -1, i32* %marks, align 4
-  %7 = load i32, i32* %marks, align 4
+  store i32 -1, i32* %marks3, align 4
+  %7 = load i32, i32* %marks3, align 4
   %8 = icmp sle i32 42, %7
-  br i1 %8, label %then4, label %else5
+  br i1 %8, label %then7, label %else8
 
-then4:                                            ; preds = %ifcont3
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
-  br label %ifcont9
+  br label %ifcont12
 
-else5:                                            ; preds = %ifcont3
-  %9 = load i32, i32* %marks, align 4
+else8:                                            ; preds = %ifcont6
+  %9 = load i32, i32* %marks3, align 4
   %10 = icmp sle i32 0, %9
-  %11 = load i32, i32* %marks, align 4
+  %11 = load i32, i32* %marks3, align 4
   %12 = icmp sle i32 %11, 38
   %13 = icmp eq i1 %10, false
   %14 = select i1 %13, i1 %10, i1 %12
-  br i1 %14, label %then6, label %else7
+  br i1 %14, label %then9, label %else10
 
-then6:                                            ; preds = %else5
+then9:                                            ; preds = %else8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @22, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
-  br label %ifcont8
+  br label %ifcont11
 
-else7:                                            ; preds = %else5
+else10:                                           ; preds = %else8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
-  br label %ifcont8
+  br label %ifcont11
 
-ifcont8:                                          ; preds = %else7, %then6
-  br label %ifcont9
+ifcont11:                                         ; preds = %else10, %then9
+  br label %ifcont12
 
-ifcont9:                                          ; preds = %ifcont8, %then4
-  %15 = load i32, i32* %marks, align 4
+ifcont12:                                         ; preds = %ifcont11, %then7
+  %15 = load i32, i32* %marks3, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %ifcont9
+return:                                           ; preds = %ifcont12
   ret i32 0
 }
 

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "6c05784cbedc41289dda74e50e96ed10b87716cfcf3302a0fc5681f3",
+    "stdout_hash": "7478e8533b794ef89172c75e46703742d7a8aee77371cf39d2221026",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -13,11 +13,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %prec11 = alloca i32, align 4
+  store i32 4, i32* %prec11, align 4
+  %prec22 = alloca i32, align 4
+  store i32 8, i32* %prec22, align 4
   %2 = alloca %complex_4, align 8
   %3 = getelementptr %complex_4, %complex_4* %2, i32 0, i32 0
   %4 = getelementptr %complex_4, %complex_4* %2, i32 0, i32 1

--- a/tests/reference/llvm-do7-8069d7a.json
+++ b/tests/reference/llvm-do7-8069d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-do7-8069d7a.stdout",
-    "stdout_hash": "c60cbb67ed092ce10a0a931c97e72fc56d39475a7406750a1b440424",
+    "stdout_hash": "182aa13417390d3ad92f7023d09500c4119ce7c694a34be5da2bab41",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-do7-8069d7a.stdout
+++ b/tests/reference/llvm-do7-8069d7a.stdout
@@ -1,6 +1,39 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value = alloca i32, align 4
+  %a = alloca i32, align 4
+  %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a1 = alloca i32, align 4
+  %i2 = alloca i32, align 4
+  store i32 0, i32* %i2, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.body, %.entry
+  %2 = load i32, i32* %i2, align 4
+  %3 = add i32 %2, 1
+  %4 = icmp sle i32 %3, 10
+  br i1 %4, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %loop.head
+  %5 = load i32, i32* %i2, align 4
+  %6 = add i32 %5, 1
+  store i32 %6, i32* %i2, align 4
+  store i32 5, i32* %call_arg_value, align 4
+  %7 = call i32 @f(i32* %call_arg_value)
+  store i32 %7, i32* %a1, align 4
+  br label %loop.head
+
+loop.end:                                         ; preds = %loop.head
+  br label %return
+
+return:                                           ; preds = %loop.end
+  ret i32 0
+}
+
 define i32 @f(i32* %a) {
 .entry:
   %f = alloca i32, align 4
@@ -12,37 +45,6 @@ define i32 @f(i32* %a) {
 return:                                           ; preds = %.entry
   %2 = load i32, i32* %f, align 4
   ret i32 %2
-}
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a = alloca i32, align 4
-  %i = alloca i32, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 10
-  br i1 %4, label %loop.body, label %loop.end
-
-loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
-  %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  store i32 5, i32* %call_arg_value, align 4
-  %7 = call i32 @f(i32* %call_arg_value)
-  store i32 %7, i32* %a, align 4
-  br label %loop.head
-
-loop.end:                                         ; preds = %loop.head
-  br label %return
-
-return:                                           ; preds = %loop.end
-  ret i32 0
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "fbc51bff77710aa889bbe9bdca0ecb321ea8b4a49b60959d7c132398",
+    "stdout_hash": "4ef7b6ac705d5bd4689598f929d2aaa406960fbee5552d10288cea55",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -70,31 +70,33 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %j, align 4
-  %8 = load i32, i32* %i, align 4
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %j2, align 4
+  %8 = load i32, i32* %i1, align 4
   %9 = add i32 %7, %8
-  store i32 %9, i32* %j, align 4
+  store i32 %9, i32* %j2, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %10 = load i32, i32* %j, align 4
+  %10 = load i32, i32* %j2, align 4
   %11 = icmp ne i32 %10, 55
   br i1 %11, label %then, label %else
 
@@ -107,371 +109,371 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load i32, i32* %j, align 4
+  %12 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 11, i32* %i, align 4
-  br label %loop.head1
+  store i32 0, i32* %j2, align 4
+  store i32 11, i32* %i1, align 4
+  br label %loop.head3
 
-loop.head1:                                       ; preds = %loop.body2, %ifcont
-  %13 = load i32, i32* %i, align 4
+loop.head3:                                       ; preds = %loop.body4, %ifcont
+  %13 = load i32, i32* %i1, align 4
   %14 = add i32 %13, -1
   %15 = icmp sge i32 %14, 1
-  br i1 %15, label %loop.body2, label %loop.end3
+  br i1 %15, label %loop.body4, label %loop.end5
 
-loop.body2:                                       ; preds = %loop.head1
-  %16 = load i32, i32* %i, align 4
+loop.body4:                                       ; preds = %loop.head3
+  %16 = load i32, i32* %i1, align 4
   %17 = add i32 %16, -1
-  store i32 %17, i32* %i, align 4
-  %18 = load i32, i32* %j, align 4
-  %19 = load i32, i32* %i, align 4
+  store i32 %17, i32* %i1, align 4
+  %18 = load i32, i32* %j2, align 4
+  %19 = load i32, i32* %i1, align 4
   %20 = add i32 %18, %19
-  store i32 %20, i32* %j, align 4
-  br label %loop.head1
+  store i32 %20, i32* %j2, align 4
+  br label %loop.head3
 
-loop.end3:                                        ; preds = %loop.head1
-  %21 = load i32, i32* %j, align 4
+loop.end5:                                        ; preds = %loop.head3
+  %21 = load i32, i32* %j2, align 4
   %22 = icmp ne i32 %21, 55
-  br i1 %22, label %then4, label %else5
+  br i1 %22, label %then6, label %else7
 
-then4:                                            ; preds = %loop.end3
+then6:                                            ; preds = %loop.end5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %loop.end3
-  br label %ifcont6
+else7:                                            ; preds = %loop.end5
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
-  %23 = load i32, i32* %j, align 4
+ifcont8:                                          ; preds = %else7, %then6
+  %23 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 -1, i32* %i, align 4
-  br label %loop.head7
+  store i32 0, i32* %j2, align 4
+  store i32 -1, i32* %i1, align 4
+  br label %loop.head9
 
-loop.head7:                                       ; preds = %loop.body8, %ifcont6
-  %24 = load i32, i32* %i, align 4
+loop.head9:                                       ; preds = %loop.body10, %ifcont8
+  %24 = load i32, i32* %i1, align 4
   %25 = add i32 %24, 2
   %26 = icmp sle i32 %25, 9
-  br i1 %26, label %loop.body8, label %loop.end9
+  br i1 %26, label %loop.body10, label %loop.end11
 
-loop.body8:                                       ; preds = %loop.head7
-  %27 = load i32, i32* %i, align 4
+loop.body10:                                      ; preds = %loop.head9
+  %27 = load i32, i32* %i1, align 4
   %28 = add i32 %27, 2
-  store i32 %28, i32* %i, align 4
-  %29 = load i32, i32* %j, align 4
-  %30 = load i32, i32* %i, align 4
+  store i32 %28, i32* %i1, align 4
+  %29 = load i32, i32* %j2, align 4
+  %30 = load i32, i32* %i1, align 4
   %31 = add i32 %29, %30
-  store i32 %31, i32* %j, align 4
-  br label %loop.head7
+  store i32 %31, i32* %j2, align 4
+  br label %loop.head9
 
-loop.end9:                                        ; preds = %loop.head7
-  %32 = load i32, i32* %j, align 4
+loop.end11:                                       ; preds = %loop.head9
+  %32 = load i32, i32* %j2, align 4
   %33 = icmp ne i32 %32, 25
-  br i1 %33, label %then10, label %else11
+  br i1 %33, label %then12, label %else13
 
-then10:                                           ; preds = %loop.end9
+then12:                                           ; preds = %loop.end11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %loop.end9
-  br label %ifcont12
+else13:                                           ; preds = %loop.end11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
-  %34 = load i32, i32* %j, align 4
+ifcont14:                                         ; preds = %else13, %then12
+  %34 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 11, i32* %i, align 4
-  br label %loop.head13
+  store i32 0, i32* %j2, align 4
+  store i32 11, i32* %i1, align 4
+  br label %loop.head15
 
-loop.head13:                                      ; preds = %loop.body14, %ifcont12
-  %35 = load i32, i32* %i, align 4
+loop.head15:                                      ; preds = %loop.body16, %ifcont14
+  %35 = load i32, i32* %i1, align 4
   %36 = add i32 %35, -2
   %37 = icmp sge i32 %36, 1
-  br i1 %37, label %loop.body14, label %loop.end15
+  br i1 %37, label %loop.body16, label %loop.end17
 
-loop.body14:                                      ; preds = %loop.head13
-  %38 = load i32, i32* %i, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %38 = load i32, i32* %i1, align 4
   %39 = add i32 %38, -2
-  store i32 %39, i32* %i, align 4
-  %40 = load i32, i32* %j, align 4
-  %41 = load i32, i32* %i, align 4
+  store i32 %39, i32* %i1, align 4
+  %40 = load i32, i32* %j2, align 4
+  %41 = load i32, i32* %i1, align 4
   %42 = add i32 %40, %41
-  store i32 %42, i32* %j, align 4
-  br label %loop.head13
+  store i32 %42, i32* %j2, align 4
+  br label %loop.head15
 
-loop.end15:                                       ; preds = %loop.head13
-  %43 = load i32, i32* %j, align 4
+loop.end17:                                       ; preds = %loop.head15
+  %43 = load i32, i32* %j2, align 4
   %44 = icmp ne i32 %43, 25
-  br i1 %44, label %then16, label %else17
+  br i1 %44, label %then18, label %else19
 
-then16:                                           ; preds = %loop.end15
+then18:                                           ; preds = %loop.end17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont20
 
-else17:                                           ; preds = %loop.end15
-  br label %ifcont18
+else19:                                           ; preds = %loop.end17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %else17, %then16
-  %45 = load i32, i32* %j, align 4
+ifcont20:                                         ; preds = %else19, %then18
+  %45 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 -1, i32* %i, align 4
-  br label %loop.head19
+  store i32 0, i32* %j2, align 4
+  store i32 -1, i32* %i1, align 4
+  br label %loop.head21
 
-loop.head19:                                      ; preds = %loop.body20, %ifcont18
-  %46 = load i32, i32* %i, align 4
+loop.head21:                                      ; preds = %loop.body22, %ifcont20
+  %46 = load i32, i32* %i1, align 4
   %47 = add i32 %46, 2
   %48 = icmp sle i32 %47, 10
-  br i1 %48, label %loop.body20, label %loop.end21
+  br i1 %48, label %loop.body22, label %loop.end23
 
-loop.body20:                                      ; preds = %loop.head19
-  %49 = load i32, i32* %i, align 4
+loop.body22:                                      ; preds = %loop.head21
+  %49 = load i32, i32* %i1, align 4
   %50 = add i32 %49, 2
-  store i32 %50, i32* %i, align 4
-  %51 = load i32, i32* %j, align 4
-  %52 = load i32, i32* %i, align 4
+  store i32 %50, i32* %i1, align 4
+  %51 = load i32, i32* %j2, align 4
+  %52 = load i32, i32* %i1, align 4
   %53 = add i32 %51, %52
-  store i32 %53, i32* %j, align 4
-  br label %loop.head19
+  store i32 %53, i32* %j2, align 4
+  br label %loop.head21
 
-loop.end21:                                       ; preds = %loop.head19
-  %54 = load i32, i32* %j, align 4
+loop.end23:                                       ; preds = %loop.head21
+  %54 = load i32, i32* %j2, align 4
   %55 = icmp ne i32 %54, 25
-  br i1 %55, label %then22, label %else23
+  br i1 %55, label %then24, label %else25
 
-then22:                                           ; preds = %loop.end21
+then24:                                           ; preds = %loop.end23
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont24
+  br label %ifcont26
 
-else23:                                           ; preds = %loop.end21
-  br label %ifcont24
+else25:                                           ; preds = %loop.end23
+  br label %ifcont26
 
-ifcont24:                                         ; preds = %else23, %then22
-  %56 = load i32, i32* %j, align 4
+ifcont26:                                         ; preds = %else25, %then24
+  %56 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 -2, i32* %i, align 4
-  br label %loop.head25
+  store i32 0, i32* %j2, align 4
+  store i32 -2, i32* %i1, align 4
+  br label %loop.head27
 
-loop.head25:                                      ; preds = %loop.body26, %ifcont24
-  %57 = load i32, i32* %i, align 4
+loop.head27:                                      ; preds = %loop.body28, %ifcont26
+  %57 = load i32, i32* %i1, align 4
   %58 = add i32 %57, 3
   %59 = icmp sle i32 %58, 10
-  br i1 %59, label %loop.body26, label %loop.end27
+  br i1 %59, label %loop.body28, label %loop.end29
 
-loop.body26:                                      ; preds = %loop.head25
-  %60 = load i32, i32* %i, align 4
+loop.body28:                                      ; preds = %loop.head27
+  %60 = load i32, i32* %i1, align 4
   %61 = add i32 %60, 3
-  store i32 %61, i32* %i, align 4
-  %62 = load i32, i32* %j, align 4
-  %63 = load i32, i32* %i, align 4
+  store i32 %61, i32* %i1, align 4
+  %62 = load i32, i32* %j2, align 4
+  %63 = load i32, i32* %i1, align 4
   %64 = add i32 %62, %63
-  store i32 %64, i32* %j, align 4
-  br label %loop.head25
+  store i32 %64, i32* %j2, align 4
+  br label %loop.head27
 
-loop.end27:                                       ; preds = %loop.head25
-  %65 = load i32, i32* %j, align 4
+loop.end29:                                       ; preds = %loop.head27
+  %65 = load i32, i32* %j2, align 4
   %66 = icmp ne i32 %65, 22
-  br i1 %66, label %then28, label %else29
+  br i1 %66, label %then30, label %else31
 
-then28:                                           ; preds = %loop.end27
+then30:                                           ; preds = %loop.end29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont32
 
-else29:                                           ; preds = %loop.end27
-  br label %ifcont30
+else31:                                           ; preds = %loop.end29
+  br label %ifcont32
 
-ifcont30:                                         ; preds = %else29, %then28
-  %67 = load i32, i32* %j, align 4
+ifcont32:                                         ; preds = %else31, %then30
+  %67 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 13, i32* %i, align 4
-  br label %loop.head31
+  store i32 0, i32* %j2, align 4
+  store i32 13, i32* %i1, align 4
+  br label %loop.head33
 
-loop.head31:                                      ; preds = %loop.body32, %ifcont30
-  %68 = load i32, i32* %i, align 4
+loop.head33:                                      ; preds = %loop.body34, %ifcont32
+  %68 = load i32, i32* %i1, align 4
   %69 = add i32 %68, -3
   %70 = icmp sge i32 %69, 1
-  br i1 %70, label %loop.body32, label %loop.end33
+  br i1 %70, label %loop.body34, label %loop.end35
 
-loop.body32:                                      ; preds = %loop.head31
-  %71 = load i32, i32* %i, align 4
+loop.body34:                                      ; preds = %loop.head33
+  %71 = load i32, i32* %i1, align 4
   %72 = add i32 %71, -3
-  store i32 %72, i32* %i, align 4
-  %73 = load i32, i32* %j, align 4
-  %74 = load i32, i32* %i, align 4
+  store i32 %72, i32* %i1, align 4
+  %73 = load i32, i32* %j2, align 4
+  %74 = load i32, i32* %i1, align 4
   %75 = add i32 %73, %74
-  store i32 %75, i32* %j, align 4
-  br label %loop.head31
+  store i32 %75, i32* %j2, align 4
+  br label %loop.head33
 
-loop.end33:                                       ; preds = %loop.head31
-  %76 = load i32, i32* %j, align 4
+loop.end35:                                       ; preds = %loop.head33
+  %76 = load i32, i32* %j2, align 4
   %77 = icmp ne i32 %76, 22
-  br i1 %77, label %then34, label %else35
+  br i1 %77, label %then36, label %else37
 
-then34:                                           ; preds = %loop.end33
+then36:                                           ; preds = %loop.end35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont38
 
-else35:                                           ; preds = %loop.end33
-  br label %ifcont36
+else37:                                           ; preds = %loop.end35
+  br label %ifcont38
 
-ifcont36:                                         ; preds = %else35, %then34
-  %78 = load i32, i32* %j, align 4
+ifcont38:                                         ; preds = %else37, %then36
+  %78 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head37
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
+  br label %loop.head39
 
-loop.head37:                                      ; preds = %loop.body38, %ifcont36
-  %79 = load i32, i32* %i, align 4
+loop.head39:                                      ; preds = %loop.body40, %ifcont38
+  %79 = load i32, i32* %i1, align 4
   %80 = add i32 %79, 1
   %81 = icmp sle i32 %80, 1
-  br i1 %81, label %loop.body38, label %loop.end39
+  br i1 %81, label %loop.body40, label %loop.end41
 
-loop.body38:                                      ; preds = %loop.head37
-  %82 = load i32, i32* %i, align 4
+loop.body40:                                      ; preds = %loop.head39
+  %82 = load i32, i32* %i1, align 4
   %83 = add i32 %82, 1
-  store i32 %83, i32* %i, align 4
-  %84 = load i32, i32* %j, align 4
-  %85 = load i32, i32* %i, align 4
+  store i32 %83, i32* %i1, align 4
+  %84 = load i32, i32* %j2, align 4
+  %85 = load i32, i32* %i1, align 4
   %86 = add i32 %84, %85
-  store i32 %86, i32* %j, align 4
-  br label %loop.head37
+  store i32 %86, i32* %j2, align 4
+  br label %loop.head39
 
-loop.end39:                                       ; preds = %loop.head37
-  %87 = load i32, i32* %j, align 4
+loop.end41:                                       ; preds = %loop.head39
+  %87 = load i32, i32* %j2, align 4
   %88 = icmp ne i32 %87, 1
-  br i1 %88, label %then40, label %else41
+  br i1 %88, label %then42, label %else43
 
-then40:                                           ; preds = %loop.end39
+then42:                                           ; preds = %loop.end41
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont42
+  br label %ifcont44
 
-else41:                                           ; preds = %loop.end39
-  br label %ifcont42
+else43:                                           ; preds = %loop.end41
+  br label %ifcont44
 
-ifcont42:                                         ; preds = %else41, %then40
-  %89 = load i32, i32* %j, align 4
+ifcont44:                                         ; preds = %else43, %then42
+  %89 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i32 %89, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 2, i32* %i, align 4
-  br label %loop.head43
+  store i32 0, i32* %j2, align 4
+  store i32 2, i32* %i1, align 4
+  br label %loop.head45
 
-loop.head43:                                      ; preds = %loop.body44, %ifcont42
-  %90 = load i32, i32* %i, align 4
+loop.head45:                                      ; preds = %loop.body46, %ifcont44
+  %90 = load i32, i32* %i1, align 4
   %91 = add i32 %90, -1
   %92 = icmp sge i32 %91, 1
-  br i1 %92, label %loop.body44, label %loop.end45
+  br i1 %92, label %loop.body46, label %loop.end47
 
-loop.body44:                                      ; preds = %loop.head43
-  %93 = load i32, i32* %i, align 4
+loop.body46:                                      ; preds = %loop.head45
+  %93 = load i32, i32* %i1, align 4
   %94 = add i32 %93, -1
-  store i32 %94, i32* %i, align 4
-  %95 = load i32, i32* %j, align 4
-  %96 = load i32, i32* %i, align 4
+  store i32 %94, i32* %i1, align 4
+  %95 = load i32, i32* %j2, align 4
+  %96 = load i32, i32* %i1, align 4
   %97 = add i32 %95, %96
-  store i32 %97, i32* %j, align 4
-  br label %loop.head43
+  store i32 %97, i32* %j2, align 4
+  br label %loop.head45
 
-loop.end45:                                       ; preds = %loop.head43
-  %98 = load i32, i32* %j, align 4
+loop.end47:                                       ; preds = %loop.head45
+  %98 = load i32, i32* %j2, align 4
   %99 = icmp ne i32 %98, 1
-  br i1 %99, label %then46, label %else47
+  br i1 %99, label %then48, label %else49
 
-then46:                                           ; preds = %loop.end45
+then48:                                           ; preds = %loop.end47
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @48, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont48
+  br label %ifcont50
 
-else47:                                           ; preds = %loop.end45
-  br label %ifcont48
+else49:                                           ; preds = %loop.end47
+  br label %ifcont50
 
-ifcont48:                                         ; preds = %else47, %then46
-  %100 = load i32, i32* %j, align 4
+ifcont50:                                         ; preds = %else49, %then48
+  %100 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i32 %100, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head49
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
+  br label %loop.head51
 
-loop.head49:                                      ; preds = %loop.body50, %ifcont48
-  %101 = load i32, i32* %i, align 4
+loop.head51:                                      ; preds = %loop.body52, %ifcont50
+  %101 = load i32, i32* %i1, align 4
   %102 = add i32 %101, 1
   %103 = icmp sle i32 %102, 0
-  br i1 %103, label %loop.body50, label %loop.end51
+  br i1 %103, label %loop.body52, label %loop.end53
 
-loop.body50:                                      ; preds = %loop.head49
-  %104 = load i32, i32* %i, align 4
+loop.body52:                                      ; preds = %loop.head51
+  %104 = load i32, i32* %i1, align 4
   %105 = add i32 %104, 1
-  store i32 %105, i32* %i, align 4
-  %106 = load i32, i32* %j, align 4
-  %107 = load i32, i32* %i, align 4
+  store i32 %105, i32* %i1, align 4
+  %106 = load i32, i32* %j2, align 4
+  %107 = load i32, i32* %i1, align 4
   %108 = add i32 %106, %107
-  store i32 %108, i32* %j, align 4
-  br label %loop.head49
+  store i32 %108, i32* %j2, align 4
+  br label %loop.head51
 
-loop.end51:                                       ; preds = %loop.head49
-  %109 = load i32, i32* %j, align 4
+loop.end53:                                       ; preds = %loop.head51
+  %109 = load i32, i32* %j2, align 4
   %110 = icmp ne i32 %109, 0
-  br i1 %110, label %then52, label %else53
+  br i1 %110, label %then54, label %else55
 
-then52:                                           ; preds = %loop.end51
+then54:                                           ; preds = %loop.end53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @56, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @54, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @55, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont54
+  br label %ifcont56
 
-else53:                                           ; preds = %loop.end51
-  br label %ifcont54
+else55:                                           ; preds = %loop.end53
+  br label %ifcont56
 
-ifcont54:                                         ; preds = %else53, %then52
-  %111 = load i32, i32* %j, align 4
+ifcont56:                                         ; preds = %else55, %then54
+  %111 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @59, i32 0, i32 0), i32 %111, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 1, i32* %i, align 4
-  br label %loop.head55
+  store i32 0, i32* %j2, align 4
+  store i32 1, i32* %i1, align 4
+  br label %loop.head57
 
-loop.head55:                                      ; preds = %loop.body56, %ifcont54
-  %112 = load i32, i32* %i, align 4
+loop.head57:                                      ; preds = %loop.body58, %ifcont56
+  %112 = load i32, i32* %i1, align 4
   %113 = add i32 %112, -1
   %114 = icmp sge i32 %113, 1
-  br i1 %114, label %loop.body56, label %loop.end57
+  br i1 %114, label %loop.body58, label %loop.end59
 
-loop.body56:                                      ; preds = %loop.head55
-  %115 = load i32, i32* %i, align 4
+loop.body58:                                      ; preds = %loop.head57
+  %115 = load i32, i32* %i1, align 4
   %116 = add i32 %115, -1
-  store i32 %116, i32* %i, align 4
-  %117 = load i32, i32* %j, align 4
-  %118 = load i32, i32* %i, align 4
+  store i32 %116, i32* %i1, align 4
+  %117 = load i32, i32* %j2, align 4
+  %118 = load i32, i32* %i1, align 4
   %119 = add i32 %117, %118
-  store i32 %119, i32* %j, align 4
-  br label %loop.head55
+  store i32 %119, i32* %j2, align 4
+  br label %loop.head57
 
-loop.end57:                                       ; preds = %loop.head55
-  %120 = load i32, i32* %j, align 4
+loop.end59:                                       ; preds = %loop.head57
+  %120 = load i32, i32* %j2, align 4
   %121 = icmp ne i32 %120, 0
-  br i1 %121, label %then58, label %else59
+  br i1 %121, label %then60, label %else61
 
-then58:                                           ; preds = %loop.end57
+then60:                                           ; preds = %loop.end59
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @60, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont60
+  br label %ifcont62
 
-else59:                                           ; preds = %loop.end57
-  br label %ifcont60
+else61:                                           ; preds = %loop.end59
+  br label %ifcont62
 
-ifcont60:                                         ; preds = %else59, %then58
-  %122 = load i32, i32* %j, align 4
+ifcont62:                                         ; preds = %else61, %then60
+  %122 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i32 %122, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %ifcont60
+return:                                           ; preds = %ifcont62
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "1d23925570cdba69b6274e1b81b3784505fe9ed2e190f29006859f4c",
+    "stdout_hash": "dd2b7756cb66f9dd151ff1221a5407d244444dc629fa928794dca11e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -22,38 +22,42 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 1, i32* %a, align 4
-  store i32 10, i32* %b, align 4
-  %2 = load i32, i32* %a, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a1 = alloca i32, align 4
+  %b2 = alloca i32, align 4
+  %i3 = alloca i32, align 4
+  %j4 = alloca i32, align 4
+  store i32 0, i32* %j4, align 4
+  store i32 1, i32* %a1, align 4
+  store i32 10, i32* %b2, align 4
+  %2 = load i32, i32* %a1, align 4
   %3 = sub i32 %2, 1
-  store i32 %3, i32* %i, align 4
+  store i32 %3, i32* %i3, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %4 = load i32, i32* %i, align 4
+  %4 = load i32, i32* %i3, align 4
   %5 = add i32 %4, 1
-  %6 = load i32, i32* %b, align 4
+  %6 = load i32, i32* %b2, align 4
   %7 = icmp sle i32 %5, %6
   br i1 %7, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %8 = load i32, i32* %i, align 4
+  %8 = load i32, i32* %i3, align 4
   %9 = add i32 %8, 1
-  store i32 %9, i32* %i, align 4
-  %10 = load i32, i32* %j, align 4
-  %11 = load i32, i32* %i, align 4
+  store i32 %9, i32* %i3, align 4
+  %10 = load i32, i32* %j4, align 4
+  %11 = load i32, i32* %i3, align 4
   %12 = add i32 %10, %11
-  store i32 %12, i32* %j, align 4
+  store i32 %12, i32* %j4, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %13 = load i32, i32* %j, align 4
+  %13 = load i32, i32* %j4, align 4
   %14 = icmp ne i32 %13, 55
   br i1 %14, label %then, label %else
 
@@ -66,120 +70,120 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %15 = load i32, i32* %j, align 4
+  %15 = load i32, i32* %j4, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  store i32 0, i32* %a, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head1
+  store i32 0, i32* %a1, align 4
+  store i32 0, i32* %i3, align 4
+  br label %loop.head5
 
-loop.head1:                                       ; preds = %loop.end5, %ifcont
-  %16 = load i32, i32* %i, align 4
+loop.head5:                                       ; preds = %loop.end9, %ifcont
+  %16 = load i32, i32* %i3, align 4
   %17 = add i32 %16, 1
   %18 = icmp sle i32 %17, 10
-  br i1 %18, label %loop.body2, label %loop.end6
+  br i1 %18, label %loop.body6, label %loop.end10
 
-loop.body2:                                       ; preds = %loop.head1
-  %19 = load i32, i32* %i, align 4
+loop.body6:                                       ; preds = %loop.head5
+  %19 = load i32, i32* %i3, align 4
   %20 = add i32 %19, 1
-  store i32 %20, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head3
+  store i32 %20, i32* %i3, align 4
+  store i32 0, i32* %j4, align 4
+  br label %loop.head7
 
-loop.head3:                                       ; preds = %loop.body4, %loop.body2
-  %21 = load i32, i32* %j, align 4
+loop.head7:                                       ; preds = %loop.body8, %loop.body6
+  %21 = load i32, i32* %j4, align 4
   %22 = add i32 %21, 1
   %23 = icmp sle i32 %22, 10
-  br i1 %23, label %loop.body4, label %loop.end5
+  br i1 %23, label %loop.body8, label %loop.end9
 
-loop.body4:                                       ; preds = %loop.head3
-  %24 = load i32, i32* %j, align 4
+loop.body8:                                       ; preds = %loop.head7
+  %24 = load i32, i32* %j4, align 4
   %25 = add i32 %24, 1
-  store i32 %25, i32* %j, align 4
-  %26 = load i32, i32* %a, align 4
-  %27 = load i32, i32* %i, align 4
+  store i32 %25, i32* %j4, align 4
+  %26 = load i32, i32* %a1, align 4
+  %27 = load i32, i32* %i3, align 4
   %28 = sub i32 %27, 1
   %29 = mul i32 %28, 10
   %30 = add i32 %26, %29
-  %31 = load i32, i32* %j, align 4
+  %31 = load i32, i32* %j4, align 4
   %32 = add i32 %30, %31
-  store i32 %32, i32* %a, align 4
-  br label %loop.head3
+  store i32 %32, i32* %a1, align 4
+  br label %loop.head7
 
-loop.end5:                                        ; preds = %loop.head3
-  br label %loop.head1
+loop.end9:                                        ; preds = %loop.head7
+  br label %loop.head5
 
-loop.end6:                                        ; preds = %loop.head1
-  %33 = load i32, i32* %a, align 4
+loop.end10:                                       ; preds = %loop.head5
+  %33 = load i32, i32* %a1, align 4
   %34 = icmp ne i32 %33, 5050
-  br i1 %34, label %then7, label %else8
+  br i1 %34, label %then11, label %else12
 
-then7:                                            ; preds = %loop.end6
+then11:                                           ; preds = %loop.end10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont13
 
-else8:                                            ; preds = %loop.end6
-  br label %ifcont9
+else12:                                           ; preds = %loop.end10
+  br label %ifcont13
 
-ifcont9:                                          ; preds = %else8, %then7
-  %35 = load i32, i32* %a, align 4
+ifcont13:                                         ; preds = %else12, %then11
+  %35 = load i32, i32* %a1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 %35, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  store i32 0, i32* %a, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head10
+  store i32 0, i32* %a1, align 4
+  store i32 0, i32* %i3, align 4
+  br label %loop.head14
 
-loop.head10:                                      ; preds = %loop.end14, %ifcont9
-  %36 = load i32, i32* %i, align 4
+loop.head14:                                      ; preds = %loop.end18, %ifcont13
+  %36 = load i32, i32* %i3, align 4
   %37 = add i32 %36, 1
   %38 = icmp sle i32 %37, 10
-  br i1 %38, label %loop.body11, label %loop.end15
+  br i1 %38, label %loop.body15, label %loop.end19
 
-loop.body11:                                      ; preds = %loop.head10
-  %39 = load i32, i32* %i, align 4
+loop.body15:                                      ; preds = %loop.head14
+  %39 = load i32, i32* %i3, align 4
   %40 = add i32 %39, 1
-  store i32 %40, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head12
+  store i32 %40, i32* %i3, align 4
+  store i32 0, i32* %j4, align 4
+  br label %loop.head16
 
-loop.head12:                                      ; preds = %loop.body13, %loop.body11
-  %41 = load i32, i32* %j, align 4
+loop.head16:                                      ; preds = %loop.body17, %loop.body15
+  %41 = load i32, i32* %j4, align 4
   %42 = add i32 %41, 1
-  %43 = load i32, i32* %i, align 4
+  %43 = load i32, i32* %i3, align 4
   %44 = icmp sle i32 %42, %43
-  br i1 %44, label %loop.body13, label %loop.end14
+  br i1 %44, label %loop.body17, label %loop.end18
 
-loop.body13:                                      ; preds = %loop.head12
-  %45 = load i32, i32* %j, align 4
+loop.body17:                                      ; preds = %loop.head16
+  %45 = load i32, i32* %j4, align 4
   %46 = add i32 %45, 1
-  store i32 %46, i32* %j, align 4
-  %47 = load i32, i32* %a, align 4
-  %48 = load i32, i32* %j, align 4
+  store i32 %46, i32* %j4, align 4
+  %47 = load i32, i32* %a1, align 4
+  %48 = load i32, i32* %j4, align 4
   %49 = add i32 %47, %48
-  store i32 %49, i32* %a, align 4
-  br label %loop.head12
+  store i32 %49, i32* %a1, align 4
+  br label %loop.head16
 
-loop.end14:                                       ; preds = %loop.head12
-  br label %loop.head10
+loop.end18:                                       ; preds = %loop.head16
+  br label %loop.head14
 
-loop.end15:                                       ; preds = %loop.head10
-  %50 = load i32, i32* %a, align 4
+loop.end19:                                       ; preds = %loop.head14
+  %50 = load i32, i32* %a1, align 4
   %51 = icmp ne i32 %50, 220
-  br i1 %51, label %then16, label %else17
+  br i1 %51, label %then20, label %else21
 
-then16:                                           ; preds = %loop.end15
+then20:                                           ; preds = %loop.end19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont22
 
-else17:                                           ; preds = %loop.end15
-  br label %ifcont18
+else21:                                           ; preds = %loop.end19
+  br label %ifcont22
 
-ifcont18:                                         ; preds = %else17, %then16
-  %52 = load i32, i32* %a, align 4
+ifcont22:                                         ; preds = %else21, %then20
+  %52 = load i32, i32* %a1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %ifcont18
+return:                                           ; preds = %ifcont22
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "9f30ecdebacc78beec3897b8cc54f234c71e52760bcb3b1cf7ad0fc2",
+    "stdout_hash": "10e15705167e561533d73b5cc83b184034acb21aac7185e1254340f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -22,28 +22,30 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont3, %.entry
-  %2 = load i32, i32* %i, align 4
+loop.head:                                        ; preds = %ifcont5, %.entry
+  %2 = load i32, i32* %i1, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %j, align 4
-  %8 = load i32, i32* %i, align 4
+  store i32 %6, i32* %i1, align 4
+  %7 = load i32, i32* %j2, align 4
+  %8 = load i32, i32* %i1, align 4
   %9 = add i32 %7, %8
-  store i32 %9, i32* %j, align 4
-  %10 = load i32, i32* %i, align 4
+  store i32 %9, i32* %j2, align 4
+  %10 = load i32, i32* %i1, align 4
   %11 = icmp eq i32 %10, 3
   br i1 %11, label %then, label %else
 
@@ -54,141 +56,141 @@ else:                                             ; preds = %loop.body
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load i32, i32* %i, align 4
+  %12 = load i32, i32* %i1, align 4
   %13 = icmp eq i32 %12, 2
-  br i1 %13, label %then1, label %else2
+  br i1 %13, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   br label %loop.end
 
 unreachable_after_exit:                           ; No predecessors!
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %unreachable_after_exit
+ifcont5:                                          ; preds = %else4, %unreachable_after_exit
   br label %loop.head
 
-loop.end:                                         ; preds = %then1, %loop.head
-  %14 = load i32, i32* %j, align 4
+loop.end:                                         ; preds = %then3, %loop.head
+  %14 = load i32, i32* %j2, align 4
   %15 = icmp ne i32 %14, 3
-  br i1 %15, label %then4, label %else5
+  br i1 %15, label %then6, label %else7
 
-then4:                                            ; preds = %loop.end
+then6:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %loop.end
-  br label %ifcont6
+else7:                                            ; preds = %loop.end
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
-  %16 = load i32, i32* %j, align 4
+ifcont8:                                          ; preds = %else7, %then6
+  %16 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head7
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
+  br label %loop.head9
 
-loop.head7:                                       ; preds = %ifcont12, %ifcont6
-  %17 = load i32, i32* %i, align 4
+loop.head9:                                       ; preds = %ifcont14, %ifcont8
+  %17 = load i32, i32* %i1, align 4
   %18 = add i32 %17, 1
   %19 = icmp sle i32 %18, 10
-  br i1 %19, label %loop.body8, label %loop.end13
+  br i1 %19, label %loop.body10, label %loop.end15
 
-loop.body8:                                       ; preds = %loop.head7
-  %20 = load i32, i32* %i, align 4
+loop.body10:                                      ; preds = %loop.head9
+  %20 = load i32, i32* %i1, align 4
   %21 = add i32 %20, 1
-  store i32 %21, i32* %i, align 4
-  %22 = load i32, i32* %i, align 4
+  store i32 %21, i32* %i1, align 4
+  %22 = load i32, i32* %i1, align 4
   %23 = icmp eq i32 %22, 2
-  br i1 %23, label %then9, label %else11
+  br i1 %23, label %then11, label %else13
 
-then9:                                            ; preds = %loop.body8
-  br label %loop.end13
+then11:                                           ; preds = %loop.body10
+  br label %loop.end15
 
-unreachable_after_exit10:                         ; No predecessors!
-  br label %ifcont12
+unreachable_after_exit12:                         ; No predecessors!
+  br label %ifcont14
 
-else11:                                           ; preds = %loop.body8
-  br label %ifcont12
+else13:                                           ; preds = %loop.body10
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %unreachable_after_exit10
-  %24 = load i32, i32* %j, align 4
-  %25 = load i32, i32* %i, align 4
+ifcont14:                                         ; preds = %else13, %unreachable_after_exit12
+  %24 = load i32, i32* %j2, align 4
+  %25 = load i32, i32* %i1, align 4
   %26 = add i32 %24, %25
-  store i32 %26, i32* %j, align 4
-  br label %loop.head7
+  store i32 %26, i32* %j2, align 4
+  br label %loop.head9
 
-loop.end13:                                       ; preds = %then9, %loop.head7
-  %27 = load i32, i32* %j, align 4
+loop.end15:                                       ; preds = %then11, %loop.head9
+  %27 = load i32, i32* %j2, align 4
   %28 = icmp ne i32 %27, 1
-  br i1 %28, label %then14, label %else15
+  br i1 %28, label %then16, label %else17
 
-then14:                                           ; preds = %loop.end13
+then16:                                           ; preds = %loop.end15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont16
+  br label %ifcont18
 
-else15:                                           ; preds = %loop.end13
-  br label %ifcont16
+else17:                                           ; preds = %loop.end15
+  br label %ifcont18
 
-ifcont16:                                         ; preds = %else15, %then14
-  %29 = load i32, i32* %j, align 4
+ifcont18:                                         ; preds = %else17, %then16
+  %29 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
-  br label %loop.head17
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
+  br label %loop.head19
 
-loop.head17:                                      ; preds = %ifcont21, %then19, %ifcont16
-  %30 = load i32, i32* %i, align 4
+loop.head19:                                      ; preds = %ifcont23, %then21, %ifcont18
+  %30 = load i32, i32* %i1, align 4
   %31 = add i32 %30, 1
   %32 = icmp sle i32 %31, 10
-  br i1 %32, label %loop.body18, label %loop.end22
+  br i1 %32, label %loop.body20, label %loop.end24
 
-loop.body18:                                      ; preds = %loop.head17
-  %33 = load i32, i32* %i, align 4
+loop.body20:                                      ; preds = %loop.head19
+  %33 = load i32, i32* %i1, align 4
   %34 = add i32 %33, 1
-  store i32 %34, i32* %i, align 4
-  %35 = load i32, i32* %i, align 4
+  store i32 %34, i32* %i1, align 4
+  %35 = load i32, i32* %i1, align 4
   %36 = icmp eq i32 %35, 2
-  br i1 %36, label %then19, label %else20
+  br i1 %36, label %then21, label %else22
 
-then19:                                           ; preds = %loop.body18
-  br label %loop.head17
+then21:                                           ; preds = %loop.body20
+  br label %loop.head19
 
 unreachable_after_cycle:                          ; No predecessors!
-  br label %ifcont21
+  br label %ifcont23
 
-else20:                                           ; preds = %loop.body18
-  br label %ifcont21
+else22:                                           ; preds = %loop.body20
+  br label %ifcont23
 
-ifcont21:                                         ; preds = %else20, %unreachable_after_cycle
-  %37 = load i32, i32* %j, align 4
-  %38 = load i32, i32* %i, align 4
+ifcont23:                                         ; preds = %else22, %unreachable_after_cycle
+  %37 = load i32, i32* %j2, align 4
+  %38 = load i32, i32* %i1, align 4
   %39 = add i32 %37, %38
-  store i32 %39, i32* %j, align 4
-  br label %loop.head17
+  store i32 %39, i32* %j2, align 4
+  br label %loop.head19
 
-loop.end22:                                       ; preds = %loop.head17
-  %40 = load i32, i32* %j, align 4
+loop.end24:                                       ; preds = %loop.head19
+  %40 = load i32, i32* %j2, align 4
   %41 = icmp ne i32 %40, 53
-  br i1 %41, label %then23, label %else24
+  br i1 %41, label %then25, label %else26
 
-then23:                                           ; preds = %loop.end22
+then25:                                           ; preds = %loop.end24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont25
+  br label %ifcont27
 
-else24:                                           ; preds = %loop.end22
-  br label %ifcont25
+else26:                                           ; preds = %loop.end24
+  br label %ifcont27
 
-ifcont25:                                         ; preds = %else24, %then23
-  %42 = load i32, i32* %j, align 4
+ifcont27:                                         ; preds = %else26, %then25
+  %42 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %ifcont25
+return:                                           ; preds = %ifcont27
   ret i32 0
 }
 

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "3ea522b53bdea99a02b419f1aa2593b4c4feb9b81ec1f94e7208b809",
+    "stdout_hash": "ec895843844feb6912849dd0f662a80a6d019fc48e3b07c1f099e24f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -25,30 +25,33 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   %k = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 2, i32* %k, align 4
-  %2 = load i32, i32* %k, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  %k3 = alloca i32, align 4
+  store i32 0, i32* %j2, align 4
+  store i32 2, i32* %k3, align 4
+  %2 = load i32, i32* %k3, align 4
   %3 = sub i32 1, %2
-  store i32 %3, i32* %i, align 4
+  store i32 %3, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %4 = load i32, i32* %k, align 4
+  %4 = load i32, i32* %k3, align 4
   %5 = icmp sgt i32 %4, 0
-  %6 = load i32, i32* %i, align 4
-  %7 = load i32, i32* %k, align 4
+  %6 = load i32, i32* %i1, align 4
+  %7 = load i32, i32* %k3, align 4
   %8 = add i32 %6, %7
   %9 = icmp sle i32 %8, 10
   %10 = icmp eq i1 %5, false
   %11 = select i1 %10, i1 %5, i1 %9
-  %12 = load i32, i32* %k, align 4
+  %12 = load i32, i32* %k3, align 4
   %13 = icmp sle i32 %12, 0
-  %14 = load i32, i32* %i, align 4
-  %15 = load i32, i32* %k, align 4
+  %14 = load i32, i32* %i1, align 4
+  %15 = load i32, i32* %k3, align 4
   %16 = add i32 %14, %15
   %17 = icmp sge i32 %16, 10
   %18 = icmp eq i1 %13, false
@@ -58,18 +61,18 @@ loop.head:                                        ; preds = %loop.body, %.entry
   br i1 %21, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %22 = load i32, i32* %i, align 4
-  %23 = load i32, i32* %k, align 4
+  %22 = load i32, i32* %i1, align 4
+  %23 = load i32, i32* %k3, align 4
   %24 = add i32 %22, %23
-  store i32 %24, i32* %i, align 4
-  %25 = load i32, i32* %j, align 4
-  %26 = load i32, i32* %i, align 4
+  store i32 %24, i32* %i1, align 4
+  %25 = load i32, i32* %j2, align 4
+  %26 = load i32, i32* %i1, align 4
   %27 = add i32 %25, %26
-  store i32 %27, i32* %j, align 4
+  store i32 %27, i32* %j2, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %28 = load i32, i32* %j, align 4
+  %28 = load i32, i32* %j2, align 4
   %29 = icmp ne i32 %28, 25
   br i1 %29, label %then, label %else
 
@@ -82,245 +85,245 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %30 = load i32, i32* %j, align 4
+  %30 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 -2, i32* %k, align 4
-  %31 = load i32, i32* %k, align 4
+  store i32 0, i32* %j2, align 4
+  store i32 -2, i32* %k3, align 4
+  %31 = load i32, i32* %k3, align 4
   %32 = sub i32 10, %31
-  store i32 %32, i32* %i, align 4
-  br label %loop.head1
+  store i32 %32, i32* %i1, align 4
+  br label %loop.head4
 
-loop.head1:                                       ; preds = %loop.body2, %ifcont
-  %33 = load i32, i32* %k, align 4
+loop.head4:                                       ; preds = %loop.body5, %ifcont
+  %33 = load i32, i32* %k3, align 4
   %34 = icmp sgt i32 %33, 0
-  %35 = load i32, i32* %i, align 4
-  %36 = load i32, i32* %k, align 4
+  %35 = load i32, i32* %i1, align 4
+  %36 = load i32, i32* %k3, align 4
   %37 = add i32 %35, %36
   %38 = icmp sle i32 %37, 1
   %39 = icmp eq i1 %34, false
   %40 = select i1 %39, i1 %34, i1 %38
-  %41 = load i32, i32* %k, align 4
+  %41 = load i32, i32* %k3, align 4
   %42 = icmp sle i32 %41, 0
-  %43 = load i32, i32* %i, align 4
-  %44 = load i32, i32* %k, align 4
+  %43 = load i32, i32* %i1, align 4
+  %44 = load i32, i32* %k3, align 4
   %45 = add i32 %43, %44
   %46 = icmp sge i32 %45, 1
   %47 = icmp eq i1 %42, false
   %48 = select i1 %47, i1 %42, i1 %46
   %49 = icmp eq i1 %40, false
   %50 = select i1 %49, i1 %48, i1 %40
-  br i1 %50, label %loop.body2, label %loop.end3
+  br i1 %50, label %loop.body5, label %loop.end6
 
-loop.body2:                                       ; preds = %loop.head1
-  %51 = load i32, i32* %i, align 4
-  %52 = load i32, i32* %k, align 4
+loop.body5:                                       ; preds = %loop.head4
+  %51 = load i32, i32* %i1, align 4
+  %52 = load i32, i32* %k3, align 4
   %53 = add i32 %51, %52
-  store i32 %53, i32* %i, align 4
-  %54 = load i32, i32* %j, align 4
-  %55 = load i32, i32* %i, align 4
+  store i32 %53, i32* %i1, align 4
+  %54 = load i32, i32* %j2, align 4
+  %55 = load i32, i32* %i1, align 4
   %56 = add i32 %54, %55
-  store i32 %56, i32* %j, align 4
-  br label %loop.head1
+  store i32 %56, i32* %j2, align 4
+  br label %loop.head4
 
-loop.end3:                                        ; preds = %loop.head1
-  %57 = load i32, i32* %j, align 4
+loop.end6:                                        ; preds = %loop.head4
+  %57 = load i32, i32* %j2, align 4
   %58 = icmp ne i32 %57, 30
-  br i1 %58, label %then4, label %else5
+  br i1 %58, label %then7, label %else8
 
-then4:                                            ; preds = %loop.end3
+then7:                                            ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont9
 
-else5:                                            ; preds = %loop.end3
-  br label %ifcont6
+else8:                                            ; preds = %loop.end6
+  br label %ifcont9
 
-ifcont6:                                          ; preds = %else5, %then4
-  %59 = load i32, i32* %j, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %59 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 %59, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i1, align 4
   br label %a.head
 
-a.head:                                           ; preds = %ifcont9, %ifcont6
-  %60 = load i32, i32* %i, align 4
+a.head:                                           ; preds = %ifcont12, %ifcont9
+  %60 = load i32, i32* %i1, align 4
   %61 = add i32 %60, 1
   %62 = icmp sle i32 %61, 10
   br i1 %62, label %a.body, label %a.end
 
 a.body:                                           ; preds = %a.head
-  %63 = load i32, i32* %i, align 4
+  %63 = load i32, i32* %i1, align 4
   %64 = add i32 %63, 1
-  store i32 %64, i32* %i, align 4
-  %65 = load i32, i32* %j, align 4
-  %66 = load i32, i32* %i, align 4
+  store i32 %64, i32* %i1, align 4
+  %65 = load i32, i32* %j2, align 4
+  %66 = load i32, i32* %i1, align 4
   %67 = add i32 %65, %66
-  store i32 %67, i32* %j, align 4
-  %68 = load i32, i32* %i, align 4
+  store i32 %67, i32* %j2, align 4
+  %68 = load i32, i32* %i1, align 4
   %69 = icmp eq i32 %68, 2
-  br i1 %69, label %then7, label %else8
+  br i1 %69, label %then10, label %else11
 
-then7:                                            ; preds = %a.body
+then10:                                           ; preds = %a.body
   br label %a.end
 
 unreachable_after_exit:                           ; No predecessors!
-  br label %ifcont9
+  br label %ifcont12
 
-else8:                                            ; preds = %a.body
-  br label %ifcont9
+else11:                                           ; preds = %a.body
+  br label %ifcont12
 
-ifcont9:                                          ; preds = %else8, %unreachable_after_exit
+ifcont12:                                         ; preds = %else11, %unreachable_after_exit
   br label %a.head
 
-a.end:                                            ; preds = %then7, %a.head
-  %70 = load i32, i32* %j, align 4
+a.end:                                            ; preds = %then10, %a.head
+  %70 = load i32, i32* %j2, align 4
   %71 = icmp ne i32 %70, 3
-  br i1 %71, label %then10, label %else11
+  br i1 %71, label %then13, label %else14
 
-then10:                                           ; preds = %a.end
+then13:                                           ; preds = %a.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont15
 
-else11:                                           ; preds = %a.end
-  br label %ifcont12
+else14:                                           ; preds = %a.end
+  br label %ifcont15
 
-ifcont12:                                         ; preds = %else11, %then10
-  store i32 0, i32* %j, align 4
-  store i32 -1, i32* %i, align 4
+ifcont15:                                         ; preds = %else14, %then13
+  store i32 0, i32* %j2, align 4
+  store i32 -1, i32* %i1, align 4
   br label %b.head
 
-b.head:                                           ; preds = %ifcont16, %ifcont12
-  %72 = load i32, i32* %i, align 4
+b.head:                                           ; preds = %ifcont19, %ifcont15
+  %72 = load i32, i32* %i1, align 4
   %73 = add i32 %72, 2
   %74 = icmp sle i32 %73, 10
   br i1 %74, label %b.body, label %b.end
 
 b.body:                                           ; preds = %b.head
-  %75 = load i32, i32* %i, align 4
+  %75 = load i32, i32* %i1, align 4
   %76 = add i32 %75, 2
-  store i32 %76, i32* %i, align 4
-  %77 = load i32, i32* %j, align 4
-  %78 = load i32, i32* %i, align 4
+  store i32 %76, i32* %i1, align 4
+  %77 = load i32, i32* %j2, align 4
+  %78 = load i32, i32* %i1, align 4
   %79 = add i32 %77, %78
-  store i32 %79, i32* %j, align 4
-  %80 = load i32, i32* %i, align 4
+  store i32 %79, i32* %j2, align 4
+  %80 = load i32, i32* %i1, align 4
   %81 = icmp eq i32 %80, 3
-  br i1 %81, label %then13, label %else15
+  br i1 %81, label %then16, label %else18
 
-then13:                                           ; preds = %b.body
+then16:                                           ; preds = %b.body
   br label %b.end
 
-unreachable_after_exit14:                         ; No predecessors!
-  br label %ifcont16
+unreachable_after_exit17:                         ; No predecessors!
+  br label %ifcont19
 
-else15:                                           ; preds = %b.body
-  br label %ifcont16
+else18:                                           ; preds = %b.body
+  br label %ifcont19
 
-ifcont16:                                         ; preds = %else15, %unreachable_after_exit14
+ifcont19:                                         ; preds = %else18, %unreachable_after_exit17
   br label %b.head
 
-b.end:                                            ; preds = %then13, %b.head
-  %82 = load i32, i32* %j, align 4
+b.end:                                            ; preds = %then16, %b.head
+  %82 = load i32, i32* %j2, align 4
   %83 = icmp ne i32 %82, 4
-  br i1 %83, label %then17, label %else18
+  br i1 %83, label %then20, label %else21
 
-then17:                                           ; preds = %b.end
+then20:                                           ; preds = %b.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont19
+  br label %ifcont22
 
-else18:                                           ; preds = %b.end
-  br label %ifcont19
+else21:                                           ; preds = %b.end
+  br label %ifcont22
 
-ifcont19:                                         ; preds = %else18, %then17
-  store i32 0, i32* %j, align 4
-  store i32 1, i32* %i, align 4
+ifcont22:                                         ; preds = %else21, %then20
+  store i32 0, i32* %j2, align 4
+  store i32 1, i32* %i1, align 4
   br label %c.head
 
-c.head:                                           ; preds = %ifcont23, %ifcont19
+c.head:                                           ; preds = %ifcont26, %ifcont22
   br i1 true, label %c.body, label %c.end
 
 c.body:                                           ; preds = %c.head
-  %84 = load i32, i32* %j, align 4
-  %85 = load i32, i32* %i, align 4
+  %84 = load i32, i32* %j2, align 4
+  %85 = load i32, i32* %i1, align 4
   %86 = add i32 %84, %85
-  store i32 %86, i32* %j, align 4
-  %87 = load i32, i32* %i, align 4
+  store i32 %86, i32* %j2, align 4
+  %87 = load i32, i32* %i1, align 4
   %88 = icmp eq i32 %87, 2
-  br i1 %88, label %then20, label %else22
+  br i1 %88, label %then23, label %else25
 
-then20:                                           ; preds = %c.body
+then23:                                           ; preds = %c.body
   br label %c.end
 
-unreachable_after_exit21:                         ; No predecessors!
-  br label %ifcont23
+unreachable_after_exit24:                         ; No predecessors!
+  br label %ifcont26
 
-else22:                                           ; preds = %c.body
-  br label %ifcont23
+else25:                                           ; preds = %c.body
+  br label %ifcont26
 
-ifcont23:                                         ; preds = %else22, %unreachable_after_exit21
-  %89 = load i32, i32* %i, align 4
+ifcont26:                                         ; preds = %else25, %unreachable_after_exit24
+  %89 = load i32, i32* %i1, align 4
   %90 = add i32 %89, 1
-  store i32 %90, i32* %i, align 4
+  store i32 %90, i32* %i1, align 4
   br label %c.head
 
-c.end:                                            ; preds = %then20, %c.head
-  %91 = load i32, i32* %j, align 4
+c.end:                                            ; preds = %then23, %c.head
+  %91 = load i32, i32* %j2, align 4
   %92 = icmp ne i32 %91, 3
-  br i1 %92, label %then24, label %else25
+  br i1 %92, label %then27, label %else28
 
-then24:                                           ; preds = %c.end
+then27:                                           ; preds = %c.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont29
 
-else25:                                           ; preds = %c.end
-  br label %ifcont26
+else28:                                           ; preds = %c.end
+  br label %ifcont29
 
-ifcont26:                                         ; preds = %else25, %then24
-  store i32 2, i32* %k, align 4
-  %93 = load i32, i32* %k, align 4
+ifcont29:                                         ; preds = %else28, %then27
+  store i32 2, i32* %k3, align 4
+  %93 = load i32, i32* %k3, align 4
   %94 = sub i32 1, %93
-  store i32 %94, i32* %i, align 4
-  br label %loop.head27
+  store i32 %94, i32* %i1, align 4
+  br label %loop.head30
 
-loop.head27:                                      ; preds = %goto_target, %ifcont26
-  %95 = load i32, i32* %k, align 4
+loop.head30:                                      ; preds = %goto_target, %ifcont29
+  %95 = load i32, i32* %k3, align 4
   %96 = icmp sgt i32 %95, 0
-  %97 = load i32, i32* %i, align 4
-  %98 = load i32, i32* %k, align 4
+  %97 = load i32, i32* %i1, align 4
+  %98 = load i32, i32* %k3, align 4
   %99 = add i32 %97, %98
   %100 = icmp sle i32 %99, 10
   %101 = icmp eq i1 %96, false
   %102 = select i1 %101, i1 %96, i1 %100
-  %103 = load i32, i32* %k, align 4
+  %103 = load i32, i32* %k3, align 4
   %104 = icmp sle i32 %103, 0
-  %105 = load i32, i32* %i, align 4
-  %106 = load i32, i32* %k, align 4
+  %105 = load i32, i32* %i1, align 4
+  %106 = load i32, i32* %k3, align 4
   %107 = add i32 %105, %106
   %108 = icmp sge i32 %107, 10
   %109 = icmp eq i1 %104, false
   %110 = select i1 %109, i1 %104, i1 %108
   %111 = icmp eq i1 %102, false
   %112 = select i1 %111, i1 %110, i1 %102
-  br i1 %112, label %loop.body28, label %loop.end29
+  br i1 %112, label %loop.body31, label %loop.end32
 
-loop.body28:                                      ; preds = %loop.head27
-  %113 = load i32, i32* %i, align 4
-  %114 = load i32, i32* %k, align 4
+loop.body31:                                      ; preds = %loop.head30
+  %113 = load i32, i32* %i1, align 4
+  %114 = load i32, i32* %k3, align 4
   %115 = add i32 %113, %114
-  store i32 %115, i32* %i, align 4
+  store i32 %115, i32* %i1, align 4
   br label %goto_target
 
-goto_target:                                      ; preds = %loop.body28
-  br label %loop.head27
+goto_target:                                      ; preds = %loop.body31
+  br label %loop.head30
 
-loop.end29:                                       ; preds = %loop.head27
+loop.end32:                                       ; preds = %loop.head30
   br label %return
 
-return:                                           ; preds = %loop.end29
+return:                                           ; preds = %loop.end32
   ret i32 0
 }
 

--- a/tests/reference/llvm-expr5-00f7fd9.json
+++ b/tests/reference/llvm-expr5-00f7fd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr5-00f7fd9.stdout",
-    "stdout_hash": "e14d19b84426b47e84cdf922cd500bd385b26ea1a44528a490e0e901",
+    "stdout_hash": "7410f9543bd52f9672fade2394b70eb451809a93c56f7f6d5df09bfe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr5-00f7fd9.stdout
+++ b/tests/reference/llvm-expr5-00f7fd9.stdout
@@ -7,10 +7,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca i32, align 4
-  store i32 25, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %x1 = alloca i32, align 4
+  store i32 25, i32* %x1, align 4
+  %2 = load i32, i32* %x1, align 4
   %3 = icmp eq i32 %2, 25
   br i1 %3, label %then, label %else
 

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "16ace134ac1433769a9713698a981074eefcce1d9dc40d4286c920d8",
+    "stdout_hash": "b929ff38b3949ee8097121fe989cc2b8d2ec6fbf1cbdfb9bba08b506",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -8,9 +8,10 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
-  %2 = load i32, i32* %a, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a1 = alloca i32, align 4
+  %2 = load i32, i32* %a1, align 4
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i32 1, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "27a1f2d15fca8571ff8c5f87058cd840811033a4536f73605dee0327",
+    "stdout_hash": "d05f163d2fb9a4d32e75e18f3b734e6e42b82ee61820d22f2b48180c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -94,6 +94,8 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %ione = alloca i32, align 4
+  %izero = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca %complextype, align 8
   %2 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
@@ -104,14 +106,14 @@ define i32 @main(i32 %0, i8** %1) {
   %fpone = alloca float, align 4
   %fptwo = alloca float, align 4
   %fpzero = alloca float, align 4
-  %ione = alloca i32, align 4
-  %izero = alloca i32, align 4
+  %ione1 = alloca i32, align 4
+  %izero2 = alloca i32, align 4
   %negfpone = alloca float, align 4
   store float 1.000000e+00, float* %fpone, align 4
   store float 2.000000e+00, float* %fptwo, align 4
   store float 0.000000e+00, float* %fpzero, align 4
-  store i32 1, i32* %ione, align 4
-  store i32 0, i32* %izero, align 4
+  store i32 1, i32* %ione1, align 4
+  store i32 0, i32* %izero2, align 4
   store float -1.000000e+00, float* %negfpone, align 4
   %6 = getelementptr %complextype, %complextype* %c, i32 0, i32 0
   %7 = load float, float* %fpone, align 4
@@ -124,7 +126,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i64 0, i64* %11, align 4
   %12 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %10, i32 0, i32 1
   store %complextype* %c, %complextype** %12, align 8
-  call void @__module_complex_module_integer_add_subrout(%complextype_polymorphic* %10, i32* %ione, i32* %izero, %complextype* %a)
+  call void @__module_complex_module_integer_add_subrout(%complextype_polymorphic* %10, i32* %ione1, i32* %izero2, %complextype* %a)
   %13 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %14 = load float, float* %13, align 4
   %15 = fpext float %14 to double
@@ -149,17 +151,17 @@ ifcont:                                           ; preds = %else, %then
   %22 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
   %23 = load float, float* %22, align 4
   %24 = fcmp one float %23, 2.000000e+00
-  br i1 %24, label %then1, label %else2
+  br i1 %24, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont5:                                          ; preds = %else4, %then3
   %25 = alloca %complextype_polymorphic, align 8
   %26 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %25, i32 0, i32 0
   store i64 0, i64* %26, align 4
@@ -176,34 +178,34 @@ ifcont3:                                          ; preds = %else2, %then1
   %34 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %35 = load float, float* %34, align 4
   %36 = fcmp one float %35, 1.000000e+00
-  br i1 %36, label %then4, label %else5
+  br i1 %36, label %then6, label %else7
 
-then4:                                            ; preds = %ifcont3
+then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @22, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
+ifcont8:                                          ; preds = %else7, %then6
   %37 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
   %38 = load float, float* %37, align 4
   %39 = fcmp one float %38, 1.000000e+00
-  br i1 %39, label %then7, label %else8
+  br i1 %39, label %then9, label %else10
 
-then7:                                            ; preds = %ifcont6
+then9:                                            ; preds = %ifcont8
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont11
 
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
+else10:                                           ; preds = %ifcont8
+  br label %ifcont11
 
-ifcont9:                                          ; preds = %else8, %then7
+ifcont11:                                         ; preds = %else10, %then9
   br label %return
 
-return:                                           ; preds = %ifcont9
+return:                                           ; preds = %ifcont11
   ret i32 0
 }
 

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "f3baa94741485b60ed26cfa779583f020cfe946097df6bcfe3bf3661",
+    "stdout_hash": "7aa21b3b8b16a1fe13124ffa0efaa9561c8c374e7e776b086077fd9b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+@main.n = internal global i32 0
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [9 x i8] c"%13.8e%s\00", align 1
@@ -20,7 +21,60 @@ source_filename = "LFortran"
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @main.b = internal global [3 x i32] zeroinitializer
-@main.n = internal global i32 0
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %array_bound = alloca i32, align 4
+  %__1_k = alloca i32, align 4
+  store i32 3, i32* @main.n, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__1_k1 = alloca i32, align 4
+  store i32 3, i32* @main.n, align 4
+  br i1 true, label %then, label %else
+
+then:                                             ; preds = %.entry
+  store i32 1, i32* %array_bound, align 4
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %2 = load i32, i32* %array_bound, align 4
+  store i32 %2, i32* %__1_k1, align 4
+  %3 = load i32, i32* %__1_k1, align 4
+  %4 = sub i32 %3, 1
+  %5 = mul i32 1, %4
+  %6 = add i32 0, %5
+  %7 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %6
+  store i32 10, i32* %7, align 4
+  %8 = load i32, i32* %__1_k1, align 4
+  %9 = add i32 %8, 1
+  store i32 %9, i32* %__1_k1, align 4
+  %10 = load i32, i32* %__1_k1, align 4
+  %11 = sub i32 %10, 1
+  %12 = mul i32 1, %11
+  %13 = add i32 0, %12
+  %14 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %13
+  store i32 20, i32* %14, align 4
+  %15 = load i32, i32* %__1_k1, align 4
+  %16 = add i32 %15, 1
+  store i32 %16, i32* %__1_k1, align 4
+  %17 = load i32, i32* %__1_k1, align 4
+  %18 = sub i32 %17, 1
+  %19 = mul i32 1, %18
+  %20 = add i32 0, %19
+  %21 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %20
+  store i32 30, i32* %21, align 4
+  %22 = load i32, i32* %__1_k1, align 4
+  %23 = add i32 %22, 1
+  store i32 %23, i32* %__1_k1, align 4
+  call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
+  br label %return
+
+return:                                           ; preds = %ifcont
+  ret i32 0
+}
 
 define void @driver(void (i32*, i32*, i32*)* %fnc, i32* %arr, i32* %m) {
 .entry:
@@ -124,57 +178,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__1_k = alloca i32, align 4
-  store i32 3, i32* @main.n, align 4
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %.entry
-  store i32 1, i32* %array_bound, align 4
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %2 = load i32, i32* %array_bound, align 4
-  store i32 %2, i32* %__1_k, align 4
-  %3 = load i32, i32* %__1_k, align 4
-  %4 = sub i32 %3, 1
-  %5 = mul i32 1, %4
-  %6 = add i32 0, %5
-  %7 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %6
-  store i32 10, i32* %7, align 4
-  %8 = load i32, i32* %__1_k, align 4
-  %9 = add i32 %8, 1
-  store i32 %9, i32* %__1_k, align 4
-  %10 = load i32, i32* %__1_k, align 4
-  %11 = sub i32 %10, 1
-  %12 = mul i32 1, %11
-  %13 = add i32 0, %12
-  %14 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %13
-  store i32 20, i32* %14, align 4
-  %15 = load i32, i32* %__1_k, align 4
-  %16 = add i32 %15, 1
-  store i32 %16, i32* %__1_k, align 4
-  %17 = load i32, i32* %__1_k, align 4
-  %18 = sub i32 %17, 1
-  %19 = mul i32 1, %18
-  %20 = add i32 0, %19
-  %21 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %20
-  store i32 30, i32* %21, align 4
-  %22 = load i32, i32* %__1_k, align 4
-  %23 = add i32 %22, 1
-  store i32 %23, i32* %__1_k, align 4
-  call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
-  br label %return
-
-return:                                           ; preds = %ifcont
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "4b4f85ee858fd5455b20e47b82547cc561df91214745deebff306472",
+    "stdout_hash": "b9b56dbc6eb288a1bef0726480073b8c522c9c53c77fbd89e74c74d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -17,13 +17,19 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a = alloca i32, align 4
+  store i32 3, i32* %a, align 4
   %i = alloca i32, align 4
   store i32 1, i32* %i, align 4
   %j = alloca i32, align 4
   store i32 2, i32* %j, align 4
-  %a = alloca i32, align 4
-  store i32 3, i32* %a, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  store i32 1, i32* %i1, align 4
+  %j2 = alloca i32, align 4
+  store i32 2, i32* %j2, align 4
+  %a3 = alloca i32, align 4
+  store i32 3, i32* %a3, align 4
   %l = alloca i1, align 1
   store i1 true, i1* %l, align 1
   %b = alloca i1, align 1

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "a4d8bdb69b8f141eaca30b34c9bb035d26d36e02241fd97f1ff56fbe",
+    "stdout_hash": "28659a97e1071bace8f6604c92bb717349e98cb695f38770136dabd1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -9,6 +9,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  store i32 2147483647, i32* @int_dp.u, align 4
+  store i64 2147483647, i64* @int_dp.v, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 2147483647, i32* @int_dp.u, align 4
   store i64 2147483647, i64* @int_dp.v, align 4

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "4cee6c94efa82a8d16b9c60fe4b68ddaf31daf56249bfd5bcb38f72f",
+    "stdout_hash": "90db33441b0039946d4eb17741e71d1ce9a46e01325cf1a4081d7977",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -9,11 +9,17 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
+  store i32 2147483647, i32* @int_dp_param.u, align 4
+  store i64 2147483647, i64* @int_dp_param.v, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %prec11 = alloca i32, align 4
+  store i32 4, i32* %prec11, align 4
+  %prec22 = alloca i32, align 4
+  store i32 8, i32* %prec22, align 4
   store i32 2147483647, i32* @int_dp_param.u, align 4
   store i64 2147483647, i64* @int_dp_param.v, align 4
   %2 = load i32, i32* @int_dp_param.u, align 4

--- a/tests/reference/llvm-interface_12-2e5ecb8.json
+++ b/tests/reference/llvm-interface_12-2e5ecb8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-interface_12-2e5ecb8.stdout",
-    "stdout_hash": "9700245bb9a12348ba44f585dddd27c41fced325dfc840eeb9f22453",
+    "stdout_hash": "043caad821da06a524ff4b468e80444493791a272a2f660fdac49803",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-interface_12-2e5ecb8.stdout
+++ b/tests/reference/llvm-interface_12-2e5ecb8.stdout
@@ -11,14 +11,6 @@ return:                                           ; preds = %.entry
 
 declare void @expr([1 x float]*)
 
-define void @expression([1 x float]* %y) {
-.entry:
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -27,6 +19,14 @@ define i32 @main(i32 %0, i8** %1) {
 
 return:                                           ; preds = %.entry
   ret i32 0
+}
+
+define void @expression([1 x float]* %y) {
+.entry:
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "89587eefed33e7761dec79fbfa1294c35256a7a3f296ed0f7d36f2b6",
+    "stdout_hash": "2f8de20d86e305db0a6c51940741ff0b1b652bf3a94f22634aece822",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -122,6 +122,7 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value5 = alloca double, align 8
   %call_arg_value1 = alloca double, align 8
   %call_arg_value = alloca float, align 4
+  store i32 -12, i32* @intrinsics_03.i, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca double, align 8
   store i32 -12, i32* @intrinsics_03.i, align 4

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "96d23aacedda3a7c42cf2385d9c91adab8fc0efe9e7545147ec9848c",
+    "stdout_hash": "4f9657a160ccc52054043d16c275bc08338272e19ebea4d73d3dc0c5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -25,9 +25,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %dp = alloca i32, align 4
   store i32 8, i32* %dp, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %dp1 = alloca i32, align 4
+  store i32 8, i32* %dp1, align 4
   %x = alloca float, align 4
   store float 1.000000e+00, float* %x, align 4
   %2 = load float, float* %x, align 4

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "024455938470e1a7f9f7502e7805e24efdfe401ebe70e7a16ad4f6be",
+    "stdout_hash": "97a3d0118cb45e29830d8258657e653f20a30ca513ab2ffd139f30a0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -25,11 +25,12 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %2 = call i32 @__module_modules_06_a_b()
-  store i32 %2, i32* %i, align 4
-  %3 = load i32, i32* %i, align 4
+  store i32 %2, i32* %i1, align 4
+  %3 = load i32, i32* %i1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "04968162f230b6d00ebca63e3191759b93d6ca4b987dd3f518af48cf",
+    "stdout_hash": "1446a664a7b041484a77b6d924c658b5e87d243f2b59e40294682c3f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -30,11 +30,12 @@ return:                                           ; preds = %.entry
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %f1 = alloca i32, align 4
   %2 = call i32 @__module_module_13_f1()
-  store i32 %2, i32* %f, align 4
-  %3 = load i32, i32* %f, align 4
+  store i32 %2, i32* %f1, align 4
+  %3 = load i32, i32* %f1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "5b404204112b752b4a9a059dc5017911a8d06b2f2586c213366cb13b",
+    "stdout_hash": "f36a4d1f8aaccee9c36e47ed90c628b06bf96b553b023b4e50556de1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -41,10 +41,11 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %c1 = alloca i32, align 4
   %2 = call i32 @__module_nested_01_a_b()
-  store i32 %2, i32* %c, align 4
+  store i32 %2, i32* %c1, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "d02896fcc035d4073e4ea00bf70bddbc1c27901d7b93b1cc7d7caf97",
+    "stdout_hash": "aec415444e495be5809a4902af036a9f87b1ed2e78dc31e2c67deb06",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -69,11 +69,12 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %test = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %test1 = alloca i32, align 4
   store i32 5, i32* %call_arg_value, align 4
   %2 = call i32 @__module_nested_04_a_b(i32* %call_arg_value)
-  store i32 %2, i32* %test, align 4
+  store i32 %2, i32* %test1, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-nullify_01-810c9d3.json
+++ b/tests/reference/llvm-nullify_01-810c9d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_01-810c9d3.stdout",
-    "stdout_hash": "be84d4a52522dbdb73606dcc77b99d735fd69743377d721abd4e268c",
+    "stdout_hash": "fecc2ccb0b3eada59719b1840a9a48fb0f449b3f26c4bb41c5cb1faa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_01-810c9d3.stdout
+++ b/tests/reference/llvm-nullify_01-810c9d3.stdout
@@ -3,14 +3,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %t1 = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
   %p2 = alloca i32*, align 8
   store i32* null, i32** %p2, align 8
-  %t1 = alloca i32, align 4
-  store i32* %t1, i32** %p1, align 8
-  store i32* %t1, i32** %p2, align 8
+  %t11 = alloca i32, align 4
+  store i32* %t11, i32** %p1, align 8
+  store i32* %t11, i32** %p2, align 8
   %2 = load i32*, i32** %p1, align 8
   store i32 1, i32* %2, align 4
   store i32* null, i32** %p1, align 8

--- a/tests/reference/llvm-nullify_02-3c7ee61.json
+++ b/tests/reference/llvm-nullify_02-3c7ee61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_02-3c7ee61.stdout",
-    "stdout_hash": "6866a24f285db352148bcfe73842a0e3b5704f67a442a70bd313c18f",
+    "stdout_hash": "9a9bd2d2c73fdfafc5e33c803d39cfed93e58c5fc43ef3589ec5d3ef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_02-3c7ee61.stdout
+++ b/tests/reference/llvm-nullify_02-3c7ee61.stdout
@@ -3,17 +3,18 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %t2 = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca float*, align 8
   store float* null, float** %p1, align 8
   %p2 = alloca i32*, align 8
   store i32* null, i32** %p2, align 8
   %t1 = alloca float, align 4
-  %t2 = alloca i32, align 4
+  %t21 = alloca i32, align 4
   store float* %t1, float** %p1, align 8
   %2 = load float*, float** %p1, align 8
   store float 1.000000e+00, float* %2, align 4
-  store i32* %t2, i32** %p2, align 8
+  store i32* %t21, i32** %p2, align 8
   %3 = load i32*, i32** %p2, align 8
   store i32 2, i32* %3, align 4
   store float* null, float** %p1, align 8

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "05003defbcce4ad16b58c26352bab9b28ecf8b977cfb738e93dac733",
+    "stdout_hash": "e7775639b3f805b641e5ca3955b9f0567e579914126221a652c5ab8b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -10,17 +10,18 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca i32, align 4
-  store i32 25, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
-  %3 = load i32, i32* %x, align 4
-  %4 = load i32, i32* %x, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %x1 = alloca i32, align 4
+  store i32 25, i32* %x1, align 4
+  %2 = load i32, i32* %x1, align 4
+  %3 = load i32, i32* %x1, align 4
+  %4 = load i32, i32* %x1, align 4
   %5 = add i32 25, %4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([21 x i8], [21 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %6 = load i32, i32* %x, align 4
-  %7 = load i32, i32* %x, align 4
-  %8 = load i32, i32* %x, align 4
+  %6 = load i32, i32* %x1, align 4
+  %7 = load i32, i32* %x1, align 4
+  %8 = load i32, i32* %x1, align 4
   %9 = add i32 25, %8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([21 x i8], [21 x i8]* @5, i32 0, i32 0), i32 %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   br label %return

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "cdbfaf5d617c93576bde5422d176e1d9e3b4a464a056c26bbd0ead30",
+    "stdout_hash": "b2d8c1847b333b747b75aadfc36668d94a66ce3c688af04f24bed13f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -10,12 +10,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
-  store i32 5, i32* %i, align 4
-  %2 = load i32, i32* %i, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  store i32 5, i32* %i1, align 4
+  %2 = load i32, i32* %i1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, i32* %i1, align 4
   %4 = add i32 %3, 1
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   br label %return

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "bcbd5a9f2f7dfc67832e70938f59ab908570b63b0b765d5f447fcec6",
+    "stdout_hash": "155785d0662c9215495c7b51d0ac80c846d9f356b03bfebf98a012db",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -6,6 +6,45 @@ source_filename = "LFortran"
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %call_arg_value = alloca i32, align 4
+  %z = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %z1 = alloca i32, align 4
+  %2 = load i32, i32* %z1, align 4
+  store i32 %2, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 0, i32* %z1, align 4
+  br label %loop.head
+
+loop.head:                                        ; preds = %loop.body, %.entry
+  %3 = load i32, i32* %z1, align 4
+  %4 = add i32 %3, 1
+  %5 = icmp sle i32 %4, 10
+  br i1 %5, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %loop.head
+  %6 = load i32, i32* %z1, align 4
+  %7 = add i32 %6, 1
+  store i32 %7, i32* %z1, align 4
+  %8 = load i32, i32* %z1, align 4
+  store i32 %8, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 1, i32* %call_arg_value, align 4
+  %9 = call i32 @apply(i32 (i32*)* @add_z, i32* %call_arg_value)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  %10 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 %10, i32* %z1, align 4
+  br label %loop.head
+
+loop.end:                                         ; preds = %loop.head
+  %11 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 %11, i32* %z1, align 4
+  br label %return
+
+return:                                           ; preds = %loop.end
+  ret i32 0
+}
+
 define i32 @add_z(i32* %x) {
 .entry:
   %y = alloca i32, align 4
@@ -33,44 +72,6 @@ return:                                           ; preds = %.entry
 }
 
 declare i32 @fun(i32*)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %z = alloca i32, align 4
-  %2 = load i32, i32* %z, align 4
-  store i32 %2, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
-  store i32 0, i32* %z, align 4
-  br label %loop.head
-
-loop.head:                                        ; preds = %loop.body, %.entry
-  %3 = load i32, i32* %z, align 4
-  %4 = add i32 %3, 1
-  %5 = icmp sle i32 %4, 10
-  br i1 %5, label %loop.body, label %loop.end
-
-loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %z, align 4
-  %7 = add i32 %6, 1
-  store i32 %7, i32* %z, align 4
-  %8 = load i32, i32* %z, align 4
-  store i32 %8, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
-  store i32 1, i32* %call_arg_value, align 4
-  %9 = call i32 @apply(i32 (i32*)* @add_z, i32* %call_arg_value)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %10 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
-  store i32 %10, i32* %z, align 4
-  br label %loop.head
-
-loop.end:                                         ; preds = %loop.head
-  %11 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
-  store i32 %11, i32* %z, align 4
-  br label %return
-
-return:                                           ; preds = %loop.end
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "a30ee14bd190e3ff486cc197efc57e0a5a77c35e35f14cfb58c6b874",
+    "stdout_hash": "70f61dfb85f902c248a4c03a2b35df22de8447598f4ad46cdd95269c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -10,11 +10,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %prec11 = alloca i32, align 4
+  store i32 4, i32* %prec11, align 4
+  %prec22 = alloca i32, align 4
+  store i32 8, i32* %prec22, align 4
   store float 0x3FF0CCCCC0000000, float* @real_dp_param.u, align 4
   store double 1.050000e+00, double* @real_dp_param.v, align 8
   store double 0.000000e+00, double* @real_dp_param.zero, align 8

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "d7f5b52dc2f1bdeba869b90907cf716f44dfa90504c06e0aeb4f9713",
+    "stdout_hash": "3b76fca36a2dd8307fc5798f181f8dfaa6f4abeef2be23ea96203958",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -112,15 +112,16 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value1 = alloca i32, align 4
+  %call_arg_value2 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %r = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %r1 = alloca i32, align 4
   store i32 3, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value1, align 4
-  %2 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %2, i32* %r, align 4
-  %3 = load i32, i32* %r, align 4
+  store i32 3, i32* %call_arg_value2, align 4
+  %2 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value2)
+  store i32 %2, i32* %r1, align 4
+  %3 = load i32, i32* %r1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "aa498762d8af778832bc25874c59fc924cf18208e26eae7afabcf5ab",
+    "stdout_hash": "790b9c3ae3bf24c1f7fb89f814af3097a470fa7cf5af1169f200efe1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -126,15 +126,16 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value1 = alloca i32, align 4
+  %call_arg_value2 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %r = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %r1 = alloca i32, align 4
   store i32 3, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value1, align 4
-  %2 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %2, i32* %r, align 4
-  %3 = load i32, i32* %r, align 4
+  store i32 3, i32* %call_arg_value2, align 4
+  %2 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value2)
+  store i32 %2, i32* %r1, align 4
+  %3 = load i32, i32* %r1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "116ac206fb7ce113eb233977f1bc8b91ac9523d107eafcf05ea148f9",
+    "stdout_hash": "d358f79298042d74f0bda3fd49690d3f1ad0568b1447480972a019bf",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -14,6 +14,20 @@ source_filename = "LFortran"
 @10 = private unnamed_addr constant [13 x i8] c"main1 called\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %main_out = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %main_out1 = alloca i32, align 4
+  %2 = call i32 @main1()
+  store i32 %2, i32* %main_out1, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret i32 0
+}
+
 define i32 @main1() {
 .entry:
   %i = alloca i32, align 4
@@ -47,18 +61,5 @@ return:                                           ; preds = %ifcont, %then
 }
 
 declare void @_lfortran_printf(i8*, ...)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %main_out = alloca i32, align 4
-  %2 = call i32 @main1()
-  store i32 %2, i32* %main_out, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "48f0ac389a5a37dba8e56d28eeb3b755268f4d8d46472af4641e148e",
+    "stdout_hash": "05911dc94791a16d651adf306702f2ce50c8c8355aaca731cd00c0a1",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -92,31 +92,32 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %call_arg_value4 = alloca i32, align 4
   %call_arg_value3 = alloca i32, align 4
   %call_arg_value2 = alloca i32, align 4
-  %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %c1 = alloca i32, align 4
   store i32 1, i32* %call_arg_value, align 4
   %2 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %2, i32* %c, align 4
-  %3 = load i32, i32* %c, align 4
+  store i32 %2, i32* %c1, align 4
+  %3 = load i32, i32* %c1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  store i32 2, i32* %call_arg_value1, align 4
-  %4 = call i32 @__module_many_returns_b(i32* %call_arg_value1)
-  store i32 %4, i32* %c, align 4
-  %5 = load i32, i32* %c, align 4
+  store i32 2, i32* %call_arg_value2, align 4
+  %4 = call i32 @__module_many_returns_b(i32* %call_arg_value2)
+  store i32 %4, i32* %c1, align 4
+  %5 = load i32, i32* %c1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i32 %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  store i32 3, i32* %call_arg_value2, align 4
-  %6 = call i32 @__module_many_returns_b(i32* %call_arg_value2)
-  store i32 %6, i32* %c, align 4
-  %7 = load i32, i32* %c, align 4
+  store i32 3, i32* %call_arg_value3, align 4
+  %6 = call i32 @__module_many_returns_b(i32* %call_arg_value3)
+  store i32 %6, i32* %c1, align 4
+  %7 = load i32, i32* %c1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @12, i32 0, i32 0), i32 %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0))
-  store i32 4, i32* %call_arg_value3, align 4
-  %8 = call i32 @__module_many_returns_b(i32* %call_arg_value3)
-  store i32 %8, i32* %c, align 4
-  %9 = load i32, i32* %c, align 4
+  store i32 4, i32* %call_arg_value4, align 4
+  %8 = call i32 @__module_many_returns_b(i32* %call_arg_value4)
+  store i32 %8, i32* %c1, align 4
+  %9 = load i32, i32* %c1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "7fd26c3514e78cc6fe933386ed1e7eefa3a16821be7c22eedeea3021",
+    "stdout_hash": "f9e1718f61fa0533a8b98e66dfa1cc706ff21b87f61c2906c38cfbe0",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+@main.main_out = internal global i32 0
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [13 x i8] c"early return\00", align 1
@@ -9,11 +10,23 @@ source_filename = "LFortran"
 @5 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @6 = private unnamed_addr constant [14 x i8] c"normal return\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
-@main.main_out = internal global i32 0
 @8 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @9 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @10 = private unnamed_addr constant [13 x i8] c"main1 called\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  store i32 999, i32* @main.main_out, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  store i32 999, i32* @main.main_out, align 4
+  call void @main1(i32* @main.main_out)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret i32 0
+}
 
 define void @main1(i32* %out_var) {
 .entry:
@@ -46,17 +59,5 @@ return:                                           ; preds = %ifcont, %then
 }
 
 declare void @_lfortran_printf(i8*, ...)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 999, i32* @main.main_out, align 4
-  call void @main1(i32* @main.main_out)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-stop-866225f.json
+++ b/tests/reference/llvm-stop-866225f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-stop-866225f.stdout",
-    "stdout_hash": "e7d0fed935ad52e15e97ab173c9fcca3207d04ca784046fa74d94d81",
+    "stdout_hash": "eb4d642ab1fe920ef37d112678c16fcda293dab703816f36674b4f78",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-stop-866225f.stdout
+++ b/tests/reference/llvm-stop-866225f.stdout
@@ -7,10 +7,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca i32, align 4
-  store i32 25, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %x1 = alloca i32, align 4
+  store i32 25, i32* %x1, align 4
+  %2 = load i32, i32* %x1, align 4
   %3 = icmp eq i32 %2, 25
   br i1 %3, label %then, label %else
 

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "6cf67e393e43ac5c5cf90a6d0cbcf527e135d5b30deaff8a54983d3d",
+    "stdout_hash": "3197657dce48757b3a3a833b68c1f2e7f9d812d2a52b25bb58076e34",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -16,13 +16,19 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %ia0 = alloca i32, align 4
   store i32 48, i32* %ia0, align 4
   %ia5 = alloca i32, align 4
   store i32 53, i32* %ia5, align 4
   %ia9 = alloca i32, align 4
   store i32 57, i32* %ia9, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %ia01 = alloca i32, align 4
+  store i32 48, i32* %ia01, align 4
+  %ia52 = alloca i32, align 4
+  store i32 53, i32* %ia52, align 4
+  %ia93 = alloca i32, align 4
+  store i32 57, i32* %ia93, align 4
   br i1 false, label %then, label %else
 
 then:                                             ; preds = %.entry
@@ -34,32 +40,32 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  br i1 false, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
   br i1 false, label %then4, label %else5
 
-then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+then4:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont6
 
-else5:                                            ; preds = %ifcont3
+else5:                                            ; preds = %ifcont
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
+  br i1 false, label %then7, label %else8
+
+then7:                                            ; preds = %ifcont6
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont9
+
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
+
+ifcont9:                                          ; preds = %else8, %then7
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @11, i32 0, i32 0), i32 48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   br label %return
 
-return:                                           ; preds = %ifcont6
+return:                                           ; preds = %ifcont9
   ret i32 0
 }
 

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "9c933aeb52d2289142d673aca832171b9f33403f27b027c313baba9d",
+    "stdout_hash": "dd41b4a39ac7c0e38be5249e898cc75967e9ef7bcf388c8f566e393e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -41,28 +41,19 @@ source_filename = "LFortran"
 @37 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @38 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @f(i32* %a, i32* %b) {
-.entry:
-  %0 = load i32, i32* %a, align 4
-  %1 = add i32 %0, 1
-  store i32 %1, i32* %b, align 4
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value23 = alloca i32, align 4
-  %call_arg_value16 = alloca i32, align 4
+  %call_arg_value25 = alloca i32, align 4
+  %call_arg_value18 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 1, i32* %i, align 4
-  store i32 1, i32* %j, align 4
-  %2 = load i32, i32* %j, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 1, i32* %i1, align 4
+  store i32 1, i32* %j2, align 4
+  %2 = load i32, i32* %j2, align 4
   %3 = icmp ne i32 %2, 1
   br i1 %3, label %then, label %else
 
@@ -75,135 +66,146 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @f(i32* %i, i32* %j)
-  %4 = load i32, i32* %i, align 4
-  %5 = load i32, i32* %j, align 4
+  call void @f(i32* %i1, i32* %j2)
+  %4 = load i32, i32* %i1, align 4
+  %5 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @5, i32 0, i32 0), i32 %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, i32* %i1, align 4
   %7 = icmp ne i32 %6, 1
-  br i1 %7, label %then1, label %else2
+  br i1 %7, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
-  %8 = load i32, i32* %j, align 4
+ifcont5:                                          ; preds = %else4, %then3
+  %8 = load i32, i32* %j2, align 4
   %9 = icmp ne i32 %8, 2
-  br i1 %9, label %then4, label %else5
+  br i1 %9, label %then6, label %else7
 
-then4:                                            ; preds = %ifcont3
+then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont8
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
 
-ifcont6:                                          ; preds = %else5, %then4
-  store i32 1, i32* %j, align 4
-  %10 = load i32, i32* %j, align 4
+ifcont8:                                          ; preds = %else7, %then6
+  store i32 1, i32* %j2, align 4
+  %10 = load i32, i32* %j2, align 4
   %11 = icmp ne i32 %10, 1
-  br i1 %11, label %then7, label %else8
+  br i1 %11, label %then9, label %else10
 
-then7:                                            ; preds = %ifcont6
+then9:                                            ; preds = %ifcont8
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont11
 
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
+else10:                                           ; preds = %ifcont8
+  br label %ifcont11
 
-ifcont9:                                          ; preds = %else8, %then7
+ifcont11:                                         ; preds = %else10, %then9
   store i32 3, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j)
-  %12 = load i32, i32* %j, align 4
+  call void @f(i32* %call_arg_value, i32* %j2)
+  %12 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  %13 = load i32, i32* %j, align 4
+  %13 = load i32, i32* %j2, align 4
   %14 = icmp ne i32 %13, 4
-  br i1 %14, label %then10, label %else11
+  br i1 %14, label %then12, label %else13
 
-then10:                                           ; preds = %ifcont9
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
-  store i32 1, i32* %j, align 4
-  %15 = load i32, i32* %j, align 4
+ifcont14:                                         ; preds = %else13, %then12
+  store i32 1, i32* %j2, align 4
+  %15 = load i32, i32* %j2, align 4
   %16 = icmp ne i32 %15, 1
-  br i1 %16, label %then13, label %else14
+  br i1 %16, label %then15, label %else16
 
-then13:                                           ; preds = %ifcont12
+then15:                                           ; preds = %ifcont14
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont17
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
 
-ifcont15:                                         ; preds = %else14, %then13
-  store i32 3, i32* %call_arg_value16, align 4
-  call void @f(i32* %call_arg_value16, i32* %j)
-  %17 = load i32, i32* %j, align 4
+ifcont17:                                         ; preds = %else16, %then15
+  store i32 3, i32* %call_arg_value18, align 4
+  call void @f(i32* %call_arg_value18, i32* %j2)
+  %17 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i32 %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
-  %18 = load i32, i32* %j, align 4
+  %18 = load i32, i32* %j2, align 4
   %19 = icmp ne i32 %18, 4
-  br i1 %19, label %then17, label %else18
+  br i1 %19, label %then19, label %else20
 
-then17:                                           ; preds = %ifcont15
+then19:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont19
+  br label %ifcont21
 
-else18:                                           ; preds = %ifcont15
-  br label %ifcont19
+else20:                                           ; preds = %ifcont17
+  br label %ifcont21
 
-ifcont19:                                         ; preds = %else18, %then17
-  store i32 1, i32* %j, align 4
-  %20 = load i32, i32* %j, align 4
+ifcont21:                                         ; preds = %else20, %then19
+  store i32 1, i32* %j2, align 4
+  %20 = load i32, i32* %j2, align 4
   %21 = icmp ne i32 %20, 1
-  br i1 %21, label %then20, label %else21
+  br i1 %21, label %then22, label %else23
 
-then20:                                           ; preds = %ifcont19
+then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont22
+  br label %ifcont24
 
-else21:                                           ; preds = %ifcont19
-  br label %ifcont22
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
 
-ifcont22:                                         ; preds = %else21, %then20
-  %22 = load i32, i32* %i, align 4
+ifcont24:                                         ; preds = %else23, %then22
+  %22 = load i32, i32* %i1, align 4
   %23 = add i32 %22, 2
-  store i32 %23, i32* %call_arg_value23, align 4
-  call void @f(i32* %call_arg_value23, i32* %j)
-  %24 = load i32, i32* %j, align 4
+  store i32 %23, i32* %call_arg_value25, align 4
+  call void @f(i32* %call_arg_value25, i32* %j2)
+  %24 = load i32, i32* %j2, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
-  %25 = load i32, i32* %j, align 4
+  %25 = load i32, i32* %j2, align 4
   %26 = icmp ne i32 %25, 4
-  br i1 %26, label %then24, label %else25
+  br i1 %26, label %then26, label %else27
 
-then24:                                           ; preds = %ifcont22
+then26:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont28
 
-else25:                                           ; preds = %ifcont22
-  br label %ifcont26
+else27:                                           ; preds = %ifcont24
+  br label %ifcont28
 
-ifcont26:                                         ; preds = %else25, %then24
+ifcont28:                                         ; preds = %else27, %then26
   br label %return
 
-return:                                           ; preds = %ifcont26
+return:                                           ; preds = %ifcont28
   ret i32 0
+}
+
+define void @f(i32* %a, i32* %b) {
+.entry:
+  %0 = load i32, i32* %a, align 4
+  %1 = add i32 %0, 1
+  store i32 %1, i32* %b, align 4
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "2d043673dccc692a529063ec790aa3d7471a195852750a83ba76cf62",
+    "stdout_hash": "78475fb1075934927da52d49f9a8b90e17869e76b195bddbe5b928b1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -29,6 +29,111 @@ source_filename = "LFortran"
 @25 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @26 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 1, i32* %i1, align 4
+  store i32 1, i32* %j2, align 4
+  call void @f(i32* %i1, i32* %j2)
+  %2 = load i32, i32* %i1, align 4
+  %3 = load i32, i32* %j2, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  %4 = load i32, i32* %i1, align 4
+  %5 = icmp ne i32 %4, 1
+  br i1 %5, label %then, label %else
+
+then:                                             ; preds = %.entry
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %6 = load i32, i32* %j2, align 4
+  %7 = icmp ne i32 %6, 2
+  br i1 %7, label %then3, label %else4
+
+then3:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont5
+
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
+
+ifcont5:                                          ; preds = %else4, %then3
+  call void @g(i32* %i1, i32* %j2)
+  %8 = load i32, i32* %i1, align 4
+  %9 = load i32, i32* %j2, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @11, i32 0, i32 0), i32 %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  %10 = load i32, i32* %i1, align 4
+  %11 = icmp ne i32 %10, 1
+  br i1 %11, label %then6, label %else7
+
+then6:                                            ; preds = %ifcont5
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont8
+
+else7:                                            ; preds = %ifcont5
+  br label %ifcont8
+
+ifcont8:                                          ; preds = %else7, %then6
+  %12 = load i32, i32* %j2, align 4
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %then9, label %else10
+
+then9:                                            ; preds = %ifcont8
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont11
+
+else10:                                           ; preds = %ifcont8
+  br label %ifcont11
+
+ifcont11:                                         ; preds = %else10, %then9
+  call void @h(i32* %i1, i32* %j2)
+  %14 = load i32, i32* %i1, align 4
+  %15 = load i32, i32* %j2, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @20, i32 0, i32 0), i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
+  %16 = load i32, i32* %i1, align 4
+  %17 = icmp ne i32 %16, 1
+  br i1 %17, label %then12, label %else13
+
+then12:                                           ; preds = %ifcont11
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont14
+
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
+
+ifcont14:                                         ; preds = %else13, %then12
+  %18 = load i32, i32* %j2, align 4
+  %19 = icmp ne i32 %18, 0
+  br i1 %19, label %then15, label %else16
+
+then15:                                           ; preds = %ifcont14
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont17
+
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
+
+ifcont17:                                         ; preds = %else16, %then15
+  br label %return
+
+return:                                           ; preds = %ifcont17
+  ret i32 0
+}
+
 define void @f(i32* %a, i32* %b) {
 .entry:
   %0 = load i32, i32* %a, align 4
@@ -58,109 +163,6 @@ define void @h(i32* %a, i32* %b) {
 
 return:                                           ; preds = %.entry
   ret void
-}
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
-  store i32 1, i32* %i, align 4
-  store i32 1, i32* %j, align 4
-  call void @f(i32* %i, i32* %j)
-  %2 = load i32, i32* %i, align 4
-  %3 = load i32, i32* %j, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %4 = load i32, i32* %i, align 4
-  %5 = icmp ne i32 %4, 1
-  br i1 %5, label %then, label %else
-
-then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %6 = load i32, i32* %j, align 4
-  %7 = icmp ne i32 %6, 2
-  br i1 %7, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
-  call void @g(i32* %i, i32* %j)
-  %8 = load i32, i32* %i, align 4
-  %9 = load i32, i32* %j, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @11, i32 0, i32 0), i32 %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  %10 = load i32, i32* %i, align 4
-  %11 = icmp ne i32 %10, 1
-  br i1 %11, label %then4, label %else5
-
-then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont6
-
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
-
-ifcont6:                                          ; preds = %else5, %then4
-  %12 = load i32, i32* %j, align 4
-  %13 = icmp ne i32 %12, 0
-  br i1 %13, label %then7, label %else8
-
-then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont9
-
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
-
-ifcont9:                                          ; preds = %else8, %then7
-  call void @h(i32* %i, i32* %j)
-  %14 = load i32, i32* %i, align 4
-  %15 = load i32, i32* %j, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @20, i32 0, i32 0), i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
-  %16 = load i32, i32* %i, align 4
-  %17 = icmp ne i32 %16, 1
-  br i1 %17, label %then10, label %else11
-
-then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont12
-
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
-
-ifcont12:                                         ; preds = %else11, %then10
-  %18 = load i32, i32* %j, align 4
-  %19 = icmp ne i32 %18, 0
-  br i1 %19, label %then13, label %else14
-
-then13:                                           ; preds = %ifcont12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont15
-
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
-
-ifcont15:                                         ; preds = %else14, %then13
-  br label %return
-
-return:                                           ; preds = %ifcont15
-  ret i32 0
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "1af78a0e295e26e2a1ebbcf6cb1d6c285e37a32be0053cd80eb2f797",
+    "stdout_hash": "470049ebb2c9b2172e9fbf0f872883373aff94e33d5db7fcdfe9e471",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -5,6 +5,16 @@ source_filename = "LFortran"
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
 
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @print_int()
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret i32 0
+}
+
 define void @print_int() {
 .entry:
   %a = alloca i32, align 4
@@ -18,15 +28,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lfortran_printf(i8*, ...)
-
-define i32 @main(i32 %0, i8** %1) {
-.entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @print_int()
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret i32 0
-}
 
 declare void @_lpython_call_initial_functions(i32, i8**)

--- a/tests/reference/llvm-sum_02-43f30ca.json
+++ b/tests/reference/llvm-sum_02-43f30ca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sum_02-43f30ca.stdout",
-    "stdout_hash": "79a538510d6e52736e507b3ccda6dcad7675a7f1edda743312f1fdb4",
+    "stdout_hash": "fd5a9f9cb0c5a852adeceb716b62c29417667b1b0ce97874d5e2d4f2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sum_02-43f30ca.stdout
+++ b/tests/reference/llvm-sum_02-43f30ca.stdout
@@ -112,44 +112,47 @@ return:                                           ; preds = %ifcont
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %call_arg_value10 = alloca i32, align 4
+  %call_arg_value9 = alloca i32, align 4
+  %call_arg_value8 = alloca i32, align 4
   %call_arg_value7 = alloca i32, align 4
-  %call_arg_value6 = alloca i32, align 4
-  %call_arg_value5 = alloca i32, align 4
-  %call_arg_value4 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  %x = alloca [50 x i32], align 4
   %xdiff = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  %x = alloca [50 x i32], align 4
+  %xdiff3 = alloca i32, align 4
+  store i32 0, i32* %i1, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.end, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 5
-  br i1 %4, label %loop.body, label %loop.end3
+  br i1 %4, label %loop.body, label %loop.end6
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head1
+  store i32 %6, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head4
 
-loop.head1:                                       ; preds = %loop.body2, %loop.body
-  %7 = load i32, i32* %j, align 4
+loop.head4:                                       ; preds = %loop.body5, %loop.body
+  %7 = load i32, i32* %j2, align 4
   %8 = add i32 %7, 1
   %9 = icmp sle i32 %8, 10
-  br i1 %9, label %loop.body2, label %loop.end
+  br i1 %9, label %loop.body5, label %loop.end
 
-loop.body2:                                       ; preds = %loop.head1
-  %10 = load i32, i32* %j, align 4
+loop.body5:                                       ; preds = %loop.head4
+  %10 = load i32, i32* %j2, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %j, align 4
-  %12 = load i32, i32* %i, align 4
-  %13 = load i32, i32* %j, align 4
+  store i32 %11, i32* %j2, align 4
+  %12 = load i32, i32* %i1, align 4
+  %13 = load i32, i32* %j2, align 4
   %14 = sub i32 %12, 1
   %15 = mul i32 1, %14
   %16 = add i32 0, %15
@@ -157,38 +160,38 @@ loop.body2:                                       ; preds = %loop.head1
   %18 = mul i32 5, %17
   %19 = add i32 %16, %18
   %20 = getelementptr [50 x i32], [50 x i32]* %x, i32 0, i32 %19
-  %21 = load i32, i32* %i, align 4
-  %22 = load i32, i32* %j, align 4
+  %21 = load i32, i32* %i1, align 4
+  %22 = load i32, i32* %j2, align 4
   %23 = add i32 %21, %22
   store i32 %23, i32* %20, align 4
-  br label %loop.head1
+  br label %loop.head4
 
-loop.end:                                         ; preds = %loop.head1
+loop.end:                                         ; preds = %loop.head4
   br label %loop.head
 
-loop.end3:                                        ; preds = %loop.head
+loop.end6:                                        ; preds = %loop.head
   %24 = getelementptr [50 x i32], [50 x i32]* %x, i32 0, i32 0
   store i32 1, i32* %call_arg_value, align 4
-  store i32 5, i32* %call_arg_value4, align 4
-  store i32 1, i32* %call_arg_value5, align 4
-  store i32 10, i32* %call_arg_value6, align 4
-  %25 = call i32 @Sum_4_2_0_integer_______0(i32* %24, i32* %call_arg_value, i32* %call_arg_value4, i32* %call_arg_value5, i32* %call_arg_value6)
+  store i32 5, i32* %call_arg_value7, align 4
+  store i32 1, i32* %call_arg_value8, align 4
+  store i32 10, i32* %call_arg_value9, align 4
+  %25 = call i32 @Sum_4_2_0_integer_______0(i32* %24, i32* %call_arg_value, i32* %call_arg_value7, i32* %call_arg_value8, i32* %call_arg_value9)
   %26 = sub i32 %25, 425
-  store i32 %26, i32* %call_arg_value7, align 4
-  %27 = call i32 @_lcompilers_abs_i32(i32* %call_arg_value7)
-  store i32 %27, i32* %xdiff, align 4
-  %28 = load i32, i32* %xdiff, align 4
+  store i32 %26, i32* %call_arg_value10, align 4
+  %27 = call i32 @_lcompilers_abs_i32(i32* %call_arg_value10)
+  store i32 %27, i32* %xdiff3, align 4
+  %28 = load i32, i32* %xdiff3, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %28, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %29 = load i32, i32* %xdiff, align 4
+  %29 = load i32, i32* %xdiff3, align 4
   %30 = icmp ne i32 %29, 0
   br i1 %30, label %then, label %else
 
-then:                                             ; preds = %loop.end3
+then:                                             ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont
 
-else:                                             ; preds = %loop.end3
+else:                                             ; preds = %loop.end6
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then

--- a/tests/reference/llvm-types_02-b5bfe0b.json
+++ b/tests/reference/llvm-types_02-b5bfe0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_02-b5bfe0b.stdout",
-    "stdout_hash": "12d518605be57463718181d26837f59f308655f124ff67ad86c43d53",
+    "stdout_hash": "6baaa53fa30e3bd77e44a6cd2b3e0e4c9690b7a6d95d721e589638c4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_02-b5bfe0b.stdout
+++ b/tests/reference/llvm-types_02-b5bfe0b.stdout
@@ -3,12 +3,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %r = alloca float, align 4
-  store i32 1, i32* %i, align 4
+  store i32 1, i32* %i1, align 4
   store float 1.000000e+00, float* %r, align 4
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = sitofp i32 %2 to float
   store float %3, float* %r, align 4
   br label %return

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "81815223e1eef819aa6a8b7c9774e0bbfc3bfb3b3ba1985cc350c19d",
+    "stdout_hash": "a08189d9ac808d2deb958c93d4d04de5c2ae628e8e8c3c0b13a8fb47",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -10,8 +10,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %r = alloca float, align 4
   store float 1.500000e+00, float* %r, align 4
   %2 = load float, float* %r, align 4
@@ -19,8 +20,8 @@ define i32 @main(i32 %0, i8** %1) {
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), double %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   %4 = load float, float* %r, align 4
   %5 = fptosi float %4 to i32
-  store i32 %5, i32* %i, align 4
-  %6 = load i32, i32* %i, align 4
+  store i32 %5, i32* %i1, align 4
+  %6 = load i32, i32* %i1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-types_04-92449d7.json
+++ b/tests/reference/llvm-types_04-92449d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_04-92449d7.stdout",
-    "stdout_hash": "64bc1d823e989c3b986836c49fd16bcb4d5ba790509ced9473c72af6",
+    "stdout_hash": "ba035f7bd898558291dc9e1f485fe4cfd835e095a1aa090d4c0fbdea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_04-92449d7.stdout
+++ b/tests/reference/llvm-types_04-92449d7.stdout
@@ -3,14 +3,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %r = alloca float, align 4
   %x = alloca float, align 4
   store float 1.500000e+00, float* %r, align 4
-  store i32 2, i32* %i, align 4
-  %2 = load i32, i32* %i, align 4
-  %3 = load i32, i32* %i, align 4
+  store i32 2, i32* %i1, align 4
+  %2 = load i32, i32* %i1, align 4
+  %3 = load i32, i32* %i1, align 4
   %4 = mul i32 %2, %3
   %5 = sitofp i32 %4 to float
   store float %5, float* %x, align 4
@@ -18,18 +19,18 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load float, float* %r, align 4
   %8 = fmul float %6, %7
   store float %8, float* %x, align 4
-  %9 = load i32, i32* %i, align 4
+  %9 = load i32, i32* %i1, align 4
   %10 = sitofp i32 %9 to float
   %11 = load float, float* %r, align 4
   %12 = fmul float %10, %11
   store float %12, float* %x, align 4
   %13 = load float, float* %r, align 4
-  %14 = load i32, i32* %i, align 4
+  %14 = load i32, i32* %i1, align 4
   %15 = sitofp i32 %14 to float
   %16 = fmul float %13, %15
   store float %16, float* %x, align 4
-  %17 = load i32, i32* %i, align 4
-  %18 = load i32, i32* %i, align 4
+  %17 = load i32, i32* %i1, align 4
+  %18 = load i32, i32* %i1, align 4
   %19 = add i32 %17, %18
   %20 = sitofp i32 %19 to float
   store float %20, float* %x, align 4
@@ -38,17 +39,17 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fadd float %21, %22
   store float %23, float* %x, align 4
   %24 = load float, float* %r, align 4
-  %25 = load i32, i32* %i, align 4
+  %25 = load i32, i32* %i1, align 4
   %26 = sitofp i32 %25 to float
   %27 = fadd float %24, %26
   store float %27, float* %x, align 4
-  %28 = load i32, i32* %i, align 4
+  %28 = load i32, i32* %i1, align 4
   %29 = sitofp i32 %28 to float
   %30 = load float, float* %r, align 4
   %31 = fadd float %29, %30
   store float %31, float* %x, align 4
-  %32 = load i32, i32* %i, align 4
-  %33 = load i32, i32* %i, align 4
+  %32 = load i32, i32* %i1, align 4
+  %33 = load i32, i32* %i1, align 4
   %34 = sub i32 %32, %33
   %35 = sitofp i32 %34 to float
   store float %35, float* %x, align 4
@@ -57,17 +58,17 @@ define i32 @main(i32 %0, i8** %1) {
   %38 = fsub float %36, %37
   store float %38, float* %x, align 4
   %39 = load float, float* %r, align 4
-  %40 = load i32, i32* %i, align 4
+  %40 = load i32, i32* %i1, align 4
   %41 = sitofp i32 %40 to float
   %42 = fsub float %39, %41
   store float %42, float* %x, align 4
-  %43 = load i32, i32* %i, align 4
+  %43 = load i32, i32* %i1, align 4
   %44 = sitofp i32 %43 to float
   %45 = load float, float* %r, align 4
   %46 = fsub float %44, %45
   store float %46, float* %x, align 4
-  %47 = load i32, i32* %i, align 4
-  %48 = load i32, i32* %i, align 4
+  %47 = load i32, i32* %i1, align 4
+  %48 = load i32, i32* %i1, align 4
   %49 = sdiv i32 %47, %48
   %50 = sitofp i32 %49 to float
   store float %50, float* %x, align 4
@@ -75,13 +76,13 @@ define i32 @main(i32 %0, i8** %1) {
   %52 = load float, float* %r, align 4
   %53 = fdiv float %51, %52
   store float %53, float* %x, align 4
-  %54 = load i32, i32* %i, align 4
+  %54 = load i32, i32* %i1, align 4
   %55 = sitofp i32 %54 to float
   %56 = load float, float* %r, align 4
   %57 = fdiv float %55, %56
   store float %57, float* %x, align 4
   %58 = load float, float* %r, align 4
-  %59 = load i32, i32* %i, align 4
+  %59 = load i32, i32* %i1, align 4
   %60 = sitofp i32 %59 to float
   %61 = fdiv float %58, %60
   store float %61, float* %x, align 4

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
-    "stdout_hash": "acbd8c0ef7cf1fe1535eb5d2d9b9bd18d5a6ff3308670e6a191ea5c9",
+    "stdout_hash": "aecb7de0edbb57bedbb871ad4d98e19a152e9762cb8528b19cc47cce",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_05-aa71aa9.stdout
+++ b/tests/reference/llvm-types_05-aa71aa9.stdout
@@ -3,8 +3,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %r = alloca float, align 4
   store float 2.000000e+00, float* %r, align 4
   store float 2.000000e+00, float* %r, align 4
@@ -13,13 +14,13 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0.000000e+00, float* %r, align 4
   store float 5.000000e-01, float* %r, align 4
   store float 5.000000e-01, float* %r, align 4
-  store i32 2, i32* %i, align 4
-  store i32 2, i32* %i, align 4
-  store i32 8, i32* %i, align 4
-  store i32 4, i32* %i, align 4
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %i, align 4
+  store i32 2, i32* %i1, align 4
+  store i32 2, i32* %i1, align 4
+  store i32 8, i32* %i1, align 4
+  store i32 4, i32* %i1, align 4
+  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %i1, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-types_06-6f66d2c.json
+++ b/tests/reference/llvm-types_06-6f66d2c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_06-6f66d2c.stdout",
-    "stdout_hash": "da72dfdd7290a68e5525570ca9909aa1505d62718e88e15e0332b135",
+    "stdout_hash": "b955ed3e8f5cc9eebf2adce4b32b558961908fda5d5b35d5572acd5b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_06-6f66d2c.stdout
+++ b/tests/reference/llvm-types_06-6f66d2c.stdout
@@ -76,13 +76,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
   %r = alloca float, align 4
   store float 2.000000e+00, float* %r, align 4
-  store i32 2, i32* %i, align 4
-  %2 = load i32, i32* %i, align 4
-  %3 = load i32, i32* %i, align 4
+  store i32 2, i32* %i1, align 4
+  %2 = load i32, i32* %i1, align 4
+  %3 = load i32, i32* %i1, align 4
   %4 = icmp slt i32 %2, %3
   br i1 %4, label %then, label %else
 
@@ -98,352 +99,352 @@ ifcont:                                           ; preds = %else, %then
   %5 = load float, float* %r, align 4
   %6 = load float, float* %r, align 4
   %7 = fcmp olt float %5, %6
-  br i1 %7, label %then1, label %else2
+  br i1 %7, label %then2, label %else3
 
-then1:                                            ; preds = %ifcont
+then2:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont4
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else3:                                            ; preds = %ifcont
+  br label %ifcont4
 
-ifcont3:                                          ; preds = %else2, %then1
+ifcont4:                                          ; preds = %else3, %then2
   %8 = load float, float* %r, align 4
-  %9 = load i32, i32* %i, align 4
+  %9 = load i32, i32* %i1, align 4
   %10 = sitofp i32 %9 to float
   %11 = fcmp olt float %8, %10
-  br i1 %11, label %then4, label %else5
+  br i1 %11, label %then5, label %else6
 
-then4:                                            ; preds = %ifcont3
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont7
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else6:                                            ; preds = %ifcont4
+  br label %ifcont7
 
-ifcont6:                                          ; preds = %else5, %then4
-  %12 = load i32, i32* %i, align 4
+ifcont7:                                          ; preds = %else6, %then5
+  %12 = load i32, i32* %i1, align 4
   %13 = sitofp i32 %12 to float
   %14 = load float, float* %r, align 4
   %15 = fcmp olt float %13, %14
-  br i1 %15, label %then7, label %else8
+  br i1 %15, label %then8, label %else9
 
-then7:                                            ; preds = %ifcont6
+then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont10
 
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
+else9:                                            ; preds = %ifcont7
+  br label %ifcont10
 
-ifcont9:                                          ; preds = %else8, %then7
-  %16 = load i32, i32* %i, align 4
-  %17 = load i32, i32* %i, align 4
+ifcont10:                                         ; preds = %else9, %then8
+  %16 = load i32, i32* %i1, align 4
+  %17 = load i32, i32* %i1, align 4
   %18 = icmp sgt i32 %16, %17
-  br i1 %18, label %then10, label %else11
+  br i1 %18, label %then11, label %else12
 
-then10:                                           ; preds = %ifcont9
+then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont13
 
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
+else12:                                           ; preds = %ifcont10
+  br label %ifcont13
 
-ifcont12:                                         ; preds = %else11, %then10
+ifcont13:                                         ; preds = %else12, %then11
   %19 = load float, float* %r, align 4
   %20 = load float, float* %r, align 4
   %21 = fcmp ogt float %19, %20
-  br i1 %21, label %then13, label %else14
+  br i1 %21, label %then14, label %else15
 
-then13:                                           ; preds = %ifcont12
+then14:                                           ; preds = %ifcont13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont16
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else15:                                           ; preds = %ifcont13
+  br label %ifcont16
 
-ifcont15:                                         ; preds = %else14, %then13
+ifcont16:                                         ; preds = %else15, %then14
   %22 = load float, float* %r, align 4
-  %23 = load i32, i32* %i, align 4
+  %23 = load i32, i32* %i1, align 4
   %24 = sitofp i32 %23 to float
   %25 = fcmp ogt float %22, %24
-  br i1 %25, label %then16, label %else17
+  br i1 %25, label %then17, label %else18
 
-then16:                                           ; preds = %ifcont15
+then17:                                           ; preds = %ifcont16
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @20, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont19
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else18:                                           ; preds = %ifcont16
+  br label %ifcont19
 
-ifcont18:                                         ; preds = %else17, %then16
-  %26 = load i32, i32* %i, align 4
+ifcont19:                                         ; preds = %else18, %then17
+  %26 = load i32, i32* %i1, align 4
   %27 = sitofp i32 %26 to float
   %28 = load float, float* %r, align 4
   %29 = fcmp ogt float %27, %28
-  br i1 %29, label %then19, label %else20
+  br i1 %29, label %then20, label %else21
 
-then19:                                           ; preds = %ifcont18
+then20:                                           ; preds = %ifcont19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont22
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else21:                                           ; preds = %ifcont19
+  br label %ifcont22
 
-ifcont21:                                         ; preds = %else20, %then19
-  %30 = load i32, i32* %i, align 4
-  %31 = load i32, i32* %i, align 4
+ifcont22:                                         ; preds = %else21, %then20
+  %30 = load i32, i32* %i1, align 4
+  %31 = load i32, i32* %i1, align 4
   %32 = icmp ne i32 %30, %31
-  br i1 %32, label %then22, label %else23
+  br i1 %32, label %then23, label %else24
 
-then22:                                           ; preds = %ifcont21
+then23:                                           ; preds = %ifcont22
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont24
+  br label %ifcont25
 
-else23:                                           ; preds = %ifcont21
-  br label %ifcont24
+else24:                                           ; preds = %ifcont22
+  br label %ifcont25
 
-ifcont24:                                         ; preds = %else23, %then22
+ifcont25:                                         ; preds = %else24, %then23
   %33 = load float, float* %r, align 4
   %34 = load float, float* %r, align 4
   %35 = fcmp one float %33, %34
-  br i1 %35, label %then25, label %else26
+  br i1 %35, label %then26, label %else27
 
-then25:                                           ; preds = %ifcont24
+then26:                                           ; preds = %ifcont25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont27
+  br label %ifcont28
 
-else26:                                           ; preds = %ifcont24
-  br label %ifcont27
+else27:                                           ; preds = %ifcont25
+  br label %ifcont28
 
-ifcont27:                                         ; preds = %else26, %then25
+ifcont28:                                         ; preds = %else27, %then26
   %36 = load float, float* %r, align 4
-  %37 = load i32, i32* %i, align 4
+  %37 = load i32, i32* %i1, align 4
   %38 = sitofp i32 %37 to float
   %39 = fcmp one float %36, %38
-  br i1 %39, label %then28, label %else29
+  br i1 %39, label %then29, label %else30
 
-then28:                                           ; preds = %ifcont27
+then29:                                           ; preds = %ifcont28
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @30, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont31
 
-else29:                                           ; preds = %ifcont27
-  br label %ifcont30
+else30:                                           ; preds = %ifcont28
+  br label %ifcont31
 
-ifcont30:                                         ; preds = %else29, %then28
-  %40 = load i32, i32* %i, align 4
+ifcont31:                                         ; preds = %else30, %then29
+  %40 = load i32, i32* %i1, align 4
   %41 = sitofp i32 %40 to float
   %42 = load float, float* %r, align 4
   %43 = fcmp one float %41, %42
-  br i1 %43, label %then31, label %else32
+  br i1 %43, label %then32, label %else33
 
-then31:                                           ; preds = %ifcont30
+then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont34
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else33:                                           ; preds = %ifcont31
+  br label %ifcont34
 
-ifcont33:                                         ; preds = %else32, %then31
-  %44 = load i32, i32* %i, align 4
+ifcont34:                                         ; preds = %else33, %then32
+  %44 = load i32, i32* %i1, align 4
   %45 = add i32 %44, 1
-  %46 = load i32, i32* %i, align 4
+  %46 = load i32, i32* %i1, align 4
   %47 = icmp sle i32 %45, %46
-  br i1 %47, label %then34, label %else35
+  br i1 %47, label %then35, label %else36
 
-then34:                                           ; preds = %ifcont33
+then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont37
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else36:                                           ; preds = %ifcont34
+  br label %ifcont37
 
-ifcont36:                                         ; preds = %else35, %then34
+ifcont37:                                         ; preds = %else36, %then35
   %48 = load float, float* %r, align 4
   %49 = fadd float %48, 1.000000e+00
   %50 = load float, float* %r, align 4
   %51 = fcmp ole float %49, %50
-  br i1 %51, label %then37, label %else38
+  br i1 %51, label %then38, label %else39
 
-then37:                                           ; preds = %ifcont36
+then38:                                           ; preds = %ifcont37
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont39
+  br label %ifcont40
 
-else38:                                           ; preds = %ifcont36
-  br label %ifcont39
+else39:                                           ; preds = %ifcont37
+  br label %ifcont40
 
-ifcont39:                                         ; preds = %else38, %then37
+ifcont40:                                         ; preds = %else39, %then38
   %52 = load float, float* %r, align 4
   %53 = fadd float %52, 1.000000e+00
-  %54 = load i32, i32* %i, align 4
+  %54 = load i32, i32* %i1, align 4
   %55 = sitofp i32 %54 to float
   %56 = fcmp ole float %53, %55
-  br i1 %56, label %then40, label %else41
+  br i1 %56, label %then41, label %else42
 
-then40:                                           ; preds = %ifcont39
+then41:                                           ; preds = %ifcont40
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont42
+  br label %ifcont43
 
-else41:                                           ; preds = %ifcont39
-  br label %ifcont42
+else42:                                           ; preds = %ifcont40
+  br label %ifcont43
 
-ifcont42:                                         ; preds = %else41, %then40
-  %57 = load i32, i32* %i, align 4
+ifcont43:                                         ; preds = %else42, %then41
+  %57 = load i32, i32* %i1, align 4
   %58 = add i32 %57, 1
   %59 = sitofp i32 %58 to float
   %60 = load float, float* %r, align 4
   %61 = fcmp ole float %59, %60
-  br i1 %61, label %then43, label %else44
+  br i1 %61, label %then44, label %else45
 
-then43:                                           ; preds = %ifcont42
+then44:                                           ; preds = %ifcont43
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont45
+  br label %ifcont46
 
-else44:                                           ; preds = %ifcont42
-  br label %ifcont45
+else45:                                           ; preds = %ifcont43
+  br label %ifcont46
 
-ifcont45:                                         ; preds = %else44, %then43
-  %62 = load i32, i32* %i, align 4
-  %63 = load i32, i32* %i, align 4
+ifcont46:                                         ; preds = %else45, %then44
+  %62 = load i32, i32* %i1, align 4
+  %63 = load i32, i32* %i1, align 4
   %64 = add i32 %63, 1
   %65 = icmp sge i32 %62, %64
-  br i1 %65, label %then46, label %else47
+  br i1 %65, label %then47, label %else48
 
-then46:                                           ; preds = %ifcont45
+then47:                                           ; preds = %ifcont46
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @48, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @49, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont48
+  br label %ifcont49
 
-else47:                                           ; preds = %ifcont45
-  br label %ifcont48
+else48:                                           ; preds = %ifcont46
+  br label %ifcont49
 
-ifcont48:                                         ; preds = %else47, %then46
+ifcont49:                                         ; preds = %else48, %then47
   %66 = load float, float* %r, align 4
   %67 = load float, float* %r, align 4
   %68 = fadd float %67, 1.000000e+00
   %69 = fcmp oge float %66, %68
-  br i1 %69, label %then49, label %else50
+  br i1 %69, label %then50, label %else51
 
-then49:                                           ; preds = %ifcont48
+then50:                                           ; preds = %ifcont49
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont51
+  br label %ifcont52
 
-else50:                                           ; preds = %ifcont48
-  br label %ifcont51
+else51:                                           ; preds = %ifcont49
+  br label %ifcont52
 
-ifcont51:                                         ; preds = %else50, %then49
+ifcont52:                                         ; preds = %else51, %then50
   %70 = load float, float* %r, align 4
-  %71 = load i32, i32* %i, align 4
+  %71 = load i32, i32* %i1, align 4
   %72 = add i32 %71, 1
   %73 = sitofp i32 %72 to float
   %74 = fcmp oge float %70, %73
-  br i1 %74, label %then52, label %else53
+  br i1 %74, label %then53, label %else54
 
-then52:                                           ; preds = %ifcont51
+then53:                                           ; preds = %ifcont52
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @56, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @54, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @55, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont54
+  br label %ifcont55
 
-else53:                                           ; preds = %ifcont51
-  br label %ifcont54
+else54:                                           ; preds = %ifcont52
+  br label %ifcont55
 
-ifcont54:                                         ; preds = %else53, %then52
-  %75 = load i32, i32* %i, align 4
+ifcont55:                                         ; preds = %else54, %then53
+  %75 = load i32, i32* %i1, align 4
   %76 = sitofp i32 %75 to float
   %77 = load float, float* %r, align 4
   %78 = fadd float %77, 1.000000e+00
   %79 = fcmp oge float %76, %78
-  br i1 %79, label %then55, label %else56
+  br i1 %79, label %then56, label %else57
 
-then55:                                           ; preds = %ifcont54
+then56:                                           ; preds = %ifcont55
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont57
+  br label %ifcont58
 
-else56:                                           ; preds = %ifcont54
-  br label %ifcont57
+else57:                                           ; preds = %ifcont55
+  br label %ifcont58
 
-ifcont57:                                         ; preds = %else56, %then55
-  %80 = load i32, i32* %i, align 4
-  %81 = load i32, i32* %i, align 4
+ifcont58:                                         ; preds = %else57, %then56
+  %80 = load i32, i32* %i1, align 4
+  %81 = load i32, i32* %i1, align 4
   %82 = add i32 %81, 1
   %83 = icmp eq i32 %80, %82
-  br i1 %83, label %then58, label %else59
+  br i1 %83, label %then59, label %else60
 
-then58:                                           ; preds = %ifcont57
+then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @60, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont60
+  br label %ifcont61
 
-else59:                                           ; preds = %ifcont57
-  br label %ifcont60
+else60:                                           ; preds = %ifcont58
+  br label %ifcont61
 
-ifcont60:                                         ; preds = %else59, %then58
+ifcont61:                                         ; preds = %else60, %then59
   %84 = load float, float* %r, align 4
   %85 = load float, float* %r, align 4
   %86 = fadd float %85, 1.000000e+00
   %87 = fcmp oeq float %84, %86
-  br i1 %87, label %then61, label %else62
+  br i1 %87, label %then62, label %else63
 
-then61:                                           ; preds = %ifcont60
+then62:                                           ; preds = %ifcont61
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont63
+  br label %ifcont64
 
-else62:                                           ; preds = %ifcont60
-  br label %ifcont63
+else63:                                           ; preds = %ifcont61
+  br label %ifcont64
 
-ifcont63:                                         ; preds = %else62, %then61
+ifcont64:                                         ; preds = %else63, %then62
   %88 = load float, float* %r, align 4
-  %89 = load i32, i32* %i, align 4
+  %89 = load i32, i32* %i1, align 4
   %90 = add i32 %89, 1
   %91 = sitofp i32 %90 to float
   %92 = fcmp oeq float %88, %91
-  br i1 %92, label %then64, label %else65
+  br i1 %92, label %then65, label %else66
 
-then64:                                           ; preds = %ifcont63
+then65:                                           ; preds = %ifcont64
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont66
+  br label %ifcont67
 
-else65:                                           ; preds = %ifcont63
-  br label %ifcont66
+else66:                                           ; preds = %ifcont64
+  br label %ifcont67
 
-ifcont66:                                         ; preds = %else65, %then64
-  %93 = load i32, i32* %i, align 4
+ifcont67:                                         ; preds = %else66, %then65
+  %93 = load i32, i32* %i1, align 4
   %94 = sitofp i32 %93 to float
   %95 = load float, float* %r, align 4
   %96 = fadd float %95, 1.000000e+00
   %97 = fcmp oeq float %94, %96
-  br i1 %97, label %then67, label %else68
+  br i1 %97, label %then68, label %else69
 
-then67:                                           ; preds = %ifcont66
+then68:                                           ; preds = %ifcont67
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont69
+  br label %ifcont70
 
-else68:                                           ; preds = %ifcont66
-  br label %ifcont69
+else69:                                           ; preds = %ifcont67
+  br label %ifcont70
 
-ifcont69:                                         ; preds = %else68, %then67
+ifcont70:                                         ; preds = %else69, %then68
   br label %return
 
-return:                                           ; preds = %ifcont69
+return:                                           ; preds = %ifcont70
   ret i32 0
 }
 

--- a/tests/reference/llvm-variables_03-4ba9d62.json
+++ b/tests/reference/llvm-variables_03-4ba9d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-variables_03-4ba9d62.stdout",
-    "stdout_hash": "c75938aba67ceb0276b4dbc38479463be7bcdd17abbd0a0852efffa5",
+    "stdout_hash": "4c04ce9a124b9d84aa6f68f45e6c334db995127027d49af83a2e5a71",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-variables_03-4ba9d62.stdout
+++ b/tests/reference/llvm-variables_03-4ba9d62.stdout
@@ -16,11 +16,12 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %x = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %b = alloca i1, align 1
-  %x = alloca i32, align 4
-  store i32 2, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
+  %x1 = alloca i32, align 4
+  store i32 2, i32* %x1, align 4
+  %2 = load i32, i32* %x1, align 4
   %3 = icmp ne i32 %2, 2
   store i1 %3, i1* %b, align 1
   %4 = load i1, i1* %b, align 1
@@ -35,59 +36,59 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %5 = load i32, i32* %x, align 4
+  %5 = load i32, i32* %x1, align 4
   %6 = icmp eq i32 %5, 2
   store i1 %6, i1* %b, align 1
   %7 = load i1, i1* %b, align 1
   %8 = xor i1 %7, true
-  br i1 %8, label %then1, label %else2
+  br i1 %8, label %then2, label %else3
 
-then1:                                            ; preds = %ifcont
+then2:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont4
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else3:                                            ; preds = %ifcont
+  br label %ifcont4
 
-ifcont3:                                          ; preds = %else2, %then1
-  %9 = load i32, i32* %x, align 4
+ifcont4:                                          ; preds = %else3, %then2
+  %9 = load i32, i32* %x1, align 4
   %10 = icmp eq i32 %9, 2
   %11 = xor i1 %10, true
   store i1 %11, i1* %b, align 1
   %12 = load i1, i1* %b, align 1
-  br i1 %12, label %then4, label %else5
+  br i1 %12, label %then5, label %else6
 
-then4:                                            ; preds = %ifcont3
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont7
 
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
+else6:                                            ; preds = %ifcont4
+  br label %ifcont7
 
-ifcont6:                                          ; preds = %else5, %then4
-  %13 = load i32, i32* %x, align 4
+ifcont7:                                          ; preds = %else6, %then5
+  %13 = load i32, i32* %x1, align 4
   %14 = icmp eq i32 %13, 2
   store i1 %14, i1* %b, align 1
   %15 = load i1, i1* %b, align 1
   %16 = xor i1 %15, true
   store i1 %16, i1* %b, align 1
   %17 = load i1, i1* %b, align 1
-  br i1 %17, label %then7, label %else8
+  br i1 %17, label %then8, label %else9
 
-then7:                                            ; preds = %ifcont6
+then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont10
 
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
+else9:                                            ; preds = %ifcont7
+  br label %ifcont10
 
-ifcont9:                                          ; preds = %else8, %then7
+ifcont10:                                         ; preds = %else9, %then8
   br label %return
 
-return:                                           ; preds = %ifcont9
+return:                                           ; preds = %ifcont10
   ret i32 0
 }
 

--- a/tests/reference/llvm-while_01-3496096.json
+++ b/tests/reference/llvm-while_01-3496096.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_01-3496096.stdout",
-    "stdout_hash": "a11deeb82e6eb96b3719f5685416f050f855842068ab57a2920b96ac",
+    "stdout_hash": "475ff439d20a378a27311333d830151171ff08e3dd5807ca07314a4b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_01-3496096.stdout
+++ b/tests/reference/llvm-while_01-3496096.stdout
@@ -22,30 +22,32 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 1, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 1, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = icmp slt i32 %2, 11
   br i1 %3, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %4 = load i32, i32* %j, align 4
-  %5 = load i32, i32* %i, align 4
+  %4 = load i32, i32* %j2, align 4
+  %5 = load i32, i32* %i1, align 4
   %6 = add i32 %4, %5
-  store i32 %6, i32* %j, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %6, i32* %j2, align 4
+  %7 = load i32, i32* %i1, align 4
   %8 = add i32 %7, 1
-  store i32 %8, i32* %i, align 4
+  store i32 %8, i32* %i1, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %9 = load i32, i32* %j, align 4
+  %9 = load i32, i32* %j2, align 4
   %10 = icmp ne i32 %9, 55
   br i1 %10, label %then, label %else
 
@@ -58,114 +60,114 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = load i32, i32* %i, align 4
+  %11 = load i32, i32* %i1, align 4
   %12 = icmp ne i32 %11, 11
-  br i1 %12, label %then1, label %else2
+  br i1 %12, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
-  store i32 1, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head4
+ifcont5:                                          ; preds = %else4, %then3
+  store i32 1, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head6
 
-loop.head4:                                       ; preds = %loop.body5, %ifcont3
-  %13 = load i32, i32* %i, align 4
+loop.head6:                                       ; preds = %loop.body7, %ifcont5
+  %13 = load i32, i32* %i1, align 4
   %14 = icmp sle i32 %13, 10
-  br i1 %14, label %loop.body5, label %loop.end6
+  br i1 %14, label %loop.body7, label %loop.end8
 
-loop.body5:                                       ; preds = %loop.head4
-  %15 = load i32, i32* %j, align 4
-  %16 = load i32, i32* %i, align 4
+loop.body7:                                       ; preds = %loop.head6
+  %15 = load i32, i32* %j2, align 4
+  %16 = load i32, i32* %i1, align 4
   %17 = add i32 %15, %16
-  store i32 %17, i32* %j, align 4
-  %18 = load i32, i32* %i, align 4
+  store i32 %17, i32* %j2, align 4
+  %18 = load i32, i32* %i1, align 4
   %19 = add i32 %18, 1
-  store i32 %19, i32* %i, align 4
-  br label %loop.head4
+  store i32 %19, i32* %i1, align 4
+  br label %loop.head6
 
-loop.end6:                                        ; preds = %loop.head4
-  %20 = load i32, i32* %j, align 4
+loop.end8:                                        ; preds = %loop.head6
+  %20 = load i32, i32* %j2, align 4
   %21 = icmp ne i32 %20, 55
-  br i1 %21, label %then7, label %else8
+  br i1 %21, label %then9, label %else10
 
-then7:                                            ; preds = %loop.end6
+then9:                                            ; preds = %loop.end8
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont11
 
-else8:                                            ; preds = %loop.end6
-  br label %ifcont9
+else10:                                           ; preds = %loop.end8
+  br label %ifcont11
 
-ifcont9:                                          ; preds = %else8, %then7
-  %22 = load i32, i32* %i, align 4
+ifcont11:                                         ; preds = %else10, %then9
+  %22 = load i32, i32* %i1, align 4
   %23 = icmp ne i32 %22, 11
-  br i1 %23, label %then10, label %else11
+  br i1 %23, label %then12, label %else13
 
-then10:                                           ; preds = %ifcont9
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
-  store i32 1, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head13
+ifcont14:                                         ; preds = %else13, %then12
+  store i32 1, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head15
 
-loop.head13:                                      ; preds = %loop.body14, %ifcont12
-  %24 = load i32, i32* %i, align 4
+loop.head15:                                      ; preds = %loop.body16, %ifcont14
+  %24 = load i32, i32* %i1, align 4
   %25 = icmp slt i32 %24, 1
-  br i1 %25, label %loop.body14, label %loop.end15
+  br i1 %25, label %loop.body16, label %loop.end17
 
-loop.body14:                                      ; preds = %loop.head13
-  %26 = load i32, i32* %j, align 4
-  %27 = load i32, i32* %i, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %26 = load i32, i32* %j2, align 4
+  %27 = load i32, i32* %i1, align 4
   %28 = add i32 %26, %27
-  store i32 %28, i32* %j, align 4
-  %29 = load i32, i32* %i, align 4
+  store i32 %28, i32* %j2, align 4
+  %29 = load i32, i32* %i1, align 4
   %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
-  br label %loop.head13
+  store i32 %30, i32* %i1, align 4
+  br label %loop.head15
 
-loop.end15:                                       ; preds = %loop.head13
-  %31 = load i32, i32* %j, align 4
+loop.end17:                                       ; preds = %loop.head15
+  %31 = load i32, i32* %j2, align 4
   %32 = icmp ne i32 %31, 0
-  br i1 %32, label %then16, label %else17
+  br i1 %32, label %then18, label %else19
 
-then16:                                           ; preds = %loop.end15
+then18:                                           ; preds = %loop.end17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont20
 
-else17:                                           ; preds = %loop.end15
-  br label %ifcont18
+else19:                                           ; preds = %loop.end17
+  br label %ifcont20
 
-ifcont18:                                         ; preds = %else17, %then16
-  %33 = load i32, i32* %i, align 4
+ifcont20:                                         ; preds = %else19, %then18
+  %33 = load i32, i32* %i1, align 4
   %34 = icmp ne i32 %33, 1
-  br i1 %34, label %then19, label %else20
+  br i1 %34, label %then21, label %else22
 
-then19:                                           ; preds = %ifcont18
+then21:                                           ; preds = %ifcont20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont21
+  br label %ifcont23
 
-else20:                                           ; preds = %ifcont18
-  br label %ifcont21
+else22:                                           ; preds = %ifcont20
+  br label %ifcont23
 
-ifcont21:                                         ; preds = %else20, %then19
+ifcont23:                                         ; preds = %else22, %then21
   br label %return
 
-return:                                           ; preds = %ifcont21
+return:                                           ; preds = %ifcont23
   ret i32 0
 }
 

--- a/tests/reference/llvm-while_02-3db2b04.json
+++ b/tests/reference/llvm-while_02-3db2b04.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_02-3db2b04.stdout",
-    "stdout_hash": "4e7de11da77bc0f399a028bd479fd2d7689d13af264ed42bad670b3a",
+    "stdout_hash": "c563afa92a33a2c2063d48a383bc38979e9f21e4af989b934804a99d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_02-3db2b04.stdout
+++ b/tests/reference/llvm-while_02-3db2b04.stdout
@@ -22,30 +22,32 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %i1 = alloca i32, align 4
+  %j2 = alloca i32, align 4
+  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, i32* %i1, align 4
   %3 = icmp slt i32 %2, 10
   br i1 %3, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %4 = load i32, i32* %i, align 4
+  %4 = load i32, i32* %i1, align 4
   %5 = add i32 %4, 1
-  store i32 %5, i32* %i, align 4
-  %6 = load i32, i32* %j, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %5, i32* %i1, align 4
+  %6 = load i32, i32* %j2, align 4
+  %7 = load i32, i32* %i1, align 4
   %8 = add i32 %6, %7
-  store i32 %8, i32* %j, align 4
+  store i32 %8, i32* %j2, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %9 = load i32, i32* %j, align 4
+  %9 = load i32, i32* %j2, align 4
   %10 = icmp ne i32 %9, 55
   br i1 %10, label %then, label %else
 
@@ -58,142 +60,142 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = load i32, i32* %i, align 4
+  %11 = load i32, i32* %i1, align 4
   %12 = icmp ne i32 %11, 10
-  br i1 %12, label %then1, label %else2
+  br i1 %12, label %then3, label %else4
 
-then1:                                            ; preds = %ifcont
+then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont3
+  br label %ifcont5
 
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
+else4:                                            ; preds = %ifcont
+  br label %ifcont5
 
-ifcont3:                                          ; preds = %else2, %then1
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head4
+ifcont5:                                          ; preds = %else4, %then3
+  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head6
 
-loop.head4:                                       ; preds = %ifcont8, %ifcont3
-  %13 = load i32, i32* %i, align 4
+loop.head6:                                       ; preds = %ifcont10, %ifcont5
+  %13 = load i32, i32* %i1, align 4
   %14 = icmp slt i32 %13, 10
-  br i1 %14, label %loop.body5, label %loop.end9
+  br i1 %14, label %loop.body7, label %loop.end11
 
-loop.body5:                                       ; preds = %loop.head4
-  %15 = load i32, i32* %i, align 4
+loop.body7:                                       ; preds = %loop.head6
+  %15 = load i32, i32* %i1, align 4
   %16 = add i32 %15, 1
-  store i32 %16, i32* %i, align 4
-  %17 = load i32, i32* %i, align 4
+  store i32 %16, i32* %i1, align 4
+  %17 = load i32, i32* %i1, align 4
   %18 = icmp eq i32 %17, 2
-  br i1 %18, label %then6, label %else7
+  br i1 %18, label %then8, label %else9
 
-then6:                                            ; preds = %loop.body5
-  br label %loop.end9
+then8:                                            ; preds = %loop.body7
+  br label %loop.end11
 
 unreachable_after_exit:                           ; No predecessors!
-  br label %ifcont8
+  br label %ifcont10
 
-else7:                                            ; preds = %loop.body5
-  br label %ifcont8
+else9:                                            ; preds = %loop.body7
+  br label %ifcont10
 
-ifcont8:                                          ; preds = %else7, %unreachable_after_exit
-  %19 = load i32, i32* %j, align 4
-  %20 = load i32, i32* %i, align 4
+ifcont10:                                         ; preds = %else9, %unreachable_after_exit
+  %19 = load i32, i32* %j2, align 4
+  %20 = load i32, i32* %i1, align 4
   %21 = add i32 %19, %20
-  store i32 %21, i32* %j, align 4
-  br label %loop.head4
+  store i32 %21, i32* %j2, align 4
+  br label %loop.head6
 
-loop.end9:                                        ; preds = %then6, %loop.head4
-  %22 = load i32, i32* %j, align 4
+loop.end11:                                       ; preds = %then8, %loop.head6
+  %22 = load i32, i32* %j2, align 4
   %23 = icmp ne i32 %22, 1
-  br i1 %23, label %then10, label %else11
+  br i1 %23, label %then12, label %else13
 
-then10:                                           ; preds = %loop.end9
+then12:                                           ; preds = %loop.end11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont12
+  br label %ifcont14
 
-else11:                                           ; preds = %loop.end9
-  br label %ifcont12
+else13:                                           ; preds = %loop.end11
+  br label %ifcont14
 
-ifcont12:                                         ; preds = %else11, %then10
-  %24 = load i32, i32* %i, align 4
+ifcont14:                                         ; preds = %else13, %then12
+  %24 = load i32, i32* %i1, align 4
   %25 = icmp ne i32 %24, 2
-  br i1 %25, label %then13, label %else14
+  br i1 %25, label %then15, label %else16
 
-then13:                                           ; preds = %ifcont12
+then15:                                           ; preds = %ifcont14
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont17
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else16:                                           ; preds = %ifcont14
+  br label %ifcont17
 
-ifcont15:                                         ; preds = %else14, %then13
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %j, align 4
-  br label %loop.head16
+ifcont17:                                         ; preds = %else16, %then15
+  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %j2, align 4
+  br label %loop.head18
 
-loop.head16:                                      ; preds = %ifcont20, %then18, %ifcont15
-  %26 = load i32, i32* %i, align 4
+loop.head18:                                      ; preds = %ifcont22, %then20, %ifcont17
+  %26 = load i32, i32* %i1, align 4
   %27 = icmp slt i32 %26, 10
-  br i1 %27, label %loop.body17, label %loop.end21
+  br i1 %27, label %loop.body19, label %loop.end23
 
-loop.body17:                                      ; preds = %loop.head16
-  %28 = load i32, i32* %i, align 4
+loop.body19:                                      ; preds = %loop.head18
+  %28 = load i32, i32* %i1, align 4
   %29 = add i32 %28, 1
-  store i32 %29, i32* %i, align 4
-  %30 = load i32, i32* %i, align 4
+  store i32 %29, i32* %i1, align 4
+  %30 = load i32, i32* %i1, align 4
   %31 = icmp eq i32 %30, 2
-  br i1 %31, label %then18, label %else19
+  br i1 %31, label %then20, label %else21
 
-then18:                                           ; preds = %loop.body17
-  br label %loop.head16
+then20:                                           ; preds = %loop.body19
+  br label %loop.head18
 
 unreachable_after_cycle:                          ; No predecessors!
-  br label %ifcont20
+  br label %ifcont22
 
-else19:                                           ; preds = %loop.body17
-  br label %ifcont20
+else21:                                           ; preds = %loop.body19
+  br label %ifcont22
 
-ifcont20:                                         ; preds = %else19, %unreachable_after_cycle
-  %32 = load i32, i32* %j, align 4
-  %33 = load i32, i32* %i, align 4
+ifcont22:                                         ; preds = %else21, %unreachable_after_cycle
+  %32 = load i32, i32* %j2, align 4
+  %33 = load i32, i32* %i1, align 4
   %34 = add i32 %32, %33
-  store i32 %34, i32* %j, align 4
-  br label %loop.head16
+  store i32 %34, i32* %j2, align 4
+  br label %loop.head18
 
-loop.end21:                                       ; preds = %loop.head16
-  %35 = load i32, i32* %j, align 4
+loop.end23:                                       ; preds = %loop.head18
+  %35 = load i32, i32* %j2, align 4
   %36 = icmp ne i32 %35, 53
-  br i1 %36, label %then22, label %else23
+  br i1 %36, label %then24, label %else25
 
-then22:                                           ; preds = %loop.end21
+then24:                                           ; preds = %loop.end23
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont24
+  br label %ifcont26
 
-else23:                                           ; preds = %loop.end21
-  br label %ifcont24
+else25:                                           ; preds = %loop.end23
+  br label %ifcont26
 
-ifcont24:                                         ; preds = %else23, %then22
-  %37 = load i32, i32* %i, align 4
+ifcont26:                                         ; preds = %else25, %then24
+  %37 = load i32, i32* %i1, align 4
   %38 = icmp ne i32 %37, 10
-  br i1 %38, label %then25, label %else26
+  br i1 %38, label %then27, label %else28
 
-then25:                                           ; preds = %ifcont24
+then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont27
+  br label %ifcont29
 
-else26:                                           ; preds = %ifcont24
-  br label %ifcont27
+else28:                                           ; preds = %ifcont26
+  br label %ifcont29
 
-ifcont27:                                         ; preds = %else26, %then25
+ifcont29:                                         ; preds = %else28, %then27
   br label %return
 
-return:                                           ; preds = %ifcont27
+return:                                           ; preds = %ifcont29
   ret i32 0
 }
 

--- a/tests/reference/llvm-write3-49c0266.json
+++ b/tests/reference/llvm-write3-49c0266.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-write3-49c0266.stdout",
-    "stdout_hash": "7a519debc1c690ebc19f17753383f5d10ec8b5c4bbfd47e547adc2eb",
+    "stdout_hash": "343d2ccf758caa0847600dfb802514c344f9875ac1980465e882584f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-write3-49c0266.stdout
+++ b/tests/reference/llvm-write3-49c0266.stdout
@@ -8,11 +8,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %nwrite = alloca i32, align 4
   store i32 6, i32* %nwrite, align 4
-  store i32 6, i32* %nwrite, align 4
-  %2 = load i32, i32* %nwrite, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %nwrite1 = alloca i32, align 4
+  store i32 6, i32* %nwrite1, align 4
+  store i32 6, i32* %nwrite1, align 4
+  %2 = load i32, i32* %nwrite1, align 4
   %3 = alloca i32, align 4
   call void (i32, i32*, i8*, ...) @_lfortran_file_write(i32 %2, i32* %3, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   br label %return

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
@@ -5,9 +5,9 @@
     "infile_hash": "3e65758e10744eea8d101be6437af3724c0ec32c832e29da968fc22d",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
+    "stdout": "run_dbg-runtime_stacktrace_01-dcc746e.stdout",
+    "stdout_hash": "808b78dd0dbf01c6cf7827830f87e34a5bc4611ac88c6878c4eb21f6",
     "stderr": "run_dbg-runtime_stacktrace_01-dcc746e.stderr",
-    "stderr_hash": "eb3c044e48ac8bbaa776077b6c9cef2ef164ade8cddef1d6a7f06792",
-    "returncode": 1
+    "stderr_hash": "d7b2063ee2384904c7372e603b621a3e739faa954e5cc144f17d9b08",
+    "returncode": 5
 }

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stderr
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stderr
@@ -1,9 +1,9 @@
-  File "tests/errors/runtime_stacktrace_01.f90", line 3
-    print *, main()
-  File "tests/errors/runtime_stacktrace_01.f90", line 10
-    print *, g()
-  File "tests/errors/runtime_stacktrace_01.f90", line 20
-    call f()
-  File "tests/errors/runtime_stacktrace_01.f90", line 14
-    stop 1
-STOP 1
+code generation error: asr_to_llvm: module failed verification. Error:
+!dbg attachment points at wrong subprogram for function
+!3 = distinct !DISubprogram(name: "expr2", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+i32 (i32, i8**)* @main
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1), !dbg !7
+!7 = !DILocation(line: 1, column: 1, scope: !8)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stdout
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stdout
@@ -1,0 +1,124 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [39 x i8] c"tests/errors/runtime_stacktrace_01.f90\00", align 1
+@1 = private unnamed_addr constant [5 x i8] c"STOP\00", align 1
+@2 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@4 = private unnamed_addr constant [9 x i8] c"%s%s%d%s\00", align 1
+@5 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@7 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
+@8 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@9 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@10 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
+
+define i32 @main(i32 %0, i8** %1) !dbg !3 {
+.entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1), !dbg !7
+  %2 = call i32 @_xx_lcompilers_changed_main_xx(), !dbg !9
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i32 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0)), !dbg !9
+  br label %return, !dbg !9
+
+return:                                           ; preds = %.entry
+  ret i32 0, !dbg !9
+}
+
+define void @f() !dbg !10 {
+.entry:
+  br i1 true, label %then, label %else, !dbg !13
+
+then:                                             ; preds = %.entry
+  call void (i8*, i1, ...) @print_stacktrace_addresses(i8* getelementptr inbounds ([39 x i8], [39 x i8]* @0, i32 0, i32 0), i1 false), !dbg !13
+  br label %ifcont, !dbg !13
+
+else:                                             ; preds = %.entry
+  br label %ifcont, !dbg !13
+
+ifcont:                                           ; preds = %else, %then
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @4, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0)), !dbg !13
+  call void @exit(i32 1), !dbg !13
+  br label %return, !dbg !13
+
+return:                                           ; preds = %ifcont
+  ret void, !dbg !13
+}
+
+define i32 @g() !dbg !14 {
+.entry:
+  %g = alloca i32, align 4, !dbg !15
+  call void @llvm.dbg.declare(metadata i32* %g, metadata !16, metadata !DIExpression()), !dbg !17
+  store i32 1, i32* %g, align 4, !dbg !18
+  call void @f(), !dbg !19
+  br label %return, !dbg !19
+
+return:                                           ; preds = %.entry
+  %0 = load i32, i32* %g, align 4, !dbg !19
+  ret i32 %0, !dbg !19
+}
+
+define i32 @_xx_lcompilers_changed_main_xx() !dbg !8 {
+.entry:
+  %main = alloca i32, align 4, !dbg !20
+  call void @llvm.dbg.declare(metadata i32* %main, metadata !21, metadata !DIExpression()), !dbg !22
+  store i32 1, i32* %main, align 4, !dbg !23
+  %0 = call i32 @g(), !dbg !24
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i32 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0)), !dbg !24
+  br label %return, !dbg !24
+
+return:                                           ; preds = %.entry
+  %1 = load i32, i32* %main, align 4, !dbg !24
+  ret i32 %1, !dbg !24
+}
+
+declare void @print_stacktrace_addresses(i8*, i1, ...)
+
+declare void @_lcompilers_print_error(i8*, ...)
+
+declare void @exit(i32)
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+attributes #0 = { nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "LPython Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "tests/errors/runtime_stacktrace_01.f90", directory: ".")
+!2 = !{}
+!3 = distinct !DISubprogram(name: "expr2", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DIBasicType(name: "integer", size: 32, encoding: DW_ATE_signed)
+!7 = !DILocation(line: 1, column: 1, scope: !8)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!9 = !DILocation(line: 3, column: 14, scope: !8)
+!10 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 13, type: !11, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !DILocation(line: 14, column: 9, scope: !10)
+!14 = distinct !DISubprogram(name: "g", scope: !1, file: !1, line: 17, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!15 = !DILocation(line: 17, column: 5, scope: !14)
+!16 = !DILocalVariable(name: "g", arg: 1, scope: !14, file: !1, line: 18, type: !6)
+!17 = !DILocation(line: 18, scope: !14)
+!18 = !DILocation(line: 19, column: 9, scope: !14)
+!19 = !DILocation(line: 20, column: 9, scope: !14)
+!20 = !DILocation(line: 7, column: 5, scope: !8)
+!21 = !DILocalVariable(name: "main", arg: 1, scope: !8, file: !1, line: 8, type: !6)
+!22 = !DILocation(line: 8, scope: !8)
+!23 = !DILocation(line: 9, column: 9, scope: !8)
+!24 = !DILocation(line: 10, column: 18, scope: !8)
+asr_to_llvm: module failed verification. Error:
+!dbg attachment points at wrong subprogram for function
+!3 = distinct !DISubprogram(name: "expr2", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+i32 (i32, i8**)* @main
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1), !dbg !7
+!7 = !DILocation(line: 1, column: 1, scope: !8)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+


### PR DESCRIPTION
Fixes #4536.

This only works for Program, we need to apply similar diff as in `visit_Program` to `visit_Module`. @kmr-srbh would you be willing to do once this PR is merged? I think this will be a good reference to learn how things work in llvm backend. 