### PR TITLE
Load LLVM sources

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -892,85 +892,10 @@ int compile_to_object_file(const std::string &infile,
         CompilerOptions &compiler_options,
         LCompilers::PassManager& lpm)
 {
-    std::string input = read_file(infile);
-
-    LCompilers::FortranEvaluator fe(compiler_options);
-    LCompilers::ASR::TranslationUnit_t* asr;
-
-
-    // Src -> AST -> ASR
-    LCompilers::LocationManager lm;
-
-    {
-        LCompilers::LocationManager::FileLocations fl;
-        fl.in_filename = infile;
-        lm.files.push_back(fl);
-        lm.file_ends.push_back(input.size());
-    }
-    LCompilers::diag::Diagnostics diagnostics;
-    LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
-        result = fe.get_asr2(input, lm, diagnostics);
-    std::cerr << diagnostics.render(lm, compiler_options);
-    if (result.ok) {
-        asr = result.result;
-    } else {
-        LCOMPILERS_ASSERT(diagnostics.has_error())
-        return 1;
-    }
-
-    // Save .mod files
-    {
-        int err = save_mod_files(*asr, compiler_options);
-        if (err) return err;
-    }
-
-    // ASR -> LLVM
+    std::string input = read_file("a.ll");
     LCompilers::LLVMEvaluator e(compiler_options.target);
-
-    if (!compiler_options.generate_object_code
-            && !LCompilers::ASRUtils::main_program_present(*asr)) {
-        // Create an empty object file (things will be actually
-        // compiled and linked when the main program is present):
-        e.create_empty_object_file(outfile);
-        return 0;
-    }
-
-    std::unique_ptr<LCompilers::LLVMModule> m;
-    diagnostics.diagnostics.clear();
-    if (compiler_options.emit_debug_info) {
-#ifndef HAVE_RUNTIME_STACKTRACE
-        diagnostics.add(LCompilers::diag::Diagnostic(
-            "The `runtime stacktrace` is not enabled. To get the stack traces "
-            "or debugging information, please re-build LFortran with "
-            "`-DWITH_RUNTIME_STACKTRACE=yes`",
-            LCompilers::diag::Level::Error,
-            LCompilers::diag::Stage::Semantic, {})
-        );
-        std::cerr << diagnostics.render(lm, compiler_options);
-        return 1;
-#endif
-    }
-    LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
-        res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
-    std::cerr << diagnostics.render(lm, compiler_options);
-    if (res.ok) {
-        m = std::move(res.result);
-    } else {
-        LCOMPILERS_ASSERT(diagnostics.has_error())
-        return 5;
-    }
-
-    if (compiler_options.po.fast) {
-        e.opt(*m->m_m);
-    }
-
-    // LLVM -> Machine code (saves to an object file)
-    if (assembly) {
-        e.save_asm_file(*(m->m_m), outfile);
-    } else {
-        e.save_object_file(*(m->m_m), outfile);
-    }
-
+    std::unique_ptr<LCompilers::LLVMModule> m = std::move(e.parse_module2(input));
+    e.save_object_file(*(m->m_m), outfile);
     return 0;
 }
 

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -216,6 +216,10 @@ std::unique_ptr<llvm::Module> LLVMEvaluator::parse_module(const std::string &sou
     return module;
 }
 
+std::unique_ptr<LLVMModule> LLVMEvaluator::parse_module2(const std::string &source) {
+    return std::make_unique<LLVMModule>(parse_module(source));
+}
+
 void LLVMEvaluator::add_module(const std::string &source) {
     std::unique_ptr<llvm::Module> module = parse_module(source);
     // TODO: apply LLVM optimizations here

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -48,6 +48,7 @@ public:
     LLVMEvaluator(const std::string &t = "");
     ~LLVMEvaluator();
     std::unique_ptr<llvm::Module> parse_module(const std::string &source);
+    std::unique_ptr<LLVMModule> parse_module2(const std::string &source);
     void add_module(const std::string &source);
     void add_module(std::unique_ptr<llvm::Module> mod);
     void add_module(std::unique_ptr<LLVMModule> m);


### PR DESCRIPTION
How to use: first create `a.ll` with the `--show-llvm`. Then compile this branch and:
```
lfortran a.f90
```
Instead of compiling `a.f90`, it will read in `a.ll` and compile it (and run it). You can save to a binary as `lfortran a.f90 -o xx`.