### PR TITLE
simplifier pass: Apply simplifier pass in passes with optimization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -401,7 +401,7 @@ jobs:
             cd integration_tests
             ./run_tests.py -m
             ./run_tests.py -b llvm
-            # ./run_tests.py -b llvm -f
+            ./run_tests.py -b llvm -f
 
   release:
     name: Check Release build

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -482,7 +482,8 @@ RUN(NAME arrays_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME arrays_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray) # maxloc
 RUN(NAME arrays_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm) # init expr with fixed size arr as dependency
 RUN(NAME arrays_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
-RUN(NAME arrays_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+RUN(NAME arrays_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray NOFAST)
+# RUN(NAME arrays_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME arrays_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME arrays_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -241,8 +241,10 @@ namespace LCompilers {
             };
 
             _with_optimization_passes = {
-                "nested_vars",
                 "global_stmts",
+                "function_call_in_declaration",
+                "simplifier",
+                "nested_vars",
                 "transform_optional_argument_functions",
                 // "init_expr",
                 "openmp",
@@ -250,14 +252,12 @@ namespace LCompilers {
                 "class_constructor",
                 "pass_list_expr",
                 "where",
-                "function_call_in_declaration",
                 "subroutine_from_function",
                 "array_op",
                 "symbolic",
                 "flip_sign",
                 "intrinsic_function",
                 "intrinsic_subroutine",
-                "subroutine_from_function",
                 "array_op",
                 "pass_array_by_data",
                 "print_struct_type",


### PR DESCRIPTION
This also uncomments the previously failing `--fast` integration tests, except one.