### PR TITLE
Fix array constructor function

### DIFF
--- a/integration_tests/assign_allocatable_array_of_struct_instances.f90
+++ b/integration_tests/assign_allocatable_array_of_struct_instances.f90
@@ -1,31 +1,34 @@
 program assign_allocatable_array_of_struct_instances
     implicit none
- 
+
     integer :: i
- 
+
     type :: string
-       character(:), allocatable :: s
+        character(:), allocatable :: s
     end type
- 
+
     type(string), allocatable :: tokens(:)
- 
+
     allocate(tokens(5))
     do i = 1, 5
-       tokens(i)%s = "a"
+        tokens(i)%s = "a"
     end do
- 
+
     tokens = merge_pair(tokens, 1)
- 
+
 contains
- 
+
     function merge_pair(intokens, idx) result(tkns)
-       ! Merge the pair `idx`
-       type(string), intent(in) :: intokens(:)
-       integer, intent(in) :: idx
-       type(string), allocatable :: tkns(:)
-       type(string) :: merged_token
-       merged_token%s = intokens(idx)%s // intokens(idx+1)%s
-       tkns = [intokens(:idx-1), merged_token, intokens(idx+2:)]
+        ! Merge the pair `idx`
+        type(string), intent(in) :: intokens(:)
+        integer, intent(in) :: idx
+        type(string), allocatable :: tkns(:)
+        type(string) :: merged_token
+        merged_token%s = intokens(idx)%s // intokens(idx+1)%s
+        ! The segmentation fault occurs at the below line, when used with
+        ! `--experimental-simplifier` flag (i.e. simplifier pass enabled) and
+        ! no `--realloc-lhs` flag is enabled for it
+        tkns = [intokens(:idx-1), merged_token, intokens(idx+2:)]
     end function
- 
+
 end program

--- a/integration_tests/assign_allocatable_array_of_struct_instances.f90
+++ b/integration_tests/assign_allocatable_array_of_struct_instances.f90
@@ -25,7 +25,6 @@ contains
        type(string), allocatable :: tkns(:)
        type(string) :: merged_token
        merged_token%s = intokens(idx)%s // intokens(idx+1)%s
-       ! The segmentation fault occurs at the below line
        tkns = [intokens(:idx-1), merged_token, intokens(idx+2:)]
     end function
  

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -176,7 +176,7 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
                 if( array_size == nullptr ) {
                     array_size = array_section_size;
                 } else {
-                    builder.Add(array_section_size, array_size);
+                    array_size = builder.Add(array_section_size, array_size);
                 }
             } else {
                 constant_size += 1;


### PR DESCRIPTION
The issue really appeared (the test failed) when I started utilizing the string descriptor built on top of this PR #4918; So I needed to do this minor fix. 