### PR TITLE
enh: reordered checking of arg type in `make_ArraySize_util`

### DIFF
--- a/integration_tests/arrays_57.f90
+++ b/integration_tests/arrays_57.f90
@@ -4,12 +4,21 @@ real :: A(2,2) = reshape([1.0,2.0,3.0,4.0], [2,2])
 call trans(A)
 print *, A
 if ( any(abs( A - 12.91 ) > 1e-6) ) error stop 
+call trans_2(A)
+print *, A
+if ( any(abs( A - 12.91 ) > 1e-6) ) error stop  
 
 contains
 
 subroutine trans(A)
 real, intent(inout) :: A(2, 2)
 A = matprod(transpose(A))
+end subroutine
+
+subroutine trans_2(A)
+real, intent(inout) :: A(2, 2)
+integer, parameter :: x = 2
+A = matprod(abs(A(1:x,:)))
 end subroutine
 
 function matprod(x) result(k)


### PR DESCRIPTION
Fixes #5334 
Here I haven't changed logic, just reordered checking of arg type as it may be case like `func(abs(A(:,1:2))` where ArraySection is detected after `IntrinsicElementFunction` check.