### PR TITLE
Throw error for single precision argument of `Idint` intrinsic 

### DIFF
--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -2519,8 +2519,13 @@ namespace Ifix {
 namespace Idint {
 
     static ASR::expr_t *eval_Idint(Allocator &al, const Location &loc,
-            ASR::ttype_t* /*arg_type*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* /*arg_type*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int val = ASR::down_cast<ASR::RealConstant_t>(expr_value(args[0]))->m_r;
+        int kind = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::RealConstant_t>(args[0])->m_type);
+        if(kind == 4) {
+            append_error(diag, "first argument of `idint` must have kind equals to 8", loc);
+            return nullptr;
+        }
         return make_ConstantWithType(make_IntegerConstant_t, val, int32, loc);
     }
 
@@ -2530,6 +2535,12 @@ namespace Idint {
         declare_basic_variables("_lcompilers_idint_" + type_to_str_python(arg_types[0]));
         fill_func_arg("a", arg_types[0]);
         auto result = declare(fn_name, return_type, ReturnVar);
+
+        int kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        if(kind == 4) {
+            throw LCompilersException("first argument of `idint` must have kind equals to 8");
+            return nullptr;
+        }
         body.push_back(al, b.Assignment(result, b.r2i_t(args[0], int32)));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -2521,7 +2521,7 @@ namespace Idint {
     static ASR::expr_t *eval_Idint(Allocator &al, const Location &loc,
             ASR::ttype_t* /*arg_type*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int val = ASR::down_cast<ASR::RealConstant_t>(expr_value(args[0]))->m_r;
-        int kind = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::RealConstant_t>(args[0])->m_type);
+        int kind = ASRUtils::extract_kind_from_ttype_t(expr_type(args[0]));
         if(kind == 4) {
             append_error(diag, "first argument of `idint` must have kind equals to 8", loc);
             return nullptr;

--- a/tests/errors/idint_real4.f90
+++ b/tests/errors/idint_real4.f90
@@ -1,3 +1,3 @@
-program idint
+program idint_real
     print *, idint(4.5)
 end program

--- a/tests/errors/idint_real4.f90
+++ b/tests/errors/idint_real4.f90
@@ -1,0 +1,3 @@
+program idint
+    print *, idint(4.5)
+end program

--- a/tests/reference/asr-idint_real4-b5321a5.json
+++ b/tests/reference/asr-idint_real4-b5321a5.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-idint_real4-b5321a5",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/idint_real4.f90",
+    "infile_hash": "16daab450ab8bb7bc737ecd03bcf13d77e34936381b850b1e620806b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-idint_real4-b5321a5.stderr",
+    "stderr_hash": "6b3f3e4f66715ccdd36d9a0fe0818ef3629fc7905cc6931bd9461c87",
+    "returncode": 2
+}

--- a/tests/reference/asr-idint_real4-b5321a5.json
+++ b/tests/reference/asr-idint_real4-b5321a5.json
@@ -2,12 +2,12 @@
     "basename": "asr-idint_real4-b5321a5",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/idint_real4.f90",
-    "infile_hash": "16daab450ab8bb7bc737ecd03bcf13d77e34936381b850b1e620806b",
+    "infile_hash": "bd122b4a77e689953e6ee65cb703713f546485a4104e5985208c98e0",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-idint_real4-b5321a5.stderr",
-    "stderr_hash": "6b3f3e4f66715ccdd36d9a0fe0818ef3629fc7905cc6931bd9461c87",
+    "stderr_hash": "9f3560397b850ea5d78daa9a3dea55ab36e6056a4a16c94e3b294ea6",
     "returncode": 2
 }

--- a/tests/reference/asr-idint_real4-b5321a5.stderr
+++ b/tests/reference/asr-idint_real4-b5321a5.stderr
@@ -1,0 +1,5 @@
+semantic error: Symbol 'idint' is not a function or an array
+ --> tests/errors/idint_real4.f90:2:14
+  |
+2 |     print *, idint(4.5)
+  |              ^^^^^^^^^^ 

--- a/tests/reference/asr-idint_real4-b5321a5.stderr
+++ b/tests/reference/asr-idint_real4-b5321a5.stderr
@@ -1,4 +1,4 @@
-semantic error: Symbol 'idint' is not a function or an array
+semantic error: first argument of `idint` must have kind equals to 8
  --> tests/errors/idint_real4.f90:2:14
   |
 2 |     print *, idint(4.5)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3991,6 +3991,10 @@ filename = "errors/sqrt_neg.f90"
 asr = true
 
 [[test]]
+filename = "errors/idint_real4.f90"
+asr = true
+
+[[test]]
 filename = "errors/ishftc_size.f90"
 asr = true
 


### PR DESCRIPTION
Towards: #4558 