### PR TITLE
revert: creating `Enum_t` node and link variables via `ExternalSymbol`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1519,10 +1519,10 @@ RUN(NAME private1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME modules_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
-RUN(NAME enum_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME enum_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME enum_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
          enum_02_module.f90)
-RUN(NAME enum_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME enum_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME array_section_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME array_section_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -3481,6 +3481,9 @@ public:
             s2c(al, sym_name), nullptr, 0, m_members.p, m_members.n, abi_type,
             dflt_access, enum_value_type, type, nullptr);
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        // Expose all enumerators into the parent scope as ExternalSymbols pointing into the enumeration, which is the semantics of Fortran enums
+        // That way `resolve_variable()` can resolve the automatically.
+        // In ASR->Fortran we do not create any Fortran code for these ExternalSymbols, since they are implicit. But in ASR we need to represent them explicitly.
         for (auto it: current_scope->get_scope()) {
             ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(it.second);
             parent_scope->add_symbol(var->m_name, ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(al,

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -3432,15 +3432,8 @@ public:
     void visit_Enum(const AST::Enum_t &x) {
         SymbolTable *parent_scope = current_scope;
         current_scope = al.make_new<SymbolTable>(parent_scope);
-        std::string sym_name = "_nameless_enum";
-        {
-            int i = 1;
-            while (parent_scope->get_symbol(std::to_string(i) +
-                    sym_name) != nullptr) {
-                i++;
-            }
-            sym_name = std::to_string(i) + sym_name;
-        }
+        std::string sym_name = "lcompilers__nameless_enum";
+        sym_name = parent_scope->get_unique_name(sym_name);
         Vec<char *> m_members;
         m_members.reserve(al, 4);
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Integer_t(al,

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -616,7 +616,7 @@ public:
     void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
         ASR::symbol_t *sym = down_cast<ASR::symbol_t>(
             ASRUtils::symbol_parent_symtab(x.m_external)->asr_owner);
-        if (!is_a<ASR::Struct_t>(*sym)) {
+        if (!is_a<ASR::Struct_t>(*sym) && !is_a<ASR::Enum_t>(*sym)) {
             src = indent;
             src += "use ";
             src.append(x.m_module_name);
@@ -648,7 +648,25 @@ public:
         src = r;
     }
 
-    // void visit_Enum(const ASR::Enum_t &x) {}
+    void visit_Enum(const ASR::Enum_t &x) {
+        std::string r = indent;
+        r += "enum, bind(c)\n";
+        inc_indent();
+        for (auto it: x.m_symtab->get_scope()) {
+            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(it.second);
+            r += indent;
+            r += "enumerator :: ";
+            r.append(var->m_name);
+            r += " = ";
+            visit_expr(*var->m_value);
+            r += src;
+            r += "\n";
+        }
+        dec_indent();
+        r += indent;
+        r += "end enum\n";
+        src = r;
+    }
 
     // void visit_UnionType(const ASR::UnionType_t &x) {}
 

--- a/tests/reference/fortran-enum_01-3bcfd6d.json
+++ b/tests/reference/fortran-enum_01-3bcfd6d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-enum_01-3bcfd6d",
+    "cmd": "lfortran --show-fortran --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/enum_01.f90",
+    "infile_hash": "5dba9f630102c9e10a43f8075bc95880e0892b33a7fb16524b5ea275",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-enum_01-3bcfd6d.stdout",
+    "stdout_hash": "46202d796cd96d7c3c507b59536814f0c04eb9e72b7a7798c6abdf9f",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-enum_01-3bcfd6d.stdout
+++ b/tests/reference/fortran-enum_01-3bcfd6d.stdout
@@ -1,0 +1,28 @@
+program enum_01
+implicit none
+enum, bind(c)
+    enumerator :: blue = 3
+    enumerator :: red = 0
+    enumerator :: yellow = 4
+end enum
+enum, bind(c)
+    enumerator :: green = 10
+    enumerator :: purple = 11
+end enum
+integer(4), parameter :: compiler_enum = 4
+if (red /= 0) then
+    error stop
+end if
+if (blue /= 3) then
+    error stop
+end if
+if (yellow /= 4) then
+    error stop
+end if
+if (green /= 10) then
+    error stop
+end if
+if (purple /= 11) then
+    error stop
+end if
+end program enum_01

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "592f8cc9e776c8e8206ffb7510757e00feb609fa2f2087ad6d099a1d",
+    "stdout_hash": "1c3ee7431281afd62a90ebebbcee3ccc35cbb189bd2d10fee1686f24",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "35fe8aa505dffca9a90342811e43a76b59ef63ff6bca7aee74598ebb",
+    "stdout_hash": "592f8cc9e776c8e8206ffb7510757e00feb609fa2f2087ad6d099a1d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%0 = type { [25 x i8], i32 }
 %string_descriptor = type { i8*, i64, i64 }
 %compiler_t_polymorphic = type { i64, %compiler_t* }
 %compiler_t = type { i32, %string_descriptor, %string_descriptor, %string_descriptor, i1, i1 }
@@ -9,6 +10,7 @@ source_filename = "LFortran"
 %dimension_descriptor = type { i32, i32, i32 }
 %__vtab_compiler_t = type { i64 }
 
+@"1_nameless_enum" = global [3 x %0] [%0 { [11 x i8] c"id_unknown\00", i32 0 }, %0 { [25 x i8] c"id_intel_classic_windows\00", i32 1 }, %0 { [22 x i8] c"id_intel_llvm_windows\00", i32 2 }]
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -10,7 +10,7 @@ source_filename = "LFortran"
 %dimension_descriptor = type { i32, i32, i32 }
 %__vtab_compiler_t = type { i64 }
 
-@"1_nameless_enum" = global [3 x %0] [%0 { [11 x i8] c"id_unknown\00", i32 0 }, %0 { [25 x i8] c"id_intel_classic_windows\00", i32 1 }, %0 { [22 x i8] c"id_intel_llvm_windows\00", i32 2 }]
+@lcompilers__nameless_enum = global [3 x %0] [%0 { [11 x i8] c"id_unknown\00", i32 0 }, %0 { [25 x i8] c"id_intel_classic_windows\00", i32 1 }, %0 { [22 x i8] c"id_intel_llvm_windows\00", i32 2 }]
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4350,3 +4350,7 @@ asr = true
 [[test]]
 filename = "errors/init1.f90"
 ast = true
+
+[[test]]
+filename = "../integration_tests/enum_01.f90"
+fortran = true


### PR DESCRIPTION
Fixes #5314. This is the same design mentioned at #5314 but due to https://github.com/lfortran/lfortran/issues/5314#issuecomment-2466649139 we cannot pull enum variable. This asks us to create an `EnumeratorLink` node, doing precisely the same thing as `ExternalSymbol` but we need to write exact same code and handler for `EnumeratorLink` as we do for `ExternalSymbol` so I think using `ExternalSymbol` is a way here to avoid duplication.