### PR TITLE
[LLVM] Fixes to build with LLVM 18,

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -746,7 +746,7 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
-        llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17"]
+        llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -33,7 +33,6 @@
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/Scalar/InstSimplifyPass.h>
-#include <llvm/Transforms/Vectorize.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/Instrumentation/AddressSanitizer.h>
@@ -47,7 +46,6 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Target/TargetOptions.h>
-#include <llvm/Support/Host.h>
 #if LLVM_VERSION_MAJOR >= 14
 #    include <llvm/MC/TargetRegistry.h>
 #else
@@ -57,6 +55,11 @@
     // TODO: removed from LLVM 17
 #else
 #    include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#endif
+
+#if LLVM_VERSION_MAJOR < 18
+#    include <llvm/Transforms/Vectorize.h>
+#    include <llvm/Support/Host.h>
 #endif
 
 #include <libasr/codegen/KaleidoscopeJIT.h>
@@ -329,7 +332,11 @@ void write_file(const std::string &filename, const std::string &contents)
 std::string LLVMEvaluator::get_asm(llvm::Module &m)
 {
     llvm::legacy::PassManager pass;
+#if LLVM_VERSION_MAJOR < 18
     llvm::CodeGenFileType ft = llvm::CGFT_AssemblyFile;
+#else
+    llvm::CodeGenFileType ft = llvm::CodeGenFileType::AssemblyFile;
+#endif
     llvm::SmallVector<char, 128> buf;
     llvm::raw_svector_ostream dest(buf);
     if (TM->addPassesToEmitFile(pass, dest, nullptr, ft)) {
@@ -349,7 +356,11 @@ void LLVMEvaluator::save_object_file(llvm::Module &m, const std::string &filenam
     m.setDataLayout(TM->createDataLayout());
 
     llvm::legacy::PassManager pass;
+#if LLVM_VERSION_MAJOR < 18
     llvm::CodeGenFileType ft = llvm::CGFT_ObjectFile;
+#else
+    llvm::CodeGenFileType ft = llvm::CodeGenFileType::ObjectFile;
+#endif
     std::error_code EC;
     llvm::raw_fd_ostream dest(filename, EC, llvm::sys::fs::OF_None);
     if (EC) {
@@ -441,7 +452,7 @@ void LLVMEvaluator::print_targets()
 
 std::string LLVMEvaluator::get_default_target_triple()
 {
-    return llvm::sys::getDefaultTargetTriple();
+    return LLVMGetDefaultTargetTriple();
 }
 
 } // namespace LCompilers

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -12,7 +12,7 @@ namespace LCompilers {
             llvm::Function *fn = module.getFunction(func_name);
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
-                        llvm::Type::getInt8PtrTy(context), {
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), {
                             llvm::Type::getInt32Ty(context)
                         }, false);
                 fn = llvm::Function::Create(function_type,
@@ -28,15 +28,15 @@ namespace LCompilers {
             llvm::Function *fn = module.getFunction(func_name);
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
-                        llvm::Type::getInt8PtrTy(context), {
-                            llvm::Type::getInt8PtrTy(context),
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), {
+                            llvm::Type::getInt8Ty(context)->getPointerTo(),
                             llvm::Type::getInt32Ty(context)
                         }, false);
                 fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, func_name, module);
             }
             std::vector<llvm::Value*> args = {
-                builder.CreateBitCast(ptr, llvm::Type::getInt8PtrTy(context)), arg_size};
+                builder.CreateBitCast(ptr, llvm::Type::getInt8Ty(context)->getPointerTo()), arg_size};
             return builder.CreateCall(fn, args);
         }
 

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -18,7 +18,7 @@ namespace LCompilers {
             llvm::Function *fn = module.getFunction(func_name);
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
-                        llvm::Type::getInt8PtrTy(context), {
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), {
                             llvm::Type::getInt32Ty(context)
                         }, false);
                 fn = llvm::Function::Create(function_type,
@@ -34,7 +34,7 @@ namespace LCompilers {
             llvm::Function *fn = module.getFunction(func_name);
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
-                        llvm::Type::getInt8PtrTy(context), {
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), {
                             llvm::Type::getInt32Ty(context),
                             llvm::Type::getInt32Ty(context)
                         }, false);
@@ -51,15 +51,15 @@ namespace LCompilers {
             llvm::Function *fn = module.getFunction(func_name);
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
-                        llvm::Type::getInt8PtrTy(context), {
-                            llvm::Type::getInt8PtrTy(context),
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), {
+                            llvm::Type::getInt8Ty(context)->getPointerTo(),
                             llvm::Type::getInt32Ty(context)
                         }, false);
                 fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, func_name, module);
             }
             std::vector<llvm::Value*> args = {
-                builder.CreateBitCast(ptr, llvm::Type::getInt8PtrTy(context)),
+                builder.CreateBitCast(ptr, llvm::Type::getInt8Ty(context)->getPointerTo()),
                 arg_size
             };
             return builder.CreateCall(fn, args);
@@ -72,13 +72,13 @@ namespace LCompilers {
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
                         llvm::Type::getVoidTy(context), {
-                            llvm::Type::getInt8PtrTy(context)
+                            llvm::Type::getInt8Ty(context)->getPointerTo()
                         }, false);
                 fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, func_name, module);
             }
             std::vector<llvm::Value*> args = {
-                builder.CreateBitCast(ptr, llvm::Type::getInt8PtrTy(context)),
+                builder.CreateBitCast(ptr, llvm::Type::getInt8Ty(context)->getPointerTo()),
             };
             return builder.CreateCall(fn, args);
         }
@@ -108,16 +108,16 @@ namespace LCompilers {
                 llvm::Type::getDoubleTy(context),
                 llvm::Type::getDoubleTy(context)};
             std::vector<llvm::Type*> els_4_ptr = {
-                llvm::Type::getFloatPtrTy(context),
-                llvm::Type::getFloatPtrTy(context)};
+                llvm::Type::getFloatTy(context)->getPointerTo(),
+                llvm::Type::getFloatTy(context)->getPointerTo()};
             std::vector<llvm::Type*> els_8_ptr = {
-                llvm::Type::getDoublePtrTy(context),
-                llvm::Type::getDoublePtrTy(context)};
+                llvm::Type::getDoubleTy(context)->getPointerTo(),
+                llvm::Type::getDoubleTy(context)->getPointerTo()};
             complex_type_4 = llvm::StructType::create(context, els_4, "complex_4");
             complex_type_8 = llvm::StructType::create(context, els_8, "complex_8");
             complex_type_4_ptr = llvm::StructType::create(context, els_4_ptr, "complex_4_ptr");
             complex_type_8_ptr = llvm::StructType::create(context, els_8_ptr, "complex_8_ptr");
-            character_type = llvm::Type::getInt8PtrTy(context);
+            character_type = llvm::Type::getInt8Ty(context)->getPointerTo();
         }
 
     void LLVMUtils::set_module(llvm::Module* module_) {
@@ -398,10 +398,10 @@ namespace LCompilers {
             switch(a_kind)
             {
                 case 4:
-                    type_ptr = llvm::Type::getFloatPtrTy(context);
+                    type_ptr = llvm::Type::getFloatTy(context)->getPointerTo();
                     break;
                 case 8:
-                    type_ptr =  llvm::Type::getDoublePtrTy(context);
+                    type_ptr =  llvm::Type::getDoubleTy(context)->getPointerTo();
                     break;
                 default:
                     throw CodeGenError("Only 32 and 64 bits real kinds are supported.");
@@ -738,7 +738,7 @@ namespace LCompilers {
                     && arg_m_value_attr) {
                     type = llvm::Type::getInt1Ty(context);
                 } else {
-                    type = llvm::Type::getInt1PtrTy(context);
+                    type = llvm::Type::getInt1Ty(context)->getPointerTo();
                 }
                 break;
             }
@@ -786,7 +786,7 @@ namespace LCompilers {
                     && arg_m_value_attr) {
                     type = llvm::Type::getInt32Ty(context);
                 } else {
-                    type = llvm::Type::getInt32PtrTy(context);
+                    type = llvm::Type::getInt32Ty(context)->getPointerTo();
                 }
                 break ;
             }
@@ -1761,16 +1761,16 @@ namespace LCompilers {
             switch(a_kind)
             {
                 case 1:
-                    type_ptr = llvm::Type::getInt8PtrTy(context);
+                    type_ptr = llvm::Type::getInt8Ty(context)->getPointerTo();
                     break;
                 case 2:
-                    type_ptr = llvm::Type::getInt16PtrTy(context);
+                    type_ptr = llvm::Type::getInt16Ty(context)->getPointerTo();
                     break;
                 case 4:
-                    type_ptr = llvm::Type::getInt32PtrTy(context);
+                    type_ptr = llvm::Type::getInt32Ty(context)->getPointerTo();
                     break;
                 case 8:
-                    type_ptr = llvm::Type::getInt64PtrTy(context);
+                    type_ptr = llvm::Type::getInt64Ty(context)->getPointerTo();
                     break;
                 default:
                     LCOMPILERS_ASSERT(false);
@@ -1817,7 +1817,7 @@ namespace LCompilers {
     llvm::Value* LLVMUtils::lfortran_str_cmp(llvm::Value* left_arg, llvm::Value* right_arg,
                                              std::string runtime_func_name, llvm::Module& module)
     {
-        llvm::Type* character_type = llvm::Type::getInt8PtrTy(context);
+        llvm::Type* character_type = llvm::Type::getInt8Ty(context)->getPointerTo();
         llvm::Function *fn = module.getFunction(runtime_func_name);
         if(!fn) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
@@ -2245,7 +2245,7 @@ namespace LCompilers {
                                         value_type_code, value_type_size);
         std::vector<llvm::Type*> dict_type_vec = {llvm::Type::getInt32Ty(context),
                                                   key_list_type, value_list_type,
-                                                  llvm::Type::getInt8PtrTy(context)};
+                                                  llvm::Type::getInt8Ty(context)->getPointerTo()};
         llvm::Type* dict_desc = llvm::StructType::create(context, dict_type_vec, "dict");
         typecode2dicttype[llvm_key] = std::make_tuple(dict_desc,
                                         std::make_pair(key_type_size, value_type_size),
@@ -2277,13 +2277,13 @@ namespace LCompilers {
         }
 
         std::vector<llvm::Type*> key_value_vec = {key_type, value_type,
-                                                  llvm::Type::getInt8PtrTy(context)};
+                                                  llvm::Type::getInt8Ty(context)->getPointerTo()};
         llvm::Type* key_value_pair = llvm::StructType::create(context, key_value_vec, "key_value");
         std::vector<llvm::Type*> dict_type_vec = {llvm::Type::getInt32Ty(context),
                                                   llvm::Type::getInt32Ty(context),
                                                   llvm::Type::getInt32Ty(context),
                                                   key_value_pair->getPointerTo(),
-                                                  llvm::Type::getInt8PtrTy(context),
+                                                  llvm::Type::getInt8Ty(context)->getPointerTo(),
                                                   llvm::Type::getInt1Ty(context)};
         llvm::Type* dict_desc = llvm::StructType::create(context, dict_type_vec, "dict");
         typecode2dicttype[llvm_key] = std::make_tuple(dict_desc,
@@ -2439,7 +2439,7 @@ namespace LCompilers {
         llvm::Value* key_value_ptr = LLVM::lfortran_malloc(context, *module, *builder, malloc_size);
         rehash_flag = builder->CreateAnd(rehash_flag,
                         builder->CreateICmpNE(key_value_ptr,
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
                     );
         key_value_ptr = builder->CreateBitCast(key_value_ptr, key_value_pair_type->getPointerTo());
         LLVM::CreateStore(*builder, key_value_ptr, get_pointer_to_key_value_pairs(dict));
@@ -2451,7 +2451,7 @@ namespace LCompilers {
                                                       llvm_mask_size);
         rehash_flag = builder->CreateAnd(rehash_flag,
                         builder->CreateICmpNE(key_mask,
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
                     );
         LLVM::CreateStore(*builder, key_mask, get_pointer_to_keymask(dict));
 
@@ -2578,14 +2578,14 @@ namespace LCompilers {
         llvm::Value* srci, llvm::Value* desti, llvm::Value* dest_key_value_pairs,
         ASR::Dict_t* dict_type, llvm::Module* module,
         std::map<std::string, std::map<std::string, int>>& name2memidx) {
-        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
-        dest_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
+        dest_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
         llvm::Type* key_value_pair_type = get_key_value_pair_type(dict_type->m_key_type, dict_type->m_value_type)->getPointerTo();
         LLVM::CreateStore(*builder,
-            builder->CreateBitCast(srci, llvm::Type::getInt8PtrTy(context)),
+            builder->CreateBitCast(srci, llvm::Type::getInt8Ty(context)->getPointerTo()),
             src_itr);
         LLVM::CreateStore(*builder,
-            builder->CreateBitCast(desti, llvm::Type::getInt8PtrTy(context)),
+            builder->CreateBitCast(desti, llvm::Type::getInt8Ty(context)->getPointerTo()),
             dest_itr);
         llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
         llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
@@ -2595,7 +2595,7 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpNE(
                 llvm_utils->CreateLoad(src_itr),
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             builder->CreateCondBr(cond, loopbody, loopend);
         }
@@ -2629,13 +2629,13 @@ namespace LCompilers {
             llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
             llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
             llvm::Value* src_next_exists = builder->CreateICmpNE(src_next_ptr,
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)));
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()));
             builder->CreateCondBr(src_next_exists, thenBB, elseBB);
             builder->SetInsertPoint(thenBB);
             {
                 llvm::Value* next_idx = llvm_utils->CreateLoad(next_ptr);
                 llvm::Value* dest_next_ptr = llvm_utils->create_ptr_gep(dest_key_value_pairs, next_idx);
-                dest_next_ptr = builder->CreateBitCast(dest_next_ptr, llvm::Type::getInt8PtrTy(context));
+                dest_next_ptr = builder->CreateBitCast(dest_next_ptr, llvm::Type::getInt8Ty(context)->getPointerTo());
                 LLVM::CreateStore(*builder, dest_next_ptr, curr_dest_next_ptr);
                 LLVM::CreateStore(*builder, dest_next_ptr, dest_itr);
                 next_idx = builder->CreateAdd(next_idx, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
@@ -2646,7 +2646,7 @@ namespace LCompilers {
             llvm_utils->start_new_block(elseBB);
             {
                 LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)),
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
                     curr_dest_next_ptr
                 );
             }
@@ -2663,10 +2663,10 @@ namespace LCompilers {
         llvm::Value* kv_ll, llvm::Value* dict, llvm::Value* capacity,
         ASR::ttype_t* m_key_type, ASR::ttype_t* m_value_type, llvm::Module* module,
         std::map<std::string, std::map<std::string, int>>& name2memidx) {
-        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
         llvm::Type* key_value_pair_type = get_key_value_pair_type(m_key_type, m_value_type)->getPointerTo();
         LLVM::CreateStore(*builder,
-            builder->CreateBitCast(kv_ll, llvm::Type::getInt8PtrTy(context)),
+            builder->CreateBitCast(kv_ll, llvm::Type::getInt8Ty(context)->getPointerTo()),
             src_itr);
         llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
         llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
@@ -2676,7 +2676,7 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpNE(
                 llvm_utils->CreateLoad(src_itr),
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             builder->CreateCondBr(cond, loopbody, loopend);
         }
@@ -3073,22 +3073,22 @@ namespace LCompilers {
          * // now, chain_itr either points to kv or is nullptr
          *
          */
-        chain_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
-        chain_itr_prev = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        chain_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
+        chain_itr_prev = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
         is_key_matching_var = llvm_utils->CreateAlloca(llvm::Type::getInt1Ty(context));
 
         LLVM::CreateStore(*builder,
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)), chain_itr_prev);
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()), chain_itr_prev);
         llvm::Value* key_mask_value = llvm_utils->CreateLoad(
             llvm_utils->create_ptr_gep(key_mask, key_hash));
         llvm_utils->create_if_else(builder->CreateICmpEQ(key_mask_value,
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1))), [&]() {
             llvm::Value* kv_ll_i8 = builder->CreateBitCast(key_value_pair_linked_list,
-                                                            llvm::Type::getInt8PtrTy(context));
+                                                            llvm::Type::getInt8Ty(context)->getPointerTo());
             LLVM::CreateStore(*builder, kv_ll_i8, chain_itr);
         }, [&]() {
             LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)), chain_itr);
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()), chain_itr);
         });
         LLVM::CreateStore(*builder,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(1, 0)),
@@ -3103,7 +3103,7 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpNE(
                 llvm_utils->CreateLoad(chain_itr),
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             cond = builder->CreateAnd(cond, builder->CreateNot(
                     llvm_utils->CreateLoad(is_key_matching_var)));
@@ -3283,14 +3283,14 @@ namespace LCompilers {
         llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
         llvm::Value* do_insert = builder->CreateICmpEQ(kv_struct_i8,
-            llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)));
+            llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()));
         builder->CreateCondBr(do_insert, thenBB, elseBB);
 
         builder->SetInsertPoint(thenBB);
         {
             llvm_utils->create_if_else(builder->CreateICmpNE(
                     llvm_utils->CreateLoad(chain_itr_prev),
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))), [&]() {
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
                 llvm::DataLayout data_layout(module);
                 size_t kv_struct_size = data_layout.getTypeAllocSize(kv_struct_type);
                 llvm::Value* malloc_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), kv_struct_size);
@@ -3299,7 +3299,7 @@ namespace LCompilers {
                 llvm_utils->deepcopy(key, llvm_utils->create_gep(new_kv_struct, 0), key_asr_type, module, name2memidx);
                 llvm_utils->deepcopy(value, llvm_utils->create_gep(new_kv_struct, 1), value_asr_type, module, name2memidx);
                 LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)),
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
                     llvm_utils->create_gep(new_kv_struct, 2));
                 llvm::Value* kv_struct_prev_i8 = llvm_utils->CreateLoad(chain_itr_prev);
                 llvm::Value* kv_struct_prev = builder->CreateBitCast(kv_struct_prev_i8, kv_struct_type->getPointerTo());
@@ -3308,7 +3308,7 @@ namespace LCompilers {
                 llvm_utils->deepcopy(key, llvm_utils->create_gep(key_value_pair_linked_list, 0), key_asr_type, module, name2memidx);
                 llvm_utils->deepcopy(value, llvm_utils->create_gep(key_value_pair_linked_list, 1), value_asr_type, module, name2memidx);
                 LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)),
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
                     llvm_utils->create_gep(key_value_pair_linked_list, 2));
             });
 
@@ -3679,7 +3679,7 @@ namespace LCompilers {
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)));
         does_kv_exists = builder->CreateAnd(does_kv_exists,
             builder->CreateICmpNE(llvm_utils->CreateLoad(chain_itr),
-            llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+            llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
         );
 
         llvm_utils->create_if_else(does_kv_exists, [&]() {
@@ -3723,7 +3723,7 @@ namespace LCompilers {
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)));
         does_kv_exists = builder->CreateAnd(does_kv_exists,
             builder->CreateICmpNE(llvm_utils->CreateLoad(chain_itr),
-            llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+            llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
         );
 
         llvm_utils->create_if_else(does_kv_exists, [&]() {
@@ -3970,8 +3970,8 @@ namespace LCompilers {
         old_occupancy = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
         old_number_of_buckets_filled = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
         idx_ptr = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
-        old_key_value_pairs = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
-        old_key_mask = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        old_key_value_pairs = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
+        old_key_mask = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
         llvm::Value* capacity_ptr = get_pointer_to_capacity(dict);
         llvm::Value* occupancy_ptr = get_pointer_to_occupancy(dict);
         llvm::Value* number_of_buckets_filled_ptr = get_pointer_to_number_of_filled_buckets(dict);
@@ -3987,7 +3987,7 @@ namespace LCompilers {
         );
         llvm::Value* old_key_mask_value = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
         llvm::Value* old_key_value_pairs_value = llvm_utils->CreateLoad(get_pointer_to_key_value_pairs(dict));
-        old_key_value_pairs_value = builder->CreateBitCast(old_key_value_pairs_value, llvm::Type::getInt8PtrTy(context));
+        old_key_value_pairs_value = builder->CreateBitCast(old_key_value_pairs_value, llvm::Type::getInt8Ty(context)->getPointerTo());
         LLVM::CreateStore(*builder, old_key_mask_value, old_key_mask);
         LLVM::CreateStore(*builder, old_key_value_pairs_value, old_key_value_pairs);
 
@@ -4314,12 +4314,12 @@ namespace LCompilers {
         llvm::Value* found_next = llvm_utils->CreateLoad(llvm_utils->create_gep(found, 2));
 
         llvm_utils->create_if_else(builder->CreateICmpNE(prev,
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))), [&]() {
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
             prev = builder->CreateBitCast(prev, kv_struct_type->getPointerTo());
             LLVM::CreateStore(*builder, found_next, llvm_utils->create_gep(prev, 2));
         }, [&]() {
             llvm_utils->create_if_else(builder->CreateICmpEQ(found_next,
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))), [&]() {
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
                 llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
                 LLVM::CreateStore(
                     *builder,
@@ -4444,7 +4444,7 @@ namespace LCompilers {
         std::map<std::string, std::map<std::string, int>>& name2memidx,
         bool key_or_value) {
         idx_ptr = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
-        chain_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        chain_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
         LLVM::CreateStore(*builder, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                             llvm::APInt(32, 0)), idx_ptr);
 
@@ -4477,7 +4477,7 @@ namespace LCompilers {
 
             llvm_utils->create_if_else(is_key_set, [&]() {
                 llvm::Value* dict_i = llvm_utils->create_ptr_gep(key_value_pairs, idx);
-                llvm::Value* kv_ll_i8 = builder->CreateBitCast(dict_i, llvm::Type::getInt8PtrTy(context));
+                llvm::Value* kv_ll_i8 = builder->CreateBitCast(dict_i, llvm::Type::getInt8Ty(context)->getPointerTo());
                 LLVM::CreateStore(*builder, kv_ll_i8, chain_itr);
 
                 llvm::BasicBlock *loop2head = llvm::BasicBlock::Create(context, "loop2.head");
@@ -4489,7 +4489,7 @@ namespace LCompilers {
                 {
                     llvm::Value *cond = builder->CreateICmpNE(
                         llvm_utils->CreateLoad(chain_itr),
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
                     );
                     builder->CreateCondBr(cond, loop2body, loop2end);
                 }
@@ -5597,7 +5597,7 @@ namespace LCompilers {
                                         type_code, type_size);
         std::vector<llvm::Type*> set_type_vec = {llvm::Type::getInt32Ty(context),
                                                 el_list_type,
-                                                llvm::Type::getInt8PtrTy(context)};
+                                                llvm::Type::getInt8Ty(context)->getPointerTo()};
         llvm::Type* set_desc = llvm::StructType::create(context, set_type_vec, "set");
         typecode2settype[type_code] = std::make_tuple(set_desc, type_size, el_type);
         return set_desc;
@@ -5610,13 +5610,13 @@ namespace LCompilers {
             return std::get<0>(typecode2settype[el_type_code]);
         }
 
-        std::vector<llvm::Type*> el_vec = {el_type, llvm::Type::getInt8PtrTy(context)};
+        std::vector<llvm::Type*> el_vec = {el_type, llvm::Type::getInt8Ty(context)->getPointerTo()};
         llvm::Type* elstruct = llvm::StructType::create(context, el_vec, "el");
         std::vector<llvm::Type*> set_type_vec = {llvm::Type::getInt32Ty(context),
                                                   llvm::Type::getInt32Ty(context),
                                                   llvm::Type::getInt32Ty(context),
                                                   elstruct->getPointerTo(),
-                                                  llvm::Type::getInt8PtrTy(context),
+                                                  llvm::Type::getInt8Ty(context)->getPointerTo(),
                                                   llvm::Type::getInt1Ty(context)};
         llvm::Type* set_desc = llvm::StructType::create(context, set_type_vec, "set");
         typecode2settype[el_type_code] = std::make_tuple(set_desc, el_type_size, el_type);
@@ -5673,7 +5673,7 @@ namespace LCompilers {
         llvm::Value* el_ptr = LLVM::lfortran_malloc(context, *module, *builder, malloc_size);
         rehash_flag = builder->CreateAnd(rehash_flag,
                         builder->CreateICmpNE(el_ptr,
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
                     );
         el_ptr = builder->CreateBitCast(el_ptr, el_type->getPointerTo());
         LLVM::CreateStore(*builder, el_ptr, get_pointer_to_elems(set));
@@ -5685,7 +5685,7 @@ namespace LCompilers {
                                                       llvm_mask_size);
         rehash_flag = builder->CreateAnd(rehash_flag,
                         builder->CreateICmpNE(el_mask,
-                        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+                        llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
                     );
         LLVM::CreateStore(*builder, el_mask, get_pointer_to_mask(set));
 
@@ -5939,21 +5939,21 @@ namespace LCompilers {
          *
          */
 
-        chain_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
-        chain_itr_prev = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        chain_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
+        chain_itr_prev = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
         is_el_matching_var = llvm_utils->CreateAlloca(llvm::Type::getInt1Ty(context));
 
         LLVM::CreateStore(*builder,
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)), chain_itr_prev);
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()), chain_itr_prev);
         llvm::Value* el_mask_value = llvm_utils->CreateLoad(
             llvm_utils->create_ptr_gep(el_mask, el_hash));
         llvm_utils->create_if_else(builder->CreateICmpEQ(el_mask_value,
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1))), [&]() {
-            llvm::Value* el_ll_i8 = builder->CreateBitCast(el_linked_list, llvm::Type::getInt8PtrTy(context));
+            llvm::Value* el_ll_i8 = builder->CreateBitCast(el_linked_list, llvm::Type::getInt8Ty(context)->getPointerTo());
             LLVM::CreateStore(*builder, el_ll_i8, chain_itr);
         }, [&]() {
             LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)), chain_itr);
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()), chain_itr);
         });
         LLVM::CreateStore(*builder,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(1, 0)),
@@ -5968,7 +5968,7 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpNE(
                 llvm_utils->CreateLoad(chain_itr),
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             cond = builder->CreateAnd(cond, builder->CreateNot(
                     llvm_utils->CreateLoad(is_el_matching_var)));
@@ -6101,14 +6101,14 @@ namespace LCompilers {
         llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
         llvm::Value* do_insert = builder->CreateICmpEQ(el_struct_i8,
-            llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)));
+            llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()));
         builder->CreateCondBr(do_insert, thenBB, elseBB);
 
         builder->SetInsertPoint(thenBB);
         {
             llvm_utils->create_if_else(builder->CreateICmpNE(
                     llvm_utils->CreateLoad(chain_itr_prev),
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))), [&]() {
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
                 llvm::DataLayout data_layout(module);
                 size_t el_struct_size = data_layout.getTypeAllocSize(el_struct_type);
                 llvm::Value* malloc_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), el_struct_size);
@@ -6116,7 +6116,7 @@ namespace LCompilers {
                 llvm::Value* new_el_struct = builder->CreateBitCast(new_el_struct_i8, el_struct_type->getPointerTo());
                 llvm_utils->deepcopy(el, llvm_utils->create_gep(new_el_struct, 0), el_asr_type, module, name2memidx);
                 LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)),
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
                     llvm_utils->create_gep(new_el_struct, 1));
                 llvm::Value* el_struct_prev_i8 = llvm_utils->CreateLoad(chain_itr_prev);
                 llvm::Value* el_struct_prev = builder->CreateBitCast(el_struct_prev_i8, el_struct_type->getPointerTo());
@@ -6124,7 +6124,7 @@ namespace LCompilers {
             }, [&]() {
                 llvm_utils->deepcopy(el, llvm_utils->create_gep(el_linked_list, 0), el_asr_type, module, name2memidx);
                 LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)),
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
                     llvm_utils->create_gep(el_linked_list, 1));
             });
 
@@ -6306,8 +6306,8 @@ namespace LCompilers {
         old_occupancy = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
         old_number_of_buckets_filled = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
         idx_ptr = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
-        old_elems = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
-        old_el_mask = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        old_elems = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
+        old_el_mask = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
 
         llvm::Value* capacity_ptr = get_pointer_to_capacity(set);
         llvm::Value* occupancy_ptr = get_pointer_to_occupancy(set);
@@ -6324,7 +6324,7 @@ namespace LCompilers {
         );
         llvm::Value* old_el_mask_value = llvm_utils->CreateLoad(get_pointer_to_mask(set));
         llvm::Value* old_elems_value = llvm_utils->CreateLoad(get_pointer_to_elems(set));
-        old_elems_value = builder->CreateBitCast(old_elems_value, llvm::Type::getInt8PtrTy(context));
+        old_elems_value = builder->CreateBitCast(old_elems_value, llvm::Type::getInt8Ty(context)->getPointerTo());
         LLVM::CreateStore(*builder, old_el_mask_value, old_el_mask);
         LLVM::CreateStore(*builder, old_elems_value, old_elems);
 
@@ -6431,11 +6431,11 @@ namespace LCompilers {
          *
          */
 
-        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
 
         llvm::Type* el_struct_type = typecode2elstruct[ASRUtils::get_type_code(m_el_type)]->getPointerTo();
         LLVM::CreateStore(*builder,
-            builder->CreateBitCast(el_ll, llvm::Type::getInt8PtrTy(context)),
+            builder->CreateBitCast(el_ll, llvm::Type::getInt8Ty(context)->getPointerTo()),
             src_itr);
         llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
         llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
@@ -6445,7 +6445,7 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpNE(
                 llvm_utils->CreateLoad(src_itr),
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             builder->CreateCondBr(cond, loopbody, loopend);
         }
@@ -6652,7 +6652,7 @@ namespace LCompilers {
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)));
         does_el_exist = builder->CreateAnd(does_el_exist,
             builder->CreateICmpNE(llvm_utils->CreateLoad(chain_itr),
-            llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)))
+            llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()))
         );
 
         llvm_utils->create_if_else(does_el_exist, []() {}, [&]() {
@@ -6727,7 +6727,7 @@ namespace LCompilers {
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
 
         builder->CreateCondBr(
-            builder->CreateICmpNE(prev, llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))),
+            builder->CreateICmpNE(prev, llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())),
             thenBB, elseBB
         );
         builder->SetInsertPoint(thenBB);
@@ -6894,15 +6894,15 @@ namespace LCompilers {
          * }
          *
          */
-        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
-        dest_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8PtrTy(context));
+        src_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
+        dest_itr = llvm_utils->CreateAlloca(llvm::Type::getInt8Ty(context)->getPointerTo());
 
         llvm::Type* el_struct_type = typecode2elstruct[ASRUtils::get_type_code(set_type->m_type)]->getPointerTo();
         LLVM::CreateStore(*builder,
-            builder->CreateBitCast(srci, llvm::Type::getInt8PtrTy(context)),
+            builder->CreateBitCast(srci, llvm::Type::getInt8Ty(context)->getPointerTo()),
             src_itr);
         LLVM::CreateStore(*builder,
-            builder->CreateBitCast(desti, llvm::Type::getInt8PtrTy(context)),
+            builder->CreateBitCast(desti, llvm::Type::getInt8Ty(context)->getPointerTo()),
             dest_itr);
         llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
         llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
@@ -6912,7 +6912,7 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpNE(
                 llvm_utils->CreateLoad(src_itr),
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context))
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             builder->CreateCondBr(cond, loopbody, loopend);
         }
@@ -6937,11 +6937,11 @@ namespace LCompilers {
             LLVM::CreateStore(*builder, src_next_ptr, src_itr);
 
             llvm::Value* src_next_exists = builder->CreateICmpNE(src_next_ptr,
-                llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)));
+                llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()));
             llvm_utils->create_if_else(src_next_exists, [&]() {
                 llvm::Value* next_idx = llvm_utils->CreateLoad(next_ptr);
                 llvm::Value* dest_next_ptr = llvm_utils->create_ptr_gep(dest_elems, next_idx);
-                dest_next_ptr = builder->CreateBitCast(dest_next_ptr, llvm::Type::getInt8PtrTy(context));
+                dest_next_ptr = builder->CreateBitCast(dest_next_ptr, llvm::Type::getInt8Ty(context)->getPointerTo());
                 LLVM::CreateStore(*builder, dest_next_ptr, curr_dest_next_ptr);
                 LLVM::CreateStore(*builder, dest_next_ptr, dest_itr);
                 next_idx = builder->CreateAdd(next_idx, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
@@ -6949,7 +6949,7 @@ namespace LCompilers {
                 LLVM::CreateStore(*builder, next_idx, next_ptr);
             }, [&]() {
                 LLVM::CreateStore(*builder,
-                    llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(context)),
+                    llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
                     curr_dest_next_ptr
                 );
             });

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -70,7 +70,7 @@ namespace LCompilers {
         llvm::Function *fn_printf = module.getFunction("_lfortran_printf");
         if (!fn_printf) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
-                    llvm::Type::getVoidTy(context), {llvm::Type::getInt8PtrTy(context)}, true);
+                    llvm::Type::getVoidTy(context), {llvm::Type::getInt8Ty(context)->getPointerTo()}, true);
             fn_printf = llvm::Function::Create(function_type,
                     llvm::Function::ExternalLinkage, "_lfortran_printf", &module);
         }
@@ -83,9 +83,9 @@ namespace LCompilers {
         llvm::Function *fn_printf = module.getFunction("_lcompilers_string_format_fortran");
         if (!fn_printf) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
-                    llvm::Type::getInt8PtrTy(context),
+                    llvm::Type::getInt8Ty(context)->getPointerTo(),
                     {llvm::Type::getInt32Ty(context),
-                    llvm::Type::getInt8PtrTy(context)}, true);
+                    llvm::Type::getInt8Ty(context)->getPointerTo()}, true);
             fn_printf = llvm::Function::Create(function_type,
                     llvm::Function::ExternalLinkage, "_lcompilers_string_format_fortran", &module);
         }
@@ -99,8 +99,8 @@ namespace LCompilers {
         if (!fn) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
                      llvm::Type::getVoidTy(context), {
-                        llvm::Type::getInt8PtrTy(context)->getPointerTo(),
-                        llvm::Type::getInt8PtrTy(context),
+                        llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(),
+                        llvm::Type::getInt8Ty(context)->getPointerTo(),
                         llvm::Type::getInt8Ty(context)
                     }, false);
             fn = llvm::Function::Create(function_type,
@@ -117,7 +117,7 @@ namespace LCompilers {
         llvm::Function *fn_printf = module.getFunction("_lcompilers_print_error");
         if (!fn_printf) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
-                    llvm::Type::getVoidTy(context), {llvm::Type::getInt8PtrTy(context)}, true);
+                    llvm::Type::getVoidTy(context), {llvm::Type::getInt8Ty(context)->getPointerTo()}, true);
             fn_printf = llvm::Function::Create(function_type,
                     llvm::Function::ExternalLinkage, "_lcompilers_print_error", &module);
         }
@@ -149,7 +149,7 @@ namespace LCompilers {
         if (!fn) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
                 llvm::Type::getVoidTy(context), {
-                    llvm::Type::getInt8PtrTy(context),
+                    llvm::Type::getInt8Ty(context)->getPointerTo(),
                     llvm::Type::getInt1Ty(context)
                 }, true);
             fn = llvm::Function::Create(function_type,


### PR DESCRIPTION
There were three issues
- llvm::CGFT_AssemblyFile moved to llvm::CodeGenFileType::AssemblyFile
- Vectorize.h, Host.h is removed
- All pointer types are removed (e.g., getInt8Ty)