### PR TITLE
chore: support different kind of args in DotProduct and add test 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -867,6 +867,7 @@ RUN(NAME intrinsics_294 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # log_gam
 RUN(NAME intrinsics_295 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # exp
 RUN(NAME intrinsics_296 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # storage_size
 RUN(NAME intrinsics_297 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # poppar
+RUN(NAME intrinsics_298 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # dot_product
 
 RUN(NAME passing_array_01 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME passing_array_02 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_298.f90
+++ b/integration_tests/intrinsics_298.f90
@@ -1,0 +1,52 @@
+program intrinsics_298
+    implicit none
+
+    integer, parameter :: x1 = dot_product([1, 2, 3], [4, 5, 6])
+    integer(8), parameter :: x2 = dot_product([12_8, 33_8, 41_8], [13_8, 1_8, 7_8])
+    real, parameter :: x3 = dot_product([3.0, 5.0, 11.0], [7.0, 13.0, 17.0])
+    real(8), parameter :: x4 = dot_product([3.0_8, 5.0_8, 11.0_8], [7.0_8, 13.0_8, 17.0_8])
+    complex, parameter :: x5 = dot_product([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], [(7.0, 8.0), (9.0, 10.0), (11.0, 12.0)])
+    complex(8), parameter :: x6 = dot_product([(1.0_8, 2.0_8), (3.0_8, 4.0_8), (5.0_8, 6.0_8)],&
+        [(7.0_8, 8.0_8), (9.0_8, 10.0_8), (11.0_8, 12.0_8)])
+    logical, parameter :: x7 = dot_product([.true., .false., .true.], [.true., .true., .false.])
+
+    integer :: i1(3) = [13, 2, 4], i2(3) = [13_8, 2_8, 4_8]
+    integer(8) :: i3(3) = [13_8, 2_8, 4_8], i4(3) = [13_8, 2_8, 4_8]
+    real :: r1(3) = [13.0, 2.0, 4.0], r2(3) = [13.0, 2.0, 4.0]
+    real(8) :: r3(3) = [13.0_8, 2.0_8, 4.0_8], r4(3) = [13.0_8, 2.0_8, 4.0_8]
+    complex :: c1(3) = [(13.0, 2.0), (2.0, 4.0), (4.0, 6.0)], c2(3) = [(13.0, 2.0), (2.0, 4.0), (4.0, 6.0)]
+    complex(8) :: c3(3) = [(13.0_8, 2.0_8), (2.0_8, 4.0_8), (4.0_8, 6.0_8)],& 
+        c4(3) = [(13.0_8, 2.0_8), (2.0_8, 4.0_8), (4.0_8, 6.0_8)]
+    logical :: l1(3) = [.true., .false., .true.], l2(3) = [.true., .false., .true.]
+
+    print *, x1
+    if (x1 /= 32) error stop
+    print *, x2
+    if (x2 /= 476) error stop
+    print *, x3
+    if (abs(x3 - 273.0) > 1e-6) error stop
+    print *, x4
+    if (abs(x4 - 273.0_8) > 1e-12) error stop
+    print *, abs(x5)
+    if (abs(abs(x5) - 217.745270) > 1e-5) error stop
+    print *, abs(x6)
+    if (abs(abs(x6) - 217.74526401279087_8) > 1e-12) error stop
+    print *, x7
+    if (.not. x7) error stop
+
+    print *, dot_product(i1, i2)
+    if (dot_product(i1, i2) /= 189) error stop
+    print *, dot_product(i3, i4)
+    if (dot_product(i3, i4) /= 189_8) error stop
+    print *, dot_product(r1, r2)
+    if (abs(dot_product(r1, r2) - 189.0) > 1e-6) error stop
+    print *, dot_product(r3, r4)
+    if (abs(dot_product(r3, r4) - 189.0_8) > 1e-12) error stop
+    print *, abs(dot_product(c1, c2))
+    if (abs(abs(dot_product(c1, c2)) - 245.0) > 1e-6) error stop
+    print *, abs(dot_product(c3, c4))
+    if (abs(abs(dot_product(c3, c4)) - 245.0_8) > 1e-12) error stop
+    print *, dot_product(l1, l2)
+    if (.not. dot_product(l1, l2)) error stop
+    
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -4757,14 +4757,15 @@ namespace DotProduct {
             body.push_back(al, b.DoLoop(i, LBound(args[0], 1), UBound(args[0], 1), {
                 b.Assignment(result, b.Add(result, EXPR(ASR::make_ComplexBinOp_t(al, loc, func_call_conjg, ASR::binopType::Mul, b.ArrayItem_01(args[1], {i}), return_type, nullptr))))
             }, nullptr));
-        } else {
-            if (is_real(*return_type)) {
-                body.push_back(al, b.Assignment(result, make_ConstantWithType(make_RealConstant_t, 0.0, return_type, loc)));
-            } else {
-                body.push_back(al, b.Assignment(result, make_ConstantWithType(make_IntegerConstant_t, 0, return_type, loc)));
-            }
+        } else if (is_real(*return_type)) {
+            body.push_back(al, b.Assignment(result, make_ConstantWithType(make_RealConstant_t, 0.0, return_type, loc)));
             body.push_back(al, b.DoLoop(i, LBound(args[0], 1), UBound(args[0], 1), {
-                b.Assignment(result, b.Add(result, b.Mul(b.ArrayItem_01(args[0], {i}), b.ArrayItem_01(args[1], {i}))))
+                b.Assignment(result, b.Add(result, b.Mul(b.ArrayItem_01(args[0], {i}), b.ArrayItem_01(b.r2r_t(args[1], arg_types[0]), {i}))))
+            }, nullptr));
+        } else {
+            body.push_back(al, b.Assignment(result, make_ConstantWithType(make_IntegerConstant_t, 0, return_type, loc)));
+            body.push_back(al, b.DoLoop(i, LBound(args[0], 1), UBound(args[0], 1), {
+                b.Assignment(result, b.Add(result, b.Mul(b.ArrayItem_01(args[0], {i}), b.ArrayItem_01(b.i2i_t(args[1], arg_types[0]), {i}))))
             }, nullptr));
         }
         body.push_back(al, b.Return());


### PR DESCRIPTION
Fixes: #4587 
Towards: #4017, #3067