### PR TITLE
remove old implementation of command_argument_count

### DIFF
--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -76,7 +76,6 @@ struct IntrinsicProcedures {
             {"is_iostat_eor", {m_builtin, &not_implemented, false}},
             {"is_iostat_end", {m_builtin, &not_implemented, false}},
             {"get_command_argument", {m_builtin, &not_implemented, false}},
-            {"command_argument_count", {m_builtin, &not_implemented, false}},
             {"newunit", {m_custom, &not_implemented, false}},
 
             // These will fail if used in symbol table visitor, but will be

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2014,6 +2014,9 @@ public:
                 }
                 break ;
             }
+            case ASRUtils::IntrinsicElementalFunctions::CommandArgumentCount: {
+                break;
+            }
             case ASRUtils::IntrinsicElementalFunctions::Expm1: {
                 switch (x.m_overload_id) {
                     case 0: {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -292,7 +292,7 @@ namespace IntrinsicElementalFunctionRegistry {
         {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerVersion),
             {nullptr, &CompilerVersion::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::CommandArgumentCount),
-            {nullptr, &CommandArgumentCount::verify_args}},
+            {&CommandArgumentCount::instantiate_CommandArgumentCount, &CommandArgumentCount::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Spacing),
             {&Spacing::instantiate_Spacing, &Spacing::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Modulo),

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -539,6 +539,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {nullptr, &SymbolicSinQ::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicGetArgument),
             {nullptr, &SymbolicGetArgument::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::CommandArgumentCount),
+            {&CommandArgumentCount::instantiate_CommandArgumentCount, &CommandArgumentCount::verify_args}},
     };
 
     static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
@@ -933,6 +935,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"isnan", {&Isnan::create_Isnan, &Isnan::eval_Isnan}},
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
                 {"compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
+                {"command_argument_count", {&CommandArgumentCount::create_CommandArgumentCount, nullptr}},
                 {"spacing", {&Spacing::create_Spacing, &Spacing::eval_Spacing}},
                 {"modulo", {&Modulo::create_Modulo, &Modulo::eval_Modulo}},
                 {"bessel_jn", {&BesselJN::create_BesselJN, &BesselJN::eval_BesselJN}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1214,7 +1214,7 @@ namespace CommandArgumentCount {
     static inline ASR::expr_t* instantiate_CommandArgumentCount(Allocator &al, const Location &loc,
             SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/){
-             std::string c_func_name;
+        std::string c_func_name;
         c_func_name = "_lfortran_command_argument_count";
         std::string new_name = "_lcompilers_command_argument_count_";
 
@@ -1226,7 +1226,7 @@ namespace CommandArgumentCount {
         }
         auto result = declare(new_name, return_type, ReturnVar);
         {
-            ASR::symbol_t *s = b.create_c_func(c_func_name, fn_symtab, return_type, 2, arg_types);
+            ASR::symbol_t *s = b.create_c_func(c_func_name, fn_symtab, return_type, 0, arg_types);
             fn_symtab->add_symbol(c_func_name, s);
             dep.push_back(al, s2c(al, c_func_name));
             body.push_back(al, b.Assignment(result, b.Call(s, args, return_type)));

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3329,11 +3329,7 @@ LFORTRAN_API void _lpython_call_initial_functions(int32_t argc_1, char *argv_1[]
 }
 
 LFORTRAN_API int32_t _lfortran_command_argument_count() {
-    int32_t result = 0;
-    for(int i=1; i<=_argc; i++) {
-        result++;
-    }
-    return result;
+    return _argc - 1;
 }
 // << Initial setup << ---------------------------------------------------------
 

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -33,10 +33,6 @@ interface
         error stop "Not implemented yet"
     end subroutine
 
-    integer function command_argument_count() result(r)
-        error stop "Not implemented yet"
-    end function
-
 end interface
 
 end module

--- a/tests/reference/asr-cmd_01-e172099.json
+++ b/tests/reference/asr-cmd_01-e172099.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cmd_01-e172099.stdout",
-    "stdout_hash": "21cb236bf4122c50f009c6ff0f6e4c454a7fd5794e17a82cb79b8cc9",
+    "stdout_hash": "d96cdaf85f2d62cf72b58021aa670c904fbc99160ad106a7d8c6c422",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cmd_01-e172099.json
+++ b/tests/reference/asr-cmd_01-e172099.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cmd_01-e172099.stdout",
-    "stdout_hash": "d96cdaf85f2d62cf72b58021aa670c904fbc99160ad106a7d8c6c422",
+    "stdout_hash": "96ba98b6f371f357a236c183a8805f8098d4958b7b9d1777de610aad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cmd_01-e172099.stdout
+++ b/tests/reference/asr-cmd_01-e172099.stdout
@@ -29,16 +29,6 @@
                                     Required
                                     .false.
                                 ),
-                            command_argument_count:
-                                (ExternalSymbol
-                                    2
-                                    command_argument_count
-                                    4 command_argument_count
-                                    lfortran_intrinsic_builtin
-                                    []
-                                    command_argument_count
-                                    Private
-                                ),
                             count:
                                 (Variable
                                     2
@@ -85,7 +75,7 @@
                                 (ExternalSymbol
                                     2
                                     len_trim
-                                    13 len_trim
+                                    12 len_trim
                                     lfortran_intrinsic_string
                                     []
                                     len_trim
@@ -95,7 +85,7 @@
                                 (ExternalSymbol
                                     2
                                     trim
-                                    13 trim
+                                    12 trim
                                     lfortran_intrinsic_string
                                     []
                                     trim
@@ -106,12 +96,11 @@
                     []
                     [(Assignment
                         (Var 2 count)
-                        (FunctionCall
-                            2 command_argument_count
-                            ()
+                        (IntrinsicElementalFunction
+                            CommandArgumentCount
                             []
+                            0
                             (Integer 4)
-                            ()
                             ()
                         )
                         ()

--- a/tests/reference/asr-fn6-a24010a.json
+++ b/tests/reference/asr-fn6-a24010a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn6-a24010a.stdout",
-    "stdout_hash": "ab17b5378aa7d8dba7a249a3d9c71308309bc9a8aed15f2c56167e27",
+    "stdout_hash": "305ed01bc2b07328821d397f1d9ae192abaa37a0763970a040627f49",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn6-a24010a.stdout
+++ b/tests/reference/asr-fn6-a24010a.stdout
@@ -486,7 +486,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     len_trim
-                                                    18 len_trim
+                                                    17 len_trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_trim
@@ -563,7 +563,7 @@
                                                                 (ExternalSymbol
                                                                     5
                                                                     len_trim
-                                                                    18 len_trim
+                                                                    17 len_trim
                                                                     lfortran_intrinsic_string
                                                                     []
                                                                     len_trim
@@ -572,7 +572,7 @@
                                                             ~select_type_block_:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        24
+                                                                        23
                                                                         {
                                                                             
                                                                         })
@@ -614,7 +614,7 @@
                                                             ~select_type_block_1:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        25
+                                                                        24
                                                                         {
                                                                             
                                                                         })
@@ -656,7 +656,7 @@
                                                             ~select_type_block_2:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        26
+                                                                        25
                                                                         {
                                                                             
                                                                         })
@@ -698,7 +698,7 @@
                                                             ~select_type_block_3:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        27
+                                                                        26
                                                                         {
                                                                             
                                                                         })
@@ -740,7 +740,7 @@
                                                             ~select_type_block_4:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        28
+                                                                        27
                                                                         {
                                                                             
                                                                         })
@@ -782,7 +782,7 @@
                                                             ~select_type_block_5:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        29
+                                                                        28
                                                                         {
                                                                             
                                                                         })
@@ -824,7 +824,7 @@
                                                             ~select_type_block_6:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        30
+                                                                        29
                                                                         {
                                                                             
                                                                         })
@@ -866,13 +866,13 @@
                                                             ~select_type_block_7:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        31
+                                                                        30
                                                                         {
                                                                             len_trim:
                                                                                 (ExternalSymbol
-                                                                                    31
+                                                                                    30
                                                                                     len_trim
-                                                                                    18 len_trim
+                                                                                    17 len_trim
                                                                                     lfortran_intrinsic_string
                                                                                     []
                                                                                     len_trim
@@ -909,7 +909,7 @@
                                                                                 ()
                                                                                 [((Var 5 generic))]
                                                                                 (Character 1 -3 (FunctionCall
-                                                                                    31 len_trim
+                                                                                    30 len_trim
                                                                                     ()
                                                                                     [((Var 5 generic))]
                                                                                     (Integer 4)
@@ -931,7 +931,7 @@
                                                             ~select_type_block_8:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        32
+                                                                        31
                                                                         {
                                                                             
                                                                         })
@@ -1143,7 +1143,7 @@
                                                 (ExternalSymbol
                                                     3
                                                     trim
-                                                    18 trim
+                                                    17 trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     trim

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "41ebef47cb6be581b8c91f81b5cd3efa21be7b96e327b69e6bfb5d93",
+    "stdout_hash": "cd17cf15045cadc949e9ecd8d118dac32769f9f057d6f0b55d562e9a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "74225e4d2436c28b683de58dae6a4d8ca85dda90c6d89f442e29d763",
+    "stdout_hash": "41ebef47cb6be581b8c91f81b5cd3efa21be7b96e327b69e6bfb5d93",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -1070,7 +1070,7 @@
                                                 (ExternalSymbol
                                                     6
                                                     len_trim
-                                                    19 len_trim
+                                                    18 len_trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     len_trim
@@ -1152,7 +1152,7 @@
                                                 (ExternalSymbol
                                                     6
                                                     trim
-                                                    19 trim
+                                                    18 trim
                                                     lfortran_intrinsic_string
                                                     []
                                                     trim

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "9c86fb161449b43306c2771a919c694da0d86c2e4e5a291a6a21c478",
+    "stdout_hash": "355ec1f69c1ba6d18469160f692c74d1ba164ae7a436ac739fa6c818",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "d73b5fb405d0db4ad6065a6dfcdbde34a25975440a5cf205668e9a91",
+    "stdout_hash": "9c86fb161449b43306c2771a919c694da0d86c2e4e5a291a6a21c478",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -602,7 +602,7 @@
             select_type4:
                 (Program
                     (SymbolTable
-                        22
+                        21
                         {
                             
                         })


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/4593