### PR TITLE
Error resilient array-03

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -441,8 +441,10 @@ public:
         ptr_loads = 2;
         for( int r = 0; r < n_dims; r++ ) {
             ASR::dimension_t m_dim = m_dims[r];
+            LCOMPILERS_ASSERT(m_dim.m_start != nullptr);
             visit_expr(*(m_dim.m_start));
             llvm::Value* start = tmp;
+            LCOMPILERS_ASSERT(m_dim.m_length != nullptr);
             visit_expr(*(m_dim.m_length));
             llvm::Value* end = tmp;
             llvm_dims.push_back(std::make_pair(start, end));

--- a/tests/errors/array_03.f90
+++ b/tests/errors/array_03.f90
@@ -1,7 +1,7 @@
 program array_03
 implicit none
 
-integer :: a(:)
+integer :: a(10)
 a(:,:) = 1
 
 end program

--- a/tests/errors/array_03_cc.f90
+++ b/tests/errors/array_03_cc.f90
@@ -1,0 +1,9 @@
+program array_03_cc
+implicit none
+
+integer :: a(10)
+a(:,:) = 1
+a(:,:) = 2
+print *, "compilation continued despite errors"
+
+end program

--- a/tests/reference/asr-array_03-a79d86f.json
+++ b/tests/reference/asr-array_03-a79d86f.json
@@ -2,7 +2,7 @@
     "basename": "asr-array_03-a79d86f",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/array_03.f90",
-    "infile_hash": "050cfc929eff0de4c108f28e7200df20bd77f9c8f514d67cfadf2d4f",
+    "infile_hash": "19770180604e3013e99175b497b5992be18301c5f8a91174421a9141",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,

--- a/tests/reference/run-array_03_cc-e368d39.json
+++ b/tests/reference/run-array_03_cc-e368d39.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-array_03_cc-e368d39",
+    "cmd": "lfortran --continue-compilation --no-color {infile}",
+    "infile": "tests/errors/array_03_cc.f90",
+    "infile_hash": "e5a21843459dbef34b8bce7c7011964e91c05bd50da7a1cfe3d1b429",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "run-array_03_cc-e368d39.stdout",
+    "stdout_hash": "a779ee4f7341ddce58a41cee3d249ecf1b37216d7d4f16eb4e0f528e",
+    "stderr": "run-array_03_cc-e368d39.stderr",
+    "stderr_hash": "495a800f1470e74fdf0f183c65a591e168012c1ec2a20cdd0dfc6fa3",
+    "returncode": 1
+}

--- a/tests/reference/run-array_03_cc-e368d39.stderr
+++ b/tests/reference/run-array_03_cc-e368d39.stderr
@@ -1,0 +1,11 @@
+semantic error: Rank mismatch in array reference: the array `a` has rank `1`, but is referenced as rank `2`
+ --> tests/errors/array_03_cc.f90:5:1
+  |
+5 | a(:,:) = 1
+  | ^^^^^^ 
+
+semantic error: Rank mismatch in array reference: the array `a` has rank `1`, but is referenced as rank `2`
+ --> tests/errors/array_03_cc.f90:6:1
+  |
+6 | a(:,:) = 2
+  | ^^^^^^ 

--- a/tests/reference/run-array_03_cc-e368d39.stdout
+++ b/tests/reference/run-array_03_cc-e368d39.stdout
@@ -1,0 +1,1 @@
+compilation continued despite errors

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3559,6 +3559,10 @@ filename = "errors/array_03.f90"
 asr = true
 
 [[test]]
+filename = "errors/array_03_cc.f90"
+continue_compilation = true
+
+[[test]]
 filename = "errors/array_04.f90"
 asr = true
 


### PR DESCRIPTION
Toward :- #5036 

```
program array_03
implicit none

integer :: a(:)
a(:,:) = 1

end program
```

Handled error in array_03 and the changes brought segmentation fault which were handled in asr_to_llvm.cpp file.