### PR TITLE
enh : Implied allocatable array assignment in StructIntanceMember

### DIFF
--- a/integration_tests/derived_types_37.f90
+++ b/integration_tests/derived_types_37.f90
@@ -14,7 +14,7 @@ program derived_types_37
     integer :: i
     
     TYPE(test_type1), DIMENSION(5) :: main_arr
-
+    TYPE(test_type1), allocatable :: main_arr_alloc(:)
     
     main_arr%num = 44
     do i =1, 5
@@ -33,5 +33,27 @@ program derived_types_37
     do i =1, 3
         print *,main_arr(1)%arr_2(i)%num
         if(main_arr(1)%arr_2(i)%num /= 22) error stop
+    end do
+
+    ! Duplicate test with allocatable array
+    ! to check that implied array assignment in structInstanceMember isn't dependent on known compile time size.
+    allocate(main_arr_alloc(5))
+    main_arr_alloc%num = 44
+    do i =1, 5
+        print *, main_arr_alloc(i)%num
+        if(main_arr_alloc(i)%num /= 44) error stop
+    end do
+    
+    
+    main_arr_alloc(1)%arr_1 = 33
+    do i =1, 3
+        print *,main_arr_alloc(1)%arr_1(i)
+        if(main_arr_alloc(1)%arr_1(i) /= 33) error stop
+    end do
+
+    main_arr_alloc(1)%arr_2%num = 22
+    do i =1, 3
+        print *,main_arr_alloc(1)%arr_2(i)%num
+        if(main_arr_alloc(1)%arr_2(i)%num /= 22) error stop
     end do
 end program derived_types_37


### PR DESCRIPTION
Fixes #4579 

The problem occurs because we create a do loop with wrong bounds. 
instead of creating a bound for such expression `type%arr%num`, We should create a bound on `arr`.

Instead of fetching the array expression from `structInstaceMember` hierarchy inside `create_array_ref()` function, We create a designated function to do so in pass `array_op` so we can build a correct do loop by setting `result_var` to the fetched array.