### PR TITLE
Undo changes which aren't needed any more in simplifier_pass

### DIFF
--- a/integration_tests/nbody.f90
+++ b/integration_tests/nbody.f90
@@ -104,14 +104,7 @@ program nbody
         real(kind=dp), dimension(3) :: p
         integer :: i
 
-        ! TODO: remove workaround
-        ! the below ImpliedDoLoop isn't handled in *simplifier_pass*
-        ! branch, so we've used a workaround by assigning values to
-        ! `p` one by one
-        ! p = (/ (sum(v(i,:) * mass(:)), i=1,3) /)
-        p(1) = sum(v(1,:) * mass(:))
-        p(2) = sum(v(2,:) * mass(:))
-        p(3) = sum(v(3,:) * mass(:))
+        p = (/ (sum(v(i,:) * mass(:)), i=1,3) /)
         v(:,k) = -p / SOLAR_MASS
     end subroutine offsetMomentum
 

--- a/src/lfortran/mod_to_asr.cpp
+++ b/src/lfortran/mod_to_asr.cpp
@@ -273,7 +273,7 @@ ASR::TranslationUnit_t* parse_gfortran_mod_file(Allocator &al, const std::string
                 a.from_str_view(s.name);
                 char *name = a.c_str(al);
                 Location loc;
-                ASR::asr_t *asr = ASRUtils::make_Variable_t_util(al, loc, nullptr,
+                ASR::asr_t *asr = ASR::make_Variable_t(al, loc, nullptr,
                     name, nullptr, 0, ASR::intentType::In, nullptr, nullptr,
                     ASR::storage_typeType::Default, s.v.type, nullptr,
                     ASR::abiType::GFortranModule,

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -938,7 +938,7 @@ public:
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, tmp_type);
-            ASR::asr_t *v = ASRUtils::make_Variable_t_util(al, x.base.base.loc, new_scope,
+            ASR::asr_t *v = ASR::make_Variable_t(al, x.base.base.loc, new_scope,
                                                  name_c, variable_dependencies_vec.p, variable_dependencies_vec.size(),
                                                  ASR::intentType::Local, nullptr, nullptr, tmp_storage, tmp_type, nullptr,
                                                  ASR::abiType::Source, ASR::accessType::Private, ASR::presenceType::Required,
@@ -1327,7 +1327,7 @@ public:
             ASR::Variable_t* assoc_variable = nullptr;
             ASR::symbol_t* assoc_sym = nullptr;
             if( x.m_assoc_name ) {
-                assoc_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+                assoc_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                     al, x.base.base.loc, current_scope, x.m_assoc_name,
                     nullptr, 0, ASR::intentType::Local, nullptr, nullptr,
                     ASR::storage_typeType::Default, nullptr, nullptr, ASR::abiType::Source,
@@ -1728,7 +1728,7 @@ public:
                         ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(master_function_arg);
                         sym_name = ASRUtils::symbol_name(var->m_v);
                     }
-                    ASR::asr_t* var_asr = ASRUtils::make_Variable_t_util(al, master_function_arg->base.loc,
+                    ASR::asr_t* var_asr = ASR::make_Variable_t(al, master_function_arg->base.loc,
                                             entry_function->m_symtab, s2c(al,sym_name), nullptr, 0, ASR::intentType::Local,
                                             nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr, ASR::abiType::Source,
                                             ASR::accessType::Public, ASR::presenceType::Required, false);
@@ -2120,11 +2120,11 @@ public:
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, int_type);
-            ASR::asr_t* a_variable = ASRUtils::make_Variable_t_util(al, x.base.base.loc, current_scope, a_var_name_f.c_str(al),
-                                                            variable_dependencies_vec.p, variable_dependencies_vec.size(),
-                                                            ASR::intentType::Local, nullptr, nullptr,
-                                                            ASR::storage_typeType::Default, int_type, nullptr,
-                                                            ASR::abiType::Source, ASR::Public, ASR::presenceType::Optional, false);
+            ASR::asr_t* a_variable = ASR::make_Variable_t(al, x.base.base.loc, current_scope, a_var_name_f.c_str(al),
+                                                          variable_dependencies_vec.p, variable_dependencies_vec.size(),
+                                                          ASR::intentType::Local, nullptr, nullptr,
+                                                          ASR::storage_typeType::Default, int_type, nullptr,
+                                                          ASR::abiType::Source, ASR::Public, ASR::presenceType::Optional, false);
             current_scope->add_symbol(var_name, ASR::down_cast<ASR::symbol_t>(a_variable));
             sym = ASR::down_cast<ASR::symbol_t>(a_variable);
         } else {
@@ -2237,7 +2237,7 @@ public:
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, ASRUtils::expr_type(end));
-            ASR::asr_t *arg_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+            ASR::asr_t *arg_var = ASR::make_Variable_t(al, x.base.base.loc,
                 current_scope, s2c(al, arg_name),
                 variable_dependencies_vec.p, variable_dependencies_vec.size(),
                 ASRUtils::intent_in, nullptr, nullptr,
@@ -2273,7 +2273,7 @@ public:
         SetChar variable_dependencies_vec;
         variable_dependencies_vec.reserve(al, 1);
         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
-        ASR::asr_t *return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+        ASR::asr_t *return_var = ASR::make_Variable_t(al, x.base.base.loc,
             current_scope, s2c(al, return_var_name),
             variable_dependencies_vec.p, variable_dependencies_vec.size(),
             ASRUtils::intent_return_var, nullptr, nullptr,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1057,7 +1057,7 @@ public:
         SetChar variable_dependencies_vec;
         variable_dependencies_vec.reserve(al, 1);
         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
-        ASR::symbol_t *v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, loc,
+        ASR::symbol_t *v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, loc,
             current_scope, s2c(al, var_name), variable_dependencies_vec.p,
             variable_dependencies_vec.size(), intent, nullptr, nullptr,
             ASR::storage_typeType::Default, type, nullptr,
@@ -1073,7 +1073,7 @@ public:
         SetChar variable_dependencies_vec;
         variable_dependencies_vec.reserve(al, 1);
         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
-        ASR::symbol_t *v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, loc,
+        ASR::symbol_t *v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, loc,
             current_scope, s2c(al, var_name), variable_dependencies_vec.p,
             variable_dependencies_vec.size(), intent, nullptr, nullptr,
             ASR::storage_typeType::Default, type, nullptr,
@@ -1171,7 +1171,7 @@ public:
                 SetChar variable_dependencies_vec;
                 variable_dependencies_vec.reserve(al, 1);
                 ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
-                v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, loc,
+                v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, loc,
                     current_scope, s2c(al, var_name), variable_dependencies_vec.p,
                     variable_dependencies_vec.size(), ASRUtils::intent_unspecified, nullptr, nullptr,
                     ASR::storage_typeType::Default, type, nullptr,
@@ -1822,7 +1822,7 @@ public:
             // create a struct instance
             ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, struct_symbol));
             std::string struct_var_name = base_struct_instance_name + common_block_name;
-            ASR::symbol_t* struct_var_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, loc, current_scope, s2c(al, struct_var_name), nullptr, 0,
+            ASR::symbol_t* struct_var_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, loc, current_scope, s2c(al, struct_var_name), nullptr, 0,
                                         ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
                                         ASR::abiType::Source, ASR::accessType::Public, ASR::presenceType::Required, false));
             current_scope->add_symbol(struct_var_name, struct_var_sym);
@@ -1847,7 +1847,7 @@ public:
     void add_sym_to_struct(ASR::Variable_t* var_, ASR::Struct_t* struct_type) {
         char* var_name = var_->m_name;
         SymbolTable* struct_scope = struct_type->m_symtab;
-        ASR::symbol_t* var_sym_new = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, var_->base.base.loc, struct_scope,
+        ASR::symbol_t* var_sym_new = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, var_->base.base.loc, struct_scope,
                         var_->m_name, var_->m_dependencies, var_->n_dependencies, var_->m_intent,
                         var_->m_symbolic_value, var_->m_value, var_->m_storage, var_->m_type,
                         var_->m_type_declaration, var_->m_abi, var_->m_access, var_->m_presence, var_->m_value_attr));
@@ -2055,7 +2055,7 @@ public:
             ASR::asr_t *return_var = nullptr;
             ASR::expr_t *to_return = nullptr;
             if (!is_subroutine) {
-                return_var = ASRUtils::make_Variable_t_util(al, loc,
+                return_var = ASR::make_Variable_t(al, loc,
                     current_scope, s2c(al, return_var_name), variable_dependencies_vec.p,
                     variable_dependencies_vec.size(), ASRUtils::intent_return_var,
                     nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
@@ -2366,7 +2366,7 @@ public:
                                                             "` must reduce to a compile time constant.",
                                             x.m_syms[i].loc);
                                     }
-                                    sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+                                    sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                                         al, x.m_syms[i].loc, current_scope,
                                         x.m_syms[i].m_name, nullptr, 0, ASR::intentType::Local,
                                         init_expr, init_expr_value, ASR::storage_typeType::Parameter,
@@ -3283,7 +3283,7 @@ public:
                         SetChar variable_dependencies_vec;
                         variable_dependencies_vec.reserve(al, 1);
                         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type, init_expr, value);
-                        ASR::asr_t *v = ASRUtils::make_Variable_t_util(al, s.loc, current_scope,
+                        ASR::asr_t *v = ASR::make_Variable_t(al, s.loc, current_scope,
                                 s2c(al, to_lower(s.m_name)), variable_dependencies_vec.p,
                                 variable_dependencies_vec.size(), s_intent, init_expr, value,
                                 storage_type, type, type_declaration, s_abi, s_access, s_presence,
@@ -6315,7 +6315,7 @@ public:
                 variable_dependencies_vec.reserve(al, 1);
                 ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, var_type);
                 v = ASR::down_cast<ASR::symbol_t>(
-                    ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+                    ASR::make_Variable_t(al, x.base.base.loc,
                     current_scope, s2c(al, arg_name), variable_dependencies_vec.p,
                     variable_dependencies_vec.size(), ASRUtils::intent_unspecified,
                     nullptr, nullptr, ASR::storage_typeType::Default, var_type, nullptr,
@@ -6334,7 +6334,7 @@ public:
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
-            ASR::asr_t *return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+            ASR::asr_t *return_var = ASR::make_Variable_t(al, x.base.base.loc,
                 current_scope, s2c(al, return_var_name), variable_dependencies_vec.p,
                 variable_dependencies_vec.size(), ASRUtils::intent_return_var,
                 nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
@@ -7713,7 +7713,7 @@ public:
                     args.reserve(al, 2);
                     for (size_t i=0; i<2; i++) {
                         std::string var_name = "arg" + std::to_string(i);
-                        ASR::asr_t *v = ASRUtils::make_Variable_t_util(al, loc, current_scope,
+                        ASR::asr_t *v = ASR::make_Variable_t(al, loc, current_scope,
                             s2c(al, var_name), nullptr, 0, ASR::intentType::In, nullptr,
                             nullptr, ASR::storage_typeType::Default,
                             (i == 0 ? ASRUtils::duplicate_type(al, left_type)
@@ -7755,7 +7755,7 @@ public:
                         value = ASRUtils::EXPR(ASRUtils::make_Cmpop_util(al, loc, cmpop, left, right, left_type));
                     }
 
-                    ASR::asr_t *return_v = ASRUtils::make_Variable_t_util(al, loc,
+                    ASR::asr_t *return_v = ASR::make_Variable_t(al, loc,
                         current_scope, s2c(al, "ret"), nullptr, 0,
                         ASR::intentType::ReturnVar, nullptr, nullptr, ASR::storage_typeType::Default,
                         return_type, nullptr, ASR::abiType::Source,

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -691,7 +691,7 @@ public:
         if (is_master) {
             // Create integer variable "entry__lcompilers"
             ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, compiler_options.po.default_integer_kind));
-            ASR::symbol_t* entry_lcompilers_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al,
+            ASR::symbol_t* entry_lcompilers_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al,
                                                 loc, current_scope, s2c(al, "entry__lcompilers"), nullptr, 0,
                                                 ASR::intentType::In, nullptr, nullptr, ASR::storage_typeType::Default,
                                                 int_type, nullptr, ASR::abiType::Source, ASR::accessType::Public, ASR::presenceType::Required,
@@ -748,7 +748,7 @@ public:
             // create return variable, with same type as parent function
             ASR::symbol_t* parent_func_sym = current_scope->resolve_symbol(parent_function_name);
             ASR::ttype_t* return_type = ASRUtils::symbol_type(parent_func_sym);
-            ASR::symbol_t* return_var_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al,
+            ASR::symbol_t* return_var_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al,
                                                 loc, current_scope, s2c(al, function_name), nullptr, 0,
                                                 ASR::intentType::ReturnVar, nullptr, nullptr, ASR::storage_typeType::Default,
                                                 return_type, nullptr, ASR::abiType::Source, ASR::accessType::Public, ASR::presenceType::Required,
@@ -1411,7 +1411,7 @@ public:
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
             // Add it as a local variable:
-            return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+            return_var = ASR::make_Variable_t(al, x.base.base.loc,
                 current_scope, s2c(al, return_var_name), variable_dependencies_vec.p,
                 variable_dependencies_vec.size(), ASRUtils::intent_return_var,
                 nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
@@ -1647,7 +1647,7 @@ public:
         }
         if ((is_requirement || is_template) && is_deferred) {
             ASR::asr_t *tp = ASR::make_TypeParameter_t(al, x.base.base.loc, s2c(al, dt_name));
-            tmp = ASRUtils::make_Variable_t_util(al, x.base.base.loc, current_scope, s2c(al, dt_name),
+            tmp = ASR::make_Variable_t(al, x.base.base.loc, current_scope, s2c(al, dt_name),
                 nullptr, 0, ASRUtils::intent_in, nullptr, nullptr, ASR::storage_typeType::Default,
                 ASRUtils::TYPE(tp), nullptr, ASR::abiType::Source, dflt_access, ASR::presenceType::Required, false);
             current_scope->add_symbol(dt_name, ASR::down_cast<ASR::symbol_t>(tmp));
@@ -3142,7 +3142,7 @@ public:
                     args.reserve(al, 2);
                     for (size_t i=0; i<2; i++) {
                         std::string var_name = "arg" + std::to_string(i);
-                        ASR::asr_t *v = ASRUtils::make_Variable_t_util(al, x.base.base.loc, current_scope,
+                        ASR::asr_t *v = ASR::make_Variable_t(al, x.base.base.loc, current_scope,
                             s2c(al, var_name), nullptr, 0, ASR::intentType::In, nullptr,
                             nullptr, ASR::storage_typeType::Default,
                             (i == 0 ? ASRUtils::duplicate_type(al, left_type)
@@ -3185,7 +3185,7 @@ public:
                         value = ASRUtils::EXPR(ASRUtils::make_Cmpop_util(al, x.base.base.loc, cmpop, left, right, left_type));
                     }
 
-                    ASR::asr_t *return_v = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+                    ASR::asr_t *return_v = ASR::make_Variable_t(al, x.base.base.loc,
                         current_scope, s2c(al, "ret"), nullptr, 0,
                         ASR::intentType::ReturnVar, nullptr, nullptr, ASR::storage_typeType::Default,
                         return_type, nullptr, ASR::abiType::Source,
@@ -3291,7 +3291,7 @@ public:
                     t = ASRUtils::make_Array_t_util(al, tp->base.base.loc,
                         t, tp_m_dims, tp_n_dims);
                 }
-                ASR::asr_t* new_v = ASRUtils::make_Variable_t_util(al, v->base.base.loc,
+                ASR::asr_t* new_v = ASR::make_Variable_t(al, v->base.base.loc,
                     current_scope, s2c(al, name), v->m_dependencies,
                     v->n_dependencies, v->m_intent,
                     v->m_symbolic_value, v->m_value, v->m_storage, t,
@@ -3347,7 +3347,7 @@ public:
                     SetChar variable_dependencies_vec;
                     variable_dependencies_vec.reserve(al, 1);
                     ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, param_type);
-                    ASR::asr_t *v = ASRUtils::make_Variable_t_util(al, loc, new_scope,
+                    ASR::asr_t *v = ASR::make_Variable_t(al, loc, new_scope,
                         s2c(al, var_name), variable_dependencies_vec.p,
                         variable_dependencies_vec.size(),
                         s_intent, init_expr, value, storage_type, param_type,
@@ -3387,7 +3387,7 @@ public:
                     SetChar variable_dependencies_vec;
                     variable_dependencies_vec.reserve(al, 1);
                     ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, return_type);
-                    ASR::asr_t *new_return_var = ASRUtils::make_Variable_t_util(al, return_var->base.base.loc,
+                    ASR::asr_t *new_return_var = ASR::make_Variable_t(al, return_var->base.base.loc,
                         new_scope, s2c(al, return_var_name),
                         variable_dependencies_vec.p,
                         variable_dependencies_vec.size(),

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -39,7 +39,7 @@ class ASRBuilder {
             ASR::ttype_t *type, ASR::intentType intent,
             ASR::abiType abi=ASR::abiType::Source, bool a_value_attr=false) {
         ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, symtab, s2c(al, var_name), nullptr, 0,
+            ASR::make_Variable_t(al, loc, symtab, s2c(al, var_name), nullptr, 0,
             intent, nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr, abi,
             ASR::Public, ASR::presenceType::Required, a_value_attr));
         symtab->add_symbol(s2c(al, var_name), sym);
@@ -50,7 +50,7 @@ class ASRBuilder {
             ASR::ttype_t *type, ASR::intentType intent,
             ASR::abiType abi=ASR::abiType::Source, bool a_value_attr=false) {
         ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, symtab, s2c(al, var_name), nullptr, 0,
+            ASR::make_Variable_t(al, loc, symtab, s2c(al, var_name), nullptr, 0,
             intent, nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr, abi,
             ASR::Public, ASR::presenceType::Required, a_value_attr));
         symtab->add_symbol(s2c(al, var_name), sym);
@@ -61,7 +61,7 @@ class ASRBuilder {
             ASR::ttype_t *type, ASR::intentType intent,
             ASR::abiType abi=ASR::abiType::Source, bool a_value_attr=false) {
         ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, symtab, s2c(al, var_name), nullptr, 0,
+            ASR::make_Variable_t(al, loc, symtab, s2c(al, var_name), nullptr, 0,
             intent, nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr, abi,
             ASR::Public, ASR::presenceType::Required, a_value_attr));
         symtab->add_or_overwrite_symbol(s2c(al, var_name), sym);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4157,16 +4157,6 @@ inline ASR::asr_t* make_Function_t_util(Allocator& al, const Location& loc,
         m_side_effect_free, m_c_header);
 }
 
-static inline ASR::asr_t* make_Variable_t_util(
-    Allocator &al, const Location &a_loc, SymbolTable* a_parent_symtab,
-    char* a_name, char** a_dependencies, size_t n_dependencies,
-    ASR::intentType a_intent, ASR::expr_t* a_symbolic_value, ASR::expr_t* a_value,
-    ASR::storage_typeType a_storage, ASR::ttype_t* a_type, ASR::symbol_t* a_type_declaration,
-    ASR::abiType a_abi, ASR::accessType a_access, ASR::presenceType a_presence, bool a_value_attr) {
-    return ASR::make_Variable_t(al, a_loc, a_parent_symtab, a_name, a_dependencies, n_dependencies,
-        a_intent, a_symbolic_value, a_value, a_storage, a_type, a_type_declaration, a_abi, a_access,
-        a_presence, a_value_attr);
-}
 
 class SymbolDuplicator {
 
@@ -4267,7 +4257,7 @@ class SymbolDuplicator {
             }
         }
         return ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, variable->base.base.loc, destination_symtab,
+            ASR::make_Variable_t(al, variable->base.base.loc, destination_symtab,
                 variable->m_name, variable->m_dependencies, variable->n_dependencies,
                 variable->m_intent, m_symbolic_value, m_value, variable->m_storage,
                 m_type, variable->m_type_declaration, variable->m_abi, variable->m_access,
@@ -5608,7 +5598,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                         ASR::ttype_t* pointer_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, orig_arg_type->base.loc, arg_array_type));
 
                         std::string cast_sym_name = current_scope->get_unique_name(sym_name + "_cast", false);
-                        ASR::asr_t* cast_ = ASRUtils::make_Variable_t_util(al, arg->base.loc,
+                        ASR::asr_t* cast_ = ASR::make_Variable_t(al, arg->base.loc,
                                         current_scope, s2c(al, cast_sym_name), nullptr,
                                         0, ASR::intentType::Local, nullptr, nullptr,
                                         ASR::storage_typeType::Default, pointer_type, nullptr,

--- a/src/libasr/pass/arr_slice.cpp
+++ b/src/libasr/pass/arr_slice.cpp
@@ -103,7 +103,7 @@ class ReplaceArraySection: public ASR::BaseExprReplacer<ReplaceArraySection> {
         slice_counter += 1;
         char* new_var_name = s2c(al, new_name);
         ASR::ttype_t* slice_asr_type = get_array_from_slice(x, x_arr_var);
-        ASR::asr_t* slice_asr = ASRUtils::make_Variable_t_util(al, x->base.base.loc, current_scope, new_var_name, nullptr, 0,
+        ASR::asr_t* slice_asr = ASR::make_Variable_t(al, x->base.base.loc, current_scope, new_var_name, nullptr, 0,
                                     ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
                                     slice_asr_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                     ASR::presenceType::Required, false);

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -505,7 +505,7 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
             for( size_t j = 0; j < var_ranks[i]; j++ ) {
                 std::string index_var_name = current_scope->get_unique_name(
                     "__libasr_index_" + std::to_string(j) + "_");
-                ASR::symbol_t* index = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+                ASR::symbol_t* index = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                     al, loc, current_scope, s2c(al, index_var_name), nullptr, 0, ASR::intentType::Local,
                     nullptr, nullptr, ASR::storage_typeType::Default, int32_type, nullptr,
                     ASR::abiType::Source, ASR::accessType::Public, ASR::presenceType::Required, false));

--- a/src/libasr/pass/global_stmts.cpp
+++ b/src/libasr/pass/global_stmts.cpp
@@ -52,7 +52,7 @@ void pass_wrap_global_stmts(Allocator &al,
                 int a_kind = down_cast<ASR::Integer_t>(ASRUtils::expr_type(value))->m_kind;
 
                 type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, a_kind));
-                return_var = ASRUtils::make_Variable_t_util(al, loc,
+                return_var = ASR::make_Variable_t(al, loc,
                     fn_scope, var_name, nullptr, 0, ASRUtils::intent_local, nullptr, nullptr,
                     ASR::storage_typeType::Default, type,
                     nullptr, ASR::abiType::BindC,
@@ -69,7 +69,7 @@ void pass_wrap_global_stmts(Allocator &al,
                 int a_kind = down_cast<ASR::Logical_t>(ASRUtils::expr_type(value))->m_kind;
 
                 type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, a_kind));
-                return_var = ASRUtils::make_Variable_t_util(al, loc,
+                return_var = ASR::make_Variable_t(al, loc,
                     fn_scope, var_name, nullptr, 0, ASRUtils::intent_local, nullptr, nullptr,
                     ASR::storage_typeType::Default, type,
                     nullptr, ASR::abiType::BindC,
@@ -83,7 +83,7 @@ void pass_wrap_global_stmts(Allocator &al,
                 s.from_str(al, fn_name_s + std::to_string(idx));
                 var_name = s.c_str(al);
                 type = ASRUtils::expr_type(value);
-                return_var = ASRUtils::make_Variable_t_util(al, loc,
+                return_var = ASR::make_Variable_t(al, loc,
                     fn_scope, var_name, nullptr, 0, ASRUtils::intent_local, nullptr, nullptr,
                     ASR::storage_typeType::Default, type,
                     nullptr, ASR::abiType::BindC,
@@ -97,7 +97,7 @@ void pass_wrap_global_stmts(Allocator &al,
                 s.from_str(al, fn_name_s + std::to_string(idx));
                 var_name = s.c_str(al);
                 type = ASRUtils::expr_type(value);
-                return_var = ASRUtils::make_Variable_t_util(al, loc,
+                return_var = ASR::make_Variable_t(al, loc,
                     fn_scope, var_name, nullptr, 0, ASRUtils::intent_local, nullptr, nullptr,
                     ASR::storage_typeType::Default, type,
                     nullptr, ASR::abiType::BindC,

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -338,7 +338,7 @@ public:
                     break;
                 }
                 ASR::ttype_t* local_var_type = func_var->m_type;
-                ASR::symbol_t* local_var = (ASR::symbol_t*) ASRUtils::make_Variable_t_util(
+                ASR::symbol_t* local_var = (ASR::symbol_t*) ASR::make_Variable_t(
                         al, func_var->base.base.loc, current_scope,
                         s2c(al, local_var_name), nullptr, 0, ASR::intentType::Local,
                         nullptr, nullptr, ASR::storage_typeType::Default,

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -68,7 +68,7 @@ public:
             return current_scope->get_symbol(new_sym_name);
         }
 
-        ASR::symbol_t* new_v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+        ASR::symbol_t* new_v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
             al, x->base.base.loc,
             current_scope, s2c(al, new_sym_name), x->m_dependencies,
             x->n_dependencies, x->m_intent, x->m_symbolic_value,
@@ -140,7 +140,7 @@ public:
             t = ASRUtils::duplicate_type(al, type_subs[tp->m_param]);
         }
 
-        ASR::symbol_t* new_v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+        ASR::symbol_t* new_v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
             al, x->base.base.loc, current_scope, x->m_name, x->m_dependencies,
             x->n_dependencies, x->m_intent, x->m_symbolic_value,
             x->m_value, x->m_storage, t, x->m_type_declaration,
@@ -390,7 +390,7 @@ public:
         variable_dependencies_vec.reserve(al, 1);
         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, new_type);
 
-        ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al,
+        ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al,
             x->base.base.loc, current_scope, s2c(al, x->m_name), variable_dependencies_vec.p,
             variable_dependencies_vec.size(), x->m_intent, nullptr, nullptr, x->m_storage,
             new_type, nullptr, x->m_abi, x->m_access, x->m_presence, x->m_value_attr));
@@ -962,7 +962,7 @@ public:
             return current_scope->get_symbol(new_sym_name);
         }
 
-        ASR::symbol_t* new_v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+        ASR::symbol_t* new_v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
             al, x->base.base.loc,
             current_scope, s2c(al, new_sym_name), x->m_dependencies,
             x->n_dependencies, x->m_intent, x->m_symbolic_value,
@@ -1029,7 +1029,7 @@ public:
         ASR::symbol_t *v = current_scope->get_symbol(x->m_name);
         if (!v) {
             ASR::ttype_t *t = substitute_type(x->m_type);
-            v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+            v = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                 al, x->base.base.loc, current_scope, x->m_name, x->m_dependencies,
                 x->n_dependencies, x->m_intent, x->m_symbolic_value,
                 x->m_value, x->m_storage, t, x->m_type_declaration,
@@ -1204,7 +1204,7 @@ public:
         variable_dependencies_vec.reserve(al, 1);
         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, new_type);
 
-        ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al,
+        ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al,
             x->base.base.loc, target_scope, s2c(al, x->m_name), variable_dependencies_vec.p,
             variable_dependencies_vec.size(), x->m_intent, nullptr, nullptr, x->m_storage,
             new_type, nullptr, x->m_abi, x->m_access, x->m_presence, x->m_value_attr));

--- a/src/libasr/pass/pass_compare.cpp
+++ b/src/libasr/pass/pass_compare.cpp
@@ -61,7 +61,7 @@ public:
 
     #define create_args(x, type, symtab, vec_exprs) { \
         ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>( \
-            ASRUtils::make_Variable_t_util(al, loc, symtab, \
+            ASR::make_Variable_t(al, loc, symtab, \
             s2c(al, x), nullptr, 0, ASR::intentType::In, nullptr, nullptr, \
             ASR::storage_typeType::Default, type, nullptr, \
             ASR::abiType::Source, ASR::accessType::Public, \
@@ -184,7 +184,7 @@ public:
 
         // Declare `result`
         ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, tup_compare_symtab,
+            ASR::make_Variable_t(al, loc, tup_compare_symtab,
             s2c(al, "result"), nullptr, 0, ASR::intentType::ReturnVar, nullptr, nullptr,
             ASR::storage_typeType::Default, bool_type, nullptr,
             ASR::abiType::Source, ASR::accessType::Public,
@@ -356,7 +356,7 @@ public:
 
         // Declare `result`
         ASR::symbol_t* res_arg = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, list_compare_symtab,
+            ASR::make_Variable_t(al, loc, list_compare_symtab,
             s2c(al, "result"), nullptr, 0, ASR::intentType::ReturnVar, nullptr, nullptr,
             ASR::storage_typeType::Default, bool_type, nullptr,
             ASR::abiType::Source, ASR::accessType::Public,

--- a/src/libasr/pass/pass_list_expr.cpp
+++ b/src/libasr/pass/pass_list_expr.cpp
@@ -98,7 +98,7 @@ public:
 
     #define create_args(x, type, symtab) { \
         ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>( \
-            ASRUtils::make_Variable_t_util(al, loc, symtab, \
+            ASR::make_Variable_t(al, loc, symtab, \
             s2c(al, x), nullptr, 0, ASR::intentType::In, nullptr, nullptr, \
             ASR::storage_typeType::Default, type, nullptr, \
             ASR::abiType::Source, ASR::accessType::Public, \
@@ -172,7 +172,7 @@ public:
 
         // Declare `result_list`
         ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, list_section_symtab,
+            ASR::make_Variable_t(al, loc, list_section_symtab,
             s2c(al, "result_list"), nullptr, 0, ASR::intentType::Local, nullptr, nullptr,
             ASR::storage_typeType::Default, list_type, nullptr,
             ASR::abiType::Source, ASR::accessType::Public,
@@ -445,7 +445,7 @@ public:
 
         // Declare `result_list`
         ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>(
-            ASRUtils::make_Variable_t_util(al, loc, list_concat_symtab,
+            ASR::make_Variable_t(al, loc, list_concat_symtab,
             s2c(al, "result_list"), nullptr, 0, ASR::intentType::Local, nullptr, nullptr,
             ASR::storage_typeType::Default, list_type, nullptr,
             ASR::abiType::Source, ASR::accessType::Public,

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -319,7 +319,7 @@ namespace LCompilers {
         char* idx_var_name = s2c(al, str_name);
 
         if( current_scope->get_symbol(std::string(idx_var_name)) == nullptr ) {
-            ASR::asr_t* idx_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, idx_var_name, nullptr, 0,
+            ASR::asr_t* idx_sym = ASR::make_Variable_t(al, loc, current_scope, idx_var_name, nullptr, 0,
                                                     ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
                                                     var_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                                     ASR::presenceType::Required, false);
@@ -371,7 +371,7 @@ namespace LCompilers {
                 char* var_name = s2c(al, idx_var_name);;
                 ASR::expr_t* var = nullptr;
                 if( current_scope->get_symbol(idx_var_name) == nullptr ) {
-                    ASR::asr_t* idx_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, var_name, nullptr, 0,
+                    ASR::asr_t* idx_sym = ASR::make_Variable_t(al, loc, current_scope, var_name, nullptr, 0,
                                                             intent, nullptr, nullptr, ASR::storage_typeType::Default,
                                                             int32_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                                             presence, false);
@@ -416,7 +416,7 @@ namespace LCompilers {
                 char* var_name = s2c(al, idx_var_name);;
                 ASR::expr_t* var = nullptr;
                 if( current_scope->get_symbol(idx_var_name) == nullptr ) {
-                    ASR::asr_t* idx_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, var_name, nullptr, 0,
+                    ASR::asr_t* idx_sym = ASR::make_Variable_t(al, loc, current_scope, var_name, nullptr, 0,
                                             ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
                                             int32_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                             ASR::presenceType::Required, false);
@@ -460,7 +460,7 @@ namespace LCompilers {
                 char* var_name = s2c(al, idx_var_name);;
                 ASR::expr_t* var = nullptr;
                 if( current_scope->get_symbol(idx_var_name) == nullptr ) {
-                    ASR::asr_t* idx_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, var_name, nullptr, 0,
+                    ASR::asr_t* idx_sym = ASR::make_Variable_t(al, loc, current_scope, var_name, nullptr, 0,
                                             ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
                                             int32_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                             ASR::presenceType::Required, false);
@@ -895,7 +895,7 @@ namespace LCompilers {
 
         ASR::expr_t* create_auxiliary_variable_for_expr(ASR::expr_t* expr, std::string& name,
             Allocator& al, SymbolTable*& current_scope, ASR::stmt_t*& assign_stmt) {
-            ASR::asr_t* expr_sym = ASRUtils::make_Variable_t_util(al, expr->base.loc, current_scope, s2c(al, name), nullptr, 0,
+            ASR::asr_t* expr_sym = ASR::make_Variable_t(al, expr->base.loc, current_scope, s2c(al, name), nullptr, 0,
                                                     ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
                                                     ASRUtils::duplicate_type(al, ASRUtils::extract_type(ASRUtils::expr_type(expr))),
                                                     nullptr, ASR::abiType::Source, ASR::accessType::Public, ASR::presenceType::Required, false);
@@ -913,7 +913,7 @@ namespace LCompilers {
             Allocator& al, SymbolTable*& current_scope, ASR::ttype_t* var_type,
             ASR::intentType var_intent) {
             ASRUtils::import_struct_t(al, loc, var_type, var_intent, current_scope);
-            ASR::asr_t* expr_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, s2c(al, name), nullptr, 0,
+            ASR::asr_t* expr_sym = ASR::make_Variable_t(al, loc, current_scope, s2c(al, name), nullptr, 0,
                                                     var_intent, nullptr, nullptr, ASR::storage_typeType::Default,
                                                     var_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                                     ASR::presenceType::Required, false);
@@ -979,7 +979,7 @@ namespace LCompilers {
             SymbolTable* vector_copy_symtab = al.make_new<SymbolTable>(global_scope);
             for( int i = 0; i < num_args; i++ ) {
                 std::string arg_name = "arg" + std::to_string(i);
-                ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, unit.base.base.loc, vector_copy_symtab,
+                ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, unit.base.base.loc, vector_copy_symtab,
                                         s2c(al, arg_name), nullptr, 0, ASR::intentType::In, nullptr, nullptr, ASR::storage_typeType::Default,
                                         types[std::min(i, (int) types.size() - 1)], nullptr, ASR::abiType::Source, ASR::accessType::Public,
                                         ASR::presenceType::Required, false));

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -363,7 +363,7 @@ public:
             if(xx.m_intent == ASR::intentType::Local){
                 ASR::ttype_t *type2 = ASRUtils::TYPE(ASR::make_Integer_t(al, xx.base.base.loc, 8));
                 ASR::symbol_t* sym2 = ASR::down_cast<ASR::symbol_t>(
-                    ASRUtils::make_Variable_t_util(al, xx.base.base.loc, current_scope,
+                    ASR::make_Variable_t(al, xx.base.base.loc, current_scope,
                                         s2c(al, placeholder), nullptr, 0,
                                         xx.m_intent, nullptr,
                                         nullptr, xx.m_storage,
@@ -458,7 +458,7 @@ public:
                 // Define necessary variables
                 ASR::ttype_t* CPtr_type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
                 std::string args_str = current_scope->get_unique_name("_lcompilers_symbolic_argument_container");
-                ASR::symbol_t* args_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+                ASR::symbol_t* args_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                     al, loc, current_scope, s2c(al, args_str), nullptr, 0, ASR::intentType::Local,
                     nullptr, nullptr, ASR::storage_typeType::Default, CPtr_type, nullptr,
                     ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));
@@ -594,7 +594,7 @@ public:
                             std::string placeholder = "_" + std::string(list_name);
 
                             ASR::symbol_t* placeholder_sym = ASR::down_cast<ASR::symbol_t>(
-                                ASRUtils::make_Variable_t_util(al, list_variable->base.base.loc, current_scope,
+                                ASR::make_Variable_t(al, list_variable->base.base.loc, current_scope,
                                                     s2c(al, placeholder), nullptr, 0,
                                                     list_variable->m_intent, nullptr,
                                                     nullptr, list_variable->m_storage,
@@ -629,7 +629,7 @@ public:
                             std::string symbolic_list_index = current_scope->get_unique_name("symbolic_list_index");
                             ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
                             ASR::symbol_t* index_sym = ASR::down_cast<ASR::symbol_t>(
-                                ASRUtils::make_Variable_t_util(al, x.base.base.loc, current_scope, s2c(al, symbolic_list_index),
+                                ASR::make_Variable_t(al, x.base.base.loc, current_scope, s2c(al, symbolic_list_index),
                                 nullptr, 0, ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
                                 int32_type, nullptr, ASR::abiType::Source, ASR::Public, ASR::presenceType::Required, false));
                             current_scope->add_symbol(symbolic_list_index, index_sym);
@@ -742,7 +742,7 @@ public:
                 ASR::IntrinsicElementalFunction_t* intrinsic_func = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(val);
                 ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_SymbolicExpression_t(al, x.base.base.loc));
                 std::string symengine_var = symengine_stack.push();
-                ASR::symbol_t *arg = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+                ASR::symbol_t *arg = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                     al, x.base.base.loc, current_scope, s2c(al, symengine_var), nullptr, 0, ASR::intentType::Local,
                     nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
                     ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));
@@ -874,7 +874,7 @@ public:
         if(x.m_type && x.m_type->type == ASR::ttypeType::SymbolicExpression) {
             ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_SymbolicExpression_t(al, x.base.base.loc));
             std::string symengine_var = symengine_stack.push();
-            ASR::symbol_t *arg = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+            ASR::symbol_t *arg = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                 al, x.base.base.loc, current_scope, s2c(al, symengine_var), nullptr, 0, ASR::intentType::Local,
                 nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
                 ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));
@@ -897,7 +897,7 @@ public:
 
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_SymbolicExpression_t(al, x.base.base.loc));
         std::string symengine_var = symengine_stack.push();
-        ASR::symbol_t *arg = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+        ASR::symbol_t *arg = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
             al, x.base.base.loc, current_scope, s2c(al, symengine_var), nullptr, 0, ASR::intentType::Local,
             nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
             ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));

--- a/src/libasr/pass/select_case.cpp
+++ b/src/libasr/pass/select_case.cpp
@@ -154,7 +154,7 @@ void case_to_if_with_fall_through(Allocator& al, const ASR::Select_t& x,
     ASR::expr_t* a_test, Vec<ASR::stmt_t*>& body, SymbolTable* scope) {
     body.reserve(al, x.n_body + 1);
     const Location& loc = x.base.base.loc;
-    ASR::symbol_t* case_found_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+    ASR::symbol_t* case_found_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
         al, loc, scope, s2c(al, scope->get_unique_name("case_found")), nullptr, 0,
         ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
         ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr, ASR::abiType::Source,

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -253,7 +253,7 @@ ASR::expr_t* create_temporary_variable_for_scalar(Allocator& al,
 
     ASR::ttype_t* var_type = ASRUtils::duplicate_type(al, ASRUtils::extract_type(value_type));
     std::string var_name = scope->get_unique_name("__libasr_created_" + name_hint);
-    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
         al, value->base.loc, scope, s2c(al, var_name), nullptr, 0, ASR::intentType::Local,
         nullptr, nullptr, ASR::storage_typeType::Default, var_type, nullptr, ASR::abiType::Source,
         ASR::accessType::Public, ASR::presenceType::Required, false));
@@ -299,7 +299,7 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al,
     }
 
     std::string var_name = scope->get_unique_name("__libasr_created_" + name_hint);
-    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
         al, value->base.loc, scope, s2c(al, var_name), nullptr, 0, ASR::intentType::Local,
         nullptr, nullptr, ASR::storage_typeType::Default, var_type, nullptr, ASR::abiType::Source,
         ASR::accessType::Public, ASR::presenceType::Required, false));
@@ -312,7 +312,7 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al, const Location& 
     SymbolTable* scope, std::string name_hint, ASR::ttype_t* value_type) {
 
     std::string var_name = scope->get_unique_name("__libasr_created_" + name_hint);
-    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
         al, loc, scope, s2c(al, var_name), nullptr, 0, ASR::intentType::Local,
         nullptr, nullptr, ASR::storage_typeType::Default, value_type, nullptr, ASR::abiType::Source,
         ASR::accessType::Public, ASR::presenceType::Required, false));
@@ -327,7 +327,7 @@ ASR::expr_t* create_temporary_variable_for_struct(Allocator& al,
     LCOMPILERS_ASSERT(ASRUtils::is_struct(*value_type));
 
     std::string var_name = scope->get_unique_name("__libasr_created_" + name_hint);
-    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+    ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
         al, value->base.loc, scope, s2c(al, var_name), nullptr, 0, ASR::intentType::Local,
         nullptr, nullptr, ASR::storage_typeType::Default, value_type, nullptr, ASR::abiType::Source,
         ASR::accessType::Public, ASR::presenceType::Required, false));

--- a/src/libasr/pass/while_else.cpp
+++ b/src/libasr/pass/while_else.cpp
@@ -84,7 +84,7 @@ public:
             ASR::ttype_t *bool_type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4));
             ASR::expr_t *true_expr = ASRUtils::EXPR(ASR::make_LogicalConstant_t(al, loc, true, bool_type));
             ASR::symbol_t *flag_symbol = LCompilers::ASR::down_cast<ASR::symbol_t>(
-                ASRUtils::make_Variable_t_util(
+                ASR::make_Variable_t(
                 al, loc, target_scope,
                 s.c_str(al), nullptr, 0, ASR::intentType::Local, nullptr, nullptr,
                 ASR::storage_typeType::Default, bool_type, nullptr,


### PR DESCRIPTION
## Description

This PR introduces the below changes:

1. undo the workaround in nbody.f90, as that workaround isn't needed anymore
2. use `ASR::make_Variable_t` instead of `ASRUtils::make_Variable_t_util`, as there isn't any difference between the two anymore (initially there was)