### PR TITLE
CI : Add test for checking if there's a pushed binary file in git commit history

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,17 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
 
 jobs:
+  Check_for_Added_Binary_Files:
+    name: Check for Added Binary Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Check for Added Binary Files
+        run: python3 check_binary_file_in_git_history.py
+
   Build:
     name: LFortran CI (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -33,12 +44,6 @@ jobs:
           environment-file: ci/environment.yml
           create-args: >-
             python=${{ matrix.python-version }}
-
-      - name: Check Any Added Binary File
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
-        run: | 
-          python3 check_binary_file_in_git_history.py
-            
 
       - name: Install Windows Packages
         if: contains(matrix.os, 'windows')

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check Any Added Binary File
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: | 
-          python3 Check_binary_file_in_git_history.py
+          python3 check_binary_file_in_git_history.py
             
 
       - name: Install Windows Packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,12 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
 
+      - name: Check Any Added Binary File
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        run: | 
+          python3 Check_binary_file_in_git_history.py
+            
+
       - name: Install Windows Packages
         if: contains(matrix.os, 'windows')
         shell: bash -e -l {0}

--- a/check_binary_file_in_git_history.py
+++ b/check_binary_file_in_git_history.py
@@ -1,47 +1,64 @@
 import subprocess
 
-def is_file_binary(path: str) -> bool:
+# Open file_path, Read it with mode 'r' which expects a utf-8 encode.
+# If the file is binary it'd conflict with
+# text mode 'r', leading to raised error `UnicodeDecodeError`.
+def is_file_binary(file_path: str) -> bool:
     try:
-        with open(path, 'r') as fp:
+        with open(file_path, 'r') as fp:
             fp.read(16)
             return False
     except UnicodeDecodeError:
             return True
-    
-def get_commit_hashes_PR_against_main() -> list : # returns list of strings
-    completedProcess_object =  subprocess.run(["git" ,"rev-list" ,"origin/main..HEAD"], stdout=subprocess.PIPE, text=True)
+
+
+# Get all commit hashes difference between `origin/main` and current `HEAD`
+def get_commit_hash_differences() -> list :
+    # Run command `git rev-list origin/main..HEAD`
+    # Use `subporcess.PIPE` as the output buffer to fetch the list of commit hashes
+    completedProcess_object =  subprocess.run(["git" ,"rev-list" ,"origin/main..HEAD"],
+                                                stdout=subprocess.PIPE
+                                                , text=True)
+    # Create list out of the resulting commit hases. 
     commit_hashes_listed  : list  = completedProcess_object.stdout.split("\n")
-    if(commit_hashes_listed[-1] == ""): commit_hashes_listed.remove("")
-    print("number of commit from current PR branch against origin/main is :", len(commit_hashes_listed))
-    print (completedProcess_object.stdout)
+    if(commit_hashes_listed[-1] == ""):
+        commit_hashes_listed.remove("") # Remove trailing empty string.
+    print("number of commits from \
+            current PR branch against origin/main is :", len(commit_hashes_listed))
+    print (completedProcess_object.stdout) # print the whole string of commit hashes.
     return commit_hashes_listed
 
-def get_changed_files() -> list : # returns list of strings.
-    completedProcess_object = subprocess.run(["git","diff","--name-only","origin/main", "--diff-filter=d"], stdout=subprocess.PIPE, text=True)
+# Fetch all files pathes that has beend changed from current `HEAD` against `origin/main`.
+def get_changed_files() -> list :
+    # Run command `git diff --name-only origin/main --diff-filter=d`
+    # Notice we filter out the deleted files.
+    completedProcess_object = subprocess.run(["git","diff","--name-only","origin/main", "--diff-filter=d"],
+                                            stdout=subprocess.PIPE, text=True)
     file_paths : list = completedProcess_object.stdout.split("\n")
-    if(file_paths[-1] == "" ): file_paths.remove("")
+    if(file_paths[-1] == ""): file_paths.remove("") # Remove trailing empty string.
     return file_paths
 
 
 
-def run() :
-    commit_hashes_list = get_commit_hashes_PR_against_main()
 
+def run_test() :
+    commit_hashes_list = get_commit_hash_differences()
+    # Run git `checkout` to each commit_hash between `origin/main` --> `HEAD`
     for commit_hash in commit_hashes_list:
-        subprocess.run(["git","checkout",commit_hash], stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
-        print("check out to commit-->",commit_hash)
-        file_paths : list = get_changed_files()
-        for path in file_paths:
-            if (is_file_binary(path)):
-                raise SystemExit(f"ERROR : FOUND PUSHED BINARY FILE --> ({path}) IN COMMIT ({commit_hash})")
-        print("--------------------------------------------------")
+        subprocess.run(["git","checkout",commit_hash], 
+                       stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True) 
+        print("checked out to commit --> ",commit_hash)
 
+        file_paths : list = get_changed_files() # fetch changed files from current-checkout-to commit.
+        for file_path in file_paths:
+            if (is_file_binary(file_path)):
+                raise SystemExit(f"ERROR : FOUND PUSHED BINARY FILE --> ({file_path}) IN COMMIT ({commit_hash})")
+
+        print("\n--------------------------------------------------\n")
+    
     print("CLEAN : No binary file found")
-    print("return back to latest commit in branch")
-    subprocess.run(["git","checkout",commit_hashes_list[0]], stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
     print("DONE")
 
 
-
-run()
+run_test()
 

--- a/check_binary_file_in_git_history.py
+++ b/check_binary_file_in_git_history.py
@@ -23,8 +23,7 @@ def get_commit_hash_differences() -> list :
     commit_hashes_listed  : list  = completedProcess_object.stdout.split("\n")
     if(commit_hashes_listed[-1] == ""):
         commit_hashes_listed.remove("") # Remove trailing empty string.
-    print("number of commits from \
-            current PR branch against origin/main is :", len(commit_hashes_listed))
+    print("number of commits from current PR branch against origin/main is :", len(commit_hashes_listed))
     print (completedProcess_object.stdout) # print the whole string of commit hashes.
     return commit_hashes_listed
 
@@ -52,11 +51,14 @@ def run_test() :
         file_paths : list = get_changed_files() # fetch changed files from current-checkout-to commit.
         for file_path in file_paths:
             if (is_file_binary(file_path)):
-                raise SystemExit(f"ERROR : FOUND PUSHED BINARY FILE --> ({file_path}) IN COMMIT ({commit_hash})")
+                print("FAIL --- binary file detected")
+                print("Binary File Name :", file_path, "In Commit : ", commit_hash)
+                raise SystemExit()
 
+        print("OK --- no binary file found")
         print("\n--------------------------------------------------\n")
     
-    print("CLEAN : No binary file found")
+    print("CLEAN : No binary file found in any commit in this PR")
     print("DONE")
 
 

--- a/check_binary_file_in_git_history.py
+++ b/check_binary_file_in_git_history.py
@@ -52,7 +52,7 @@ def run_test() :
         for file_path in file_paths:
             if (is_file_binary(file_path)):
                 print("FAIL --- binary file detected")
-                print("Binary File Name :", file_path, "In Commit : ", commit_hash)
+                print(f"Binary File Name : ({file_path}) In Commit : ({commit_hash})")
                 raise SystemExit()
 
         print("OK --- no binary file found")

--- a/check_binary_file_in_git_history.py
+++ b/check_binary_file_in_git_history.py
@@ -1,0 +1,47 @@
+import subprocess
+
+def is_file_binary(path: str) -> bool:
+    try:
+        with open(path, 'r') as fp:
+            fp.read(16)
+            return False
+    except UnicodeDecodeError:
+            return True
+    
+def get_commit_hashes_PR_against_main() -> list : # returns list of strings
+    completedProcess_object =  subprocess.run(["git" ,"rev-list" ,"origin/main..HEAD"], stdout=subprocess.PIPE, text=True)
+    commit_hashes_listed  : list  = completedProcess_object.stdout.split("\n")
+    if(commit_hashes_listed[-1] == ""): commit_hashes_listed.remove("")
+    print("number of commit from current PR branch against origin/main is :", len(commit_hashes_listed))
+    print (completedProcess_object.stdout)
+    return commit_hashes_listed
+
+def get_changed_files() -> list : # returns list of strings.
+    completedProcess_object = subprocess.run(["git","diff","--name-only","origin/main", "--diff-filter=d"], stdout=subprocess.PIPE, text=True)
+    file_paths : list = completedProcess_object.stdout.split("\n")
+    if(file_paths[-1] == "" ): file_paths.remove("")
+    return file_paths
+
+
+
+def run() :
+    commit_hashes_list = get_commit_hashes_PR_against_main()
+
+    for commit_hash in commit_hashes_list:
+        subprocess.run(["git","checkout",commit_hash], stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
+        print("check out to commit-->",commit_hash)
+        file_paths : list = get_changed_files()
+        for path in file_paths:
+            if (is_file_binary(path)):
+                raise SystemExit(f"ERROR : FOUND PUSHED BINARY FILE --> ({path}) IN COMMIT ({commit_hash})")
+        print("--------------------------------------------------")
+
+    print("CLEAN : No binary file found")
+    print("return back to latest commit in branch")
+    subprocess.run(["git","checkout",commit_hashes_list[0]], stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
+    print("DONE")
+
+
+
+run()
+


### PR DESCRIPTION
closes https://github.com/lfortran/lfortran/issues/5018

I don't know if it should be a dedicated job to test for binary files. Anyways, I tried to not interrupt the flow of the CI and did a checkout back to latest commit when the test succeeds. maybe we can call github action `checkout@v4` again right after running the test.