### PR TITLE
LLVM17: Fix select_type_05

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1022,11 +1022,11 @@ RUN(NAME case_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm17)
 RUN(NAME case_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm17)
 RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 
-RUN(NAME select_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME select_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME select_type_04 LABELS gfortran
         EXTRAFILES select_type_03_module.f90 select_type_03.f90)
-RUN(NAME select_type_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME select_type_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 
 RUN(NAME program_02 LABELS gfortran llvm llvm17)
 RUN(NAME program_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -141,7 +141,7 @@ namespace LCompilers {
                 virtual
                 void fill_array_details(
                     llvm::Value* source, llvm::Value* destination,
-                    ASR::ttype_t* asr_shape_type, bool ignore_data) = 0;
+                    ASR::ttype_t* source_array_type, ASR::ttype_t* dest_array_type, llvm::Module* module, bool ignore_data) = 0;
 
                 /*
                 * Fills the elements of the input array descriptor
@@ -365,7 +365,7 @@ namespace LCompilers {
                 virtual
                 void fill_array_details(
                     llvm::Value* source, llvm::Value* destination,
-                    ASR::ttype_t* asr_shape_type, bool ignore_data);
+                    ASR::ttype_t* source_array_type, ASR::ttype_t* dest_array_type, llvm::Module* module, bool ignore_data);
 
                 virtual
                 void fill_malloc_array_details(


### PR DESCRIPTION
As a side effect, `current_select_type_block_type` now refers to the underlying type instead of the pointer, since we need that information later on.