### PR TITLE
chore: Temporary for transpose intrinsic array function

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -721,7 +721,7 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
 
             git checkout origin/lf21
-            git checkout c0d22f7f281eae621f03778b387325d3acb9e9ac
+            git checkout f06d89524bd5d3b5dc2a06c807a5c67190fe0371
             micromamba install -c conda-forge fypp gfortran
             git clean -fdx
             FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"
@@ -980,7 +980,7 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
 
             git checkout origin/lf21
-            git checkout c0d22f7f281eae621f03778b387325d3acb9e9ac
+            git checkout f06d89524bd5d3b5dc2a06c807a5c67190fe0371
             micromamba install -c conda-forge fypp gfortran
             git clean -fdx
             FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs"

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1526,6 +1526,14 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         std::string name_hint = std::string("_intrinsic_array_function_") + ASRUtils::get_array_intrinsic_name(x->m_arr_intrinsic_id);
         if (!(is_current_expr_linked_to_target || ASRUtils::is_array(x->m_type))) {
             force_replace_current_expr_for_scalar(name_hint)
+        } else if (is_current_expr_linked_to_target &&
+            static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Transpose) == x->m_arr_intrinsic_id &&
+            exprs_with_target[*current_expr].second == targetType::OriginalTarget
+        ) {
+            // x = transpose(x), where 'x' is user-variable
+            // needs have a temporary, there might be more
+            // intrinsic array functions needing this
+            force_replace_current_expr_for_array(name_hint)
         } else {
             replace_current_expr(name_hint)
         }


### PR DESCRIPTION
## Description

For an assignment like `c = transpose(c)` we need to create a temporary variable for `transpose(c)`.

This helps us get rid of the last workaround in *stdlib*