### PR TITLE
Improve the error message for Program as a Var

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1206,10 +1206,13 @@ public:
         if (ASR::is_a<ASR::Variable_t>(*vpast) || ASR::is_a<ASR::Function_t>(*vpast)) {
             return ASR::make_Var_t(al, loc, v);
         } else {
-            diag.semantic_error_label("Symbol '" + var_name
-                + "' must be a variable or a function", {loc},
-                "'" + var_name + "' is a '" +
-                ASRUtils::symbol_type_name(*vpast) + "', not a variable or a function");
+            std::string sym_type = ASRUtils::symbol_type_name(*vpast);
+            diag.diagnostics.push_back(diag::Diagnostic(
+                "Symbol '" + var_name + "' must be a variable or a procedure",
+                diag::Level::Error, diag::Stage::Semantic, {
+                    diag::Label("cannot use a '" + sym_type + "' as a variable", {loc}),
+                    diag::Label("'" + var_name + "' declared as a '" + sym_type + "' here", {vpast->base.loc}, false),
+                }));
             throw SemanticAbort();
         }
     }

--- a/tests/reference/asr-program_variable-066cc64.json
+++ b/tests/reference/asr-program_variable-066cc64.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-program_variable-066cc64.stderr",
-    "stderr_hash": "c63ac7db2dd11f7aac268c08904dead16ac65e98fb2aa5695cf273a7",
+    "stderr_hash": "9ac4c72ac0e4499a011db1ab078da5b9630f015e5bde28dec8eb6edd",
     "returncode": 2
 }

--- a/tests/reference/asr-program_variable-066cc64.stderr
+++ b/tests/reference/asr-program_variable-066cc64.stderr
@@ -1,5 +1,12 @@
-semantic error: Symbol 'foo' must be a variable or a function
+semantic error: Symbol 'foo' must be a variable or a procedure
  --> tests/errors/program_variable.f90:3:7
   |
 3 | bar = foo
-  |       ^^^ 'foo' is a 'Program', not a variable or a function
+  |       ^^^ cannot use a 'Program' as a variable
+  |
+1 |    program foo
+  |    ~~~~~~~~~~~...
+...
+  |
+4 |    end program
+  | ...~~~~~~~~~~~ 'foo' declared as a 'Program' here


### PR DESCRIPTION
Show a secondary label with the declaration location.

Follow up for #5291.

Before:
![image](https://github.com/user-attachments/assets/38dc07ae-617a-4a70-9278-415c76d05629)


After:
![image](https://github.com/user-attachments/assets/d2ec2d2a-1fb9-4ed6-9c28-3fb1da24fba6)
