### PR TITLE
chore: tokenize 'do concurrent' in fixed-form program

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -956,6 +956,11 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        if (next_is(cur, "doconcurrent(")) {
+            lex_do_concurrent(cur);
+            return true;
+        }
+
         if (next_is(cur, "dowhile(")) {
             lex_dowhile(cur);
             return true;
@@ -1265,6 +1270,27 @@ struct FixedFormRecursiveDescent {
             }
         }
         return false;
+    }
+
+    void lex_do_concurrent(unsigned char *&cur) {
+        push_token_advance(cur, "do");
+        push_token_advance(cur, "concurrent");
+        tokenize_line(cur);
+
+        while (true) {
+            if (next_is(cur, "enddo")) {
+                push_token_no_advance(cur, "enddo");
+                push_token_no_advance(cur, "\n");
+                next_line(cur);
+                break;
+            } else if (!lex_body_statement(cur)) {
+                Location loc;
+                loc.first = cur - string_start;
+                loc.last = cur - string_start;
+                throw parser_local::TokenizerError("Expected an executable "
+                    "statement inside do concurrent loop", loc);
+            }
+        }
     }
 
     void lex_do(unsigned char *&cur) {

--- a/tests/fixed_form_interface.f
+++ b/tests/fixed_form_interface.f
@@ -1,5 +1,6 @@
         program fixed_form_interface
             implicit none
+            integer :: i, arr(5)
 
 c           tests that 'interface' is tokenized correctly
             interface
@@ -23,6 +24,10 @@ c           tests that 'deallocate' is tokenized correctly
 
     1       FORMAT (TR1, A)
             print 1, factors
+
+            do concurrent (i=1:10:2)
+                arr(i) = i
+            enddo
         contains
 
         end program fixed_form_interface

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.json
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.json
@@ -2,11 +2,11 @@
     "basename": "ast-fixed_form_interface-a8dfdb0",
     "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/fixed_form_interface.f",
-    "infile_hash": "1f2489004a3edd5fdec33dd5d1ca68493fa737c8d35b72105d9a2a9e",
+    "infile_hash": "8c315ad045e914196eb3ffd821c09112f9616bc735f980538fcb3f47",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_interface-a8dfdb0.stdout",
-    "stdout_hash": "6a91e987f2af713e13babb7576536fcc260cbf2f1babad8c3cd9bc31",
+    "stdout_hash": "9fe3fd31308c147dbce4f0a2e1eff495d021f874abba550a76b3a81a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
@@ -7,7 +7,34 @@
             []
             ()
         )]
-        [(Interface
+        [(Declaration
+            (AttrType
+                TypeInteger
+                []
+                ()
+                ()
+                None
+            )
+            []
+            [(i
+            []
+            []
+            ()
+            ()
+            None
+            ())
+            (arr
+            [(1
+            5
+            DimensionExpr)]
+            []
+            ()
+            ()
+            None
+            ())]
+            ()
+        )
+        (Interface
             (InterfaceHeader)
             ()
             [(InterfaceProc
@@ -191,6 +218,36 @@
             0
             1
             [factors]
+            ()
+        )
+        (DoConcurrentLoop
+            0
+            ()
+            [(ConcurrentControl
+                i
+                1
+                10
+                2
+            )]
+            ()
+            []
+            [(Assignment
+                0
+                (FuncCallOrArray
+                    arr
+                    []
+                    [(()
+                    i
+                    ()
+                    0)]
+                    []
+                    []
+                    []
+                )
+                i
+                ()
+            )]
+            ()
             ()
         )]
         []


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5220