### PR TITLE
Enh:-Added Integration OpenMp test

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1776,6 +1776,7 @@ RUN(NAME openmp_31 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_32 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_33 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # mandelbrot
 RUN(NAME openmp_34 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # Ensure uniform load distribution over threads
+RUN(NAME openmp_35 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 

--- a/integration_tests/openmp_35.f90
+++ b/integration_tests/openmp_35.f90
@@ -1,0 +1,53 @@
+subroutine operations(n, ctr, sum_v1, sum_v2,sum_v3)
+    use omp_lib
+    implicit none
+    integer, intent(in) :: n
+    double precision, intent(inout) :: ctr
+    double precision, intent(inout) :: sum_v1, sum_v2, sum_v3
+    
+    integer :: local_ctr
+    double precision :: local_sum_v1, local_sum_v2,local_sum_v3
+
+    integer :: i
+
+    local_ctr = 0
+    local_sum_v1 = 0.0
+    local_sum_v2 = 1.0
+    local_sum_v3 = 0.0
+
+    !$omp parallel private(i) reduction(+:local_ctr, local_sum_v1, local_sum_v3) reduction(*:local_sum_v2) 
+    !$omp do
+    do i = 1, n
+        local_ctr = local_ctr + 1            ! Counting increment
+        local_sum_v2 = local_sum_v2 * i      ! Sample multiplication operation for v2
+        local_sum_v1 = local_sum_v1 + i      ! Sample sum operation for v1
+        local_sum_v3 = local_sum_v3 - i      ! Sample subtraction operation for v3
+    end do
+
+    !$omp end do
+    !$omp end parallel
+
+    ctr = ctr + local_ctr
+    sum_v1 = sum_v1 + local_sum_v1
+    sum_v2 = sum_v2 * local_sum_v2  
+    sum_v3 = sum_v3 + local_sum_v3
+end subroutine
+
+program openmp_35
+    use omp_lib
+    integer, parameter :: n = 5
+    double precision :: ctr, sum_v1, sum_v2, sum_v3
+
+    call omp_set_num_threads(5)
+    ctr = 0.0
+    sum_v1 = 0.0
+    sum_v2 = 1.0  ! Initializing for multiplicative reduction
+    sum_v3 = 0.0
+
+    call operations(n, ctr, sum_v1, sum_v2,sum_v3)
+
+    print *, "Total count: ", ctr
+    print *, "Sum of v1: ", sum_v1
+    print *, "Product result for v2: ", sum_v2
+    print *, "Difference result for v3: ", sum_v3
+end program

--- a/integration_tests/openmp_35.f90
+++ b/integration_tests/openmp_35.f90
@@ -35,10 +35,10 @@ end subroutine
 
 program openmp_35
     use omp_lib
-    integer, parameter :: n = 5
+    integer, parameter :: n = 16
     double precision :: ctr, sum_v1, sum_v2, sum_v3
 
-    call omp_set_num_threads(5)
+    call omp_set_num_threads(8)
     ctr = 0.0
     sum_v1 = 0.0
     sum_v2 = 1.0  ! Initializing for multiplicative reduction


### PR DESCRIPTION
Added case of using multiple reduction with double precision data type
Output:-
```shell
(lf) aditya-trivedi@Observer:~/thats_me/main/lfortran$ ./src/bin/lfortran --openmp --link-with-gcc ./integration_tests/openmp_35.f90 --cpp -o a --openmp-lib-dir=${CONDA_PREFIX}/lib  && ./a
Total count:     1.60000000000000000e+01
Sum of v1:     1.36000000000000000e+02
Product result for v2:     2.09227898880000000e+13
Difference result for v3:     -1.36000000000000000e+02
``` 