### PR TITLE
Error for division by zero issue_#4339

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7805,6 +7805,23 @@ public:
         ASR::expr_t *left = ASRUtils::EXPR(tmp);
         this->visit_expr(*x.m_right);
         ASR::expr_t *right = ASRUtils::EXPR(tmp);
+   
+        ASR::expr_t *right_value = ASRUtils::expr_value(right); 
+
+        if(x.m_op == AST::operatorType::Div){
+            
+            if (right_value != nullptr) {
+
+                if (ASR::is_a<ASR::IntegerConstant_t>(*right_value)) {
+                    int64_t right_int = ASR::down_cast<ASR::IntegerConstant_t>(right_value)->m_n;
+                    
+                    if(right_int == 0){
+                        throw SemanticError("Division by zero", x.base.base.loc);
+                    }
+                }
+            }
+        }
+
         visit_BinOp2(al, x, left, right, tmp, binop2str[x.m_op], current_scope);
     }
 

--- a/tests/errors/division_by_zero.f90
+++ b/tests/errors/division_by_zero.f90
@@ -1,0 +1,5 @@
+PROGRAM main
+   IMPLICIT NONE
+   PRINT *, 1/0
+
+END PROGRAM main

--- a/tests/reference/asr-division_by_zero-f2c0127.json
+++ b/tests/reference/asr-division_by_zero-f2c0127.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-division_by_zero-f2c0127",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/division_by_zero.f90",
+    "infile_hash": "7dbb41c0e1efccc63e393850d2d114b032e75a75f671f6b684c414df",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-division_by_zero-f2c0127.stderr",
+    "stderr_hash": "2c12be64a51c73ea3d9cdbfcd381c657549ad0ba34a8d0d64f8a4c46",
+    "returncode": 2
+}

--- a/tests/reference/asr-division_by_zero-f2c0127.stderr
+++ b/tests/reference/asr-division_by_zero-f2c0127.stderr
@@ -1,0 +1,5 @@
+semantic error: Division by zero
+ --> tests/errors/division_by_zero.f90:3:13
+  |
+3 |    PRINT *, 1/0
+  |             ^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4220,3 +4220,7 @@ asr_implicit_interface_and_typing = true
 [[test]]
 filename = "errors/func_arg_array.f90"
 asr = true
+
+[[test]]
+filename = "errors/division_by_zero.f90"
+asr = true


### PR DESCRIPTION
This PR aims to fix issue #4339. So , basically , the PR throws semantic error for division by zero error for compile time implementations like 1/0 and  1/(1-1) . 