### PR TITLE
Revert "Remove old implementation of command_argument_count"

### DIFF
--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1688,17 +1688,6 @@ int64_t compute_trailing_zeros(int64_t number, int64_t kind) {
     return trailing_zeros;
 }
 
-int32_t _argc;
-char** _argv;
-
-int32_t get_command_argument_count() {
-    int32_t result = 0;
-    for(int i=1; i<=_argc; i++) {
-        result++;
-    }
-    return result;
-}
-
 int64_t compute_leading_zeros(int64_t number, int64_t kind) {
     int64_t leading_zeros = 0;
     int64_t total_bits = 32;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5791,7 +5791,6 @@ inline ASR::ttype_t* make_Pointer_t_util(Allocator& al, const Location& loc, ASR
 
 int64_t compute_trailing_zeros(int64_t number, int64_t kind);
 int64_t compute_leading_zeros(int64_t number, int64_t kind);
-int32_t get_command_argument_count();
 void append_error(diag::Diagnostics& diag, const std::string& msg,
                 const Location& loc);
 

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -928,7 +928,6 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"isnan", {&Isnan::create_Isnan, &Isnan::eval_Isnan}},
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
                 {"compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
-                {"command_argument_count", {&CommandArgumentCount::create_CommandArgumentCount, &CommandArgumentCount::eval_CommandArgumentCount}},
                 {"spacing", {&Spacing::create_Spacing, &Spacing::eval_Spacing}},
                 {"modulo", {&Modulo::create_Modulo, &Modulo::eval_Modulo}},
                 {"bessel_jn", {&BesselJN::create_BesselJN, &BesselJN::eval_BesselJN}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1167,7 +1167,7 @@ namespace CompilerVersion {
 
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args == 0,
-            "compiler_version() takes no argument",
+            "ASR Verify: compiler_version() takes no argument",
             x.base.base.loc, diagnostics);
     }
 
@@ -1194,21 +1194,15 @@ namespace CommandArgumentCount {
 
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args == 0,
-            "command_argument_count() takes no argument",
+            "ASR Verify: command_argument_count() takes no argument",
             x.base.base.loc, diagnostics);
     }
 
-    static ASR::expr_t *eval_CommandArgumentCount(Allocator &al, const Location &loc,
-            ASR::ttype_t *t1, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
-        ASRBuilder b(al, loc);
-        int64_t cnt = ASRUtils::get_command_argument_count();
-        return make_ConstantWithType(make_IntegerConstant_t, cnt, t1, loc);
-    }
-
-    static inline ASR::asr_t* create_CommandArgumentCount(Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
-        ASR::ttype_t *return_type = ASRUtils::extract_type(ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)));
+    static inline ASR::asr_t* create_CommandArgumentCount(Allocator& al, const Location& loc, Vec<ASR::expr_t*>& /*args*/, diag::Diagnostics& diag) {
+        ASR::ttype_t *return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
         ASR::expr_t *m_value = nullptr;
-        m_value = eval_CommandArgumentCount(al, loc, return_type, args, diag);
+        return_type = ASRUtils::extract_type(return_type);
+        m_value = nullptr;
         if (diag.has_error()) {
             return nullptr;
         }
@@ -1216,6 +1210,32 @@ namespace CommandArgumentCount {
                 nullptr, 0, 0, return_type, m_value);
     }
 
+    static inline ASR::expr_t* instantiate_CommandArgumentCount(Allocator &al, const Location &loc,
+            SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
+            Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/){
+             std::string c_func_name;
+        c_func_name = "_lfortran_command_argument_count";
+        std::string new_name = "_lcompilers_command_argument_count_";
+
+        declare_basic_variables(new_name);
+        if (scope->get_symbol(new_name)) {
+            ASR::symbol_t *s = scope->get_symbol(new_name);
+            ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(s);
+            return b.Call(s, new_args, expr_type(f->m_return_var));
+        }
+        auto result = declare(new_name, return_type, ReturnVar);
+        {
+            ASR::symbol_t *s = b.create_c_func(c_func_name, fn_symtab, return_type, 2, arg_types);
+            fn_symtab->add_symbol(c_func_name, s);
+            dep.push_back(al, s2c(al, c_func_name));
+            body.push_back(al, b.Assignment(result, b.Call(s, args, return_type)));
+        }
+
+        ASR::symbol_t *new_symbol = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
+            body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+        scope->add_symbol(fn_name, new_symbol);
+        return b.Call(new_symbol, new_args, return_type);
+    }
 } // namespace CommandArgumentCount
 
 namespace Sign {

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -37,6 +37,10 @@ interface
         error stop "Not implemented yet"
     end subroutine
 
+    integer function command_argument_count() result(r)
+        error stop "Not implemented yet"
+    end function
+
 end interface
 
 end module

--- a/tests/reference/asr-cmd_01-e172099.json
+++ b/tests/reference/asr-cmd_01-e172099.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cmd_01-e172099.stdout",
-    "stdout_hash": "05e29442e74d987f6b3ce12e842b23e358351e392cac507ffadef181",
+    "stdout_hash": "0920de6b115de26692b01256bcc1e9604e2eabfe7a5d321be4db7a12",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cmd_01-e172099.stdout
+++ b/tests/reference/asr-cmd_01-e172099.stdout
@@ -29,6 +29,16 @@
                                     Required
                                     .false.
                                 ),
+                            command_argument_count:
+                                (ExternalSymbol
+                                    2
+                                    command_argument_count
+                                    4 command_argument_count
+                                    lfortran_intrinsic_builtin
+                                    []
+                                    command_argument_count
+                                    Private
+                                ),
                             count:
                                 (Variable
                                     2
@@ -75,7 +85,7 @@
                                 (ExternalSymbol
                                     2
                                     len_trim
-                                    13 len_trim
+                                    14 len_trim
                                     lfortran_intrinsic_string
                                     []
                                     len_trim
@@ -85,7 +95,7 @@
                                 (ExternalSymbol
                                     2
                                     trim
-                                    13 trim
+                                    14 trim
                                     lfortran_intrinsic_string
                                     []
                                     trim
@@ -96,12 +106,13 @@
                     []
                     [(Assignment
                         (Var 2 count)
-                        (IntrinsicElementalFunction
-                            CommandArgumentCount
+                        (FunctionCall
+                            2 command_argument_count
+                            ()
                             []
-                            0
                             (Integer 4)
-                            (IntegerConstant 0 (Integer 4) Decimal)
+                            ()
+                            ()
                         )
                         ()
                     )

--- a/tests/reference/asr-fn6-a24010a.json
+++ b/tests/reference/asr-fn6-a24010a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn6-a24010a.stdout",
-    "stdout_hash": "ab17b5378aa7d8dba7a249a3d9c71308309bc9a8aed15f2c56167e27",
+    "stdout_hash": "1f8794dd5a4322065808773a2d0701e90c9f7d6ae50be67d466469ef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn6-a24010a.stdout
+++ b/tests/reference/asr-fn6-a24010a.stdout
@@ -486,7 +486,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     len_trim
-                                                    18 len_trim
+                                                    19 len_trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_trim
@@ -563,7 +563,7 @@
                                                                 (ExternalSymbol
                                                                     5
                                                                     len_trim
-                                                                    18 len_trim
+                                                                    19 len_trim
                                                                     lfortran_intrinsic_string
                                                                     []
                                                                     len_trim
@@ -572,7 +572,7 @@
                                                             ~select_type_block_:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        24
+                                                                        25
                                                                         {
                                                                             
                                                                         })
@@ -614,7 +614,7 @@
                                                             ~select_type_block_1:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        25
+                                                                        26
                                                                         {
                                                                             
                                                                         })
@@ -656,7 +656,7 @@
                                                             ~select_type_block_2:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        26
+                                                                        27
                                                                         {
                                                                             
                                                                         })
@@ -698,7 +698,7 @@
                                                             ~select_type_block_3:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        27
+                                                                        28
                                                                         {
                                                                             
                                                                         })
@@ -740,7 +740,7 @@
                                                             ~select_type_block_4:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        28
+                                                                        29
                                                                         {
                                                                             
                                                                         })
@@ -782,7 +782,7 @@
                                                             ~select_type_block_5:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        29
+                                                                        30
                                                                         {
                                                                             
                                                                         })
@@ -824,7 +824,7 @@
                                                             ~select_type_block_6:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        30
+                                                                        31
                                                                         {
                                                                             
                                                                         })
@@ -866,13 +866,13 @@
                                                             ~select_type_block_7:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        31
+                                                                        32
                                                                         {
                                                                             len_trim:
                                                                                 (ExternalSymbol
-                                                                                    31
+                                                                                    32
                                                                                     len_trim
-                                                                                    18 len_trim
+                                                                                    19 len_trim
                                                                                     lfortran_intrinsic_string
                                                                                     []
                                                                                     len_trim
@@ -909,7 +909,7 @@
                                                                                 ()
                                                                                 [((Var 5 generic))]
                                                                                 (Character 1 -3 (FunctionCall
-                                                                                    31 len_trim
+                                                                                    32 len_trim
                                                                                     ()
                                                                                     [((Var 5 generic))]
                                                                                     (Integer 4)
@@ -931,7 +931,7 @@
                                                             ~select_type_block_8:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        32
+                                                                        33
                                                                         {
                                                                             
                                                                         })
@@ -1143,7 +1143,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     trim
-                                                    18 trim
+                                                    19 trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     trim

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "fc9f30a7e0ed02cacbeb25ef5516ce0f05baa312b25a9a7d592ccb29",
+    "stdout_hash": "51c699d446252a19ecbd493e41c2b5d3fa1dc783cba36fbb51e5dd53",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -1078,7 +1078,7 @@
                                                 (ExternalSymbol
                                                     6
                                                     len_trim
-                                                    19 len_trim
+                                                    20 len_trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_trim
@@ -1160,7 +1160,7 @@
                                                 (ExternalSymbol
                                                     6
                                                     trim
-                                                    19 trim
+                                                    20 trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     trim

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "ae083a673e6fe17998f5c1cc46869296d0030b6fae68abe5cd566343",
+    "stdout_hash": "9a5ad5f2f5e9c72b6d3c8b58bdc9bfa376249658eb0ae802612acef2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -604,7 +604,7 @@
             select_type4:
                 (Program
                     (SymbolTable
-                        22
+                        23
                         {
                             
                         })


### PR DESCRIPTION
Reverts lfortran/lfortran#4863