### PR TITLE
fix: do ASR verification conditionally for `ExternalSymbol` in `ArraySize`

### DIFF
--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -873,8 +873,10 @@ public:
     }
 
     void visit_ArraySize(const ArraySize_t& x) {
-        require(ASRUtils::is_array(ASRUtils::expr_type(x.m_v)),
-            "ArraySize::m_v must be an array");
+        if (check_external) {
+            require(ASRUtils::is_array(ASRUtils::expr_type(x.m_v)),
+                "ArraySize::m_v must be an array");
+        }
         BaseWalkVisitor<VerifyVisitor>::visit_ArraySize(x);
     }
 


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/4738#issuecomment-2355830539

```console
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran/integration_tests$ lfortran -c modules_58_module.f90
(lf) saurabh-kumar@Awadh:~/Projects/System/lfortran/integration_tests$ lfortran modules_58.f90
Size of nx1    555
Size of nx2    1000
555
```