### PR TITLE
parser: allow MODULE statement in fixed form parser

### DIFF
--- a/tests/fixedform_module.f
+++ b/tests/fixedform_module.f
@@ -1,0 +1,6 @@
+        MODULE E
+        END MODULE E
+
+        PROGRAM MAIN
+        IMPLICIT NONE
+        END PROGRAM MAIN

--- a/tests/reference/ast-fixedform_module-3f800f0.json
+++ b/tests/reference/ast-fixedform_module-3f800f0.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixedform_module-3f800f0",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/fixedform_module.f",
+    "infile_hash": "032fb00debb25bd84eafae8de804901f317da59470d4206d18b7fad0",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "ast-fixedform_module-3f800f0.stdout",
+    "stdout_hash": "2dc542642992285eb91bbfb115fcac0fdfbced5aa5f5e9fda8f7de40",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/ast-fixedform_module-3f800f0.stdout
+++ b/tests/reference/ast-fixedform_module-3f800f0.stdout
@@ -1,0 +1,23 @@
+(TranslationUnit
+    [(Module
+        e
+        ()
+        []
+        []
+        []
+        []
+        []
+    )
+    (Program
+        main
+        ()
+        []
+        [(ImplicitNone
+            []
+            ()
+        )]
+        []
+        []
+        []
+    )]
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2679,6 +2679,10 @@ filename = "fixedform_data.f"
 ast = true
 
 [[test]]
+filename = "fixedform_module.f"
+ast = true
+
+[[test]]
 filename = "../integration_tests/format_03.f"
 ast = true
 


### PR DESCRIPTION
This will take us a little forward in the direction of being able to [compile POT3D](https://github.com/lfortran/lfortran/issues/2862).