### PR TITLE
Rework the declaration parsing

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -4,8 +4,8 @@
 %param {LCompilers::LFortran::Parser &p}
 %locations
 %glr-parser
-%expect    210 // shift/reduce conflicts
-%expect-rr 193 // reduce/reduce conflicts
+%expect    228 // shift/reduce conflicts
+%expect-rr 175 // reduce/reduce conflicts
 
 // Uncomment this to get verbose error messages
 //%define parse.error verbose
@@ -1318,8 +1318,12 @@ var_decl_star
     ;
 
 var_decl
-    : var_type var_modifiers var_sym_decl_list sep {
-        LLOC(@$, @3); $$ = VAR_DECL1($1, $2, $3, TRIVIA_AFTER($4, @$), @$); }
+    : var_type var_modifier_list "::" var_sym_decl_list sep {
+        LLOC(@$, @4); $$ = VAR_DECL1a($1, $2, $4, TRIVIA_AFTER($5, @$), @$); }
+    | var_type "::" var_sym_decl_list sep {
+        LLOC(@$, @3); $$ = VAR_DECL1b($1, $3, TRIVIA_AFTER($4, @$), @$); }
+    | var_type var_sym_decl_list sep {
+        LLOC(@$, @2); $$ = VAR_DECL1c($1, $2, TRIVIA_AFTER($3, @$), @$); }
     | var_modifier sep {
         LLOC(@$, @1); $$ = VAR_DECL2($1, TRIVIA_AFTER($2, @$), @$); }
     | var_modifier var_sym_decl_list sep {

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -302,12 +302,35 @@ static inline ast_t* VAR_DECL_PRAGMA2(Allocator &al, Location &loc,
             import_modifierType::Import##x, \
             trivia_cast(trivia))
 
-
-#define VAR_DECL1(vartype, xattr, varsym, trivia, l) \
+ #define VAR_DECL1a(vartype, xattr, varsym, trivia, l) \
         make_Declaration_t(p.m_a, l, \
         down_cast<decl_attribute_t>(vartype), \
         VEC_CAST(xattr, decl_attribute), xattr.n, \
         varsym.p, varsym.n, trivia_cast(trivia))
+
+ #define VAR_DECL1b(vartype,  varsym, trivia, l) \
+        make_Declaration_t(p.m_a, l, \
+        down_cast<decl_attribute_t>(vartype), \
+        nullptr, 0, \
+        varsym.p, varsym.n, trivia_cast(trivia))
+
+ast_t* fn_VAR_DECL1c(Allocator &al,
+    ast_t *vartype, const Vec<var_sym_t> &varsym, ast_t *trivia,
+            Location l) {
+    for (size_t i=0; i<varsym.size(); i++) {
+        if (varsym[i].m_sym == symbolType::Equal) {
+            throw LCompilers::LFortran::parser_local::ParserError(
+                "Invalid syntax for variable initialization (try inserting '::' after the type)", l);
+        }
+    }
+    return make_Declaration_t(al, l,
+        down_cast<decl_attribute_t>(vartype),
+        nullptr, 0,
+        varsym.p, varsym.n, trivia_cast(trivia));
+}
+
+#define VAR_DECL1c(vartype, varsym, trivia, l) \
+    fn_VAR_DECL1c(p.m_a, vartype, varsym, trivia, l)
 
 decl_attribute_t** VAR_DECL2b(Allocator &al,
             ast_t *xattr0) {

--- a/tests/errors/init1.f90
+++ b/tests/errors/init1.f90
@@ -1,0 +1,3 @@
+program init1
+integer x = 1
+end

--- a/tests/reference/ast-init1-a99a704.json
+++ b/tests/reference/ast-init1-a99a704.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-init1-a99a704",
+    "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/init1.f90",
+    "infile_hash": "9ec670cb5b8c7f2baae3997ae0911acdd19199100666c44da310ff4f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-init1-a99a704.stderr",
+    "stderr_hash": "201d19c7bf14660170792288e575568c171f968dfe1987869b73324b",
+    "returncode": 2
+}

--- a/tests/reference/ast-init1-a99a704.stderr
+++ b/tests/reference/ast-init1-a99a704.stderr
@@ -1,0 +1,5 @@
+syntax error: Invalid syntax for variable initialization (try inserting '::' after the type)
+ --> tests/errors/init1.f90:2:1
+  |
+2 | integer x = 1
+  | ^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4346,3 +4346,7 @@ asr = true
 [[test]]
 filename = "errors/data_implied_do3.f90"
 asr = true
+
+[[test]]
+filename = "errors/init1.f90"
+ast = true


### PR DESCRIPTION
The parser conflict changes are non-essential.

Add an error test for "integer x = 1".

Depends on #5362, must be merged first.

Fixes #3945.