### PR TITLE
Adjust DATA statement parsing

### DIFF
--- a/tests/data3.f90
+++ b/tests/data3.f90
@@ -1,0 +1,16 @@
+program datatest
+  implicit none
+  integer :: ivon01,ivon02,ivon03,ivon04,ivon05
+  integer :: ivon06,ivon07,ivon08,ivon09,ivon10
+  integer :: ivon11,ivon12,ivon13,ivon14,ivon15
+  integer :: ivon16,ivon17,ivon18,ivon19,ivon20
+  integer, parameter :: vals(5) = [3,76,587,9999,21111]
+  complex :: axvc
+  
+  data ivon01,ivon02,ivon03,ivon04,ivon05 /vals(1), vals(2), vals(3), vals(4), vals(5)/
+  data ivon06,ivon07,ivon08,ivon09,ivon10 /+3,+76,+587,+9999,+21111/
+  
+  data ivon11,ivon12,ivon13,ivon14,ivon15 /-3,-76,-587,-9999,-21111/ 
+  data ivon16,ivon17,ivon18,ivon19,ivon20 / 2*119, 2*7, -427/
+!  data axvc /(-234.23, 34)/
+end program datatest

--- a/tests/data3.f90
+++ b/tests/data3.f90
@@ -4,13 +4,13 @@ program datatest
   integer :: ivon06,ivon07,ivon08,ivon09,ivon10
   integer :: ivon11,ivon12,ivon13,ivon14,ivon15
   integer :: ivon16,ivon17,ivon18,ivon19,ivon20
-  integer, parameter :: vals(5) = [3,76,587,9999,21111]
-  complex :: axvc
+  integer, parameter :: vals(5) = [2,76,587,9999,21111]
+  complex :: axva,axvb
   
   data ivon01,ivon02,ivon03,ivon04,ivon05 /vals(1), vals(2), vals(3), vals(4), vals(5)/
   data ivon06,ivon07,ivon08,ivon09,ivon10 /+3,+76,+587,+9999,+21111/
   
   data ivon11,ivon12,ivon13,ivon14,ivon15 /-3,-76,-587,-9999,-21111/ 
   data ivon16,ivon17,ivon18,ivon19,ivon20 / 2*119, 2*7, -427/
-!  data axvc /(-234.23, 34)/
+  data axva,axvb /(-234.23, 3), (+2, -3.0)/
 end program datatest

--- a/tests/reference/asr-data3-0afaffe.json
+++ b/tests/reference/asr-data3-0afaffe.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-data3-0afaffe",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/data3.f90",
+    "infile_hash": "b4838a394f3b26e78e6092c67193187a539ff83b61c12d3468a6a030",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-data3-0afaffe.stdout",
+    "stdout_hash": "eb53829791c304ff41c9d497f716eb0e8c4024d2308265d43df7a832",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-data3-0afaffe.stdout
+++ b/tests/reference/asr-data3-0afaffe.stdout
@@ -1,0 +1,543 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            datatest:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            axva:
+                                (Variable
+                                    2
+                                    axva
+                                    []
+                                    Local
+                                    (ComplexConstant
+                                        -234.230000
+                                        3.000000
+                                        (Complex 4)
+                                    )
+                                    (ComplexConstant
+                                        -234.230000
+                                        3.000000
+                                        (Complex 4)
+                                    )
+                                    Default
+                                    (Complex 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            axvb:
+                                (Variable
+                                    2
+                                    axvb
+                                    []
+                                    Local
+                                    (ComplexConstant
+                                        2.000000
+                                        -3.000000
+                                        (Complex 4)
+                                    )
+                                    (ComplexConstant
+                                        2.000000
+                                        -3.000000
+                                        (Complex 4)
+                                    )
+                                    Default
+                                    (Complex 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon01:
+                                (Variable
+                                    2
+                                    ivon01
+                                    []
+                                    Local
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon02:
+                                (Variable
+                                    2
+                                    ivon02
+                                    []
+                                    Local
+                                    (IntegerConstant 76 (Integer 4) Decimal)
+                                    (IntegerConstant 76 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon03:
+                                (Variable
+                                    2
+                                    ivon03
+                                    []
+                                    Local
+                                    (IntegerConstant 587 (Integer 4) Decimal)
+                                    (IntegerConstant 587 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon04:
+                                (Variable
+                                    2
+                                    ivon04
+                                    []
+                                    Local
+                                    (IntegerConstant 9999 (Integer 4) Decimal)
+                                    (IntegerConstant 9999 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon05:
+                                (Variable
+                                    2
+                                    ivon05
+                                    []
+                                    Local
+                                    (IntegerConstant 21111 (Integer 4) Decimal)
+                                    (IntegerConstant 21111 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon06:
+                                (Variable
+                                    2
+                                    ivon06
+                                    []
+                                    Local
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon07:
+                                (Variable
+                                    2
+                                    ivon07
+                                    []
+                                    Local
+                                    (IntegerConstant 76 (Integer 4) Decimal)
+                                    (IntegerConstant 76 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon08:
+                                (Variable
+                                    2
+                                    ivon08
+                                    []
+                                    Local
+                                    (IntegerConstant 587 (Integer 4) Decimal)
+                                    (IntegerConstant 587 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon09:
+                                (Variable
+                                    2
+                                    ivon09
+                                    []
+                                    Local
+                                    (IntegerConstant 9999 (Integer 4) Decimal)
+                                    (IntegerConstant 9999 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon10:
+                                (Variable
+                                    2
+                                    ivon10
+                                    []
+                                    Local
+                                    (IntegerConstant 21111 (Integer 4) Decimal)
+                                    (IntegerConstant 21111 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon11:
+                                (Variable
+                                    2
+                                    ivon11
+                                    []
+                                    Local
+                                    (IntegerConstant -3 (Integer 4) Decimal)
+                                    (IntegerConstant -3 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon12:
+                                (Variable
+                                    2
+                                    ivon12
+                                    []
+                                    Local
+                                    (IntegerConstant -76 (Integer 4) Decimal)
+                                    (IntegerConstant -76 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon13:
+                                (Variable
+                                    2
+                                    ivon13
+                                    []
+                                    Local
+                                    (IntegerConstant -587 (Integer 4) Decimal)
+                                    (IntegerConstant -587 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon14:
+                                (Variable
+                                    2
+                                    ivon14
+                                    []
+                                    Local
+                                    (IntegerConstant -9999 (Integer 4) Decimal)
+                                    (IntegerConstant -9999 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon15:
+                                (Variable
+                                    2
+                                    ivon15
+                                    []
+                                    Local
+                                    (IntegerConstant -21111 (Integer 4) Decimal)
+                                    (IntegerConstant -21111 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon16:
+                                (Variable
+                                    2
+                                    ivon16
+                                    []
+                                    Local
+                                    (IntegerConstant 119 (Integer 4) Decimal)
+                                    (IntegerConstant 119 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon17:
+                                (Variable
+                                    2
+                                    ivon17
+                                    []
+                                    Local
+                                    (IntegerConstant 119 (Integer 4) Decimal)
+                                    (IntegerConstant 119 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon18:
+                                (Variable
+                                    2
+                                    ivon18
+                                    []
+                                    Local
+                                    (IntegerConstant 7 (Integer 4) Decimal)
+                                    (IntegerConstant 7 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon19:
+                                (Variable
+                                    2
+                                    ivon19
+                                    []
+                                    Local
+                                    (IntegerConstant 7 (Integer 4) Decimal)
+                                    (IntegerConstant 7 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            ivon20:
+                                (Variable
+                                    2
+                                    ivon20
+                                    []
+                                    Local
+                                    (IntegerConstant -427 (Integer 4) Decimal)
+                                    (IntegerConstant -427 (Integer 4) Decimal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            vals:
+                                (Variable
+                                    2
+                                    vals
+                                    []
+                                    Local
+                                    (ArrayConstant
+                                        20
+                                        [2, 76, 587, 9999, 21111]
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 5 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ColMajor
+                                    )
+                                    (ArrayConstant
+                                        20
+                                        [2, 76, 587, 9999, 21111]
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 5 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ColMajor
+                                    )
+                                    Parameter
+                                    (Array
+                                        (Integer 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 5 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    datatest
+                    []
+                    [(Assignment
+                        (Var 2 ivon01)
+                        (IntegerConstant 2 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon02)
+                        (IntegerConstant 76 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon03)
+                        (IntegerConstant 587 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon04)
+                        (IntegerConstant 9999 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon05)
+                        (IntegerConstant 21111 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon06)
+                        (IntegerConstant 3 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon07)
+                        (IntegerConstant 76 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon08)
+                        (IntegerConstant 587 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon09)
+                        (IntegerConstant 9999 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon10)
+                        (IntegerConstant 21111 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon11)
+                        (IntegerConstant -3 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon12)
+                        (IntegerConstant -76 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon13)
+                        (IntegerConstant -587 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon14)
+                        (IntegerConstant -9999 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon15)
+                        (IntegerConstant -21111 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon16)
+                        (IntegerConstant 119 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon17)
+                        (IntegerConstant 119 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon18)
+                        (IntegerConstant 7 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon19)
+                        (IntegerConstant 7 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 ivon20)
+                        (IntegerConstant -427 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 axva)
+                        (ComplexConstant
+                            -234.230000
+                            3.000000
+                            (Complex 4)
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 axvb)
+                        (ComplexConstant
+                            2.000000
+                            -3.000000
+                            (Complex 4)
+                        )
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3426,6 +3426,10 @@ filename = "data2.f90"
 asr = true
 
 [[test]]
+filename = "data3.f90"
+asr = true
+
+[[test]]
 filename = "special_chars_json.f90"
 ast_json = true
 asr_json = true


### PR DESCRIPTION
Trying to run the FCVS_95 validation suite in #480, I found that some `DATA` statement constructs were not supported in LFortran, such as positive signed integers and complex:
```f90
  data ivon06,ivon07,ivon08,ivon09,ivon10 /+3,+76,+587,+9999,+21111/
  data axva,axvb /(-234.23, 3), (+2, -3.0)/
```
While I was working on fixing those, I noted that the `data_stmt_repeat` grammar rule was too permissive in some cases, and that the `data_stmt_constant` was not supporting _scalar-constant-subobject_, so I tried to fix those as well.  Added a new test as well.