### PR TITLE
Adjust default integer kinds in iso_fortran_env

### DIFF
--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -1,13 +1,20 @@
 module lfortran_intrinsic_iso_fortran_env
 implicit none
 
-integer, parameter :: int8 = 1
-integer, parameter :: int16 = 2
+integer, parameter :: int8 = -2
+integer, parameter :: int16 = -2
 integer, parameter :: int32 = 4
 integer, parameter :: int64 = 8
+
+integer, parameter :: real16 = -2
 integer, parameter :: real32 = 4
 integer, parameter :: real64 = 8
 integer, parameter :: real128 = -1
+
+integer, parameter :: logical8  = -2
+integer, parameter :: logical16 = -2
+integer, parameter :: logical32 = 4
+integer, parameter :: logical64 = -1
 
 integer, parameter :: input_unit = 5
 integer, parameter :: output_unit = 6
@@ -19,5 +26,8 @@ integer, parameter :: character_kinds(1) = [1]
 integer, parameter :: logical_kinds(1) = [4]
 
 integer, parameter :: iostat_end = -1
+
+integer, parameter :: character_storage_size = 8
+integer, parameter :: numeric_storage_size = 32
 
 end module


### PR DESCRIPTION
Address a few minor points of https://github.com/lfortran/lfortran/issues/4742.

The `numeric_storage_size` is the default storage size for default integers, reals, and logicals (which must be the same). 