### PR TITLE
feat: duplicate return type before setting in function call

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4429,7 +4429,9 @@ public:
                             ASRUtils::get_FunctionType(func)->m_return_var_type,
                             &new_dims);
         } else {
+            ASRUtils::ExprStmtWithScopeDuplicator node_duplicator(al, current_scope);
             type = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
+            type = node_duplicator.duplicate_ttype(type);
         }
         if (ASRUtils::symbol_parent_symtab(v)->get_counter() != current_scope->get_counter()) {
             ADD_ASR_DEPENDENCIES(current_scope, v, current_function_dependencies);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3898,6 +3898,20 @@ class ExprStmtDuplicator: public ASR::BaseExprStmtDuplicator<ExprStmtDuplicator>
 
 };
 
+class ExprStmtWithScopeDuplicator: public ASR::BaseExprStmtDuplicator<ExprStmtWithScopeDuplicator>
+{
+    public:
+    SymbolTable* current_scope;
+    ExprStmtWithScopeDuplicator(Allocator &al, SymbolTable* current_scope): BaseExprStmtDuplicator(al), current_scope(current_scope) {}
+
+    ASR::asr_t* duplicate_Var(ASR::Var_t* x) {
+        ASR::symbol_t* m_v = current_scope->get_symbol(ASRUtils::symbol_name(x->m_v));
+        LCOMPILERS_ASSERT(m_v != nullptr);
+        return ASR::make_Var_t(al, x->base.base.loc, m_v);
+    }
+
+};
+
 class FixScopedTypeVisitor: public ASR::BaseExprReplacer<FixScopedTypeVisitor> {
 
     private:

--- a/tests/function_call1.f90
+++ b/tests/function_call1.f90
@@ -1,0 +1,20 @@
+module module_function_call1
+    type :: softmax
+    contains
+      procedure :: eval_1d
+    end type softmax
+  contains
+  
+    pure function eval_1d(self, x) result(res)
+      class(softmax), intent(in) :: self
+      real, intent(in) :: x(:)
+      real :: res(size(x))
+    end function eval_1d
+  
+    pure function eval_1d_prime(self, x) result(res)
+      class(softmax), intent(in) :: self
+      real, intent(in) :: x(:)
+      real :: res(size(x))
+      res = self%eval_1d(x)
+    end function eval_1d_prime
+end module module_function_call1

--- a/tests/reference/asr-function_call1-0b992da.json
+++ b/tests/reference/asr-function_call1-0b992da.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-function_call1-0b992da",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/function_call1.f90",
+    "infile_hash": "45acf463b1d977f1bdf3d9420205c7979fc03de58d60260cb37fd0bc",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-function_call1-0b992da.stdout",
+    "stdout_hash": "89c81f91c55a5e0f143505b6baacd542695ca9212096d701373c7773",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-function_call1-0b992da.stdout
+++ b/tests/reference/asr-function_call1-0b992da.stdout
@@ -1,0 +1,334 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            module_function_call1:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            eval_1d:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            res:
+                                                (Variable
+                                                    4
+                                                    res
+                                                    [x]
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (ArraySize
+                                                            (Var 4 x)
+                                                            ()
+                                                            (Integer 4)
+                                                            ()
+                                                        ))]
+                                                        PointerToDataArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            self:
+                                                (Variable
+                                                    4
+                                                    self
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (ClassType
+                                                        2 softmax
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            x:
+                                                (Variable
+                                                    4
+                                                    x
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    eval_1d
+                                    (FunctionType
+                                        [(ClassType
+                                            2 softmax
+                                        )
+                                        (Array
+                                            (Real 4)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )]
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (ArraySize
+                                                (FunctionParam
+                                                    1
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                )
+                                                ()
+                                                (Integer 4)
+                                                ()
+                                            ))]
+                                            PointerToDataArray
+                                        )
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .true.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 4 self)
+                                    (Var 4 x)]
+                                    []
+                                    (Var 4 res)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            eval_1d_prime:
+                                (Function
+                                    (SymbolTable
+                                        5
+                                        {
+                                            1_eval_1d:
+                                                (ExternalSymbol
+                                                    5
+                                                    1_eval_1d
+                                                    3 eval_1d
+                                                    softmax
+                                                    []
+                                                    eval_1d
+                                                    Public
+                                                ),
+                                            res:
+                                                (Variable
+                                                    5
+                                                    res
+                                                    [x]
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (ArraySize
+                                                            (Var 5 x)
+                                                            ()
+                                                            (Integer 4)
+                                                            ()
+                                                        ))]
+                                                        PointerToDataArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            self:
+                                                (Variable
+                                                    5
+                                                    self
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (ClassType
+                                                        2 softmax
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            x:
+                                                (Variable
+                                                    5
+                                                    x
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    eval_1d_prime
+                                    (FunctionType
+                                        [(ClassType
+                                            2 softmax
+                                        )
+                                        (Array
+                                            (Real 4)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )]
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (ArraySize
+                                                (FunctionParam
+                                                    1
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                )
+                                                ()
+                                                (Integer 4)
+                                                ()
+                                            ))]
+                                            PointerToDataArray
+                                        )
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .true.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 5 self)
+                                    (Var 5 x)]
+                                    [(Assignment
+                                        (Var 5 res)
+                                        (FunctionCall
+                                            5 1_eval_1d
+                                            ()
+                                            [((ArrayPhysicalCast
+                                                (Var 5 x)
+                                                DescriptorArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Real 4)
+                                                    [(()
+                                                    ())]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            ))]
+                                            (Array
+                                                (Real 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (ArraySize
+                                                    (Var 5 x)
+                                                    ()
+                                                    (Integer 4)
+                                                    ()
+                                                ))]
+                                                PointerToDataArray
+                                            )
+                                            ()
+                                            (Var 5 self)
+                                        )
+                                        ()
+                                    )]
+                                    (Var 5 res)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            softmax:
+                                (Struct
+                                    (SymbolTable
+                                        3
+                                        {
+                                            eval_1d:
+                                                (ClassProcedure
+                                                    3
+                                                    eval_1d
+                                                    ()
+                                                    eval_1d
+                                                    2 eval_1d
+                                                    Source
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    softmax
+                                    []
+                                    []
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
+                                )
+                        })
+                    module_function_call1
+                    [module_function_call1]
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4179,3 +4179,7 @@ ast = true
 [[test]]
 filename = "errors/incompatible_rank_assign.f90"
 asr = true
+
+[[test]]
+filename = "function_call1.f90"
+asr = true


### PR DESCRIPTION
Fixes #4759.

It still fails with `--show-llvm`