### PR TITLE
rem: verify check that StructType must lie in same symtab as parent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1763,3 +1763,5 @@ RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME exit_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME exit_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
+RUN(NAME struct_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/struct_type_01.f90
+++ b/integration_tests/struct_type_01.f90
@@ -1,0 +1,38 @@
+MODULE struct_type_01_module
+
+TYPE diag_type
+    INTEGER :: len
+END TYPE diag_type
+
+TYPE(diag_type), DIMENSION(1) :: diag
+
+END MODULE struct_type_01_module
+
+subroutine set_diag_len(len)
+USE struct_type_01_module, ONLY: diag
+INTEGER, INTENT(IN) :: len
+
+print *, diag(1)%len
+if (diag(1)%len /= 10) error stop
+
+diag(1)%len = len
+
+end subroutine set_diag_len
+
+PROGRAM struct_type_01
+USE struct_type_01_module, ONLY: diag
+
+diag(1)%len = 10
+call set_diag_len(20)
+print *, get_diag_len()
+if (get_diag_len() /= 20) error stop
+
+contains
+function get_diag_len() result(len)
+USE struct_type_01_module, ONLY: diag
+INTEGER :: len
+
+len = diag(1)%len
+end function get_diag_len
+
+END PROGRAM struct_type_01

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1141,11 +1141,6 @@ public:
         if( ASRUtils::get_asr_owner(x.m_derived_type) ) {
             symbol_owner = ASRUtils::symbol_name(ASRUtils::get_asr_owner(x.m_derived_type));
         }
-        require(symtab_in_scope(current_symtab, x.m_derived_type),
-            "StructType::m_derived_type '" +
-            std::string(ASRUtils::symbol_name(x.m_derived_type)) +
-            "' cannot point outside of its symbol table, owner: " +
-            symbol_owner);
     }
 
     void visit_ArrayConstructor(const ArrayConstructor_t& x) {


### PR DESCRIPTION
Closes #4192.

I believe this is a right fix because, when you see generated llvm code, the types are declared globally free from symtab. Thereby we need not to validate the symbol of type, or `StructType` must not have a symbol init, it should be free of symtabs just like other types.