### PR TITLE
Fix (nullify) : use malloc instead of allocation on stack 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -505,6 +505,7 @@ RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_array_pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME pointer_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran llvm)

--- a/integration_tests/pointer_02.f90
+++ b/integration_tests/pointer_02.f90
@@ -1,0 +1,26 @@
+MODULE solvar_module
+    REAL, DIMENSION(:,:), POINTER :: ptr_out
+ CONTAINS
+    SUBROUTINE solvar_allocate
+       NULLIFY(ptr_out)
+       ALLOCATE(ptr_out(5,1))
+    END SUBROUTINE solvar_allocate
+ 
+    SUBROUTINE dim3_sweep(ptr_out)
+       REAL, DIMENSION(5), INTENT(OUT) :: ptr_out
+       PRINT *, ptr_out
+       STOP
+    END SUBROUTINE dim3_sweep
+ 
+    SUBROUTINE octsweep
+       !REAL, DIMENSION(5), pointer :: x
+       !x = ptr_out(:,1)
+       CALL dim3_sweep( ptr_out(:,1) )
+    END SUBROUTINE octsweep
+ END MODULE solvar_module
+ 
+ PROGRAM snap_main
+    USE solvar_module, ONLY: solvar_allocate, octsweep
+    CALL solvar_allocate
+    CALL octsweep
+ END PROGRAM snap_main

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1065,7 +1065,8 @@ public:
                             //create memory on heap
                             std::vector<llvm::Value*> idx_vec = {
                             llvm::ConstantInt::get(context, llvm::APInt(32, 1))};
-                            llvm::Value* size_of_array_struct = CreateGEP(llvm::ConstantPointerNull::get(type->getPointerTo()), idx_vec);
+                            llvm::Value* null_array_ptr = llvm::ConstantPointerNull::get(type->getPointerTo());
+                            llvm::Value* size_of_array_struct = CreateGEP(null_array_ptr, idx_vec);
                             llvm::Value* size_of_array_struct_casted = builder->CreatePtrToInt(size_of_array_struct, llvm::Type::getInt32Ty(context)); //cast to int32
                             llvm::Value* struct_ptr = LLVMArrUtils::lfortran_malloc(
                                 context, *module, *builder, size_of_array_struct_casted);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1060,8 +1060,21 @@ public:
                         llvm::Type* type = llvm_utils->get_type_from_ttype_t_util(
                             ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(
                                 ASRUtils::expr_type(tmp_expr))), module.get());
-                        llvm::Value* ptr_ = builder->CreateAlloca(type, nullptr);
-                        arr_descr->fill_dimension_descriptor(ptr_, n_dims);
+                        llvm::Value* ptr_;
+                        if(ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(tmp_expr))){
+                            //create memory on heap
+                            std::vector<llvm::Value*> idx_vec = {
+                            llvm::ConstantInt::get(context, llvm::APInt(32, 1))};
+                            llvm::Value* size_of_array_struct = CreateGEP(llvm::ConstantPointerNull::get(type->getPointerTo()), idx_vec);
+                            llvm::Value* size_of_array_struct_casted = builder->CreatePtrToInt(size_of_array_struct, llvm::Type::getInt32Ty(context)); //cast to int32
+                            llvm::Value* struct_ptr = LLVMArrUtils::lfortran_malloc(
+                                context, *module, *builder, size_of_array_struct_casted);
+                            ptr_ = builder->CreateBitCast(struct_ptr, type->getPointerTo());
+                            arr_descr->fill_dimension_descriptor(ptr_, n_dims, module.get(), ASRUtils::expr_type(tmp_expr));
+                        } else {
+                            ptr_ = builder->CreateAlloca(type, nullptr);
+                            arr_descr->fill_dimension_descriptor(ptr_, n_dims,nullptr,nullptr);
+                        }
                         LLVM::CreateStore(*builder, ptr_, x_arr);
                     },
                     []() {});
@@ -3291,7 +3304,7 @@ public:
         llvm::Value* ptr_ = nullptr;
         if( is_malloc_array_type && !is_list && !is_data_only ) {
             ptr_ = builder->CreateAlloca(type_, nullptr, "arr_desc");
-            arr_descr->fill_dimension_descriptor(ptr_, n_dims);
+            arr_descr->fill_dimension_descriptor(ptr_, n_dims, nullptr, nullptr);
         }
         if( is_array_type && !is_malloc_array_type &&
             !is_list ) {

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -390,7 +390,8 @@ namespace LCompilers {
             if(type && ASR::is_a<ASR::Pointer_t>(*type)){
                 std::vector<llvm::Value*> idx_vec = {
                     llvm::ConstantInt::get(context, llvm::APInt(32, 1))};
-                    llvm::Value* size_of_dim_des_struct = builder->CreateGEP(llvm::ConstantPointerNull::get(dim_des->getPointerTo()), idx_vec);
+                    llvm::Value* null_dim_des_ptr = llvm::ConstantPointerNull::get(dim_des->getPointerTo());
+                    llvm::Value* size_of_dim_des_struct = builder->CreateGEP(null_dim_des_ptr, idx_vec);
                     llvm::Value* size_of_dim_des_struct_casted = builder->CreatePtrToInt(size_of_dim_des_struct, llvm::Type::getInt32Ty(context)); //cast to int32
                     llvm::Value* size_mul_ndim = builder->CreateMul(size_of_dim_des_struct_casted, llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)));
                     llvm::Value* struct_ptr = LLVMArrUtils::lfortran_malloc(

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -391,7 +391,7 @@ namespace LCompilers {
                 std::vector<llvm::Value*> idx_vec = {
                     llvm::ConstantInt::get(context, llvm::APInt(32, 1))};
                     llvm::Value* null_dim_des_ptr = llvm::ConstantPointerNull::get(dim_des->getPointerTo());
-                    llvm::Value* size_of_dim_des_struct = builder->CreateGEP(null_dim_des_ptr, idx_vec);
+                    llvm::Value* size_of_dim_des_struct = LLVM::CreateGEP(*builder,null_dim_des_ptr, idx_vec);
                     llvm::Value* size_of_dim_des_struct_casted = builder->CreatePtrToInt(size_of_dim_des_struct, llvm::Type::getInt32Ty(context)); //cast to int32
                     llvm::Value* size_mul_ndim = builder->CreateMul(size_of_dim_des_struct_casted, llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)));
                     llvm::Value* struct_ptr = LLVMArrUtils::lfortran_malloc(

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -155,7 +155,7 @@ namespace LCompilers {
 
                 virtual
                 void fill_dimension_descriptor(
-                    llvm::Value* arr, int n_dims) = 0;
+                    llvm::Value* arr, int n_dims, llvm::Module* module,ASR::ttype_t* type) = 0;
 
                 virtual
                 void reset_array_details(
@@ -375,7 +375,7 @@ namespace LCompilers {
 
                 virtual
                 void fill_dimension_descriptor(
-                    llvm::Value* arr, int n_dims);
+                    llvm::Value* arr, int n_dims, llvm::Module* module, ASR::ttype_t* type);
 
                 virtual
                 void reset_array_details(


### PR DESCRIPTION
fixes #4635 

-We treat array of `pointer` as the same as `allocatable` when it comes to creating the ex `array { float*, i32,%dimension_descriptor*, i1, i32 }` and the dimension_descriptor `%dimension_descriptor = type { i32, i32, i32 }`.
- These LLVM structs get created by using alloca which creates an LLVM struct on the stack.
- We use `alloca` in the main function, so that object stay in the memory in the livetime of the running program
- But when we `nullify()`, We get disattached from that object.
- whenever we try to allocate again in a function, we would create an object in the stack that eventually would get freed
- That's why we couldn't produce it unless there's some function calls
***
**How fix Works**
- access the size of the struct (array, dimension_descriptor) by using GEP with null pointer (It seems weird way but works)
- allocate memory for this size using malloc
- cast it to the designated type