### PR TITLE
Enh : Utilize stringDescriptor size for `len()`

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5338,7 +5338,7 @@ public:
             if(ASRUtils::is_descriptorString(ASRUtils::expr_type(args.p[i]))){
                 // Any compile-time intrinsic function doesn't need a cast from 
                 // descriptorString to pointerString. Only runtime ones need a cast.
-                if(intrinsic_name != "present"){
+                if(intrinsic_name != "present" && intrinsic_name != "len"){
                     args.p[i] = ASRUtils::cast_string_descriptor_to_pointer(al, args.p[i]);
                 }
             }
@@ -5534,9 +5534,6 @@ public:
         std::vector<std::string> kwarg_names = {"string", "kind"};
         handle_intrinsic_node_args(x, args, kwarg_names, 1, 2, std::string("len"));
         ASR::expr_t *v_Var = args[0], *kind = args[1];
-        if(ASRUtils::is_descriptorString(ASRUtils::expr_type(v_Var))){
-            v_Var = ASRUtils::cast_string_descriptor_to_pointer(al, v_Var);
-        }
         int64_t kind_const = handle_kind(kind);
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, kind_const));
         if( ASRUtils::is_array(ASRUtils::expr_type(v_Var)) ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6264,6 +6264,13 @@ public:
         ptr_loads = 2 - LLVM::is_llvm_pointer(*ASRUtils::expr_type(x.m_arg));
         this->visit_expr_wrapper(x.m_arg, true);
         ptr_loads = ptr_loads_copy;
+        if(ASRUtils::is_descriptorString(ASRUtils::expr_type(x.m_arg))){
+            llvm::Value* str_size = builder->CreateLoad(llvm::Type::getInt64Ty(context),
+                llvm_utils->create_gep2(string_descriptor, tmp, 1));
+            tmp = builder->CreateSExtOrTrunc(str_size,
+                llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get()));
+            return;
+        }
         llvm::AllocaInst *parg = llvm_utils->CreateAlloca(*builder, character_type);
         builder->CreateStore(tmp, parg);
         ASR::ttype_t* arg_type = ASRUtils::get_contained_type(ASRUtils::expr_type(x.m_arg));

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2068,7 +2068,6 @@ LFORTRAN_API void _lfortran_strcpy_descriptor_string(char** x, char *y, int64_t*
         int8_t null_char_len = 1;
         if(*x_string_capacity < (y_len + null_char_len)){
             extend_string(x, y_len+1, x_string_capacity);
-            *x_string_size = y_len;
         }
     }
     int64_t null_character_index = x_len;
@@ -2076,6 +2075,7 @@ LFORTRAN_API void _lfortran_strcpy_descriptor_string(char** x, char *y, int64_t*
     for (size_t i = 0; i < x_len; i++) {
         (*x)[i] = y[i];
     }
+    *x_string_size = y_len;
 }
 
 LFORTRAN_API void _lfortran_strcpy_pointer_string(char** x, char *y)

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "d877ebdde98140150ea7269fd2c47285e2d85dd00bb356b9e05d19f1",
+    "stdout_hash": "e3955fd32ea2b55bb2eabda5fef897319952ea78f351ba655640f53f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -1279,15 +1279,7 @@
                                     (If
                                         (IntegerCompare
                                             (StringLen
-                                                (StringPhysicalCast
-                                                    (Var 6 name)
-                                                    DescriptorString
-                                                    PointerString
-                                                    (Allocatable
-                                                        (String 1 -2 () PointerString)
-                                                    )
-                                                    ()
-                                                )
+                                                (Var 6 name)
                                                 (Integer 4)
                                                 ()
                                             )
@@ -1403,15 +1395,7 @@
                                                 And
                                                 (IntegerCompare
                                                     (StringLen
-                                                        (StringPhysicalCast
-                                                            (Var 6 name)
-                                                            DescriptorString
-                                                            PointerString
-                                                            (Allocatable
-                                                                (String 1 -2 () PointerString)
-                                                            )
-                                                            ()
-                                                        )
+                                                        (Var 6 name)
                                                         (Integer 4)
                                                         ()
                                                     )

--- a/tests/reference/asr-string_17-29e01e3.json
+++ b/tests/reference/asr-string_17-29e01e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_17-29e01e3.stdout",
-    "stdout_hash": "c54e75d92b2a3f338e76cc937e3db9f67c095477943bc0200053506d",
+    "stdout_hash": "431c994bccf7067d7ae051516b3628718082abee0088f5ef8e649f41",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_17-29e01e3.stdout
+++ b/tests/reference/asr-string_17-29e01e3.stdout
@@ -109,19 +109,11 @@
                                         [(Assignment
                                             (Var 4 length)
                                             (StringLen
-                                                (StringPhysicalCast
-                                                    (StructInstanceMember
-                                                        (Var 4 string)
-                                                        4 1_string_type_raw
-                                                        (Allocatable
-                                                            (String 1 -2 () DescriptorString)
-                                                        )
-                                                        ()
-                                                    )
-                                                    DescriptorString
-                                                    PointerString
+                                                (StructInstanceMember
+                                                    (Var 4 string)
+                                                    4 1_string_type_raw
                                                     (Allocatable
-                                                        (String 1 -2 () PointerString)
+                                                        (String 1 -2 () DescriptorString)
                                                     )
                                                     ()
                                                 )


### PR DESCRIPTION
Instead of relaying on runtime C's `strlen` to return the size of the string by iterating over the consecutive characters till it reaches the null character, We simply use the size if the string we have is of physical type stringDescriptor `{char_ptr, size, capacity}`