### PR TITLE
Add basic llvm stacktrace support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if (WITH_LLVM)
         find_package(StaticZSTD REQUIRED)
     endif()
 
-    set(LFORTRAN_LLVM_COMPONENTS core support mcjit orcjit native asmparser asmprinter)
+    set(LFORTRAN_LLVM_COMPONENTS core support mcjit orcjit native asmparser asmprinter symbolize object)
     find_package(LLVM REQUIRED)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
     message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -307,7 +307,7 @@ int prompt(bool verbose, CompilerOptions &cu)
             std::cerr << "Internal Compiler Error: Unhandled exception" << std::endl;
             std::vector<LCompilers::StacktraceItem> d = e.stacktrace_addresses();
             get_local_addresses(d);
-            get_llvm_info(d);
+            get_local_info(d);
             std::cerr << stacktrace2str(d, LCompilers::stacktrace_depth);
             std::cerr << e.name() + ": " << e.msg() << std::endl;
             continue;
@@ -2508,11 +2508,7 @@ int main(int argc, char *argv[])
         std::cerr << "Internal Compiler Error: Unhandled exception" << std::endl;
         std::vector<LCompilers::StacktraceItem> d = e.stacktrace_addresses();
         get_local_addresses(d);
-#ifdef HAVE_LFORTRAN_LLVM
-        get_llvm_info(d);
-#else
         get_local_info(d);
-#endif
         std::cerr << stacktrace2str(d, LCompilers::stacktrace_depth);
         std::cerr << e.name() + ": " << e.msg() << std::endl;
         return 1;

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -307,7 +307,7 @@ int prompt(bool verbose, CompilerOptions &cu)
             std::cerr << "Internal Compiler Error: Unhandled exception" << std::endl;
             std::vector<LCompilers::StacktraceItem> d = e.stacktrace_addresses();
             get_local_addresses(d);
-            get_local_info(d);
+            get_llvm_info(d);
             std::cerr << stacktrace2str(d, LCompilers::stacktrace_depth);
             std::cerr << e.name() + ": " << e.msg() << std::endl;
             continue;
@@ -2508,7 +2508,7 @@ int main(int argc, char *argv[])
         std::cerr << "Internal Compiler Error: Unhandled exception" << std::endl;
         std::vector<LCompilers::StacktraceItem> d = e.stacktrace_addresses();
         get_local_addresses(d);
-        get_local_info(d);
+        get_llvm_info(d);
         std::cerr << stacktrace2str(d, LCompilers::stacktrace_depth);
         std::cerr << e.name() + ": " << e.msg() << std::endl;
         return 1;

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2508,7 +2508,11 @@ int main(int argc, char *argv[])
         std::cerr << "Internal Compiler Error: Unhandled exception" << std::endl;
         std::vector<LCompilers::StacktraceItem> d = e.stacktrace_addresses();
         get_local_addresses(d);
+#ifdef HAVE_LFORTRAN_LLVM
         get_llvm_info(d);
+#else
+        get_local_info(d);
+#endif
         std::cerr << stacktrace2str(d, LCompilers::stacktrace_depth);
         std::cerr << e.name() + ": " << e.msg() << std::endl;
         return 1;

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -75,7 +75,6 @@ set(SRC
     asr_utils.cpp
     casting_utils.cpp
     diagnostics.cpp
-    stacktrace.cpp
     string_utils.cpp
     asr_scopes.cpp
     modfile.cpp
@@ -89,6 +88,7 @@ if (WITH_LLVM)
         codegen/asr_to_llvm.cpp
         codegen/llvm_array_utils.cpp
         codegen/llvm_utils.cpp
+        stacktrace.cpp
     )
     # We use deprecated API in LLVM, so we disable the warning until we upgrade
     if (NOT MSVC)
@@ -99,6 +99,8 @@ if (WITH_LLVM)
         set_source_files_properties(codegen/llvm_array_utils.cpp PROPERTIES
             COMPILE_FLAGS -Wno-deprecated-declarations)
         set_source_files_properties(codegen/llvm_utils.cpp PROPERTIES
+            COMPILE_FLAGS -Wno-deprecated-declarations)
+        set_source_files_properties(stacktrace.cpp PROPERTIES
             COMPILE_FLAGS -Wno-deprecated-declarations)
     endif()
 endif()

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SRC
     modfile.cpp
     pickle.cpp
     serialization.cpp
+    stacktrace.cpp
     utils2.cpp
 )
 if (WITH_LLVM)
@@ -88,7 +89,6 @@ if (WITH_LLVM)
         codegen/asr_to_llvm.cpp
         codegen/llvm_array_utils.cpp
         codegen/llvm_utils.cpp
-        stacktrace.cpp
     )
     # We use deprecated API in LLVM, so we disable the warning until we upgrade
     if (NOT MSVC)

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -591,11 +591,7 @@ std::string get_stacktrace(int skip)
 {
   std::vector<StacktraceItem> d = get_stacktrace_addresses();
   get_local_addresses(d);
-#ifdef HAVE_LFORTRAN_LLVM
-    get_llvm_info(d);
-#else
-    get_local_info(d);
-#endif
+  get_local_info(d);
   return stacktrace2str(d, skip);
 }
 
@@ -693,6 +689,9 @@ void get_local_info(std::vector<StacktraceItem> &d)
 #ifdef HAVE_LFORTRAN_DWARFDUMP
   get_local_info_dwarfdump(d);
 #else
+#ifdef HAVE_LFORTRAN_LLVM
+    get_llvm_info(d);
+#else
 #  ifdef HAVE_LFORTRAN_BFD
   bfd_init();
 #  endif
@@ -702,6 +701,7 @@ void get_local_info(std::vector<StacktraceItem> &d)
       d[i].source_filename, d[i].function_name, d[i].line_number);
 #  endif
   }
+#endif // HAVE_LFORTRAN_LLVMJ
 #endif
 }
 
@@ -709,11 +709,7 @@ std::string error_stacktrace(const std::vector<StacktraceItem> &stacktrace)
 {
     std::vector<StacktraceItem> d = stacktrace;
     get_local_addresses(d);
-#ifdef HAVE_LFORTRAN_LLVM
-    get_llvm_info(d);
-#else
     get_local_info(d);
-#endif
     return stacktrace2str(d, stacktrace_depth-1);
 }
 

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -502,6 +502,11 @@ void get_symbol_info_llvm(StacktraceItem &item, llvm::symbolize::LLVMSymbolizer 
   auto binary_file = llvm::object::ObjectFile::createObjectFile(item.binary_filename);
 
   if (!binary_file) {
+#ifdef __APPLE__
+    // This can happen for dynamic libraries in macOS,
+    // like /usr/lib/system/libsystem_c.dylib
+    return;
+#endif
     std::cout << "Cannot open the binary file '" + item.binary_filename + "'\n";
     abort();
   }

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -686,23 +686,21 @@ void get_local_info_dwarfdump(std::vector<StacktraceItem> &d)
 
 void get_local_info(std::vector<StacktraceItem> &d)
 {
-#ifdef HAVE_LFORTRAN_DWARFDUMP
-  get_local_info_dwarfdump(d);
-#else
 #ifdef HAVE_LFORTRAN_LLVM
     get_llvm_info(d);
 #else
-#  ifdef HAVE_LFORTRAN_BFD
+#ifdef HAVE_LFORTRAN_DWARFDUMP
+  get_local_info_dwarfdump(d);
+#else
+#ifdef HAVE_LFORTRAN_BFD
   bfd_init();
-#  endif
   for (size_t i=0; i < d.size(); i++) {
-#  ifdef HAVE_LFORTRAN_BFD
     get_symbol_info_bfd(d[i].binary_filename, d[i].local_pc,
       d[i].source_filename, d[i].function_name, d[i].line_number);
-#  endif
   }
-#endif // HAVE_LFORTRAN_LLVMJ
-#endif
+#endif // HAVE_LFORTRAN_BFD
+#endif // HAVE_LFOTRAN_DWARFDUMP
+#endif // HAVE_LFORTRAN_LLVM
 }
 
 std::string error_stacktrace(const std::vector<StacktraceItem> &stacktrace)

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -3,17 +3,19 @@
 #include <libasr/colors.h>
 #include <libasr/exception.h>
 
-#include <llvm/DebugInfo/Symbolize/Symbolize.h>
-#include <llvm/Support/CommandLine.h>
-#include <llvm/Support/raw_ostream.h>
-#include <llvm/Support/TargetSelect.h>
-#include <llvm/Object/ELFObjectFile.h>
-
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#ifdef HAVE_LFORTRAN_LLVM
+#include <llvm/DebugInfo/Symbolize/Symbolize.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Object/ELFObjectFile.h>
+#endif
 
 // free() and abort() functions
 #include <cstdlib>
@@ -495,6 +497,7 @@ std::string addr2str(const StacktraceItem &i)
   return s.str();
 }
 
+#ifdef HAVE_LFORTRAN_LLVM
 void get_symbol_info_llvm(StacktraceItem &item, llvm::symbolize::LLVMSymbolizer &symbolizer) {
   auto binary_file = llvm::object::ObjectFile::createObjectFile(item.binary_filename);
 
@@ -545,6 +548,7 @@ void get_llvm_info(std::vector<StacktraceItem> &d)
   }
 }
 
+#endif
 
 /*
   Returns a std::string with the stacktrace corresponding to the

--- a/src/libasr/stacktrace.h
+++ b/src/libasr/stacktrace.h
@@ -51,6 +51,8 @@ void get_local_addresses(std::vector<StacktraceItem> &d);
 // `source_filename` and `line_number` if available
 void get_local_info(std::vector<StacktraceItem> &d);
 
+void get_llvm_info(std::vector<StacktraceItem> &d);
+
 // Converts the information stored in `d` into a string
 std::string stacktrace2str(const std::vector<StacktraceItem> &d,
     int skip);


### PR DESCRIPTION
Since stacktraces on Ubuntu are very slow, LLVM stacktraces are being implemented to speed up the Ubuntu implementation,a s well as create a platform independent stacktracer.

More discussion in : #4236 