### PR TITLE
Allow enum in interactive mode

### DIFF
--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -87,7 +87,7 @@ void fix_program_without_program_line(Allocator &al, AST::TranslationUnit_t &ast
             AST::expr_t* expr = AST::down_cast<AST::expr_t>(ast.m_items[i]);
             if (AST::is_a<AST::Name_t>(*expr)) {
                 AST::Name_t* name = AST::down_cast<AST::Name_t>(expr);
-                if (strcmp(name->m_id, "stop") == 0) {
+                if (to_lower(name->m_id) == "stop") {
                     AST::ast_t* stop_ast = AST::make_Stop_t(al, name->base.base.loc, 0, nullptr, nullptr, nullptr);
                     body.push_back(al, AST::down_cast<AST::stmt_t>(stop_ast));
                 } else if (is_program_end(name)) {
@@ -97,7 +97,7 @@ void fix_program_without_program_line(Allocator &al, AST::TranslationUnit_t &ast
 
                     global_items.push_back(al, program_ast);
                     program_added = true;
-                } else if (strcmp(name->m_id, "contains") == 0) {
+                } else if (to_lower(name->m_id) == "contains") {
                     contains = true;
                 } else {
                     throw parser_local::ParserError("Statement or Declaration expected inside program, found Variable name", ast.m_items[i]->loc);

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -29,8 +29,8 @@ bool is_program_end(AST::Name_t* name) {
     // "end program" should not be a name. Ideally, it should be a special entity.
     // It is used as a Name_t here, so that `end`, `endprogram` and `end program`
     // can all be handled together and this simplifies the code logic.
-    return (strcmp(name->m_id, "end") == 0 || strcmp(name->m_id, "endprogram") == 0
-            || strcmp(name->m_id, "end program") == 0);
+    return (to_lower(name->m_id) == "end" || to_lower(name->m_id) == "endprogram"
+            || to_lower(name->m_id) == "end program");
 }
 
 void fix_program_without_program_line(Allocator &al, AST::TranslationUnit_t &ast) {

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -5,7 +5,7 @@
 %locations
 %glr-parser
 %expect    210 // shift/reduce conflicts
-%expect-rr 189 // reduce/reduce conflicts
+%expect-rr 193 // reduce/reduce conflicts
 
 // Uncomment this to get verbose error messages
 //%define parse.error verbose
@@ -611,6 +611,7 @@ script_unit
     | implicit_statement
     | var_decl
     | derived_type_decl
+    | enum_decl
     | statement          %dprec 7
     | expr sep           %dprec 8
     | KW_END_PROGRAM sep { $$ = SYMBOL($1, @$); }

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3972,7 +3972,7 @@ public:
                 ASR::make_DoConcurrentLoop_t(al,loc, heads.p, heads.n, m_shared.p,
                 m_shared.n, m_local.p, m_local.n, m_reduction.p, m_reduction.n, nullptr, 0)));
                 
-            } else if ( strcmp(x.m_construct_name, "do") == 0 ) {
+            } else if ( to_lower(x.m_construct_name) == "do" ) {
                 // pass
             } else {
                 throw SemanticError("The construct "+ std::string(x.m_construct_name)

--- a/tests/parser/enum_decl_without_start_program.f90
+++ b/tests/parser/enum_decl_without_start_program.f90
@@ -1,4 +1,4 @@
     enum, bind(c)
         enumerator yellow
     end enum
-end program
+END program

--- a/tests/parser/enum_decl_without_start_program.f90
+++ b/tests/parser/enum_decl_without_start_program.f90
@@ -1,0 +1,4 @@
+    enum, bind(c)
+        enumerator yellow
+    end enum
+end program

--- a/tests/reference/ast-enum_decl_without_start_program-9ae6425.json
+++ b/tests/reference/ast-enum_decl_without_start_program-9ae6425.json
@@ -2,7 +2,7 @@
     "basename": "ast-enum_decl_without_start_program-9ae6425",
     "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/parser/enum_decl_without_start_program.f90",
-    "infile_hash": "45e026808b67362441f7c7cb3007d9d5ac7d85c16d25de41004cee6c",
+    "infile_hash": "909085f2f597ac1a26957705cc3df72bd7773cebc9abb83269f1fea3",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-enum_decl_without_start_program-9ae6425.stdout",

--- a/tests/reference/ast-enum_decl_without_start_program-9ae6425.json
+++ b/tests/reference/ast-enum_decl_without_start_program-9ae6425.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-enum_decl_without_start_program-9ae6425",
+    "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/parser/enum_decl_without_start_program.f90",
+    "infile_hash": "45e026808b67362441f7c7cb3007d9d5ac7d85c16d25de41004cee6c",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "ast-enum_decl_without_start_program-9ae6425.stdout",
+    "stdout_hash": "ace71891d74fa8904e1c67e993d35d3b1e3a20bde48971021a537e3c",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/ast-enum_decl_without_start_program-9ae6425.stdout
+++ b/tests/reference/ast-enum_decl_without_start_program-9ae6425.stdout
@@ -1,0 +1,33 @@
+(TranslationUnit
+    [(Program
+        __xx_main
+        ()
+        []
+        []
+        [(Enum
+            [(AttrBind
+                (Bind
+                    [c]
+                    []
+                )
+            )]
+            ()
+            [(Declaration
+                ()
+                [(SimpleAttribute
+                    AttrEnumerator
+                )]
+                [(yellow
+                []
+                []
+                ()
+                ()
+                None
+                ())]
+                ()
+            )]
+        )]
+        []
+        []
+    )]
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3716,6 +3716,10 @@ ast = true
 filename = "parser/derived_type_without_start_program.f90"
 ast = true
 
+[[test]]
+filename = "parser/enum_decl_without_start_program.f90"
+ast = true
+
 # Parser errors
 
 [[test]]


### PR DESCRIPTION
This makes it also work without the program statement present. There was also a bug in being case sensitive in recognize "end program", so I fixed it, together with other places that used `strcmp()` instead of `to_lower()`.

Fixes #5270.