### PR TITLE
test: add MRE for dftatom as integration test case

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1746,6 +1746,8 @@ RUN(NAME polymorphic_argument LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME binop_of_struct_instance_in_function_call gfortran llvm fortran)
 
+RUN(NAME test_call_arg_structinstance_member gfortran llvm fortran)
+
 RUN(NAME openmp_bindc_01 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_bindc_02 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_bindc_03 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)

--- a/integration_tests/test_call_arg_structinstance_member.f90
+++ b/integration_tests/test_call_arg_structinstance_member.f90
@@ -1,0 +1,26 @@
+module module_test_call_arg_structinstance_member
+    implicit none
+    type :: data_type
+        real(4) :: arr(4)
+    end type data_type
+
+contains
+    subroutine sub(arr)
+        real(4), intent(inout) :: arr(:)
+        integer :: i
+        do i = 1, 4
+            arr(i) = real(i, kind=4) + 10.0_4
+        end do
+    end subroutine sub
+end module module_test_call_arg_structinstance_member
+
+program test_call_arg_structinstance_member
+    use module_test_call_arg_structinstance_member
+    implicit none
+    type(data_type) :: d
+    d%arr = 0.0_4
+    call sub(d%arr)
+
+    print *, d%arr
+    if (any(d%arr /= [11., 12., 13., 14.])) error stop
+end program


### PR DESCRIPTION
### Why this test case?

this tests to make sure that when a StructInstanceMember is passed as an argument to a subroutine call (with intent(out)), then the changes are indeed made to the StructInstanceMember directly

### MRE

Initially reported here https://github.com/lfortran/lfortran/issues/4761#issuecomment-2401815359