### PR TITLE
CI: fix bug with fastGPT ubuntu & fpm in Test LLVM CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -875,8 +875,8 @@ jobs:
             ./gsnap ../qasnap/sample/inp out
 
   test_llvm:
-    name: Test LLVM ${{ matrix.llvm-version }}
-    runs-on: ubuntu-latest
+    name: Test LLVM ${{ matrix.llvm-version }} - OS (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -887,6 +887,7 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
+        os: ["macos-latest", "ubuntu-latest"]
         llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
     steps:
       - uses: actions/checkout@v4
@@ -907,6 +908,7 @@ jobs:
 
       - name: Build Linux
         shell: bash -e -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             ./build0.sh
             cmake . -GNinja \
@@ -922,9 +924,17 @@ jobs:
 
             cmake --build . -j16 --target install
 
+      - name: Build MacOS
+        shell: bash -e -l {0}
+        if: contains(matrix.os, 'macos')
+        run: |
+            ./build0.sh
+            ./build1.sh
+
       # LLVM 10-19 all work in exactly the same way, so the test is identical
       - name: Test Linux LLVM 10-19
         shell: bash -e -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             ctest --output-on-failure
             cd integration_tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -875,8 +875,8 @@ jobs:
             ./gsnap ../qasnap/sample/inp out
 
   test_llvm:
-    name: Test LLVM ${{ matrix.llvm-version }} - OS (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Test LLVM ${{ matrix.llvm-version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -887,7 +887,6 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
-        os: ["macos-latest", "ubuntu-latest"]
         llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
     steps:
       - uses: actions/checkout@v4
@@ -908,7 +907,6 @@ jobs:
 
       - name: Build Linux
         shell: bash -e -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             ./build0.sh
             cmake . -GNinja \
@@ -924,17 +922,9 @@ jobs:
 
             cmake --build . -j16 --target install
 
-      - name: Build MacOS
-        shell: bash -e -l {0}
-        if: contains(matrix.os, 'macos')
-        run: |
-            ./build0.sh
-            ./build1.sh
-
       # LLVM 10-19 all work in exactly the same way, so the test is identical
       - name: Test Linux LLVM 10-19
         shell: bash -e -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             ctest --output-on-failure
             cd integration_tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -880,8 +880,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
-        python-version: ["3.10"]
         # Note: The LLVM 11 test is redundant, since it is already tested by
         # most other tests (since LLVM 11 is our default version), but we have
         # it here as well for consistency, and that way other tests can freely
@@ -889,6 +887,7 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
+        os: ["macos-latest", "ubuntu-latest"]
         llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
     steps:
       - uses: actions/checkout@v4
@@ -900,12 +899,7 @@ jobs:
           micromamba-version: '1.5.10-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
-            python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            cmake=3.26.4
-            make=4.3
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -880,6 +880,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: ["macos-latest", "ubuntu-latest"]
+        python-version: ["3.10"]
         # Note: The LLVM 11 test is redundant, since it is already tested by
         # most other tests (since LLVM 11 is our default version), but we have
         # it here as well for consistency, and that way other tests can freely
@@ -887,7 +889,6 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
-        os: ["macos-latest", "ubuntu-latest"]
         llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
     steps:
       - uses: actions/checkout@v4
@@ -899,7 +900,12 @@ jobs:
           micromamba-version: '1.5.10-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
+            python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
+            bison=3.4
+            openblas=0.3.21
+            cmake=3.26.4
+            make=4.3
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -952,7 +952,6 @@ jobs:
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/minpack.git
             cd minpack
@@ -986,7 +985,6 @@ jobs:
 
       - name: Test Modern Minpack (Fortran-Lang)
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/fortran-lang/minpack modern_minpack_01
             cd modern_minpack_01
@@ -1006,7 +1004,6 @@ jobs:
 
       - name: Test Modern Minpack (check results)
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/Pranavchiku/modern_minpack.git modern_minpack_02
             cd modern_minpack_02
@@ -1032,7 +1029,6 @@ jobs:
 
       - name: Test dftatom
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/czgdp1807/dftatom.git
             cd dftatom
@@ -1225,7 +1221,6 @@ jobs:
 
       - name: Test stdlib
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/czgdp1807/stdlib.git
             cd stdlib
@@ -1256,7 +1251,6 @@ jobs:
 
       - name: Test SNAP
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/SNAP.git
             cd SNAP

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1037,7 +1037,6 @@ jobs:
 
       - name: Test fastGPT ( ubuntu-latest )
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/fastGPT.git
             cd fastGPT
@@ -1160,6 +1159,9 @@ jobs:
 
             rm -rf fastGPT/
 
+      # The below job isn't every run because this run on 'macOS' and it
+      # isn't worth the extra runners on CI to for testing fastGPT on macOS
+      # with all the LLVM versions
       - name: Test fastGPT ( macos-latest )
         shell: bash -e -x -l {0}
         if: contains(matrix.os, 'macos')
@@ -1193,7 +1195,6 @@ jobs:
 
       - name: Test fpm
         shell: bash -e -x -l {0}
-        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/fpm.git
             cd fpm

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -952,6 +952,7 @@ jobs:
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/minpack.git
             cd minpack
@@ -985,6 +986,7 @@ jobs:
 
       - name: Test Modern Minpack (Fortran-Lang)
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/fortran-lang/minpack modern_minpack_01
             cd modern_minpack_01
@@ -1004,6 +1006,7 @@ jobs:
 
       - name: Test Modern Minpack (check results)
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/Pranavchiku/modern_minpack.git modern_minpack_02
             cd modern_minpack_02
@@ -1029,6 +1032,7 @@ jobs:
 
       - name: Test dftatom
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/czgdp1807/dftatom.git
             cd dftatom
@@ -1221,6 +1225,7 @@ jobs:
 
       - name: Test stdlib
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/czgdp1807/stdlib.git
             cd stdlib
@@ -1251,6 +1256,7 @@ jobs:
 
       - name: Test SNAP
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/SNAP.git
             cd SNAP

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -876,10 +876,12 @@ jobs:
 
   test_llvm:
     name: Test LLVM ${{ matrix.llvm-version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        # this is only run on ubuntu intentionally
+        os: ["ubuntu-latest"]
         # Note: The LLVM 11 test is redundant, since it is already tested by
         # most other tests (since LLVM 11 is our default version), but we have
         # it here as well for consistency, and that way other tests can freely
@@ -888,6 +890,7 @@ jobs:
         # `llvmdev` version in their conda environment and everything will just
         # work.
         llvm-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -898,7 +901,13 @@ jobs:
           micromamba-version: '1.5.10-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
+            python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
+            bison=3.4
+            openblas=0.3.21
+            llvm-openmp=14.0.4
+            cmake=3.26.4
+            make=4.3
 
       - uses: hendrikmuhs/ccache-action@main
         with:
@@ -1037,6 +1046,7 @@ jobs:
 
       - name: Test fastGPT ( ubuntu-latest )
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/fastGPT.git
             cd fastGPT
@@ -1159,7 +1169,7 @@ jobs:
 
             rm -rf fastGPT/
 
-      # The below job isn't every run because this run on 'macOS' and it
+      # The below job isn't ever run because this runs on 'macOS' and it
       # isn't worth the extra runners on CI to for testing fastGPT on macOS
       # with all the LLVM versions
       - name: Test fastGPT ( macos-latest )
@@ -1195,6 +1205,7 @@ jobs:
 
       - name: Test fpm
         shell: bash -e -x -l {0}
+        if: contains(matrix.os, 'ubuntu')
         run: |
             git clone https://github.com/certik/fpm.git
             cd fpm

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -904,7 +904,6 @@ jobs:
             llvmdev=${{ matrix.llvm-version }}
             bison=3.4
             openblas=0.3.21
-            llvm-openmp=14.0.4
             cmake=3.26.4
             make=4.3
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -904,6 +904,7 @@ jobs:
             llvmdev=${{ matrix.llvm-version }}
             bison=3.4
             openblas=0.3.21
+            llvm-openmp=14.0.4
             cmake=3.26.4
             make=4.3
 


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5231

some of third party packages in it need a specific version i.e. either macOS or ubuntu, this PR makes sure that the OS is used as a variable, where the different third party can decide whether something needs to be run with 'macOS' or 'ubuntu' or both

before this commit, 'Test fpm', 'Test fastGPT ( ubuntu-latest )' or 'Test fastGPT ( macos-latest )' weren't being run under 'Test LLVM' CI job as 'matrix.os' was always empty

Below are the third party packages, which are now tested twice for each OS (ubuntu and macOS), and for each LLVM version (earlier they are were tested on only ubuntu):
* Test Legacy Minpack (SciPy)
* Test Modern Minpack (Fortran-Lang)
* Test Modern Minpack (check results)
* Test dftatom
* Test stdlib
* Test SNAP

unless needed, we can skip their testing with macOS and only do that on ubuntu, as that will save sometime on the CI. @certik thoughts?