### PR TITLE
enh: r2r logic to avoid unnecessary cast node

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -924,6 +924,7 @@ RUN(NAME intrinsics_319 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # system_
 RUN(NAME intrinsics_320 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # len_trim
 RUN(NAME intrinsics_321 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trim
 RUN(NAME intrinsics_322 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # index
+RUN(NAME intrinsics_323 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dot_product
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/intrinsics_323.f90
+++ b/integration_tests/intrinsics_323.f90
@@ -1,0 +1,14 @@
+program intrinsics_323
+    real, allocatable :: L(:,:), U(:,:)
+    call lu(L, U)
+contains
+subroutine lu(L, U)
+    real, intent(out), allocatable :: L(:,:), U(:,:)
+
+    allocate(L(5,5), U(5,5))
+    L = 12.91
+    U = -12.91
+    print *, dot_product(L(4,1:3), U(1:3,4))
+    if (abs(dot_product(L(4,1:3), U(1:3,4)) - (-500.004272)) > 1e-8) error stop
+end subroutine
+end program

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -323,6 +323,11 @@ class ASRBuilder {
     }
 
     inline ASR::expr_t* r2r_t(ASR::expr_t* x, ASR::ttype_t* t) {
+        int kind_x = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x));
+        int kind_t = ASRUtils::extract_kind_from_ttype_t(t);
+        if (kind_x == kind_t) {
+            return x;
+        }
         return EXPR(ASR::make_Cast_t(al, loc, x, ASR::cast_kindType::RealToReal, t, nullptr));
     }
 


### PR DESCRIPTION
Foxes #5243

With this PR and https://github.com/Pranavchiku/numerical-methods-fortran/commits/lf1/, we compile https://github.com/lfortran/lfortran/issues/4703 fully, 1 workaround ( https://github.com/lfortran/lfortran/issues/5245 ), 2 commented tests ( which will be easy to fix )