### PR TITLE
introduce 'nollvm17orhigher' label for tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -792,13 +792,13 @@ jobs:
 
       # In LLVM 17 we can only compile a subset for now, so we have a dedicated
       # LLVM 17 test here:
-      # - name: Test Linux LLVM 17
-      #   if: contains(matrix.llvm-version, '17') == true
-      #   shell: bash -e -l {0}
-      #   run: |
-      #       cd integration_tests
-      #       ./run_tests.py -b llvm17
-      #       ./run_tests.py -b llvm17 -f
+      - name: Test Linux LLVM 17
+        if: contains(matrix.llvm-version, '17') == true
+        shell: bash -e -l {0}
+        run: |
+            cd integration_tests
+            ./run_tests.py -b llvm17
+            #./run_tests.py -b llvm17 -f
 
   test_llvm_wasm:
     name: Test LLVM->WASM ${{ matrix.llvm-version }}

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -12,6 +12,9 @@ set(FAST no CACHE BOOL "Run supported tests with --fast")
 
 enable_testing()
 
+find_package(LLVM REQUIRED)
+message("LLVM version: ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+
 message("\n")
 message("Configuration results")
 message("---------------------")
@@ -40,7 +43,11 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
         message(FATAL_ERROR "Must specify the NAME argument")
     endif()
 
-    if (LFORTRAN_BACKEND)
+    if ("nollvm17orhigher" IN_LIST labels AND LLVM_VERSION_MAJOR GREATER_EQUAL 17)
+        # Skip the test for LLVM version 17 or higher
+        message(STATUS "Skipping test ${name} for LLVM version 17 or higher")
+        set(ADD_TEST OFF)
+    elseif (LFORTRAN_BACKEND)
         if (${LFORTRAN_BACKEND} IN_LIST labels)
             # Test is supported by the given LFortran backend
             set(ADD_TEST ON)
@@ -173,7 +180,7 @@ macro(RUN)
                         "${multiValueArgs}" ${ARGN} )
 
     foreach(b ${RUN_LABELS})
-        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|llvm_wasm|llvm_wasm_emcc|llvm_omp|mlir|llvm17)$"))
+        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|llvm_wasm|llvm_wasm_emcc|llvm_omp|mlir|llvm17|nollvm17orhigher)$"))
             message(FATAL_ERROR "Unsupported backend: ${b}")
         endif()
     endforeach()
@@ -458,7 +465,7 @@ RUN(NAME arrays_op_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArr
 RUN(NAME arrays_op_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 RUN(NAME arrays_op_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 RUN(NAME arrays_op_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
-RUN(NAME arrays_reshape_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
+RUN(NAME arrays_reshape_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17 nollvm17orhigher)
 RUN(NAME arrays_reshape_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
 RUN(NAME arrays_reshape_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 RUN(NAME arrays_reshape_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17)
@@ -478,7 +485,7 @@ RUN(NAME arrays_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray 
 RUN(NAME arrays_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 RUN(NAME arrays_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 RUN(NAME arrays_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
-RUN(NAME arrays_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17) # maxloc, minloc
+RUN(NAME arrays_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17 nollvm17orhigher) # maxloc, minloc
 RUN(NAME arrays_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 RUN(NAME arrays_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17) # maxloc
 RUN(NAME arrays_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm llvm17) # init expr with fixed size arr as dependency
@@ -492,7 +499,7 @@ RUN(NAME arrays_38 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME arrays_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME arrays_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME arrays_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME arrays_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME arrays_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
 RUN(NAME arrays_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME arrays_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran llvm17 NOFAST EXTRA_ARGS --realloc-lhs)
 RUN(NAME arrays_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
@@ -984,7 +991,7 @@ RUN(NAME modules_39 LABELS gfortran EXTRAFILES
 RUN(NAME modules_44 LABELS gfortran EXTRAFILES
         modules_44_module.f90)
 RUN(NAME modules_40 LABELS gfortran llvm llvm17)
-RUN(NAME modules_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME modules_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc nollvm17orhigher)
 # RUN(NAME modules_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME modules_43 LABELS gfortran)
 RUN(NAME modules_45 LABELS gfortran)
@@ -1009,11 +1016,11 @@ RUN(NAME lfortran_intrinsic_sin LABELS gfortran llvm llvm17 EXTRAFILES lfortran_
 RUN(NAME bindc1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME bindc2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME bindc3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME bindc4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME bindc_01 LABELS gfortran llvm llvm17 EXTRAFILES bindc_01b.f90 bindc_01c.c NOFAST)
+RUN(NAME bindc4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
+RUN(NAME bindc_01 LABELS gfortran llvm llvm17 nollvm17orhigher EXTRAFILES bindc_01b.f90 bindc_01c.c NOFAST)
 RUN(NAME bindc_02 LABELS gfortran llvm llvm17 EXTRAFILES bindc_02b.f90 bindc_02c.c NOFAST)
 RUN(NAME bindc_03 LABELS gfortran llvm llvm17 EXTRAFILES bindc_03c.c NOFAST)
-RUN(NAME bindc_04 LABELS gfortran llvm llvm17 EXTRAFILES bindc_04c.c NOFAST)
+RUN(NAME bindc_04 LABELS gfortran llvm llvm17 nollvm17orhigher EXTRAFILES bindc_04c.c NOFAST)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm17)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
@@ -1204,9 +1211,9 @@ RUN(NAME allocate_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME allocate_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME allocate_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17
     EXTRA_ARGS --realloc-lhs)
-RUN(NAME allocate_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
+RUN(NAME allocate_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc nollvm17orhigher
     EXTRA_ARGS --realloc-lhs)
-RUN(NAME allocate_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME allocate_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc nollvm17orhigher)
 RUN(NAME allocate_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17
     EXTRA_ARGS --realloc-lhs)
 RUN(NAME allocate_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
@@ -1442,7 +1449,7 @@ RUN(NAME template_matrix_test LABELS llvm llvm_wasm llvm_wasm_emcc llvm17 EXTRAF
     template_matrix.f90
     )
 RUN(NAME template_struct_01 LABELS llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME template_vector LABELS llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME template_vector LABELS llvm llvm_wasm llvm_wasm_emcc nollvm17orhigher)
 RUN(NAME template_simple_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm llvm17)
 RUN(NAME template_simple_02 LABELS llvm llvm_wasm llvm_wasm_emcc wasm llvm17)
 RUN(NAME template_simple_03 LABELS llvm llvm_wasm llvm_wasm_emcc wasm llvm17)
@@ -1609,7 +1616,7 @@ RUN(NAME char_array_indexing LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm1
 RUN(NAME character_parameter_padding_trimming LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 
 RUN(NAME c_ptr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray llvm17)
 
@@ -1676,14 +1683,14 @@ RUN(NAME shifta_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 RUN(NAME shifta_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 
 RUN(NAME equivalence_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME equivalence_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME equivalence_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME equivalence_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME equivalence_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
+RUN(NAME equivalence_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
+RUN(NAME equivalence_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
 RUN(NAME equivalence_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME equivalence_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME equivalence_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
 RUN(NAME equivalence_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME equivalence_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
-RUN(NAME equivalence_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
+RUN(NAME equivalence_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
+RUN(NAME equivalence_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17 nollvm17orhigher)
 
 RUN(NAME fortran_primes_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm17)
 


### PR DESCRIPTION
## Changes

This PR introduces a label `nollvm17orhigher` in CMakeLists.txt, which ensures that tests labeled with `nollvm17orhigher` aren't run with LLVM 17 or higher versions, but are only run with LLVM 10-16 only.

## Why do we need the changes?

This will help us enable LLVM 17 CI job on *simplifier_pass* until we fix the tests failing with LLVM 17 on *simplifier_pass* branch.


You can follow the discussion here on zulip as well: https://lfortran.zulipchat.com/#narrow/stream/452774-Internal/topic/Simplifier.20pass/near/474866001