### PR TITLE
Support different kind of args in min/max and update tests

### DIFF
--- a/integration_tests/intrinsics_131.f90
+++ b/integration_tests/intrinsics_131.f90
@@ -1,8 +1,64 @@
 program intrinsics_131
+    implicit none
+    integer, parameter :: x1 = max(1, 2)
+    integer(8), parameter :: x2 = max(1_8, 2_8)
+    real, parameter :: x3 = max(1.0, 2.0)
+    real(8), parameter :: x4 = max(1.0_8, 2.0_8)
+    character(len=10), parameter :: x5 = max("str", "string")
+    integer, parameter :: ar1(3) = max([1, 12, 3], [4, 5, 6])
+    integer(8), parameter :: ar2(3) = max([1_8, 12_8, 3_8], [4_8, 5_8, 6_8])
+    real, parameter :: ar3(3) = max([1.0, 12.0, 3.0], [4.0, 5.0, 6.0])
+    real(8), parameter :: ar4(3) = max([1.0_8, 12.0_8, 3.0_8], [4.0_8, 5.0_8, 6.0_8])
+    ! character(len=10), parameter :: ar5(3) = max(["str1", "str2", "char"], ["!str#$", "xtring", "charac"]) ! Does not work - #4582
+
+    integer :: i1, i2
+    integer(8) :: i3, i4
+    real :: r1, r2
+    real(8) :: r3, r4
     character(len=10) :: string_var, string_var2, string_var3
+    i1 = 123
+    i2 = 456 
+    i3 = 123_8 
+    i4 = 456_8
+    r1 = 123.0 
+    r2 = 456.0 
+    r3 = 123.0_8 
+    r4 = 456.0_8
     string_var = "str"
     string_var2 = "string"
     string_var3 = "character"
+
+    print *, x1
+    if (x1 /= 2) error stop
+    print *, x2
+    if (x2 /= 2_8) error stop
+    print *, x3
+    if (x3 /= 2.0) error stop
+    print *, x4
+    if (x4 /= 2.0_8) error stop
+    print *, x5
+    if (x5 /= "string") error stop
+
+    print *, ar1
+    if (any(ar1 /= [4, 12, 6])) error stop
+    print *, ar2
+    if (any(ar2 /= [4_8, 12_8, 6_8])) error stop
+    print *, ar3
+    if (any(ar3 /= [4.0, 12.0, 6.0])) error stop
+    print *, ar4
+    if (any(ar4 /= [4.0_8, 12.0_8, 6.0_8])) error stop
+    ! print *, ar5
+    ! if (any(ar5 /= ["str1", "string", "charac"])) error stop
+
+    print *, max(i1, i2)
+    if (max(i1, i2) /= i2) error stop
+    print *, max(i3, i4)
+    if (max(i3, i4) /= i4) error stop
+    print *, max(r1, r2)
+    if (max(r1, r2) /= r2) error stop
+    print *, max(r3, r4)
+    if (max(r3, r4) /= r4) error stop
+    
 
     print*, max("str", "character")
     if (max("str", "character") /= "str") error stop

--- a/integration_tests/intrinsics_88.f90
+++ b/integration_tests/intrinsics_88.f90
@@ -1,8 +1,64 @@
 program intrinsics_88
+    implicit none
+    integer, parameter :: x1 = min(1, 2)
+    integer(8), parameter :: x2 = min(1_8, 2_8)
+    real, parameter :: x3 = min(1.0, 2.0)
+    real(8), parameter :: x4 = min(1.0_8, 2.0_8)
+    character(len=10), parameter :: x5 = min("str", "string")
+    integer, parameter :: ar1(3) = min([1, 12, 3], [4, 5, 6])
+    integer(8), parameter :: ar2(3) = min([1_8, 12_8, 3_8], [4_8, 5_8, 6_8])
+    real, parameter :: ar3(3) = min([1.0, 12.0, 3.0], [4.0, 5.0, 6.0])
+    real(8), parameter :: ar4(3) = min([1.0_8, 12.0_8, 3.0_8], [4.0_8, 5.0_8, 6.0_8])
+    ! character(len=10), parameter :: ar5(3) = min(["str1", "str2", "char"], ["!str#$", "xtring", "charac"]) ! Does not work - #4582
+
+    integer :: i1, i2
+    integer(8) :: i3, i4
+    real :: r1, r2
+    real(8) :: r3, r4
     character(len=10) :: string_var, string_var2, string_var3
+    i1 = 123
+    i2 = 456 
+    i3 = 123_8 
+    i4 = 456_8
+    r1 = 123.0 
+    r2 = 456.0 
+    r3 = 123.0_8 
+    r4 = 456.0_8
+
     string_var = "str"
     string_var2 = "string"
     string_var3 = "character"
+
+    print *, x1
+    if (x1 /= 1) error stop
+    print *, x2
+    if (x2 /= 1_8) error stop
+    print *, x3
+    if (x3 /= 1.0) error stop
+    print *, x4
+    if (x4 /= 1.0_8) error stop
+    print *, x5
+    if (x5 /= "str") error stop
+
+    print *, ar1
+    if (any(ar1 /= [1, 5, 3])) error stop
+    print *, ar2
+    if (any(ar2 /= [1_8, 5_8, 3_8])) error stop
+    print *, ar3
+    if (any(ar3 /= [1.0, 5.0, 3.0])) error stop
+    print *, ar4
+    if (any(ar4 /= [1.0_8, 5.0_8, 3.0_8])) error stop
+    ! print *, ar5
+    ! if (any(ar5 /= ["str1", "string", "charac"])) error stop
+
+    print *, min(i1, i2)
+    if (min(i1, i2) /= i1) error stop
+    print *, min(i3, i4)
+    if (min(i3, i4) /= i3) error stop
+    print *, min(r1, r2)
+    if (min(r1, r2) /= r1) error stop
+    print *, min(r3, r4)
+    if (min(r3, r4) /= r3) error stop
 
     print*, min("str", "character")
     if (min("str", "character") /= "character") error stop

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5313,8 +5313,7 @@ namespace Max {
         }
     }
 
-    static inline ASR::asr_t* create_Max(
-        Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args,
+    static inline ASR::asr_t* create_Max(Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args,
         diag::Diagnostics& diag) {
         bool is_compile_time = true;
         for(size_t i=0; i<100;i++){
@@ -5325,7 +5324,12 @@ namespace Max {
             return nullptr;
         }
         ASR::ttype_t *arg_type = ASRUtils::expr_type(args[0]);
-        for(size_t i=1;i<args.size();i++) {
+        int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
+        for(size_t i=1; i<args.size(); i++) {
+            if (ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[i])) != kind) {
+                diag.semantic_warning_label("Different kinds of args in max0 is a non-standard extension", {loc}, 
+                "help: ensure all arguments have the same kind to make it standard");
+            }
             if (arg_type->type != ASRUtils::expr_type(args[i])->type) {
                 append_error(diag, "All arguments to max0 must be of the same type", loc);
             return nullptr;
@@ -5471,7 +5475,12 @@ namespace Min {
             return nullptr;
         }
         ASR::ttype_t *arg_type = ASRUtils::expr_type(args[0]);
-        for(size_t i=0;i<args.size();i++){
+        int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
+        for(size_t i=1; i<args.size(); i++){
+            if (ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[i])) != kind) {
+                diag.semantic_warning_label("Different kinds of args in max0 is a non-standard extension", {loc}, 
+                "help: ensure all arguments have the same kind to make it standard");
+            }
             if (arg_type->type != ASRUtils::expr_type(args[i])->type) {
                 append_error(diag, "All arguments to min0 must be of the same type", loc);
                 return nullptr;

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5325,9 +5325,9 @@ namespace Max {
             return nullptr;
         }
         ASR::ttype_t *arg_type = ASRUtils::expr_type(args[0]);
-        for(size_t i=0;i<args.size();i++){
-            if (!ASRUtils::check_equal_type(arg_type, ASRUtils::expr_type(args[i]))) {
-                append_error(diag, "All arguments to max0 must be of the same type and kind", loc);
+        for(size_t i=1;i<args.size();i++) {
+            if (arg_type->type != ASRUtils::expr_type(args[i])->type) {
+                append_error(diag, "All arguments to max0 must be of the same type", loc);
             return nullptr;
             }
         }
@@ -5472,8 +5472,8 @@ namespace Min {
         }
         ASR::ttype_t *arg_type = ASRUtils::expr_type(args[0]);
         for(size_t i=0;i<args.size();i++){
-            if (!ASRUtils::check_equal_type(arg_type, ASRUtils::expr_type(args[i]))) {
-                append_error(diag, "All arguments to min0 must be of the same type and kind", loc);
+            if (arg_type->type != ASRUtils::expr_type(args[i])->type) {
+                append_error(diag, "All arguments to min0 must be of the same type", loc);
                 return nullptr;
             }
         }

--- a/tests/errors/intrinsics12.f90
+++ b/tests/errors/intrinsics12.f90
@@ -1,0 +1,3 @@
+program intrinsics12
+    print *, max(12, 13.94)
+end program

--- a/tests/errors/intrinsics13.f90
+++ b/tests/errors/intrinsics13.f90
@@ -1,0 +1,3 @@
+program intrinsics13
+    print *, min(12, 13.94)
+end program

--- a/tests/reference/asr-intrinsics12-16f1580.json
+++ b/tests/reference/asr-intrinsics12-16f1580.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics12-16f1580",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics12.f90",
+    "infile_hash": "c9cc798e66e3f673e1047fb55c47dc10fbff936e0d1d1c8dcc62b11b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics12-16f1580.stderr",
+    "stderr_hash": "29df00272486b11796ce5fbf13088c12dc5c67225fa566bef976fe0e",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics12-16f1580.stderr
+++ b/tests/reference/asr-intrinsics12-16f1580.stderr
@@ -1,0 +1,5 @@
+semantic error: All arguments to max0 must be of the same type
+ --> tests/errors/intrinsics12.f90:2:14
+  |
+2 |     print *, max(12, 13.94)
+  |              ^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-intrinsics13-349f6ac.json
+++ b/tests/reference/asr-intrinsics13-349f6ac.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics13-349f6ac",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics13.f90",
+    "infile_hash": "d8cd233c3150d185f9e9e6c6f89d70471bb5b362d82cf142a51d0b82",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics13-349f6ac.stderr",
+    "stderr_hash": "a5688f270ca65cae87f17411d2cbda408ffc88927b5f76033ad4b0ff",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics13-349f6ac.stderr
+++ b/tests/reference/asr-intrinsics13-349f6ac.stderr
@@ -1,0 +1,5 @@
+semantic error: All arguments to min0 must be of the same type
+ --> tests/errors/intrinsics13.f90:2:14
+  |
+2 |     print *, min(12, 13.94)
+  |              ^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-max_01-b3ef694.json
+++ b/tests/reference/asr-max_01-b3ef694.json
@@ -5,9 +5,9 @@
     "infile_hash": "96c2be2ccab6e4a1ed29b0d707ac35303f33d40c3f1fd2aace27dc62",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
-    "stderr": "asr-max_01-b3ef694.stderr",
-    "stderr_hash": "a2c44ad95fc5eac18ac029853a1346888a2951867da680abc7f25ebf",
-    "returncode": 2
+    "stdout": "asr-max_01-b3ef694.stdout",
+    "stdout_hash": "035e1370645362877d17c9b37ba819e594df924f1325ae9683b34163",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
 }

--- a/tests/reference/asr-max_01-b3ef694.json
+++ b/tests/reference/asr-max_01-b3ef694.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-max_01-b3ef694.stdout",
     "stdout_hash": "035e1370645362877d17c9b37ba819e594df924f1325ae9683b34163",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-max_01-b3ef694.stderr",
+    "stderr_hash": "f97f2e3f378cf73c5c8399f1edfc3bf4a98c01b8b688e0f8bfb5a875",
     "returncode": 0
 }

--- a/tests/reference/asr-max_01-b3ef694.stderr
+++ b/tests/reference/asr-max_01-b3ef694.stderr
@@ -1,5 +1,5 @@
-semantic error: All arguments to max0 must be of the same type and kind
+warning: Different kinds of args in max0 is a non-standard extension
  --> tests/errors/max_01.f90:6:14
   |
 6 |     print *, max(y, z)
-  |              ^^^^^^^^^ 
+  |              ^^^^^^^^^ help: ensure all arguments have the same kind to make it standard

--- a/tests/reference/asr-max_01-b3ef694.stdout
+++ b/tests/reference/asr-max_01-b3ef694.stdout
@@ -1,0 +1,76 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            max_01:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    max_01
+                    []
+                    [(Assignment
+                        (Var 2 y)
+                        (RealConstant
+                            5.200000
+                            (Real 8)
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 z)
+                        (RealConstant
+                            9.000000
+                            (Real 4)
+                        )
+                        ()
+                    )
+                    (Print
+                        [(IntrinsicElementalFunction
+                            Max
+                            [(Var 2 y)
+                            (Var 2 z)]
+                            0
+                            (Real 8)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/asr-max_02-ddd1334.json
+++ b/tests/reference/asr-max_02-ddd1334.json
@@ -5,9 +5,9 @@
     "infile_hash": "bd78accf5e71c42d049416709f9c7e4f8e68f8f78e66bb1a5a47834a",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
-    "stderr": "asr-max_02-ddd1334.stderr",
-    "stderr_hash": "94450f9dc25e1fe371e42ad0eb0a9628f8c7cfaf58e0c700feb0a70c",
-    "returncode": 2
+    "stdout": "asr-max_02-ddd1334.stdout",
+    "stdout_hash": "af22cd9e812051a6574089941a117a8fbd3065f2179d2981484d1139",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
 }

--- a/tests/reference/asr-max_02-ddd1334.json
+++ b/tests/reference/asr-max_02-ddd1334.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-max_02-ddd1334.stdout",
     "stdout_hash": "af22cd9e812051a6574089941a117a8fbd3065f2179d2981484d1139",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-max_02-ddd1334.stderr",
+    "stderr_hash": "b128346c58a0af1795a2a3f4a4c1e8adb773fad013db5ac335ff8d06",
     "returncode": 0
 }

--- a/tests/reference/asr-max_02-ddd1334.stderr
+++ b/tests/reference/asr-max_02-ddd1334.stderr
@@ -1,5 +1,5 @@
-semantic error: All arguments to max0 must be of the same type and kind
+warning: Different kinds of args in max0 is a non-standard extension
  --> tests/errors/max_02.f90:4:14
   |
 4 |     print *, max(y, z)
-  |              ^^^^^^^^^ 
+  |              ^^^^^^^^^ help: ensure all arguments have the same kind to make it standard

--- a/tests/reference/asr-max_02-ddd1334.stdout
+++ b/tests/reference/asr-max_02-ddd1334.stdout
@@ -1,0 +1,60 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            max_02:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    max_02
+                    []
+                    [(Print
+                        [(IntrinsicElementalFunction
+                            Max
+                            [(Var 2 y)
+                            (Var 2 z)]
+                            0
+                            (Integer 8)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/asr-min_01-aefbe8a.json
+++ b/tests/reference/asr-min_01-aefbe8a.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-min_01-aefbe8a.stdout",
     "stdout_hash": "7bdd08fe45f9e340d2cd7f567cf22b15c6e5e8084d6aae22f60a11ae",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-min_01-aefbe8a.stderr",
+    "stderr_hash": "89a0a5e0b7e026a056095742cf701f20b354573d1802d74c364a0159",
     "returncode": 0
 }

--- a/tests/reference/asr-min_01-aefbe8a.json
+++ b/tests/reference/asr-min_01-aefbe8a.json
@@ -5,9 +5,9 @@
     "infile_hash": "4f2b6a5d17d5444ec72785deb89d7ba6cfb6e8d5dd05afde0d4ebdc4",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
-    "stderr": "asr-min_01-aefbe8a.stderr",
-    "stderr_hash": "015963226afd5fcf9944b68699fd396cc63056b0f90823b6af16bf59",
-    "returncode": 2
+    "stdout": "asr-min_01-aefbe8a.stdout",
+    "stdout_hash": "7bdd08fe45f9e340d2cd7f567cf22b15c6e5e8084d6aae22f60a11ae",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
 }

--- a/tests/reference/asr-min_01-aefbe8a.stderr
+++ b/tests/reference/asr-min_01-aefbe8a.stderr
@@ -1,5 +1,5 @@
-semantic error: All arguments to min0 must be of the same type and kind
+warning: Different kinds of args in max0 is a non-standard extension
  --> tests/errors/min_01.f90:6:14
   |
 6 |     print *, min(y, z)
-  |              ^^^^^^^^^ 
+  |              ^^^^^^^^^ help: ensure all arguments have the same kind to make it standard

--- a/tests/reference/asr-min_01-aefbe8a.stdout
+++ b/tests/reference/asr-min_01-aefbe8a.stdout
@@ -1,0 +1,76 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            min_01:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    min_01
+                    []
+                    [(Assignment
+                        (Var 2 y)
+                        (RealConstant
+                            5.200000
+                            (Real 8)
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 z)
+                        (RealConstant
+                            9.000000
+                            (Real 4)
+                        )
+                        ()
+                    )
+                    (Print
+                        [(IntrinsicElementalFunction
+                            Min
+                            [(Var 2 y)
+                            (Var 2 z)]
+                            0
+                            (Real 8)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/asr-min_02-81ef3b7.json
+++ b/tests/reference/asr-min_02-81ef3b7.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-min_02-81ef3b7.stdout",
     "stdout_hash": "22d18fe2d338478c9055a1b09e1328dd9dcad17b90a274f5765d83e0",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-min_02-81ef3b7.stderr",
+    "stderr_hash": "1b5b435ea8bc96394fb46a13efc04fb68ad028c1a8ff9be5782a977c",
     "returncode": 0
 }

--- a/tests/reference/asr-min_02-81ef3b7.json
+++ b/tests/reference/asr-min_02-81ef3b7.json
@@ -5,9 +5,9 @@
     "infile_hash": "395cfc5a8d60d306a6e51a8c1619bb4e36adede48c2fc96880e6c260",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
-    "stderr": "asr-min_02-81ef3b7.stderr",
-    "stderr_hash": "1d1fe383f36e981177ba02a6a85d47e28894cd10a0bb9ac6765a914e",
-    "returncode": 2
+    "stdout": "asr-min_02-81ef3b7.stdout",
+    "stdout_hash": "22d18fe2d338478c9055a1b09e1328dd9dcad17b90a274f5765d83e0",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
 }

--- a/tests/reference/asr-min_02-81ef3b7.stderr
+++ b/tests/reference/asr-min_02-81ef3b7.stderr
@@ -1,5 +1,5 @@
-semantic error: All arguments to min0 must be of the same type and kind
+warning: Different kinds of args in max0 is a non-standard extension
  --> tests/errors/min_02.f90:4:14
   |
 4 |     print *, min(y, z)
-  |              ^^^^^^^^^ 
+  |              ^^^^^^^^^ help: ensure all arguments have the same kind to make it standard

--- a/tests/reference/asr-min_02-81ef3b7.stdout
+++ b/tests/reference/asr-min_02-81ef3b7.stdout
@@ -1,0 +1,60 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            min_02:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    min_02
+                    []
+                    [(Print
+                        [(IntrinsicElementalFunction
+                            Min
+                            [(Var 2 y)
+                            (Var 2 z)]
+                            0
+                            (Integer 8)
+                            ()
+                        )]
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4089,3 +4089,11 @@ asr = true
 [[test]]
 filename = "errors/do_concurrent1.f90"
 asr = true
+
+[[test]]
+filename = "errors/intrinsics12.f90"
+asr = true
+
+[[test]]
+filename = "errors/intrinsics13.f90"
+asr = true


### PR DESCRIPTION
Fixes: #4581 
Towards: #4017, #3067
