### PR TITLE
simplifier pass: convert initialization to assignment in the same scope as initialization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -366,7 +366,7 @@ RUN(NAME subroutines_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm llvm1
 RUN(NAME subroutines_09 LABELS gfortran llvm)
 RUN(NAME subroutines_10 LABELS gfortran)
 RUN(NAME subroutines_11 LABELS gfortran llvm llvm17)
-# RUN(NAME subroutines_12 LABELS gfortran llvm llvm17)
+RUN(NAME subroutines_12 LABELS gfortran llvm llvm17)
 RUN(NAME subroutines_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 
 RUN(NAME functions_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm llvm17)

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1723,11 +1723,11 @@ class TransformVariableInitialiser:
 
         ASR::Variable_t& xx = const_cast<ASR::Variable_t&>(x);
         if( x.m_symbolic_value) {
-            if( symtab2decls.find(current_scope) == symtab2decls.end() ) {
+            if( symtab2decls.find(x.m_parent_symtab) == symtab2decls.end() ) {
                 Vec<ASR::stmt_t*> result_vec; result_vec.reserve(al, 1);
-                symtab2decls[current_scope] = result_vec;
+                symtab2decls[x.m_parent_symtab] = result_vec;
             }
-            Vec<ASR::stmt_t*>& result_vec = symtab2decls[current_scope];
+            Vec<ASR::stmt_t*>& result_vec = symtab2decls[x.m_parent_symtab];
             ASR::expr_t* target = ASRUtils::EXPR(ASR::make_Var_t(al, loc, &(xx.base)));
 
             // if `m_value` is present, then use that for converting it into


### PR DESCRIPTION
### On *simplifier pass* branch

We convert variable initilization to assignment in all of the scopes where the variable is present. E.g; below is the output of *simplifier pass* branch for `subroutines_12.f90`:
```f90
! Fortran code after applying the pass: simplifier
program subroutines_12
    implicit none
    integer(4), save :: nang ! initialized in `subroutines_12.f90` as `nang = 2`, but un-initialized now
call my_subroutine()

contains

subroutine my_subroutine()
    integer(4), dimension(nang) :: fxhv
    nang = 2 ! initilized here in this scope, where it's used
end subroutine my_subroutine

end program subroutines_12


```

### On *this* branch

```f90
! Fortran code after applying the pass: simplifier
program subroutines_12
    implicit none
    integer(4), save :: nang ! in `subroutines_12.f90` it's nang = 2 at initialization
    nang = 2 ! convert to assignment in the original scope on this branch, where the variable is initialized originally
call my_subroutine()

contains

subroutine my_subroutine()
    integer(4), dimension(nang) :: fxhv
end subroutine my_subroutine

end program subroutines_12
```