### PR TITLE
Correct type handling in `scale` intrinsic and update tests

### DIFF
--- a/integration_tests/intrinsics_141.f90
+++ b/integration_tests/intrinsics_141.f90
@@ -1,8 +1,36 @@
 program intrinsic_141
+    implicit none
     real :: x = 178.1387e-4
     integer :: i = 5
     real :: y = -186.3245e-4
     integer :: j = 3
+    real, parameter :: x1 = scale(11.0, 2)
+    real(8), parameter :: y1 = scale(-11.0_8, 2)
+    real(8), parameter :: z1 = scale(11.0, 2_8)
+    real, parameter ::ar1(3) = scale([1.0, 21.0, 13.0], 2)
+    real(8), parameter :: ar2(3) = scale([1.0_8, 2.0_8, 3.0_8], 2)
+    real(8), parameter :: ar3(3) = scale([1.0, 2.0, 3.0], 2_8)
+    real :: arr1(3) = [1.0, 21.0, 13.0]
+    real(8) :: arr2(3) = [1.0_8, 2.0_8, 3.0_8]
+    integer :: arr3(3) = [1, 2, 3]
+
+    print *, scale(arr1, arr3)
+    if (any(abs(scale(arr1, arr3) - [2.00000000e+00, 84.0000000, 104.000000]) > 1e-7)) error stop
+
+    print *, scale(arr2, 2)
+    if (any(abs(scale(arr2, 2) - [4.00000000e+00, 8.00000000, 12.0000000]) > 1e-7)) error stop
+    print *, x1
+    if (abs(x1 - 4.40000000e+01) > 1e-7) error stop
+    print *, y1
+    if (abs(y1 - (-4.40000000000000000e+01)) > 1e-7) error stop
+    print *, z1
+    if (abs(z1 - 4.40000000000000000e+01) > 1e-7) error stop
+    print *, ar1
+    if (any(abs(ar1 - [4.00000000e+00, 8.40000000e+01, 5.20000000e+01]) > 1e-7)) error stop
+    print *, ar2
+    if (any(abs(ar2 - [4.00000000000000000e+00, 8.00000000000000000e+00, 1.20000000000000000e+01]) > 1e-7)) error stop
+    print *, ar3
+    if (any(abs(ar3 - [4.00000000000000000e+00, 8.00000000000000000e+00, 1.20000000000000000e+01]) > 1e-7)) error stop
 
     print *, scale(y,j)
     if (abs(scale(y, j) - (-1.49059594e-01)) > 1e-7) error stop

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1037,7 +1037,7 @@ namespace IntrinsicElementalFunctionRegistry {
     }
 
     static inline create_intrinsic_function get_create_function(const std::string& name) {
-        return  std::get<0>(intrinsic_function_by_name_db.at(name));
+        return std::get<0>(intrinsic_function_by_name_db.at(name));
     }
 
     static inline verify_function get_verify_function(int64_t id) {

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -888,9 +888,9 @@ namespace Scale {
     static inline ASR::expr_t* instantiate_Scale(Allocator &al, const Location &loc,
             SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
-        declare_basic_variables("");
+        declare_basic_variables("_lcompilers_scale_" + type_to_str_python(arg_types[0]));
         fill_func_arg("x", arg_types[0]);
-        fill_func_arg("y", arg_types[1]);
+        fill_func_arg("i", arg_types[1]);
         auto result = declare(fn_name, return_type, ReturnVar);
         /*
         * r = scale(x, y)
@@ -898,7 +898,7 @@ namespace Scale {
         */
 
        //TODO: Radix for most of the device is 2, so we can use the b.i2r_t(2, real32) instead of args[1]. Fix (find a way to get the radix of the device and use it here)
-        body.push_back(al, b.Assignment(result, b.Mul(args[0], b.i2r_t(b.Pow(b.i_t(2, arg_types[1]), args[1]), real32))));
+        body.push_back(al, b.Assignment(result, b.Mul(args[0], b.i2r_t(b.Pow(b.i_t(2, arg_types[1]), args[1]), return_type))));
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args, body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);
         return b.Call(f_sym, new_args, return_type, nullptr);


### PR DESCRIPTION
Fixes: #4585
Towards: #4017, #3067