### PR TITLE
enh: support fallback to different compiler for linking if one is not found

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1550,6 +1550,22 @@ int compile_to_binary_fortran(const std::string &infile,
     return 0;
 }
 
+void check_compiler_installation(std::string &compiler) {
+    static int counter = 0;
+    if (counter == 2) {
+        std::cerr << "No supported compiler found." << std::endl;
+        return;
+    }
+    
+    counter++;
+    int err = system((compiler + " --version").c_str());
+    if (err) {
+        // Support linking through more compilers
+        compiler = compiler == "clang" ? "gcc" : "clang";
+        check_compiler_installation(compiler);
+    }
+}
+
 // infile is an object file
 // outfile will become the executable
 int link_executable(const std::vector<std::string> &infiles,
@@ -1697,8 +1713,10 @@ int link_executable(const std::vector<std::string> &infiles,
 
             if (link_with_gcc) {
                 CC = "gcc";
+                check_compiler_installation(CC);
             } else {
                 CC = "clang";
+                check_compiler_installation(CC);
             }
 
             char *env_CC = std::getenv("LFORTRAN_CC");

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1558,9 +1558,15 @@ void check_compiler_installation(std::string &compiler) {
     }
     
     counter++;
-    int err = system((compiler + " --version").c_str());
+
+#ifdef _WIN32
+    int err = system((compiler + " --version > NUL 2>&1").c_str());
+#else
+    int err = system((compiler + " --version > /dev/null 2>&1").c_str());
+#endif
+
     if (err) {
-        // Support linking through more compilers
+        // TODO: Support linking through more compilers
         compiler = compiler == "clang" ? "gcc" : "clang";
         check_compiler_installation(compiler);
     }


### PR DESCRIPTION
An example of LFortran switching compilers automatically for linking:

```fortran
program main
   print *, "hello, world!"
end program main
```

```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/example.f90
hello, world!
```

Discussed here: https://lfortran.zulipchat.com/#narrow/stream/197339-General/topic/Issue.20.234261/near/468339547