### PR TITLE
refactor: remove unused `#include` directives

### DIFF
--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <fstream>
 
 #include <lfortran/fortran_evaluator.h>

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -1,7 +1,6 @@
 #ifndef LFORTRAN_FORTRAN_EVALUATOR_H
 #define LFORTRAN_FORTRAN_EVALUATOR_H
 
-#include <iostream>
 #include <memory>
 
 #include <libasr/alloc.h>

--- a/src/lfortran/mod_to_asr.cpp
+++ b/src/lfortran/mod_to_asr.cpp
@@ -3,7 +3,6 @@
 #include <iterator>
 #include <vector>
 #include <map>
-#include <memory>
 
 #ifdef HAVE_ZLIB
     #include <zlib.h>

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -6,7 +6,6 @@ fed into our Bison parser, that is shared with the free-form parser.
 
 Note: The prescanner removes CR, so we only handle LF here.
 */
-#include <limits>
 #include <utility>
 
 #include <lfortran/parser/parser_exception.h>

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <string>
-#include <sstream>
 #include <cctype>
 
 #include <lfortran/parser/parser.h>

--- a/src/lfortran/parser/parser.h
+++ b/src/lfortran/parser/parser.h
@@ -1,9 +1,6 @@
 #ifndef LFORTRAN_PARSER_PARSER_H
 #define LFORTRAN_PARSER_PARSER_H
 
-#include <fstream>
-#include <algorithm>
-#include <memory>
 #include <filesystem>
 
 #include <libasr/utils.h>

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1,11 +1,7 @@
-#include <fstream>
-#include <iostream>
-#include <limits>
-#include <map>
-#include <memory>
 #include <string>
 #include <cmath>
 #include <set>
+#include <unordered_set>
 
 #include <lfortran/ast.h>
 #include <libasr/asr.h>

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -14,8 +14,6 @@
 #include <lfortran/semantics/comptime_eval.h>
 #include <libasr/pass/instantiate_template.h>
 #include <string>
-#include <unordered_set>
-#include <queue>
 #include <set>
 #include <map>
 

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1,10 +1,7 @@
-#include <fstream>
 #include <iostream>
 #include <map>
-#include <memory>
 #include <string>
 #include <cmath>
-#include <limits>
 #include <queue>
 
 #include <lfortran/ast.h>

--- a/src/lfortran/semantics/ast_to_asr.cpp
+++ b/src/lfortran/semantics/ast_to_asr.cpp
@@ -1,7 +1,5 @@
 #include <fstream>
-#include <iostream>
 #include <map>
-#include <memory>
 #include <string>
 #include <cmath>
 

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -7,7 +7,6 @@
 
 #include <config.h>
 
-#include <fstream>
 #include <iostream>
 
 #include <bin/tpl/whereami/whereami.h>

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3,7 +3,6 @@
 
 #include <functional>
 #include <map>
-#include <set>
 #include <limits>
 
 #include <libasr/assert.h>

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -6,6 +6,8 @@
 #include <libasr/pass/intrinsic_function_registry.h>
 #include <libasr/pass/intrinsic_array_function_registry.h>
 
+#include <set>
+
 namespace LCompilers {
 
 namespace ASR {

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <fstream>
 #include <memory>
 

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -11,7 +11,6 @@
  * for both C and C++ code generation.
  */
 
-#include <iostream>
 #include <memory>
 #include <set>
 
@@ -28,7 +27,6 @@
 
 
 #include <map>
-#include <tuple>
 
 #define CHECK_FAST_C_CPP(compiler_options, x)                   \
         if (compiler_options.po.fast && x.m_value != nullptr) { \

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <memory>
 
 #include <libasr/asr.h>

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <unordered_map>
-#include <functional>
-#include <string_view>
 #include <utility>
 
 #include <llvm/ADT/STLExtras.h>

--- a/src/libasr/codegen/asr_to_py.cpp
+++ b/src/libasr/codegen/asr_to_py.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <memory>
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 #include <libasr/exception.h>

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
-#include <memory>
 #include <chrono>
 #include <iomanip>
-#include <fstream>
 #include <climits>
 
 #include <libasr/asr.h>

--- a/src/libasr/codegen/asr_to_x86.cpp
+++ b/src/libasr/codegen/asr_to_x86.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <memory>
 #include <chrono>
 
 #include <libasr/asr.h>

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -1,8 +1,6 @@
 #ifndef LFORTRAN_LLVM_UTILS_H
 #define LFORTRAN_LLVM_UTILS_H
 
-#include <memory>
-
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/IRBuilder.h>

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -1,6 +1,7 @@
 #include <libasr/assert.h>
 #include <libasr/codegen/wasm_utils.h>
 #include <libasr/wasm_visitor.h>
+#include <fstream>
 
 namespace LCompilers {
 

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -1,4 +1,3 @@
-#include <fstream>
 
 #include <libasr/assert.h>
 #include <libasr/string_utils.h>

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -1,4 +1,3 @@
-#include <fstream>
 #include <chrono>
 #include <iomanip>
 

--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -1,4 +1,3 @@
-#include <fstream>
 #include <chrono>
 #include <iomanip>
 

--- a/src/libasr/pass/arr_slice.cpp
+++ b/src/libasr/pass/arr_slice.cpp
@@ -7,7 +7,6 @@
 #include <libasr/pass/replace_arr_slice.h>
 
 #include <vector>
-#include <utility>
 
 
 namespace LCompilers {

--- a/src/libasr/pass/array_op_simplifier.cpp
+++ b/src/libasr/pass/array_op_simplifier.cpp
@@ -11,7 +11,6 @@
 #include <libasr/asr_builder.h>
 
 #include <vector>
-#include <utility>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/class_constructor.cpp
+++ b/src/libasr/pass/class_constructor.cpp
@@ -6,8 +6,6 @@
 #include <libasr/pass/replace_class_constructor.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <utility>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/dead_code_removal.cpp
+++ b/src/libasr/pass/dead_code_removal.cpp
@@ -6,10 +6,6 @@
 #include <libasr/pass/dead_code_removal.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <map>
-#include <utility>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/div_to_mul.cpp
+++ b/src/libasr/pass/div_to_mul.cpp
@@ -6,9 +6,6 @@
 #include <libasr/pass/replace_div_to_mul.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <utility>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/flip_sign.cpp
+++ b/src/libasr/pass/flip_sign.cpp
@@ -7,9 +7,6 @@
 #include <libasr/pass/pass_utils.h>
 #include <libasr/pass/intrinsic_function_registry.h>
 
-#include <vector>
-#include <utility>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/fma.cpp
+++ b/src/libasr/pass/fma.cpp
@@ -6,9 +6,6 @@
 #include <libasr/pass/replace_fma.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <utility>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -7,8 +7,6 @@
 #include <libasr/pass/pass_utils.h>
 #include <libasr/pass/intrinsic_function_registry.h>
 
-#include <vector>
-#include <utility>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/init_expr.cpp
+++ b/src/libasr/pass/init_expr.cpp
@@ -7,7 +7,6 @@
 #include <libasr/pass/pass_utils.h>
 
 #include <vector>
-#include <utility>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -5,9 +5,6 @@
 #include <libasr/asr_verify.h>
 #include <libasr/pass/insert_deallocate.h>
 
-#include <vector>
-#include <utility>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -9,7 +9,6 @@
 #include <libasr/pass/pass_utils.h>
 
 #include <vector>
-#include <utility>
 
 
 namespace LCompilers {

--- a/src/libasr/pass/loop_unroll.cpp
+++ b/src/libasr/pass/loop_unroll.cpp
@@ -6,9 +6,6 @@
 #include <libasr/pass/loop_unroll.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <map>
-#include <utility>
 #include <cmath>
 
 

--- a/src/libasr/pass/loop_vectorise.cpp
+++ b/src/libasr/pass/loop_vectorise.cpp
@@ -6,8 +6,6 @@
 #include <libasr/pass/loop_vectorise.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <utility>
 #include <cmath>
 
 

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -5,7 +5,7 @@
 #include <libasr/asr_verify.h>
 #include <libasr/pass/nested_vars.h>
 #include <libasr/pass/pass_utils.h>
-#include <unordered_map>
+#include <set>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <utility>
 #include <deque>
+#include <set>
 
 /*
 This ASR to ASR pass can be called whenever you want to avoid

--- a/src/libasr/pass/pass_compare.cpp
+++ b/src/libasr/pass/pass_compare.cpp
@@ -6,8 +6,6 @@
 #include <libasr/pass/compare.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <utility>
 
 
 namespace LCompilers {

--- a/src/libasr/pass/pass_list_expr.cpp
+++ b/src/libasr/pass/pass_list_expr.cpp
@@ -6,9 +6,6 @@
 #include <libasr/pass/list_expr.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <utility>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -1,6 +1,8 @@
 #ifndef LCOMPILERS_PASS_MANAGER_H
 #define LCOMPILERS_PASS_MANAGER_H
 
+#include <iostream>
+
 #include <libasr/asr.h>
 #include <libasr/string_utils.h>
 #include <libasr/alloc.h>

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -4,7 +4,7 @@
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 
-#include <queue>
+#include <deque>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -8,6 +8,8 @@
 #include <libasr/pass/intrinsic_function_registry.h>
 #include <libasr/asr_builder.h>
 
+#include <set>
+
 namespace LCompilers {
 
 using ASR::down_cast;

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -6,7 +6,6 @@
 #include <libasr/pass/replace_sign_from_value.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
 #include <string>
 
 

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -10,7 +10,6 @@
 
 #include <vector>
 #include <utility>
-#include <set>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/subroutine_from_function_simplifier.cpp
+++ b/src/libasr/pass/subroutine_from_function_simplifier.cpp
@@ -8,9 +8,6 @@
 #include <libasr/pass/intrinsic_array_function_registry.h>
 #include <libasr/pass/pass_utils.h>
 
-#include <vector>
-#include <string>
-
 
 namespace LCompilers {
 

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <string>
+#include <set>
 
 /*
 Need for the pass

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -6,7 +6,6 @@
 #include <libasr/pass/unique_symbols.h>
 #include <libasr/pass/pass_utils.h>
 #include <unordered_map>
-#include <set>
 #include<unordered_set>
 
 

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
@@ -6,9 +6,6 @@
 #include <libasr/pass/pass_utils.h>
 #include <libasr/pass/update_array_dim_intrinsic_calls.h>
 
-#include <vector>
-#include <utility>
-
 
 namespace LCompilers {
 


### PR DESCRIPTION
Part of #5414 