### PR TITLE
Raise error for duplicate functions in interface

### DIFF
--- a/tests/errors/duplicate_module_procedures.f90
+++ b/tests/errors/duplicate_module_procedures.f90
@@ -1,0 +1,20 @@
+MODULE input_module
+    implicit none
+    INTERFACE test_interface
+       MODULE PROCEDURE test_01, test_01, test_01
+    END INTERFACE test_interface
+CONTAINS
+
+    SUBROUTINE test_01 (x)
+        implicit none
+        integer , intent(in):: x
+        print *, x
+    END SUBROUTINE test_01
+
+END MODULE input_module
+
+
+PROGRAM main
+    USE input_module
+    CALL test_interface(1)
+END PROGRAM main

--- a/tests/errors/duplicate_module_procedures.f90
+++ b/tests/errors/duplicate_module_procedures.f90
@@ -1,20 +1,20 @@
-MODULE input_module
+module input_module
     implicit none
-    INTERFACE test_interface
-       MODULE PROCEDURE test_01, test_01, test_01
-    END INTERFACE test_interface
-CONTAINS
+    interface test_interface
+       module procedure test_01, test_01, test_01
+    end interface test_interface
+contains
 
-    SUBROUTINE test_01 (x)
+    subroutine test_01 (x)
         implicit none
         integer , intent(in):: x
         print *, x
-    END SUBROUTINE test_01
+    end subroutine test_01
 
-END MODULE input_module
+end module input_module
 
 
-PROGRAM main
-    USE input_module
-    CALL test_interface(1)
-END PROGRAM main
+program main
+    use input_module
+    call test_interface(1)
+end program main

--- a/tests/reference/asr-duplicate_module_procedures-3eaed23.json
+++ b/tests/reference/asr-duplicate_module_procedures-3eaed23.json
@@ -2,12 +2,12 @@
     "basename": "asr-duplicate_module_procedures-3eaed23",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/duplicate_module_procedures.f90",
-    "infile_hash": "e9cde8ba3a436d435bbef78838652ac5e8b74afc461c5136c192897a",
+    "infile_hash": "3a9e11036265ddc79e565af9c00310f2d8d7235a45c7c805375832bd",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-duplicate_module_procedures-3eaed23.stderr",
-    "stderr_hash": "f3cacc46469d9104c8c16606af96213f14e133c8f4b104a49a3778c0",
+    "stderr_hash": "38d21afeae8536898184a80cf9b870afed4bd09bc105d7be51f34fbe",
     "returncode": 2
 }

--- a/tests/reference/asr-duplicate_module_procedures-3eaed23.json
+++ b/tests/reference/asr-duplicate_module_procedures-3eaed23.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-duplicate_module_procedures-3eaed23.stderr",
-    "stderr_hash": "411c842caeeb2d38d64876b95e787e9929f0ba90773ee6abf14fcb8a",
+    "stderr_hash": "f3cacc46469d9104c8c16606af96213f14e133c8f4b104a49a3778c0",
     "returncode": 2
 }

--- a/tests/reference/asr-duplicate_module_procedures-3eaed23.json
+++ b/tests/reference/asr-duplicate_module_procedures-3eaed23.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-duplicate_module_procedures-3eaed23",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/duplicate_module_procedures.f90",
+    "infile_hash": "e9cde8ba3a436d435bbef78838652ac5e8b74afc461c5136c192897a",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-duplicate_module_procedures-3eaed23.stderr",
+    "stderr_hash": "411c842caeeb2d38d64876b95e787e9929f0ba90773ee6abf14fcb8a",
+    "returncode": 2
+}

--- a/tests/reference/asr-duplicate_module_procedures-3eaed23.stderr
+++ b/tests/reference/asr-duplicate_module_procedures-3eaed23.stderr
@@ -1,9 +1,5 @@
 semantic error: Entity test_01 is already present in the interface
-  --> tests/errors/duplicate_module_procedures.f90:8:5 - 12:26
-   |
- 8 |        SUBROUTINE test_01 (x)
-   |        ^^^^^^^^^^^^^^^^^^^^^^...
-...
-   |
-12 |        END SUBROUTINE test_01
-   | ...^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+ --> tests/errors/duplicate_module_procedures.f90:4:8
+  |
+4 |        MODULE PROCEDURE test_01, test_01, test_01
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  

--- a/tests/reference/asr-duplicate_module_procedures-3eaed23.stderr
+++ b/tests/reference/asr-duplicate_module_procedures-3eaed23.stderr
@@ -1,0 +1,9 @@
+semantic error: Entity test_01 is already present in the interface
+  --> tests/errors/duplicate_module_procedures.f90:8:5 - 12:26
+   |
+ 8 |        SUBROUTINE test_01 (x)
+   |        ^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+12 |        END SUBROUTINE test_01
+   | ...^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-duplicate_module_procedures-3eaed23.stderr
+++ b/tests/reference/asr-duplicate_module_procedures-3eaed23.stderr
@@ -1,5 +1,5 @@
 semantic error: Entity test_01 is already present in the interface
  --> tests/errors/duplicate_module_procedures.f90:4:8
   |
-4 |        MODULE PROCEDURE test_01, test_01, test_01
+4 |        module procedure test_01, test_01, test_01
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4226,5 +4226,9 @@ filename = "errors/func_arg_array.f90"
 asr = true
 
 [[test]]
+filename = "errors/duplicate_module_procedures.f90"
+asr = true
+
+[[test]]
 filename = "errors/string_negative_start_index.f90"
 asr = true


### PR DESCRIPTION
### PR Description:
This PR addresses an issue where duplicate symbols in the `add_generic_procedures()` function were not being properly caught and reported, potentially leading to incorrect compilation results. The problem occurred while pushing symbols into the `Vec<ASR::symbol_t*>` structure in `ast_symboltable_visitor.cpp`.
fixes: #4222 

### Key Changes:
Added logic to detect and report duplicate symbols in `add_generic_procedures()`.
### Testing:
Verified with test cases that the system now correctly handles and reports duplicates.