### PR TITLE
uncomment passing tests

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1445,8 +1445,8 @@ RUN(NAME template_interface_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm llvm17)
 RUN(NAME statement1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 
 RUN(NAME implied_do_loops1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-# RUN(NAME implied_do_loops2 LABELS gfortran)
-# RUN(NAME implied_do_loops3 LABELS gfortran)
+RUN(NAME implied_do_loops2 LABELS gfortran)
+RUN(NAME implied_do_loops3 LABELS gfortran)
 RUN(NAME implied_do_loops4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME implied_do_loops5 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 


### PR DESCRIPTION
I didn't notice that on *main*, we only have compilation of *gfortran* label. So, this shouldn't be a problem anyways.