### PR TITLE
fix: printing incorrect name of `IntrinsicImpureSubroutine` in ASR

### DIFF
--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -57,7 +57,7 @@ stmt
     | Stop(expr? code)
     | Assert(expr test, expr? msg)
     | SubroutineCall(symbol name, symbol? original_name, call_arg* args, expr? dt)
-    | IntrinsicImpureSubroutine(int intrinsic_id, expr* args, int overload_id)
+    | IntrinsicImpureSubroutine(int sub_intrinsic_id, expr* args, int overload_id)
     | Where(expr test, stmt* body, stmt* orelse)
     | WhileLoop(identifier? name, expr test, stmt* body, stmt* orelse)
     | Nullify(symbol* vars)

--- a/src/libasr/asdl_cpp.py
+++ b/src/libasr/asdl_cpp.py
@@ -1677,6 +1677,8 @@ class PickleVisitorVisitor(ASDLVisitor):
                         self.emit('s.append(self().convert_intrinsic_id(x.m_%s));' % field.name, 2)
                     elif field.name == "impure_intrinsic_id":
                         self.emit('s.append(self().convert_impure_intrinsic_id(x.m_%s));' % field.name, 2)
+                    elif field.name == "sub_intrinsic_id":
+                        self.emit('s.append(self().convert_sub_intrinsic_id(x.m_%s));' % field.name, 2)
                     elif field.name == "arr_intrinsic_id":
                         self.emit('s.append(self().convert_array_intrinsic_id(x.m_%s));' % field.name, 2)
                     else:

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -9,6 +9,7 @@
 #include <libasr/modfile.h>
 #include <libasr/pass/pass_utils.h>
 #include <libasr/pass/intrinsic_function_registry.h>
+#include <libasr/pass/intrinsic_subroutine_registry.h>
 #include <libasr/pass/intrinsic_array_function_registry.h>
 
 namespace LCompilers {

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1252,12 +1252,12 @@ public:
     void visit_IntrinsicImpureSubroutine( const ASR::IntrinsicImpureSubroutine_t &x ) {
         std::string out;
         out = "call ";
-        switch ( x.m_intrinsic_id ) {
+        switch ( x.m_sub_intrinsic_id ) {
             SET_INTRINSIC_SUBROUTINE_NAME(RandomNumber, "random_number");
             SET_INTRINSIC_SUBROUTINE_NAME(RandomInit, "random_init");
             default : {
                 throw LCompilersException("IntrinsicImpureSubroutine: `"
-                    + ASRUtils::get_intrinsic_name(x.m_intrinsic_id)
+                    + ASRUtils::get_intrinsic_name(x.m_sub_intrinsic_id)
                     + "` is not implemented");
             }
         }

--- a/src/libasr/pass/intrinsic_subroutine.cpp
+++ b/src/libasr/pass/intrinsic_subroutine.cpp
@@ -51,7 +51,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
                 new_args.push_back(al, arg0);
             }
             ASRUtils::impl_subroutine instantiate_subroutine =
-                ASRUtils::IntrinsicImpureSubroutineRegistry::get_instantiate_subroutine(x.m_intrinsic_id);
+                ASRUtils::IntrinsicImpureSubroutineRegistry::get_instantiate_subroutine(x.m_sub_intrinsic_id);
             if( instantiate_subroutine == nullptr ) {
                 return ;
             }

--- a/src/libasr/pass/intrinsic_subroutine_registry.h
+++ b/src/libasr/pass/intrinsic_subroutine_registry.h
@@ -83,7 +83,7 @@ namespace IntrinsicImpureSubroutineRegistry {
         return std::get<0>(intrinsic_subroutine_by_id_db.at(id));
     }
 
-    static inline std::string get_intrinsic_subroutine_name(int64_t id) {
+    inline std::string get_intrinsic_subroutine_name(int64_t id) {
         if( intrinsic_subroutine_id_to_name.find(id) == intrinsic_subroutine_id_to_name.end() ) {
             throw LCompilersException("IntrinsicSubroutine with ID " + std::to_string(id) +
                                       " has no name registered for it");

--- a/src/libasr/pickle.cpp
+++ b/src/libasr/pickle.cpp
@@ -2,6 +2,7 @@
 #include <libasr/location.h>
 #include <libasr/asr_utils.h>
 #include <libasr/pass/intrinsic_function_registry.h>
+#include <libasr/pass/intrinsic_subroutine_registry.h>
 #include <libasr/pass/intrinsic_array_function_registry.h>
 
 namespace LCompilers {
@@ -136,6 +137,20 @@ public:
             s.append(color(fg::green));
         }
         s.append(ASRUtils::get_intrinsic_name(x));
+        if (use_colors) {
+            s.append(color(fg::reset));
+            s.append(color(style::reset));
+        }
+        return s;
+    }
+
+    std::string convert_sub_intrinsic_id(int x) {
+        std::string s;
+        if (use_colors) {
+            s.append(color(style::bold));
+            s.append(color(fg::green));
+        }
+        s.append(ASRUtils::get_intrinsic_subroutine_name(x));
         if (use_colors) {
             s.append(color(fg::reset));
             s.append(color(style::reset));

--- a/tests/reference/asr-intrinsics_29-d4080f2.json
+++ b/tests/reference/asr-intrinsics_29-d4080f2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_29-d4080f2.stdout",
-    "stdout_hash": "5d95e0c28b6ef501782feb27a3a040a5936a131d6df30ec789da0f3f",
+    "stdout_hash": "5a9fdbaa216e083d774f3ebd68df904ee098cd9991e6c5f331223980",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_29-d4080f2.stdout
+++ b/tests/reference/asr-intrinsics_29-d4080f2.stdout
@@ -43,12 +43,12 @@
                     intrinsics_29
                     []
                     [(IntrinsicImpureSubroutine
-                        ObjectType
+                        RandomNumber
                         [(Var 2 random_sp)]
                         0
                     )
                     (IntrinsicImpureSubroutine
-                        ObjectType
+                        RandomNumber
                         [(Var 2 random_dp)]
                         0
                     )

--- a/tests/reference/asr-matmul_01-7b0b0c2.json
+++ b/tests/reference/asr-matmul_01-7b0b0c2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matmul_01-7b0b0c2.stdout",
-    "stdout_hash": "90c3c4ca36ae85321ca176f2fee5d74686226e396eaa29192f991ffe",
+    "stdout_hash": "a2ba2c202446e5c3fc3c272bfbd49eb8985be20f7be9e3448c759c8e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matmul_01-7b0b0c2.stdout
+++ b/tests/reference/asr-matmul_01-7b0b0c2.stdout
@@ -507,12 +507,12 @@
                         ()
                     )
                     (IntrinsicImpureSubroutine
-                        ObjectType
+                        RandomNumber
                         [(Var 6 a)]
                         0
                     )
                     (IntrinsicImpureSubroutine
-                        ObjectType
+                        RandomNumber
                         [(Var 6 b)]
                         0
                     )


### PR DESCRIPTION
Fixes #4654.