### PR TITLE
ASR: fix ArrayReshape ttype

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5199,40 +5199,43 @@ public:
 
     ASR::asr_t* create_ArrayReshape(const AST::FuncCallOrArray_t& x) {
         if( x.n_args != 2 ) {
-             throw SemanticError("reshape accepts only 2 arguments, got " +
-                                 std::to_string(x.n_args) + " arguments instead.",
-                                 x.base.base.loc);
-         }
-         this->visit_expr(*x.m_args[0].m_end);
-         ASR::expr_t* array = ASRUtils::EXPR(tmp);
-         this->visit_expr(*x.m_args[1].m_end);
-         ASR::expr_t* newshape = ASRUtils::EXPR(tmp);
-         if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
-             throw SemanticError("reshape only accept arrays for shape "
-                                 "arguments, found " +
-                                 ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
-                                 " instead.",
-                                 x.base.base.loc);
-         }
-         Vec<ASR::dimension_t> dims;
-         dims.reserve(al, 1);
-         ASR::dimension_t newdim;
-         newdim.loc = x.base.base.loc;
-         newdim.m_start = nullptr, newdim.m_length = nullptr;
-         dims.push_back(al, newdim);
-         ASR::ttype_t* empty_type = nullptr;
-         ASR::array_physical_typeType array_physical_type = ASRUtils::extract_physical_type(
-                                                                ASRUtils::expr_type(array));
-         if( array_physical_type == ASR::array_physical_typeType::FixedSizeArray ) {
+            throw SemanticError("reshape accepts only 2 arguments, got " +
+                                std::to_string(x.n_args) + " arguments instead.",
+                                x.base.base.loc);
+        }
+        this->visit_expr(*x.m_args[0].m_end);
+        ASR::expr_t* array = ASRUtils::EXPR(tmp);
+        this->visit_expr(*x.m_args[1].m_end);
+        ASR::expr_t* newshape = ASRUtils::EXPR(tmp);
+        if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
+            throw SemanticError("reshape only accept arrays for shape "
+                "arguments, found " +
+                ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
+                " instead.", x.base.base.loc);
+        }
+        Vec<ASR::dimension_t> dims;
+        dims.reserve(al, 1);
+        ASR::dimension_t newdim;
+        newdim.loc = x.base.base.loc;
+        newdim.m_start = nullptr, newdim.m_length = nullptr;
+        dims.push_back(al, newdim);
+        ASR::ttype_t* empty_type = nullptr;
+        ASR::array_physical_typeType array_physical_type = ASRUtils::extract_physical_type(
+                                                            ASRUtils::expr_type(array));
+        if( array_physical_type == ASR::array_physical_typeType::FixedSizeArray ) {
             empty_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(
                             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(array))),
                             &dims, array_physical_type, true);
-         } else {
-            empty_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(
-                            ASRUtils::type_get_past_pointer(ASRUtils::expr_type(array))), &dims);
-         }
-         newshape = ASRUtils::cast_to_descriptor(al, newshape);
-         return ASR::make_ArrayReshape_t(al, x.base.base.loc, array, newshape, empty_type, nullptr);
+        } else {
+            ASR::Array_t* newshape_array_type = ASR::down_cast<ASR::Array_t>(ASRUtils::expr_type(newshape));
+            size_t newshape_dims = ASR::down_cast<ASR::IntegerConstant_t>(newshape_array_type->m_dims[0].m_length)->m_n;
+            ASR::ttype_t* arr_element_type = ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(array));
+            ASR::ttype_t* reshape_ttype = ASRUtils::TYPE(ASR::make_Array_t(al, arr_element_type->base.loc, arr_element_type,
+                                            nullptr, newshape_dims, ASR::array_physical_typeType::FixedSizeArray));
+            empty_type = ASRUtils::duplicate_type_with_empty_dims(al, reshape_ttype);
+        }
+        newshape = ASRUtils::cast_to_descriptor(al, newshape);
+        return ASR::make_ArrayReshape_t(al, x.base.base.loc, array, newshape, empty_type, nullptr);
     }
 
     ASR::asr_t* create_BitCast(const AST::FuncCallOrArray_t& x) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5213,31 +5213,54 @@ public:
                 ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
                 " instead.", x.base.base.loc);
         }
-        Vec<ASR::dimension_t> dims;
-        dims.reserve(al, 1);
-        ASR::dimension_t newdim;
-        newdim.loc = x.base.base.loc;
-        newdim.m_start = nullptr, newdim.m_length = nullptr;
-        dims.push_back(al, newdim);
-        ASR::ttype_t* empty_type = nullptr;
         ASR::array_physical_typeType array_physical_type = ASRUtils::extract_physical_type(
                                                             ASRUtils::expr_type(array));
 
+        // the size (i.e. number of elements) of 'newshape' array determines
+        // the dimension size of 'ArrayReshape'
         ASR::Array_t* newshape_array_type = ASR::down_cast<ASR::Array_t>(ASRUtils::expr_type(newshape));
         size_t newshape_dims = ASR::down_cast<ASR::IntegerConstant_t>(newshape_array_type->m_dims[0].m_length)->m_n;
         ASR::ttype_t* arr_element_type = ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(array));
+
         ASR::ttype_t* reshape_ttype = ASRUtils::TYPE(ASR::make_Array_t(al, arr_element_type->base.loc, arr_element_type,
-                                        nullptr, newshape_dims, ASR::array_physical_typeType::FixedSizeArray));
-        if( array_physical_type == ASR::array_physical_typeType::FixedSizeArray ) {
-            empty_type = ASRUtils::duplicate_type_with_empty_dims(al, reshape_ttype, array_physical_type, true);
-            // empty_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(
-            //                 ASRUtils::type_get_past_pointer(ASRUtils::expr_type(array))),
-            //                 &dims, array_physical_type, true);
+                                                    nullptr, newshape_dims, ASR::array_physical_typeType::FixedSizeArray));
+
+        size_t n_dims_array_reshape = ASRUtils::extract_n_dims_from_ttype(reshape_ttype);
+
+        Vec<ASR::dimension_t> dims;
+        dims.reserve(al, n_dims_array_reshape);
+
+        Location loc = newshape->base.loc;
+        // if 'newshape' is an ArrayConstant, then assign all of it's
+        // elements as dimensions
+        if (ASR::is_a<ASR::ArrayConstant_t>(*newshape)) {
+            ASR::ArrayConstant_t* const_newshape = ASR::down_cast<ASR::ArrayConstant_t>(newshape);
+            ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
+            for (size_t i=0; i < n_dims_array_reshape; i++) {
+                ASR::dimension_t dim;
+                dim.loc = loc;
+                dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int_type));
+                dim.m_length = ASRUtils::fetch_ArrayConstant_value(al, const_newshape, i);
+                dims.push_back(al, dim);
+            }
         } else {
-            empty_type = ASRUtils::duplicate_type_with_empty_dims(al, reshape_ttype);
+            // otherwise empty dimensions
+            dims.reserve(al, n_dims_array_reshape);
+            for (size_t i=0; i < n_dims_array_reshape; i++) {
+                ASR::dimension_t dim;
+                dim.loc = loc;
+                dim.m_start = nullptr;
+                dim.m_length = nullptr;
+                dims.push_back(al, dim);
+            }
         }
+
+        reshape_ttype = ASRUtils::duplicate_type(al, reshape_ttype, &dims, array_physical_type, true);
         newshape = ASRUtils::cast_to_descriptor(al, newshape);
-        return ASR::make_ArrayReshape_t(al, x.base.base.loc, array, newshape, empty_type, nullptr);
+        // TODO: 'value' is assigned as nullptr always to ArrayReshape, when both
+        // 'array' and 'newshape' are ArrayConstant's we can set 'value'
+        // as well
+        return ASR::make_ArrayReshape_t(al, x.base.base.loc, array, newshape, reshape_ttype, nullptr);
     }
 
     ASR::asr_t* create_BitCast(const AST::FuncCallOrArray_t& x) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5222,16 +5222,18 @@ public:
         ASR::ttype_t* empty_type = nullptr;
         ASR::array_physical_typeType array_physical_type = ASRUtils::extract_physical_type(
                                                             ASRUtils::expr_type(array));
+
+        ASR::Array_t* newshape_array_type = ASR::down_cast<ASR::Array_t>(ASRUtils::expr_type(newshape));
+        size_t newshape_dims = ASR::down_cast<ASR::IntegerConstant_t>(newshape_array_type->m_dims[0].m_length)->m_n;
+        ASR::ttype_t* arr_element_type = ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(array));
+        ASR::ttype_t* reshape_ttype = ASRUtils::TYPE(ASR::make_Array_t(al, arr_element_type->base.loc, arr_element_type,
+                                        nullptr, newshape_dims, ASR::array_physical_typeType::FixedSizeArray));
         if( array_physical_type == ASR::array_physical_typeType::FixedSizeArray ) {
-            empty_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(
-                            ASRUtils::type_get_past_pointer(ASRUtils::expr_type(array))),
-                            &dims, array_physical_type, true);
+            empty_type = ASRUtils::duplicate_type_with_empty_dims(al, reshape_ttype, array_physical_type, true);
+            // empty_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(
+            //                 ASRUtils::type_get_past_pointer(ASRUtils::expr_type(array))),
+            //                 &dims, array_physical_type, true);
         } else {
-            ASR::Array_t* newshape_array_type = ASR::down_cast<ASR::Array_t>(ASRUtils::expr_type(newshape));
-            size_t newshape_dims = ASR::down_cast<ASR::IntegerConstant_t>(newshape_array_type->m_dims[0].m_length)->m_n;
-            ASR::ttype_t* arr_element_type = ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(array));
-            ASR::ttype_t* reshape_ttype = ASRUtils::TYPE(ASR::make_Array_t(al, arr_element_type->base.loc, arr_element_type,
-                                            nullptr, newshape_dims, ASR::array_physical_typeType::FixedSizeArray));
             empty_type = ASRUtils::duplicate_type_with_empty_dims(al, reshape_ttype);
         }
         newshape = ASRUtils::cast_to_descriptor(al, newshape);

--- a/tests/reference/asr-arrays_reshape_14-913f34e.json
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_reshape_14-913f34e.stdout",
-    "stdout_hash": "ce1282b78ae62401d0958a74d8397b82449b1e1df94df22774f143de",
+    "stdout_hash": "4fbc2c71134ce745782b3b1aef8d578144dea24868a903049fa37c04",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_reshape_14-913f34e.json
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_reshape_14-913f34e.stdout",
-    "stdout_hash": "ef3b06bfcbddabb9e99fcdd2c19c5583a3cf2ad995a922d6b9824334",
+    "stdout_hash": "ddb46a68bca4b899eec5e6ea3d47fba8a92a37d82fc6b9455fc2d362",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_reshape_14-913f34e.json
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_reshape_14-913f34e.stdout",
-    "stdout_hash": "4fbc2c71134ce745782b3b1aef8d578144dea24868a903049fa37c04",
+    "stdout_hash": "ef3b06bfcbddabb9e99fcdd2c19c5583a3cf2ad995a922d6b9824334",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_reshape_14-913f34e.stdout
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.stdout
@@ -620,6 +620,10 @@
                                             (Array
                                                 (Real 8)
                                                 [(()
+                                                ())
+                                                (()
+                                                ())
+                                                (()
                                                 ())]
                                                 DescriptorArray
                                             )

--- a/tests/reference/asr-arrays_reshape_14-913f34e.stdout
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.stdout
@@ -50,6 +50,8 @@
                                         (Array
                                             (Integer 4)
                                             [(()
+                                            ())
+                                            (()
                                             ())]
                                             FixedSizeArray
                                         )
@@ -458,6 +460,8 @@
                                             (Array
                                                 (Real 8)
                                                 [(()
+                                                ())
+                                                (()
                                                 ())]
                                                 FixedSizeArray
                                             )

--- a/tests/reference/asr-arrays_reshape_14-913f34e.stdout
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.stdout
@@ -49,10 +49,10 @@
                                         )
                                         (Array
                                             (Integer 4)
-                                            [(()
-                                            ())
-                                            (()
-                                            ())]
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))
+                                            ((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 3 (Integer 4) Decimal))]
                                             FixedSizeArray
                                         )
                                         ()

--- a/tests/reference/asr-implied_do_loops2-98464d0.json
+++ b/tests/reference/asr-implied_do_loops2-98464d0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implied_do_loops2-98464d0.stdout",
-    "stdout_hash": "fe3c479b468b335877ff167975019a2d00d21831583e17d9daf60a0f",
+    "stdout_hash": "6e6d3fb41bda36d22dca98f846e8a0072c60e9006e398a3a31ed3400",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implied_do_loops2-98464d0.json
+++ b/tests/reference/asr-implied_do_loops2-98464d0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implied_do_loops2-98464d0.stdout",
-    "stdout_hash": "6e6d3fb41bda36d22dca98f846e8a0072c60e9006e398a3a31ed3400",
+    "stdout_hash": "34b76fa0f18a53cd0d4d00c893cf301d099e6c0b292864d2dc175228",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implied_do_loops2-98464d0.stdout
+++ b/tests/reference/asr-implied_do_loops2-98464d0.stdout
@@ -146,10 +146,10 @@
                             )
                             (Array
                                 (Integer 4)
-                                [(()
-                                ())
-                                (()
-                                ())]
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 3 (Integer 4) Decimal))
+                                ((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 5 (Integer 4) Decimal))]
                                 DescriptorArray
                             )
                             ()

--- a/tests/reference/asr-implied_do_loops2-98464d0.stdout
+++ b/tests/reference/asr-implied_do_loops2-98464d0.stdout
@@ -147,6 +147,8 @@
                             (Array
                                 (Integer 4)
                                 [(()
+                                ())
+                                (()
                                 ())]
                                 DescriptorArray
                             )

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.json
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matrix_01_transpose-fb3276a.stdout",
-    "stdout_hash": "264edb97bd2134c4daca750b1b5d307082152455724ef7568c37ad4c",
+    "stdout_hash": "b45496b71ccc6ac6c3c21c29325b3923687e89a5c424dd471c195a42",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.json
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matrix_01_transpose-fb3276a.stdout",
-    "stdout_hash": "b45496b71ccc6ac6c3c21c29325b3923687e89a5c424dd471c195a42",
+    "stdout_hash": "1e5de84254256cb4341d5cd67134055575a66223c4a7f06b4e3a2536",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
@@ -311,6 +311,8 @@
                             (Array
                                 (Integer 4)
                                 [(()
+                                ())
+                                (()
                                 ())]
                                 FixedSizeArray
                             )
@@ -464,6 +466,8 @@
                                 (Array
                                     (Integer 4)
                                     [(()
+                                    ())
+                                    (()
                                     ())]
                                     FixedSizeArray
                                 )
@@ -643,6 +647,8 @@
                                 (Array
                                     (Integer 4)
                                     [(()
+                                    ())
+                                    (()
                                     ())]
                                     FixedSizeArray
                                 )
@@ -878,6 +884,8 @@
                             (Array
                                 (Complex 4)
                                 [(()
+                                ())
+                                (()
                                 ())]
                                 FixedSizeArray
                             )

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
@@ -310,10 +310,10 @@
                             )
                             (Array
                                 (Integer 4)
-                                [(()
-                                ())
-                                (()
-                                ())]
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 3 (Integer 4) Decimal))
+                                ((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 4 (Integer 4) Decimal))]
                                 FixedSizeArray
                             )
                             ()
@@ -465,10 +465,10 @@
                                 )
                                 (Array
                                     (Integer 4)
-                                    [(()
-                                    ())
-                                    (()
-                                    ())]
+                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 5 (Integer 4) Decimal))
+                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 5 (Integer 4) Decimal))]
                                     FixedSizeArray
                                 )
                                 ()
@@ -646,10 +646,10 @@
                                 )
                                 (Array
                                     (Integer 4)
-                                    [(()
-                                    ())
-                                    (()
-                                    ())]
+                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 1 (Integer 4) Decimal))
+                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 2 (Integer 4) Decimal))]
                                     FixedSizeArray
                                 )
                                 ()
@@ -883,10 +883,10 @@
                             )
                             (Array
                                 (Complex 4)
-                                [(()
-                                ())
-                                (()
-                                ())]
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 2 (Integer 4) Decimal))
+                                ((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 2 (Integer 4) Decimal))]
                                 FixedSizeArray
                             )
                             ()


### PR DESCRIPTION
I made a similar PR against the *simplifier pass* branch, where it causes segmentation fault on a few of the cases on Linux (but not on macOS).

Let me know if there are more extra test cases needed for this.