### PR TITLE
Fix integer/real/logical save variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1618,6 +1618,7 @@ RUN(NAME save_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME save_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME save_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME save_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME save_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME entry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/save_09.f90
+++ b/integration_tests/save_09.f90
@@ -1,0 +1,24 @@
+subroutine foo(ir, rr, lr)
+integer, intent(in) :: ir
+real, intent(in)    :: rr
+logical, intent(in) :: lr
+integer, save :: ic = 1
+real, save    :: rc = 1
+logical, save :: lc = .true.
+ic = ic + 1
+rc = rc + 1
+lc = .not. lc
+print *, 'FOO: ', ic, ir, rc, rr, lc, lr
+if (ic /= ir) error stop
+if (rc /= rr) error stop
+if (lc .neqv. lr) error stop
+end subroutine
+
+program save_09
+integer i
+logical :: lr = .false.
+do i = 2, 4
+    call foo(i, real(i), lr)
+    lr = .not. lr
+end do
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3819,7 +3819,16 @@ public:
                         strings_to_be_deallocated.push_back(al, llvm_utils->CreateLoad2(v->m_type, target_var));
                     }
                 } else {
-                    builder->CreateStore(init_value, target_var);
+                    if (v->m_storage == ASR::storage_typeType::Save
+                        && v->m_value
+                        && (ASR::is_a<ASR::Integer_t>(*v->m_type)
+                        || ASR::is_a<ASR::Real_t>(*v->m_type)
+                        || ASR::is_a<ASR::Logical_t>(*v->m_type))) {
+                        // Do nothing, the value is already initialized
+                        // in the global variable
+                    } else {
+                        builder->CreateStore(init_value, target_var);
+                    }
                 }
             } else {
                 if (is_a<ASR::String_t>(*v->m_type) && !is_array_type && !is_list) {

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "59838883898fd2648466208f21995325c405a5a9d191f11b3cb5d3e1",
+    "stdout_hash": "bd2e0d734b39464f7c385eee8c9f9c893093dcf8d048559f2062a232",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -37,9 +37,6 @@ define i32 @main(i32 %0, i8** %1) {
   %__3_t = alloca i32, align 4
   %__3_u = alloca i32, align 4
   %__3_v = alloca i32, align 4
-  store i32 10, i32* @array_op_3.dim1, align 4
-  store i32 100, i32* @array_op_3.dim2, align 4
-  store i32 1, i32* @array_op_3.dim3, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   %k = alloca i32, align 4
@@ -95,9 +92,6 @@ define i32 @main(i32 %0, i8** %1) {
   %19 = getelementptr %array, %array* %arr_desc11, i32 0, i32 0
   store i1* null, i1** %19, align 8
   store %array* %arr_desc11, %array** %c, align 8
-  store i32 10, i32* @array_op_3.dim1, align 4
-  store i32 100, i32* @array_op_3.dim2, align 4
-  store i32 1, i32* @array_op_3.dim3, align 4
   %i12 = alloca i32, align 4
   %j13 = alloca i32, align 4
   %k14 = alloca i32, align 4

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "0f0980b749eb0b42ded2a395d13feb924bb6b9d6c5c027adc935e312",
+    "stdout_hash": "711eae1ef4cd10c7181e9435cbc1ec95ac09f5e40252e74308e37599",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -25,7 +25,6 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  store i32 2, i32* @associate_02.t1, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
@@ -33,8 +32,6 @@ define i32 @main(i32 %0, i8** %1) {
   store double* null, double** %p2, align 8
   %p3 = alloca %complex_4*, align 8
   store %complex_4* null, %complex_4** %p3, align 8
-  store i32 2, i32* @associate_02.t1, align 4
-  store double 2.000000e+00, double* @associate_02.t2, align 8
   %2 = alloca %complex_4, align 8
   %3 = getelementptr %complex_4, %complex_4* %2, i32 0, i32 0
   %4 = getelementptr %complex_4, %complex_4* %2, i32 0, i32 1

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "72ca3ab43872df0e19b078b7efbb378ee93ab49f9de5b93636d891b4",
+    "stdout_hash": "556a0c239256b26591e9df2a3ab9ff512c1a3bd3c8ebca24f852daec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -14,14 +14,10 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %i = alloca i32, align 4
-  store i32 2, i32* @associate_03.t1, align 4
-  store i32 1, i32* @associate_03.t2, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i1 = alloca i32, align 4
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
-  store i32 2, i32* @associate_03.t1, align 4
-  store i32 1, i32* @associate_03.t2, align 4
   %2 = load i32, i32* @associate_03.t1, align 4
   %3 = sext i32 %2 to i64
   %4 = load i32, i32* @associate_03.t2, align 4

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "f66d9c13d933054d416c7dad55183baf041f553fe72b46865ee6af04",
+    "stdout_hash": "eb5faa0ae27ec41db86e157465b6943cf0f4e31b6e266311ad4d920c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -9,10 +9,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  store i32 1, i32* @bindc3.idx, align 4
   %y = alloca i16, align 2
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 1, i32* @bindc3.idx, align 4
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
   store i16* null, i16** %x, align 8

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "ac80ae9f0208004b5b2625d55cda08bc25e50b9ec7776f38fcdac862",
+    "stdout_hash": "08f21e63b075a27a8cb59b6bf665a1ea612a57672071792e3a2128d1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -72,7 +72,6 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 0.000000e+00, float* @main.res, align 4
   store float 1.500000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @main.res)

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "173271dc680d869f19f2dbcee9fd5dd1fa5ddd4a707c83ae0fd754fa",
+    "stdout_hash": "df28cfe8b46cdffb478ece027b15aa4522e1faeef68305c99da2a0cb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -54,9 +54,7 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  store i32 5, i32* @main.x, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 5, i32* @main.x, align 4
   call void @__module_callback_05_px_call1(i32* @main.x)
   br label %return
 

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "2bd9e30187638610358b177774d8cf7c5d0f0bfdd226447dee85103c",
+    "stdout_hash": "468527cd471d61862f20307823efc9aa0b706bef534f321c5db34bfd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -25,10 +25,8 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %array_bound = alloca i32, align 4
   %__1_k = alloca i32, align 4
-  store i32 3, i32* @main.n, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__1_k1 = alloca i32, align 4
-  store i32 3, i32* @main.n, align 4
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "6a3d41cc3c55dbf307b481577e884ac207b3154a4e0499a970cdd58d",
+    "stdout_hash": "f3742de07c20f668f77749078520b4d358756efcf517bae039dae734",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -8,11 +8,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  store i32 2147483647, i32* @int_dp.u, align 4
-  store i64 2147483647, i64* @int_dp.v, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 2147483647, i32* @int_dp.u, align 4
-  store i64 2147483647, i64* @int_dp.v, align 4
   %2 = load i32, i32* @int_dp.u, align 4
   %3 = sext i32 %2 to i64
   %4 = load i64, i64* @int_dp.v, align 4

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "5601826a80c0d41b572ce99dad8173253539bb1b0e4a8fdb36955849",
+    "stdout_hash": "934c21fb555ad8c712a6bef0ea55c373651fdf5f9b586e96e21c9efb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -12,15 +12,11 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  store i32 2147483647, i32* @int_dp_param.u, align 4
-  store i64 2147483647, i64* @int_dp_param.v, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec11 = alloca i32, align 4
   store i32 4, i32* %prec11, align 4
   %prec22 = alloca i32, align 4
   store i32 8, i32* %prec22, align 4
-  store i32 2147483647, i32* @int_dp_param.u, align 4
-  store i64 2147483647, i64* @int_dp_param.v, align 4
   %2 = load i32, i32* @int_dp_param.u, align 4
   %3 = sext i32 %2 to i64
   %4 = load i64, i64* @int_dp_param.v, align 4

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "670083396203f9422827884a38f91950b0e78d1e763fdecd1f17a07f",
+    "stdout_hash": "890e6c60de6fd5392015ee705546c85688281880d9e7e2aadc9c093c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -111,7 +111,6 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 0x3FEFEB7AA0000000, float* @intrinsics_02.x, align 4
   %y = alloca double, align 8
   store double 0x3FEFEB7A9B2C6D8B, double* %y, align 8
   %2 = load float, float* @intrinsics_02.x, align 4

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "441fad540a043c6d550d6d1a73583b1496a7234e338d184b4e1eff6c",
+    "stdout_hash": "bb65dfbe378f817b09c80861e35bd584441c9408183e462387dd7676",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -121,10 +121,8 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value5 = alloca double, align 8
   %call_arg_value1 = alloca double, align 8
   %call_arg_value = alloca float, align 4
-  store i32 -12, i32* @intrinsics_03.i, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca double, align 8
-  store i32 -12, i32* @intrinsics_03.i, align 4
   %r1 = alloca double, align 8
   %r2 = alloca double, align 8
   %x = alloca float, align 4

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "f8eb219fabcc94ae4365001d05375f686051ba98d26fb1162c12e47b",
+    "stdout_hash": "a72982549c2d47ea66d05101d19eb46ba377f92c270eb97ab064121e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -18,9 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 4, i32* %prec11, align 4
   %prec22 = alloca i32, align 4
   store i32 8, i32* %prec22, align 4
-  store float 0x3FF0CCCCC0000000, float* @real_dp_param.u, align 4
-  store double 1.050000e+00, double* @real_dp_param.v, align 8
-  store double 0.000000e+00, double* @real_dp_param.zero, align 8
   %2 = load float, float* @real_dp_param.u, align 4
   %3 = fpext float %2 to double
   %4 = load double, double* @real_dp_param.v, align 8

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "c5261ec0429817ab4838010cb3cae197678a1ccd023edf906924e388",
+    "stdout_hash": "bb541f6fe44cae6a15fbb234d3087a9a499316024bf62f9a7d598746",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -14,9 +14,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  store i32 999, i32* @main.main_out, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 999, i32* @main.main_out, align 4
   call void @main1(i32* @main.main_out)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   br label %return


### PR DESCRIPTION
Fixes #5308.

This is the second part of the fix after https://github.com/lfortran/lfortran/pull/5316.

This finishes the basic implementation for integer/real/logical scalar variables. See the issue https://github.com/lfortran/lfortran/issues/5319 to implement this for the rest of the types.