### PR TITLE
Print LLVM version in `--version`

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2272,6 +2272,7 @@ int main_app(int argc, char *argv[]) {
         std::cout << "LFortran version: " << version << std::endl;
         std::cout << "Platform: " << pf2s(compiler_options.platform) << std::endl;
 #ifdef HAVE_LFORTRAN_LLVM
+        std::cout << "LLVM: " << LCompilers::LLVMEvaluator::llvm_version() << std::endl;
         std::cout << "Default target: " << LCompilers::LLVMEvaluator::get_default_target_triple() << std::endl;
 #endif
         return 0;

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -438,6 +438,11 @@ void LLVMEvaluator::print_version_message()
     llvm::cl::PrintVersionMessage();
 }
 
+std::string LLVMEvaluator::llvm_version()
+{
+    return LLVM_VERSION_STRING;
+}
+
 llvm::LLVMContext &LLVMEvaluator::get_context()
 {
     return *context;

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -78,6 +78,7 @@ public:
     void opt(llvm::Module &m);
     static std::string module_to_string(llvm::Module &m);
     static void print_version_message();
+    static std::string llvm_version();
     llvm::LLVMContext &get_context();
     static void print_targets();
     static std::string get_default_target_triple();


### PR DESCRIPTION
This will now print:
```console
$ lfortran --version
LFortran version: 0.41.0-147-g0588e0f67-dirty
Platform: Linux
LLVM: 11.1.0
Default target: x86_64-unknown-linux-gnu
```