### PR TITLE
chore: fix return type of elemental function (could be of generic procedure)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -713,21 +713,21 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
             ./build.sh
 
-      # - name: Test stdlib
-      #   shell: bash -e -x -l {0}
-      #   run: |
-      #       git clone https://github.com/czgdp1807/stdlib.git
-      #       cd stdlib
-      #       export PATH="$(pwd)/../src/bin:$PATH"
+      - name: Test stdlib
+        shell: bash -e -x -l {0}
+        run: |
+            git clone https://github.com/czgdp1807/stdlib.git
+            cd stdlib
+            export PATH="$(pwd)/../src/bin:$PATH"
 
-      #       git checkout lf20
-      #       git checkout abb1d33d6ae02d8b62a13be7f9e51f6117c67ba4
-      #       micromamba install -c conda-forge fypp gfortran
-      #       git clean -fdx
-      #       FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"
-      #       make -j8
-      #       ctest
-      #       ./build_test_gf.sh
+            git checkout lf20
+            git checkout abb1d33d6ae02d8b62a13be7f9e51f6117c67ba4
+            micromamba install -c conda-forge fypp gfortran
+            git clean -fdx
+            FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"
+            make -j8
+            #ctest
+            ./build_test_gf.sh
 
       - name: Test SNAP
         shell: bash -e -x -l {0}
@@ -972,21 +972,21 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
             ./build.sh
 
-      # - name: Test stdlib
-      #   shell: bash -e -x -l {0}
-      #   run: |
-      #       git clone https://github.com/czgdp1807/stdlib.git
-      #       cd stdlib
-      #       export PATH="$(pwd)/../src/bin:$PATH"
+      - name: Test stdlib
+        shell: bash -e -x -l {0}
+        run: |
+            git clone https://github.com/czgdp1807/stdlib.git
+            cd stdlib
+            export PATH="$(pwd)/../src/bin:$PATH"
 
-      #       git checkout lf20
-      #       git checkout abb1d33d6ae02d8b62a13be7f9e51f6117c67ba4
-      #       micromamba install -c conda-forge fypp gfortran
-      #       git clean -fdx
-      #       FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"
-      #       make -j8
-      #       ctest
-      #       ./build_test_gf.sh
+            git checkout lf20
+            git checkout abb1d33d6ae02d8b62a13be7f9e51f6117c67ba4
+            micromamba install -c conda-forge fypp gfortran
+            git clean -fdx
+            FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"
+            make -j8
+            #ctest
+            ./build_test_gf.sh
 
       - name: Test SNAP
         shell: bash -e -x -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -716,12 +716,12 @@ jobs:
       - name: Test stdlib
         shell: bash -e -x -l {0}
         run: |
-            git clone https://github.com/czgdp1807/stdlib.git
+            git clone https://github.com/gxyd/stdlib.git
             cd stdlib
             export PATH="$(pwd)/../src/bin:$PATH"
 
-            git checkout lf20
-            git checkout abb1d33d6ae02d8b62a13be7f9e51f6117c67ba4
+            git checkout workarounds_simplifier_pass
+            git checkout f06d89524bd5d3b5dc2a06c807a5c67190fe0371
             micromamba install -c conda-forge fypp gfortran
             git clean -fdx
             FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"
@@ -975,12 +975,12 @@ jobs:
       - name: Test stdlib
         shell: bash -e -x -l {0}
         run: |
-            git clone https://github.com/czgdp1807/stdlib.git
+            git clone https://github.com/gxyd/stdlib.git
             cd stdlib
             export PATH="$(pwd)/../src/bin:$PATH"
 
-            git checkout lf20
-            git checkout abb1d33d6ae02d8b62a13be7f9e51f6117c67ba4
+            git checkout workarounds_simplifier_pass
+            git checkout f06d89524bd5d3b5dc2a06c807a5c67190fe0371
             micromamba install -c conda-forge fypp gfortran
             git clean -fdx
             FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1808,3 +1808,5 @@ RUN(NAME struct_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME func_parameter_type_02 LABELS gfortran) # function passed in other argument of function
 RUN(NAME logical_not_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+# TODO: we should eventually save the below program's ASR as well
+RUN(NAME elemental_function_scalar_array_arg LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/elemental_function_scalar_array_arg.f90
+++ b/integration_tests/elemental_function_scalar_array_arg.f90
@@ -1,5 +1,9 @@
 module mod_elemental_function_scalar_array_arg
     implicit none
+    interface count
+        module procedure count_char_char
+    end interface
+
     contains
 
     !> Returns an integer
@@ -17,10 +21,15 @@ program elemental_function_scalar_array_arg
     use mod_elemental_function_scalar_array_arg
     implicit none
     character(len=128) :: string
-    integer :: count(3)
+    integer :: count_value1(3)
+    integer :: count_value2(3)
 
     string = "How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
     print *, count_char_char(string, ["would", "chuck", "could"])
-    count = count_char_char(string, ["would", "chuck", "could"])
-    if (any(count /= [1, 1, 1])) error stop
+    count_value1 = count_char_char(string, ["would", "chuck", "could"])
+    if (any(count_value1 /= [1, 1, 1])) error stop
+
+    print *, count(string, ["would", "chuck", "could"])
+    count_value2 = count(string, ["would", "chuck", "could"])
+    if (any(count_value2 /= [1, 1, 1])) error stop
 end program

--- a/integration_tests/elemental_function_scalar_array_arg.f90
+++ b/integration_tests/elemental_function_scalar_array_arg.f90
@@ -1,0 +1,26 @@
+module mod_elemental_function_scalar_array_arg
+    implicit none
+    contains
+
+    !> Returns an integer
+    elemental function count_char_char(string, pattern) result(res)
+        character(len=*), intent(in) :: string
+        character(len=*), intent(in) :: pattern
+        integer :: res
+
+        res = 1
+    end function count_char_char
+
+end module
+
+program elemental_function_scalar_array_arg
+    use mod_elemental_function_scalar_array_arg
+    implicit none
+    character(len=128) :: string
+    integer :: count(3)
+  
+    string = "How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
+    print *, count_char_char(string, ["would", "chuck", "could"])
+    count = count_char_char(string, ["would", "chuck", "could"])
+    if (any(count /= [1, 1, 1])) error stop
+end program 

--- a/integration_tests/elemental_function_scalar_array_arg.f90
+++ b/integration_tests/elemental_function_scalar_array_arg.f90
@@ -18,9 +18,9 @@ program elemental_function_scalar_array_arg
     implicit none
     character(len=128) :: string
     integer :: count(3)
-  
+
     string = "How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
     print *, count_char_char(string, ["would", "chuck", "could"])
     count = count_char_char(string, ["would", "chuck", "could"])
     if (any(count /= [1, 1, 1])) error stop
-end program 
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4873,12 +4873,23 @@ public:
         ASR::symbol_t *f2 = ASRUtils::symbol_get_past_external(v);
         ASR::ttype_t *return_type = nullptr;
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(f2);
-        if( ASRUtils::get_FunctionType(func)->m_elemental &&
-            func->n_args >= 1 &&
-            ASRUtils::is_array(ASRUtils::expr_type(args[0].m_value)) ) {
+        bool is_elemental = ASRUtils::get_FunctionType(func)->m_elemental;
+        bool any_array_arg = false;
+        ASR::expr_t* first_array_arg = nullptr;
+        if (is_elemental && func->n_args >= 1) {
+            for (size_t i=0; i < args.size(); i++) {
+                if (ASRUtils::is_array(ASRUtils::expr_type(args[i].m_value))) {
+                    any_array_arg = true;
+                    first_array_arg = args[i].m_value;
+                    break;
+                }
+            }
+        }
+        if( is_elemental && func->n_args >= 1 && any_array_arg) {
+            LCOMPILERS_ASSERT(first_array_arg)
             ASR::dimension_t* array_dims;
             size_t array_n_dims = ASRUtils::extract_dimensions_from_ttype(
-                ASRUtils::expr_type(args[0].m_value), array_dims);
+                ASRUtils::expr_type(first_array_arg), array_dims);
             Vec<ASR::dimension_t> new_dims;
             new_dims.from_pointer_n_copy(al, array_dims, array_n_dims);
             return_type = ASRUtils::duplicate_type(al,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4313,12 +4313,23 @@ public:
         }
         ASR::ttype_t *return_type = nullptr;
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(final_sym);
-        if( ASRUtils::get_FunctionType(func)->m_elemental &&
-            func->n_args >= 1 &&
-            ASRUtils::is_array(ASRUtils::expr_type(args[0].m_value)) ) {
+        bool is_elemental = ASRUtils::get_FunctionType(func)->m_elemental;
+        bool any_array_arg = false;
+        ASR::expr_t* first_array_arg = nullptr;
+        if (is_elemental && func->n_args >= 1) {
+            for (size_t i=0; i < args.size(); i++) {
+                if (args[i].m_value && ASRUtils::is_array(ASRUtils::expr_type(args[i].m_value))) {
+                    any_array_arg = true;
+                    first_array_arg = args[i].m_value;
+                    break;
+                }
+            }
+        }
+        if( is_elemental && func->n_args >= 1 && any_array_arg) {
+            LCOMPILERS_ASSERT(first_array_arg)
             ASR::dimension_t* array_dims;
             size_t array_n_dims = ASRUtils::extract_dimensions_from_ttype(
-            ASRUtils::expr_type(args[0].m_value), array_dims);
+                ASRUtils::expr_type(first_array_arg), array_dims);
             Vec<ASR::dimension_t> new_dims;
             new_dims.from_pointer_n_copy(al, array_dims, array_n_dims);
             return_type = ASRUtils::duplicate_type(
@@ -4521,12 +4532,22 @@ public:
             }
             LCOMPILERS_ASSERT(ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(final_sym)))
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(final_sym));
-            if( ASRUtils::get_FunctionType(func)->m_elemental &&
-                func->n_args >= 1 &&
-                ASRUtils::is_array(ASRUtils::expr_type(args[0].m_value)) ) {
+            bool is_elemental = ASRUtils::get_FunctionType(func)->m_elemental;
+            bool any_array_arg = false;
+            ASR::expr_t* first_array_arg = nullptr;
+            if (is_elemental && func->n_args >= 1) {
+                for (size_t i=0; i < args.size(); i++) {
+                    if (ASRUtils::is_array(ASRUtils::expr_type(args[i].m_value))) {
+                        any_array_arg = true;
+                        first_array_arg = args[i].m_value;
+                        break;
+                    }
+                }
+            }
+            if( is_elemental && func->n_args >= 1 && any_array_arg) {
                 ASR::dimension_t* array_dims;
                 size_t array_n_dims = ASRUtils::extract_dimensions_from_ttype(
-                ASRUtils::expr_type(args[0].m_value), array_dims);
+                    ASRUtils::expr_type(first_array_arg), array_dims);
                 Vec<ASR::dimension_t> new_dims;
                 new_dims.from_pointer_n_copy(al, array_dims, array_n_dims);
                 type = ASRUtils::duplicate_type(al,

--- a/tests/reference/asr-template_03b-0778e50.json
+++ b/tests/reference/asr-template_03b-0778e50.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_03b-0778e50.stdout",
-    "stdout_hash": "e8286da432e3a2375db876bc59852dfdde2cb99f71e649c369de93d6",
+    "stdout_hash": "715e22ed13438e81691c9ecd5eaddb31f36fd16a01298899b9cd022f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_03b-0778e50.stdout
+++ b/tests/reference/asr-template_03b-0778e50.stdout
@@ -131,8 +131,18 @@
                                                                 ()
                                                                 [((Var 8 a))
                                                                 ((Var 8 x))]
-                                                                (TypeParameter
-                                                                    w
+                                                                (Array
+                                                                    (TypeParameter
+                                                                        w
+                                                                    )
+                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (ArraySize
+                                                                        (Var 8 x)
+                                                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    ))]
+                                                                    DescriptorArray
                                                                 )
                                                                 ()
                                                                 ()
@@ -567,7 +577,17 @@
                                                                 ()
                                                                 [((Var 15 a))
                                                                 ((Var 15 x))]
-                                                                (Real 4)
+                                                                (Array
+                                                                    (Real 4)
+                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (ArraySize
+                                                                        (Var 15 x)
+                                                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    ))]
+                                                                    PointerToDataArray
+                                                                )
                                                                 ()
                                                                 ()
                                                             ))]
@@ -1331,7 +1351,17 @@
                                                 ()
                                                 [((Var 11 a))
                                                 ((Var 11 x))]
-                                                (Real 4)
+                                                (Array
+                                                    (Real 4)
+                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                    (ArraySize
+                                                        (Var 11 x)
+                                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                                        (Integer 4)
+                                                        ()
+                                                    ))]
+                                                    DescriptorArray
+                                                )
                                                 ()
                                                 ()
                                             ))]

--- a/tests/reference/asr-template_04-f41dd3e.json
+++ b/tests/reference/asr-template_04-f41dd3e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_04-f41dd3e.stdout",
-    "stdout_hash": "0317a6064308f9b5a910224c6ce6ac20de4d5bc20ab24811dbff905e",
+    "stdout_hash": "81193d9500c8541f03e235430980a32b08ecf1c544de81059380cbb5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_04-f41dd3e.stdout
+++ b/tests/reference/asr-template_04-f41dd3e.stdout
@@ -353,7 +353,66 @@
                                                             )
                                                             ()
                                                         ))]
-                                                        (Integer 4)
+                                                        (Array
+                                                            (Integer 4)
+                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                            (IntegerBinOp
+                                                                (IntegerBinOp
+                                                                    (IntegerBinOp
+                                                                        (ArrayBound
+                                                                            (StructInstanceMember
+                                                                                (Var 198 solved)
+                                                                                198 1_integer_matrix_elements
+                                                                                (Array
+                                                                                    (Integer 4)
+                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 198 n))
+                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 198 n))]
+                                                                                    PointerToDataArray
+                                                                                )
+                                                                                ()
+                                                                            )
+                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                            (Integer 4)
+                                                                            UBound
+                                                                            ()
+                                                                        )
+                                                                        Sub
+                                                                        (ArrayBound
+                                                                            (StructInstanceMember
+                                                                                (Var 198 solved)
+                                                                                198 1_integer_matrix_elements
+                                                                                (Array
+                                                                                    (Integer 4)
+                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 198 n))
+                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 198 n))]
+                                                                                    PointerToDataArray
+                                                                                )
+                                                                                ()
+                                                                            )
+                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                            (Integer 4)
+                                                                            LBound
+                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                        )
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    )
+                                                                    Div
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                Add
+                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            DescriptorArray
+                                                        )
                                                         ()
                                                         ()
                                                     ))]
@@ -992,7 +1051,66 @@
                                                             )
                                                             ()
                                                         ))]
-                                                        (Real 4)
+                                                        (Array
+                                                            (Real 4)
+                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                            (IntegerBinOp
+                                                                (IntegerBinOp
+                                                                    (IntegerBinOp
+                                                                        (ArrayBound
+                                                                            (StructInstanceMember
+                                                                                (Var 200 solved)
+                                                                                200 1_real_matrix_elements
+                                                                                (Array
+                                                                                    (Real 4)
+                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 200 n))
+                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 200 n))]
+                                                                                    PointerToDataArray
+                                                                                )
+                                                                                ()
+                                                                            )
+                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                            (Integer 4)
+                                                                            UBound
+                                                                            ()
+                                                                        )
+                                                                        Sub
+                                                                        (ArrayBound
+                                                                            (StructInstanceMember
+                                                                                (Var 200 solved)
+                                                                                200 1_real_matrix_elements
+                                                                                (Array
+                                                                                    (Real 4)
+                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 200 n))
+                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Var 200 n))]
+                                                                                    PointerToDataArray
+                                                                                )
+                                                                                ()
+                                                                            )
+                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                            (Integer 4)
+                                                                            LBound
+                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                        )
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    )
+                                                                    Div
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                Add
+                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                (Integer 4)
+                                                                ()
+                                                            ))]
+                                                            DescriptorArray
+                                                        )
                                                         ()
                                                         ()
                                                     ))]
@@ -2554,7 +2672,66 @@
                                                                             )
                                                                             ()
                                                                         ))]
-                                                                        (Integer 4)
+                                                                        (Array
+                                                                            (Integer 4)
+                                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                            (IntegerBinOp
+                                                                                (IntegerBinOp
+                                                                                    (IntegerBinOp
+                                                                                        (ArrayBound
+                                                                                            (StructInstanceMember
+                                                                                                (Var 165 solved)
+                                                                                                165 1_integer_matrix_elements
+                                                                                                (Array
+                                                                                                    (Integer 4)
+                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 165 n))
+                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 165 n))]
+                                                                                                    PointerToDataArray
+                                                                                                )
+                                                                                                ()
+                                                                                            )
+                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                            (Integer 4)
+                                                                                            UBound
+                                                                                            ()
+                                                                                        )
+                                                                                        Sub
+                                                                                        (ArrayBound
+                                                                                            (StructInstanceMember
+                                                                                                (Var 165 solved)
+                                                                                                165 1_integer_matrix_elements
+                                                                                                (Array
+                                                                                                    (Integer 4)
+                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 165 n))
+                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 165 n))]
+                                                                                                    PointerToDataArray
+                                                                                                )
+                                                                                                ()
+                                                                                            )
+                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                            (Integer 4)
+                                                                                            LBound
+                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                        )
+                                                                                        (Integer 4)
+                                                                                        ()
+                                                                                    )
+                                                                                    Div
+                                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Integer 4)
+                                                                                    ()
+                                                                                )
+                                                                                Add
+                                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                (Integer 4)
+                                                                                ()
+                                                                            ))]
+                                                                            DescriptorArray
+                                                                        )
                                                                         ()
                                                                         ()
                                                                     ))]
@@ -3921,7 +4098,66 @@
                                                                                             )
                                                                                             ()
                                                                                         ))]
-                                                                                        (Integer 4)
+                                                                                        (Array
+                                                                                            (Integer 4)
+                                                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                            (IntegerBinOp
+                                                                                                (IntegerBinOp
+                                                                                                    (IntegerBinOp
+                                                                                                        (ArrayBound
+                                                                                                            (StructInstanceMember
+                                                                                                                (Var 154 solved)
+                                                                                                                154 1_integer_matrix_elements
+                                                                                                                (Array
+                                                                                                                    (Integer 4)
+                                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))
+                                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))]
+                                                                                                                    FixedSizeArray
+                                                                                                                )
+                                                                                                                ()
+                                                                                                            )
+                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                            (Integer 4)
+                                                                                                            UBound
+                                                                                                            ()
+                                                                                                        )
+                                                                                                        Sub
+                                                                                                        (ArrayBound
+                                                                                                            (StructInstanceMember
+                                                                                                                (Var 154 solved)
+                                                                                                                154 1_integer_matrix_elements
+                                                                                                                (Array
+                                                                                                                    (Integer 4)
+                                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))
+                                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))]
+                                                                                                                    FixedSizeArray
+                                                                                                                )
+                                                                                                                ()
+                                                                                                            )
+                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                            (Integer 4)
+                                                                                                            LBound
+                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                        )
+                                                                                                        (Integer 4)
+                                                                                                        ()
+                                                                                                    )
+                                                                                                    Div
+                                                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Integer 4)
+                                                                                                    ()
+                                                                                                )
+                                                                                                Add
+                                                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                (Integer 4)
+                                                                                                ()
+                                                                                            ))]
+                                                                                            DescriptorArray
+                                                                                        )
                                                                                         ()
                                                                                         ()
                                                                                     ))]
@@ -6596,7 +6832,66 @@
                                                                             )
                                                                             ()
                                                                         ))]
-                                                                        (Real 4)
+                                                                        (Array
+                                                                            (Real 4)
+                                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                            (IntegerBinOp
+                                                                                (IntegerBinOp
+                                                                                    (IntegerBinOp
+                                                                                        (ArrayBound
+                                                                                            (StructInstanceMember
+                                                                                                (Var 190 solved)
+                                                                                                190 1_real_matrix_elements
+                                                                                                (Array
+                                                                                                    (Real 4)
+                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 190 n))
+                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 190 n))]
+                                                                                                    PointerToDataArray
+                                                                                                )
+                                                                                                ()
+                                                                                            )
+                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                            (Integer 4)
+                                                                                            UBound
+                                                                                            ()
+                                                                                        )
+                                                                                        Sub
+                                                                                        (ArrayBound
+                                                                                            (StructInstanceMember
+                                                                                                (Var 190 solved)
+                                                                                                190 1_real_matrix_elements
+                                                                                                (Array
+                                                                                                    (Real 4)
+                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 190 n))
+                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Var 190 n))]
+                                                                                                    PointerToDataArray
+                                                                                                )
+                                                                                                ()
+                                                                                            )
+                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                            (Integer 4)
+                                                                                            LBound
+                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                        )
+                                                                                        (Integer 4)
+                                                                                        ()
+                                                                                    )
+                                                                                    Div
+                                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                    (Integer 4)
+                                                                                    ()
+                                                                                )
+                                                                                Add
+                                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                (Integer 4)
+                                                                                ()
+                                                                            ))]
+                                                                            DescriptorArray
+                                                                        )
                                                                         ()
                                                                         ()
                                                                     ))]
@@ -7963,7 +8258,66 @@
                                                                                             )
                                                                                             ()
                                                                                         ))]
-                                                                                        (Real 4)
+                                                                                        (Array
+                                                                                            (Real 4)
+                                                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                            (IntegerBinOp
+                                                                                                (IntegerBinOp
+                                                                                                    (IntegerBinOp
+                                                                                                        (ArrayBound
+                                                                                                            (StructInstanceMember
+                                                                                                                (Var 179 solved)
+                                                                                                                179 1_real_matrix_elements
+                                                                                                                (Array
+                                                                                                                    (Real 4)
+                                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))
+                                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))]
+                                                                                                                    FixedSizeArray
+                                                                                                                )
+                                                                                                                ()
+                                                                                                            )
+                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                            (Integer 4)
+                                                                                                            UBound
+                                                                                                            ()
+                                                                                                        )
+                                                                                                        Sub
+                                                                                                        (ArrayBound
+                                                                                                            (StructInstanceMember
+                                                                                                                (Var 179 solved)
+                                                                                                                179 1_real_matrix_elements
+                                                                                                                (Array
+                                                                                                                    (Real 4)
+                                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))
+                                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Var 146 n))]
+                                                                                                                    FixedSizeArray
+                                                                                                                )
+                                                                                                                ()
+                                                                                                            )
+                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                            (Integer 4)
+                                                                                                            LBound
+                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                        )
+                                                                                                        (Integer 4)
+                                                                                                        ()
+                                                                                                    )
+                                                                                                    Div
+                                                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                    (Integer 4)
+                                                                                                    ()
+                                                                                                )
+                                                                                                Add
+                                                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                (Integer 4)
+                                                                                                ()
+                                                                                            ))]
+                                                                                            DescriptorArray
+                                                                                        )
                                                                                         ()
                                                                                         ()
                                                                                     ))]
@@ -15677,8 +16031,71 @@
                                                                                                             )
                                                                                                             ()
                                                                                                         ))]
-                                                                                                        (TypeParameter
-                                                                                                            t
+                                                                                                        (Array
+                                                                                                            (TypeParameter
+                                                                                                                t
+                                                                                                            )
+                                                                                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                            (IntegerBinOp
+                                                                                                                (IntegerBinOp
+                                                                                                                    (IntegerBinOp
+                                                                                                                        (ArrayBound
+                                                                                                                            (StructInstanceMember
+                                                                                                                                (Var 134 solved)
+                                                                                                                                134 1_matrix_elements
+                                                                                                                                (Array
+                                                                                                                                    (TypeParameter
+                                                                                                                                        t
+                                                                                                                                    )
+                                                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                                    (Var 113 n))
+                                                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                                    (Var 113 n))]
+                                                                                                                                    PointerToDataArray
+                                                                                                                                )
+                                                                                                                                ()
+                                                                                                                            )
+                                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                            (Integer 4)
+                                                                                                                            UBound
+                                                                                                                            ()
+                                                                                                                        )
+                                                                                                                        Sub
+                                                                                                                        (ArrayBound
+                                                                                                                            (StructInstanceMember
+                                                                                                                                (Var 134 solved)
+                                                                                                                                134 1_matrix_elements
+                                                                                                                                (Array
+                                                                                                                                    (TypeParameter
+                                                                                                                                        t
+                                                                                                                                    )
+                                                                                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                                    (Var 113 n))
+                                                                                                                                    ((IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                                    (Var 113 n))]
+                                                                                                                                    PointerToDataArray
+                                                                                                                                )
+                                                                                                                                ()
+                                                                                                                            )
+                                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                            (Integer 4)
+                                                                                                                            LBound
+                                                                                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                        )
+                                                                                                                        (Integer 4)
+                                                                                                                        ()
+                                                                                                                    )
+                                                                                                                    Div
+                                                                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                    (Integer 4)
+                                                                                                                    ()
+                                                                                                                )
+                                                                                                                Add
+                                                                                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                                                                                (Integer 4)
+                                                                                                                ()
+                                                                                                            ))]
+                                                                                                            DescriptorArray
                                                                                                         )
                                                                                                         ()
                                                                                                         ()


### PR DESCRIPTION
## Description

If atleast one of the argument is an array, we should create the return type accordingly

## Why PR against *simplifier_pass*?

This PR is ideally to be created against *main* and not *simplifier_pass*, but I'll like to do that just before *simplifier_pass* is ready to be merged.