### PR TITLE
enh: Fortran Backend : Handling C_loc

### DIFF
--- a/integration_tests/fortran_01.f90
+++ b/integration_tests/fortran_01.f90
@@ -1,7 +1,7 @@
 program fortran_01
-    use iso_c_binding, only: c_ptr!, c_loc
+    use iso_c_binding, only: c_ptr, c_loc
     implicit none
     integer, pointer :: x
     type(c_ptr) :: ptr
-    ! ptr = c_loc(x)
+    ptr = c_loc(x)
 end program

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -619,20 +619,23 @@ public:
     void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
         ASR::symbol_t *sym = down_cast<ASR::symbol_t>(
             ASRUtils::symbol_parent_symtab(x.m_external)->asr_owner);
+        if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0) {
+            SymbolTable* st = ASRUtils::symbol_parent_symtab(sym);
+            ASR::symbol_t *sym = st->resolve_symbol("iso_c_binding");
+            if ( sym && ASR::is_a<ASR::Module_t>(*sym) && ASR::down_cast<ASR::Module_t>(sym)->m_intrinsic) {
+                src = indent;
+                src += "use ";
+                src += "iso_c_binding";
+                src += ", only: ";
+                src.append(x.m_original_name);
+                src += "\n";
+                return;
+            }
+        }
         if (!is_a<ASR::Struct_t>(*sym) && !is_a<ASR::Enum_t>(*sym)) {
             src = indent;
             src += "use ";
-            if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0) {
-                SymbolTable* st = ASRUtils::symbol_parent_symtab(sym);
-                ASR::symbol_t *sym = st->resolve_symbol(x.m_original_name);
-                if (sym && ASR::is_a<ASR::Module_t>(*sym) && ASR::down_cast<ASR::Module_t>(sym)->m_intrinsic) {
-                    src += "iso_c_binding";
-                } else {
-                    src.append(x.m_module_name);
-                }
-        } else {
-                src.append(x.m_module_name);
-            }
+            src.append(x.m_module_name);
             src += ", only: ";
             src.append(x.m_original_name);
             src += "\n";

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -620,8 +620,6 @@ public:
         ASR::symbol_t *sym = down_cast<ASR::symbol_t>(
             ASRUtils::symbol_parent_symtab(x.m_external)->asr_owner);
         if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0) {
-            SymbolTable* st = ASRUtils::symbol_parent_symtab(sym);
-            ASR::symbol_t *sym = st->resolve_symbol("iso_c_binding");
             if ( sym && ASR::is_a<ASR::Module_t>(*sym) && ASR::down_cast<ASR::Module_t>(sym)->m_intrinsic) {
                 src = indent;
                 src += "use ";

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -623,8 +623,14 @@ public:
             src = indent;
             src += "use ";
             if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0) {
-                src += "iso_c_binding";
-            } else {
+                SymbolTable* st = ASRUtils::symbol_parent_symtab(sym);
+                ASR::symbol_t *sym = st->resolve_symbol(x.m_original_name);
+                if (sym && ASR::is_a<ASR::Module_t>(*sym) && ASR::down_cast<ASR::Module_t>(sym)->m_intrinsic) {
+                    src += "iso_c_binding";
+                } else {
+                    src.append(x.m_module_name);
+                }
+        } else {
                 src.append(x.m_module_name);
             }
             src += ", only: ";

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1850,7 +1850,10 @@ public:
 
     // void visit_CLoc(const ASR::CLoc_t &x) {}
 
-    // void visit_PointerToCPtr(const ASR::PointerToCPtr_t &x) {}
+    void visit_PointerToCPtr(const ASR::PointerToCPtr_t &x) {
+        visit_expr(*x.m_arg);
+        src = "c_loc(" + src + ")";
+    }
 
     // void visit_GetPointer(const ASR::GetPointer_t &x) {}
 

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -619,16 +619,15 @@ public:
     void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
         ASR::symbol_t *sym = down_cast<ASR::symbol_t>(
             ASRUtils::symbol_parent_symtab(x.m_external)->asr_owner);
-        if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0) {
-            if ( sym && ASR::is_a<ASR::Module_t>(*sym) && ASR::down_cast<ASR::Module_t>(sym)->m_intrinsic) {
-                src = indent;
-                src += "use ";
-                src += "iso_c_binding";
-                src += ", only: ";
-                src.append(x.m_original_name);
-                src += "\n";
-                return;
-            }
+        if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0 &&
+            sym && ASR::is_a<ASR::Module_t>(*sym) && ASR::down_cast<ASR::Module_t>(sym)->m_intrinsic) {
+            src = indent;
+            src += "use ";
+            src += "iso_c_binding";
+            src += ", only: ";
+            src.append(x.m_original_name);
+            src += "\n";
+            return;
         }
         if (!is_a<ASR::Struct_t>(*sym) && !is_a<ASR::Enum_t>(*sym)) {
             src = indent;

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -378,7 +378,7 @@ public:
 
     void visit_Module(const ASR::Module_t &x) {
         std::string r;
-        if (strcmp(x.m_name,"lfortran_intrinsic_iso_c_binding")==0) {
+        if (strcmp(x.m_name,"lfortran_intrinsic_iso_c_binding")==0 && x.m_intrinsic) {
             return;
         }
         r = "module";

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -378,6 +378,9 @@ public:
 
     void visit_Module(const ASR::Module_t &x) {
         std::string r;
+        if (strcmp(x.m_name,"lfortran_intrinsic_iso_c_binding")==0) {
+            return;
+        }
         r = "module";
         r += " ";
         r.append(x.m_name);
@@ -619,7 +622,11 @@ public:
         if (!is_a<ASR::Struct_t>(*sym) && !is_a<ASR::Enum_t>(*sym)) {
             src = indent;
             src += "use ";
-            src.append(x.m_module_name);
+            if (strcmp(x.m_module_name,"lfortran_intrinsic_iso_c_binding")==0) {
+                src += "iso_c_binding";
+            } else {
+                src.append(x.m_module_name);
+            }
             src += ", only: ";
             src.append(x.m_original_name);
             src += "\n";


### PR DESCRIPTION
In continuation of #5278
And Towards #5260

Generates proper fortran code for ptr = c_loc(x)