### PR TITLE
[LLVM] Specify type for Load in StringCompare

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -704,7 +704,6 @@ jobs:
 
       - name: Test stdlib
         shell: bash -e -x -l {0}
-        if: contains(matrix.llvm-version, '19') == false
         run: |
             git clone https://github.com/czgdp1807/stdlib.git
             cd stdlib

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5825,8 +5825,8 @@ public:
         bool is_single_char = (ASR::is_a<ASR::StringItem_t>(*x.m_left) &&
                                ASR::is_a<ASR::StringItem_t>(*x.m_right));
         if( is_single_char ) {
-            left = llvm_utils->CreateLoad(left);
-            right = llvm_utils->CreateLoad(right);
+            left = llvm_utils->CreateLoad2(character_type, left);
+            right = llvm_utils->CreateLoad2(character_type, right);
         }
         std::string fn;
         switch (x.m_op) {


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4982