### PR TITLE
Revert "build: add `CMAKE_EXPORT_COMPILE_COMMANDS` option to build sc…

### DIFF
--- a/build1.bat
+++ b/build1.bat
@@ -5,6 +5,5 @@ cmake ^
     -DWITH_STACKTRACE=no ^
     -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX=%cd%/inst ^
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes ^
     .
 cmake --build . --config Release -j2 --target install

--- a/build1.sh
+++ b/build1.sh
@@ -13,6 +13,5 @@ cmake \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
     -DCMAKE_INSTALL_LIBDIR=share/lfortran/lib \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16 --target install

--- a/build_release.sh
+++ b/build_release.sh
@@ -13,6 +13,5 @@ cmake \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
     -DCMAKE_INSTALL_LIBDIR=share/lfortran/lib \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16 --target install

--- a/build_to_wasm.sh
+++ b/build_to_wasm.sh
@@ -9,7 +9,6 @@ cmake \
     -DWITH_STACKTRACE=no \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16 --target install
 
@@ -28,6 +27,5 @@ emcmake cmake \
     -DWITH_LSP=no \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
     .
 cmake --build . -j16


### PR DESCRIPTION
## Description

After the PR: https://github.com/lfortran/lfortran/pull/5404 was merged in *main*, I noticed a failure of CI in *main*, the run that failed in CI is: https://github.com/lfortran/lfortran/actions/runs/11884738350/job/33113364806 (a re-run of the failed run, resulted in a same error).

With this PR, the attempt is to revert the changes in #5404 and see if the failure goes away or persists.