### PR TITLE
Error resilient array_04

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -126,6 +126,14 @@ public:
                     tmp = nullptr;
                     tmp_vec.clear();
                 }
+            } catch (const SemanticError &e) {
+                if (!compiler_options.continue_compilation) {
+                    throw e;
+                } else {
+                    diag.add(e.d);
+                    tmp = nullptr;
+                    tmp_vec.clear();
+                }
             }
             if (tmp != nullptr) {
                 ASR::stmt_t* tmp_stmt = ASRUtils::STMT(tmp);

--- a/tests/errors/array_04_cc.f90
+++ b/tests/errors/array_04_cc.f90
@@ -1,0 +1,11 @@
+program array_04
+implicit none
+
+type :: t
+    integer :: a
+end type
+type(t) :: b
+b%a(:) = 1
+print *, "compilation continued despite errors"
+
+end program

--- a/tests/reference/run-array_04_cc-c986e51.json
+++ b/tests/reference/run-array_04_cc-c986e51.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-array_04_cc-c986e51",
+    "cmd": "lfortran --continue-compilation --no-color {infile}",
+    "infile": "tests/errors/array_04_cc.f90",
+    "infile_hash": "4586ee4918a11e96727cd100eba57030af7773ad249afa2e6fc8d9a3",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "run-array_04_cc-c986e51.stdout",
+    "stdout_hash": "a779ee4f7341ddce58a41cee3d249ecf1b37216d7d4f16eb4e0f528e",
+    "stderr": "run-array_04_cc-c986e51.stderr",
+    "stderr_hash": "2c7e5527c750a5c707d2cd485aab5cd94c0499e93878a69fb3ad3354",
+    "returncode": 0
+}

--- a/tests/reference/run-array_04_cc-c986e51.stderr
+++ b/tests/reference/run-array_04_cc-c986e51.stderr
@@ -1,0 +1,5 @@
+semantic error: Type member a is not an array so it cannot be indexed.
+ --> tests/errors/array_04_cc.f90:8:1
+  |
+8 | b%a(:) = 1
+  | ^^^^^^ 

--- a/tests/reference/run-array_04_cc-c986e51.stdout
+++ b/tests/reference/run-array_04_cc-c986e51.stdout
@@ -1,0 +1,1 @@
+compilation continued despite errors

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3563,6 +3563,10 @@ filename = "errors/array_04.f90"
 asr = true
 
 [[test]]
+filename = "errors/array_04_cc.f90"
+continue_compilation = true
+
+[[test]]
 filename = "errors/array_05.f90"
 asr = true
 


### PR DESCRIPTION
Toward :- #5036 

I am not sure that should we handle this error file.

Error message for this file is thrown through asr_utils and so , didn't break the semantic error into diagnostic and semantic abort and instead used catch for semantic error

```
File "/mnt/d/lfortran2/lfortran/src/libasr/asr_utils.h", line 4752, in LCompilers::ASR::expr_t* LCompilers::ASRUtils::get_bound<LCompilers::LFortran::SemanticError>(LCompilers::ASR::expr_t*, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Allocator&)
    throw SemanticError(msg, arr_expr->base.loc);
semantic error: Type member a is not an array so it cannot be indexed.
 --> try.f90:8:1
  |
8 | b%a(:) = 1
  | ^^^^^^


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```