### PR TITLE
enh: Refine OpenMP Test to Confirm Thread Load Balancing

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1772,6 +1772,7 @@ RUN(NAME openmp_30 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # matmul
 RUN(NAME openmp_31 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_32 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_33 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # mandelbrot
+RUN(NAME openmp_34 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # Ensure uniform load distribution over threads
 
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 

--- a/integration_tests/openmp_01.f90
+++ b/integration_tests/openmp_01.f90
@@ -1,22 +1,25 @@
 subroutine omp_func(n)
+    use omp_lib
 implicit none
 integer, intent(in) :: n
 integer :: i
-
-!$omp parallel private(i) shared(n)
+call omp_set_num_threads(5)
+!$omp parallel  private(i) shared(n)
 !$omp do
 do i = 1, n
+    !omp critical
+    print *,omp_get_thread_num()
     print *, "xyz"
 end do
 !$omp end do
 !$omp end parallel
 
 print *, "n = ", n
-if (n /= 100) error stop
+if (n /= 10) error stop
 end subroutine
 
 program openmp_01
-integer, parameter :: n = 100
+integer, parameter :: n = 10
 call omp_func(n)
 print *, "Done for n = ", n
 end program

--- a/integration_tests/openmp_34.f90
+++ b/integration_tests/openmp_34.f90
@@ -1,22 +1,25 @@
 subroutine omp_func(n)
+    use omp_lib
 implicit none
 integer, intent(in) :: n
 integer :: i
-
-!$omp parallel private(i) shared(n)
+call omp_set_num_threads(5)
+!$omp parallel  private(i) shared(n)
 !$omp do
 do i = 1, n
+    !omp critical
+    print *,omp_get_thread_num()
     print *, "xyz"
 end do
 !$omp end do
 !$omp end parallel
 
 print *, "n = ", n
-if (n /= 100) error stop
+if (n /= 10) error stop
 end subroutine
 
 program openmp_01
-integer, parameter :: n = 100
+integer, parameter :: n = 10
 call omp_func(n)
 print *, "Done for n = ", n
 end program

--- a/integration_tests/openmp_34.f90
+++ b/integration_tests/openmp_34.f90
@@ -18,7 +18,7 @@ print *, "n = ", n
 if (n /= 10) error stop
 end subroutine
 
-program openmp_01
+program openmp_34
 integer, parameter :: n = 10
 call omp_func(n)
 print *, "Done for n = ", n


### PR DESCRIPTION
Thread IDs are now shown to confirm active threads and ensure even distribution of iterations. The output will display "xyz" printed 10 times, with each thread ID appearing twice, indicating that the 10 iterations are evenly distributed among 5 threads.
```shell
(lf2) aditya-trivedi@Observer:~/thats_me/Main_Repo$ ./lfortran/src/bin/lfortran --openmp --link-with-gcc ./lfortran/integration_tests/openmp_01.f90 -o a --openmp-lib-dir=${CONDA_PREFIX}/lib && ./a
0
xyz
2
xyz
2
3
xyz
3
xyz
1
xyz
1
xyz
4
xyz
xyz
0
xyz
4
xyz
n =     10
Done for n =     10
``` 