### PR TITLE
enh : Support array printing in backend

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -265,6 +265,7 @@ RUN(NAME print_arr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 wasm c
 RUN(NAME print_arr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 wasm c fortran)
 RUN(NAME print_arr_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 fortran)
 RUN(NAME print_arr_04 LABELS llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --apply-fortran-mangling)
+RUN(NAME print_arr_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --skip-pass=print_arr) #test printing array in backend (works only with stringformat)
 
 RUN(NAME include_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME include_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)

--- a/integration_tests/print_arr_06.f90
+++ b/integration_tests/print_arr_06.f90
@@ -1,0 +1,41 @@
+program print_arr_06
+
+    character(5),allocatable:: arr_str(:)
+    integer(8):: arr_int(3)
+    real(8):: arr_real(4)
+    logical :: arr_logical(3)
+    integer(2) :: w
+    real(4) ::m
+    character(20) ::s
+    character(200) :: FORMAT_STR 
+    character(300) ::res
+    character(300) ::lfortran_output
+    character(300) ::gfortran_output
+    allocate(arr_str(5))
+
+    ! set format string
+    FORMAT_STR = "(5a,2X,3i1,2X,4f3.1,2X,3l,2X,1i2,2X,1f5.3,2X,1a)"
+    
+    ! set values for scalar variables and arrays
+    arr_str = ["a","b","c","d","e"]
+    arr_int = [1,2,3]
+    arr_real = [1.1,1.2,1.3,1.4]
+    arr_logical = [.true.,.false.,.true.]
+    w = 10
+    m = 1.4
+    s = "test"
+
+    ! write to res with formatting 
+    write(res,FORMAT_STR) arr_str,arr_int,arr_real,arr_logical,w,m,s
+    
+    ! print
+    print FORMAT_STR,arr_str,arr_int,arr_real,arr_logical,w,m,s
+    print "(a)",res
+
+    ! Testing
+    lfortran_output = "abcde  123  1.11.21.31.4  TFT  10  1.400  test"
+    gfortran_output = "a    b    c    d    e      123  1.11.21.31.4  TFT  10  1.400  test"  
+
+    ! GFortran and LFortran vary while printing array of characters.
+    if(res /= lfortran_output .and. res /= gfortran_output) error stop 
+end program print_arr_06

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -744,6 +744,129 @@ char** parse_fortran_format(char* format, int *count, int *item_start) {
     return format_values_2;
 }
 
+void check_format_match(char* format_value, int* current_arg_type_int){
+    //TO DO : check format_value() (user-specified) against current_arg_type_int(actual passed argumet) to raise runtime errors.
+}
+
+int64_t array_size = -1 ;
+int64_t current_arr_index = -1;
+bool check_array_iteration(int* count, int* current_arg_type_int, va_list* args,
+        int64_t* arr_int64_val, double* arr_double_val, char** arr_charPtr_val, bool* arr_bool_val) {
+    static int64_t* arr_ptr_int64 = NULL;
+    static int32_t* arr_ptr_int32 = NULL;
+    static int16_t* arr_ptr_int16 = NULL;
+    static int8_t* arr_ptr_int8 = NULL;
+    static float* arr_ptr_float = NULL;
+    static double* arr_ptr_double = NULL;
+    static char** arr_ptr_charPtr = NULL;
+    static bool* arr_ptr_bool = NULL;
+    bool is_array = true;
+    switch (*current_arg_type_int){
+        case 9 : //arr[i64]
+            if(current_arr_index != array_size){
+                *arr_int64_val = arr_ptr_int64[current_arr_index++];
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_int64 = va_arg(*args,int64_t*);
+                *arr_int64_val = arr_ptr_int64[current_arr_index++];
+                *count+= array_size - 2;
+            }
+            break;
+        case 10 : //arr[i32]
+            if(current_arr_index != array_size){
+                int32_t temp_val = arr_ptr_int32[current_arr_index++];
+                *arr_int64_val = (int64_t)temp_val;
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0;
+                arr_ptr_int32 = va_arg(*args,int32_t*);
+                int32_t temp_val = arr_ptr_int32[current_arr_index++];
+                *arr_int64_val = (int64_t)temp_val;
+                *count+= array_size - 2;
+            }
+            break;
+        case 11 : //arr[i16]
+            if(current_arr_index != array_size){
+                int16_t temp_val = arr_ptr_int16[current_arr_index++];
+                *arr_int64_val = (int64_t)temp_val;
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_int16 = va_arg(*args,int16_t*);
+                int16_t temp_val = arr_ptr_int16[current_arr_index++];
+                *arr_int64_val = (int64_t)temp_val;
+                *count+= array_size - 2;
+            }
+            break;
+        case 12 : //arr[i8]
+            if(current_arr_index != array_size){
+                int8_t temp_val = arr_ptr_int8[current_arr_index++];
+                *arr_int64_val = (int64_t)temp_val;
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_int8 = va_arg(*args,int8_t*);
+                int8_t temp_val = arr_ptr_int8[current_arr_index++];
+                *arr_int64_val = (int64_t)temp_val;
+                *count+= array_size - 2;
+            }
+            break;
+        case 13: // arr[f64]
+            if(current_arr_index != array_size){
+                *arr_double_val = arr_ptr_double[current_arr_index++];
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_double = va_arg(*args,double*);
+                *arr_double_val = arr_ptr_double[current_arr_index++];
+                *count+= array_size - 2;
+            }
+            break;
+        case 14: // arr[f32]
+            if(current_arr_index != array_size){
+                float temp_val = arr_ptr_float[current_arr_index++];
+                *arr_double_val = (double)temp_val;
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_float = va_arg(*args,float*);
+                float temp_val = arr_ptr_float[current_arr_index++];
+                *arr_double_val = (double)temp_val;
+                *count+= array_size - 2;
+            }
+            break;
+        case 15: //arr[character]
+            if(current_arr_index != array_size){
+                *arr_charPtr_val = arr_ptr_charPtr[current_arr_index++];
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_charPtr = va_arg(*args,char**);
+                *arr_charPtr_val = arr_ptr_charPtr[current_arr_index++];
+                *count+= array_size - 2;
+            }
+            break;
+        case 16: //arr[logical]
+            if(current_arr_index != array_size){
+                *arr_bool_val = arr_ptr_bool[current_arr_index++];
+            } else {
+                array_size = va_arg(*args,int64_t);
+                current_arr_index = 0; 
+                arr_ptr_bool = va_arg(*args,bool*);
+                *arr_bool_val = arr_ptr_bool[current_arr_index++];
+                *count+= array_size - 2;
+            }
+            break;
+        //To DO : handle --> arr[cptr], arr[enumType] 
+        default:
+            is_array = false;
+            break;
+    }
+    return is_array;
+    
+}
+
 LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* format, ...)
 {
     va_list args;
@@ -769,10 +892,16 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
     bool array = false;
     while (1) {
         int scale = 0;
+        int64_t current_arr_element_int64;
+        double current_arr_element_double;
+        char* current_arr_element_char_ptr;
+        bool current_arr_element_bool;
+
+        int32_t current_arg_type_int = -1; // holds int that represents type of argument.
+        bool is_array = false;
         for (int i = item_start; i < format_values_count; i++) {
             if(format_values[i] == NULL) continue;
             char* value = format_values[i];
-
             if (value[0] == '(' && value[strlen(value)-1] == ')') {
                 value[strlen(value)-1] = '\0';
                 int new_fmt_val_count = 0;
@@ -814,68 +943,10 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                 value = substring(value, 1, strlen(value) - 1);
                 result = append_to_string(result, value);
                 free(value);
-            } else if (tolower(value[0]) == 'a') {
-                // Character Editing (A[n])
-                if ( count == 0 ) break;
-                count--;
-                char* arg = va_arg(args, char*);
-                if (arg == NULL) continue;
-                if (strlen(value) == 1) {
-                    result = append_to_string(result, arg);
-                } else {
-                    char* str = (char*)malloc((strlen(value)) * sizeof(char));
-                    memmove(str, value+1, strlen(value));
-                    int buffer_size = 20;
-                    char* s = (char*)malloc(buffer_size * sizeof(char));
-                    snprintf(s, buffer_size, "%%%s.%ss", str, str);
-                    char* string = (char*)malloc((atoi(str) + 1) * sizeof(char));
-                    sprintf(string,s, arg);
-                    result = append_to_string(result, string);
-                    free(str);
-                    free(s);
-                    free(string);
-                }
             } else if (tolower(value[strlen(value) - 1]) == 'x') {
                 result = append_to_string(result, " ");
-            } else if (tolower(value[0]) == 'i') {
-                // Integer Editing ( I[w[.m]] )
-                if ( count == 0 ) break;
-                count--;
-                int64_t val = va_arg(args, int64_t);
-                handle_integer(value, val, &result);
-            } else if (tolower(value[0]) == 'd') {
-                // D Editing (D[w[.d]])
-                if ( count == 0 ) break;
-                count--;
-                double val = va_arg(args, double);
-                handle_decimal(value, val, scale, &result, "D");
-            } else if (tolower(value[0]) == 'e') {
-                // Check if the next character is 'N' for EN format
-                char format_type = tolower(value[1]);
-                if (format_type == 'n') {
-                    if (count == 0) break;
-                    count--;
-                    double val = va_arg(args, double);
-                    handle_en(value, val, scale, &result, "E");
-                } else {
-                    if (count == 0) break;
-                    count--;
-                    double val = va_arg(args, double);
-                    handle_decimal(value, val, scale, &result, "E");
-                }
-            } else if (tolower(value[0]) == 'f') {
-                if ( count == 0 ) break;
-                count--;
-                double val = va_arg(args, double);
-                handle_float(value, val, &result);
-            } else if (tolower(value[0]) == 'l') {
-                if ( count == 0 ) break;
-                count--;
-                char* val_str = va_arg(args, char*);
-                bool val = (strcmp(val_str, "True") == 0);
-                handle_logical(value, val, &result);
             } else if (tolower(value[0]) == 't') {
-                if (count == 0) break;
+                if (count <= 0) break;
                 int tab_position = atoi(value + 1);
                 int current_length = strlen(result);
                 int spaces_needed = tab_position - current_length - 1;
@@ -891,11 +962,107 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                         result[tab_position] = '\0';  // Truncate the string at the position specified by Tn
                     }
                 }
-            } else if (strlen(value) != 0) {
-                if ( count == 0 ) break;
-                count--;
-                printf("Printing support is not available for %s format.\n",value);
+            } else {
+                if((current_arr_index == array_size) && (count > 0)){ // Fetch type integer when we don't have an array.
+                    current_arg_type_int =  va_arg(args,int32_t);
+                    count--;
+                }
+                is_array = check_array_iteration(&count, &current_arg_type_int, &args,
+                            &current_arr_element_int64, &current_arr_element_double,
+                            &current_arr_element_char_ptr, &current_arr_element_bool);
+                if (tolower(value[0]) == 'a') {
+                    // Character Editing (A[n])
+                    if ( count <= 0 ) break;
+                    count--;
+                    char* arg = NULL;
+                    if(is_array){
+                        arg = current_arr_element_char_ptr; 
+                    } else {
+                        arg = va_arg(args, char*);
+                    }
+                    if (arg == NULL) continue;
+                    if (strlen(value) == 1) {
+                        result = append_to_string(result, arg);
+                    } else {
+                        char* str = (char*)malloc((strlen(value)) * sizeof(char));
+                        memmove(str, value+1, strlen(value));
+                        int buffer_size = 20;
+                        char* s = (char*)malloc(buffer_size * sizeof(char));
+                        snprintf(s, buffer_size, "%%%s.%ss", str, str);
+                        char* string = (char*)malloc((atoi(str) + 1) * sizeof(char));
+                        sprintf(string,s, arg);
+                        result = append_to_string(result, string);
+                        free(str);
+                        free(s);
+                        free(string);
+                    }
+                } else if (tolower(value[0]) == 'i') {
+                    // Integer Editing ( I[w[.m]] )
+                    if ( count <= 0 ) break;
+                    count--;
+                    if(is_array){
+                        handle_integer(value, current_arr_element_int64, &result);
+                    } else {
+                        int64_t val = va_arg(args, int64_t);
+                        handle_integer(value, val, &result);
+                    }
+                } else if (tolower(value[0]) == 'd') {
+                    // D Editing (D[w[.d]])
+                    if ( count <= 0 ) break;
+                    count--;
+                    if(is_array){
+                        handle_decimal(value, current_arr_element_double, scale, &result, "D");;
+                    } else {
+                        double val = va_arg(args, double);
+                        handle_decimal(value, val, scale, &result, "D");
+                    }
+                } else if (tolower(value[0]) == 'e') {
+                    // Check if the next character is 'N' for EN format
+                    char format_type = tolower(value[1]);
+                    if ( count <= 0 ) break;
+                    count--;
+                    if (format_type == 'n') {
+                        if(is_array){
+                            handle_en(value, current_arr_element_double, scale, &result, "E");
+                        } else {
+                            double val = va_arg(args, double);
+                            handle_en(value, val, scale, &result, "E");
+                        }
+                    } else {
+                        if(is_array){
+                            handle_decimal(value, current_arr_element_double, scale, &result, "E");
+                        } else {
+                            double val = va_arg(args, double);
+                            handle_decimal(value, val, scale, &result, "E");
+                        }
+                    }
+                } else if (tolower(value[0]) == 'f') {
+                    if ( count <= 0 ) break;
+                    count--;
+                    if(is_array){
+                        handle_float(value,current_arr_element_double, &result);
+                    } else {
+                        double val = va_arg(args, double);
+                        handle_float(value, val, &result);
+                    }
+                } else if (tolower(value[0]) == 'l') {
+                    if ( count <= 0 ) break;
+                    count--;
+                    if(is_array){
+                        bool val = current_arr_element_bool;
+                        handle_logical(value, val, &result);
+                    } else {
+                        char* val_str = va_arg(args, char*);
+                        bool val = (strcmp(val_str, "True") == 0);
+                        handle_logical(value, val, &result);
+                    }
+                } else if (strlen(value) != 0) {
+                    if ( count <= 0 ) break;
+                    count--;
+                    printf("Printing support is not available for %s format.\n",value);
+                }
             }
+
 
         }
         if ( count > 0 ) {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -748,114 +748,123 @@ void check_format_match(char* format_value, int* current_arg_type_int){
     //TO DO : check format_value() (user-specified) against current_arg_type_int(actual passed argumet) to raise runtime errors.
 }
 
-int64_t array_size = -1 ;
-int64_t current_arr_index = -1;
-bool check_array_iteration(int* count, int* current_arg_type_int, va_list* args,
-        int64_t* arr_int64_val, double* arr_double_val, char** arr_charPtr_val, bool* arr_bool_val) {
-    static int64_t* arr_ptr_int64 = NULL;
-    static int32_t* arr_ptr_int32 = NULL;
-    static int16_t* arr_ptr_int16 = NULL;
-    static int8_t* arr_ptr_int8 = NULL;
-    static float* arr_ptr_float = NULL;
-    static double* arr_ptr_double = NULL;
-    static char** arr_ptr_charPtr = NULL;
-    static bool* arr_ptr_bool = NULL;
+struct array_iteration_state{
+    //Preserve array size and current element index
+    int64_t array_size;
+    int64_t current_arr_index;
+    //Hold array pointers for each type.
+    int64_t* arr_ptr_int64;
+    int32_t* arr_ptr_int32;
+    int16_t* arr_ptr_int16;
+    int8_t* arr_ptr_int8;
+    float* arr_ptr_float;
+    double* arr_ptr_double;
+    char** arr_ptr_charPtr;
+    bool* arr_ptr_bool;
+    //Hold current element (We support array of int64, double, char*, bool)
+    int64_t current_arr_element_int64;
+    double current_arr_element_double;
+    char* current_arr_element_char_ptr;
+    bool current_arr_element_bool;
+};
+
+bool check_array_iteration(int* count, int* current_arg_type_int, va_list* args,struct array_iteration_state* state){
     bool is_array = true;
     switch (*current_arg_type_int){
         case 9 : //arr[i64]
-            if(current_arr_index != array_size){
-                *arr_int64_val = arr_ptr_int64[current_arr_index++];
+            if(state->current_arr_index != state->array_size){
+                state->current_arr_element_int64 = state->arr_ptr_int64[state->current_arr_index++];
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_int64 = va_arg(*args,int64_t*);
-                *arr_int64_val = arr_ptr_int64[current_arr_index++];
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_int64 = va_arg(*args,int64_t*);
+                state->current_arr_element_int64 = state->arr_ptr_int64[state->current_arr_index++];
+                *count+= state->array_size - 2;
             }
             break;
         case 10 : //arr[i32]
-            if(current_arr_index != array_size){
-                int32_t temp_val = arr_ptr_int32[current_arr_index++];
-                *arr_int64_val = (int64_t)temp_val;
+            if(state->current_arr_index != state->array_size){
+                int32_t temp_val = state->arr_ptr_int32[state->current_arr_index++];
+                state->current_arr_element_int64 = (int64_t)temp_val;
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0;
-                arr_ptr_int32 = va_arg(*args,int32_t*);
-                int32_t temp_val = arr_ptr_int32[current_arr_index++];
-                *arr_int64_val = (int64_t)temp_val;
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0;
+                state->arr_ptr_int32 = va_arg(*args,int32_t*);
+                int32_t temp_val = state->arr_ptr_int32[state->current_arr_index++];
+                state->current_arr_element_int64 = (int64_t)temp_val;
+                *count+= state->array_size - 2;
             }
             break;
         case 11 : //arr[i16]
-            if(current_arr_index != array_size){
-                int16_t temp_val = arr_ptr_int16[current_arr_index++];
-                *arr_int64_val = (int64_t)temp_val;
+            if(state->current_arr_index != state->array_size){
+                int16_t temp_val = state->arr_ptr_int16[state->current_arr_index++];
+                state->current_arr_element_int64 = (int64_t)temp_val;
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_int16 = va_arg(*args,int16_t*);
-                int16_t temp_val = arr_ptr_int16[current_arr_index++];
-                *arr_int64_val = (int64_t)temp_val;
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_int16 = va_arg(*args,int16_t*);
+                int16_t temp_val = state->arr_ptr_int16[state->current_arr_index++];
+                state->current_arr_element_int64 = (int64_t)temp_val;
+                *count+= state->array_size - 2;
             }
             break;
         case 12 : //arr[i8]
-            if(current_arr_index != array_size){
-                int8_t temp_val = arr_ptr_int8[current_arr_index++];
-                *arr_int64_val = (int64_t)temp_val;
+            if(state->current_arr_index != state->array_size){
+                int8_t temp_val = state->arr_ptr_int8[state->current_arr_index++];
+                state->current_arr_element_int64 = (int64_t)temp_val;
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_int8 = va_arg(*args,int8_t*);
-                int8_t temp_val = arr_ptr_int8[current_arr_index++];
-                *arr_int64_val = (int64_t)temp_val;
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_int8 = va_arg(*args,int8_t*);
+                int8_t temp_val = state->arr_ptr_int8[state->current_arr_index++];
+                state->current_arr_element_int64 = (int64_t)temp_val;
+                *count+= state->array_size - 2;
             }
             break;
         case 13: // arr[f64]
-            if(current_arr_index != array_size){
-                *arr_double_val = arr_ptr_double[current_arr_index++];
+            if(state->current_arr_index != state->array_size){
+                state->current_arr_element_double = state->arr_ptr_double[state->current_arr_index++];
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_double = va_arg(*args,double*);
-                *arr_double_val = arr_ptr_double[current_arr_index++];
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_double = va_arg(*args,double*);
+                state->current_arr_element_double = state->arr_ptr_double[state->current_arr_index++];
+                *count+= state->array_size - 2;
             }
             break;
         case 14: // arr[f32]
-            if(current_arr_index != array_size){
-                float temp_val = arr_ptr_float[current_arr_index++];
-                *arr_double_val = (double)temp_val;
+            if(state->current_arr_index != state->array_size){
+                float temp_val = state->arr_ptr_float[state->current_arr_index++];
+                state->current_arr_element_double = (double)temp_val;
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_float = va_arg(*args,float*);
-                float temp_val = arr_ptr_float[current_arr_index++];
-                *arr_double_val = (double)temp_val;
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_float = va_arg(*args,float*);
+                float temp_val = state->arr_ptr_float[state->current_arr_index++];
+                state->current_arr_element_double = (double)temp_val;
+                *count+= state->array_size - 2;
             }
             break;
         case 15: //arr[character]
-            if(current_arr_index != array_size){
-                *arr_charPtr_val = arr_ptr_charPtr[current_arr_index++];
+            if(state->current_arr_index != state->array_size){
+                state->current_arr_element_char_ptr = state->arr_ptr_charPtr[state->current_arr_index++];
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_charPtr = va_arg(*args,char**);
-                *arr_charPtr_val = arr_ptr_charPtr[current_arr_index++];
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_charPtr = va_arg(*args,char**);
+                state->current_arr_element_char_ptr = state->arr_ptr_charPtr[state->current_arr_index++];
+                *count+= state->array_size - 2;
             }
             break;
         case 16: //arr[logical]
-            if(current_arr_index != array_size){
-                *arr_bool_val = arr_ptr_bool[current_arr_index++];
+            if(state->current_arr_index != state->array_size){
+                state->current_arr_element_bool = state->arr_ptr_bool[state->current_arr_index++];
             } else {
-                array_size = va_arg(*args,int64_t);
-                current_arr_index = 0; 
-                arr_ptr_bool = va_arg(*args,bool*);
-                *arr_bool_val = arr_ptr_bool[current_arr_index++];
-                *count+= array_size - 2;
+                state->array_size = va_arg(*args,int64_t);
+                state->current_arr_index = 0; 
+                state->arr_ptr_bool = va_arg(*args,bool*);
+                state->current_arr_element_bool = state->arr_ptr_bool[state->current_arr_index++];
+                *count+= state->array_size - 2;
             }
             break;
         //To DO : handle --> arr[cptr], arr[enumType] 
@@ -890,13 +899,12 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
     result[0] = '\0';
     int item_start = 0;
     bool array = false;
+    //initialize array_state to hold information about any passed array pointer arg.
+    struct array_iteration_state array_state;
+    array_state.array_size = -1;
+    array_state.current_arr_index = -1;
     while (1) {
         int scale = 0;
-        int64_t current_arr_element_int64;
-        double current_arr_element_double;
-        char* current_arr_element_char_ptr;
-        bool current_arr_element_bool;
-
         int32_t current_arg_type_int = -1; // holds int that represents type of argument.
         bool is_array = false;
         for (int i = item_start; i < format_values_count; i++) {
@@ -963,20 +971,18 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                     }
                 }
             } else {
-                if((current_arr_index == array_size) && (count > 0)){ // Fetch type integer when we don't have an array.
+                if((array_state.current_arr_index == array_state.array_size) && (count > 0)){ // Fetch type integer when we don't have an array.
                     current_arg_type_int =  va_arg(args,int32_t);
                     count--;
                 }
-                is_array = check_array_iteration(&count, &current_arg_type_int, &args,
-                            &current_arr_element_int64, &current_arr_element_double,
-                            &current_arr_element_char_ptr, &current_arr_element_bool);
+                is_array = check_array_iteration(&count, &current_arg_type_int, &args,&array_state);
                 if (tolower(value[0]) == 'a') {
                     // Character Editing (A[n])
                     if ( count <= 0 ) break;
                     count--;
                     char* arg = NULL;
                     if(is_array){
-                        arg = current_arr_element_char_ptr; 
+                        arg = array_state.current_arr_element_char_ptr; 
                     } else {
                         arg = va_arg(args, char*);
                     }
@@ -1001,7 +1007,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                     if ( count <= 0 ) break;
                     count--;
                     if(is_array){
-                        handle_integer(value, current_arr_element_int64, &result);
+                        handle_integer(value, array_state.current_arr_element_int64, &result);
                     } else {
                         int64_t val = va_arg(args, int64_t);
                         handle_integer(value, val, &result);
@@ -1011,7 +1017,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                     if ( count <= 0 ) break;
                     count--;
                     if(is_array){
-                        handle_decimal(value, current_arr_element_double, scale, &result, "D");;
+                        handle_decimal(value, array_state.current_arr_element_double, scale, &result, "D");;
                     } else {
                         double val = va_arg(args, double);
                         handle_decimal(value, val, scale, &result, "D");
@@ -1023,14 +1029,14 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                     count--;
                     if (format_type == 'n') {
                         if(is_array){
-                            handle_en(value, current_arr_element_double, scale, &result, "E");
+                            handle_en(value, array_state.current_arr_element_double, scale, &result, "E");
                         } else {
                             double val = va_arg(args, double);
                             handle_en(value, val, scale, &result, "E");
                         }
                     } else {
                         if(is_array){
-                            handle_decimal(value, current_arr_element_double, scale, &result, "E");
+                            handle_decimal(value, array_state.current_arr_element_double, scale, &result, "E");
                         } else {
                             double val = va_arg(args, double);
                             handle_decimal(value, val, scale, &result, "E");
@@ -1040,7 +1046,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                     if ( count <= 0 ) break;
                     count--;
                     if(is_array){
-                        handle_float(value,current_arr_element_double, &result);
+                        handle_float(value,array_state.current_arr_element_double, &result);
                     } else {
                         double val = va_arg(args, double);
                         handle_float(value, val, &result);
@@ -1049,7 +1055,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(int count, const char* form
                     if ( count <= 0 ) break;
                     count--;
                     if(is_array){
-                        bool val = current_arr_element_bool;
+                        bool val = array_state.current_arr_element_bool;
                         handle_logical(value, val, &result);
                     } else {
                         char* val_str = va_arg(args, char*);

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "87341eb2dd14c4b8627fcda92b5ab8ff017050a46e1cd0a78dfe0ad8",
+    "stdout_hash": "afc1decde20d744c695ac1228099343147045505bd352da9dc6c6a87",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -145,7 +145,7 @@ define i8* @__module_testdrive_derived_types_32_real_dp_to_string(double* %val) 
   store i8* null, i8** %string, align 8
   %2 = alloca i32, align 4
   %3 = load double, double* %val, align 8
-  %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 1, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), double %3)
+  %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i32 5, double %3)
   call void (i8**, i32*, i8*, ...) @_lfortran_string_write(i8** %buffer, i32* %2, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0), i8* %4)
   %5 = call i8* @__module_lfortran_intrinsic_string_trim(i8** %buffer)
   call void @_lfortran_strcpy(i8** %string, i8* %5, i8 1)

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "6b81e1c62f8c4d8046115490b6d6e39d74d14ac60c326d72920dcdb3",
+    "stdout_hash": "16ace134ac1433769a9713698a981074eefcce1d9dc40d4286c920d8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -12,7 +12,7 @@ define i32 @main(i32 %0, i8** %1) {
   %a = alloca i32, align 4
   %2 = load i32, i32* %a, align 4
   %3 = sext i32 %2 to i64
-  %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 1, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i64 %3)
+  %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i32 1, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
   br label %return
 


### PR DESCRIPTION
towards https://github.com/lfortran/lfortran/issues/2543, https://github.com/lfortran/lfortran/issues/4523
***
**Description** : 

This PR enhances the backend to support printing arrays directly out of its pointer.

This PR utilizes `compute_fmt_specifier_and_args()` so it embeds type integers as passed args to `string_format_intrinsic()`;We use flag `add_type_as_int` to do that.

To print arrays using its pointer in the backend use `--skip-pass=print_arr`
We embed types as integers to be passed to `string_format_intrinsic()` function in c to be able to know what are the types, This would make use able to identify types mismatch to avoid segfaults and to know if we have an array pointer so we can loop on it.
***

**Next To Do**
- In order to only pass strings to `printf()` in c with case like `print *,arr`, We have to deduce the types of the arguments that will be printed, We can do this with the help of the type integers we embed (Is this the best approach?).
- implement `check_format_match()` to avoid segfaults.
-  Remove not needed modifications done by `print_arr` pass.
***

**concerns**
- Types enumeration needs modifications?
- maybe some tips for better code flow.