### PR TITLE
tests: add MRE extracted from stdlib

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1807,3 +1807,5 @@ RUN(NAME func_parameter_type_02 LABELS gfortran) # function passed in other argu
 RUN(NAME logical_not_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_interface_function_call_of_function_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --realloc-lhs)
+RUN(NAME elemental_function_overloaded_compare LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
+    EXTRA_ARGS --realloc-lhs)

--- a/integration_tests/elemental_function_overloaded_compare.f90
+++ b/integration_tests/elemental_function_overloaded_compare.f90
@@ -1,0 +1,55 @@
+! program extracted as MRE from https://github.com/fortran-lang/stdlib
+! there is missing implementation of functions/subroutines like
+! check_logical, eq_string_char, new_string_from_integer_int32 etc.
+! but as that's not need to be able to compile and run the MRE,
+! that's being skipped for now, actually we tried having their implementation
+! as well, but the program failed to run (take that as a TODO)
+module stdlib_string_type
+    use iso_fortran_env, only: int32
+    implicit none
+    !> String type holding an arbitrary sequence of characters.
+
+    interface operator(==)
+        module procedure :: eq_string_char
+    end interface operator(==)
+
+    type :: string_type
+        sequence
+        private
+        character(len=:), allocatable :: raw
+    end type string_type
+
+    contains
+
+    subroutine check_logical(expression)
+        logical, intent(in) :: expression
+        if (.not. expression) then
+            print *, "Condition not fulfilled"
+        end if
+    end subroutine check_logical
+
+    elemental function eq_string_char(lhs, rhs) result(is_eq)
+        type(string_type), intent(in) :: lhs
+        character(len=*), intent(in) :: rhs
+        logical :: is_eq
+    end function eq_string_char
+
+    elemental module function new_string_from_integer_int32(val) result(new)
+        integer(int32), intent(in) :: val
+        type(string_type) :: new
+    end function new_string_from_integer_int32
+
+    subroutine test_constructor()
+        character(len=128) :: flc
+
+        write(flc, '(i0)') -1026191
+        call check_logical(new_string_from_integer_int32(-1026191) == trim(flc))
+    end subroutine test_constructor
+
+end module stdlib_string_type
+
+program main
+    use stdlib_string_type
+    implicit none
+    call test_constructor()
+end program main

--- a/integration_tests/elemental_function_overloaded_compare.f90
+++ b/integration_tests/elemental_function_overloaded_compare.f90
@@ -4,7 +4,7 @@
 ! but as that's not need to be able to compile and run the MRE,
 ! that's being skipped for now, actually we tried having their implementation
 ! as well, but the program failed to run (take that as a TODO)
-module stdlib_string_type
+module mod_elemental_function_overloaded_compare
     use iso_fortran_env, only: int32
     implicit none
     !> String type holding an arbitrary sequence of characters.
@@ -46,10 +46,10 @@ module stdlib_string_type
         call check_logical(new_string_from_integer_int32(-1026191) == trim(flc))
     end subroutine test_constructor
 
-end module stdlib_string_type
+end module mod_elemental_function_overloaded_compare
 
-program main
-    use stdlib_string_type
+program test_elemental_function_overloaded_compare
+    use mod_elemental_function_overloaded_compare
     implicit none
     call test_constructor()
-end program main
+end program


### PR DESCRIPTION
## Description

this tests to make sure that elemental function which overloads a comparison operator works correctly

There is a scope of improvement in the test-case in future, as it probably wouldn't compile and run currently if the program is extended to include the implementation of different functions in all ways