### PR TITLE
CI: introduce dummy CI jobs to resolve "expected check" error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -479,7 +479,7 @@ jobs:
             test -f inst/man/O/man/man1/lfortran.1
 
   third_party_code_compile_dummy:
-    name: Check Third Party Code Compilation - OS (${{ matrix.llvm-version }}), LLVM (${{ matrix.llvm-version }})
+    name: Check Third Party Code Compilation
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -485,7 +485,6 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
-        llvm-version: ["11", "19"]
         python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -478,6 +478,21 @@ jobs:
             test -f inst/incl/O/Matic/lfortran/impure/lfortran_intrinsics.h
             test -f inst/man/O/man/man1/lfortran.1
 
+  third_party_code_compile_dummy:
+    name: Check Third Party Code Compilation - OS (${{ matrix.llvm-version }}), LLVM (${{ matrix.llvm-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-latest", "ubuntu-latest"]
+        llvm-version: ["11", "19"]
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          echo "Skipping test"
+          exit 0
+
   third_party_code_compile:
     name: Check Third Party Code Compilation - OS (${{ matrix.os }}), LLVM (${{ matrix.llvm-version }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Currently, when we create a PR against *simplifier_pass* branch, this leads to two CI checks, which always remain on *Expected — Waiting for status to be report..* (see example screenshot below):

![Screenshot 2024-10-08 at 6 32 00 PM](https://github.com/user-attachments/assets/04c82375-fb17-41fa-9dff-0249d76ed4e3)

Example PR where this happens: https://github.com/lfortran/lfortran/pull/5009

### Fix

With this we introduce two dummy CI jobs (one for macOS and other for Linux), which do nothing at all (so they will always pass)

This solution followed after certik's comment here: https://github.com/lfortran/lfortran/pull/5004#issuecomment-2397002183