### PR TITLE
Mod refactoring changes and extended logic to real

### DIFF
--- a/integration_tests/intrinsics_78.f90
+++ b/integration_tests/intrinsics_78.f90
@@ -1,8 +1,8 @@
 program intrinsics_78
     implicit none
     integer :: ix, iy, iresult
-    integer(8) :: i
-    integer(4) :: j
+    integer(8) :: j
+    integer(4) :: i
     real(8) :: a
     real(4) :: b
     real :: rx, ry, rresult
@@ -92,7 +92,7 @@ program intrinsics_78
     ! Test integer values with different kinds
     i = 121
     j = 121
-    iresult = kind(mod(i,j))
+    iresult = kind(mod(j,i))
     print *, "Test 14: kind(mod(", i, ",", j, ")) = ", iresult 
     if(iresult /= 8) error stop "Test 14 failed"
 

--- a/integration_tests/intrinsics_78.f90
+++ b/integration_tests/intrinsics_78.f90
@@ -1,8 +1,10 @@
 program intrinsics_78
     implicit none
     integer :: ix, iy, iresult
-    integer(8) :: j
-    integer(4) :: i
+    integer(8) :: i
+    integer(4) :: j
+    real(8) :: a
+    real(4) :: b
     real :: rx, ry, rresult
     double precision :: dx, dy, dresult
 
@@ -90,7 +92,14 @@ program intrinsics_78
     ! Test integer values with different kinds
     i = 121
     j = 121
-    iresult = kind(mod(j,i))
+    iresult = kind(mod(i,j))
     print *, "Test 14: kind(mod(", i, ",", j, ")) = ", iresult 
     if(iresult /= 8) error stop "Test 14 failed"
+
+    ! Test real values with different kinds
+    a = 121.882
+    b = 121.882
+    iresult = kind(mod(a,b))
+    print *, "Test 15: kind(mod(", a, ",", b, ")) = ", iresult 
+    if(iresult /= 8) error stop "Test 15 failed"
 end program intrinsics_78

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -133,18 +133,6 @@ class ASRBuilder {
         return make_Array_t_util(al, loc, type, m_dims.p, m_dims.n);
     }
 
-    ASR::ttype_t* duplicate_type_change_kind(ASR::ttype_t* t, int64_t kind) {
-        if (ASRUtils::is_integer(*t)) {
-            return ASRUtils::TYPE(ASR::make_Integer_t(al, loc, kind));
-        } else if (ASRUtils::is_real(*t)) {
-            return ASRUtils::TYPE(ASR::make_Real_t(al, loc, kind));
-        } else if (ASRUtils::is_complex(*t)) {
-            return ASRUtils::TYPE(ASR::make_Complex_t(al, loc, kind));
-        } else {
-            throw LCompilersException("Type not supported");
-        }
-    }
-
     ASR::ttype_t* CPtr() {
         return TYPE(ASR::make_CPtr_t(al, loc));
     }

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -133,7 +133,7 @@ class ASRBuilder {
         return make_Array_t_util(al, loc, type, m_dims.p, m_dims.n);
     }
 
-    ASR::ttype_t* create_type(ASR::ttype_t* t, int64_t kind) {
+    ASR::ttype_t* duplicate_type_change_kind(ASR::ttype_t* t, int64_t kind) {
         if (ASRUtils::is_integer(*t)) {
             return ASRUtils::TYPE(ASR::make_Integer_t(al, loc, kind));
         } else if (ASRUtils::is_real(*t)) {

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -1042,7 +1042,7 @@ def add_create_func_return_src(func_name):
             src += indent * 3 + f"upper_kind = std::max(upper_kind,ASRUtils::extract_kind_from_ttype_t(expr_type(args[i])));\n"
             src += indent * 2 + f"}}\n"
             src += indent * 2 + f"ASR::ttype_t* type_ = expr_duplicator.duplicate_ttype(ASRUtils::type_get_past_array_pointer_allocatable(expr_type(args[0])));\n"
-            src += indent * 2 + f"type_ = b.create_type(type_, upper_kind);\n"
+            src += indent * 2 + f"type_ = b.duplicate_type_change_kind(type_, upper_kind);\n"
         else:
             src += indent * 2 + f"ASR::ttype_t* type_ = expr_duplicator.duplicate_ttype(expr_type(args[{ret_type_arg_idx}]));\n"
         ret_type = "type_"

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -1036,13 +1036,12 @@ def add_create_func_return_src(func_name):
         src += indent * 2 + "ASRUtils::ExprStmtDuplicator expr_duplicator(al);\n"
         src += indent * 2 + "expr_duplicator.allow_procedure_calls = true;\n"
         if ( ret_type_arg_idx == "dynamic"):
-            src += indent * 2 + f"ASRUtils::ASRBuilder b(al, loc);\n"
             src += indent * 2 + f"int upper_kind = 0;\n"
             src += indent * 2 + f"for(size_t i=0;i<args.size();i++){{\n"
             src += indent * 3 + f"upper_kind = std::max(upper_kind,ASRUtils::extract_kind_from_ttype_t(expr_type(args[i])));\n"
             src += indent * 2 + f"}}\n"
             src += indent * 2 + f"ASR::ttype_t* type_ = expr_duplicator.duplicate_ttype(ASRUtils::type_get_past_array_pointer_allocatable(expr_type(args[0])));\n"
-            src += indent * 2 + f"type_ = b.duplicate_type_change_kind(type_, upper_kind);\n"
+            src += indent * 2 + f"set_kind_to_ttype_t(type_,upper_kind);\n"
         else:
             src += indent * 2 + f"ASR::ttype_t* type_ = expr_duplicator.duplicate_ttype(expr_type(args[{ret_type_arg_idx}]));\n"
         ret_type = "type_"

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3275,48 +3275,25 @@ namespace Mod {
         */
         int kind = ASRUtils::extract_kind_from_ttype_t(arg_types[1]);
         int kind2 = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        int upper_kind = std::max(kind, kind2); 
         if (is_real(*arg_types[1])) {
+            ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, upper_kind));
+            ASR::expr_t* arg0 = b.r2r_t(args[0], new_type);
+            ASR::expr_t* arg1 = b.r2r_t(args[1], new_type);
 
-            if(kind != kind2){
-
-                int upper_kind = std::max(kind, kind2);
-
-                ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, upper_kind));
-                ASR::expr_t* arg0 = b.r2r_t(args[0], new_type);
-                ASR::expr_t* arg1 = b.r2r_t(args[1], new_type);
-
-                if(upper_kind == 4){
-                    body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.i2r_t(b.r2i_t(b.Div(arg0, arg1), real32), real32)))));
-                }
-                else{
-                    body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.i2r_t(b.r2i_t(b.Div(arg0, arg1), real64), real64)))));
-                }
-            }
-            else{
-
-                if (kind == 4) {
-                    body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.i2r_t(b.r2i_t(b.Div(args[0], args[1]), real32), real32)))));
-                } else {
-                    body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.i2r_t(b.r2i_t(b.Div(args[0], args[1]), real64), real64)))));
-                }
+            if (upper_kind == 4) {
+                body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.i2r_t(b.r2i_t(b.Div(arg0, arg1), real32), real32)))));
+            } else {
+                body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.i2r_t(b.r2i_t(b.Div(arg0, arg1), real64), real64)))));
             }
         } else {
+            ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, upper_kind));
+            ASR::expr_t* arg0 = b.i2i_t(args[0], new_type);
+            ASR::expr_t* arg1 = b.i2i_t(args[1], new_type);
 
-            if(kind != kind2){
-
-                int upper_kind = std::max(kind, kind2);
-
-                ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, upper_kind));
-                ASR::expr_t* arg0 = b.i2i_t(args[0], new_type);
-                ASR::expr_t* arg1 = b.i2i_t(args[1], new_type);
-
-                body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.Div(arg0, arg1)))));
-            }
-            else{
-                body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.Div(args[0], args[1])))));
-            }
+            body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.Div(arg0, arg1)))));
         }
-
+        
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3276,32 +3276,45 @@ namespace Mod {
         int kind = ASRUtils::extract_kind_from_ttype_t(arg_types[1]);
         int kind2 = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
         if (is_real(*arg_types[1])) {
-            if (kind == 4) {
-                body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.i2r_t(b.r2i_t(b.Div(args[0], args[1]), real32), real32)))));
-            } else {
-                body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.i2r_t(b.r2i_t(b.Div(args[0], args[1]), real64), real64)))));
-            }
-        } else {
-            
-            if(is_integer(*arg_types[0]) && is_integer(*arg_types[1]) && is_integer(*return_type)){
 
-                if(kind != kind2){
+            if(kind != kind2){
 
-                    int upper_kind = std::max(kind, kind2);
+                int upper_kind = std::max(kind, kind2);
 
-                    ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, upper_kind));
-                    ASR::expr_t* arg0 = b.i2i_t(args[0], new_type);
-                    ASR::expr_t* arg1 = b.i2i_t(args[1], new_type);
+                ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, upper_kind));
+                ASR::expr_t* arg0 = b.r2r_t(args[0], new_type);
+                ASR::expr_t* arg1 = b.r2r_t(args[1], new_type);
 
-                    body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.Div(arg0, arg1))))); 
+                if(upper_kind == 4){
+                    body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.i2r_t(b.r2i_t(b.Div(arg0, arg1), real32), real32)))));
                 }
                 else{
-                    body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.Div(args[0], args[1])))));
+                    body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.i2r_t(b.r2i_t(b.Div(arg0, arg1), real64), real64)))));
                 }
             }
             else{
+
+                if (kind == 4) {
+                    body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.i2r_t(b.r2i_t(b.Div(args[0], args[1]), real32), real32)))));
+                } else {
+                    body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.i2r_t(b.r2i_t(b.Div(args[0], args[1]), real64), real64)))));
+                }
+            }
+        } else {
+
+            if(kind != kind2){
+
+                int upper_kind = std::max(kind, kind2);
+
+                ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, upper_kind));
+                ASR::expr_t* arg0 = b.i2i_t(args[0], new_type);
+                ASR::expr_t* arg1 = b.i2i_t(args[1], new_type);
+
+                body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.Div(arg0, arg1)))));
+            }
+            else{
                 body.push_back(al, b.Assignment(result, b.Sub(args[0], b.Mul(args[1], b.Div(args[0], args[1])))));
-            }  
+            }
         }
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,


### PR DESCRIPTION
In continuation of :- #4645 
Basically , the logic is extended to promote lower kind in case of real.
Also , some refactoring changes are made like removeing ```create_type``` function which was added to create type with given kind but the workaround achieved by a earlier function ```set_kind_to_ttype_t```.