### PR TITLE
Duplicate functions in interface not raising error #4222

### DIFF
--- a/tests/errors/test_duplicate_module_procedures.f90
+++ b/tests/errors/test_duplicate_module_procedures.f90
@@ -1,0 +1,20 @@
+MODULE input_module
+    implicit none
+    INTERFACE test_interface
+       MODULE PROCEDURE test_01, test_01, test_01
+    END INTERFACE test_interface
+CONTAINS
+
+    SUBROUTINE test_01 (x)
+        implicit none
+        integer , intent(in):: x
+        print *, x
+    END SUBROUTINE test_01
+
+END MODULE input_module
+
+
+PROGRAM main
+    USE input_module
+    CALL test_interface(1)
+END PROGRAM main

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4138,3 +4138,7 @@ run = true
 [[test]]
 filename = "exit2.f90"
 run = true
+
+[[test]]
+name = "test_duplicate_module_procedures"
+path = "errors/test_duplicate_module_procedures.f90"


### PR DESCRIPTION
I have added a test case to check for duplicate module procedure names and registered it in tests.toml.