### PR TITLE
chore: don't create temporary for StructInstanceMember when present as call argument

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -605,8 +605,8 @@ jobs:
             git checkout 6e0f6e7506440b042aae93e57b10444ee6c36f7a
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
-            #make -f Makefile.manual test
-            #git clean -dfx
+            make -f Makefile.manual test
+            git clean -dfx
             #make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
             #make -f Makefile.manual test
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -593,8 +593,8 @@ jobs:
             make -f Makefile.manual
             make -f Makefile.manual test
             git clean -dfx
-            #make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
-            #make -f Makefile.manual test
+            make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
+            make -f Makefile.manual test
 
       # - name: Test fastGPT ( ubuntu-latest )
       #   shell: bash -e -x -l {0}
@@ -848,10 +848,10 @@ jobs:
             git checkout 6e0f6e7506440b042aae93e57b10444ee6c36f7a
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
-      #       make -f Makefile.manual test
-      #       git clean -dfx
-      #       make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
-      #       make -f Makefile.manual test
+            make -f Makefile.manual test
+            git clean -dfx
+            make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
+            make -f Makefile.manual test
 
       # - name: Test fastGPT ( ubuntu-latest )
       #   shell: bash -e -x -l {0}

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -883,7 +883,8 @@ ASR::expr_t* create_and_allocate_temporary_variable_for_struct(
 bool is_elemental_expr(ASR::expr_t* value) {
     value = ASRUtils::get_past_array_physical_cast(value);
     switch( value->type ) {
-        case ASR::exprType::Var: {
+        case ASR::exprType::Var:
+        case ASR::exprType::StructInstanceMember: {
             return true;
         }
         default: {


### PR DESCRIPTION
This probably completely helps us compile dftatom on *simplifier_pass* branch, (excluding ofcourse the fast test cases, which I haven't checked)