### PR TITLE
CI: speedup dftatom tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -576,26 +576,20 @@ jobs:
       - name: Test dftatom
         shell: bash -e -x -l {0}
         run: |
-            git clone https://github.com/czgdp1807/dftatom.git
+            git clone https://github.com/certik/dftatom.git
             cd dftatom
-            git checkout -t origin/lf40
-            git checkout 6e0f6e7506440b042aae93e57b10444ee6c36f7a
+            git checkout 3815c86b0144fd69981dc7dfd7e28adf671c64ac
             export PATH="$(pwd)/../src/bin:$PATH"
-            make -f Makefile.manual
+            make -f Makefile.manual F90=lfortran F90FLAGS=-I../../src
             make -f Makefile.manual test
 
             # Test with experimental simplifier
             git clean -dfx
-            make -f Makefile.manual F90="lfortran --experimental-simplifier"
+            make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src --experimental-simplifier"
             make -f Makefile.manual test
 
             git clean -dfx
-            make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
-            make -f Makefile.manual test
-
-            # Test with experimental simplifier
-            git clean -dfx
-            make -f Makefile.manual F90="lfortran --experimental-simplifier --skip-pass=inline_function_calls,fma --fast"
+            make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src --skip-pass=inline_function_calls,fma --fast"
             make -f Makefile.manual test
 
       - name: Test fastGPT ( ubuntu-latest )
@@ -1069,27 +1063,21 @@ jobs:
       - name: Test dftatom
         shell: bash -e -x -l {0}
         run: |
-            git clone https://github.com/czgdp1807/dftatom.git
+            git clone https://github.com/certik/dftatom.git
             cd dftatom
-            git checkout -t origin/lf40
-            git checkout 6e0f6e7506440b042aae93e57b10444ee6c36f7a
+            git checkout 3815c86b0144fd69981dc7dfd7e28adf671c64ac
             export PATH="$(pwd)/../src/bin:$PATH"
-            make -f Makefile.manual
-            make -f Makefile.manual test
+            make -f Makefile.manual F90=lfortran F90FLAGS=-I../../src
+            ./tests/atom_U/F_atom_U
 
             # Test with experimental simplifier
             git clean -dfx
-            make -f Makefile.manual F90="lfortran --experimental-simplifier"
-            make -f Makefile.manual test
+            make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src --experimental-simplifier"
+            ./tests/atom_U/F_atom_U
 
             git clean -dfx
-            make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast"
-            make -f Makefile.manual test
-
-            # Test with experimental simplifier
-            git clean -dfx
-            make -f Makefile.manual F90="lfortran --experimental-simplifier --skip-pass=inline_function_calls,fma --fast"
-            make -f Makefile.manual test
+            make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src --skip-pass=inline_function_calls,fma --fast"
+            ./tests/atom_U/F_atom_U
 
       - name: Test fastGPT ( ubuntu-latest )
         shell: bash -e -x -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -578,19 +578,19 @@ jobs:
         run: |
             git clone https://github.com/certik/dftatom.git
             cd dftatom
-            git checkout 3815c86b0144fd69981dc7dfd7e28adf671c64ac
+            git checkout 9b678177f67e350b8a32e08cb61f51e6e708e87a
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual F90=lfortran F90FLAGS=-I../../src
-            make -f Makefile.manual test
+            make -f Makefile.manual quicktest
 
             # Test with experimental simplifier
             git clean -dfx
             make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src --experimental-simplifier"
-            make -f Makefile.manual test
+            make -f Makefile.manual quicktest
 
             git clean -dfx
             make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src --skip-pass=inline_function_calls,fma --fast"
-            make -f Makefile.manual test
+            make -f Makefile.manual quicktest
 
       - name: Test fastGPT ( ubuntu-latest )
         shell: bash -e -x -l {0}
@@ -1065,7 +1065,7 @@ jobs:
         run: |
             git clone https://github.com/certik/dftatom.git
             cd dftatom
-            git checkout 3815c86b0144fd69981dc7dfd7e28adf671c64ac
+            git checkout 9b678177f67e350b8a32e08cb61f51e6e708e87a
             export PATH="$(pwd)/../src/bin:$PATH"
             make -f Makefile.manual F90=lfortran F90FLAGS=-I../../src
             ./tests/atom_U/F_atom_U


### PR DESCRIPTION
Several changes were made:

* Use the upstream master unmodified
* In LLVM 10-19 only test one test, not the full testsuite
* In 3rd party tests only test simplifier without `--fast`.