### PR TITLE
build: add `CMAKE_EXPORT_COMPILE_COMMANDS` option to build script for working with `clangd` LSP

### DIFF
--- a/build1.bat
+++ b/build1.bat
@@ -5,5 +5,6 @@ cmake ^
     -DWITH_STACKTRACE=no ^
     -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX=%cd%/inst ^
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes ^
     .
 cmake --build . --config Release -j2 --target install

--- a/build1.sh
+++ b/build1.sh
@@ -13,5 +13,6 @@ cmake \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
     -DCMAKE_INSTALL_LIBDIR=share/lfortran/lib \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16 --target install

--- a/build_release.sh
+++ b/build_release.sh
@@ -13,5 +13,6 @@ cmake \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
     -DCMAKE_INSTALL_LIBDIR=share/lfortran/lib \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16 --target install

--- a/build_to_wasm.sh
+++ b/build_to_wasm.sh
@@ -9,6 +9,7 @@ cmake \
     -DWITH_STACKTRACE=no \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16 --target install
 
@@ -27,5 +28,6 @@ emcmake cmake \
     -DWITH_LSP=no \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16


### PR DESCRIPTION
This option creates a json file called `compile_commands.json` containing the exact compiler calls for all translation units of the project. The file is required for using the `clangd` LSP. Please see https://clang.llvm.org/docs/JSONCompilationDatabase.html.