### PR TITLE
enh: set_allocation_size for transpose intrinsic array function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -932,6 +932,7 @@ RUN(NAME intrinsics_323 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dot_pro
 RUN(NAME intrinsics_324 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # max
 RUN(NAME intrinsics_325 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # spread
 RUN(NAME intrinsics_326 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # minloc
+RUN(NAME intrinsics_327 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # transpose
 
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -523,7 +523,7 @@ RUN(NAME arrays_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 # is enabled i.e. works on `simplifier_pass` branch
 # RUN(NAME arrays_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-RUN(NAME arrays_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_EXPERIMENTAL_SIMPLIFIER)
+RUN(NAME arrays_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_array_pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_327.f90
+++ b/integration_tests/intrinsics_327.f90
@@ -1,0 +1,26 @@
+program intrinsics_327
+    real :: A(2,3) = reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+    real, allocatable :: B(:, :)
+    allocate(B(3, 2))
+    call wrapper_transpose(A, B)
+    print *, B(1, 1)
+    if (B(1, 1) /= 1.0) error stop
+    print *, B(1, 2)
+    if (B(1, 2) /= 2.0) error stop
+    print *, B(2, 1)
+    if (B(2, 1) /= 3.0) error stop
+    print *, B(2, 2)
+    if (B(2, 2) /= 4.0) error stop
+    print *, B(3, 1)
+    if (B(3, 1) /= 5.0) error stop
+    print *, B(3, 2)
+    if (B(3, 2) /= 6.0) error stop
+
+    contains
+
+    subroutine wrapper_transpose(M, N)
+        real, intent(in) :: M(:, :)
+        real, intent(out) :: N(:, :)
+        N = transpose(M)
+    end subroutine
+end program

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -490,6 +490,26 @@ bool set_allocation_size(
                     }
                     break;
                 }
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Transpose): {
+                    size_t n_dims = ASRUtils::extract_n_dims_from_ttype(intrinsic_array_function->m_type);
+                    LCOMPILERS_ASSERT(n_dims == 2);
+                    allocate_dims.reserve(al, n_dims);
+                    // Transpose swaps the dimensions
+                    for (size_t i = 0; i < n_dims; i++) {
+                        ASR::dimension_t allocate_dim;
+                        allocate_dim.loc = loc;
+                        allocate_dim.m_start = int32_one;
+                        ASR::expr_t* size_i = ASRUtils::EXPR(ASR::make_ArraySize_t(
+                            al, loc, intrinsic_array_function->m_args[0],
+                            ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                al, loc, n_dims - i, ASRUtils::expr_type(int32_one))),
+                            ASRUtils::expr_type(int32_one), nullptr));
+
+                        allocate_dim.m_length = size_i;
+                        allocate_dims.push_back(al, allocate_dim);
+                    }
+                    break;
+                }
                 default: {
                     LCOMPILERS_ASSERT_MSG(false, "ASR::IntrinsicArrayFunctions::" +
                         ASRUtils::get_array_intrinsic_name(intrinsic_array_function->m_arr_intrinsic_id)


### PR DESCRIPTION
## Description

I'll first want to see if the tests pass or not. The idea is to make the test case being added here: https://github.com/lfortran/lfortran/pull/5349 to pass with `--experimental-simplifier`.

Currently, I've commented out the test case because it doesn't work without *experimental-simplifier*.