### PR TITLE
chore: uncomment function to free strings

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1169,13 +1169,13 @@ public:
     }
 
     inline void call_lcompilers_free_strings() {
-        // if (strings_to_be_deallocated.n > 0) {
-        //     llvm::Function* free_fn = _Deallocate();
-        //     for( auto &value: strings_to_be_deallocated ) {
-        //         builder->CreateCall(free_fn, {value});
-        //     }
-        //     strings_to_be_deallocated.reserve(al, 1);
-        // }
+        if (strings_to_be_deallocated.n > 0) {
+            llvm::Function* free_fn = _Deallocate();
+            for( auto &value: strings_to_be_deallocated ) {
+                builder->CreateCall(free_fn, {value});
+            }
+            strings_to_be_deallocated.reserve(al, 1);
+        }
     }
 
     llvm::Function* _Allocate(bool realloc_lhs) {

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "806a91418e9e8ac1f55667ef5587651e151c4bebf1303ad4324e785c",
+    "stdout_hash": "224154c60c65483dd709f7343d1d6df6a8b3f236558573277a9ea956",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -39,6 +39,7 @@ loop.head:                                        ; preds = %ifcont, %then
   %9 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i8** %9, align 8
   %10 = call i1 @_lpython_str_compare_eq(i8** %8, i8** %9)
+  call void @_lfortran_free(i8* %7)
   br i1 %10, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
@@ -100,43 +101,42 @@ define %string_descriptor @__module_testdrive_derived_types_32_real_dp_to_string
   %0 = call i8* @_lfortran_malloc(i32 129)
   call void @_lfortran_string_init(i32 129, i8* %0)
   store i8* %0, i8** %buffer, align 8
-  %1 = load i8*, i8** %buffer, align 8
   %buffer_len = alloca i32, align 4
   store i32 128, i32* %buffer_len, align 4
   %string = alloca %string_descriptor, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  store i8* null, i8** %2, align 8
-  %3 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
+  %1 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
+  store i8* null, i8** %1, align 8
+  %2 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
+  store i64 0, i64* %2, align 4
+  %3 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
   store i64 0, i64* %3, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
-  store i64 0, i64* %4, align 4
   %negative_one_constant = alloca i64, align 8
   store i64 -1, i64* %negative_one_constant, align 4
-  %5 = alloca i32*, align 8
-  store i32* null, i32** %5, align 8
-  %6 = load i32*, i32** %5, align 8
-  %7 = load double, double* %val, align 8
-  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 5, double %7)
-  call void (i8**, i64*, i64*, i32*, i8*, ...) @_lfortran_string_write(i8** %buffer, i64* %negative_one_constant, i64* %negative_one_constant, i32* %6, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @3, i32 0, i32 0), i8* %8)
+  %4 = alloca i32*, align 8
+  store i32* null, i32** %4, align 8
+  %5 = load i32*, i32** %4, align 8
+  %6 = load double, double* %val, align 8
+  %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 5, double %6)
+  call void (i8**, i64*, i64*, i32*, i8*, ...) @_lfortran_string_write(i8** %buffer, i64* %negative_one_constant, i64* %negative_one_constant, i32* %5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @3, i32 0, i32 0), i8* %7)
   %casted_string_ptr_to_desc = alloca %string_descriptor, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
-  %10 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 2
-  %12 = call i8* @_lcompilers_trim_str(i8** %buffer)
-  store i8* %12, i8** %9, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
+  %9 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 1
+  %10 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 2
+  %11 = call i8* @_lcompilers_trim_str(i8** %buffer)
+  store i8* %11, i8** %8, align 8
+  store i64 -1, i64* %9, align 4
   store i64 -1, i64* %10, align 4
-  store i64 -1, i64* %11, align 4
-  %13 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %14 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
-  %16 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  call void @_lfortran_strcpy_descriptor_string(i8** %13, i8* %17, i64* %14, i64* %15)
+  %12 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
+  %13 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
+  %14 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
+  %15 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
+  %16 = load i8*, i8** %15, align 8
+  call void @_lfortran_strcpy_descriptor_string(i8** %12, i8* %16, i64* %13, i64* %14)
   br label %return
 
 return:                                           ; preds = %.entry
-  %18 = load %string_descriptor, %string_descriptor* %string, align 8
-  ret %string_descriptor %18
+  %17 = load %string_descriptor, %string_descriptor* %string, align 8
+  ret %string_descriptor %17
 }
 
 declare i8* @_lfortran_malloc(i32)
@@ -154,6 +154,8 @@ declare i32 @_lfortran_str_len(i8**)
 declare i8* @_lfortran_str_item(i8*, i32)
 
 declare i1 @_lpython_str_compare_eq(i8**, i8**)
+
+declare void @_lfortran_free(i8*)
 
 declare i8* @_lfortran_str_slice(i8*, i32, i32, i32, i1, i1)
 

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "e50a994bb07d778e2f2b0dc61434a7b4069126b7454bb74c1ea07e3c",
+    "stdout_hash": "4558d0821fe551f931337c13e1f8704c40e9fac0dcaaa0e3b78c0c0b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -81,6 +81,9 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fpext float %22 to double
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 20, i8* null, i32 2, i64 1, i32 2, i64 2, i32 6, double 4.000000e+00, i32 6, double %19, i32 6, double %23, i32 2, i64 3, i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i32 6, double -4.000000e+00, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %7)
+  call void @_lfortran_free(i8* %9)
+  call void @_lfortran_free(i8* %11)
   call void @_lpython_free_argv()
   br label %return
 
@@ -99,5 +102,7 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "80e9cfcddbfffc792ce51e8fffe33f7899b67389e269a3b84b24764e",
+    "stdout_hash": "ce0a33e92358e1451801e3bd167ae8f476e34929f1252820ea4a9bbd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -119,37 +119,36 @@ loop.end:                                         ; preds = %loop.head
   %28 = call i8* @_lfortran_malloc(i32 4)
   call void @_lfortran_string_init(i32 4, i8* %28)
   store i8* %28, i8** %prefix_arg, align 8
-  %29 = load i8*, i8** %prefix_arg, align 8
-  %30 = alloca %compiler_t_polymorphic, align 8
-  %31 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %30, i32 0, i32 0
-  store i64 0, i64* %31, align 4
-  %32 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %30, i32 0, i32 1
-  store %compiler_t* %compiler_arg, %compiler_t** %32, align 8
-  %33 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
-  %34 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
-  store %string_t* %33, %string_t** %34, align 8
-  %35 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
-  store i32 0, i32* %35, align 4
-  %36 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
-  %37 = alloca %dimension_descriptor, align 8
-  store %dimension_descriptor* %37, %dimension_descriptor** %36, align 8
-  %38 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
-  store i32 1, i32* %38, align 4
-  %39 = load %dimension_descriptor*, %dimension_descriptor** %36, align 8
-  %40 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %39, i32 0
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 0
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 1
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 2
+  %29 = alloca %compiler_t_polymorphic, align 8
+  %30 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %29, i32 0, i32 0
+  store i64 0, i64* %30, align 4
+  %31 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %29, i32 0, i32 1
+  store %compiler_t* %compiler_arg, %compiler_t** %31, align 8
+  %32 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
+  %33 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
+  store %string_t* %32, %string_t** %33, align 8
+  %34 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
+  store i32 0, i32* %34, align 4
+  %35 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
+  %36 = alloca %dimension_descriptor, align 8
+  store %dimension_descriptor* %36, %dimension_descriptor** %35, align 8
+  %37 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
+  store i32 1, i32* %37, align 4
+  %38 = load %dimension_descriptor*, %dimension_descriptor** %35, align 8
+  %39 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %38, i32 0
+  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 0
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 1
+  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 2
+  store i32 1, i32* %40, align 4
   store i32 1, i32* %41, align 4
-  store i32 1, i32* %42, align 4
-  store i32 4, i32* %43, align 4
-  %44 = call %string_descriptor @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %30, i8** %prefix_arg, %array* %array_descriptor)
-  %45 = alloca %string_descriptor, align 8
-  store %string_descriptor %44, %string_descriptor* %45, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %45, i32 0, i32 0
-  %47 = load i8*, i8** %46, align 8
-  %48 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %47)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  store i32 4, i32* %42, align 4
+  %43 = call %string_descriptor @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %29, i8** %prefix_arg, %array* %array_descriptor)
+  %44 = alloca %string_descriptor, align 8
+  store %string_descriptor %43, %string_descriptor* %44, align 8
+  %45 = getelementptr %string_descriptor, %string_descriptor* %44, i32 0, i32 0
+  %46 = load i8*, i8** %45, align 8
+  %47 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %46)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %47, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "98a0520faba6db392ada7bdcfc24dcb90a30a2b6a6292baa6663dc00",
+    "stdout_hash": "9b504aba911c2f85315bf9e31dd2ae5b39ad5f6c3de113caf05eacc8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -18,6 +18,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i8*, i8** @print_01.my_name, align 8
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i32 7, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   call void @_lpython_free_argv()
   br label %return
 
@@ -36,5 +37,7 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "cb2afbbea6488d72b26a902c2a6d1cd3c4897a25c90efc78b57beaab",
+    "stdout_hash": "82e61f363fe11ada8c6b13cf21209af8f1debdeb6554789e3e7d331d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -18,33 +18,29 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i8* @_lfortran_malloc(i32 16)
   call void @_lfortran_string_init(i32 16, i8* %2)
   store i8* %2, i8** %firstname, align 8
-  %3 = load i8*, i8** %firstname, align 8
   %greetings = alloca i8*, align 8
-  %4 = call i8* @_lfortran_malloc(i32 26)
-  call void @_lfortran_string_init(i32 26, i8* %4)
-  store i8* %4, i8** %greetings, align 8
-  %5 = load i8*, i8** %greetings, align 8
+  %3 = call i8* @_lfortran_malloc(i32 26)
+  call void @_lfortran_string_init(i32 26, i8* %3)
+  store i8* %3, i8** %greetings, align 8
   %surname = alloca i8*, align 8
-  %6 = call i8* @_lfortran_malloc(i32 16)
-  call void @_lfortran_string_init(i32 16, i8* %6)
-  store i8* %6, i8** %surname, align 8
-  %7 = load i8*, i8** %surname, align 8
+  %4 = call i8* @_lfortran_malloc(i32 16)
+  call void @_lfortran_string_init(i32 16, i8* %4)
+  store i8* %4, i8** %surname, align 8
   %title = alloca i8*, align 8
-  %8 = call i8* @_lfortran_malloc(i32 7)
-  call void @_lfortran_string_init(i32 7, i8* %8)
-  store i8* %8, i8** %title, align 8
-  %9 = load i8*, i8** %title, align 8
+  %5 = call i8* @_lfortran_malloc(i32 7)
+  call void @_lfortran_string_init(i32 7, i8* %5)
+  store i8* %5, i8** %title, align 8
   call void @_lfortran_strcpy_pointer_string(i8** %title, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @0, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %firstname, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @1, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %surname, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %greetings, i8* getelementptr inbounds ([26 x i8], [26 x i8]* @3, i32 0, i32 0))
-  %10 = load i8*, i8** %title, align 8
-  %11 = load i8*, i8** %firstname, align 8
-  %12 = load i8*, i8** %surname, align 8
-  %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 7, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @5, i32 0, i32 0), i32 7, i8* %10, i32 7, i8* %11, i32 7, i8* %12)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %14 = load i8*, i8** %greetings, align 8
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  %6 = load i8*, i8** %title, align 8
+  %7 = load i8*, i8** %firstname, align 8
+  %8 = load i8*, i8** %surname, align 8
+  %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 7, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @5, i32 0, i32 0), i32 7, i8* %6, i32 7, i8* %7, i32 7, i8* %8)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  %10 = load i8*, i8** %greetings, align 8
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "b1048f4b974c34500f7ecb351e481ca4a3f051db96c46a2802ee823e",
+    "stdout_hash": "f6439e9cc0941ece58ba42559f7ac6cd8bdbc0b4909f7ad2b3c4ddef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -17,78 +17,68 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i8* @_lfortran_malloc(i32 30)
   call void @_lfortran_string_init(i32 30, i8* %2)
   store i8* %2, i8** %combined, align 8
-  %3 = load i8*, i8** %combined, align 8
   %last_name = alloca i8*, align 8
-  %4 = call i8* @_lfortran_malloc(i32 8)
-  call void @_lfortran_string_init(i32 8, i8* %4)
-  store i8* %4, i8** %last_name, align 8
-  %5 = load i8*, i8** %last_name, align 8
+  %3 = call i8* @_lfortran_malloc(i32 8)
+  call void @_lfortran_string_init(i32 8, i8* %3)
+  store i8* %3, i8** %last_name, align 8
   %posit = alloca i8*, align 8
-  %6 = call i8* @_lfortran_malloc(i32 6)
-  call void @_lfortran_string_init(i32 6, i8* %6)
-  store i8* %6, i8** %posit, align 8
-  %7 = load i8*, i8** %posit, align 8
+  %4 = call i8* @_lfortran_malloc(i32 6)
+  call void @_lfortran_string_init(i32 6, i8* %4)
+  store i8* %4, i8** %posit, align 8
   %title = alloca i8*, align 8
-  %8 = call i8* @_lfortran_malloc(i32 5)
-  call void @_lfortran_string_init(i32 5, i8* %8)
-  store i8* %8, i8** %title, align 8
-  %9 = load i8*, i8** %title, align 8
+  %5 = call i8* @_lfortran_malloc(i32 5)
+  call void @_lfortran_string_init(i32 5, i8* %5)
+  store i8* %5, i8** %title, align 8
   %verb = alloca i8*, align 8
-  %10 = call i8* @_lfortran_malloc(i32 9)
-  call void @_lfortran_string_init(i32 9, i8* %10)
-  store i8* %10, i8** %verb, align 8
-  %11 = load i8*, i8** %verb, align 8
+  %6 = call i8* @_lfortran_malloc(i32 9)
+  call void @_lfortran_string_init(i32 9, i8* %6)
+  store i8* %6, i8** %verb, align 8
   call void @_lfortran_strcpy_pointer_string(i8** %verb, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @0, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %posit, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %title, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %last_name, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0))
-  %12 = load i8*, i8** %verb, align 8
+  %7 = load i8*, i8** %verb, align 8
+  %8 = alloca i8*, align 8
+  store i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i32 0, i32 0), i8** %8, align 8
+  %9 = alloca i8*, align 8
+  store i8* %7, i8** %9, align 8
+  %10 = alloca i8*, align 8
+  call void @_lfortran_strcat(i8** %8, i8** %9, i8** %10)
+  %11 = load i8*, i8** %10, align 8
+  %12 = load i8*, i8** %posit, align 8
   %13 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i32 0, i32 0), i8** %13, align 8
+  store i8* %11, i8** %13, align 8
   %14 = alloca i8*, align 8
   store i8* %12, i8** %14, align 8
   %15 = alloca i8*, align 8
   call void @_lfortran_strcat(i8** %13, i8** %14, i8** %15)
   %16 = load i8*, i8** %15, align 8
-  %17 = load i8*, i8** %15, align 8
-  %18 = load i8*, i8** %posit, align 8
+  %17 = load i8*, i8** %title, align 8
+  %18 = alloca i8*, align 8
+  store i8* %16, i8** %18, align 8
   %19 = alloca i8*, align 8
   store i8* %17, i8** %19, align 8
   %20 = alloca i8*, align 8
-  store i8* %18, i8** %20, align 8
-  %21 = alloca i8*, align 8
-  call void @_lfortran_strcat(i8** %19, i8** %20, i8** %21)
-  %22 = load i8*, i8** %21, align 8
-  %23 = load i8*, i8** %21, align 8
-  %24 = load i8*, i8** %title, align 8
+  call void @_lfortran_strcat(i8** %18, i8** %19, i8** %20)
+  %21 = load i8*, i8** %20, align 8
+  %22 = load i8*, i8** %last_name, align 8
+  %23 = alloca i8*, align 8
+  store i8* %21, i8** %23, align 8
+  %24 = alloca i8*, align 8
+  store i8* %22, i8** %24, align 8
   %25 = alloca i8*, align 8
-  store i8* %23, i8** %25, align 8
-  %26 = alloca i8*, align 8
-  store i8* %24, i8** %26, align 8
+  call void @_lfortran_strcat(i8** %23, i8** %24, i8** %25)
+  %26 = load i8*, i8** %25, align 8
   %27 = alloca i8*, align 8
-  call void @_lfortran_strcat(i8** %25, i8** %26, i8** %27)
-  %28 = load i8*, i8** %27, align 8
-  %29 = load i8*, i8** %27, align 8
-  %30 = load i8*, i8** %last_name, align 8
-  %31 = alloca i8*, align 8
-  store i8* %29, i8** %31, align 8
-  %32 = alloca i8*, align 8
-  store i8* %30, i8** %32, align 8
-  %33 = alloca i8*, align 8
-  call void @_lfortran_strcat(i8** %31, i8** %32, i8** %33)
-  %34 = load i8*, i8** %33, align 8
-  %35 = load i8*, i8** %33, align 8
-  %36 = alloca i8*, align 8
-  store i8* %35, i8** %36, align 8
-  %37 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0), i8** %37, align 8
-  %38 = alloca i8*, align 8
-  call void @_lfortran_strcat(i8** %36, i8** %37, i8** %38)
-  %39 = load i8*, i8** %38, align 8
-  %40 = load i8*, i8** %38, align 8
-  store i8* %40, i8** %combined, align 8
-  %41 = load i8*, i8** %combined, align 8
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  store i8* %26, i8** %27, align 8
+  %28 = alloca i8*, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0), i8** %28, align 8
+  %29 = alloca i8*, align 8
+  call void @_lfortran_strcat(i8** %27, i8** %28, i8** %29)
+  %30 = load i8*, i8** %29, align 8
+  store i8* %30, i8** %combined, align 8
+  %31 = load i8*, i8** %combined, align 8
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "4b48d8f4a71a62c339b67f55e9a1f9bf1a4dde684f8cf1fd7ef55405",
+    "stdout_hash": "df379d84871e04fbcdff6fc1bdb5a1e4fc9104be7621208186ebe3dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -48,127 +48,126 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = call i8* @_lfortran_malloc(i32 4)
   call void @_lfortran_string_init(i32 4, i8* %4)
   store i8* %4, i8** %num, align 8
-  %5 = load i8*, i8** %num, align 8
-  %6 = load i8*, i8** @string_10.c, align 8
+  %5 = load i8*, i8** @string_10.c, align 8
+  %6 = alloca i8*, align 8
+  store i8* %5, i8** %6, align 8
   %7 = alloca i8*, align 8
-  store i8* %6, i8** %7, align 8
-  %8 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0), i8** %8, align 8
-  %9 = call i1 @_lpython_str_compare_gte(i8** %7, i8** %8)
-  %10 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0), i8** %7, align 8
+  %8 = call i1 @_lpython_str_compare_gte(i8** %6, i8** %7)
+  %9 = load i8*, i8** @string_10.c, align 8
+  %10 = alloca i8*, align 8
+  store i8* %9, i8** %10, align 8
   %11 = alloca i8*, align 8
-  store i8* %10, i8** %11, align 8
-  %12 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i8** %12, align 8
-  %13 = call i1 @_lpython_str_compare_lte(i8** %11, i8** %12)
-  %14 = icmp eq i1 %9, false
-  %15 = select i1 %14, i1 %9, i1 %13
-  %16 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i8** %11, align 8
+  %12 = call i1 @_lpython_str_compare_lte(i8** %10, i8** %11)
+  %13 = icmp eq i1 %8, false
+  %14 = select i1 %13, i1 %8, i1 %12
+  %15 = load i8*, i8** @string_10.c, align 8
+  %16 = alloca i8*, align 8
+  store i8* %15, i8** %16, align 8
   %17 = alloca i8*, align 8
-  store i8* %16, i8** %17, align 8
-  %18 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i8** %18, align 8
-  %19 = call i1 @_lpython_str_compare_gte(i8** %17, i8** %18)
-  %20 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i8** %17, align 8
+  %18 = call i1 @_lpython_str_compare_gte(i8** %16, i8** %17)
+  %19 = load i8*, i8** @string_10.c, align 8
+  %20 = alloca i8*, align 8
+  store i8* %19, i8** %20, align 8
   %21 = alloca i8*, align 8
-  store i8* %20, i8** %21, align 8
-  %22 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i8** %22, align 8
-  %23 = call i1 @_lpython_str_compare_lte(i8** %21, i8** %22)
-  %24 = icmp eq i1 %19, false
-  %25 = select i1 %24, i1 %19, i1 %23
-  %26 = icmp eq i1 %15, false
-  %27 = select i1 %26, i1 %25, i1 %15
-  store i1 %27, i1* %is_alpha, align 1
-  %28 = load i1, i1* %is_alpha, align 1
-  %29 = icmp eq i1 %28, false
-  %30 = select i1 %29, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0)
-  %31 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %30)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i8** %21, align 8
+  %22 = call i1 @_lpython_str_compare_lte(i8** %20, i8** %21)
+  %23 = icmp eq i1 %18, false
+  %24 = select i1 %23, i1 %18, i1 %22
+  %25 = icmp eq i1 %14, false
+  %26 = select i1 %25, i1 %24, i1 %14
+  store i1 %26, i1* %is_alpha, align 1
+  %27 = load i1, i1* %is_alpha, align 1
+  %28 = icmp eq i1 %27, false
+  %29 = select i1 %28, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0)
+  %30 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %29)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
-  %32 = load i8*, i8** @string_10.c, align 8
+  %31 = load i8*, i8** @string_10.c, align 8
+  %32 = alloca i8*, align 8
+  store i8* %31, i8** %32, align 8
   %33 = alloca i8*, align 8
-  store i8* %32, i8** %33, align 8
-  %34 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i8** %34, align 8
-  %35 = call i1 @_lpython_str_compare_gte(i8** %33, i8** %34)
-  %36 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i8** %33, align 8
+  %34 = call i1 @_lpython_str_compare_gte(i8** %32, i8** %33)
+  %35 = load i8*, i8** @string_10.c, align 8
+  %36 = alloca i8*, align 8
+  store i8* %35, i8** %36, align 8
   %37 = alloca i8*, align 8
-  store i8* %36, i8** %37, align 8
-  %38 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0), i8** %38, align 8
-  %39 = call i1 @_lpython_str_compare_lte(i8** %37, i8** %38)
-  %40 = icmp eq i1 %35, false
-  %41 = select i1 %40, i1 %35, i1 %39
-  %42 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0), i8** %37, align 8
+  %38 = call i1 @_lpython_str_compare_lte(i8** %36, i8** %37)
+  %39 = icmp eq i1 %34, false
+  %40 = select i1 %39, i1 %34, i1 %38
+  %41 = load i8*, i8** @string_10.c, align 8
+  %42 = alloca i8*, align 8
+  store i8* %41, i8** %42, align 8
   %43 = alloca i8*, align 8
-  store i8* %42, i8** %43, align 8
-  %44 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i8** %44, align 8
-  %45 = call i1 @_lpython_str_compare_gte(i8** %43, i8** %44)
-  %46 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i8** %43, align 8
+  %44 = call i1 @_lpython_str_compare_gte(i8** %42, i8** %43)
+  %45 = load i8*, i8** @string_10.c, align 8
+  %46 = alloca i8*, align 8
+  store i8* %45, i8** %46, align 8
   %47 = alloca i8*, align 8
-  store i8* %46, i8** %47, align 8
-  %48 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0), i8** %48, align 8
-  %49 = call i1 @_lpython_str_compare_lte(i8** %47, i8** %48)
-  %50 = icmp eq i1 %45, false
-  %51 = select i1 %50, i1 %45, i1 %49
-  %52 = icmp eq i1 %41, false
-  %53 = select i1 %52, i1 %51, i1 %41
-  store i1 %53, i1* %is_alpha, align 1
-  %54 = load i1, i1* %is_alpha, align 1
-  %55 = icmp eq i1 %54, false
-  %56 = select i1 %55, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0)
-  %57 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %56)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0), i8** %47, align 8
+  %48 = call i1 @_lpython_str_compare_lte(i8** %46, i8** %47)
+  %49 = icmp eq i1 %44, false
+  %50 = select i1 %49, i1 %44, i1 %48
+  %51 = icmp eq i1 %40, false
+  %52 = select i1 %51, i1 %50, i1 %40
+  store i1 %52, i1* %is_alpha, align 1
+  %53 = load i1, i1* %is_alpha, align 1
+  %54 = icmp eq i1 %53, false
+  %55 = select i1 %54, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0)
+  %56 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %55)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @18, i32 0, i32 0))
-  %58 = load i8*, i8** @string_10.c, align 8
+  %57 = load i8*, i8** @string_10.c, align 8
+  %58 = alloca i8*, align 8
+  store i8* %57, i8** %58, align 8
   %59 = alloca i8*, align 8
-  store i8* %58, i8** %59, align 8
-  %60 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0), i8** %60, align 8
-  %61 = call i1 @_lpython_str_compare_gte(i8** %59, i8** %60)
-  %62 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @19, i32 0, i32 0), i8** %59, align 8
+  %60 = call i1 @_lpython_str_compare_gte(i8** %58, i8** %59)
+  %61 = load i8*, i8** @string_10.c, align 8
+  %62 = alloca i8*, align 8
+  store i8* %61, i8** %62, align 8
   %63 = alloca i8*, align 8
-  store i8* %62, i8** %63, align 8
-  %64 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i8** %64, align 8
-  %65 = call i1 @_lpython_str_compare_lte(i8** %63, i8** %64)
-  %66 = icmp eq i1 %61, false
-  %67 = select i1 %66, i1 %61, i1 %65
-  %68 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i8** %63, align 8
+  %64 = call i1 @_lpython_str_compare_lte(i8** %62, i8** %63)
+  %65 = icmp eq i1 %60, false
+  %66 = select i1 %65, i1 %60, i1 %64
+  %67 = load i8*, i8** @string_10.c, align 8
+  %68 = alloca i8*, align 8
+  store i8* %67, i8** %68, align 8
   %69 = alloca i8*, align 8
-  store i8* %68, i8** %69, align 8
-  %70 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0), i8** %70, align 8
-  %71 = call i1 @_lpython_str_compare_gte(i8** %69, i8** %70)
-  %72 = load i8*, i8** @string_10.c, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0), i8** %69, align 8
+  %70 = call i1 @_lpython_str_compare_gte(i8** %68, i8** %69)
+  %71 = load i8*, i8** @string_10.c, align 8
+  %72 = alloca i8*, align 8
+  store i8* %71, i8** %72, align 8
   %73 = alloca i8*, align 8
-  store i8* %72, i8** %73, align 8
-  %74 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i8** %74, align 8
-  %75 = call i1 @_lpython_str_compare_lte(i8** %73, i8** %74)
-  %76 = icmp eq i1 %71, false
-  %77 = select i1 %76, i1 %71, i1 %75
-  %78 = icmp eq i1 %67, false
-  %79 = select i1 %78, i1 %77, i1 %67
-  store i1 %79, i1* %is_alpha, align 1
-  %80 = load i1, i1* %is_alpha, align 1
-  %81 = icmp eq i1 %80, false
-  %82 = select i1 %81, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0)
-  %83 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %82)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* %83, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0))
-  %84 = load i8*, i8** %num, align 8
-  %85 = call i8* @_lfortran_str_slice_assign(i8* %84, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @27, i32 0, i32 0), i32 0, i32 3, i32 1, i1 true, i1 true)
-  call void @_lfortran_strcpy_pointer_string(i8** %num, i8* %85)
-  %86 = load i8*, i8** %num, align 8
+  store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i8** %73, align 8
+  %74 = call i1 @_lpython_str_compare_lte(i8** %72, i8** %73)
+  %75 = icmp eq i1 %70, false
+  %76 = select i1 %75, i1 %70, i1 %74
+  %77 = icmp eq i1 %66, false
+  %78 = select i1 %77, i1 %76, i1 %66
+  store i1 %78, i1* %is_alpha, align 1
+  %79 = load i1, i1* %is_alpha, align 1
+  %80 = icmp eq i1 %79, false
+  %81 = select i1 %80, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0)
+  %82 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %81)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* %82, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0))
+  %83 = load i8*, i8** %num, align 8
+  %84 = call i8* @_lfortran_str_slice_assign(i8* %83, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @27, i32 0, i32 0), i32 0, i32 3, i32 1, i1 true, i1 true)
+  call void @_lfortran_strcpy_pointer_string(i8** %num, i8* %84)
+  %85 = load i8*, i8** %num, align 8
+  %86 = alloca i8*, align 8
+  store i8* %85, i8** %86, align 8
   %87 = alloca i8*, align 8
-  store i8* %86, i8** %87, align 8
-  %88 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @28, i32 0, i32 0), i8** %88, align 8
-  %89 = call i1 @_lpython_str_compare_noteq(i8** %87, i8** %88)
-  br i1 %89, label %then, label %else
+  store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @28, i32 0, i32 0), i8** %87, align 8
+  %88 = call i1 @_lpython_str_compare_noteq(i8** %86, i8** %87)
+  br i1 %88, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
@@ -179,6 +178,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lfortran_free(i8* %3)
   call void @_lpython_free_argv()
   br label %return
 
@@ -209,5 +209,7 @@ declare i1 @_lpython_str_compare_noteq(i8**, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "5ca4341a4fbd7f264271a84d09c30a32bd770f701d6b3cb9eb33dcd8",
+    "stdout_hash": "72af2457d0cdf8d6a15d0850105f374f17c12605c2e63c508c4a434c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -297,19 +297,17 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i8* @_lfortran_malloc(i32 31)
   call void @_lfortran_string_init(i32 31, i8* %2)
   store i8* %2, i8** %mystring, align 8
-  %3 = load i8*, i8** %mystring, align 8
   %teststring = alloca i8*, align 8
-  %4 = call i8* @_lfortran_malloc(i32 11)
-  call void @_lfortran_string_init(i32 11, i8* %4)
-  store i8* %4, i8** %teststring, align 8
-  %5 = load i8*, i8** %teststring, align 8
+  %3 = call i8* @_lfortran_malloc(i32 11)
+  call void @_lfortran_string_init(i32 11, i8* %3)
+  store i8* %3, i8** %teststring, align 8
   call void @_lfortran_strcpy_pointer_string(i8** %mystring, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @0, i32 0, i32 0))
   call void @_lfortran_strcpy_pointer_string(i8** %teststring, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0))
   store i1 false, i1* %call_arg_value, align 1
   store i32 4, i32* %call_arg_value1, align 4
-  %6 = call i32 @_lcompilers_index_str(i8** %mystring, i8** %teststring, i1* %call_arg_value, i32* %call_arg_value1)
-  %7 = icmp eq i32 %6, 0
-  br i1 %7, label %then, label %else
+  %4 = call i32 @_lcompilers_index_str(i8** %mystring, i8** %teststring, i1* %call_arg_value, i32* %call_arg_value1)
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* getelementptr inbounds ([18 x i8], [18 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
@@ -318,10 +316,10 @@ then:                                             ; preds = %.entry
 else:                                             ; preds = %.entry
   store i1 false, i1* %call_arg_value2, align 1
   store i32 4, i32* %call_arg_value3, align 4
-  %8 = call i32 @_lcompilers_index_str1(i8** %mystring, i8** %teststring, i1* %call_arg_value2, i32* %call_arg_value3)
-  %9 = sext i32 %8 to i64
-  %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @6, i32 0, i32 0), i32 2, i64 %9)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  %6 = call i32 @_lcompilers_index_str1(i8** %mystring, i8** %teststring, i1* %call_arg_value2, i32* %call_arg_value3)
+  %7 = sext i32 %6 to i64
+  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @6, i32 0, i32 0), i32 2, i64 %7)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then


### PR DESCRIPTION
This was commented out while syncing `libasr` with LPython in #2837.