### PR TITLE
feat: add support for array type indices in `ArrayItem`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1670,6 +1670,7 @@ RUN(NAME c_ptr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 
 RUN(NAME implicit_argument_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-argument-casting

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1670,7 +1670,7 @@ RUN(NAME c_ptr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
-RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray NO_EXPERIMENTAL_SIMPLIFIER)
 
 RUN(NAME implicit_argument_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-argument-casting

--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -3,6 +3,7 @@ program array_indices_array_item
     implicit none
 
     integer :: arr_idx(2)
+    integer, allocatable :: arr_idx2(:)
     real ::  arr_1(2, 2), arr_2(2), arr_3(2, 2, 2), arr_4(2, 2)
     real :: arr_2_reshape(2), arr_4_reshape(2, 2)
     integer :: rank_val
@@ -11,6 +12,8 @@ program array_indices_array_item
     arr_1 = reshape([1.0, 2.0, 3.0, 4.0], shape(arr_1))
     arr_3 = reshape([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 5.0], shape(arr_3))
     arr_idx = [2, 1]
+    allocate(arr_idx2(2))
+    arr_idx2 = [2, 1]
 
      !Slicing
     arr_2 = arr_1(arr_idx, 1)
@@ -26,6 +29,22 @@ program array_indices_array_item
     if (all(arr_4 /= arr_4_reshape)) error stop
 
     rank_val = rank(arr_3(1, arr_idx, 2))
+    print *, rank_val
+    if (rank_val /= 1) error stop
+
+    arr_2 = arr_1(arr_idx2, 1)
+    arr_2_reshape = reshape([3.0, 1.0], shape(arr_2_reshape));
+    print *, rank(arr_2)
+    if (rank(arr_2) /= 1) error stop
+    if (all(arr_2 /= arr_2_reshape)) error stop
+
+    arr_4 = arr_3(1, arr_idx2, arr_idx2)
+    arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
+    print *, rank(arr_4)
+    if (rank(arr_4) /= 2) error stop
+    if (all(arr_4 /= arr_4_reshape)) error stop
+
+    rank_val = rank(arr_3(1, arr_idx2, 2))
     print *, rank_val
     if (rank_val /= 1) error stop
 

--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -4,27 +4,29 @@ program array_indices_array_item
 
     integer :: arr_idx(2)
     real ::  arr_1(2, 2), arr_2(2), arr_3(2, 2, 2), arr_4(2, 2)
-    real :: arr_2_reshape(2, 2), arr_4_reshape(2, 2, 2)
+    real :: arr_2_reshape(2), arr_4_reshape(2, 2)
+    integer :: rank_val
 
     ! Initialize the matrices and arrays
     arr_1 = reshape([1.0, 2.0, 3.0, 4.0], shape(arr_1))
     arr_3 = reshape([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 5.0], shape(arr_3))
     arr_idx = [2, 1]
 
-    ! Slicing
+     !Slicing
     arr_2 = arr_1(arr_idx, 1)
     arr_2_reshape = reshape([3.0, 1.0], shape(arr_2_reshape));
     print *, rank(arr_2)
     if (rank(arr_2) /= 1) error stop
     if (all(arr_2 /= arr_2_reshape)) error stop
 
-    !arr_4 = arr_3(1, arr_idx, arr_idx)
-    !arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
-    !print *, rank(arr_4)
-    !if (rank(arr_4) /= 2) error stop
-    !if (all(arr_4 /= arr_4_reshape)) error stop
+    arr_4 = arr_3(1, arr_idx, arr_idx)
+    arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
+    print *, rank(arr_4)
+    if (rank(arr_4) /= 2) error stop
+    if (all(arr_4 /= arr_4_reshape)) error stop
 
-    !print *, rank(arr_3(1, arr_idx, 2))
-    !if (rank(arr_3(1, arr_idx, 2)) /= 1) error stop
+    rank_val = rank(arr_3(1, arr_idx, 2))
+    print *, rank_val
+    if (rank_val /= 1) error stop
 
 end program array_indices_array_item

--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -3,7 +3,7 @@ program array_indices_array_item
     implicit none
 
     integer :: arr_idx(2)
-    real ::  arr_1(2, 2), arr_2(2, 1), arr_3(2, 2, 2), arr_4(1, 2, 2)
+    real ::  arr_1(2, 2), arr_2(2), arr_3(2, 2, 2), arr_4(2, 2)
     real :: arr_2_reshape(2, 2), arr_4_reshape(2, 2, 2)
 
     ! Initialize the matrices and arrays
@@ -18,13 +18,13 @@ program array_indices_array_item
     if (rank(arr_2) /= 1) error stop
     if (all(arr_2 /= arr_2_reshape)) error stop
 
-    arr_4 = arr_3(1, arr_idx, arr_idx)
-    arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
-    print *, rank(arr_4)
-    if (rank(arr_4) /= 2) error stop
-    if (all(arr_4 /= arr_4_reshape)) error stop
+    !arr_4 = arr_3(1, arr_idx, arr_idx)
+    !arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
+    !print *, rank(arr_4)
+    !if (rank(arr_4) /= 2) error stop
+    !if (all(arr_4 /= arr_4_reshape)) error stop
 
-    print *, rank(arr_3(1, arr_idx, 2))
-    if (rank(arr_3(1, arr_idx, 2)) /= 1) error stop
+    !print *, rank(arr_3(1, arr_idx, 2))
+    !if (rank(arr_3(1, arr_idx, 2)) /= 1) error stop
 
 end program array_indices_array_item

--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -1,0 +1,30 @@
+program array_indices_array_item
+
+    implicit none
+
+    integer :: arr_idx(2)
+    real ::  arr_1(2, 2), arr_2(2, 1), arr_3(2, 2, 2), arr_4(1, 2, 2)
+    real :: arr_2_reshape(2, 2), arr_4_reshape(2, 2, 2)
+
+    ! Initialize the matrices and arrays
+    arr_1 = reshape([1.0, 2.0, 3.0, 4.0], shape(arr_1))
+    arr_3 = reshape([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 5.0], shape(arr_3))
+    arr_idx = [2, 1]
+
+    ! Slicing
+    arr_2 = arr_1(arr_idx, 1)
+    arr_2_reshape = reshape([3.0, 1.0], shape(arr_2_reshape));
+    print *, rank(arr_2)
+    if (rank(arr_2) /= 1) error stop
+    if (all(arr_2 /= arr_2_reshape)) error stop
+
+    arr_4 = arr_3(1, arr_idx, arr_idx)
+    arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
+    print *, rank(arr_4)
+    if (rank(arr_4) /= 2) error stop
+    if (all(arr_4 /= arr_4_reshape)) error stop
+
+    print *, rank(arr_3(1, arr_idx, 2))
+    if (rank(arr_3(1, arr_idx, 2)) /= 1) error stop
+
+end program array_indices_array_item

--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -4,6 +4,7 @@ program array_indices_array_item
 
     integer :: arr_idx(2)
     integer, allocatable :: arr_idx2(:)
+    integer, allocatable ::  arr(:, :)
     real ::  arr_1(2, 2), arr_2(2), arr_3(2, 2, 2), arr_4(2, 2)
     real :: arr_2_reshape(2), arr_4_reshape(2, 2)
     integer :: rank_val
@@ -47,5 +48,12 @@ program array_indices_array_item
     rank_val = rank(arr_3(1, arr_idx2, 2))
     print *, rank_val
     if (rank_val /= 1) error stop
+
+    allocate(arr(1, 3))
+    arr = reshape([1, 2, 3], shape(arr))
+    rank_val = rank(arr(arr_idx, 1))
+    print *, rank_val
+    if (rank_val /= 1) error stop
+    if (all(arr(arr_idx, 1) /= [3, 1])) error stop
 
 end program array_indices_array_item

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4306,13 +4306,14 @@ public:
             if( a.m_right ) {
                 if (ASRUtils::is_array(ASRUtils::expr_type(a.m_right))) {
                     is_arg_array = true;
-                    if (ASRUtils::is_array(ASRUtils::expr_type(a.m_right))) {
-                        ASR::dimension_t* arg_dim = nullptr;
-                        LCOMPILERS_ASSERT(
-                            ASRUtils::extract_dimensions_from_ttype(
-                                ASRUtils::expr_type(a.m_right), arg_dim) == 1);
-                        res_dims_vec.push_back(al, arg_dim[0]);
+                    ASR::dimension_t* arg_dim = nullptr;
+                    if (!(ASRUtils::extract_dimensions_from_ttype(
+                            ASRUtils::expr_type(a.m_right), arg_dim) == 1)) {
+                        diag.add(Diagnostic("Array index must be of rank 1",
+                            Level::Error, Stage::Semantic, {Label("", {a.m_right->base.loc})}));
+                        throw SemanticAbort();
                     }
+                    res_dims_vec.push_back(al, arg_dim[0]);
                 }
                 if( all_args_eval ) {
                     flag = true;

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -464,7 +464,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 create_do_loop(
                     x->base.base.loc, res_rank,
                     idx_vars, idx_vars_value, loop_vars, loop_var_indices, doloop_body, arg,
-                    [=, this, &idx_vars, &doloop_body] {
+                    [=, &idx_vars, &doloop_body] {
                         ASR::expr_t* res = PassUtils::create_array_ref(result_var, idx_vars, al, current_scope);
 
                         for (size_t j = 0, k = 0; j < x->n_args; j++) {

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -435,7 +435,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                     bool allocate = false;
                     ASR::dimension_t* res_dims_p;
                     int res_dims_n = ASRUtils::extract_dimensions_from_ttype(x->m_type, res_dims_p);
-                    ASR::ttype_t* result_var_type = get_result_type(ASRUtils::expr_type(x->m_v),
+                    ASR::ttype_t* result_var_type = get_result_type(ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(x->m_v)),
                         res_dims_p, res_dims_n, loc, x->class_type, allocate);
                     if( allocate ) {
                         result_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -431,34 +431,13 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 std::vector<int> loop_var_indices;
                 Vec<ASR::stmt_t*> doloop_body;
                 const Location& loc = x->base.base.loc;
-                int res_rank = 0;
+                int res_rank = ASR::down_cast<ASR::Array_t>(x->m_type)->n_dims;
                 
                 if( result_var == nullptr ) {
-                    bool allocate = false;
-                    Vec<ASR::dimension_t> res_dims_vec;
-                    res_dims_vec.reserve(al, x->n_args);
-                    for (size_t j = 0; j < x->n_args; j++) {
-                        if (ASRUtils::is_array(ASRUtils::expr_type(x->m_args[j].m_right))) {
-                            ASR::dimension_t* arg_dim = nullptr;
-                            LCOMPILERS_ASSERT(
-                                ASRUtils::extract_dimensions_from_ttype(
-                                    ASRUtils::expr_type(x->m_args[j].m_right), arg_dim) == 1);
-                            res_dims_vec.push_back(al, arg_dim[0]);
-                            res_rank++;
-                        }
-                    }
-                    ASR::ttype_t* result_var_type = get_result_type(ASRUtils::expr_type(x->m_v),
-                        res_dims_vec.p, (int)res_dims_vec.size(), loc, x->class_type, allocate);
-                    if( allocate ) {
-                        result_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
-                           ASRUtils::type_get_past_allocatable(result_var_type)));
-                    }
+                    ASR::ttype_t* result_var_type = x->m_type;
                     result_var = PassUtils::create_var(result_counter, "array_item", loc,
                                     result_var_type, al, current_scope);
                     result_counter += 1;
-                    if( allocate ) {
-                        allocate_result_var(x->m_v, res_dims_vec.p, (int)res_dims_vec.size(), true, true);
-                    }
                 }
 
                 create_do_loop(

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -467,14 +467,14 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                     [=, this, &idx_vars, &doloop_body] {
                         ASR::expr_t* res = PassUtils::create_array_ref(result_var, idx_vars, al, current_scope);
 
-                        for (int j = 0; j < res_rank; j++) {
+                        for (size_t j = 0, k = 0; j < x->n_args; j++) {
                             if (ASRUtils::is_array(ASRUtils::expr_type(x->m_args[j].m_right))) {
                                 Vec<ASR::array_index_t> arr_dims;
                                 arr_dims.reserve(al, idx_vars.size());
                                 ASR::array_index_t ai;
-                                ai.loc = idx_vars[j]->base.loc;
+                                ai.loc = x->m_args[j].loc;
                                 ai.m_left = nullptr;
-                                ai.m_right = idx_vars[j];
+                                ai.m_right = idx_vars[k];
                                 ai.m_step = nullptr;
                                 arr_dims.push_back(al, ai);
 
@@ -485,10 +485,11 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                                                             ASR::arraystorageType::ColMajor,
                                                             nullptr));
                                 x->m_args[j].m_right = arr_index;
+                                k++;
                             } else {
-                                x->m_args[j].loc = idx_vars[j]->base.loc;
+                                x->m_args[j].loc = x->m_args[j].loc;
                                 x->m_args[j].m_left = nullptr;
-                                x->m_args[j].m_right = idx_vars[j];
+                                x->m_args[j].m_right = x->m_args[j].m_right;
                                 x->m_args[j].m_step = nullptr;
                             }
                         }

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -433,19 +433,10 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 
                 if( result_var == nullptr ) {
                     bool allocate = false;
-                    Vec<ASR::dimension_t> res_dims_vec;
-                    res_dims_vec.reserve(al, x->n_args);
-                    for (size_t j = 0; j < x->n_args; j++) {
-                        if (ASRUtils::is_array(ASRUtils::expr_type(x->m_args[j].m_right))) {
-                            ASR::dimension_t* arg_dim = nullptr;
-                            LCOMPILERS_ASSERT(
-                                ASRUtils::extract_dimensions_from_ttype(
-                                    ASRUtils::expr_type(x->m_args[j].m_right), arg_dim) == 1);
-                            res_dims_vec.push_back(al, arg_dim[0]);
-                        }
-                    }
+                    ASR::dimension_t* res_dims_p;
+                    int res_dims_n = ASRUtils::extract_dimensions_from_ttype(x->m_type, res_dims_p);
                     ASR::ttype_t* result_var_type = get_result_type(ASRUtils::expr_type(x->m_v),
-                        res_dims_vec.p, (int)res_dims_vec.size(), loc, x->class_type, allocate);
+                        res_dims_p, res_dims_n, loc, x->class_type, allocate);
                     if( allocate ) {
                         result_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
                            ASRUtils::type_get_past_allocatable(result_var_type)));
@@ -454,7 +445,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                                     result_var_type, al, current_scope);
                     result_counter += 1;
                     if( allocate ) {
-                        allocate_result_var(x->m_v, res_dims_vec.p, (int)res_dims_vec.size(), true, true);
+                        allocate_result_var(x->m_v, res_dims_p, res_dims_n, true, true);
                     }
                 }
 

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -492,6 +492,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                                 x->m_args[j].m_step = nullptr;
                             }
                         }
+                        x->m_type = ASRUtils::extract_type(ASRUtils::expr_type(x->m_v));
 
                         ASR::stmt_t* assign = ASRUtils::STMT(
                                                 ASR::make_Assignment_t(al, x->base.base.loc, res,


### PR DESCRIPTION
fixes #4420 

We convert an `ArrayItem` like `x(loc, loc)`, where `loc` is an array, to:

```fortran
do __1_t = lbound(__libasr__created__var__0__array_item, 1), ubound(__libasr__created__var__0__array_item, 1)
    do __2_t = lbound(__libasr__created__var__0__array_item, 2), ubound(__libasr__created__var__0__array_item, 2)
        __libasr__created__var__0__array_item(__1_t, __2_t) = x(loc(__1_t), loc(__2_t))
    end do
end do
```

### TODO:

- [ ] Add correct dimension for `result_var`