### PR TITLE
fix: replace `ArrayBroadcast` in `where` pass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1034,11 +1034,11 @@ RUN(NAME program_04 LABELS gfortran llvm llvm17)
 
 RUN(NAME where_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
-# RUN(NAME where_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME where_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 # RUN(NAME where_04 LABELS gfortran) # TODO: Fix this test #1631
 # RUN(NAME where_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME where_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-# RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
+RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 # RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1035,10 +1035,10 @@ RUN(NAME program_04 LABELS gfortran llvm llvm17)
 RUN(NAME where_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-# RUN(NAME where_04 LABELS gfortran) # TODO: Fix this test #1631
+RUN(NAME where_04 LABELS gfortran) # TODO: Fix this test #1631
 # RUN(NAME where_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME where_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
+# RUN(NAME where_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME where_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 # RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1583,7 +1583,6 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             replace_expr(x->m_value);
             current_expr = current_expr_copy_163;
         }
-        replace_current_expr("_array_broadcast_")
     }
 
     void replace_ArrayItem(ASR::ArrayItem_t* x) {

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1583,6 +1583,7 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             replace_expr(x->m_value);
             current_expr = current_expr_copy_163;
         }
+        replace_current_expr("_array_broadcast_")
     }
 
     void replace_ArrayItem(ASR::ArrayItem_t* x) {

--- a/src/libasr/pass/where.cpp
+++ b/src/libasr/pass/where.cpp
@@ -112,6 +112,14 @@ public:
         *current_expr = new_expr;
     }
 
+    void replace_ArrayBroadcast(ASR::ArrayBroadcast_t* x) {
+        ASR::expr_t** current_expr_copy_161 = current_expr;
+        current_expr = &(x->m_array);
+        replace_expr(x->m_array);
+        current_expr = current_expr_copy_161;
+        *current_expr = x->m_array;
+    }
+
     void replace_Array(ASR::Array_t */*x*/) {
         // pass
     }
@@ -182,6 +190,16 @@ public:
         }
         ASR::stmt_t* tmp_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, target, value, nullptr));
         pass_result.push_back(al, tmp_stmt);
+    }
+
+    void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t &x) {
+        ASR::expr_t** current_expr_copy_269 = current_expr;
+        current_expr = const_cast<ASR::expr_t**>(&(x.m_array));
+        call_replacer();
+        current_expr = current_expr_copy_269;
+        if (x.m_array) {
+            visit_expr(*x.m_array);
+        }
     }
 };
 


### PR DESCRIPTION
```fortran
program main
   call where_03

contains

   subroutine where_03
      implicit none
      real a(4)

      a = [1.0, 2.0, 1.0, 4.0]

      where(a == 1.0) a = a * 3.0

   end subroutine
end program
```

is transformed to

```fortran
! Fortran code after applying the pass: simplifier
program main
implicit none
call where_03()

contains

subroutine where_03()
    real(4), dimension(4) :: __libasr_created__array_broadcast_
    real(4), dimension(4) :: a
    a = [1.00000000e+00, 2.00000000e+00, 3.00000000e+00, 4.00000000e+00]
    where (a == 1.00000000e+00)
        __libasr_created__array_broadcast_ = 3.00000000e+00
        a = a*__libasr_created__array_broadcast_
    end where
    print *, a
end subroutine where_03

end program main
```