### PR TITLE
test: add MRE tests against main

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -368,6 +368,7 @@ RUN(NAME subroutines_10 LABELS gfortran)
 RUN(NAME subroutines_11 LABELS gfortran llvm)
 RUN(NAME subroutines_12 LABELS gfortran llvm)
 RUN(NAME subroutines_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME subroutines_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 
 RUN(NAME functions_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm)
 RUN(NAME functions_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
@@ -1289,6 +1290,8 @@ RUN(NAME string_38 LABELS gfortran llvm
     EXTRA_ARGS -fdefault-integer-8
     GFORTRAN_ARGS -fdefault-integer-8)
 RUN(NAME string_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
+RUN(NAME string_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -1666,6 +1669,7 @@ RUN(NAME legacy_array_sections_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc 
 RUN(NAME legacy_array_sections_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --legacy-array-sections --implicit-interface)
 RUN(NAME legacy_array_sections_04 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface --legacy-array-sections EXTRAFILES legacy_array_sections_04b)
+RUN(NAME legacy_array_sections_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
@@ -1799,3 +1803,4 @@ RUN(NAME exit_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME struct_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME func_parameter_type_02 LABELS gfortran) # function passed in other argument of function
+RUN(NAME logical_not_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/legacy_array_sections_05.f90
+++ b/integration_tests/legacy_array_sections_05.f90
@@ -1,0 +1,28 @@
+subroutine qrfac()
+    implicit none
+
+    real:: a(5, 5)
+
+    a = 12.9
+    print *, enorm(a(1, 1))
+    if ( abs(enorm(a(1,1)) - 832.049927 ) > 1e-8) error stop
+
+    contains
+        pure real function enorm(x)
+
+        implicit none
+        real, intent(in) :: x(5)
+        integer :: i
+
+        enorm = 0.0
+        do i = 1, 5
+            enorm = enorm + x(i)**2
+        end do
+
+        end function enorm
+end subroutine qrfac
+
+program legacy_array_sections_05
+    implicit none
+    call qrfac()
+end program

--- a/integration_tests/logical_not_01.f90
+++ b/integration_tests/logical_not_01.f90
@@ -1,0 +1,14 @@
+subroutine test_falseloc_pack()
+    real, allocatable :: bvec(:)
+    logical :: lvec(10)
+    allocate(bvec(10))
+    bvec = 0
+    print *, .not. (bvec > 0)
+    lvec = .not. (bvec > 0)
+    print *, lvec
+    if (any(.not. lvec)) error stop
+end subroutine
+    
+program logical_not_01
+    call test_falseloc_pack()
+end program

--- a/integration_tests/string_40.f90
+++ b/integration_tests/string_40.f90
@@ -1,0 +1,16 @@
+program string_40
+    print *, integer_i1_to_string(5)
+    if (integer_i1_to_string(5) /= 'ingLFortran') error stop
+    contains
+    
+    pure function integer_i1_to_string(pos) result(string)
+    character(len=:), allocatable :: string
+    
+    integer, parameter :: buffer_len = 128
+    character(len=buffer_len) :: buffer
+    integer, intent(in) :: pos
+    
+    buffer = 'TestingLFortran'
+    string = buffer(pos:)
+    end function integer_i1_to_string
+end program

--- a/integration_tests/string_41.f90
+++ b/integration_tests/string_41.f90
@@ -1,0 +1,12 @@
+program string_41
+    print *, real_sp_to_string()
+    if (real_sp_to_string() /= 'TestingLFortran') error stop
+    contains
+    pure function real_sp_to_string() result(string)
+    character(len=:), allocatable :: string
+    integer, parameter :: buffer_len = 128
+    character(len=buffer_len) :: buffer
+    buffer = 'TestingLFortran'
+    string = trim(buffer)
+    end function real_sp_to_string
+end program

--- a/integration_tests/subroutines_14.f90
+++ b/integration_tests/subroutines_14.f90
@@ -1,0 +1,19 @@
+subroutine check_logical(expression)
+    logical, intent(in) :: expression
+    print *, expression
+    if (.not. expression) error stop
+    end subroutine check_logical
+    
+    subroutine test_trueloc_empty()
+    real, allocatable :: avec(:), bvec(:)
+    allocate(avec(10))
+    allocate(bvec(10))
+    
+    avec = 0
+    bvec = 0
+    call check_logical(all(bvec == avec))
+end subroutine test_trueloc_empty
+    
+program subroutines_14
+    call test_trueloc_empty()
+end program


### PR DESCRIPTION
## Changes explained

The above tests were created in *simplifier_pass* branch, but as it creates conflicts (e.g. recently a `string_39.f90` test was created in *main* and a similar test was created in *simplifier_pass* branch, leading to conflicts)

Link to the *Simplifier Pass* PR: https://github.com/lfortran/lfortran/pull/4700.

## Post merge of these changes

We'll undo these changes in *simplifier_pass* branch.