### PR TITLE
enh: Fortran backend to support openmp dump

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1831,6 +1831,7 @@ RUN(NAME openmp_36 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_37 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_38 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_39 LABELS gfortran GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_40 LABELS gfortran fortran GFORTRAN_ARGS -fopenmp)
 
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1831,7 +1831,8 @@ RUN(NAME openmp_36 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_37 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_38 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_39 LABELS gfortran GFORTRAN_ARGS -fopenmp)
-RUN(NAME openmp_40 LABELS gfortran fortran GFORTRAN_ARGS -fopenmp)
+
+RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fortran_01.f90
+++ b/integration_tests/fortran_01.f90
@@ -1,4 +1,4 @@
-program main
+program fortran_01
     use iso_c_binding, only: c_ptr!, c_loc
     implicit none
     integer, pointer :: x

--- a/integration_tests/openmp_40.f90
+++ b/integration_tests/openmp_40.f90
@@ -1,7 +1,7 @@
-program openmp_40
-    use omp_lib
-    integer :: i
-    do i = 1, 5
-        print *, i
-    end do 
+program main
+    use iso_c_binding, only: c_ptr!, c_loc
+    implicit none
+    integer, pointer :: x
+    type(c_ptr) :: ptr
+    ! ptr = c_loc(x)
 end program

--- a/integration_tests/openmp_40.f90
+++ b/integration_tests/openmp_40.f90
@@ -1,0 +1,7 @@
+program openmp_40
+    use omp_lib
+    integer :: i
+    do i = 1, 5
+        print *, i
+    end do 
+end program

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -246,6 +246,9 @@ public:
                     import_struct_type.push_back(struct_name);
                 }
                 break;
+            } case ASR::ttypeType::CPtr: {
+                r = "type(c_ptr)";
+                break;
             }
             default:
                 throw LCompilersException("The type `"


### PR DESCRIPTION
Towards [ Fortran Backend](https://github.com/lfortran/lfortran/issues/5260)

Starting with minimal fix
