### PR TITLE
chore: tokenize 'FLUSH' in fixedform

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1010,6 +1010,12 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        if (next_is(cur, "flush")) {
+            push_token_advance(cur, "flush");
+            tokenize_line(cur);
+            return true;
+        }
+
         if (next_is(cur, "allocate")) {
             push_token_advance(cur, "allocate");
             tokenize_line(cur);

--- a/tests/fixed_form_interface.f
+++ b/tests/fixed_form_interface.f
@@ -1,6 +1,7 @@
         program fixed_form_interface
             implicit none
             integer :: i, arr(5)
+            integer :: OUTPUT_UNIT
 
 c           tests that 'interface' is tokenized correctly
             interface
@@ -28,6 +29,9 @@ c           tests that 'deallocate' is tokenized correctly
             do concurrent (i=1:10:2)
                 arr(i) = i
             enddo
+
+c           ensures that 'FLUSH' is tokenized
+            FLUSH(OUTPUT_UNIT)
         contains
 
         end program fixed_form_interface

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.json
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.json
@@ -2,11 +2,11 @@
     "basename": "ast-fixed_form_interface-a8dfdb0",
     "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/fixed_form_interface.f",
-    "infile_hash": "8c315ad045e914196eb3ffd821c09112f9616bc735f980538fcb3f47",
+    "infile_hash": "d82b348db147a93fac2457e4d9840a31cde6df9b8a576ee6eea3841e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_interface-a8dfdb0.stdout",
-    "stdout_hash": "9fe3fd31308c147dbce4f0a2e1eff495d021f874abba550a76b3a81a",
+    "stdout_hash": "d35e3b4d3f16894f177dc933d8a7663c7dcf2be6250498ae052f4277",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
@@ -34,6 +34,24 @@
             ())]
             ()
         )
+        (Declaration
+            (AttrType
+                TypeInteger
+                []
+                ()
+                ()
+                None
+            )
+            []
+            [(output_unit
+            []
+            []
+            ()
+            ()
+            None
+            ())]
+            ()
+        )
         (Interface
             (InterfaceHeader)
             ()
@@ -248,6 +266,12 @@
                 ()
             )]
             ()
+            ()
+        )
+        (Flush
+            0
+            [output_unit]
+            []
             ()
         )]
         []


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5234