### PR TITLE
enh: `--lookup-name` to return symbol name

### DIFF
--- a/src/lfortran/tests/test_ast.cpp
+++ b/src/lfortran/tests/test_ast.cpp
@@ -3,7 +3,7 @@
 #include <sstream>
 
 #include <iostream>
-
+#include <libasr/lsp.cpp>
 #include <lfortran/fortran_evaluator.h>
 #include <libasr/codegen/evaluator.h>
 #include <libasr/alloc.h>
@@ -169,22 +169,9 @@ end program
         fl.in_filename = "input.f90";
         lm.files.push_back(fl);
     }
-    FortranEvaluator e(compiler_options);
-    LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
-        r = e.get_asr2(src, lm, diagnostics);
-    ASR::asr_t* asr2 = e.handle_lookup_name(r.result, lm.linecol_to_pos(2, 12));
-    LCOMPILERS_ASSERT(ASR::is_a<ASR::symbol_t>(*asr2));
-    ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(asr2);
-    std::string symbol_name = ASRUtils::symbol_name(sym);
-    LCOMPILERS_ASSERT(symbol_name == "expr2");
-    std::vector<diag::Span> spans2 = diag::Label("", {asr2->loc}).spans;
-    for( auto it: spans2 ) {
-        populate_span(it, lm);
-        CHECK(it.first_line == 2);
-        CHECK(it.first_column == 1);
-        CHECK(it.last_line == 7);
-        CHECK(it.last_column == 11);
-    }
+    std::string json = get_definitions_source_code(src, compiler_options);
+    std::string expected_json = R"""([{"kind":1,"location":{"range":{"start":{"character":1,"line":1},"end":{"character":11,"line":6}},"uri":"uri"},"name":"expr2"}])""";
+    LCOMPILERS_ASSERT(json == expected_json)
 }
 
 

--- a/src/lfortran/tests/test_ast.cpp
+++ b/src/lfortran/tests/test_ast.cpp
@@ -169,7 +169,7 @@ end program
         fl.in_filename = "input.f90";
         lm.files.push_back(fl);
     }
-#ifdef HAVE_LFORTRAN_RAPIDJSON
+#ifdef WITH_LSP
     std::string json = get_definitions_source_code(src, compiler_options);
     std::string expected_json = R"""([{"kind":1,"location":{"range":{"start":{"character":1,"line":1},"end":{"character":11,"line":6}},"uri":"uri"},"name":"expr2"}])""";
     LCOMPILERS_ASSERT(json == expected_json)

--- a/src/lfortran/tests/test_ast.cpp
+++ b/src/lfortran/tests/test_ast.cpp
@@ -169,9 +169,11 @@ end program
         fl.in_filename = "input.f90";
         lm.files.push_back(fl);
     }
+#ifdef HAVE_LFORTRAN_RAPIDJSON
     std::string json = get_definitions_source_code(src, compiler_options);
     std::string expected_json = R"""([{"kind":1,"location":{"range":{"start":{"character":1,"line":1},"end":{"character":11,"line":6}},"uri":"uri"},"name":"expr2"}])""";
     LCOMPILERS_ASSERT(json == expected_json)
+#endif
 }
 
 

--- a/src/libasr/lsp.cpp
+++ b/src/libasr/lsp.cpp
@@ -251,7 +251,13 @@ int get_definitions(const std::string &infile, LCompilers::CompilerOptions &comp
             LCompilers::ASR::asr_t* asr = fe.handle_lookup_name(x.result, pos);
             LCompilers::document_symbols loc;
             // TODO: make sure it returns us the symbol name
-            std::string symbol_name = "a.first";
+            std::string symbol_name;
+            try {
+                ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(asr);
+                symbol_name = ASRUtils::symbol_name( s );
+            } catch (std::exception &e) {
+                symbol_name = "a.first";
+            }
             uint32_t first_line;
             uint32_t last_line;
             uint32_t first_column;

--- a/src/libasr/lsp.cpp
+++ b/src/libasr/lsp.cpp
@@ -326,6 +326,105 @@ int get_definitions(const std::string &infile, LCompilers::CompilerOptions &comp
 
     return 0;
 }
+
+std::string get_definitions_source_code(std::string input, LCompilers::CompilerOptions &compiler_options)
+{
+    LCompilers::FortranEvaluator fe(compiler_options);
+    std::vector<LCompilers::document_symbols> symbol_lists;
+
+    LCompilers::LocationManager lm;
+    {
+        LCompilers::LocationManager::FileLocations fl;
+        fl.in_filename = "xx.f90";
+        lm.files.push_back(fl);
+        lm.file_ends.push_back(input.size());
+    }
+    {
+        LCompilers::diag::Diagnostics diagnostics;
+        LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
+            x = fe.get_asr2(input, lm, diagnostics);
+        if (x.ok) {
+            // populate_symbol_lists(x.result, lm, symbol_lists);
+            uint16_t l = std::stoi(compiler_options.line);
+            uint16_t c = std::stoi(compiler_options.column);
+            uint64_t pos = lm.linecol_to_pos(l, c);
+            LCompilers::ASR::asr_t* asr = fe.handle_lookup_name(x.result, pos);
+            LCompilers::document_symbols loc;
+            if (!ASR::is_a<ASR::symbol_t>(*asr)) {
+                return "{}";
+            }
+            ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(asr);
+            std::string symbol_name = ASRUtils::symbol_name( s );
+            uint32_t first_line;
+            uint32_t last_line;
+            uint32_t first_column;
+            uint32_t last_column;
+            std::string filename;
+            lm.pos_to_linecol(asr->loc.first, first_line,
+                first_column, filename);
+            lm.pos_to_linecol(asr->loc.last, last_line,
+                last_column, filename);
+            loc.first_column = first_column;
+            loc.last_column = last_column;
+            loc.first_line = first_line-1;
+            loc.last_line = last_line-1;
+            loc.symbol_name = symbol_name;
+            loc.filename = filename;
+            symbol_lists.push_back(loc);
+        } else {
+            return "{}";
+        }
+    }
+
+    rapidjson::Document test_output(rapidjson::kArrayType);
+    rapidjson::Document range_object(rapidjson::kObjectType);
+    rapidjson::Document start_detail(rapidjson::kObjectType);
+    rapidjson::Document end_detail(rapidjson::kObjectType);
+    rapidjson::Document location_object(rapidjson::kObjectType);
+    rapidjson::Document test_capture(rapidjson::kObjectType);
+
+    test_output.SetArray();
+
+    for (auto symbol : symbol_lists) {
+        uint32_t start_character = symbol.first_column;
+        uint32_t start_line = symbol.first_line;
+        uint32_t end_character = symbol.last_column;
+        uint32_t end_line = symbol.last_line;
+        std::string name = symbol.symbol_name;
+
+        range_object.SetObject();
+        rapidjson::Document::AllocatorType &allocator = range_object.GetAllocator();
+
+        start_detail.SetObject();
+        start_detail.AddMember("character", rapidjson::Value().SetInt(start_character), allocator);
+        start_detail.AddMember("line", rapidjson::Value().SetInt(start_line), allocator);
+        range_object.AddMember("start", start_detail, allocator);
+
+        end_detail.SetObject();
+        end_detail.AddMember("character", rapidjson::Value().SetInt(end_character), allocator);
+        end_detail.AddMember("line", rapidjson::Value().SetInt(end_line), allocator);
+        range_object.AddMember("end", end_detail, allocator);
+
+        location_object.SetObject();
+        location_object.AddMember("range", range_object, allocator);
+        location_object.AddMember("uri", rapidjson::Value().SetString("uri", allocator), allocator);
+
+        test_capture.SetObject();
+        test_capture.AddMember("kind", rapidjson::Value().SetInt(1), allocator);
+        test_capture.AddMember("location", location_object, allocator);
+        test_capture.AddMember("name", rapidjson::Value().SetString(name.c_str(), allocator), allocator);
+        test_output.PushBack(test_capture, test_output.GetAllocator());
+    }
+    rapidjson::StringBuffer buffer;
+    buffer.Clear();
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    test_output.Accept(writer);
+    std::string resp_str( buffer.GetString() );
+
+    return resp_str;
+}
 #endif
 }
+
+
 

--- a/src/libasr/lsp.cpp
+++ b/src/libasr/lsp.cpp
@@ -250,14 +250,11 @@ int get_definitions(const std::string &infile, LCompilers::CompilerOptions &comp
             uint64_t pos = lm.linecol_to_pos(l, c);
             LCompilers::ASR::asr_t* asr = fe.handle_lookup_name(x.result, pos);
             LCompilers::document_symbols loc;
-            // TODO: make sure it returns us the symbol name
-            std::string symbol_name;
-            try {
-                ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(asr);
-                symbol_name = ASRUtils::symbol_name( s );
-            } catch (std::exception &e) {
-                symbol_name = "a.first";
+            if (!ASR::is_a<ASR::symbol_t>(*asr)) {
+                return 0;
             }
+            ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(asr);
+            std::string symbol_name = ASRUtils::symbol_name( s );
             uint32_t first_line;
             uint32_t last_line;
             uint32_t first_column;


### PR DESCRIPTION
Fixes the hardwired returning of `a.first`. Refer #5420