### PR TITLE
fix: struct type out of symbol error by duplicating it inside symbol table whenever required

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1763,3 +1763,5 @@ RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME exit_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME exit_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
+RUN(NAME struct_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/struct_type_01.f90
+++ b/integration_tests/struct_type_01.f90
@@ -1,0 +1,39 @@
+MODULE struct_type_01_module
+
+TYPE diag_type
+    INTEGER :: len
+END TYPE diag_type
+
+TYPE(diag_type), DIMENSION(1) :: diag
+
+END MODULE struct_type_01_module
+
+subroutine set_diag_len(len)
+USE struct_type_01_module, ONLY: diag
+INTEGER, INTENT(IN) :: len
+
+print *, diag(1)%len
+if (diag(1)%len /= 10) error stop
+
+diag(1)%len = len
+
+end subroutine set_diag_len
+
+PROGRAM struct_type_01
+USE struct_type_01_module, ONLY: diag
+
+diag(1)%len = 10
+call set_diag_len(20)
+print *, get_diag_len()
+if (get_diag_len() /= 20) error stop
+
+contains
+function get_diag_len() result(len)
+USE struct_type_01_module, ONLY: diag
+INTEGER :: len
+
+len = diag(1)%len
+end function get_diag_len
+
+END PROGRAM struct_type_01
+

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1515,6 +1515,7 @@ public:
             v->n_dependencies = module_dependencies.size();
         }
 
+        create_and_replace_structType();
         current_scope = old_scope;
         current_module = nullptr;
         tmp = nullptr;

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1581,6 +1581,7 @@ public:
             visit_program_unit(*x.m_contains[i]);
         }
 
+        create_and_replace_structType();
         ASRUtils::update_call_args(al, current_scope, compiler_options.implicit_interface, changed_external_function_symbol);
 
         starting_m_body = nullptr;
@@ -1983,6 +1984,7 @@ public:
             visit_program_unit(*x.m_contains[i]);
         }
 
+        create_and_replace_structType();
         ASRUtils::update_call_args(al, current_scope, compiler_options.implicit_interface, changed_external_function_symbol);
 
         starting_m_body = nullptr;
@@ -2064,6 +2066,7 @@ public:
             is_Function = false;
         }
 
+        create_and_replace_structType();
         ASRUtils::update_call_args(al, current_scope, compiler_options.implicit_interface, changed_external_function_symbol);
 
         starting_m_body = nullptr;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3630,6 +3630,56 @@ public:
         return 1; // default
     }
 
+    void create_and_replace_structType() {
+
+        class StructTypeVisitor : public ASR::BaseWalkVisitor<StructTypeVisitor> {
+            private:
+                Allocator &al;
+
+            public:
+                int sem = -1;
+                SymbolTable* local_current_scope;
+                StructTypeVisitor (Allocator &_al, SymbolTable* current_scope) : al(_al) {
+                    local_current_scope = current_scope;
+                    sem = -1;
+                }
+
+                void visit_ArrayItem(const ASR::ArrayItem_t& x) {
+                    if ( ASR::is_a<ASR::StructType_t>(*x.m_type) ) {
+                        sem += 1;
+                        visit_StructType(*ASR::down_cast<ASR::StructType_t>(x.m_type));
+                        sem -= 1;
+                    }
+                }
+
+                void visit_StructType( const ASR::StructType_t& x ) {
+                    if ( sem >= 0 ) {
+                        ASR::StructType_t& xx = const_cast<ASR::StructType_t&>(x);
+                        if ( ASRUtils::symbol_parent_symtab(xx.m_derived_type)->counter != local_current_scope->counter) {
+                            if ((local_current_scope->resolve_symbol(ASRUtils::symbol_name(xx.m_derived_type)) == nullptr)) {
+                                ASRUtils::SymbolDuplicator sd(al);
+                                sd.duplicate_symbol(xx.m_derived_type, local_current_scope);
+                            }
+                            xx.m_derived_type = local_current_scope->resolve_symbol(ASRUtils::symbol_name(xx.m_derived_type));
+                        }
+                    }
+                }
+        };
+
+        StructTypeVisitor v(al, current_scope);
+        ASR::asr_t* asr_owner = current_scope->asr_owner;
+        if ( ASR::is_a<ASR::symbol_t>(*asr_owner) ) {
+            ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(asr_owner);
+            if ( ASR::is_a<ASR::Function_t>(*sym) ) {
+                ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(sym);
+                v.visit_Function(*f);
+            } else if ( ASR::is_a<ASR::Program_t>(*sym) ) {
+                ASR::Program_t* p = ASR::down_cast<ASR::Program_t>(sym);
+                v.visit_Program(*p);
+            }
+        }
+    }
+
     ASR::asr_t* create_ArrayRef(const Location &loc, AST::fnarg_t* m_args,
         size_t n_args, AST::fnarg_t* m_subargs, size_t n_subargs,
         ASR::expr_t* v_expr, ASR::symbol_t *v, ASR::symbol_t *f2) {
@@ -4688,7 +4738,7 @@ public:
                 indices.size(), array_section_type, nullptr);
         } else {
             array_item_node = ASRUtils::make_ArrayItem_t_util(al, loc, expr, indices.p,
-                indices.size(), ASRUtils::extract_type(ASRUtils::expr_type(expr)),
+                indices.size(), ASRUtils::duplicate_type(al, ASRUtils::extract_type(ASRUtils::expr_type(expr))),
                 ASR::arraystorageType::ColMajor, nullptr);
         }
         array_item_node = (ASR::asr_t*) replace_with_common_block_variables(
@@ -4705,7 +4755,7 @@ public:
             throw SemanticError("Variable '" + dt_name + "' not declared", loc);
         }
         ASR::Variable_t* v_variable = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(v));
-        ASR::ttype_t* v_variable_m_type = ASRUtils::extract_type(v_variable->m_type);
+        ASR::ttype_t* v_variable_m_type = ASRUtils::duplicate_type(al, ASRUtils::extract_type(v_variable->m_type));
         if (ASR::is_a<ASR::StructType_t>(*v_variable_m_type) ||
                 ASR::is_a<ASR::ClassType_t>(*v_variable_m_type)) {
             ASR::ttype_t* v_type = v_variable_m_type;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5634,7 +5634,7 @@ static inline ASR::asr_t* make_SubroutineCall_t_util(
         *ASRUtils::symbol_get_past_external(a_name)) &&
         ASR::is_a<ASR::FunctionType_t>(*ASRUtils::symbol_type(a_name)) ) {
         a_dt = ASRUtils::EXPR(ASR::make_StructInstanceMember_t(al, a_loc,
-            a_dt, a_name, ASRUtils::symbol_type(a_name), nullptr));
+            a_dt, a_name, ASRUtils::duplicate_type(al, ASRUtils::symbol_type(a_name)), nullptr));
     }
 
     return ASR::make_SubroutineCall_t(al, a_loc, a_name, a_original_name, a_args, n_args, a_dt);


### PR DESCRIPTION
Fixes #4192