### PR TITLE
Remove unused interface for is_iostat_end and is_iostat_eor from old runtime lib

### DIFF
--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -25,9 +25,8 @@ struct IntrinsicProceduresAsASRNodes {
 
         IntrinsicProceduresAsASRNodes() {
             intrinsics_present_in_ASR = {"size", "lbound", "ubound",
-                "transpose", "matmul", "pack", "transfer", "cmplx",
-                "dcmplx", "reshape", "ichar", "iachar", "char", "maxloc",
-                "null", "associated", "len", "complex"};
+                "transpose", "transfer", "cmplx", "dcmplx", "reshape",
+                "iachar", "null", "associated", "len", "complex"};
 
             kind_based_intrinsics = {};
         }
@@ -70,11 +69,7 @@ struct IntrinsicProcedures {
             // in intrinsic_function_transformation()
             // So we shouldn't even encounter them here
             {"int", {m_builtin, &eval_int, false}},
-            {"is_iostat_eor", {m_builtin, &not_implemented, false}},
-            {"is_iostat_end", {m_builtin, &not_implemented, false}},
             {"newunit", {m_custom, &not_implemented, false}},
-
-            // Subroutines
             {"present", {m_builtin, &not_implemented, false}},
 
             // IEEE Arithmetic

--- a/src/runtime/builtin/lfortran_intrinsic_builtin.f90
+++ b/src/runtime/builtin/lfortran_intrinsic_builtin.f90
@@ -12,14 +12,6 @@ interface
     integer, optional, intent(in) :: x
     end function
 
-    logical function is_iostat_eor(i) result(r)
-    integer, intent(in) :: i
-    end function
-
-    logical function is_iostat_end(i) result(r)
-    integer, intent(in) :: i
-    end function
-
 end interface
 
 end module

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "a730b13648ea5d86f142c86dbbbfbcfd0c82cbc18c7f26bee00ea9ba",
+    "stdout_hash": "487ba4bc8ba6eb89ca9e676aa903655f1c20c966e3e6e2d1245e4cde",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -602,7 +602,7 @@
             select_type4:
                 (Program
                     (SymbolTable
-                        19
+                        17
                         {
                             
                         })


### PR DESCRIPTION
Towards: #4593