### PR TITLE
chore: create temporary for a function call only when the return type is an Array

### DIFF
--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1509,7 +1509,8 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
 
         if( is_current_expr_linked_to_target && ASRUtils::is_array(x->m_type) ) {
             targetType target_Type = exprs_with_target[*current_expr].second;
-            if( target_Type == targetType::OriginalTarget && realloc_lhs ) {
+            if( target_Type == targetType::OriginalTarget && realloc_lhs &&
+                ASRUtils::is_allocatable(x->m_type)) {
                 force_replace_current_expr_for_array(std::string("_function_call_") +
                                            ASRUtils::symbol_name(x->m_name))
                 return ;


### PR DESCRIPTION
## Description

Helps fix the MRE present here: https://github.com/lfortran/lfortran/issues/4761

## Testing

Test program for this has been sent as a PR against *main* here: https://github.com/lfortran/lfortran/pull/5068. Once that's merged, I'll merge *main* into *simplifier_pass*.

Currently, I've ensured locally (on macOS m1) that this change helps us run the test program in https://github.com/lfortran/lfortran/pull/5068