### PR TITLE
enh: add support for reporting errors during LLVM IR execution

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1057,7 +1057,7 @@ int compile_llvm_to_object_file(const std::string& infile,
     std::string input = read_file(infile);
     LCompilers::LLVMEvaluator e(compiler_options.target);
 
-    std::unique_ptr<LCompilers::LLVMModule> m = e.parse_module2(input);
+    std::unique_ptr<LCompilers::LLVMModule> m = e.parse_module2(input, infile);
     e.save_object_file(*(m->m_m), outfile);
 
     return 0;

--- a/src/lfortran/tests/ir.ll
+++ b/src/lfortran/tests/ir.ll
@@ -1,0 +1,33 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %a = alloca i32, align 4
+  %b = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a1 = alloca i32, align 4
+  %b2 = alloca i32, align 4
+  store i64 1, i32* %a1, align 4
+  store i32 2, i32* %b2, align 4
+  %2 = load i32, i32* %a1, align 4
+  %3 = load i32, i32* %b2, align 4
+  %4 = add i32 %2, %3
+  %5 = sext i32 %4 to i64
+  %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %5)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_printf(i8*, ...)

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1312,6 +1312,12 @@ end function sub
     CHECK(r.result.f32 == -1.0);
 }
 
+TEST_CASE("llvm ir 1") {
+    LCompilers::LLVMEvaluator e;
+    CHECK_THROWS_AS(e.parse_module2("", "src/lfortran/tests/ir.ll"), LCompilers::LCompilersException);
+    CHECK_THROWS_WITH(e.parse_module2("", "src/lfortran/tests/ir.ll"), "parse_module(): Invalid LLVM IR");
+}
+
 // This test does not work on Windows yet
 // https://github.com/lfortran/lfortran/issues/913
 #if !defined(_WIN32)

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -245,7 +245,7 @@ std::unique_ptr<llvm::Module> LLVMEvaluator::parse_module(const std::string &sou
     }
     if (!module) {
         err.print("", llvm::errs());
-        std::exit(1);
+        throw LCompilersException("parse_module(): Invalid LLVM IR");
     }
     bool v = llvm::verifyModule(*module);
     if (v) {

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -234,13 +234,18 @@ LLVMEvaluator::~LLVMEvaluator()
     context.reset();
 }
 
-std::unique_ptr<llvm::Module> LLVMEvaluator::parse_module(const std::string &source)
+std::unique_ptr<llvm::Module> LLVMEvaluator::parse_module(const std::string &source, const std::string &filename="")
 {
     llvm::SMDiagnostic err;
-    std::unique_ptr<llvm::Module> module
-        = llvm::parseAssemblyString(source, err, *context);
+    std::unique_ptr<llvm::Module> module;
+    if (!filename.empty()) {
+        module = llvm::parseAssemblyFile(filename, err, *context);
+    } else {
+        module = llvm::parseAssemblyString(source, err, *context);
+    }
     if (!module) {
-        throw LCompilersException("parse_module(): Invalid LLVM IR");
+        err.print("", llvm::errs());
+        std::exit(1);
     }
     bool v = llvm::verifyModule(*module);
     if (v) {
@@ -251,8 +256,8 @@ std::unique_ptr<llvm::Module> LLVMEvaluator::parse_module(const std::string &sou
     return module;
 }
 
-std::unique_ptr<LLVMModule> LLVMEvaluator::parse_module2(const std::string &source) {
-    return std::make_unique<LLVMModule>(parse_module(source));
+std::unique_ptr<LLVMModule> LLVMEvaluator::parse_module2(const std::string &source, const std::string &filename="") {
+    return std::make_unique<LLVMModule>(parse_module(source, filename));
 }
 
 void LLVMEvaluator::add_module(const std::string &source) {

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -65,8 +65,8 @@ private:
 public:
     LLVMEvaluator(const std::string &t = "");
     ~LLVMEvaluator();
-    std::unique_ptr<llvm::Module> parse_module(const std::string &source);
-    std::unique_ptr<LLVMModule> parse_module2(const std::string &source);
+    std::unique_ptr<llvm::Module> parse_module(const std::string &source, const std::string &filename);
+    std::unique_ptr<LLVMModule> parse_module2(const std::string &source, const std::string &filename);
     void add_module(const std::string &source);
     void add_module(std::unique_ptr<llvm::Module> mod);
     void add_module(std::unique_ptr<LLVMModule> m);


### PR DESCRIPTION
resolves #4790 

```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ lfortran ./examples/ir.ll
./examples/ir.ll:15:9: error: stored value and pointer type do not match
  store i64 1, i32* %a1, align 4
        ^
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  Binary file "/home/saurabh-kumar/Projects/System/lfortran/src/bin/lfortran", in _start
  File "./csu/../csu/libc-start.c", line 360, in __libc_start_main
  File "./csu/../sysdeps/nptl/libc_start_call_main.h", line 58, in __libc_start_call_main
  File "/home/saurabh-kumar/Projects/System/lfortran/src/bin/lfortran.cpp", line 2624, in main
    return main_app(argc, argv);
  File "/home/saurabh-kumar/Projects/System/lfortran/src/bin/lfortran.cpp", line 2599, in main_app(int, char**)
    err = compile_llvm_to_object_file(arg_file, tmp_o, compiler_options);
  File "/home/saurabh-kumar/Projects/System/lfortran/src/bin/lfortran.cpp", line 1060, in (anonymous namespace)::compile_llvm_to_object_file(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, LCompilers::CompilerOptions&)
    std::unique_ptr<LCompilers::LLVMModule> m = e.parse_module2(input, infile);
  File "/home/saurabh-kumar/Projects/System/lfortran/src/libasr/codegen/evaluator.cpp", line 260, in LCompilers::LLVMEvaluator::parse_module2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    return std::make_unique<LLVMModule>(parse_module(source, filename));
LCompilersException: parse_module(): Invalid LLVM IR
```