### PR TITLE
comment out "experimental simplifier" sections from CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -424,8 +424,8 @@ jobs:
             ./run_tests.py -m
             ./run_tests.py -b llvm
             ./run_tests.py -b llvm -f
-            ./run_tests.py -b llvm --experimental-simplifier
-            ./run_tests.py -b llvm -f --experimental-simplifier
+            # ./run_tests.py -b llvm --experimental-simplifier
+            # ./run_tests.py -b llvm -f --experimental-simplifier
 
   release:
     name: Check Release build
@@ -481,8 +481,8 @@ jobs:
             ./run_tests.py -m
             ./run_tests.py -b llvm
             ./run_tests.py -b llvm -f
-            ./run_tests.py -b llvm --experimental-simplifier
-            ./run_tests.py -b llvm -f --experimental-simplifier
+            # ./run_tests.py -b llvm --experimental-simplifier
+            # ./run_tests.py -b llvm -f --experimental-simplifier
 
       - name: Test Installation
         shell: bash -e -l {0}
@@ -1093,7 +1093,7 @@ jobs:
             export WASMTIME_NEW_CLI=0
             cd integration_tests
             ./run_tests.py -b llvm_wasm llvm_wasm_emcc
-            ./run_tests.py -b llvm_wasm llvm_wasm_emcc --experimental-simplifier
+            # ./run_tests.py -b llvm_wasm llvm_wasm_emcc --experimental-simplifier
 
   gfortran:
     name: Test integration_tests with GFortran
@@ -1152,7 +1152,7 @@ jobs:
         run: |
             cd integration_tests
             ./run_tests.py -b llvm_omp
-            ./run_tests.py -b llvm_omp --experimental-simplifier
+            # ./run_tests.py -b llvm_omp --experimental-simplifier
 
   test_without_llvm:
     name: Test without LLVM Backend
@@ -1244,8 +1244,8 @@ jobs:
             cd integration_tests
             ./run_tests.py -b wasm
             ./run_tests.py -b wasm -f
-            ./run_tests.py -b wasm --experimental-simplifier
-            ./run_tests.py -b wasm -f --experimental-simplifier
+            # ./run_tests.py -b wasm --experimental-simplifier
+            # ./run_tests.py -b wasm -f --experimental-simplifier
 
   test_fortran:
     name: Test Fortran backend
@@ -1289,8 +1289,8 @@ jobs:
             cd integration_tests
             ./run_tests.py -b fortran -j1
             ./run_tests.py -b fortran -f -j1
-            ./run_tests.py -b fortran -j1 --experimental-simplifier
-            ./run_tests.py -b fortran -f -j1 --experimental-simplifier
+            # ./run_tests.py -b fortran -j1 --experimental-simplifier
+            # ./run_tests.py -b fortran -f -j1 --experimental-simplifier
 
   test_mlir:
     name: Test MLIR backend
@@ -1336,7 +1336,7 @@ jobs:
         run: |
             cd integration_tests
             ./run_tests.py -b mlir -j1
-            ./run_tests.py -b mlir -j1 --experimental-simplifier
+            # ./run_tests.py -b mlir -j1 --experimental-simplifier
 
 
   test_c_cpp:
@@ -1394,8 +1394,8 @@ jobs:
             cd integration_tests
             ./run_tests.py -b cpp c c_nopragma
             ./run_tests.py -b cpp c c_nopragma -f
-            ./run_tests.py -b cpp c c_nopragma --experimental-simplifier
-            ./run_tests.py -b cpp c c_nopragma -f --experimental-simplifier
+            # ./run_tests.py -b cpp c c_nopragma --experimental-simplifier
+            # ./run_tests.py -b cpp c c_nopragma -f --experimental-simplifier
 
   upload_tarball:
     name: Upload Tarball


### PR DESCRIPTION
## Description

This PR against *simplifier_pass* branch, since those job when run on simplifier_pass don't help much we can simply comment it out. This will help help speedup our CI, once we're done with porting changes from *simplifier_pass* PR to *main*, we can ignore these changes anyways.