### PR TITLE
chore: tokenize 'allocate' statement in fixed-form

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1005,6 +1005,12 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        if (next_is(cur, "allocate")) {
+            push_token_advance(cur, "allocate");
+            tokenize_line(cur);
+            return true;
+        }
+
         if (next_is(cur, "goto")) {
             push_token_advance(cur, "goto");
             tokenize_line(cur);

--- a/tests/fixed_form_interface.f
+++ b/tests/fixed_form_interface.f
@@ -1,7 +1,7 @@
         program fixed_form_interface
             implicit none
 
-            ! tests that 'interface' is tokinized correctly
+c           tests that 'interface' is tokinized correctly
             interface
                 subroutine my_subroutine(a)
                     integer, intent(in) :: a
@@ -13,8 +13,7 @@
                 end function my_function
             end interface
 
-            ! tests that 'allocate' is tokenized correctly
-
+c           tests that 'allocate' is tokenized correctly
             integer :: num = 2
             integer, dimension(:), allocatable :: factors
 

--- a/tests/fixed_form_interface.f
+++ b/tests/fixed_form_interface.f
@@ -1,6 +1,7 @@
         program fixed_form_interface
             implicit none
 
+            ! tests that 'interface' is tokinized correctly
             interface
                 subroutine my_subroutine(a)
                     integer, intent(in) :: a
@@ -11,6 +12,13 @@
                     integer :: res
                 end function my_function
             end interface
+
+            ! tests that 'allocate' is tokenized correctly
+
+            integer :: num = 2
+            integer, dimension(:), allocatable :: factors
+
+            allocate ( factors(num) )
         contains
 
         end program fixed_form_interface

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.json
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.json
@@ -2,7 +2,7 @@
     "basename": "ast-fixed_form_interface-a8dfdb0",
     "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/fixed_form_interface.f",
-    "infile_hash": "285ec9526f743c7b70971b319129f9c2700eb05a76e63c18a28f3d76",
+    "infile_hash": "2599cab0bbd9b1f01fa1acb3efdc3a8c16115e1ee7f88fd82d85615b",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_interface-a8dfdb0.stdout",

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.json
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.json
@@ -2,11 +2,11 @@
     "basename": "ast-fixed_form_interface-a8dfdb0",
     "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/fixed_form_interface.f",
-    "infile_hash": "8371968071bed3b9b0d988eac42412e79ae6d973ca1305a683e829dc",
+    "infile_hash": "285ec9526f743c7b70971b319129f9c2700eb05a76e63c18a28f3d76",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_interface-a8dfdb0.stdout",
-    "stdout_hash": "2fd0ca15a0b39abda3414f4c8b564d7a39050a22bbd3e57f408ae07d",
+    "stdout_hash": "1dbd1d22af21e4a3de32dcd7004e9e6b99d14b908e3ffef5c4032f32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
@@ -99,8 +99,69 @@
                     []
                 )
             )]
+        )
+        (Declaration
+            (AttrType
+                TypeInteger
+                []
+                ()
+                ()
+                None
+            )
+            []
+            [(num
+            []
+            []
+            ()
+            2
+            Equal
+            ())]
+            ()
+        )
+        (Declaration
+            (AttrType
+                TypeInteger
+                []
+                ()
+                ()
+                None
+            )
+            [(AttrDimension
+                [(()
+                ()
+                DimensionExpr)]
+            )
+            (SimpleAttribute
+                AttrAllocatable
+            )]
+            [(factors
+            []
+            []
+            ()
+            ()
+            None
+            ())]
+            ()
         )]
-        []
+        [(Allocate
+            0
+            [(()
+            (FuncCallOrArray
+                factors
+                []
+                [(()
+                num
+                ()
+                0)]
+                []
+                []
+                []
+            )
+            ()
+            0)]
+            []
+            ()
+        )]
         []
     )]
 )


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5209