### PR TITLE
Enh: added casting from logical to integer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1158,6 +1158,7 @@ RUN(NAME logical1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME logical2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME logical3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME logical4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
+RUN(NAME logical5 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME logical_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
     EXTRA_ARGS --logical-casting)
 

--- a/integration_tests/logical5.f90
+++ b/integration_tests/logical5.f90
@@ -1,0 +1,15 @@
+program logical5
+! this program checks logical operators
+implicit none
+    
+! variable declaration
+integer :: a, b, c
+       
+! assigning values
+a = .True.
+b = .False.
+c = .True.
+
+print *, a, b, c
+       
+end program logical5

--- a/src/lfortran/semantics/asr_implicit_cast_rules.h
+++ b/src/lfortran/semantics/asr_implicit_cast_rules.h
@@ -70,7 +70,7 @@ private:
        no_cast_required, no_cast_required, no_cast_required},
 
       // Logical
-      {no_cast_required, no_cast_required, no_cast_required, no_cast_required,
+      {logical_to_integer, no_cast_required, no_cast_required, no_cast_required,
        no_cast_required, no_cast_required, no_cast_required},
 
       // Derived

--- a/tests/reference/asr-logical5-75b1def.json
+++ b/tests/reference/asr-logical5-75b1def.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-logical5-75b1def",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/logical5.f90",
+    "infile_hash": "f44f503aa7262fed1bd2e925e83435b4d7bdcb63ea5833a3fc7a6113",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-logical5-75b1def.stdout",
+    "stdout_hash": "dff35916bcace7c14d76caeab86d9a8175221c67d749126d6f0181d5",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-logical5-75b1def.stdout
+++ b/tests/reference/asr-logical5-75b1def.stdout
@@ -1,0 +1,114 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            logical5:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            a:
+                                (Variable
+                                    2
+                                    a
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            b:
+                                (Variable
+                                    2
+                                    b
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            c:
+                                (Variable
+                                    2
+                                    c
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    logical5
+                    []
+                    [(Assignment
+                        (Var 2 a)
+                        (Cast
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
+                            LogicalToInteger
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 b)
+                        (Cast
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
+                            LogicalToInteger
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 c)
+                        (Cast
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
+                            LogicalToInteger
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(Var 2 a)
+                            (Var 2 b)
+                            (Var 2 c)]
+                            FormatFortran
+                            (Character -1 0 () PointerString)
+                            ()
+                        )
+                    )]
+                )
+        })
+    []
+)

--- a/tests/reference/llvm-logical5-ed90709.json
+++ b/tests/reference/llvm-logical5-ed90709.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-logical5-ed90709",
+    "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/logical5.f90",
+    "infile_hash": "f44f503aa7262fed1bd2e925e83435b4d7bdcb63ea5833a3fc7a6113",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-logical5-ed90709.stdout",
+    "stdout_hash": "7eec5b11535a9bd226a59fee859158187c39139f4be776980e0a9e93",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-logical5-ed90709.stdout
+++ b/tests/reference/llvm-logical5-ed90709.stdout
@@ -1,0 +1,37 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %a = alloca i32, align 4
+  %b = alloca i32, align 4
+  %c = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %a1 = alloca i32, align 4
+  %b2 = alloca i32, align 4
+  %c3 = alloca i32, align 4
+  store i32 1, i32* %a1, align 4
+  store i32 0, i32* %b2, align 4
+  store i32 1, i32* %c3, align 4
+  %2 = load i32, i32* %a1, align 4
+  %3 = sext i32 %2 to i64
+  %4 = load i32, i32* %b2, align 4
+  %5 = sext i32 %4 to i64
+  %6 = load i32, i32* %c3, align 4
+  %7 = sext i32 %6 to i64
+  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %3, i32 2, i64 %5, i32 2, i64 %7)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_printf(i8*, ...)

--- a/tests/reference/wat-logical5-0c6cbb8.json
+++ b/tests/reference/wat-logical5-0c6cbb8.json
@@ -1,0 +1,13 @@
+{
+    "basename": "wat-logical5-0c6cbb8",
+    "cmd": "lfortran --no-color --show-wat {infile}",
+    "infile": "tests/../integration_tests/logical5.f90",
+    "infile_hash": "f44f503aa7262fed1bd2e925e83435b4d7bdcb63ea5833a3fc7a6113",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "wat-logical5-0c6cbb8.stdout",
+    "stdout_hash": "6c8af5fdb72af2f5b64e3e32b85e2b26926321d9ce4e9de6bd415535",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/wat-logical5-0c6cbb8.stdout
+++ b/tests/reference/wat-logical5-0c6cbb8.stdout
@@ -1,0 +1,197 @@
+(module
+    (type (;0;) (func (param i32) (result)))
+    (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;2;) (func (param) (result)))
+    (type (;3;) (func (param i64) (result)))
+    (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
+    (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 (mut i32) (i32.const 0))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f32) (f32.const 0.000000))
+    (global $5 (mut f64) (f64.const 0.000000))
+    (global $6 (mut f64) (f64.const 0.000000))
+    (func $2 (type 2) (param) (result)
+        (local i32 i32 i32)
+        i32.const 1
+        local.set 0
+        i32.const 0
+        local.set 1
+        i32.const 1
+        local.set 2
+        local.get 0
+        i64.extend_i32_s
+        call 3
+        i32.const 1
+        i32.const 4
+        i32.const 1
+        i32.const 0
+        call 1
+        drop
+        local.get 1
+        i64.extend_i32_s
+        call 3
+        i32.const 1
+        i32.const 4
+        i32.const 1
+        i32.const 0
+        call 1
+        drop
+        local.get 2
+        i64.extend_i32_s
+        call 3
+        i32.const 1
+        i32.const 16
+        i32.const 1
+        i32.const 0
+        call 1
+        drop
+        i32.const 0
+        call 0
+        return
+    )
+    (func $3 (type 3) (param i64) (result)
+        (local i64 i64 i64 i64)
+        local.get 0
+        i64.const 0
+        i64.eq
+        if
+            i32.const 1
+            i32.const 88
+            i32.const 1
+            i32.const 0
+            call 1
+            drop
+            return
+        else
+        end
+        local.get 0
+        i64.const 0
+        i64.lt_s
+        if
+            i32.const 1
+            i32.const 28
+            i32.const 1
+            i32.const 0
+            call 1
+            drop
+            local.get 0
+            i64.const -1
+            i64.mul
+            local.set 0
+        else
+        end
+        local.get 0
+        local.set 4
+        i64.const 0
+        local.set 1
+        loop
+            local.get 0
+            i64.const 0
+            i64.gt_s
+            if
+                local.get 1
+                i64.const 1
+                i64.add
+                local.set 1
+                local.get 0
+                i64.const 10
+                i64.div_s
+                local.set 0
+                br 1
+            else
+            end
+        end
+        loop
+            local.get 1
+            i64.const 0
+            i64.gt_s
+            if
+                local.get 1
+                i64.const 1
+                i64.sub
+                local.set 1
+                i64.const 1
+                local.set 2
+                i64.const 0
+                local.set 3
+                loop
+                    local.get 3
+                    local.get 1
+                    i64.lt_s
+                    if
+                        local.get 3
+                        i64.const 1
+                        i64.add
+                        local.set 3
+                        local.get 2
+                        i64.const 10
+                        i64.mul
+                        local.set 2
+                        br 1
+                    else
+                    end
+                end
+                local.get 4
+                local.get 2
+                i64.div_s
+                i64.const 10
+                i64.rem_s
+                i64.const 12
+                i64.mul
+                i64.const 88
+                i64.add
+                local.set 0
+                i32.const 1
+                local.get 0
+                i32.wrap_i64
+                i32.const 1
+                i32.const 0
+                call 1
+                drop
+                br 1
+            else
+            end
+        end
+        return
+    )
+    (memory (;0;) 1000 1000)
+    (export "memory" (memory 0))
+    (export "_start" (func 2))
+    (export "print_i64" (func 3))
+    (data (;0;) (i32.const 4) "\0c\00\00\00\01\00\00\00")
+    (data (;1;) (i32.const 12) "    ")
+    (data (;2;) (i32.const 16) "\18\00\00\00\01\00\00\00")
+    (data (;3;) (i32.const 24) "\n   ")
+    (data (;4;) (i32.const 28) "\24\00\00\00\01\00\00\00")
+    (data (;5;) (i32.const 36) "-   ")
+    (data (;6;) (i32.const 40) "\30\00\00\00\01\00\00\00")
+    (data (;7;) (i32.const 48) ".   ")
+    (data (;8;) (i32.const 52) "\3c\00\00\00\01\00\00\00")
+    (data (;9;) (i32.const 60) "(   ")
+    (data (;10;) (i32.const 64) "\48\00\00\00\01\00\00\00")
+    (data (;11;) (i32.const 72) ")   ")
+    (data (;12;) (i32.const 76) "\54\00\00\00\01\00\00\00")
+    (data (;13;) (i32.const 84) ",   ")
+    (data (;14;) (i32.const 88) "\60\00\00\00\01\00\00\00")
+    (data (;15;) (i32.const 96) "0   ")
+    (data (;16;) (i32.const 100) "\6c\00\00\00\01\00\00\00")
+    (data (;17;) (i32.const 108) "1   ")
+    (data (;18;) (i32.const 112) "\78\00\00\00\01\00\00\00")
+    (data (;19;) (i32.const 120) "2   ")
+    (data (;20;) (i32.const 124) "\84\00\00\00\01\00\00\00")
+    (data (;21;) (i32.const 132) "3   ")
+    (data (;22;) (i32.const 136) "\90\00\00\00\01\00\00\00")
+    (data (;23;) (i32.const 144) "4   ")
+    (data (;24;) (i32.const 148) "\9c\00\00\00\01\00\00\00")
+    (data (;25;) (i32.const 156) "5   ")
+    (data (;26;) (i32.const 160) "\a8\00\00\00\01\00\00\00")
+    (data (;27;) (i32.const 168) "6   ")
+    (data (;28;) (i32.const 172) "\b4\00\00\00\01\00\00\00")
+    (data (;29;) (i32.const 180) "7   ")
+    (data (;30;) (i32.const 184) "\c0\00\00\00\01\00\00\00")
+    (data (;31;) (i32.const 192) "8   ")
+    (data (;32;) (i32.const 196) "\cc\00\00\00\01\00\00\00")
+    (data (;33;) (i32.const 204) "9   ")
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1922,6 +1922,12 @@ llvm = true
 wat = true
 
 [[test]]
+filename = "../integration_tests/logical5.f90"
+asr = true
+llvm = true
+wat = true
+
+[[test]]
 filename = "../integration_tests/real_dp_01.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
### PR Description:
This PR adds an enhancement to handle logical-to-integer casting by introducing the `logical_to_integer` rule in the `rule_map`. This enhancement ensures that logical values can now be correctly cast to integers during compilation, expanding the type casting capabilities of the compiler.
ref: https://github.com/lfortran/lfortran/issues/4286

### Testing:
Verified with test cases that the system now correctly handles logical-to-integer casting.