### PR TITLE
test: added subroutine call in procedure declaration test

### DIFF
--- a/integration_tests/procedure_decl_01_b.f90
+++ b/integration_tests/procedure_decl_01_b.f90
@@ -10,5 +10,6 @@ subroutine evaluate(calcfc)
     use eval_dependency
     implicit none
     procedure(OBJCON) :: calcfc 
+    call calcfc()
 end subroutine evaluate
 end module procedure_decl_01_b


### PR DESCRIPTION
In continuation of #5208.
Just added `call calcfc()` to justify change of `asr_verify.cpp`.