### PR TITLE
CI: do not run simplifier for llvm_wasm tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -952,7 +952,6 @@ jobs:
             export WASMTIME_NEW_CLI=0
             cd integration_tests
             ./run_tests.py -b llvm_wasm llvm_wasm_emcc
-            ./run_tests.py -b llvm_wasm llvm_wasm_emcc --experimental-simplifier
 
       - name: Build Linux
         if: "!( (contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')) )"


### PR DESCRIPTION
Given:

* The simplifier is tested with LLVM in other tests
* We only changed the backend in LLVM to use WASM

And assuming:

* No bugs in LLVM

We do not need to test simplifier with llvm_wasm, because it should not trigger any bugs. If it does, those would be LLVM bugs, or integration bugs, but those are rare. For now the main thing is to ensure the simplifier pass works and it works with all the other passes and with LLVM. We already test that. We do not need to test every combination of the simplifier and other options.

Once simplifier becomes ready, then we can start testing it with all combinations. Until then we just need to ensure it works with one set of options, not all.