### PR TITLE
Treat spaces in first 72 columns as a comment

### DIFF
--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -261,7 +261,7 @@ enum LineType {
 
 // Determines the type of line in the fixed-form prescanner
 // `pos` points to the first character (column) of the line
-// The line ends with either `\n` or `\0`.
+// The line ends with either `\n` or `\0`.  Only used for fixed-form
 LineType determine_line_type(const unsigned char *pos)
 {
     int col=1;
@@ -292,7 +292,9 @@ LineType determine_line_type(const unsigned char *pos)
             pos++;
             col+=1;
         }
-        if (*pos == '\n' || *pos == '\0' || (*pos == '\r' && *(pos+1) == '\n')) return LineType::Comment;
+        if (*pos == '\n' || *pos == '\0' || (*pos == '\r' && *(pos+1) == '\n')
+	    || col > 72)
+	  return LineType::Comment;
         if (*pos == '!' && col != 6) return LineType::Comment;
         if (col == 6) {
             if (*pos == ' ' || *pos == '0') {

--- a/tests/fixed_form_line_limit.f
+++ b/tests/fixed_form_line_limit.f
@@ -7,6 +7,11 @@ c     789012345678901234567890123456789012345678901234567890123456789012
      $ignores text past column 72"
       print *, "test that we can still see the quote in the last column"<-
       print *, "test that we avoid double "" lookahead in col 73       ""
+      print *, "                                  end-of-line double """"
+c The next line only has text past column 72
+                                                                        00770402
+c     The next pattern is used to do continuations in code that is read
+c     by both fixed-form AND free-form parsers
       a=                                                                &
      &     5                                                            &
      &     + 3

--- a/tests/reference/ast-fixed_form_line_limit-0a3f0f0.json
+++ b/tests/reference/ast-fixed_form_line_limit-0a3f0f0.json
@@ -2,11 +2,11 @@
     "basename": "ast-fixed_form_line_limit-0a3f0f0",
     "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/fixed_form_line_limit.f",
-    "infile_hash": "a8829a4044e72c377c54632d77b22920f7d53d81972e49294d3ac22b",
+    "infile_hash": "474de788602ebc9fe11f04fe1962c667fa1ae3261c04710af3358dc9",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_line_limit-0a3f0f0.stdout",
-    "stdout_hash": "38adab8c011edae61d4ed50fcf5c9e2fb62c069fb3652432c6f41fca",
+    "stdout_hash": "75eaf85e20fe883cb1d69898b8ad04fcecc0e28bbfdbce1e2d86c327",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_line_limit-0a3f0f0.stdout
+++ b/tests/reference/ast-fixed_form_line_limit-0a3f0f0.stdout
@@ -40,6 +40,12 @@
             [(String "test that we avoid double \"\" lookahead in col 73       ")]
             ()
         )
+        (Print
+            0
+            ()
+            [(String "                                  end-of-line double \"\"")]
+            ()
+        )
         (Assignment
             0
             a


### PR DESCRIPTION
This PR addresses a fixed-form failure where the first 72 columns are spaces, but there is non-blank text afterwards, such as in the second line of this snippet:
```fortran
      CHARACTER CVTN01*1                                                00760402
                                                                        00770402
```
This is now correctly categorized as a blank line (=> comment).  Testing has been updated to cover this case.

This closes #5311.