### PR TITLE
ASR: assign m_value to ComplexToComplex Cast node

### DIFF
--- a/tests/cast_node_m_value.f90
+++ b/tests/cast_node_m_value.f90
@@ -4,11 +4,12 @@
 ! correctly
 program cast_node_m_value
     implicit none
-    real(4) :: i4_to_r4(3) = [1, 2, 3]
-    real(8) :: i4_to_r8(3) = [1, 2, 3]
-    complex(4) :: i4_to_c4(3) = [1, 2, 3]
-    complex(8) :: i4_to_c8(3) = [1, 2, 3]
-    complex(4) :: r4_to_c4(3) = [1., 2., 3.]
-    complex(8) :: r4_to_c8(3) = [1., 2., 3.]
-    integer(1) :: i4_to_i1(3) = [1, 2, 3]
+    real(4), parameter :: i4_to_r4(3) = [1, 2, 3]
+    real(8), parameter :: i4_to_r8(3) = [1, 2, 3]
+    complex(4), parameter :: i4_to_c4(3) = [1, 2, 3]
+    complex(8), parameter :: i4_to_c8(3) = [1, 2, 3]
+    complex(4), parameter :: r4_to_c4(3) = [1., 2., 3.]
+    complex(8), parameter :: r4_to_c8(3) = [1., 2., 3.]
+    integer(1), parameter :: i4_to_i1(3) = [1, 2, 3]
+    complex(8), parameter :: c4_to_c8(3) = [(1.0, 0.0), (2.0, 0.0), (3.0, 0.0)]
 end program cast_node_m_value

--- a/tests/reference/asr-cast_node_m_value-8b7098f.json
+++ b/tests/reference/asr-cast_node_m_value-8b7098f.json
@@ -2,11 +2,11 @@
     "basename": "asr-cast_node_m_value-8b7098f",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/cast_node_m_value.f90",
-    "infile_hash": "ad6bd64908b24838c0ef6c59ab91820cb1f6c047f45d9fd6194c2b61",
+    "infile_hash": "9935456d6f13100b0649b0da43367516a22c1d8d747656cc2e9ac9d3",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cast_node_m_value-8b7098f.stdout",
-    "stdout_hash": "3b4b7e2cd4f9795143171ee8393b1192def52eff5211713cf16f9b78",
+    "stdout_hash": "a11fc0dabceb52910d8bd78c2dd73a4a7ff08bcac90e73087d5fd0fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cast_node_m_value-8b7098f.stdout
+++ b/tests/reference/asr-cast_node_m_value-8b7098f.stdout
@@ -7,6 +7,124 @@
                     (SymbolTable
                         2
                         {
+                            c4_to_c8:
+                                (Variable
+                                    2
+                                    c4_to_c8
+                                    []
+                                    Local
+                                    (Cast
+                                        (ArrayConstructor
+                                            [(ComplexConstructor
+                                                (RealConstant
+                                                    1.000000
+                                                    (Real 4)
+                                                )
+                                                (RealConstant
+                                                    0.000000
+                                                    (Real 4)
+                                                )
+                                                (Complex 4)
+                                                (ComplexConstant
+                                                    1.000000
+                                                    0.000000
+                                                    (Complex 4)
+                                                )
+                                            )
+                                            (ComplexConstructor
+                                                (RealConstant
+                                                    2.000000
+                                                    (Real 4)
+                                                )
+                                                (RealConstant
+                                                    0.000000
+                                                    (Real 4)
+                                                )
+                                                (Complex 4)
+                                                (ComplexConstant
+                                                    2.000000
+                                                    0.000000
+                                                    (Complex 4)
+                                                )
+                                            )
+                                            (ComplexConstructor
+                                                (RealConstant
+                                                    3.000000
+                                                    (Real 4)
+                                                )
+                                                (RealConstant
+                                                    0.000000
+                                                    (Real 4)
+                                                )
+                                                (Complex 4)
+                                                (ComplexConstant
+                                                    3.000000
+                                                    0.000000
+                                                    (Complex 4)
+                                                )
+                                            )]
+                                            (Array
+                                                (Complex 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            (ArrayConstant
+                                                12
+                                                [(1.00000000e+00, 0.00000000e+00), (2.00000000e+00, 0.00000000e+00), (3.00000000e+00, 0.00000000e+00)]
+                                                (Array
+                                                    (Complex 4)
+                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                    (IntegerConstant 3 (Integer 4) Decimal))]
+                                                    FixedSizeArray
+                                                )
+                                                ColMajor
+                                            )
+                                            ColMajor
+                                        )
+                                        ComplexToComplex
+                                        (Array
+                                            (Complex 8)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 3 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        (ArrayConstant
+                                            24
+                                            [(1.0000000000000000e+00, 0.0000000000000000e+00), (2.0000000000000000e+00, 0.0000000000000000e+00), (3.0000000000000000e+00, 0.0000000000000000e+00)]
+                                            (Array
+                                                (Complex 8)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        )
+                                    )
+                                    (ArrayConstant
+                                        24
+                                        [(1.0000000000000000e+00, 0.0000000000000000e+00), (2.0000000000000000e+00, 0.0000000000000000e+00), (3.0000000000000000e+00, 0.0000000000000000e+00)]
+                                        (Array
+                                            (Complex 8)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 3 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ColMajor
+                                    )
+                                    Parameter
+                                    (Array
+                                        (Complex 8)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
                             i4_to_c4:
                                 (Variable
                                     2
@@ -55,7 +173,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Complex 4)
                                         [((IntegerConstant 1 (Integer 4) Decimal)
@@ -116,7 +234,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Complex 8)
                                         [((IntegerConstant 1 (Integer 4) Decimal)
@@ -177,7 +295,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Integer 1)
                                         [((IntegerConstant 1 (Integer 4) Decimal)
@@ -238,7 +356,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Real 4)
                                         [((IntegerConstant 1 (Integer 4) Decimal)
@@ -299,7 +417,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Real 8)
                                         [((IntegerConstant 1 (Integer 4) Decimal)
@@ -360,7 +478,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Complex 4)
                                         [((IntegerConstant 1 (Integer 4) Decimal)
@@ -421,7 +539,7 @@
                                         )
                                         ColMajor
                                     )
-                                    Save
+                                    Parameter
                                     (Array
                                         (Complex 8)
                                         [((IntegerConstant 1 (Integer 4) Decimal)


### PR DESCRIPTION
## Description of changes
Following the changes in https://github.com/lfortran/lfortran/pull/4778, this probably got missed. I noticed this while trying to see, which ASR nodes have non-nullptr `m_symbolic_value`, while `m_value` is nullptr, and I noticed this case.

Also, I made all the variables as parameters, ensuring that the m_value is set  at compile-time.