### PR TITLE
chore: use empty dims for mask argument in maxminloc instantiation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -930,6 +930,7 @@ RUN(NAME intrinsics_322 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_323 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dot_product
 RUN(NAME intrinsics_324 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # max
 RUN(NAME intrinsics_325 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # spread
+RUN(NAME intrinsics_326 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # minloc
 
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants

--- a/integration_tests/intrinsics_326.f90
+++ b/integration_tests/intrinsics_326.f90
@@ -1,0 +1,15 @@
+program intrinsics_326 
+integer :: A(3)
+A = [1, 9, -1]
+call temp(A)
+contains
+subroutine temp(xpt)
+    integer, intent(in) :: xpt(:) 
+    logical :: y(size(xpt))
+    integer :: iubd
+    real :: subd_test(size(xpt))
+    y = .true.
+    print *,  minloc(subd_test, mask = y)
+    if (any(minloc(subd_test, mask = y) /= 1)) error stop
+end subroutine
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1265,7 +1265,7 @@ static inline ASR::expr_t *instantiate_MaxMinLoc(Allocator &al,
         fill_func_arg("mask", ASRUtils::duplicate_type_with_empty_dims(
             al, arg_types[2], ASR::array_physical_typeType::DescriptorArray, true));
     } else {
-        fill_func_arg("mask", arg_types[2]);
+        fill_func_arg("mask", ASRUtils::duplicate_type_with_empty_dims(al, arg_types[2]));
     }
     fill_func_arg("kind", arg_types[3]);
     fill_func_arg("back", arg_types[4]);


### PR DESCRIPTION
Fixes #5368