### PR TITLE
Reduce severity of missing input file

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2416,8 +2416,10 @@ int main_app(int argc, char *argv[]) {
         }
     }
 
-    if (CLI::NonexistentPath(arg_file).empty())
-        throw LCompilers::LCompilersException("File does not exist: " + arg_file);
+    if (CLI::NonexistentPath(arg_file).empty()) {
+        std::cerr << "error: no such file or directory: '" << arg_file << "'" << std::endl;
+	return 1;
+    }
 
     // Decide if a file is fixed format based on the extension
     // Gfortran does the same thing


### PR DESCRIPTION
Converts the response to a specified but missing input file from an `LCompilersException` to a message on `std::cerr` and a non-zero return code, both modeled on clang's response.  This addresses issue #5286 (which is a duplicate of issue #3796)