### PR TITLE
Throw error if `kind` arg in intrinsics is non-scalar

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5392,6 +5392,18 @@ public:
         }
     }
 
+    void scalar_kind_arg(std::string &name, Vec<ASR::expr_t*> &args) {
+        std::vector<std::string> optional_kind_arg = {"logical", "storage_size", "anint", "nint", "aint", "floor", 
+            "ceiling", "aimag", "maskl", "maskr", "ichar", "char", "achar", "real"};
+        if (std::find(optional_kind_arg.begin(), optional_kind_arg.end(), name) != optional_kind_arg.end()) {
+            if (args[1]) {
+                if (ASRUtils::is_array(ASRUtils::expr_type(args[1]))) {
+                    throw SemanticError("Expected scalar argument for " + name + " intrinsic", args[1]->base.loc);
+                }
+            }
+        }
+    }
+
     void fill_optional_args(std::string intrinsic_name, Vec<ASR::expr_t*> &args, const Location &loc) {
         ASR::ttype_t *int_type = ASRUtils::TYPE(
                     ASR::make_Integer_t(al, loc, 4));
@@ -5684,7 +5696,7 @@ public:
                 if( ASRUtils::IntrinsicElementalFunctionRegistry::is_intrinsic_function(var_name) ) {
                     const bool are_all_args_evaluated { ASRUtils::all_args_evaluated(args, true) };
                     fill_optional_kind_arg(var_name, args);
-
+                    scalar_kind_arg(var_name, args);
                     ASRUtils::create_intrinsic_function create_func =
                         ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function(var_name);
 

--- a/tests/errors/kind_01.f90
+++ b/tests/errors/kind_01.f90
@@ -1,0 +1,4 @@
+program kind_01
+    implicit none
+    print *, aint([1.0, 2.0, 3.0], [4, 4])
+end

--- a/tests/reference/asr-kind_01-6c675be.json
+++ b/tests/reference/asr-kind_01-6c675be.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-kind_01-6c675be",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/kind_01.f90",
+    "infile_hash": "b5be2245f43395dd32e9fbc5f06c07ac6c70905e5b83bf65ca745c30",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-kind_01-6c675be.stderr",
+    "stderr_hash": "d4d0c7f1134a9ace57aee82382e8fc165086d42a07fb08c78c494c2e",
+    "returncode": 2
+}

--- a/tests/reference/asr-kind_01-6c675be.stderr
+++ b/tests/reference/asr-kind_01-6c675be.stderr
@@ -1,0 +1,5 @@
+semantic error: Expected scalar argument for aint intrinsic
+ --> tests/errors/kind_01.f90:3:36
+  |
+3 |     print *, aint([1.0, 2.0, 3.0], [4, 4])
+  |                                    ^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4138,3 +4138,7 @@ run = true
 [[test]]
 filename = "exit2.f90"
 run = true
+
+[[test]]
+filename = "errors/kind_01.f90"
+asr = true


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/4539