### PR TITLE
Fix implied DO loop rules #4520

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -1,3 +1,5 @@
+/* Flag to track if we are inside an array constructor */
+int in_array_constructor = 0;
 %require "3.0"
 %define api.pure
 %define api.value.type {LCompilers::LFortran::YYSTYPE}
@@ -2330,6 +2332,14 @@ expr_list
     | expr { LIST_NEW($$); LIST_ADD($$, $1); }
     ;
 
+array_constructor
+    : '{' expr_list '}' {
+        in_array_constructor = 1;
+        $$ = create_array_constructor($2);
+        in_array_constructor = 0;
+    }
+    ;
+
 rbracket
     : "]"
     | "/)"
@@ -2368,18 +2378,47 @@ expr
     | "(" expr ")" { $$ = PAREN($2, @$); }
     | "(" expr "," expr ")" { $$ = COMPLEX($2, $4, @$); }
     | "(" expr "," id "=" expr "," expr ")" {
-            $$ = IMPLIED_DO_LOOP1($2, $4, $6, $8, @$); }
-    | "(" expr "," expr "," id "=" expr "," expr ")" {
-            $$ = IMPLIED_DO_LOOP2($2, $4, $6, $8, $10, @$); }
-    | "(" expr "," expr "," expr_list "," id "=" expr "," expr ")" {
-            $$ = IMPLIED_DO_LOOP3($2, $4, $6, $8, $10, $12, @$); }
-    | "(" expr "," id "=" expr "," expr "," expr ")" {
-            $$ = IMPLIED_DO_LOOP4($2, $4, $6, $8, $10, @$); }
-    | "(" expr "," expr "," id "=" expr "," expr "," expr ")" {
-            $$ = IMPLIED_DO_LOOP5($2, $4, $6, $8, $10, $12, @$); }
-    | "(" expr "," expr "," expr_list "," id "=" expr "," expr "," expr ")" {
-            $$ = IMPLIED_DO_LOOP6($2, $4, $6, $8, $10, $12, $14, @$); }
-
+    if (!in_array_constructor) {
+        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
+    } else {
+        $$ = IMPLIED_DO_LOOP1($2, $4, $6, $8, @$);
+    }
+}
+| "(" expr "," expr "," id "=" expr "," expr ")" {
+    if (!in_array_constructor) {
+        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
+    } else {
+        $$ = IMPLIED_DO_LOOP2($2, $4, $6, $8, $10, @$);
+    }
+}
+| "(" expr "," expr "," expr_list "," id "=" expr "," expr ")" {
+    if (!in_array_constructor) {
+        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
+    } else {
+        $$ = IMPLIED_DO_LOOP3($2, $4, $6, $8, $10, $12, @$);
+    }
+}
+| "(" expr "," id "=" expr "," expr "," expr ")" {
+    if (!in_array_constructor) {
+        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
+    } else {
+        $$ = IMPLIED_DO_LOOP4($2, $4, $6, $8, $10, @$);
+    }
+}
+| "(" expr "," expr "," id "=" expr "," expr "," expr ")" {
+    if (!in_array_constructor) {
+        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
+    } else {
+        $$ = IMPLIED_DO_LOOP5($2, $4, $6, $8, $10, $12, @$);
+    }
+}
+| "(" expr "," expr "," expr_list "," id "=" expr "," expr "," expr ")" {
+    if (!in_array_constructor) {
+        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
+    } else {
+        $$ = IMPLIED_DO_LOOP6($2, $4, $6, $8, $10, $12, $14, @$);
+    }
+}
 // ### level-1
     | TK_DEF_OP expr { $$ = UNARY_DEFOP($1, $2, @$); }
 

--- a/test.f90
+++ b/test.f90
@@ -1,0 +1,7 @@
+PROGRAM example
+    integer :: i
+    integer ::arr(4)
+    arr =  (  i , i = 1, 4 )
+    !arr = (/ (i, i = 1, 4) /)
+    print *,arr
+ END PROGRAM example


### PR DESCRIPTION
I Located the parser file parser.yymake changes to handle implied DO loops in Fortran
Added the array constructor flag in parser.yy
```
/* Flag to track if we are inside an array constructor */
int in_array_constructor = 0;
 ```
then defined a simple rule for array_constructor

```
array_constructor
    : '{' expr_list '}' {
        in_array_constructor = 1;
        $$ = create_array_constructor($2);
        in_array_constructor = 0;
    }
    ;
```
This ensures that when the parser encounters an array constructor, it sets the flag in array constructor to 1. After processing the array constructor, it resets the flag to 0.
Now i modified the implied DO loop rules to check if they’re inside an array constructor

```
| "(" expr "," id "=" expr "," expr ")" {
    if (!in_array_constructor) {
        yyerror("Error: Implied DO loops must be wrapped in an array constructor (/ ... /).");
    } else {
        $$ = IMPLIED_DO_LOOP1($2, $4, $6, $8, @$);
    }
}
```
Repeated this for every implied DO loop rule but then i save the changes and rebuild the project again it gives this error
```
    2 | int in_array_constructor = 0;
      | ^~~
```
Summary of Changes

1. Add the in array constructor flag at the top of the parser file.
2. Modified each IMPLIED DO LOOP rule to check if the parser is inside an array constructor.
3. Modified the array constructor rule to set and reset the in array constructor flag when entering and exiting an array constructor.
