### PR TITLE
Initalize save variables in program for arrays and complex

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1621,6 +1621,8 @@ RUN(NAME save_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME save_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME save_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME save_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME save_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME save_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME entry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/save_10.f90
+++ b/integration_tests/save_10.f90
@@ -1,0 +1,14 @@
+subroutine foo_save_10(reference)
+    integer, intent(in) :: reference(2)
+    integer, save :: calls(2) = [1, 1]
+    calls = calls + 1
+    print *, 'FOO: ', calls, reference
+    if (all(calls /= reference)) error stop
+end subroutine foo_save_10
+    
+program save_10
+    integer i
+    do i=2,4
+        call foo_save_10([i,i])
+    end do
+end program save_10

--- a/integration_tests/save_11.f90
+++ b/integration_tests/save_11.f90
@@ -1,0 +1,16 @@
+subroutine foo_save_11(reference)
+    integer , intent(in) :: reference 
+    integer, save , dimension(2) :: arr = [1,1]
+    complex :: c  = (1,1) 
+        arr = arr + 1 
+        c = c + (1, 1)
+    print *, arr
+    if(any(arr /= reference)) error stop
+    print *, c
+    if(c /= complex(reference, reference)) error stop
+
+end subroutine foo_save_11
+program save_11
+    call foo_save_11(2)
+    call foo_save_11(3)
+end program save_11

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3635,7 +3635,16 @@ public:
                 strings_to_be_deallocated.push_back(al, llvm_utils->CreateLoad2(v->m_type, target_var));
             }
         } else {
-            builder->CreateStore(init_value, target_var);
+            if (v->m_storage == ASR::storage_typeType::Save
+                && v->m_value
+                && (ASR::is_a<ASR::Integer_t>(*v->m_type)
+                || ASR::is_a<ASR::Real_t>(*v->m_type)
+                || ASR::is_a<ASR::Logical_t>(*v->m_type))) {
+                // Do nothing, the value is already initialized
+                // in the global variable
+            } else {
+                builder->CreateStore(init_value, target_var);
+            }
         }
     }
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -216,6 +216,11 @@ public:
         size_t n_dims;
     };
     std::vector<to_be_allocated_array> allocatable_array_details;
+    struct variable_inital_value { /* Saves information for variables that need to be initialized once. To be initialized in `program`*/
+        ASR::Variable_t* v;  
+        llvm::Value* target_var; // Corresponds to variable `v` in llvm IR.
+    };
+    std::vector<variable_inital_value> variable_inital_value_vec; /* Saves information for variables that need to be initialized once. To be initialized in `program`*/
     ASRToLLVMVisitor(Allocator &al, llvm::LLVMContext &context, std::string infile,
         CompilerOptions &compiler_options_, diag::Diagnostics &diagnostics) :
     diag{diagnostics},
@@ -3275,6 +3280,9 @@ public:
                 true, true, false, array.var_type);
         }
         declare_vars(x);
+        for(variable_inital_value var_to_initalize : variable_inital_value_vec){
+            set_VariableInital_value(var_to_initalize.v, var_to_initalize.target_var);
+        }
         for(auto &value: strings_to_be_allocated) {
             llvm::Value *init_value = LLVM::lfortran_malloc(context, *module,
                 *builder, value.second);
@@ -3585,6 +3593,51 @@ public:
         }
         collect_class_type_names_and_struct_types(class_type_names, struct_types, x_symtab->parent);
     }
+    void set_VariableInital_value(ASR::Variable_t* v, llvm::Value* target_var){
+        if (v->m_value != nullptr) {
+            this->visit_expr_wrapper(v->m_value, true);
+        } else {
+            this->visit_expr_wrapper(v->m_symbolic_value, true);
+        }
+        llvm::Value *init_value = tmp;
+        if( ASRUtils::is_array(v->m_type) &&
+            ASRUtils::is_array(ASRUtils::expr_type(v->m_symbolic_value)) &&
+            (ASR::is_a<ASR::ArrayConstant_t>(*v->m_symbolic_value) ||
+            (v->m_value && ASR::is_a<ASR::ArrayConstant_t>(*v->m_value)))) {
+            ASR::array_physical_typeType target_ptype = ASRUtils::extract_physical_type(v->m_type);
+            if( target_ptype == ASR::array_physical_typeType::DescriptorArray ) {
+                target_var = arr_descr->get_pointer_to_data(target_var);
+                builder->CreateStore(init_value, target_var);
+            } else if( target_ptype == ASR::array_physical_typeType::FixedSizeArray ) {
+                llvm::Value* arg_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
+                llvm::APInt(32, ASRUtils::get_fixed_size_of_array(ASR::down_cast<ASR::ArrayConstant_t>(v->m_value)->m_type)));
+                llvm::Type* llvm_data_type = llvm_utils->get_type_from_ttype_t_util(
+                    ASRUtils::type_get_past_array(ASRUtils::expr_type(v->m_value)), module.get());
+                llvm::DataLayout data_layout(module.get());
+                size_t dt_size = data_layout.getTypeAllocSize(llvm_data_type);
+                arg_size = builder->CreateMul(llvm::ConstantInt::get(
+                    llvm::Type::getInt32Ty(context), llvm::APInt(32, dt_size)), arg_size);
+                builder->CreateMemCpy(llvm_utils->create_gep(target_var, 0),
+                    llvm::MaybeAlign(), init_value, llvm::MaybeAlign(), arg_size);
+            }
+        } else if (ASR::is_a<ASR::ArrayReshape_t>(*v->m_symbolic_value)) {
+            builder->CreateStore(llvm_utils->CreateLoad(init_value), target_var);
+        } else if (is_a<ASR::String_t>(*v->m_type)) {
+            ASR::String_t *t = down_cast<ASR::String_t>(v->m_type);
+            llvm::Value *arg_size = llvm::ConstantInt::get(context,
+                        llvm::APInt(32, t->m_len+1));
+            llvm::Value *s_malloc = LLVM::lfortran_malloc(context, *module, *builder, arg_size);
+            string_init(context, *module, *builder, arg_size, s_malloc);
+            builder->CreateStore(s_malloc, target_var);
+            // target decides if the str_copy is performed on string descriptor or pointer.
+            tmp = lfortran_str_copy(target_var, init_value, ASRUtils::is_descriptorString(v->m_type)); 
+            if (v->m_intent == intent_local) {
+                strings_to_be_deallocated.push_back(al, llvm_utils->CreateLoad2(v->m_type, target_var));
+            }
+        } else {
+            builder->CreateStore(init_value, target_var);
+        }
+    }
 
     template<typename T>
     void process_Variable(ASR::symbol_t* var_sym, T& x, uint32_t &debug_arg_count) {
@@ -3774,61 +3827,14 @@ public:
                     }
                 }
             }
-            if( init_expr != nullptr &&
-                !is_list) {
+            if( init_expr != nullptr && !is_list) {
                 target_var = ptr;
-                tmp = nullptr;
-                if (v->m_value != nullptr) {
-                    this->visit_expr_wrapper(v->m_value, true);
+                if(v->m_storage == ASR::storage_typeType::Save && 
+                    ASR::is_a<ASR::Function_t>(
+                        *ASR::down_cast<ASR::symbol_t>(v->m_parent_symtab->asr_owner))){
+                    variable_inital_value_vec.push_back({v, target_var});   
                 } else {
-                    this->visit_expr_wrapper(v->m_symbolic_value, true);
-                }
-                llvm::Value *init_value = tmp;
-                if( ASRUtils::is_array(v->m_type) &&
-                    ASRUtils::is_array(ASRUtils::expr_type(v->m_symbolic_value)) &&
-                    (ASR::is_a<ASR::ArrayConstant_t>(*v->m_symbolic_value) ||
-                    (v->m_value && ASR::is_a<ASR::ArrayConstant_t>(*v->m_value))) ) {
-                    ASR::array_physical_typeType target_ptype = ASRUtils::extract_physical_type(v->m_type);
-                    if( target_ptype == ASR::array_physical_typeType::DescriptorArray ) {
-                        target_var = arr_descr->get_pointer_to_data(target_var);
-                        builder->CreateStore(init_value, target_var);
-                    } else if( target_ptype == ASR::array_physical_typeType::FixedSizeArray ) {
-                        llvm::Value* arg_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
-                        llvm::APInt(32, ASRUtils::get_fixed_size_of_array(ASR::down_cast<ASR::ArrayConstant_t>(v->m_value)->m_type)));
-                        llvm::Type* llvm_data_type = llvm_utils->get_type_from_ttype_t_util(
-                            ASRUtils::type_get_past_array(ASRUtils::expr_type(v->m_value)), module.get());
-                        llvm::DataLayout data_layout(module.get());
-                        size_t dt_size = data_layout.getTypeAllocSize(llvm_data_type);
-                        arg_size = builder->CreateMul(llvm::ConstantInt::get(
-                            llvm::Type::getInt32Ty(context), llvm::APInt(32, dt_size)), arg_size);
-                        builder->CreateMemCpy(llvm_utils->create_gep(target_var, 0),
-                            llvm::MaybeAlign(), init_value, llvm::MaybeAlign(), arg_size);
-                    }
-                } else if (ASR::is_a<ASR::ArrayReshape_t>(*v->m_symbolic_value)) {
-                    builder->CreateStore(llvm_utils->CreateLoad(init_value), target_var);
-                } else if (is_a<ASR::String_t>(*v->m_type) && !is_array_type) {
-                    ASR::String_t *t = down_cast<ASR::String_t>(v->m_type);
-                    llvm::Value *arg_size = llvm::ConstantInt::get(context,
-                                llvm::APInt(32, t->m_len+1));
-                    llvm::Value *s_malloc = LLVM::lfortran_malloc(context, *module, *builder, arg_size);
-                    string_init(context, *module, *builder, arg_size, s_malloc);
-                    builder->CreateStore(s_malloc, target_var);
-                    // target decides if the str_copy is performed on string descriptor or pointer.
-                    tmp = lfortran_str_copy(target_var, init_value, ASRUtils::is_descriptorString(v->m_type)); 
-                    if (v->m_intent == intent_local) {
-                        strings_to_be_deallocated.push_back(al, llvm_utils->CreateLoad2(v->m_type, target_var));
-                    }
-                } else {
-                    if (v->m_storage == ASR::storage_typeType::Save
-                        && v->m_value
-                        && (ASR::is_a<ASR::Integer_t>(*v->m_type)
-                        || ASR::is_a<ASR::Real_t>(*v->m_type)
-                        || ASR::is_a<ASR::Logical_t>(*v->m_type))) {
-                        // Do nothing, the value is already initialized
-                        // in the global variable
-                    } else {
-                        builder->CreateStore(init_value, target_var);
-                    }
+                    set_VariableInital_value(v, target_var);
                 }
             } else {
                 if (is_a<ASR::String_t>(*v->m_type) && !is_array_type && !is_list) {

--- a/src/libasr/pass/init_expr.cpp
+++ b/src/libasr/pass/init_expr.cpp
@@ -191,7 +191,9 @@ class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVis
                    ASR::is_a<ASR::ArrayConstructor_t>(*symbolic_value))) ||
                  (ASR::is_a<ASR::Module_t>(*asr_owner) &&
                   (ASR::is_a<ASR::ArrayConstant_t>(*symbolic_value) ||
-                  ASR::is_a<ASR::ArrayConstructor_t>(*symbolic_value)))) {
+                  ASR::is_a<ASR::ArrayConstructor_t>(*symbolic_value))) ||
+                (x.m_storage == ASR::storage_typeType::Save && 
+                ASR::is_a<ASR::Function_t>(*ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner)))) {
                 return ;
             }
 

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1734,8 +1734,7 @@ class TransformVariableInitialiser:
             ) || (
                 x.m_storage == ASR::storage_typeType::Save &&
                 value &&
-                ASRUtils::is_value_constant(value) &&
-                !ASRUtils::is_array(ASRUtils::expr_type(value))
+                ASRUtils::is_value_constant(value)
             )
         ) {
             return;
@@ -2118,8 +2117,7 @@ class VerifySimplifierASROutput:
             !(check_if_ASR_owner_is_enum(x.m_parent_symtab->asr_owner)) &&
             !(check_if_ASR_owner_is_struct(x.m_parent_symtab->asr_owner)) &&
             !(x.m_storage == ASR::storage_typeType::Save && x.m_symbolic_value &&
-                ASRUtils::is_value_constant(x.m_symbolic_value) &&
-                !ASRUtils::is_array(ASRUtils::expr_type(x.m_symbolic_value))
+                ASRUtils::is_value_constant(x.m_symbolic_value)
             ) &&
             x.m_storage != ASR::storage_typeType::Parameter ) {
             LCOMPILERS_ASSERT(x.m_symbolic_value == nullptr);


### PR DESCRIPTION
Towards #5319.
The fix doesn't work for `structTypes` yet. but it should be easy after this PR to do so.

I don't like the workarounds in `init_expr` and `simplifier` pass to make this feature work. They simplify things for the backend, but that's the way I found it would work.

Things that gets done in `program` instead of locally in the function or while creating the module (like allocating an array desc) are getting a lot. maybe we need to look into that matter to simplify things further. maybe use lambda functions to preserve these actions so it get applied one by one without caring about preserving the arguments and calling the needed function. 