### PR TITLE
lfortran: hand verbose option through to linker

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1653,6 +1653,7 @@ int link_executable(const std::vector<std::string> &infiles,
             run_cmd = "./" + outfile;
         }
         if (verbose) {
+            compile_cmd += " -v";
             std::cout << compile_cmd << std::endl;
         }
         int err = system(compile_cmd.c_str());


### PR DESCRIPTION
See https://gitlab.kitware.com/cmake/cmake/-/issues/26145#note_1554135