### PR TITLE
Throw error when first arg to `scale`/`set_exponent` intrinsic is integer array

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5595,6 +5595,9 @@ public:
             }
             // Call the intrinsic function for the current combination of arguments
             // result_array->m_args[i] = ASRUtils::expr_value(ASRUtils::EXPR(create_func(al, loc, intrinsic_args, diag)));
+            if (create_func(al, loc, intrinsic_args, diag) == nullptr) {
+                throw SemanticAbort();
+            }
             ASR::expr_t* result = ASRUtils::expr_value(ASRUtils::EXPR(create_func(al, loc, intrinsic_args, diag)));
             array_type = ASRUtils::expr_type(result);
             new_expr.push_back(al, result);

--- a/tests/errors/intrinsics14.f90
+++ b/tests/errors/intrinsics14.f90
@@ -1,0 +1,3 @@
+program intrinsics14
+    print *, scale([1, 2, 3], 2)
+end

--- a/tests/errors/intrinsics15.f90
+++ b/tests/errors/intrinsics15.f90
@@ -1,0 +1,3 @@
+program intrinsics15
+    print *, set_exponent([1, 2, 3], 2)
+end

--- a/tests/reference/asr-intrinsics14-5a6d04e.json
+++ b/tests/reference/asr-intrinsics14-5a6d04e.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics14-5a6d04e",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics14.f90",
+    "infile_hash": "e5abcb6a33f84a36c3412054dd1092db703e97cebdb5e26d69b29702",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics14-5a6d04e.stderr",
+    "stderr_hash": "249e6e7185993869a1a130554f0fcf10c43c67fef75ae76089e4717c",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics14-5a6d04e.stderr
+++ b/tests/reference/asr-intrinsics14-5a6d04e.stderr
@@ -1,0 +1,5 @@
+semantic error: Unexpected args, Scale expects (real, int) as arguments
+ --> tests/errors/intrinsics14.f90:2:14
+  |
+2 |     print *, scale([1, 2, 3], 2)
+  |              ^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-intrinsics15-76ae493.json
+++ b/tests/reference/asr-intrinsics15-76ae493.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics15-76ae493",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/intrinsics15.f90",
+    "infile_hash": "afc1933e8bca77d3f9caf7d466f010a578d93125b222309c194480a8",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics15-76ae493.stderr",
+    "stderr_hash": "ef97af68d4eb0d2d985d19d15914e508a21c6a3a4615b9c686359ae1",
+    "returncode": 2
+}

--- a/tests/reference/asr-intrinsics15-76ae493.stderr
+++ b/tests/reference/asr-intrinsics15-76ae493.stderr
@@ -1,0 +1,5 @@
+semantic error: Unexpected args, SetExponent expects (real, int) as arguments
+ --> tests/errors/intrinsics15.f90:2:14
+  |
+2 |     print *, set_exponent([1, 2, 3], 2)
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4122,3 +4122,11 @@ asr = true
 [[test]]
 filename = "errors/ifix_01.f90"
 asr = true
+
+[[test]]
+filename = "errors/intrinsics14.f90"
+asr = true
+
+[[test]]
+filename = "errors/intrinsics14.f90"
+asr = true

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4128,5 +4128,5 @@ filename = "errors/intrinsics14.f90"
 asr = true
 
 [[test]]
-filename = "errors/intrinsics14.f90"
+filename = "errors/intrinsics15.f90"
 asr = true


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4584