### PR TITLE
fix: return non-zero exit code with `--continue-compilation`

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -628,7 +628,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
     LCompilers::diag::Diagnostics diagnostics;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         r = fe.get_asr2(input, lm, diagnostics);
-    bool has_error_w_cc = diagnostics.has_error() && compiler_options.continue_compilation;
+    bool has_error_w_cc = compiler_options.continue_compilation && diagnostics.has_error();
     std::cerr << diagnostics.render(lm, compiler_options);
     if (!r.ok) {
         LCOMPILERS_ASSERT(diagnostics.has_error())
@@ -767,7 +767,7 @@ int emit_fortran(const std::string &infile, CompilerOptions &compiler_options) {
     std::cerr << diagnostics.render(lm, compiler_options);
     if (src.ok) {
         std::cout << src.result;
-        return diagnostics.has_error() && compiler_options.continue_compilation;
+        return compiler_options.continue_compilation && diagnostics.has_error();
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return 1;
@@ -943,7 +943,7 @@ int emit_llvm(const std::string &infile, LCompilers::PassManager& pass_manager,
     std::cerr << diagnostics.render(lm, compiler_options);
     if (llvm.ok) {
         std::cout << llvm.result;
-        return diagnostics.has_error() && compiler_options.continue_compilation;
+        return compiler_options.continue_compilation && diagnostics.has_error();
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return 1;
@@ -1000,7 +1000,7 @@ int compile_src_to_object_file(const std::string &infile,
     LCompilers::diag::Diagnostics diagnostics;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
-    bool has_error_w_cc = diagnostics.has_error() && compiler_options.continue_compilation;
+    bool has_error_w_cc = compiler_options.continue_compilation && diagnostics.has_error();
     std::cerr << diagnostics.render(lm, compiler_options);
     if (result.ok) {
         asr = result.result;

--- a/tests/reference/run-array_02_cc-634bad3.json
+++ b/tests/reference/run-array_02_cc-634bad3.json
@@ -9,5 +9,5 @@
     "stdout_hash": "a779ee4f7341ddce58a41cee3d249ecf1b37216d7d4f16eb4e0f528e",
     "stderr": "run-array_02_cc-634bad3.stderr",
     "stderr_hash": "e5dac3833910ebb373f5c18d40cbb77da46d1932776c3970b6a1c2f5",
-    "returncode": 0
+    "returncode": 1
 }

--- a/tests/reference/run-array_04_cc-c986e51.json
+++ b/tests/reference/run-array_04_cc-c986e51.json
@@ -9,5 +9,5 @@
     "stdout_hash": "a779ee4f7341ddce58a41cee3d249ecf1b37216d7d4f16eb4e0f528e",
     "stderr": "run-array_04_cc-c986e51.stderr",
     "stderr_hash": "2c7e5527c750a5c707d2cd485aab5cd94c0499e93878a69fb3ad3354",
-    "returncode": 0
+    "returncode": 1
 }

--- a/tests/reference/run-array_05_cc-4c5cdb4.json
+++ b/tests/reference/run-array_05_cc-4c5cdb4.json
@@ -9,5 +9,5 @@
     "stdout_hash": "a779ee4f7341ddce58a41cee3d249ecf1b37216d7d4f16eb4e0f528e",
     "stderr": "run-array_05_cc-4c5cdb4.stderr",
     "stderr_hash": "fb2430ac2eb05e0bb79ec0d1c97481fda53d7e1b8aee6d47a8b5cd08",
-    "returncode": 0
+    "returncode": 1
 }

--- a/tests/reference/run-array_06_cc-e5490ba.json
+++ b/tests/reference/run-array_06_cc-e5490ba.json
@@ -9,5 +9,5 @@
     "stdout_hash": "a779ee4f7341ddce58a41cee3d249ecf1b37216d7d4f16eb4e0f528e",
     "stderr": "run-array_06_cc-e5490ba.stderr",
     "stderr_hash": "7693cfc58dcea3cd56180737479dfd7acc086f9167d54ff905e5f51f",
-    "returncode": 0
+    "returncode": 1
 }

--- a/tests/reference/run-array_07-de10142.json
+++ b/tests/reference/run-array_07-de10142.json
@@ -9,5 +9,5 @@
     "stdout_hash": null,
     "stderr": "run-array_07-de10142.stderr",
     "stderr_hash": "e296de2f71cfe937baf04103cc25b6a928e23e9fcfcd1b903d14a147",
-    "returncode": 0
+    "returncode": 1
 }

--- a/tests/reference/run-assign_01-f454e20.json
+++ b/tests/reference/run-assign_01-f454e20.json
@@ -9,5 +9,5 @@
     "stdout_hash": "7f04f368ab5b53d568c1590932a5ceebec89b14fcb03bf7f46197078",
     "stderr": "run-assign_01-f454e20.stderr",
     "stderr_hash": "22926a0ca854e3a26213cee88788e52c189e7e6d275089ff0cdc971c",
-    "returncode": 0
+    "returncode": 1
 }


### PR DESCRIPTION
Fixes #5248

We now return non-zero code with `--show-llvm`, `--show-fortran`, `--show-asr`, binary generation and execution when `--continue-compilation` is on and there are error messages.