### PR TITLE
enh: implement "TL/TR" format specifiers

### DIFF
--- a/integration_tests/format_14.f90
+++ b/integration_tests/format_14.f90
@@ -1,9 +1,12 @@
-! test "T" format specifier
+! test "T"/"TL"/"TR" format specifier
 program format_14
     implicit none
 
     character(len=30) wr
+    character(len=20) :: hello_god
+    hello_god = "Hello God!"
 
+    ! Test "T" format specifier (tab)
     write(wr, '(I5, T6, F5.2)') 1, sqrt(real(1))
     print *, wr
     if (wr /= "    1 1.00") error stop
@@ -26,4 +29,25 @@ program format_14
     print *, wr
     if (wr /= "   2   1     1") error stop
 
+    ! Test "TL" format specifier (tab left)
+    write(wr, '(I4, T10, TL2, F5.2)') 5, sqrt(real(5))
+    print *, wr
+    if (wr /= "   5    2.24") error stop
+    write(wr, '(I4, T10, TL3, F5.2)') 6, sqrt(real(6))
+    print *, wr
+    if (wr /= "   6   2.45") error stop
+    write(wr, "(TR7, TL3, A)") hello_god
+    print *, wr
+    if (wr /= "    Hello God!") error stop
+
+    ! Test "TR" format specifier (tab right)
+    write(wr, '(I4, TR2, F5.2)') 3, sqrt(real(3))
+    print *, wr
+    if (wr /= "   3   1.73") error stop
+    write(wr, '(I4, TR4, F5.2)') 4, sqrt(real(4))
+    print *, wr
+    if (wr /= "   4     2.00") error stop
+    write(wr, "(TR5, A)") hello_god
+    print *, wr
+    if (wr /= "     Hello God!") error stop
 end program format_14


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5224.

Since this would anyway be eventually needed for compilation of POT3D third party package, I picked it up.