### PR TITLE
chore: use `ASRUtils::use_experimental_simplifier` for enabling/disabling experimental simplifier

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -719,6 +719,7 @@ jobs:
             ctest -V
 
             # Test with experimental simplifier
+            git clean -dfx
             FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
@@ -762,6 +763,7 @@ jobs:
             ./test_more_inputs
 
             # Test with experimental simplifier
+            git clean -dfx
             FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
@@ -1073,6 +1075,7 @@ jobs:
             ctest -V
 
             # Test with experimental simplifier
+            git clean -dfx
             FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
@@ -1116,6 +1119,7 @@ jobs:
             ./test_more_inputs
 
             # Test with experimental simplifier
+            git clean -dfx
             FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -669,6 +669,18 @@ jobs:
             ldd ./test_chat
             ldd ./test_more_inputs
 
+            # Test with experimental simplifier
+            git clean -dfx
+            FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_Fortran_FLAGS="--experimental-simplifier" .
+            make
+            ls -l ./gpt2 ./chat ./test_basic_input ./test_chat ./test_more_inputs
+            file ./gpt2 ./chat ./test_basic_input ./test_chat ./test_more_inputs
+            ldd ./gpt2
+            ldd ./chat
+            ldd ./test_basic_input
+            ldd ./test_chat
+            ldd ./test_more_inputs
+
             git clean -dfx
             git checkout -t origin/lf36run
             git checkout c915a244354df2e23b0dc613e302893b496549e2
@@ -683,11 +695,31 @@ jobs:
             ./test_more_inputs
             ./test_chat
             ctest -V
+
+            # Test with experimental simplifier
+            git clean -dfx
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_more_inputs
+            ./test_chat
+            ctest -V
+
             cd ..
 
             mkdir lf-fast
             cd lf-fast
             FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_more_inputs
+            ./test_chat
+            ctest -V
+
+            # Test with experimental simplifier
+            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
             make VERBOSE=1
             ln -s ../model.dat .
             ./gpt2
@@ -709,6 +741,15 @@ jobs:
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
+
+            # Test with experimental simplifier
+            git clean -dfx
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_basic_input
+            ./test_more_inputs
             cd ..
 
             mkdir lf-fast
@@ -719,6 +760,15 @@ jobs:
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
+
+            # Test with experimental simplifier
+            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_basic_input
+            ./test_more_inputs
+
             cd ..
 
             rm -rf fastGPT/
@@ -728,30 +778,28 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
             git clone https://github.com/certik/fastGPT.git
-            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
             cd fastGPT
 
             git clean -dfx
             git checkout -t origin/namelist
             git checkout d3eef520c1be8e2db98a3c2189740af1ae7c3e06
+            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 
             mkdir lf
             cd lf
             FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug ..
             make VERBOSE=1
-            ln -s ../../model.dat .
+            ln -s ../model.dat .
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
             cd ..
 
             # Test with experimental simplifier
-            git clean -dfx
-            mkdir lf
-            cd lf
+            git clean -fdx
             FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug .. -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs"
             make VERBOSE=1
-            ln -s ../../model.dat .
+            ln -s ../model.dat .
             ./gpt2
             ./test_basic_input
             ./test_more_inputs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -566,6 +566,21 @@ jobs:
             examples/example_primes
             ctest
 
+            cd ..
+
+            # Test with experimental simplifier
+            git clean -dfx
+            mkdir lf
+            cd lf
+            FC="$(pwd)/../../src/bin/lfortran --intrinsic-mangling --experimental-simplifier" cmake ..
+            make
+            examples/example_hybrd
+            examples/example_hybrd1
+            examples/example_lmder1
+            examples/example_lmdif1
+            examples/example_primes
+            ctest
+
       - name: Test Modern Minpack (Fortran-Lang)
         shell: bash -e -x -l {0}
         run: |
@@ -578,6 +593,13 @@ jobs:
             $(pwd)/../src/bin/lfortran ./examples/example_lmdif1.f90 --legacy-array-sections
             $(pwd)/../src/bin/lfortran ./examples/example_lmder1.f90 --legacy-array-sections
 
+            # Test with experimental simplifier
+            $(pwd)/../src/bin/lfortran ./src/minpack.f90 -c --legacy-array-sections --experimental-simplifier
+            $(pwd)/../src/bin/lfortran ./examples/example_hybrd.f90 --legacy-array-sections --experimental-simplifier
+            $(pwd)/../src/bin/lfortran ./examples/example_hybrd1.f90 --legacy-array-sections --experimental-simplifier
+            $(pwd)/../src/bin/lfortran ./examples/example_lmdif1.f90 --legacy-array-sections --experimental-simplifier
+            $(pwd)/../src/bin/lfortran ./examples/example_lmder1.f90 --legacy-array-sections --experimental-simplifier
+
       - name: Test Modern Minpack (check results)
         shell: bash -e -x -l {0}
         run: |
@@ -585,6 +607,13 @@ jobs:
             cd modern_minpack_02
             git checkout -t origin/w5
             git checkout fcde66ca86348eb0c4012dbdf0f4d8dba61261d8
+            $(pwd)/../src/bin/lfortran ./src/minpack.f90 -c --legacy-array-sections
+            $(pwd)/../src/bin/lfortran ./examples/example_hybrd.f90 --legacy-array-sections
+            $(pwd)/../src/bin/lfortran ./examples/example_hybrd1.f90 --legacy-array-sections
+            $(pwd)/../src/bin/lfortran ./examples/example_lmdif1.f90 --legacy-array-sections
+            $(pwd)/../src/bin/lfortran ./examples/example_lmder1.f90 --legacy-array-sections
+
+            # Test with experimental simplifier
             $(pwd)/../src/bin/lfortran ./src/minpack.f90 -c --legacy-array-sections
             $(pwd)/../src/bin/lfortran ./examples/example_hybrd.f90 --legacy-array-sections
             $(pwd)/../src/bin/lfortran ./examples/example_hybrd1.f90 --legacy-array-sections
@@ -606,8 +635,19 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
             make -f Makefile.manual test
+
+            # Test with experimental simplifier
+            git clean -dfx
+            make -f Makefile.manual F90="lfortran --experimental-simplifier"
+            make -f Makefile.manual test
+
             git clean -dfx
             make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
+            make -f Makefile.manual test
+
+            # Test with experimental simplifier
+            git clean -dfx
+            make -f Makefile.manual F90="lfortran --experimental-simplifier --skip-pass=inline_function_calls,fma --fast"
             make -f Makefile.manual test
 
       - name: Test fastGPT ( ubuntu-latest )
@@ -688,23 +728,34 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
             git clone https://github.com/certik/fastGPT.git
+            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
             cd fastGPT
 
             git clean -dfx
             git checkout -t origin/namelist
             git checkout d3eef520c1be8e2db98a3c2189740af1ae7c3e06
-            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 
             mkdir lf
             cd lf
             FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug ..
             make VERBOSE=1
-            ln -s ../model.dat .
+            ln -s ../../model.dat .
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
             cd ..
 
+            # Test with experimental simplifier
+            git clean -dfx
+            mkdir lf
+            cd lf
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug .. -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs"
+            make VERBOSE=1
+            ln -s ../../model.dat .
+            ./gpt2
+            ./test_basic_input
+            ./test_more_inputs
+            cd ..
 
       - name: Test fpm
         shell: bash -e -x -l {0}
@@ -733,6 +784,20 @@ jobs:
             ctest
             ./build_test_gf.sh
 
+            # Test with experimental simplifier
+            cd ..
+            rm -rf stdlib
+            git clone https://github.com/Pranavchiku/stdlib-fortran-lang.git stdlib
+            cd stdlib
+            export PATH="$(pwd)/../src/bin:$PATH"
+            git checkout origin/lf21
+            git checkout f06d89524bd5d3b5dc2a06c807a5c67190fe0371
+            git clean -fdx
+            FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs --experimental-simplifier"
+            make -j8
+            ctest
+            ./build_test_gf.sh
+
       - name: Test SNAP
         shell: bash -e -x -l {0}
         run: |
@@ -746,8 +811,18 @@ jobs:
             make -j8 FORTRAN=lfortran FFLAGS= MPI=no OPENMP=no
             ./gsnap ../qasnap/sample/inp out
 
+            # Test with experimental simplifier
+            make clean
+            make -j8 FORTRAN=lfortran FFLAGS="--experimental-simplifier" MPI=no OPENMP=no
+            ./gsnap ../qasnap/sample/inp out
+
             make clean
             make -j8 FORTRAN=lfortran FFLAGS="--fast --skip-pass=promote_allocatable_to_nonallocatable" MPI=no OPENMP=no
+            ./gsnap ../qasnap/sample/inp out
+
+            # Test with experimental simplifier
+            make clean
+            make -j8 FORTRAN=lfortran FFLAGS="--fast --skip-pass=promote_allocatable_to_nonallocatable --experimental-simplifier" MPI=no OPENMP=no
             ./gsnap ../qasnap/sample/inp out
 
   test_llvm:
@@ -867,8 +942,19 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual
             make -f Makefile.manual test
+
+            # Test with experimental simplifier
+            git clean -dfx
+            make -f Makefile.manual F90="lfortran --experimental-simplifier"
+            make -f Makefile.manual test
+
             git clean -dfx
             make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
+            make -f Makefile.manual test
+
+            # Test with experimental simplifier
+            git clean -dfx
+            make -f Makefile.manual F90="lfortran --experimental-simplifier --skip-pass=inline_function_calls,fma --fast"
             make -f Makefile.manual test
 
       - name: Test fastGPT ( ubuntu-latest )
@@ -949,23 +1035,34 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
             git clone https://github.com/certik/fastGPT.git
+            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
             cd fastGPT
 
             git clean -dfx
             git checkout -t origin/namelist
             git checkout d3eef520c1be8e2db98a3c2189740af1ae7c3e06
-            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 
             mkdir lf
             cd lf
             FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug ..
             make VERBOSE=1
-            ln -s ../model.dat .
+            ln -s ../../model.dat .
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
             cd ..
 
+            # Test with experimental simplifier
+            git clean -dfx
+            mkdir lf
+            cd lf
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug .. -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs"
+            make VERBOSE=1
+            ln -s ../../model.dat .
+            ./gpt2
+            ./test_basic_input
+            ./test_more_inputs
+            cd ..
 
       - name: Test fpm
         shell: bash -e -x -l {0}
@@ -994,6 +1091,20 @@ jobs:
             ctest
             ./build_test_gf.sh
 
+            # Test with experimental simplifier
+            cd ..
+            rm -rf stdlib
+            git clone https://github.com/Pranavchiku/stdlib-fortran-lang.git stdlib
+            cd stdlib
+            export PATH="$(pwd)/../src/bin:$PATH"
+            git checkout origin/lf21
+            git checkout f06d89524bd5d3b5dc2a06c807a5c67190fe0371
+            git clean -fdx
+            FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs --experimental-simplifier"
+            make -j8
+            ctest
+            ./build_test_gf.sh
+
       - name: Test SNAP
         shell: bash -e -x -l {0}
         run: |
@@ -1007,8 +1118,18 @@ jobs:
             make -j8 FORTRAN=lfortran FFLAGS= MPI=no OPENMP=no
             ./gsnap ../qasnap/sample/inp out
 
+            # Test with experimental simplifier
+            make clean
+            make -j8 FORTRAN=lfortran FFLAGS="--experimental-simplifier" MPI=no OPENMP=no
+            ./gsnap ../qasnap/sample/inp out
+
             make clean
             make -j8 FORTRAN=lfortran FFLAGS="--fast --skip-pass=promote_allocatable_to_nonallocatable" MPI=no OPENMP=no
+            ./gsnap ../qasnap/sample/inp out
+
+            # Test with experimental simplifier
+            make clean
+            make -j8 FORTRAN=lfortran FFLAGS="--fast --skip-pass=promote_allocatable_to_nonallocatable --experimental-simplifier" MPI=no OPENMP=no
             ./gsnap ../qasnap/sample/inp out
 
   test_llvm_wasm:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -671,7 +671,7 @@ jobs:
 
             # Test with experimental simplifier
             git clean -dfx
-            FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_Fortran_FLAGS="--experimental-simplifier" .
+            FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" .
             make
             ls -l ./gpt2 ./chat ./test_basic_input ./test_chat ./test_more_inputs
             file ./gpt2 ./chat ./test_basic_input ./test_chat ./test_more_inputs
@@ -698,7 +698,7 @@ jobs:
 
             # Test with experimental simplifier
             git clean -dfx
-            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
             ./gpt2
@@ -719,7 +719,7 @@ jobs:
             ctest -V
 
             # Test with experimental simplifier
-            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
             ./gpt2
@@ -744,7 +744,7 @@ jobs:
 
             # Test with experimental simplifier
             git clean -dfx
-            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
             ./gpt2
@@ -762,7 +762,7 @@ jobs:
             ./test_more_inputs
 
             # Test with experimental simplifier
-            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier" ..
+            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
             ./gpt2
@@ -793,7 +793,6 @@ jobs:
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
-            cd ..
 
             # Test with experimental simplifier
             git clean -fdx
@@ -1024,6 +1023,18 @@ jobs:
             ldd ./test_chat
             ldd ./test_more_inputs
 
+            # Test with experimental simplifier
+            git clean -dfx
+            FC=$(pwd)/../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" .
+            make
+            ls -l ./gpt2 ./chat ./test_basic_input ./test_chat ./test_more_inputs
+            file ./gpt2 ./chat ./test_basic_input ./test_chat ./test_more_inputs
+            ldd ./gpt2
+            ldd ./chat
+            ldd ./test_basic_input
+            ldd ./test_chat
+            ldd ./test_more_inputs
+
             git clean -dfx
             git checkout -t origin/lf36run
             git checkout c915a244354df2e23b0dc613e302893b496549e2
@@ -1038,11 +1049,31 @@ jobs:
             ./test_more_inputs
             ./test_chat
             ctest -V
+
+            # Test with experimental simplifier
+            git clean -dfx
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_more_inputs
+            ./test_chat
+            ctest -V
+
             cd ..
 
             mkdir lf-fast
             cd lf-fast
             FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_more_inputs
+            ./test_chat
+            ctest -V
+
+            # Test with experimental simplifier
+            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
             make VERBOSE=1
             ln -s ../model.dat .
             ./gpt2
@@ -1064,6 +1095,15 @@ jobs:
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
+
+            # Test with experimental simplifier
+            git clean -dfx
+            FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_basic_input
+            ./test_more_inputs
             cd ..
 
             mkdir lf-fast
@@ -1074,6 +1114,15 @@ jobs:
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
+
+            # Test with experimental simplifier
+            FC="$(pwd)/../../src/bin/lfortran --fast" CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs" ..
+            make VERBOSE=1
+            ln -s ../model.dat .
+            ./gpt2
+            ./test_basic_input
+            ./test_more_inputs
+
             cd ..
 
             rm -rf fastGPT/
@@ -1083,30 +1132,27 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
             git clone https://github.com/certik/fastGPT.git
-            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
             cd fastGPT
 
             git clean -dfx
             git checkout -t origin/namelist
             git checkout d3eef520c1be8e2db98a3c2189740af1ae7c3e06
+            curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 
             mkdir lf
             cd lf
             FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug ..
             make VERBOSE=1
-            ln -s ../../model.dat .
+            ln -s ../model.dat .
             ./gpt2
             ./test_basic_input
             ./test_more_inputs
-            cd ..
 
             # Test with experimental simplifier
-            git clean -dfx
-            mkdir lf
-            cd lf
+            git clean -fdx
             FC=$(pwd)/../../src/bin/lfortran CMAKE_PREFIX_PATH=$CONDA_PREFIX cmake -DFASTGPT_BLAS=OpenBLAS -DCMAKE_BUILD_TYPE=Debug .. -DCMAKE_Fortran_FLAGS="--experimental-simplifier --realloc-lhs"
             make VERBOSE=1
-            ln -s ../../model.dat .
+            ln -s ../model.dat .
             ./gpt2
             ./test_basic_input
             ./test_more_inputs

--- a/src/libasr/asr_verify.h
+++ b/src/libasr/asr_verify.h
@@ -36,8 +36,7 @@ namespace LCompilers {
     //   LCOMPILERS_ASSERT(asr_verify(*asr));
     //
     bool asr_verify(const ASR::TranslationUnit_t &unit,
-        bool check_external, diag::Diagnostics &diagnostics,
-        const LCompilers::PassOptions& pass_options = LCompilers::PassOptions());
+        bool check_external, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -22,7 +22,6 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
     Allocator& al;
     Vec<ASR::stmt_t*>& pass_result;
     bool& remove_original_statement;
-    bool pass_simplifier = false;
 
     SymbolTable* current_scope;
     ASR::expr_t* result_var;
@@ -33,10 +32,9 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
     ReplaceArrayConstant(Allocator& al_, Vec<ASR::stmt_t*>& pass_result_,
         bool& remove_original_statement_,
         std::map<ASR::expr_t*, ASR::expr_t*>& resultvar2value_,
-        bool realloc_lhs_, bool allocate_target_, bool pass_simplifier_) :
+        bool realloc_lhs_, bool allocate_target_) :
     al(al_), pass_result(pass_result_),
     remove_original_statement(remove_original_statement_),
-    pass_simplifier(pass_simplifier_),
     current_scope(nullptr), 
     result_var(nullptr), result_counter(0),
     resultvar2value(resultvar2value_), 
@@ -293,9 +291,13 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
         }
         LCOMPILERS_ASSERT(result_var != nullptr);
         Vec<ASR::stmt_t*>* result_vec = &pass_result;
-        if (pass_simplifier) PassUtils::ReplacerUtils::replace_ArrayConstructor_(al, x, result_var, result_vec, current_scope);
-        else PassUtils::ReplacerUtils::replace_ArrayConstructor(x, this,
-            remove_original_statement, result_vec);
+        if (ASRUtils::use_experimental_simplifier) {
+            PassUtils::ReplacerUtils::replace_ArrayConstructor_(al, x, result_var,
+                result_vec, current_scope);
+        } else {
+            PassUtils::ReplacerUtils::replace_ArrayConstructor(x, this,
+                remove_original_statement, result_vec);
+        }
         result_var = result_var_copy;
     }
 
@@ -425,10 +427,10 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
 
     public:
 
-        ArrayConstantVisitor(Allocator& al_, bool realloc_lhs_, bool pass_simplifier_) :
+        ArrayConstantVisitor(Allocator& al_, bool realloc_lhs_) :
         al(al_), remove_original_statement(false),
         replacer(al_, pass_result, remove_original_statement,
-            resultvar2value, realloc_lhs_, allocate_target, pass_simplifier_),
+            resultvar2value, realloc_lhs_, allocate_target),
         parent_body(nullptr) {
             pass_result.n = 0;
             pass_result.reserve(al, 0);
@@ -724,7 +726,7 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
 void pass_replace_implied_do_loops(Allocator &al,
     ASR::TranslationUnit_t &unit,
     const LCompilers::PassOptions& pass_options) {
-    ArrayConstantVisitor v(al, pass_options.realloc_lhs, pass_options.experimental_simplifier);
+    ArrayConstantVisitor v(al, pass_options.realloc_lhs);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);
     u.visit_TranslationUnit(unit);

--- a/src/libasr/pass/init_expr.cpp
+++ b/src/libasr/pass/init_expr.cpp
@@ -26,15 +26,14 @@ class ReplaceInitExpr: public ASR::BaseExprReplacer<ReplaceInitExpr> {
     ASR::cast_kindType cast_kind;
     ASR::ttype_t* casted_type;
     bool perform_cast;
-    bool pass_simplifier = false;
 
     ReplaceInitExpr(
         Allocator& al_,
-        std::map<SymbolTable*, Vec<ASR::stmt_t*>>& symtab2decls_, bool pass_simplifier_) :
+        std::map<SymbolTable*, Vec<ASR::stmt_t*>>& symtab2decls_) :
     al(al_), symtab2decls(symtab2decls_),
     current_scope(nullptr), result_var(nullptr),
     cast_kind(ASR::cast_kindType::IntegerToInteger),
-    casted_type(nullptr), perform_cast(false), pass_simplifier(pass_simplifier_) {}
+    casted_type(nullptr), perform_cast(false) {}
 
     void replace_ArrayConstant(ASR::ArrayConstant_t* x) {
         if( symtab2decls.find(current_scope) == symtab2decls.end() ) {
@@ -64,12 +63,15 @@ class ReplaceInitExpr: public ASR::BaseExprReplacer<ReplaceInitExpr> {
         if( casted_type != nullptr ) {
             casted_type = ASRUtils::type_get_past_array(casted_type);
         }
-        if (pass_simplifier) PassUtils::ReplacerUtils::replace_ArrayConstructor_(al, x, result_var, result_vec,
-            current_scope, perform_cast, cast_kind, casted_type);
-        else PassUtils::ReplacerUtils::replace_ArrayConstructor(x, this,
-            remove_original_statement, result_vec,
-            perform_cast, cast_kind, casted_type);
-            *current_expr = nullptr;
+        if (ASRUtils::use_experimental_simplifier) {
+            PassUtils::ReplacerUtils::replace_ArrayConstructor_(al, x, result_var, result_vec,
+                current_scope, perform_cast, cast_kind, casted_type);
+        } else {
+            PassUtils::ReplacerUtils::replace_ArrayConstructor(x, this,
+                remove_original_statement, result_vec,
+                perform_cast, cast_kind, casted_type);
+        }
+        *current_expr = nullptr;
     }
 
     void replace_StructConstructor(ASR::StructConstructor_t* x) {
@@ -114,8 +116,8 @@ class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVis
 
     public:
 
-        InitExprVisitor(Allocator& al_, bool pass_simplifier_) :
-        al(al_), replacer(al_, symtab2decls, pass_simplifier_) {
+        InitExprVisitor(Allocator& al_) :
+        al(al_), replacer(al_, symtab2decls) {
         }
 
         void call_replacer() {
@@ -219,8 +221,8 @@ class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVis
 
 void pass_replace_init_expr(Allocator &al,
     ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& pass_options) {
-    InitExprVisitor v(al, pass_options.experimental_simplifier);
+    const LCompilers::PassOptions& /*pass_options*/) {
+    InitExprVisitor v(al);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor w(al);
     w.visit_TranslationUnit(unit);

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -394,14 +394,14 @@ namespace LCompilers {
                 apply_passes(al, asr, _user_defined_passes, pass_options,
                     diagnostics);
             } else if( apply_default_passes ) {
-                if( pass_options.fast && !pass_options.experimental_simplifier ) {
+                if( pass_options.fast && !ASRUtils::use_experimental_simplifier ) {
                     apply_passes(al, asr, _with_optimization_passes, pass_options,
                         diagnostics);
-                } else if (!pass_options.fast && !pass_options.experimental_simplifier) {
+                } else if (!pass_options.fast && !ASRUtils::use_experimental_simplifier) {
                     apply_passes(al, asr, _passes, pass_options, diagnostics);
-                } else if (pass_options.fast && pass_options.experimental_simplifier){
+                } else if (pass_options.fast && ASRUtils::use_experimental_simplifier){
                     apply_passes(al, asr, _with_optimization_passes_for_experimental_simplifier, pass_options, diagnostics);
-                } else if (!pass_options.fast && pass_options.experimental_simplifier) {
+                } else if (!pass_options.fast && ASRUtils::use_experimental_simplifier) {
                     apply_passes(al, asr, _passes_with_experimental_simplifier, pass_options, diagnostics);
                 }
             }


### PR DESCRIPTION
## Description

This will ensure that there is only a single place to enable/disable experimental simplifier pass, instead of use `pass_options.experimental_simplifier` at some places and `ASRUtils::use_experimental_simplifier` at others.

Also, toggling experimental_simplififer in hard-coded manner will produce expected results, once `ASRUtils::use_experimental_simplifier` is set to true/false, it will be used as that value throughout our codebase.