### PR TITLE
Remove old implementation of `len` intrinsic from old runtime lib

### DIFF
--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -8,11 +8,6 @@ interface
     integer, optional, intent(in) :: kind
     end function
 
-    integer function len(x, kind)
-    character(len=*), intent(in) :: x
-    integer, optional, intent(in) :: kind
-    end function
-
     logical function present(x)
     integer, optional, intent(in) :: x
     end function

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "9d9dd284bd9f6d7b82d8c155e6c6dd4b892fc196bd354f39d4981030",
+    "stdout_hash": "a730b13648ea5d86f142c86dbbbfbcfd0c82cbc18c7f26bee00ea9ba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -602,7 +602,7 @@
             select_type4:
                 (Program
                     (SymbolTable
-                        20
+                        19
                         {
                             
                         })


### PR DESCRIPTION
Towards: #4593