### PR TITLE
enh: lsp document symbols to collect nested symbols as well

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -843,6 +843,40 @@ int save_mod_files(const LCompilers::ASR::TranslationUnit_t &u,
 
 #ifdef HAVE_LFORTRAN_RAPIDJSON
 
+template <typename T>
+void populate_symbol_lists(T* x, LCompilers::LocationManager lm, std::vector<LCompilers::document_symbols> &symbol_lists) {
+    LCompilers::document_symbols loc;
+    for (auto &a : x->m_symtab->get_scope()) {
+        std::string symbol_name = a.first;
+        uint32_t first_line;
+        uint32_t last_line;
+        uint32_t first_column;
+        uint32_t last_column;
+        std::string filename;
+        lm.pos_to_linecol(a.second->base.loc.first, first_line,
+            first_column, filename);
+        lm.pos_to_linecol(a.second->base.loc.last, last_line,
+            last_column, filename);
+        loc.first_column = first_column;
+        loc.last_column = last_column;
+        loc.first_line = first_line-1;
+        loc.last_line = last_line-1;
+        loc.symbol_name = symbol_name;
+        loc.filename = filename;
+        symbol_lists.push_back(loc);
+        if ( LCompilers::ASR::is_a<LCompilers::ASR::Module_t>(*a.second) ) {
+            LCompilers::ASR::Module_t *m = LCompilers::ASR::down_cast<LCompilers::ASR::Module_t>(a.second);
+            populate_symbol_lists(m, lm, symbol_lists);
+        } else if ( LCompilers::ASR::is_a<LCompilers::ASR::Function_t>(*a.second) ) {
+            LCompilers::ASR::Function_t *f = LCompilers::ASR::down_cast<LCompilers::ASR::Function_t>(a.second);
+            populate_symbol_lists(f, lm, symbol_lists);
+        } else if ( LCompilers::ASR::is_a<LCompilers::ASR::Program_t>(*a.second) ) {
+            LCompilers::ASR::Program_t *p = LCompilers::ASR::down_cast<LCompilers::ASR::Program_t>(a.second);
+            populate_symbol_lists(p, lm, symbol_lists);
+        }
+    }
+}
+
 int get_symbols(const std::string &infile, CompilerOptions &compiler_options)
 {
     std::string input = read_file(infile);
@@ -861,26 +895,7 @@ int get_symbols(const std::string &infile, CompilerOptions &compiler_options)
         LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
             x = fe.get_asr2(input, lm, diagnostics);
         if (x.ok) {
-           LCompilers::document_symbols loc;
-           for (auto &a : x.result->m_symtab->get_scope()) {
-               std::string symbol_name = a.first;
-               uint32_t first_line;
-               uint32_t last_line;
-               uint32_t first_column;
-               uint32_t last_column;
-               std::string filename;
-               lm.pos_to_linecol(a.second->base.loc.first, first_line,
-                    first_column, filename);
-               lm.pos_to_linecol(a.second->base.loc.last, last_line,
-                    last_column, filename);
-               loc.first_column = first_column;
-               loc.last_column = last_column;
-               loc.first_line = first_line-1;
-               loc.last_line = last_line-1;
-               loc.symbol_name = symbol_name;
-               loc.filename = filename;
-               symbol_lists.push_back(loc);
-           }
+            populate_symbol_lists(x.result, lm, symbol_lists);
         } else {
             std::cout << "{}";
             return 0;


### PR DESCRIPTION
Towards #4808

With this PR we can now show symbols inside `module`, `program`,`function`, `subroutine`. Previously symbols present inside scope of `TranslationUnit` were shown.

Previous:

![image](https://github.com/user-attachments/assets/f4068c36-bbc9-432e-824a-76d4d26387af)


With this PR:

![image](https://github.com/user-attachments/assets/ec17c49f-cb08-4fd2-a2fa-59b00b60d86a)
