### PR TITLE
Initialize the `save` variable in LLVM

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3669,12 +3669,24 @@ public:
                 ptr = builder->CreateBitCast(ptr_i8, type->getPointerTo());
             } else {
                 if (v->m_storage == ASR::storage_typeType::Save) {
+                    ASR::ttype_t *v_type = ASRUtils::
+                        type_get_past_pointer(
+                        ASRUtils::type_get_past_allocatable(v->m_type));
                     std::string parent_function_name = std::string(x.m_name);
                     std::string global_name = parent_function_name+ "." + v->m_name;
                     ptr = module->getOrInsertGlobal(global_name, type);
                     llvm::GlobalVariable *gptr = module->getNamedGlobal(global_name);
                     gptr->setLinkage(llvm::GlobalValue::InternalLinkage);
-                    llvm::Constant *init_value = llvm::Constant::getNullValue(type);
+                    llvm::Constant *init_value;
+                    if (v->m_value
+                            && (ASR::is_a<ASR::Integer_t>(*v_type)
+                            || ASR::is_a<ASR::Real_t>(*v_type)
+                            || ASR::is_a<ASR::Logical_t>(*v_type))) {
+                        this->visit_expr(*v->m_value);
+                        init_value = llvm::dyn_cast<llvm::Constant>(tmp);
+                    } else {
+                        init_value = llvm::Constant::getNullValue(type);
+                    }
                     gptr->setInitializer(init_value);
 #if LLVM_VERSION_MAJOR > 16
                     ptr_type[ptr] = type;

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "418ffd3de78b6007559518058064b78d3c3d92cd768ba36c6214dbc5",
+    "stdout_hash": "59838883898fd2648466208f21995325c405a5a9d191f11b3cb5d3e1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -4,9 +4,9 @@ source_filename = "LFortran"
 %array = type { i1*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
 
-@array_op_3.dim1 = internal global i32 0
-@array_op_3.dim2 = internal global i32 0
-@array_op_3.dim3 = internal global i32 0
+@array_op_3.dim1 = internal global i32 10
+@array_op_3.dim2 = internal global i32 100
+@array_op_3.dim3 = internal global i32 1
 @0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "69f0f1ab312bd76d53f3a2f55da91f4199dce4200f164cdd0517b1d0",
+    "stdout_hash": "0f0980b749eb0b42ded2a395d13feb924bb6b9d6c5c027adc935e312",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -3,8 +3,8 @@ source_filename = "LFortran"
 
 %complex_4 = type { float, float }
 
-@associate_02.t1 = internal global i32 0
-@associate_02.t2 = internal global double 0.000000e+00
+@associate_02.t1 = internal global i32 2
+@associate_02.t2 = internal global double 2.000000e+00
 @associate_02.t3 = internal global %complex_4 zeroinitializer
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "3f5e6460ddd3c6160a3a6faf4053b5ba926ee6f99dbb8b8b1969c830",
+    "stdout_hash": "72ca3ab43872df0e19b078b7efbb378ee93ab49f9de5b93636d891b4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@associate_03.t1 = internal global i32 0
-@associate_03.t2 = internal global i32 0
+@associate_03.t1 = internal global i32 2
+@associate_03.t2 = internal global i32 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "8597b3a7a947ad5774d600ceb6bd20aef350411dc7cb6093071426dd",
+    "stdout_hash": "f66d9c13d933054d416c7dad55183baf041f553fe72b46865ee6af04",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@bindc3.idx = internal global i32 0
+@bindc3.idx = internal global i32 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "c4e760c41cf92130d766d77a4d0fdd12e2dd6fbfff97bf913d2cf709",
+    "stdout_hash": "173271dc680d869f19f2dbcee9fd5dd1fa5ddd4a707c83ae0fd754fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -3,7 +3,7 @@ source_filename = "LFortran"
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
-@main.x = internal global i32 0
+@main.x = internal global i32 5
 
 define void @__module_callback_05_px_call1(i32* %x) {
 .entry:

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "ff329b2b302199affa2927e7e641077a8c5916ff11b697cb16893624",
+    "stdout_hash": "2bd9e30187638610358b177774d8cf7c5d0f0bfdd226447dee85103c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@main.n = internal global i32 0
+@main.n = internal global i32 3
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "88c00a3187072a74d6e06520334303076d35a3b570ed549ad1cef2f1",
+    "stdout_hash": "6a3d41cc3c55dbf307b481577e884ac207b3154a4e0499a970cdd58d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@int_dp.u = internal global i32 0
-@int_dp.v = internal global i64 0
+@int_dp.u = internal global i32 2147483647
+@int_dp.v = internal global i64 2147483647
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "b0bbfa24537e54208f23bf06f8af2873455280e0e833d1cc08cd118b",
+    "stdout_hash": "5601826a80c0d41b572ce99dad8173253539bb1b0e4a8fdb36955849",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@int_dp_param.u = internal global i32 0
-@int_dp_param.v = internal global i64 0
+@int_dp_param.u = internal global i32 2147483647
+@int_dp_param.v = internal global i64 2147483647
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "4e747ce85a7e44e1fc21c26f686e6788151805012ed9bad51ddeda17",
+    "stdout_hash": "670083396203f9422827884a38f91950b0e78d1e763fdecd1f17a07f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@intrinsics_02.x = internal global float 0.000000e+00
+@intrinsics_02.x = internal global float 0x3FEFEB7AA0000000
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "40268f12fc5767672dc323e3473b8d93a16496044bdf649196dd0701",
+    "stdout_hash": "441fad540a043c6d550d6d1a73583b1496a7234e338d184b4e1eff6c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@intrinsics_03.i = internal global i32 0
+@intrinsics_03.i = internal global i32 -12
 @0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "1cfe988d69cc1065160de995c9895b48434813991a5011b09ba8a3f4",
+    "stdout_hash": "f8eb219fabcc94ae4365001d05375f686051ba98d26fb1162c12e47b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@real_dp_param.u = internal global float 0.000000e+00
-@real_dp_param.v = internal global double 0.000000e+00
+@real_dp_param.u = internal global float 0x3FF0CCCCC0000000
+@real_dp_param.v = internal global double 1.050000e+00
 @real_dp_param.zero = internal global double 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "0814e54ded4561270edf129df5c8606edfaebf02a82678505651a26e",
+    "stdout_hash": "c5261ec0429817ab4838010cb3cae197678a1ccd023edf906924e388",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@main.main_out = internal global i32 0
+@main.main_out = internal global i32 999
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [13 x i8] c"early return\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1


### PR DESCRIPTION
Towards #5308. 

This implements the first part of the fix. The second part is to not initialize Integer/Real/Logical in the function, since they are already initialized globally.