### PR TITLE
Add several fixes to read_file()

### DIFF
--- a/src/libasr/utils2.cpp
+++ b/src/libasr/utils2.cpp
@@ -30,8 +30,10 @@ std::string get_unique_ID() {
 
 bool read_file(const std::string &filename, std::string &text)
 {
+    if (filename.empty()) return false;
     std::ifstream ifs(filename.c_str(), std::ios::in | std::ios::binary
             | std::ios::ate);
+    if (!ifs.is_open()) return false;
 
     std::ifstream::pos_type filesize = ifs.tellg();
     if (filesize < 0) return false;
@@ -39,6 +41,7 @@ bool read_file(const std::string &filename, std::string &text)
     ifs.seekg(0, std::ios::beg);
 
     std::vector<char> bytes(filesize);
+    if (filesize == 0) bytes.reserve(1);
     ifs.read(&bytes[0], filesize);
 
     text = std::string(&bytes[0], filesize);


### PR DESCRIPTION
This handles several failure modes explicitly, and fixes a bug for empty files.

This should fix https://github.com/lfortran/lfortran/issues/4859.