### PR TITLE
Handle allocatable args for max and min intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -926,6 +926,7 @@ RUN(NAME intrinsics_320 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_321 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trim
 RUN(NAME intrinsics_322 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # index
 RUN(NAME intrinsics_323 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dot_product
+RUN(NAME intrinsics_324 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # max
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/intrinsics_324.f90
+++ b/integration_tests/intrinsics_324.f90
@@ -1,0 +1,9 @@
+program intrinsics_324
+    integer, allocatable :: A(:) 
+    integer :: B(2) = [2,2]
+    allocate(A(2))
+    A = [1,2]
+    A = max(A, B)
+    print *, A
+    if (any(A /= 2)) error stop
+end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5926,13 +5926,13 @@ namespace Max {
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args > 1, "Call to max0 must have at least two arguments",
             x.base.base.loc, diagnostics);
-        ASR::ttype_t* arg0_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(x.m_args[0]));
+        ASR::ttype_t* arg0_type = ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(x.m_args[0]));
         ASRUtils::require_impl(ASR::is_a<ASR::Real_t>(*arg0_type) ||
             ASR::is_a<ASR::Integer_t>(*arg0_type) || ASR::is_a<ASR::Character_t>(*arg0_type),
              "Arguments to max0 must be of real, integer or character type",
             x.base.base.loc, diagnostics);
         for(size_t i=0;i<x.n_args;i++){
-            ASR::ttype_t* arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(x.m_args[i]));
+            ASR::ttype_t* arg_type = ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(x.m_args[i]));
             ASRUtils::require_impl((ASR::is_a<ASR::Real_t>(*arg_type) && ASR::is_a<ASR::Real_t>(*arg0_type)) ||
                 (ASR::is_a<ASR::Integer_t>(*arg_type) && ASR::is_a<ASR::Integer_t>(*arg0_type)) ||
                 (ASR::is_a<ASR::Character_t>(*arg_type) && ASR::is_a<ASR::Character_t>(*arg0_type) ),
@@ -5989,7 +5989,7 @@ namespace Max {
                 diag.semantic_warning_label("Different kinds of args in max0 is a non-standard extension", {loc},
                 "help: ensure all arguments have the same kind to make it standard");
             }
-            if (ASRUtils::type_get_past_array(arg_type)->type != ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]))->type) {
+            if (ASRUtils::type_get_past_array_pointer_allocatable(arg_type)->type != ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(args[i]))->type) {
                 append_error(diag, "All arguments to max0 must be of the same type", loc);
             return nullptr;
             }
@@ -6037,7 +6037,7 @@ namespace Max {
         } else {
             throw LCompilersException("Arguments to max0 must be of real, integer or character type");
         }
-
+        return_type = ASRUtils::type_get_past_array_pointer_allocatable(return_type);
         auto result = declare(fn_name, return_type, ReturnVar);
         body.push_back(al, b.Assignment(result, args[0]));
         if (ASR::is_a<ASR::Integer_t>(*return_type)) {
@@ -6140,7 +6140,7 @@ namespace Min {
                 diag.semantic_warning_label("Different kinds of args in max0 is a non-standard extension", {loc},
                 "help: ensure all arguments have the same kind to make it standard");
             }
-            if (ASRUtils::type_get_past_array(arg_type)->type != ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]))->type) {
+            if (ASRUtils::type_get_past_array_pointer_allocatable(arg_type)->type != ASRUtils::type_get_past_array_pointer_allocatable(ASRUtils::expr_type(args[i]))->type) {
                 append_error(diag, "All arguments to min0 must be of the same type", loc);
                 return nullptr;
             }
@@ -6188,7 +6188,7 @@ namespace Min {
         } else {
             throw LCompilersException("Arguments to min0 must be of real, integer or character type");
         }
-
+        return_type = ASRUtils::type_get_past_array_pointer_allocatable(return_type);
         auto result = declare(fn_name, return_type, ReturnVar);
         body.push_back(al, b.Assignment(result, args[0]));
         if (ASR::is_a<ASR::Integer_t>(*return_type)) {


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/5259