### PR TITLE
Fix a bug in fixed-form tokenizer for assignments

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -483,6 +483,17 @@ struct FixedFormRecursiveDescent {
         return false;
     }
 
+    bool contains2(unsigned char *start, unsigned char *end, const char ch[2]) {
+        unsigned char *cur = start;
+        while (*cur != '\0' && cur < end) {
+            if (*cur == ch[0] && *(cur+1) == ch[1]) {
+                return true;
+            }
+            cur++;
+        }
+        return false;
+    }
+
     std::string tostr(unsigned char *start, unsigned char *end) {
         return std::string((char *)start, end-start);
     }
@@ -793,6 +804,12 @@ struct FixedFormRecursiveDescent {
     bool lex_declaration(unsigned char *&cur) {
         unsigned char *start = cur;
         next_line(cur);
+        // TODO: this is fragile
+        if (contains(start, cur, '=') && !contains2(start, cur, "::")) {
+            // This must be an assignment
+            cur = start;
+            return false;
+        }
         if (lex_declarator(start)) {
             tokenize_line(start);
             return true;

--- a/tests/reference/ast-fixed_form3-1e78b3b.json
+++ b/tests/reference/ast-fixed_form3-1e78b3b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form3-1e78b3b.stdout",
-    "stdout_hash": "2736f8ce5937a2e9adaf9d7febabd5deb1639ee078e61734bf2b4175",
+    "stdout_hash": "65c3bbc021c20afde386d4f160263645f0c62e5476649fd2548cac44",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form3-1e78b3b.stdout
+++ b/tests/reference/ast-fixed_form3-1e78b3b.stdout
@@ -151,46 +151,22 @@
             None
             ())]
             ()
-        )
-        (Declaration
-            (AttrType
-                TypeInteger
-                []
-                ()
-                ()
-                None
-            )
-            []
-            [(x
-            []
-            []
-            ()
-            5
-            Equal
-            ())]
-            ()
-        )
-        (Declaration
-            (AttrType
-                TypeInteger
-                []
-                ()
-                ()
-                None
-            )
-            []
-            [(x
-            []
-            []
-            ()
-            5
-            Equal
-            ())]
-            ()
         )]
         [(Assignment
             0
+            integerx
+            5
+            ()
+        )
+        (Assignment
+            0
             x
+            5
+            ()
+        )
+        (Assignment
+            0
+            integerx
             5
             ()
         )]
@@ -248,28 +224,16 @@
             Equal
             ())]
             ()
-        )
-        (Declaration
-            (AttrType
-                TypeInteger
-                []
-                ()
-                ()
-                None
-            )
-            []
-            [(x
-            []
-            []
-            ()
-            5
-            Equal
-            ())]
-            ()
         )]
         [(Assignment
             0
             x
+            5
+            ()
+        )
+        (Assignment
+            0
+            integerx
             5
             ()
         )]


### PR DESCRIPTION
When we have `integerx = 5`, it must be parsed as an assignment, not a declaration, so the first token must be `integerx`, not `integer`.

Tests updated.