### PR TITLE
refactor: remove redundant `ImplicitDeallocate` node addition during AST -> ASR transformation

### DIFF
--- a/tests/reference/asr-allocate_01-f3446f6.json
+++ b/tests/reference/asr-allocate_01-f3446f6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_01-f3446f6.stdout",
-    "stdout_hash": "cdc3cba54e4ecf4f87e29c52338ba458acb7216cd271a1887db0edfc",
+    "stdout_hash": "448e1ff868aa5a368b4d9be087a10f20490ab323e9c9d2a296f78de7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_01-f3446f6.stdout
+++ b/tests/reference/asr-allocate_01-f3446f6.stdout
@@ -986,9 +986,6 @@
                                     )
                                     (ExplicitDeallocate
                                         [(Var 3 c_copy)]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 c_copy)]
                                     )]
                                     ()
                                     Public
@@ -1633,11 +1630,6 @@
                             ()
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 a)
-                        (Var 2 b)
-                        (Var 2 c)]
                     )]
                 )
         })

--- a/tests/reference/asr-allocate_02-3c0d7c8.json
+++ b/tests/reference/asr-allocate_02-3c0d7c8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_02-3c0d7c8.stdout",
-    "stdout_hash": "7dd5d12a5dad421dc4efc295a721edb3a0c37dd9a186c5d899fedd67",
+    "stdout_hash": "2ac2f574a30b9eca31a167deeca1a3a3cc07d246176c39a062e5ad3a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_02-3c0d7c8.stdout
+++ b/tests/reference/asr-allocate_02-3c0d7c8.stdout
@@ -757,15 +757,6 @@
                                         (Var 3 status)
                                         (IntegerConstant 1 (Integer 4) Decimal)
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 a_2)
-                                        (Var 3 ab)
-                                        (Var 3 abc)
-                                        (Var 3 b_2)
-                                        (Var 3 bc)
-                                        (Var 3 c_2)
-                                        (Var 3 ca)]
                                     )]
                                     (Var 3 status)
                                     Public
@@ -902,11 +893,6 @@
                             (String -1 0 () PointerString)
                             ()
                         )
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 a)
-                        (Var 2 b)
-                        (Var 2 c)]
                     )]
                 )
         })

--- a/tests/reference/asr-allocate_03-8219a72.json
+++ b/tests/reference/asr-allocate_03-8219a72.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_03-8219a72.stdout",
-    "stdout_hash": "2aca5093ea1a59872002e21342f2d744cb3c5d41a42d4e867e83d2ec",
+    "stdout_hash": "624579a4561229d5504d58e08fc2f80b8c876ee2741cb4483d4864a4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_03-8219a72.stdout
+++ b/tests/reference/asr-allocate_03-8219a72.stdout
@@ -664,9 +664,6 @@
                             (String -1 0 () PointerString)
                             ()
                         )
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 c)]
                     )]
                 )
         })

--- a/tests/reference/asr-allocate_04-68facec.json
+++ b/tests/reference/asr-allocate_04-68facec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_04-68facec.stdout",
-    "stdout_hash": "d2717330f748d02b3d41df119dabe7693a8b6f5c461d1cc37e7f2b98",
+    "stdout_hash": "276092a598aa3fe0a0064060b46189498dd5977a1abfe0db6791372b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_04-68facec.stdout
+++ b/tests/reference/asr-allocate_04-68facec.stdout
@@ -282,11 +282,6 @@
                             (String -1 0 () PointerString)
                             ()
                         )
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 c)
-                        (Var 2 message)
-                        (Var 2 string)]
                     )]
                 )
         })

--- a/tests/reference/asr-allocate_05-48fb994.json
+++ b/tests/reference/asr-allocate_05-48fb994.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_05-48fb994.stdout",
-    "stdout_hash": "bd0f83de38606f0097789a32251f439af11fa7f5795b1633fe3060e6",
+    "stdout_hash": "5df96f030245e8dc7e49ae8e4a7042df812d024daa383a6c237759d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_05-48fb994.stdout
+++ b/tests/reference/asr-allocate_05-48fb994.stdout
@@ -141,9 +141,6 @@
                             ()
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 string)]
                     )]
                 )
         })

--- a/tests/reference/asr-array12-cb81afc.json
+++ b/tests/reference/asr-array12-cb81afc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array12-cb81afc.stdout",
-    "stdout_hash": "1cb403be55ade3a292d0aafc8c0bb64278ed3b7ee2d2ac6484856463",
+    "stdout_hash": "9b6585b19094f60ece4e697c1b8019f438c61c2fa8010b0a0944b178",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array12-cb81afc.stdout
+++ b/tests/reference/asr-array12-cb81afc.stdout
@@ -189,9 +189,6 @@
                                             )
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 12 cpath)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-arrays_20-4b5a0e4.json
+++ b/tests/reference/asr-arrays_20-4b5a0e4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_20-4b5a0e4.stdout",
-    "stdout_hash": "b7a2f6abc57f91c1314c9fea1c8eb4930dab98eef88b2d57653446b2",
+    "stdout_hash": "fc5c8908db840fd9f8142c874f6c62be9ef2965476c979180ba39547",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_20-4b5a0e4.stdout
+++ b/tests/reference/asr-arrays_20-4b5a0e4.stdout
@@ -123,11 +123,6 @@
                             ColMajor
                         )
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 list_character)
-                        (Var 2 list_integer)
-                        (Var 2 list_logical)]
                     )]
                 )
         })

--- a/tests/reference/asr-arrays_op_4-ca3318f.json
+++ b/tests/reference/asr-arrays_op_4-ca3318f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_op_4-ca3318f.stdout",
-    "stdout_hash": "ed35a3874603746afabbc016d52e47f3306d12d9a6f521641ace9897",
+    "stdout_hash": "21da3594f88922b01a8bece20cd2d64a4e3f03a05aac86e489b1ca73",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_op_4-ca3318f.stdout
+++ b/tests/reference/asr-arrays_op_4-ca3318f.stdout
@@ -978,11 +978,6 @@
                         [((Var 2 c))
                         ((IntegerConstant 3 (Integer 4) Decimal))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 a)
-                        (Var 2 b)
-                        (Var 2 c)]
                     )]
                 )
         })

--- a/tests/reference/asr-associate_05-4641244.json
+++ b/tests/reference/asr-associate_05-4641244.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-associate_05-4641244.stdout",
-    "stdout_hash": "94bc527370e74f91dc53b74bc7025d45aadcaa66f32cb556a4d0dc35",
+    "stdout_hash": "d13a6dc70037ba7d45af73607953267c50ae656ef8704d0ab9168393",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-associate_05-4641244.stdout
+++ b/tests/reference/asr-associate_05-4641244.stdout
@@ -685,9 +685,6 @@
                             (String -1 0 () PointerString)
                             ()
                         )
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 myreal)]
                     )]
                 )
         })

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "fa15818ce5f555b7aab06704730ea4e11a2158edbd1b3af23f0aa9f2",
+    "stdout_hash": "9e28658f94b99daa0c7d69bed0acad1e83b7f56426df0ef2d511de0c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -415,9 +415,6 @@
                                             )]
                                             []
                                         )]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 8 temporary)]
                                     )]
                                     ()
                                     Private

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "e11c120932ecf6c7034736e51cdc123129bd8dbd0b999481fa3cbc7b",
+    "stdout_hash": "541571e80a8bf2e76a0415e2ed25ea4a9d62068e72f2761c17790c18",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -415,9 +415,6 @@
                                             )]
                                             []
                                         )]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 12 temporary)]
                                     )]
                                     ()
                                     Private

--- a/tests/reference/asr-derived_types_16_module-4aac273.json
+++ b/tests/reference/asr-derived_types_16_module-4aac273.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_16_module-4aac273.stdout",
-    "stdout_hash": "2e506c9f182d139949b2a5804fa7b2bcdc7e38d42ec1ef554e0d5ab1",
+    "stdout_hash": "437a68064a989f77161e840d1655c9b0a93a5475ae81c2cd092de153",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_16_module-4aac273.stdout
+++ b/tests/reference/asr-derived_types_16_module-4aac273.stdout
@@ -172,9 +172,6 @@
                             ()
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 5 settings)]
                     )]
                 ),
             fpm_command_line:

--- a/tests/reference/asr-derived_types_20-b526066.json
+++ b/tests/reference/asr-derived_types_20-b526066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_20-b526066.stdout",
-    "stdout_hash": "3158c149a340c5774c59679d00b8f3c59c24617a1586a1126c461235",
+    "stdout_hash": "b4d56b72abdf46808f5bd5028147f5ca4ecf39bbf4f5b4af7e28a6fd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_20-b526066.stdout
+++ b/tests/reference/asr-derived_types_20-b526066.stdout
@@ -562,9 +562,6 @@
                         ()
                         [((Var 2 cmd_settings))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 cmd_settings)]
                     )]
                 )
         })

--- a/tests/reference/asr-fn5-3d75eb7.json
+++ b/tests/reference/asr-fn5-3d75eb7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn5-3d75eb7.stdout",
-    "stdout_hash": "6dc640a660d185c71241f61dd3c61949feb9c267d74fc3d24c717b52",
+    "stdout_hash": "615754f3bc6404c1ede5c9209a468d19b8c25b8538924b0de97c624f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn5-3d75eb7.stdout
+++ b/tests/reference/asr-fn5-3d75eb7.stdout
@@ -665,12 +665,6 @@
                                         ()
                                         ()
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 4 keywords)
-                                        (Var 4 present_in)
-                                        (Var 4 shorts)
-                                        (Var 4 values)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-functions_16-3e10090.json
+++ b/tests/reference/asr-functions_16-3e10090.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_16-3e10090.stdout",
-    "stdout_hash": "25766efa7fb9fc7eae07a67d6603bc9ccee7963844303f7ea4bbb817",
+    "stdout_hash": "87d955d70af4dd0c5f1547ebdc20216d5d757c512aa199563de4eee1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_16-3e10090.stdout
+++ b/tests/reference/asr-functions_16-3e10090.stdout
@@ -1099,10 +1099,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 5 indexarray)
-                                        (Var 5 sorted)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.json
+++ b/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface_allocatable_array-38d4afe.stdout",
-    "stdout_hash": "343fca4cbcf2785dbc298a35ef2b2d064a6e729c79800f3013bb700a",
+    "stdout_hash": "71c875cefd2eeaac5728e1ccbda3fdf6279694e1ebb16f2b6a415a11",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.stdout
+++ b/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.stdout
@@ -266,9 +266,6 @@
                             ()
                         ))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 r_g)]
                     )]
                     ()
                     Public

--- a/tests/reference/asr-loop_unroll_large-c6b628b.json
+++ b/tests/reference/asr-loop_unroll_large-c6b628b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-loop_unroll_large-c6b628b.stdout",
-    "stdout_hash": "5b52d92c389d3ef6e7b1064e6f7f43fe3f02380380858e1d44ba9493",
+    "stdout_hash": "6b71983eec7fde44147ea04106bce4867537f1d94899346dabc4361f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-loop_unroll_large-c6b628b.stdout
+++ b/tests/reference/asr-loop_unroll_large-c6b628b.stdout
@@ -136,9 +136,6 @@
                             )
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 array)]
                     )]
                 )
         })

--- a/tests/reference/asr-matmul_01-7b0b0c2.json
+++ b/tests/reference/asr-matmul_01-7b0b0c2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matmul_01-7b0b0c2.stdout",
-    "stdout_hash": "48f9f0bd0427b6ff30b091f930e1a978212f4044aeb7bc0652956197",
+    "stdout_hash": "d57e33748efdaea2a82797d8a536018dfba99afc30121980b613e332",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matmul_01-7b0b0c2.stdout
+++ b/tests/reference/asr-matmul_01-7b0b0c2.stdout
@@ -1267,12 +1267,6 @@
                             ()
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 6 a)
-                        (Var 6 b)
-                        (Var 6 c)
-                        (Var 6 c2)]
                     )]
                 ),
             matmul_01_cpu:

--- a/tests/reference/asr-modules_28-9506bba.json
+++ b/tests/reference/asr-modules_28-9506bba.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_28-9506bba.stdout",
-    "stdout_hash": "86524b9b92ccd1ffcebf37276793e6bcda03ff9ecfabe0520db39636",
+    "stdout_hash": "2c986aec09764b01bda926c80835a2befee245ee9ea684c92e391e32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_28-9506bba.stdout
+++ b/tests/reference/asr-modules_28-9506bba.stdout
@@ -603,10 +603,6 @@
                                             ()
                                         )
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 9 obj)
-                                        (Var 9 url)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_29-dc71c55.json
+++ b/tests/reference/asr-modules_29-dc71c55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_29-dc71c55.stdout",
-    "stdout_hash": "317dc33f5fc82d4e20bb332945530d6d3f385406e428953affde337a",
+    "stdout_hash": "5478182cc561249939ec08ee2b841cda5cbd1d846e67005829f5668f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_29-dc71c55.stdout
+++ b/tests/reference/asr-modules_29-dc71c55.stdout
@@ -603,10 +603,6 @@
                                             ()
                                         )
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 13 obj)
-                                        (Var 13 url)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_31-cd9bfef.json
+++ b/tests/reference/asr-modules_31-cd9bfef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_31-cd9bfef.stdout",
-    "stdout_hash": "014c9e65313fcb871fc098f7aa550796a76f66827d7fee97c1be2615",
+    "stdout_hash": "9022a0763956a2bbf1b027664092bd9d54dee3f4d7cb85ff3d5a270e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_31-cd9bfef.stdout
+++ b/tests/reference/asr-modules_31-cd9bfef.stdout
@@ -209,9 +209,6 @@
                                         ))
                                         ((Var 7 error))]
                                         (Var 7 deps)
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 7 error)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_34-f98f7e3.json
+++ b/tests/reference/asr-modules_34-f98f7e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_34-f98f7e3.stdout",
-    "stdout_hash": "84a9b0b4ed09045b1d971c86e1d498a338616f041768ae70d18cbc4b",
+    "stdout_hash": "0127290f13b93614915b90e60ce20dc82044511e69ad3b60aef48280",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_34-f98f7e3.stdout
+++ b/tests/reference/asr-modules_34-f98f7e3.stdout
@@ -295,9 +295,6 @@
                                     [(Var 5 package)]
                                     [(AssociateBlockCall
                                         5 associate_block
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 5 version)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_35-5fba3e7.json
+++ b/tests/reference/asr-modules_35-5fba3e7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_35-5fba3e7.stdout",
-    "stdout_hash": "d5dc41c91dcbf10c547f9a1bea9f0806438cbd96ef19a87881715039",
+    "stdout_hash": "7ecd6e31e9d52816047b8c0af345e72df1f6ead0713c49c18cdefd0c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_35-5fba3e7.stdout
+++ b/tests/reference/asr-modules_35-5fba3e7.stdout
@@ -208,9 +208,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 strings_a)]
                                     )]
                                     ()
                                     Public
@@ -286,9 +283,6 @@
                         ()
                         [((Var 4 string))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 4 string)]
                     )]
                 )
         })

--- a/tests/reference/asr-modules_37-7eba027.json
+++ b/tests/reference/asr-modules_37-7eba027.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_37-7eba027.stdout",
-    "stdout_hash": "8b9a0448e9dc6f7a05bfe38de9988ed83350797b958340e9f9b3a984",
+    "stdout_hash": "d3ad0ff25893df5ca47127f85e15382ae99ec669d698342702219bfd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_37-7eba027.stdout
+++ b/tests/reference/asr-modules_37-7eba027.stdout
@@ -337,9 +337,6 @@
                                             9 associate_block
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 9 build_dirs)]
                                     )]
                                     ()
                                     Public
@@ -539,9 +536,6 @@
                                             ()
                                         ))]
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 10 targets)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_43-d01691f.json
+++ b/tests/reference/asr-modules_43-d01691f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_43-d01691f.stdout",
-    "stdout_hash": "cf72aba20df66ddc41fd4e217d09aaf93c85a5be819c9b98c22482f6",
+    "stdout_hash": "ee92f7db8daa1161261b08d8c9540c323c49de86cfc872c6352cd727",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_43-d01691f.stdout
+++ b/tests/reference/asr-modules_43-d01691f.stdout
@@ -70,9 +70,6 @@
                         ()
                         [((Var 5 sources))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 5 sources)]
                     )]
                 ),
             modules_43_fpm_sources:
@@ -358,9 +355,6 @@
                                             )
                                             ()
                                         )]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 4 dir_sources)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_44-ec0baa3.json
+++ b/tests/reference/asr-modules_44-ec0baa3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_44-ec0baa3.stdout",
-    "stdout_hash": "51c0ac2859f3dd8f10d7a97640620fb079ac84911b6eaddbad703695",
+    "stdout_hash": "69a7ff590bfc8153b6200edc3433be3e34328937c0ce3d30ce8dda32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_44-ec0baa3.stdout
+++ b/tests/reference/asr-modules_44-ec0baa3.stdout
@@ -192,9 +192,6 @@
                                         ))
                                         ((Var 8 littlefile))]
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 8 littlefile)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_45-c69c75f.json
+++ b/tests/reference/asr-modules_45-c69c75f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_45-c69c75f.stdout",
-    "stdout_hash": "a64af1b040fbe1d636edad68ef85f12463755cb4c9b80c286ef61590",
+    "stdout_hash": "c2d4090ae494196e5904ff9619159c927affd1f1a61c3cba7b787b46",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_45-c69c75f.stdout
+++ b/tests/reference/asr-modules_45-c69c75f.stdout
@@ -197,11 +197,6 @@
                         ((Var 7 profindex))
                         ((Var 7 os_valid))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 7 compiler_name)
-                        (Var 7 profile_name)
-                        (Var 7 profiles)]
                     )]
                 ),
             modules_45_fpm_manifest_profile:
@@ -705,17 +700,6 @@
                                             ()
                                         )
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 6 c_flags)
-                                        (Var 6 cxx_flags)
-                                        (Var 6 err_message)
-                                        (Var 6 file_flags)
-                                        (Var 6 file_name)
-                                        (Var 6 file_scope_flags)
-                                        (Var 6 flags)
-                                        (Var 6 key_name)
-                                        (Var 6 link_time_flags)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "e3955fd32ea2b55bb2eabda5fef897319952ea78f351ba655640f53f",
+    "stdout_hash": "87abd3a82d0d0e948bf884fd1047982e9c98c19c3da0d01b0be12d73",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -658,10 +658,6 @@
                             ()
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 8 cat_str_alloc)
-                        (Var 8 char_str_alloc)]
                     )]
                 ),
             modules_48_fpm_strings:
@@ -1417,9 +1413,6 @@
                                             )
                                             ()
                                         )]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 6 name)]
                                     )]
                                     (Var 6 lout)
                                     Public
@@ -1730,9 +1723,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 7 delim_str)]
                                     )]
                                     (Var 7 cat)
                                     Public

--- a/tests/reference/asr-modules_50-31fb049.json
+++ b/tests/reference/asr-modules_50-31fb049.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_50-31fb049.stdout",
-    "stdout_hash": "c2848e808ec44f96ef914328e6a0a7d865d83a200b80ed5b7fc72685",
+    "stdout_hash": "2178d5d2608ece908bd116ad7d7e4038fb4b8adf092a5b3a3d25c6fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_50-31fb049.stdout
+++ b/tests/reference/asr-modules_50-31fb049.stdout
@@ -328,9 +328,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 5 modules_used)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-modules_52-5261d38.json
+++ b/tests/reference/asr-modules_52-5261d38.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_52-5261d38.stdout",
-    "stdout_hash": "bc8effd42aae98a2f2918e8459e0e0602a5eed1d19a4a339901c9d09",
+    "stdout_hash": "9f1ba31c83677df956a722108b17347b66f8ae89437e63bf9f81f0ec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_52-5261d38.stdout
+++ b/tests/reference/asr-modules_52-5261d38.stdout
@@ -153,9 +153,6 @@
                                         ((Var 3 input))
                                         (())]
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 table)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-string2-3425046.json
+++ b/tests/reference/asr-string2-3425046.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-3425046.stdout",
-    "stdout_hash": "cdd800ea4891f07f2e9795afa19780a037ad951dbd94a342b2ca9d18",
+    "stdout_hash": "30843096c52137922fc33da17a3c68cb4bb3b0eceb01808f07b43b83",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-3425046.stdout
+++ b/tests/reference/asr-string2-3425046.stdout
@@ -282,9 +282,6 @@
                                             )]
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 18 string_fortran)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/asr-string_04-2ebc0e6.json
+++ b/tests/reference/asr-string_04-2ebc0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_04-2ebc0e6.stdout",
-    "stdout_hash": "413587783e8c4e4f68fa3b46cbd29ca37de51fa0e67eef74a2a62e7d",
+    "stdout_hash": "196d11563fc34ae47b372232d27088b9e28f3df9827d8e4f8d6e8489",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_04-2ebc0e6.stdout
+++ b/tests/reference/asr-string_04-2ebc0e6.stdout
@@ -332,11 +332,6 @@
                             ()
                         )]
                         []
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 greetings)
-                        (Var 2 str)
-                        (Var 2 user_data)]
                     )]
                 )
         })

--- a/tests/reference/asr-string_14-861794e.json
+++ b/tests/reference/asr-string_14-861794e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_14-861794e.stdout",
-    "stdout_hash": "9bb868faf9a05c93764eb77bcb4135b4c3bdcfa99a91f83c651e1446",
+    "stdout_hash": "5d4b2b791cf40390bd69cc2cc4e58fc4f5898addead85495014b89fd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_14-861794e.stdout
+++ b/tests/reference/asr-string_14-861794e.stdout
@@ -179,9 +179,7 @@
                                     (Var 5 v_list)
                                     (Var 5 iostat)
                                     (Var 5 iomsg)]
-                                    [(ImplicitDeallocate
-                                        [(Var 5 line)]
-                                    )]
+                                    []
                                     ()
                                     Private
                                     .false.

--- a/tests/reference/asr-template_02-021cc51.json
+++ b/tests/reference/asr-template_02-021cc51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_02-021cc51.stdout",
-    "stdout_hash": "8d23db88789ca4507c5f5aecad3e23afb9bab0bf3dbf84022ba1fc3e",
+    "stdout_hash": "926e00ed9deb04daa96d637ad198a43d89baddbe72d0f267ef99dbcf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_02-021cc51.stdout
+++ b/tests/reference/asr-template_02-021cc51.stdout
@@ -338,9 +338,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 12 pos)]
                                     )]
                                     (Var 12 mask)
                                     Public
@@ -679,9 +676,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 10 pos)]
                                     )]
                                     (Var 10 mask)
                                     Public
@@ -1338,9 +1332,6 @@
                                                             ()
                                                         )]
                                                         []
-                                                    )
-                                                    (ImplicitDeallocate
-                                                        [(Var 7 pos)]
                                                     )]
                                                     (Var 7 mask)
                                                     Public

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "5f80b60921a04dd47327f3d31d526eb865a3e3d9d8e9ef8d1b2a999d",
+    "stdout_hash": "65d4282a7bc31bfa112b468327fb990fa577fa6998f249866231b1d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -518,9 +518,6 @@
                                                         )
                                                         (Var 10 tmp)
                                                         ()
-                                                    )
-                                                    (ImplicitDeallocate
-                                                        [(Var 10 tmp)]
                                                     )]
                                                     ()
                                                     Private
@@ -1180,9 +1177,6 @@
                                                         )
                                                         (Var 6 tmp)
                                                         ()
-                                                    )
-                                                    (ImplicitDeallocate
-                                                        [(Var 6 tmp)]
                                                     )]
                                                     ()
                                                     Private

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "0aa8b287342c853de9047e4d736987ff7affb29b843be1958e341c9a",
+    "stdout_hash": "1a168dfb939e76b287b131f3bb42fd0dee9b7678d65f3e0cdb3b52ea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -288,32 +288,9 @@ else13:                                           ; preds = %ifcont11
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
-  %167 = load %array*, %array** %c, align 8
-  %168 = getelementptr %array, %array* %167, i32 0, i32 0
-  %169 = load i32*, i32** %168, align 8
-  %170 = ptrtoint i32* %169 to i64
-  %171 = icmp ne i64 %170, 0
-  br i1 %171, label %then15, label %else16
-
-then15:                                           ; preds = %ifcont14
-  %172 = getelementptr %array, %array* %167, i32 0, i32 0
-  %173 = load i32*, i32** %172, align 8
-  %174 = alloca i8*, align 8
-  %175 = bitcast i32* %173 to i8*
-  store i8* %175, i8** %174, align 8
-  %176 = load i8*, i8** %174, align 8
-  call void @_lfortran_free(i8* %176)
-  %177 = getelementptr %array, %array* %167, i32 0, i32 0
-  store i32* null, i32** %177, align 8
-  br label %ifcont17
-
-else16:                                           ; preds = %ifcont14
-  br label %ifcont17
-
-ifcont17:                                         ; preds = %else16, %then15
   br label %return
 
-return:                                           ; preds = %ifcont17
+return:                                           ; preds = %ifcont14
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "bd2e0d734b39464f7c385eee8c9f9c893093dcf8d048559f2062a232",
+    "stdout_hash": "757212bc390102a9118ed16c7c593ea926c3c0738d91c9fc829c74a4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -1592,78 +1592,9 @@ else75:                                           ; preds = %ifcont73
   br label %ifcont76
 
 ifcont76:                                         ; preds = %else75, %then74
-  %1177 = load %array*, %array** %a, align 8
-  %1178 = getelementptr %array, %array* %1177, i32 0, i32 0
-  %1179 = load i1*, i1** %1178, align 8
-  %1180 = ptrtoint i1* %1179 to i64
-  %1181 = icmp ne i64 %1180, 0
-  br i1 %1181, label %then77, label %else78
-
-then77:                                           ; preds = %ifcont76
-  %1182 = getelementptr %array, %array* %1177, i32 0, i32 0
-  %1183 = load i1*, i1** %1182, align 8
-  %1184 = alloca i8*, align 8
-  %1185 = bitcast i1* %1183 to i8*
-  store i8* %1185, i8** %1184, align 8
-  %1186 = load i8*, i8** %1184, align 8
-  call void @_lfortran_free(i8* %1186)
-  %1187 = getelementptr %array, %array* %1177, i32 0, i32 0
-  store i1* null, i1** %1187, align 8
-  br label %ifcont79
-
-else78:                                           ; preds = %ifcont76
-  br label %ifcont79
-
-ifcont79:                                         ; preds = %else78, %then77
-  %1188 = load %array*, %array** %b, align 8
-  %1189 = getelementptr %array, %array* %1188, i32 0, i32 0
-  %1190 = load i1*, i1** %1189, align 8
-  %1191 = ptrtoint i1* %1190 to i64
-  %1192 = icmp ne i64 %1191, 0
-  br i1 %1192, label %then80, label %else81
-
-then80:                                           ; preds = %ifcont79
-  %1193 = getelementptr %array, %array* %1188, i32 0, i32 0
-  %1194 = load i1*, i1** %1193, align 8
-  %1195 = alloca i8*, align 8
-  %1196 = bitcast i1* %1194 to i8*
-  store i8* %1196, i8** %1195, align 8
-  %1197 = load i8*, i8** %1195, align 8
-  call void @_lfortran_free(i8* %1197)
-  %1198 = getelementptr %array, %array* %1188, i32 0, i32 0
-  store i1* null, i1** %1198, align 8
-  br label %ifcont82
-
-else81:                                           ; preds = %ifcont79
-  br label %ifcont82
-
-ifcont82:                                         ; preds = %else81, %then80
-  %1199 = load %array*, %array** %c, align 8
-  %1200 = getelementptr %array, %array* %1199, i32 0, i32 0
-  %1201 = load i1*, i1** %1200, align 8
-  %1202 = ptrtoint i1* %1201 to i64
-  %1203 = icmp ne i64 %1202, 0
-  br i1 %1203, label %then83, label %else84
-
-then83:                                           ; preds = %ifcont82
-  %1204 = getelementptr %array, %array* %1199, i32 0, i32 0
-  %1205 = load i1*, i1** %1204, align 8
-  %1206 = alloca i8*, align 8
-  %1207 = bitcast i1* %1205 to i8*
-  store i8* %1207, i8** %1206, align 8
-  %1208 = load i8*, i8** %1206, align 8
-  call void @_lfortran_free(i8* %1208)
-  %1209 = getelementptr %array, %array* %1199, i32 0, i32 0
-  store i1* null, i1** %1209, align 8
-  br label %ifcont85
-
-else84:                                           ; preds = %ifcont82
-  br label %ifcont85
-
-ifcont85:                                         ; preds = %else84, %then83
   br label %return
 
-return:                                           ; preds = %ifcont85
+return:                                           ; preds = %ifcont76
   ret i32 0
 }
 

--- a/tests/reference/pass_array_op-modules_43-6930881.json
+++ b/tests/reference/pass_array_op-modules_43-6930881.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_array_op-modules_43-6930881.stdout",
-    "stdout_hash": "041c64c936356f03dfc29155ad852908750120d9f5f92caab68fc247",
+    "stdout_hash": "47d8ca2e47efb522d0ea2232c209a5162453f4af80cc111eb36dd6d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_array_op-modules_43-6930881.stdout
+++ b/tests/reference/pass_array_op-modules_43-6930881.stdout
@@ -70,9 +70,6 @@
                         ()
                         [((Var 5 sources))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 5 sources)]
                     )]
                 ),
             modules_43_fpm_sources:
@@ -469,9 +466,6 @@
                                             )
                                             ()
                                         )]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 4 dir_sources)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/pass_class_constructor-derived_types_20-740d6ce.json
+++ b/tests/reference/pass_class_constructor-derived_types_20-740d6ce.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-derived_types_20-740d6ce.stdout",
-    "stdout_hash": "8df12778a52a5c5b6da9c0265f070f9e84e4d9d13db6b518657f47f1",
+    "stdout_hash": "0a56bd410b602695fcc6d50d5360b9cd03acf1e3b5e7965eca8aa10a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-derived_types_20-740d6ce.stdout
+++ b/tests/reference/pass_class_constructor-derived_types_20-740d6ce.stdout
@@ -683,9 +683,6 @@
                         ()
                         [((Var 2 cmd_settings))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 cmd_settings)]
                     )]
                 )
         })

--- a/tests/reference/pass_implied_do_loops-modules_35-c089638.json
+++ b/tests/reference/pass_implied_do_loops-modules_35-c089638.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_implied_do_loops-modules_35-c089638.stdout",
-    "stdout_hash": "7ca45dd296fde1e60fd4ecfe826447427df39e5c3f33cac466abd865",
+    "stdout_hash": "64c79b5e0c29b352604150c51db0f1ad1aca38538e35bc763a75b6c2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_implied_do_loops-modules_35-c089638.stdout
+++ b/tests/reference/pass_implied_do_loops-modules_35-c089638.stdout
@@ -250,9 +250,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 strings_a)]
                                     )]
                                     ()
                                     Public
@@ -328,9 +325,6 @@
                         ()
                         [((Var 4 string))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 4 string)]
                     )]
                 )
         })

--- a/tests/reference/pass_loop_unroll-loop_unroll_large-8723774.json
+++ b/tests/reference/pass_loop_unroll-loop_unroll_large-8723774.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_unroll-loop_unroll_large-8723774.stdout",
-    "stdout_hash": "7dedf1a2121f29e810ad7c9ada48822e21c6a2dd5e62abced26590dc",
+    "stdout_hash": "01b388c5e958740368439386f192d5d4703ad29e25745f6ce9a9c703",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_unroll-loop_unroll_large-8723774.stdout
+++ b/tests/reference/pass_loop_unroll-loop_unroll_large-8723774.stdout
@@ -1966,9 +1966,6 @@
                             (String -1 0 () PointerString)
                             ()
                         )
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 array)]
                     )]
                 )
         })

--- a/tests/reference/pass_nested_vars_implied_do_loops-modules_50-b1d05ce.json
+++ b/tests/reference/pass_nested_vars_implied_do_loops-modules_50-b1d05ce.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_nested_vars_implied_do_loops-modules_50-b1d05ce.stdout",
-    "stdout_hash": "025b4de57b4c4a19a2abe77c05b33fa885c06f565ed715dbfa356e9b",
+    "stdout_hash": "364385ae1f2b20c2b1c2e7a89fced6339c37e4999a5dacf7cb847a4c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_nested_vars_implied_do_loops-modules_50-b1d05ce.stdout
+++ b/tests/reference/pass_nested_vars_implied_do_loops-modules_50-b1d05ce.stdout
@@ -530,9 +530,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 5 modules_used)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/pass_pass_array_by_data-modules_44-cd82150.json
+++ b/tests/reference/pass_pass_array_by_data-modules_44-cd82150.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data-modules_44-cd82150.stdout",
-    "stdout_hash": "5cc3009964fcb5e9c402c419908548b7f340077382ab66738988f506",
+    "stdout_hash": "53ca13d85cb90b59b05d3b209dea1e30be9cf4385f92297ddaca6640",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data-modules_44-cd82150.stdout
+++ b/tests/reference/pass_pass_array_by_data-modules_44-cd82150.stdout
@@ -208,9 +208,6 @@
                                             ()
                                         ))]
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 8 littlefile)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout",
-    "stdout_hash": "abaedc15c263035caddc690a3903cc83762e225d27b13f2bfac945ac",
+    "stdout_hash": "2c7b377ea9ba0ee320160e529e4ad0e8dda1d3fd99db5cd82918683c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
@@ -382,9 +382,6 @@
                                             13 associate_block
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 13 build_dirs)]
                                     )]
                                     ()
                                     Public
@@ -612,9 +609,6 @@
                                             ()
                                         ))]
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 10 targets)]
                                     )]
                                     ()
                                     Public

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout",
-    "stdout_hash": "63c5c2f749bd95a39e21c0ef4b7e7ee8fad25549c03ad847dcb26da5",
+    "stdout_hash": "79e9757cc92334a97acb513eeed11ab4af6237eee9dd516ffd864600",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
@@ -197,11 +197,6 @@
                         ((Var 7 profindex))
                         ((Var 7 os_valid))]
                         ()
-                    )
-                    (ImplicitDeallocate
-                        [(Var 7 compiler_name)
-                        (Var 7 profile_name)
-                        (Var 7 profiles)]
                     )]
                 ),
             modules_45_fpm_manifest_profile:
@@ -837,17 +832,6 @@
                                             ()
                                         )
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 6 c_flags)
-                                        (Var 6 cxx_flags)
-                                        (Var 6 err_message)
-                                        (Var 6 file_flags)
-                                        (Var 6 file_name)
-                                        (Var 6 file_scope_flags)
-                                        (Var 6 flags)
-                                        (Var 6 key_name)
-                                        (Var 6 link_time_flags)]
                                     )]
                                     ()
                                     Public


### PR DESCRIPTION
Cleanup as part of #3770. Fixes #2763.

We handle this explicitly in the `insert_deallocate` pass, so this is not required here.