### PR TITLE
Add `dockerfile` to support building docker image 

### DIFF
--- a/.github/workflows/upload_docker_build.yml
+++ b/.github/workflows/upload_docker_build.yml
@@ -1,0 +1,40 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  USER: lfortran
+  PROJECT: lfortran
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to the Container registry
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ env.REGISTRY }}/${{ env.USER }}/${{ env.PROJECT }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:22.04 AS build
+
+USER root
+
+RUN apt update
+RUN apt install curl git build-essential binutils-dev zlib1g-dev clang -y
+
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN bash Miniforge3-$(uname)-$(uname -m).sh -b
+
+RUN /root/miniforge3/bin/mamba init bash
+
+WORKDIR /lfortran
+
+COPY . .
+
+RUN /root/miniforge3/bin/mamba env create -f environment_linux.yml -y
+SHELL ["/root/miniforge3/bin/mamba", "run", "-n", "lf", "/bin/bash", "-c"]
+
+RUN ./build1.sh
+
+RUN ctest
+RUN python integration_tests/run_tests.py
+RUN python run_tests.py
+
+FROM ubuntu:22.04 AS app
+
+RUN apt update
+RUN apt install binutils clang --no-install-recommends -y
+
+COPY --from=build /lfortran/inst /app


### PR DESCRIPTION
### Summary

fixes https://github.com/lfortran/lfortran/issues/2478

This PR adds a docker file to support building a docker image for `lfortran`. The built docker image is currently uploaded here https://hub.docker.com/repository/docker/ubaidsh/lfortran-build/general. 

It also adds a new workflow to auto-build and upload docker builds for every merge commit in `main`. The built images are uploaded to github packages. We currently overwrite the same image on every push.

### Test plan

First install docker https://docs.docker.com/engine/install/.

#### To test the docker image

- run the image interactively `docker run -it ubaidsh/lfortran-build`
- one can find `lfortran` in `/app/bin/lfortran`

#### To generate the docker image

- run `docker build -t lfortran-build .` from the root directory of `lfortran` project