### PR TITLE
ci: use `node-18.20.3-64bit` for emsdk installation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -306,7 +306,7 @@ jobs:
             source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
             which node
             node -v
-            node --experimental-wasm-bigint src/lfortran/tests/test_lfortran.js
+            node src/lfortran/tests/test_lfortran.js
 
       - name: Upload to wasm_builds
         shell: bash -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -277,9 +277,9 @@ jobs:
 
             ./emsdk activate 3.1.35
 
-            ./emsdk install node-14.18.2-64bit
+            ./emsdk install node-18.20.3-64bit
 
-            ./emsdk activate node-14.18.2-64bit
+            ./emsdk activate node-18.20.3-64bit
 
       - name: Show Emscripten and Node Info
         shell: bash -l {0}


### PR DESCRIPTION
Refer: https://github.com/emscripten-core/emsdk/commit/53249b91e7ce47253502efdf3ee1900757d7f700#diff-ae070fbd66c55f7bf108994c0a42ffe69eee7319b5bf0f47bef0fcdbd8b496b3R180