### PR TITLE
Fix: Handling maxval array function with comparision operator

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1561,6 +1561,7 @@ RUN(NAME array_op_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArra
 RUN(NAME array_op_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_op_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_op_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NOFAST)
+RUN(NAME array_op_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_slice_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray c)
 RUN(NAME array_slice_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_slice_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray c)

--- a/integration_tests/array_op_07.f90
+++ b/integration_tests/array_op_07.f90
@@ -1,0 +1,9 @@
+program array_op_7
+integer :: A(2) = [2,2]
+logical :: B(2)
+integer :: i
+B = abs(A) > maxval(abs(A))
+do i = 1, 2
+    if (B(i) .neqv. .false.) error stop
+end do
+end program 


### PR DESCRIPTION
Fix :- #5285
Earlier , we were not visiting arguments of Array Function which can be an IntrinsicElementalFunction and thus , this PR tries to incorporate this thing in array_op.