### PR TITLE
chore: don't call replacer on ExternalSymbol with the same underling symbol

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1534,6 +1534,7 @@ RUN(NAME external_06 LABELS gfortran llvmImplicit)
 RUN(NAME external_07 LABELS gfortran llvmImplicit)
 RUN(NAME external_08 LABELS gfortran llvmImplicit)
 RUN(NAME external_09 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_10 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 
 RUN(NAME interface_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/external_10.f90
+++ b/integration_tests/external_10.f90
@@ -1,0 +1,25 @@
+module external_10_module
+    implicit none
+    integer :: g = 2
+end module
+
+subroutine sub1_external_10
+    use external_10_module
+    implicit none
+    call sub2_external_10 (g)
+    print *, g
+    if (g /= 10) error stop
+end subroutine
+
+subroutine sub2_external_10 (x)
+    implicit none
+    integer, intent(inout) :: x
+    print *, x
+    if (x /= 2) error stop
+    x = 10
+end subroutine
+
+program external_10
+    implicit none
+    call sub1_external_10
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -202,7 +202,7 @@ void update_call_args(Allocator &al, SymbolTable *current_scope, bool implicit_i
                 ASR::symbol_t* arg_sym = arg_var->m_v;
                 ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym);
                 ASR::symbol_t* sym = fetch_sym(arg_sym_underlying);
-                if (sym != arg_sym) {
+                if (sym != arg_sym_underlying) {
                     ASR::expr_t** current_expr_copy = current_expr;
                     current_expr = const_cast<ASR::expr_t**>((expr_to_replace));
                     this->call_replacer_(sym);
@@ -255,7 +255,7 @@ void update_call_args(Allocator &al, SymbolTable *current_scope, bool implicit_i
                     ASR::symbol_t* arg_sym = arg_var->m_v;
                     ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym);
                     ASR::symbol_t* sym = fetch_sym(arg_sym_underlying);
-                    if (sym != arg_sym) {
+                    if (sym != arg_sym_underlying) {
                         ASR::expr_t** current_expr_copy = current_expr;
                         current_expr = const_cast<ASR::expr_t**>(&(func->m_args[i]));
                         this->call_replacer_(sym);


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5294

The program linked in the issue (or the one added as a test case in this PR) already works without any use of `--implicit-interface` (and it's expected to work), but this PR focuses on making that program work with use of `--implicit-interface` as well, as *POT3D* needs `--implicit-interface` flag necessarily.

## Changes in ASR

Currently the MRE in the linked issue when run with `--implicit-interface` on the current-main raises the below error:
```console
ASR verify pass error: ASR verify: The symbol table was not found in the scope of `symtab`.
 --> /Users/gxyd/OpenSource/lfortran/test.f90:3:16
  |
3 |     integer :: g = 2
  |                ^^^^^ failed here

ASR verify pass error: Var::m_v `g` cannot point outside of its symbol table
 --> /Users/gxyd/OpenSource/lfortran/test.f90:9:16
  |
9 |     call sub2 (g)
  |                ^ failed here

```


### ASR in *main*
so to still be able to get the ASR, I commented out ASR verify check on *main* local branch and below is the ASR generated by `lfortran test.f90 --impliicit-interface --show-asr`:
```clj
(TranslationUnit
    (SymbolTable
        1
        {
            sub:
                (Function
                    (SymbolTable
                        4
                        {
                            arg:
                                (Variable
                                    4
                                    arg
                                    []
                                    Unspecified
                                    ()
                                    ()
                                    Default
                                    (Integer 4)
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                )
                        })
                    sub
                    (FunctionType
                        [(Integer 4)]
                        ()
                        Source
                        Implementation
                        ()
                        .false.
                        .false.
                        .false.
                        .false.
                        .false.
                        []
                        .false.
                    )
                    []
                    [(Var 4 arg)]
                    []
                    ()
                    Public
                    .false.
                    .false.
                    ()
                ),
            vars:
                (Module
                    (SymbolTable
                        2
                        {
                            var_g:
                                (Variable
                                    2
                                    var_g
                                    []
                                    Local
                                    (IntegerConstant 2 (Integer 4) Decimal)
                                    (IntegerConstant 2 (Integer 4) Decimal)
                                    Save
                                    (Integer 4)
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                )
                        })
                    vars
                    []
                    .false.
                    .false.
                ),
            wrapper:
                (Function
                    (SymbolTable
                        3
                        {
                            var_g:
                                (ExternalSymbol
                                    3
                                    var_g
                                    2 var_g
                                    vars
                                    []
                                    var_g
                                    Public
                                )
                        })
                    wrapper
                    (FunctionType
                        []
                        ()
                        Source
                        Implementation
                        ()
                        .false.
                        .false.
                        .false.
                        .false.
                        .false.
                        []
                        .false.
                    )
                    [sub]
                    []
                    [(SubroutineCall
                        1 sub
                        ()
                        [((Var 2 var_g))]     ;; notice this part of the ASR only which is concerned
                        ()
                    )]
                    ()
                    Public
                    .false.
                    .false.
                    ()
                )
        })
    []
)
```

### ASR in this PR

generated by `lfortran test.f90 --implicit-interface --show-asr`
```clj
(TranslationUnit
    (SymbolTable
        1
        {
            sub:
                (Function
                    (SymbolTable
                        4
                        {
                            arg:
                                (Variable
                                    4
                                    arg
                                    []
                                    Unspecified
                                    ()
                                    ()
                                    Default
                                    (Integer 4)
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                )
                        })
                    sub
                    (FunctionType
                        [(Integer 4)]
                        ()
                        Source
                        Implementation
                        ()
                        .false.
                        .false.
                        .false.
                        .false.
                        .false.
                        []
                        .false.
                    )
                    []
                    [(Var 4 arg)]
                    []
                    ()
                    Public
                    .false.
                    .false.
                    ()
                ),
            vars:
                (Module
                    (SymbolTable
                        2
                        {
                            var_g:
                                (Variable
                                    2
                                    var_g
                                    []
                                    Local
                                    (IntegerConstant 2 (Integer 4) Decimal)
                                    (IntegerConstant 2 (Integer 4) Decimal)
                                    Save
                                    (Integer 4)
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                )
                        })
                    vars
                    []
                    .false.
                    .false.
                ),
            wrapper:
                (Function
                    (SymbolTable
                        3
                        {
                            var_g:
                                (ExternalSymbol
                                    3
                                    var_g
                                    2 var_g
                                    vars
                                    []
                                    var_g
                                    Public
                                )
                        })
                    wrapper
                    (FunctionType
                        []
                        ()
                        Source
                        Implementation
                        ()
                        .false.
                        .false.
                        .false.
                        .false.
                        .false.
                        []
                        .false.
                    )
                    [sub]
                    []
                    [(SubroutineCall
                        1 sub
                        ()
                        [((Var 3 var_g))]   ;; notice the diff, now the SymbolTable is '3' which is correct
                        ()
                    )]
                    ()
                    Public
                    .false.
                    .false.
                    ()
                )
        })
    []
)
```

the ASR generated above is the same as what it would be without use of `--implicit-interface` flag