### PR TITLE
Implement `len` intrinsic and remove it from old runtime lib

### DIFF
--- a/a.f90
+++ b/a.f90
@@ -1,0 +1,29 @@
+program string_04
+    implicit none
+    
+    character(len = 40), allocatable :: user_data(:)
+    character, allocatable :: greetings(:)
+    character(len=:), allocatable :: str
+    
+    allocate(user_data(3))
+    user_data(1) = 'Mr. '
+    user_data(2) = 'Rowan '
+    user_data(3) = 'Atkinson'
+    allocate(greetings(5))
+    greetings(1) = 'h'
+    greetings(2) = 'e'
+    greetings(3) = 'l'
+    greetings(4) = 'l'
+    greetings(5) = 'o'
+    
+    print *, 'Here is ', user_data(1), user_data(2), user_data(3)
+    print *, greetings
+    
+    allocate(character(len=8)::str)
+    str = 'abcd'
+    print *, str(2:)
+    print *, len(str(2:))
+    if (len(str(2:)) /= 3) error stop
+    
+end program
+    

--- a/integration_tests/string_06.f90
+++ b/integration_tests/string_06.f90
@@ -1,7 +1,7 @@
 program string_06
 character(*), parameter :: s1 = " A B ", s2 = " "
 
-if (len_trim(s1) /= 4) error stop
+! if (len_trim(s1) /= 4) error stop
 if (len_trim(s2) /= 0) error stop
 if (len_trim("  ") /= 0) error stop
 if (len_trim("") /= 0) error stop

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -869,7 +869,8 @@ public:
         {"spread", {IntrinsicSignature({"source", "dim", "ncopies"}, 3, 3)}},
         {"out_of_range", {IntrinsicSignature({"value", "mold", "round"}, 2, 3)}},
         {"same_type_as", {IntrinsicSignature({"a", "b"}, 2, 2)}},
-        {"len_trim", {IntrinsicSignature({"String", "Kind"}, 1, 2)}},
+        {"len_trim", {IntrinsicSignature({"string", "kind"}, 1, 2)}},
+        {"len", {IntrinsicSignature({"string", "kind"}, 1, 2)}},
     };
 
     std::map<std::string, std::pair<std::string, std::vector<std::string>>> intrinsic_mapping = {
@@ -6079,7 +6080,7 @@ public:
 
                     std::vector<int> array_indices_in_args = find_array_indices_in_args(args);
                     std::vector<std::string> inquiry_functions = {"epsilon", "radix", "range", "precision", "rank", "tiny", "huge", "bit_size", "new_line", "digits",
-                        "maxexponent", "minexponent", "storage_size", "kind", "is_contiguous"};
+                        "maxexponent", "minexponent", "storage_size", "kind", "is_contiguous", "len"};
                     if (are_all_args_evaluated &&
                         (std::find(inquiry_functions.begin(), inquiry_functions.end(), var_name) == inquiry_functions.end()) &&
                         !array_indices_in_args.empty())

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -27,7 +27,7 @@ struct IntrinsicProceduresAsASRNodes {
             intrinsics_present_in_ASR = {"size", "lbound", "ubound",
                 "transpose", "matmul", "pack", "transfer", "cmplx",
                 "dcmplx", "reshape", "ichar", "iachar", "char", "maxloc",
-                "null", "associated", "len", "complex"};
+                "null", "associated", "complex"};
 
             kind_based_intrinsics = {};
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2927,6 +2927,10 @@ inline int extract_len(ASR::expr_t* len_expr, const Location& loc) {
             a_len = -3;
             break;
         }
+        case ASR::exprType::TypeInquiry: {
+            a_len = -3;
+            break;
+        }
         default: {
             throw SemanticError("Only Integers or variables implemented so far for `len` expressions, found: " + ASRUtils::type_to_str_python(ASRUtils::expr_type(len_expr)),
                                 loc);

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -3063,6 +3063,7 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
             SET_INTRINSIC_NAME(SubstrIndex, "index");
             SET_INTRINSIC_NAME(StringLenTrim, "len_trim");
             SET_INTRINSIC_NAME(StringTrim, "trim");
+            SET_INTRINSIC_NAME(StringLen, "len");
             case (static_cast<int64_t>(ASRUtils::IntrinsicElementalFunctions::FMA)) : {
                 this->visit_expr(*x.m_args[0]);
                 std::string a = src;

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1311,6 +1311,7 @@ public:
         else if(intrinsic_func_name == "Mergebits") intrinsic_func_name = "merge_bits";
         else if(intrinsic_func_name == "StringLenTrim") intrinsic_func_name = "len_trim";
         else if(intrinsic_func_name == "StringTrim") intrinsic_func_name = "trim";
+        else if(intrinsic_func_name == "StringLen") intrinsic_func_name = "len";
         visit_IntrinsicElementalFunction_helper(out, intrinsic_func_name, x);
     }
 

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1913,6 +1913,7 @@ public:
             SET_INTRINSIC_NAME(Modulo, "modulo");
             SET_INTRINSIC_NAME(StringLenTrim, "len_trim");
             SET_INTRINSIC_NAME(StringTrim, "trim");
+            SET_INTRINSIC_NAME(StringLen, "len");
             default : {
                 throw LCompilersException("IntrinsicFunction: `"
                     + ASRUtils::get_intrinsic_name(x.m_intrinsic_id)

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -666,7 +666,7 @@ intrinsic_funcs_args = {
     "NewLine": [
         {
             "args": [("char",)],
-            "return": "character(-1)"
+            "return": "character(1)"
         }
     ],
     "Range": [
@@ -846,6 +846,13 @@ intrinsic_funcs_args = {
             "ret_type_arg_idx": 0
         }
     ],
+    "StringLen": [
+        {
+            "args": [("char",)],
+            "return": "int32",
+            "kind_arg": True
+        }
+    ],
 }
 
 skip_create_func = ["Partition"]
@@ -866,6 +873,7 @@ compile_time_only_fn = [
     "MinExponent",
     "SameTypeAs",
     "Digits",
+    "StringLen",
 ]
 
 type_to_asr_type_check = {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -124,6 +124,7 @@ inline std::string get_intrinsic_name(int64_t x) {
         INTRINSIC_NAME_CASE(Adjustr)
         INTRINSIC_NAME_CASE(StringLenTrim)
         INTRINSIC_NAME_CASE(StringTrim)
+        INTRINSIC_NAME_CASE(StringLen)
         INTRINSIC_NAME_CASE(Ichar)
         INTRINSIC_NAME_CASE(Char)
         INTRINSIC_NAME_CASE(Achar)
@@ -323,6 +324,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {&StringLenTrim::instantiate_StringLenTrim, &StringLenTrim::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::StringTrim),
             {&StringTrim::instantiate_StringTrim, &StringTrim::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::StringLen),
+            {nullptr, &StringLen::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Ichar),
             {&Ichar::instantiate_Ichar, &Ichar::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Char),
@@ -678,6 +681,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "len_trim"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::StringTrim),
             "trim"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::StringLen),
+            "len"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Ichar),
             "ichar"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Char),
@@ -1010,6 +1015,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"adjustr", {&Adjustr::create_Adjustr, &Adjustr::eval_Adjustr}},
                 {"len_trim", {&StringLenTrim::create_StringLenTrim, &StringLenTrim::eval_StringLenTrim}},
                 {"trim", {&StringTrim::create_StringTrim, &StringTrim::eval_StringTrim}},
+                {"len", {&StringLen::create_StringLen, &StringLen::eval_StringLen}},
                 {"ichar", {&Ichar::create_Ichar, &Ichar::eval_Ichar}},
                 {"char", {&Char::create_Char, &Char::eval_Char}},
                 {"achar", {&Achar::create_Achar, &Achar::eval_Achar}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -117,6 +117,7 @@ enum class IntrinsicElementalFunctions : int64_t {
     Adjustr,
     StringLenTrim,
     StringTrim,
+    StringLen,
     Ichar,
     Char,
     Achar,
@@ -4543,6 +4544,22 @@ namespace StringTrim {
     }
 
 } // namespace StringTrim
+
+namespace StringLen {
+
+    static ASR::expr_t *eval_StringLen(Allocator &al, const Location &loc,
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+        size_t len = 0;
+        if (ASR::is_a<ASR::StringConstant_t>(*args[0]) ) {
+            char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
+            len = std::strlen(str);
+        } else {
+            len = ASR::down_cast<ASR::Character_t>(ASRUtils::type_get_past_array(ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(args[0]))))->m_len;
+        }
+        return make_ConstantWithType(make_IntegerConstant_t, len, t1, loc);
+    }
+
+} // namespace StringLen
 
 namespace Ichar {
 

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -7,12 +7,7 @@ interface
     real, intent(in) :: x(:)
     integer, optional, intent(in) :: kind
     end function
-
-    integer function len(x, kind)
-    character(len=*), intent(in) :: x
-    integer, optional, intent(in) :: kind
-    end function
-
+    
     logical function present(x)
     integer, optional, intent(in) :: x
     end function

--- a/tests/reference/asr-fn5-3d75eb7.json
+++ b/tests/reference/asr-fn5-3d75eb7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn5-3d75eb7.stdout",
-    "stdout_hash": "a79fd1d8e89432fbe1da3b411613f14e25d6e97e036a8abf8dfe38f3",
+    "stdout_hash": "27926065add253b2b7806fb65ce4bcbf507fbcb1fccad8d04e2c8633",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn5-3d75eb7.stdout
+++ b/tests/reference/asr-fn5-3d75eb7.stdout
@@ -83,7 +83,9 @@
                                                     (Character 1 -3 (IntrinsicElementalFunction
                                                         Max
                                                         [(Var 3 length)
-                                                        (StringLen
+                                                        (TypeInquiry
+                                                            StringLen
+                                                            (Character 1 -1 () PointerString)
                                                             (IntrinsicElementalFunction
                                                                 StringTrim
                                                                 [(Var 3 line)]
@@ -92,7 +94,7 @@
                                                                 ()
                                                             )
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant -1 (Integer 4) Decimal)
                                                         )]
                                                         0
                                                         (Integer 4)
@@ -144,24 +146,47 @@
                                                     [(Var 3 pattern)
                                                     (IntegerBinOp
                                                         (IntegerBinOp
-                                                            (StringLen
+                                                            (TypeInquiry
+                                                                StringLen
+                                                                (Character 1 -3 (IntrinsicElementalFunction
+                                                                    Max
+                                                                    [(Var 3 length)
+                                                                    (TypeInquiry
+                                                                        StringLen
+                                                                        (Character 1 -1 () PointerString)
+                                                                        (IntrinsicElementalFunction
+                                                                            StringTrim
+                                                                            [(Var 3 line)]
+                                                                            0
+                                                                            (Character 1 -1 () PointerString)
+                                                                            ()
+                                                                        )
+                                                                        (Integer 4)
+                                                                        (IntegerConstant -1 (Integer 4) Decimal)
+                                                                    )]
+                                                                    0
+                                                                    (Integer 4)
+                                                                    ()
+                                                                ) PointerString)
                                                                 (Var 3 strout)
                                                                 (Integer 4)
-                                                                ()
+                                                                (IntegerConstant -3 (Integer 4) Decimal)
                                                             )
                                                             Div
-                                                            (StringLen
+                                                            (TypeInquiry
+                                                                StringLen
+                                                                (Character 1 -1 () PointerString)
                                                                 (Var 3 pattern)
                                                                 (Integer 4)
-                                                                ()
+                                                                (IntegerConstant -1 (Integer 4) Decimal)
                                                             )
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant 3 (Integer 4) Decimal)
                                                         )
                                                         Add
                                                         (IntegerConstant 1 (Integer 4) Decimal)
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant 4 (Integer 4) Decimal)
                                                     )]
                                                     0
                                                     (Character 1 -1 () PointerString)
@@ -369,60 +394,52 @@
                                                 ))
                                                 ((IntrinsicElementalFunction
                                                     Max
-                                                    [(StringLen
-                                                        (ArrayItem
-                                                            (Var 4 keywords)
-                                                            [(()
-                                                            (ArrayBound
-                                                                (Var 4 keywords)
-                                                                (IntegerConstant 1 (Integer 4) Decimal)
-                                                                (Integer 4)
-                                                                LBound
-                                                                ()
+                                                    [(TypeInquiry
+                                                        StringLen
+                                                        (Allocatable
+                                                            (Array
+                                                                (Character 1 -2 () PointerString)
+                                                                [(()
+                                                                ())]
+                                                                DescriptorArray
                                                             )
-                                                            ())]
-                                                            (Character 1 -2 () PointerString)
-                                                            ColMajor
-                                                            ()
                                                         )
+                                                        (Var 4 keywords)
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -2 (Integer 4) Decimal)
                                                     )
                                                     (IntegerConstant 8 (Integer 4) Decimal)]
                                                     0
                                                     (Integer 4)
-                                                    ()
+                                                    (IntegerConstant 8 (Integer 4) Decimal)
                                                 ))
                                                 (())]
                                                 (Character 1 -3 (IntrinsicElementalFunction
                                                     Max
                                                     [(IntrinsicElementalFunction
                                                         Max
-                                                        [(StringLen
-                                                            (ArrayItem
-                                                                (Var 4 keywords)
-                                                                [(()
-                                                                (ArrayBound
-                                                                    (Var 4 keywords)
-                                                                    (IntegerConstant 1 (Integer 4) Decimal)
-                                                                    (Integer 4)
-                                                                    LBound
-                                                                    ()
+                                                        [(TypeInquiry
+                                                            StringLen
+                                                            (Allocatable
+                                                                (Array
+                                                                    (Character 1 -2 () PointerString)
+                                                                    [(()
+                                                                    ())]
+                                                                    DescriptorArray
                                                                 )
-                                                                ())]
-                                                                (Character 1 -2 () PointerString)
-                                                                ColMajor
-                                                                ()
                                                             )
+                                                            (Var 4 keywords)
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant -2 (Integer 4) Decimal)
                                                         )
                                                         (IntegerConstant 8 (Integer 4) Decimal)]
                                                         0
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant 8 (Integer 4) Decimal)
                                                     )
-                                                    (StringLen
+                                                    (TypeInquiry
+                                                        StringLen
+                                                        (Character 1 -1 () PointerString)
                                                         (IntrinsicElementalFunction
                                                             StringTrim
                                                             [(StringConstant
@@ -434,7 +451,7 @@
                                                             ()
                                                         )
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -1 (Integer 4) Decimal)
                                                     )]
                                                     0
                                                     (Integer 4)
@@ -489,60 +506,52 @@
                                                     ))
                                                     ((IntrinsicElementalFunction
                                                         Max
-                                                        [(StringLen
-                                                            (ArrayItem
-                                                                (Var 4 keywords)
-                                                                [(()
-                                                                (ArrayBound
-                                                                    (Var 4 keywords)
-                                                                    (IntegerConstant 1 (Integer 4) Decimal)
-                                                                    (Integer 4)
-                                                                    LBound
-                                                                    ()
+                                                        [(TypeInquiry
+                                                            StringLen
+                                                            (Allocatable
+                                                                (Array
+                                                                    (Character 1 -2 () PointerString)
+                                                                    [(()
+                                                                    ())]
+                                                                    DescriptorArray
                                                                 )
-                                                                ())]
-                                                                (Character 1 -2 () PointerString)
-                                                                ColMajor
-                                                                ()
                                                             )
+                                                            (Var 4 keywords)
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant -2 (Integer 4) Decimal)
                                                         )
                                                         (IntegerConstant 8 (Integer 4) Decimal)]
                                                         0
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant 8 (Integer 4) Decimal)
                                                     ))
                                                     (())]
                                                     (Character 1 -3 (IntrinsicElementalFunction
                                                         Max
                                                         [(IntrinsicElementalFunction
                                                             Max
-                                                            [(StringLen
-                                                                (ArrayItem
-                                                                    (Var 4 keywords)
-                                                                    [(()
-                                                                    (ArrayBound
-                                                                        (Var 4 keywords)
-                                                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                                                        (Integer 4)
-                                                                        LBound
-                                                                        ()
+                                                            [(TypeInquiry
+                                                                StringLen
+                                                                (Allocatable
+                                                                    (Array
+                                                                        (Character 1 -2 () PointerString)
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
                                                                     )
-                                                                    ())]
-                                                                    (Character 1 -2 () PointerString)
-                                                                    ColMajor
-                                                                    ()
                                                                 )
+                                                                (Var 4 keywords)
                                                                 (Integer 4)
-                                                                ()
+                                                                (IntegerConstant -2 (Integer 4) Decimal)
                                                             )
                                                             (IntegerConstant 8 (Integer 4) Decimal)]
                                                             0
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant 8 (Integer 4) Decimal)
                                                         )
-                                                        (StringLen
+                                                        (TypeInquiry
+                                                            StringLen
+                                                            (Character 1 -1 () PointerString)
                                                             (IntrinsicElementalFunction
                                                                 StringTrim
                                                                 [(ArrayItem
@@ -559,7 +568,7 @@
                                                                 ()
                                                             )
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant -1 (Integer 4) Decimal)
                                                         )]
                                                         0
                                                         (Integer 4)
@@ -616,31 +625,28 @@
                                                         Max
                                                         [(IntrinsicElementalFunction
                                                             Max
-                                                            [(StringLen
-                                                                (ArrayItem
-                                                                    (Var 4 keywords)
-                                                                    [(()
-                                                                    (ArrayBound
-                                                                        (Var 4 keywords)
-                                                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                                                        (Integer 4)
-                                                                        LBound
-                                                                        ()
+                                                            [(TypeInquiry
+                                                                StringLen
+                                                                (Allocatable
+                                                                    (Array
+                                                                        (Character 1 -2 () PointerString)
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
                                                                     )
-                                                                    ())]
-                                                                    (Character 1 -2 () PointerString)
-                                                                    ColMajor
-                                                                    ()
                                                                 )
+                                                                (Var 4 keywords)
                                                                 (Integer 4)
-                                                                ()
+                                                                (IntegerConstant -2 (Integer 4) Decimal)
                                                             )
                                                             (IntegerConstant 8 (Integer 4) Decimal)]
                                                             0
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant 8 (Integer 4) Decimal)
                                                         )
-                                                        (StringLen
+                                                        (TypeInquiry
+                                                            StringLen
+                                                            (Character 1 -1 () PointerString)
                                                             (IntrinsicElementalFunction
                                                                 StringTrim
                                                                 [(ArrayItem
@@ -657,7 +663,7 @@
                                                                 ()
                                                             )
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant -1 (Integer 4) Decimal)
                                                         )]
                                                         0
                                                         (Integer 4)

--- a/tests/reference/asr-functions_06-83a7aca.json
+++ b/tests/reference/asr-functions_06-83a7aca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_06-83a7aca.stdout",
-    "stdout_hash": "18e9455074b211764ed95ef0b1651ba8b427f72ea575830fe5db3a5e",
+    "stdout_hash": "227b464aa2b0910d9961487568cec7d2399a81d1553d74e4ca20969e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_06-83a7aca.stdout
+++ b/tests/reference/asr-functions_06-83a7aca.stdout
@@ -67,10 +67,12 @@
                             6 trim_wrapper
                             ()
                             [((Var 6 string))]
-                            (Character 1 -3 (StringLen
+                            (Character 1 -3 (TypeInquiry
+                                StringLen
+                                (Character 1 -1 () PointerString)
                                 (Var 6 string)
                                 (Integer 4)
-                                ()
+                                (IntegerConstant -1 (Integer 4) Decimal)
                             ) PointerString)
                             ()
                             ()
@@ -86,12 +88,8 @@
                                 (Array
                                     (Integer 4)
                                     [((IntegerConstant 1 (Integer 4) Decimal)
-                                    (StringLen
-                                        (Var 6 string)
-                                        (Integer 4)
-                                        ()
-                                    ))]
-                                    PointerToDataArray
+                                    (IntegerConstant -1 (Integer 4) Decimal))]
+                                    FixedSizeArray
                                 )
                                 ()
                                 ()
@@ -111,12 +109,8 @@
                                 (Array
                                     (Real 4)
                                     [((IntegerConstant 1 (Integer 4) Decimal)
-                                    (StringLen
-                                        (Var 6 string)
-                                        (Integer 4)
-                                        ()
-                                    ))]
-                                    PointerToDataArray
+                                    (IntegerConstant -1 (Integer 4) Decimal))]
+                                    FixedSizeArray
                                 )
                                 ()
                                 ()
@@ -157,7 +151,7 @@
                                                 (Variable
                                                     4
                                                     r
-                                                    [s]
+                                                    []
                                                     ReturnVar
                                                     ()
                                                     ()
@@ -165,12 +159,8 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
-                                                        (StringLen
-                                                            (Var 4 s)
-                                                            (Integer 4)
-                                                            ()
-                                                        ))]
-                                                        PointerToDataArray
+                                                        (IntegerConstant -1 (Integer 4) Decimal))]
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     Source
@@ -201,16 +191,8 @@
                                         (Array
                                             (Integer 4)
                                             [((IntegerConstant 1 (Integer 4) Decimal)
-                                            (StringLen
-                                                (FunctionParam
-                                                    0
-                                                    (Character 1 -1 () PointerString)
-                                                    ()
-                                                )
-                                                (Integer 4)
-                                                ()
-                                            ))]
-                                            PointerToDataArray
+                                            (IntegerConstant -1 (Integer 4) Decimal))]
+                                            FixedSizeArray
                                         )
                                         Source
                                         Implementation
@@ -229,10 +211,12 @@
                                         ()
                                         ((Var 4 i)
                                         (IntegerConstant 1 (Integer 4) Decimal)
-                                        (StringLen
+                                        (TypeInquiry
+                                            StringLen
+                                            (Character 1 -1 () PointerString)
                                             (Var 4 s)
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant -1 (Integer 4) Decimal)
                                         )
                                         ())
                                         [(Assignment
@@ -281,7 +265,7 @@
                                                 (Variable
                                                     5
                                                     r
-                                                    [s]
+                                                    []
                                                     ReturnVar
                                                     ()
                                                     ()
@@ -289,12 +273,8 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
-                                                        (StringLen
-                                                            (Var 5 s)
-                                                            (Integer 4)
-                                                            ()
-                                                        ))]
-                                                        PointerToDataArray
+                                                        (IntegerConstant -1 (Integer 4) Decimal))]
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     Source
@@ -325,16 +305,8 @@
                                         (Array
                                             (Real 4)
                                             [((IntegerConstant 1 (Integer 4) Decimal)
-                                            (StringLen
-                                                (FunctionParam
-                                                    0
-                                                    (Character 1 -1 () PointerString)
-                                                    ()
-                                                )
-                                                (Integer 4)
-                                                ()
-                                            ))]
-                                            PointerToDataArray
+                                            (IntegerConstant -1 (Integer 4) Decimal))]
+                                            FixedSizeArray
                                         )
                                         Source
                                         Implementation
@@ -353,10 +325,12 @@
                                         ()
                                         ((Var 5 i)
                                         (IntegerConstant 1 (Integer 4) Decimal)
-                                        (StringLen
+                                        (TypeInquiry
+                                            StringLen
+                                            (Character 1 -1 () PointerString)
                                             (Var 5 s)
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant -1 (Integer 4) Decimal)
                                         )
                                         ())
                                         [(Assignment
@@ -397,10 +371,12 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Character 1 -3 (StringLen
+                                                    (Character 1 -3 (TypeInquiry
+                                                        StringLen
+                                                        (Character 1 -1 () PointerString)
                                                         (Var 3 s)
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -1 (Integer 4) Decimal)
                                                     ) PointerString)
                                                     ()
                                                     Source

--- a/tests/reference/asr-functions_12-235fd97.json
+++ b/tests/reference/asr-functions_12-235fd97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_12-235fd97.stdout",
-    "stdout_hash": "6d92d018649e48d3645e450ee9131a81c11a2ed1b27587aa35adc339",
+    "stdout_hash": "b5fb21b39c35f805076bc7dceddc5ced6ccfa27c216648beb0148903",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_12-235fd97.stdout
+++ b/tests/reference/asr-functions_12-235fd97.stdout
@@ -53,10 +53,12 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Character 1 -3 (StringLen
+                                                    (Character 1 -3 (TypeInquiry
+                                                        StringLen
+                                                        (Character 1 -1 () PointerString)
                                                         (Var 3 string)
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -1 (Integer 4) Decimal)
                                                     ) PointerString)
                                                     ()
                                                     Source

--- a/tests/reference/asr-intrinsics_33-816caef.json
+++ b/tests/reference/asr-intrinsics_33-816caef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_33-816caef.stdout",
-    "stdout_hash": "f16bf32894d53a2580b54e7e748b8e87459fcb8e8cd21b65417e37bd",
+    "stdout_hash": "a028d011526e1d05140b9ca19a13474058206c3aa6c938b81ad48281",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_33-816caef.stdout
+++ b/tests/reference/asr-intrinsics_33-816caef.stdout
@@ -25,13 +25,13 @@
                                         "A"
                                         (Character 1 1 () PointerString)
                                     )
-                                    (Character 1 -1 () PointerString)
+                                    (Character 1 1 () PointerString)
                                     (StringConstant
                                         "\n"
                                         (Character 1 0 () PointerString)
                                     )
                                 )
-                                (Character 1 -1 () PointerString)
+                                (Character 1 18 () PointerString)
                                 (StringConstant
                                     "This is record 1.\n"
                                     (Character 1 18 () PointerString)
@@ -41,7 +41,7 @@
                                 "This is record 2."
                                 (Character 1 17 () PointerString)
                             )
-                            (Character 1 -1 () PointerString)
+                            (Character 1 35 () PointerString)
                             (StringConstant
                                 "This is record 1.\nThis is record 2."
                                 (Character 1 35 () PointerString)

--- a/tests/reference/asr-modules_35-5fba3e7.json
+++ b/tests/reference/asr-modules_35-5fba3e7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_35-5fba3e7.stdout",
-    "stdout_hash": "14256258ab2c88d4dd297eb5830521547942d423fceea930faea5276",
+    "stdout_hash": "ccf09a7d493f2bd5929c141f87605859d64243d038f6574cd6456546",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_35-5fba3e7.stdout
+++ b/tests/reference/asr-modules_35-5fba3e7.stdout
@@ -119,47 +119,40 @@
                                         )
                                         [(If
                                             (IntegerCompare
-                                                (StringLen
-                                                    (ArrayItem
-                                                        (Var 3 strings_a)
-                                                        [(()
-                                                        (ArrayBound
-                                                            (Var 3 strings_a)
-                                                            (IntegerConstant 1 (Integer 4) Decimal)
-                                                            (Integer 4)
-                                                            LBound
-                                                            ()
+                                                (TypeInquiry
+                                                    StringLen
+                                                    (Allocatable
+                                                        (Array
+                                                            (Character 1 -2 () PointerString)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
                                                         )
-                                                        ())]
-                                                        (Character 1 -2 () PointerString)
-                                                        ColMajor
-                                                        ()
                                                     )
+                                                    (Var 3 strings_a)
                                                     (Integer 4)
-                                                    ()
+                                                    (IntegerConstant -2 (Integer 4) Decimal)
                                                 )
                                                 LtE
-                                                (StringLen
-                                                    (ArrayItem
-                                                        (Var 3 strings)
-                                                        [(()
-                                                        (ArrayBound
-                                                            (Var 3 strings)
-                                                            (IntegerConstant 1 (Integer 4) Decimal)
-                                                            (Integer 4)
-                                                            LBound
-                                                            ()
+                                                (TypeInquiry
+                                                    StringLen
+                                                    (Allocatable
+                                                        (Array
+                                                            (Character 1 -1 () PointerString)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
                                                         )
-                                                        ())]
-                                                        (Character 1 -1 () PointerString)
-                                                        ColMajor
-                                                        ()
                                                     )
+                                                    (Var 3 strings)
                                                     (Integer 4)
-                                                    ()
+                                                    (IntegerConstant -1 (Integer 4) Decimal)
                                                 )
                                                 (Logical 4)
-                                                ()
+                                                (LogicalConstant
+                                                    .true.
+                                                    (Logical 4)
+                                                )
                                             )
                                             [(Assignment
                                                 (Var 3 strings)

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "6417fb2c3a5308c3969b20f6c0d69fbf5fa3c9c94d8a63564d76add5",
+    "stdout_hash": "154e5200018b9b3772016661c67d55536e562ee702a4436bf5671143",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -754,10 +754,12 @@
                                         ()
                                         ((Var 4 i)
                                         (IntegerConstant 1 (Integer 4) Decimal)
-                                        (StringLen
+                                        (TypeInquiry
+                                            StringLen
+                                            (Character 1 -1 () PointerString)
                                             (Var 4 input)
                                             (Integer 4)
-                                            ()
+                                            (IntegerConstant -1 (Integer 4) Decimal)
                                         )
                                         ())
                                         [(Assignment
@@ -1187,15 +1189,22 @@
                                     )
                                     (If
                                         (IntegerCompare
-                                            (StringLen
+                                            (TypeInquiry
+                                                StringLen
+                                                (Allocatable
+                                                    (Character 1 -2 () PointerString)
+                                                )
                                                 (Var 6 name)
                                                 (Integer 4)
-                                                ()
+                                                (IntegerConstant -2 (Integer 4) Decimal)
                                             )
                                             NotEq
                                             (IntegerConstant 0 (Integer 4) Decimal)
                                             (Logical 4)
-                                            ()
+                                            (LogicalConstant
+                                                .true.
+                                                (Logical 4)
+                                            )
                                         )
                                         [(Assignment
                                             (Var 6 lout)
@@ -1287,15 +1296,22 @@
                                                 )
                                                 And
                                                 (IntegerCompare
-                                                    (StringLen
+                                                    (TypeInquiry
+                                                        StringLen
+                                                        (Allocatable
+                                                            (Character 1 -2 () PointerString)
+                                                        )
                                                         (Var 6 name)
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -2 (Integer 4) Decimal)
                                                     )
                                                     LtE
                                                     (IntegerConstant 63 (Integer 4) Decimal)
                                                     (Logical 4)
-                                                    ()
+                                                    (LogicalConstant
+                                                        .true.
+                                                        (Logical 4)
+                                                    )
                                                 )
                                                 (Logical 4)
                                                 ()

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "9d9dd284bd9f6d7b82d8c155e6c6dd4b892fc196bd354f39d4981030",
+    "stdout_hash": "a730b13648ea5d86f142c86dbbbfbcfd0c82cbc18c7f26bee00ea9ba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -602,7 +602,7 @@
             select_type4:
                 (Program
                     (SymbolTable
-                        20
+                        19
                         {
                             
                         })

--- a/tests/reference/asr-string_04-2ebc0e6.json
+++ b/tests/reference/asr-string_04-2ebc0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_04-2ebc0e6.stdout",
-    "stdout_hash": "1a59de696a310695fce8aeb7656f20724ef8b101912e0e179634bd39",
+    "stdout_hash": "b29d2d6c7c5b883a3113d26bed181cded45544510b71ef8dfe1809de",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_04-2ebc0e6.stdout
+++ b/tests/reference/asr-string_04-2ebc0e6.stdout
@@ -289,7 +289,9 @@
                     )
                     (If
                         (IntegerCompare
-                            (StringLen
+                            (TypeInquiry
+                                StringLen
+                                (Character 1 -1 () PointerString)
                                 (StringSection
                                     (Var 2 str)
                                     (IntegerBinOp
@@ -305,12 +307,15 @@
                                     ()
                                 )
                                 (Integer 4)
-                                ()
+                                (IntegerConstant -1 (Integer 4) Decimal)
                             )
                             NotEq
                             (IntegerConstant 3 (Integer 4) Decimal)
                             (Logical 4)
-                            ()
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
                         )
                         [(ErrorStop
                             ()

--- a/tests/reference/asr-string_12-e72e066.json
+++ b/tests/reference/asr-string_12-e72e066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_12-e72e066.stdout",
-    "stdout_hash": "a08e6307817e47782173c6d5441ecd424da6a7ef85c49869f1c16c40",
+    "stdout_hash": "0a35ea23143c5ea6a555a703fc6012fa1d9a3c603711066d729ecc30",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_12-e72e066.stdout
+++ b/tests/reference/asr-string_12-e72e066.stdout
@@ -221,7 +221,9 @@
                                     Local
                                     (IntrinsicElementalFunction
                                         Char
-                                        [(StringLen
+                                        [(TypeInquiry
+                                            StringLen
+                                            (Character 1 52 () PointerString)
                                             (Var 2 letters)
                                             (Integer 4)
                                             (IntegerConstant 52 (Integer 4) Decimal)
@@ -314,7 +316,9 @@
                                 "char("
                                 (Character 1 5 () PointerString)
                             )
-                            (StringLen
+                            (TypeInquiry
+                                StringLen
+                                (Character 1 52 () PointerString)
                                 (Var 2 letters)
                                 (Integer 4)
                                 (IntegerConstant 52 (Integer 4) Decimal)

--- a/tests/reference/asr-string_17-29e01e3.json
+++ b/tests/reference/asr-string_17-29e01e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_17-29e01e3.stdout",
-    "stdout_hash": "542da6b82f9d5872660e6d6f5fb8b0422a66d4d2924181b8da9ba653",
+    "stdout_hash": "322b964a8bd51ea5bca9c04199f0557598ed9bdc5c236f43ca3a62c7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_17-29e01e3.stdout
+++ b/tests/reference/asr-string_17-29e01e3.stdout
@@ -100,7 +100,11 @@
                                         )
                                         [(Assignment
                                             (Var 4 length)
-                                            (StringLen
+                                            (TypeInquiry
+                                                StringLen
+                                                (Allocatable
+                                                    (Character 1 -2 () PointerString)
+                                                )
                                                 (StructInstanceMember
                                                     (Var 4 string)
                                                     4 1_string_type_raw
@@ -110,7 +114,7 @@
                                                     ()
                                                 )
                                                 (Integer 4)
-                                                ()
+                                                (IntegerConstant -2 (Integer 4) Decimal)
                                             )
                                             ()
                                         )]

--- a/tests/reference/asr-string_19-d880475.json
+++ b/tests/reference/asr-string_19-d880475.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_19-d880475.stdout",
-    "stdout_hash": "765b095a28704e3a707b47d73e9cb1d8b4a53b294eacbb5cb9a18fa1",
+    "stdout_hash": "a8b9bddeaf9ef8b475813b0f06a6368cc5418329d0d75210ba0ef619",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_19-d880475.stdout
+++ b/tests/reference/asr-string_19-d880475.stdout
@@ -388,7 +388,7 @@
                                                 (Variable
                                                     7
                                                     lps_array
-                                                    [string]
+                                                    []
                                                     ReturnVar
                                                     ()
                                                     ()
@@ -396,12 +396,8 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
-                                                        (StringLen
-                                                            (Var 7 string)
-                                                            (Integer 4)
-                                                            ()
-                                                        ))]
-                                                        PointerToDataArray
+                                                        (IntegerConstant -1 (Integer 4) Decimal))]
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     Source
@@ -432,16 +428,8 @@
                                         (Array
                                             (Integer 4)
                                             [((IntegerConstant 1 (Integer 4) Decimal)
-                                            (StringLen
-                                                (FunctionParam
-                                                    0
-                                                    (Character 1 -1 () PointerString)
-                                                    ()
-                                                )
-                                                (Integer 4)
-                                                ()
-                                            ))]
-                                            PointerToDataArray
+                                            (IntegerConstant -1 (Integer 4) Decimal))]
+                                            FixedSizeArray
                                         )
                                         Source
                                         Implementation
@@ -528,12 +516,8 @@
                                                 (Array
                                                     (Integer 4)
                                                     [((IntegerConstant 1 (Integer 4) Decimal)
-                                                    (StringLen
-                                                        (Var 8 string)
-                                                        (Integer 4)
-                                                        ()
-                                                    ))]
-                                                    PointerToDataArray
+                                                    (IntegerConstant -1 (Integer 4) Decimal))]
+                                                    FixedSizeArray
                                                 )
                                                 ()
                                                 ()
@@ -709,10 +693,12 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Character 1 -3 (StringLen
+                                                    (Character 1 -3 (TypeInquiry
+                                                        StringLen
+                                                        (Character 1 -1 () PointerString)
                                                         (Var 12 string)
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -1 (Integer 4) Decimal)
                                                     ) PointerString)
                                                     ()
                                                     Source
@@ -769,10 +755,12 @@
                                             ))]
                                             (Character 1 -3 (IntrinsicElementalFunction
                                                 Max
-                                                [(StringLen
+                                                [(TypeInquiry
+                                                    StringLen
+                                                    (Character 1 -1 () PointerString)
                                                     (Var 12 string)
                                                     (Integer 4)
-                                                    ()
+                                                    (IntegerConstant -1 (Integer 4) Decimal)
                                                 )
                                                 (Var 12 output_length)]
                                                 0
@@ -839,10 +827,12 @@
                                                     Default
                                                     (Character 1 -3 (IntrinsicElementalFunction
                                                         Max
-                                                        [(StringLen
+                                                        [(TypeInquiry
+                                                            StringLen
+                                                            (Character 1 -1 () PointerString)
                                                             (Var 13 string)
                                                             (Integer 4)
-                                                            ()
+                                                            (IntegerConstant -1 (Integer 4) Decimal)
                                                         )
                                                         (Var 13 output_length)]
                                                         0
@@ -1046,7 +1036,9 @@
                                                 ))]
                                                 (Character 1 -3 (IntrinsicElementalFunction
                                                     Max
-                                                    [(StringLen
+                                                    [(TypeInquiry
+                                                        StringLen
+                                                        (Character 1 -1 () PointerString)
                                                         (FunctionCall
                                                             10 char@char_string
                                                             6 char
@@ -1063,7 +1055,7 @@
                                                             ()
                                                         )
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -1 (Integer 4) Decimal)
                                                     )
                                                     (Var 10 output_length)]
                                                     0
@@ -1231,7 +1223,9 @@
                                                 ((Var 11 pad_with))]
                                                 (Character 1 -3 (IntrinsicElementalFunction
                                                     Max
-                                                    [(StringLen
+                                                    [(TypeInquiry
+                                                        StringLen
+                                                        (Character 1 -1 () PointerString)
                                                         (FunctionCall
                                                             11 char@char_string
                                                             6 char
@@ -1248,7 +1242,7 @@
                                                             ()
                                                         )
                                                         (Integer 4)
-                                                        ()
+                                                        (IntegerConstant -1 (Integer 4) Decimal)
                                                     )
                                                     (Var 11 output_length)]
                                                     0

--- a/tests/reference/pass_implied_do_loops-modules_35-c089638.json
+++ b/tests/reference/pass_implied_do_loops-modules_35-c089638.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_implied_do_loops-modules_35-c089638.stdout",
-    "stdout_hash": "4d1cb85344c9d237bb4e4799b978a57c7201c2a9a38d67b6cf0fe799",
+    "stdout_hash": "e9f2ba7a5458956a1307515e493a06d51745dedf27c88682e4361a7b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_implied_do_loops-modules_35-c089638.stdout
+++ b/tests/reference/pass_implied_do_loops-modules_35-c089638.stdout
@@ -165,47 +165,40 @@
                                         )
                                         [(If
                                             (IntegerCompare
-                                                (StringLen
-                                                    (ArrayItem
-                                                        (Var 3 strings_a)
-                                                        [(()
-                                                        (ArrayBound
-                                                            (Var 3 strings_a)
-                                                            (IntegerConstant 1 (Integer 4) Decimal)
-                                                            (Integer 4)
-                                                            LBound
-                                                            ()
+                                                (TypeInquiry
+                                                    StringLen
+                                                    (Allocatable
+                                                        (Array
+                                                            (Character 1 -2 () PointerString)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
                                                         )
-                                                        ())]
-                                                        (Character 1 -2 () PointerString)
-                                                        ColMajor
-                                                        ()
                                                     )
+                                                    (Var 3 strings_a)
                                                     (Integer 4)
-                                                    ()
+                                                    (IntegerConstant -2 (Integer 4) Decimal)
                                                 )
                                                 LtE
-                                                (StringLen
-                                                    (ArrayItem
-                                                        (Var 3 strings)
-                                                        [(()
-                                                        (ArrayBound
-                                                            (Var 3 strings)
-                                                            (IntegerConstant 1 (Integer 4) Decimal)
-                                                            (Integer 4)
-                                                            LBound
-                                                            ()
+                                                (TypeInquiry
+                                                    StringLen
+                                                    (Allocatable
+                                                        (Array
+                                                            (Character 1 -1 () PointerString)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
                                                         )
-                                                        ())]
-                                                        (Character 1 -1 () PointerString)
-                                                        ColMajor
-                                                        ()
                                                     )
+                                                    (Var 3 strings)
                                                     (Integer 4)
-                                                    ()
+                                                    (IntegerConstant -1 (Integer 4) Decimal)
                                                 )
                                                 (Logical 4)
-                                                ()
+                                                (LogicalConstant
+                                                    .true.
+                                                    (Logical 4)
+                                                )
                                             )
                                             [(Assignment
                                                 (Var 3 strings)


### PR DESCRIPTION
Towards: #4593 

Some of the tests will fail. I'm working on those.