### PR TITLE
enh: update error message to suggest compiler flag when passing array item to a subroutine

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9226,8 +9226,12 @@ public:
                     ASR::ttype_t* passed_arg_type = ASRUtils::expr_type(passed_arg);
                     if (ASR::is_a<ASR::ArrayItem_t>(*passed_arg)) {
                         if (!ASRUtils::types_equal(expected_arg_type, passed_arg_type, true)) {
-                            throw CodeGenError("Type mismatch in subroutine call, expected `" + ASRUtils::type_to_str_python(expected_arg_type)
-                                    + "`, passed `" + ASRUtils::type_to_str_python(passed_arg_type) + "`", x.m_args[i].m_value->base.loc);
+                            throw CodeGenError(
+                                "Type mismatch in subroutine call, expected `"
+                                    + ASRUtils::type_to_str_python(expected_arg_type)
+                                    + "`, passed `" + ASRUtils::type_to_str_python(passed_arg_type)
+                                    + "`. Hint: Use the `--legacy-array-sections` flag to compile.",
+                                x.m_args[i].m_value->base.loc);
                         }
                     }
                 }

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "llvm-legacy_array_sections_01-2515c0f.stderr",
-    "stderr_hash": "f19c3431555a5c60366d9ac2c1c12b43af7a37e4b4d317bb61c830b0",
+    "stderr_hash": "114ca504160d91e61127d84188eb67a579b792df005b565159aa62d4",
     "returncode": 1
 }

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stderr
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stderr
@@ -1,4 +1,4 @@
-code generation error: Type mismatch in subroutine call, expected `f64[:]`, passed `f64`
+code generation error: Type mismatch in subroutine call, expected `f64[:]`, passed `f64`. Hint: Use the `--legacy-array-sections` flag to compile.
  --> tests/../integration_tests/legacy_array_sections_01.f90:5:8
   |
 5 | call b(w(icon))


### PR DESCRIPTION
closes #4603