### PR TITLE
Parser: allow parameter in interactive mode

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -609,7 +609,7 @@ script_unit
     | function
     | use_statement
     | implicit_statement
-    | var_decl
+    | var_decl           %dprec 9
     | derived_type_decl
     | enum_decl
     | statement          %dprec 7

--- a/tests/parser/parameter_without_start_program.f90
+++ b/tests/parser/parameter_without_start_program.f90
@@ -1,0 +1,2 @@
+parameter(x=10)
+end

--- a/tests/reference/ast-parameter_without_start_program-a99ac57.json
+++ b/tests/reference/ast-parameter_without_start_program-a99ac57.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-parameter_without_start_program-a99ac57",
+    "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/parser/parameter_without_start_program.f90",
+    "infile_hash": "2e9169dd781045b7103a73b5edc20a422355169a278a6bf1f7f8323d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "ast-parameter_without_start_program-a99ac57.stdout",
+    "stdout_hash": "5df73fd7386389919b5b62e9f0083173af9e8f6fd9efb263eba84599",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/ast-parameter_without_start_program-a99ac57.stdout
+++ b/tests/reference/ast-parameter_without_start_program-a99ac57.stdout
@@ -1,0 +1,24 @@
+(TranslationUnit
+    [(Program
+        __xx_main
+        ()
+        []
+        []
+        [(Declaration
+            ()
+            [(SimpleAttribute
+                AttrParameter
+            )]
+            [(x
+            []
+            []
+            ()
+            10
+            Equal
+            ())]
+            ()
+        )]
+        []
+        []
+    )]
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3720,6 +3720,10 @@ ast = true
 filename = "parser/enum_decl_without_start_program.f90"
 ast = true
 
+[[test]]
+filename = "parser/parameter_without_start_program.f90"
+ast = true
+
 # Parser errors
 
 [[test]]


### PR DESCRIPTION
This also makes it work without the program statement.

Fixes #5269.