### PR TITLE
Parser: error at the statement level

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -681,7 +681,6 @@ endinterface
     | endinterface0 KW_OPERATOR "(" operator_type ")"
     | endinterface0 KW_OPERATOR "(" "/)"
     | endinterface0 KW_OPERATOR "(" TK_DEF_OP ")"
-    | error
     ;
 
 endinterface0
@@ -723,7 +722,6 @@ endenum
 enum_var_modifiers
     : %empty { LIST_NEW($$); }
     | var_modifier_list { $$ = $1; }
-    | error { LIST_NEW($$); }
     ;
 
 derived_type_decl
@@ -757,7 +755,6 @@ require_decl
 unit_require_plus
     : unit_require_plus "," unit_require { $$ = $1; LIST_ADD($$, $3); }
     | unit_require { LIST_NEW($$); LIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 unit_require
@@ -818,19 +815,16 @@ procedure_decl
             $$ = GENERIC_READ($2, $5, $8, TRIVIA_AFTER($9, @$), @$); }
     | KW_FINAL "::" id sep { $$ = FINAL_NAME($3, TRIVIA_AFTER($4, @$), @$); }
     | KW_PRIVATE sep { $$ = PRIVATE(Private, TRIVIA_AFTER($2, @$), @$); }
-    | error { $$ = nullptr; }
     ;
 
 access_spec_list
     : "::" { LIST_NEW($$); }
     | access_spec "::" { LIST_NEW($$); LIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 access_spec
     : "," KW_PRIVATE  { $$ = SIMPLE_ATTR(Private, @$); }
     | "," KW_PUBLIC { $$ = SIMPLE_ATTR(Public, @$); }
-    | error { $$ = SIMPLE_ATTR_INVALID(@$); }
     ;
 
 operator_type
@@ -852,7 +846,6 @@ operator_type
     | ".xor."  { $$ = OPERATOR(XOR, @$); }
     | ".eqv."  { $$ = OPERATOR(EQV, @$); }
     | ".neqv." { $$ = OPERATOR(NEQV, @$); }
-    | error { $$ = OPERATOR_INVALID(@$); }
     ;
 
 proc_modifiers
@@ -874,7 +867,6 @@ proc_modifier
     | KW_NOPASS { $$ = SIMPLE_ATTR(NoPass, @$); }
     | KW_DEFERRED { $$ = SIMPLE_ATTR(Deferred, @$); }
     | KW_NON_OVERRIDABLE { $$ = SIMPLE_ATTR(NonDeferred, @$); }
-    | error { $$ = SIMPLE_ATTR_INVALID(@$); }
     ;
 
 
@@ -910,7 +902,6 @@ end_blockdata
     : KW_END_BLOCK_DATA id_opt
     | KW_ENDBLOCKDATA id_opt
     | KW_END
-    | error
     ;
 
 end_subroutine
@@ -934,13 +925,11 @@ end_function
 end_associate
     : KW_END_ASSOCIATE
     | KW_ENDASSOCIATE
-    | error
     ;
 
 end_block
     : KW_END_BLOCK
     | KW_ENDBLOCK
-    | error
     ;
 
 end_select
@@ -951,7 +940,6 @@ end_select
 end_critical
     : KW_END_CRITICAL
     | KW_ENDCRITICAL
-    | error
     ;
 
 end_team
@@ -1057,7 +1045,6 @@ function
 fn_mod_plus
     : fn_mod_plus fn_mod { $$ = $1; LIST_ADD($$, $2); }
     | fn_mod { LIST_NEW($$); LIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 fn_mod
@@ -1102,13 +1089,11 @@ contains_block_opt
     : KW_CONTAINS sep sub_or_func_plus { $$ = $3; }
     | KW_CONTAINS sep { LIST_NEW($$); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 sub_or_func_star
     : sub_or_func_plus
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
 
 sub_or_func_plus
     : sub_or_func_plus sub_or_func { LIST_ADD($$, $2); }
@@ -1124,7 +1109,6 @@ sub_or_func
 sub_args
     : "(" id_or_star_list ")" { $$ = $2; }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 id_or_star_list
@@ -1150,7 +1134,6 @@ bind
 result_opt
     : result { $$ = $1; }
     | %empty { $$ = nullptr; }
-    | error { $$ = nullptr; }
     ;
 
 result
@@ -1224,7 +1207,6 @@ implicit_statement
 implicit_none_spec_list
     : implicit_none_spec_list "," implicit_none_spec { $$ = $1; LIST_ADD($$, $3); }
     | implicit_none_spec { LIST_NEW($$); LIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 implicit_none_spec
@@ -1307,14 +1289,12 @@ use_modifier_list
 use_modifier
     : KW_INTRINSIC { $$ = SIMPLE_ATTR(Intrinsic, @$); }
     | KW_NON_INTRINSIC { $$ = SIMPLE_ATTR(Non_Intrinsic, @$); }
-    | error { $$ = SIMPLE_ATTR_INVALID(@$); }
     ;
 
 // var_decl*
 var_decl_star
     : var_decl_star var_decl { $$ = $1; LIST_ADD($$, $2); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 var_decl
@@ -1345,7 +1325,6 @@ var_decl
 equivalence_set_list
     : equivalence_set_list "," equivalence_set { $$ = $1; PLIST_ADD($$, $3); }
     | equivalence_set { LIST_NEW($$); PLIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 equivalence_set
@@ -1356,7 +1335,6 @@ named_constant_def_list
     : named_constant_def_list "," named_constant_def {
             $$ = $1; PLIST_ADD($$, $3); }
     | named_constant_def { LIST_NEW($$); PLIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 named_constant_def
@@ -1436,7 +1414,6 @@ data_stmt_constant
 integer_type
     : KW_INTEGER "(" kind_arg_list ")" "::" {
             $$ = ATTR_TYPE_KIND(Integer, $3, @$); }
-    | error { $$ = nullptr; }
     ;
 
 kind_arg_list
@@ -1635,6 +1612,7 @@ sep_one
 decl_statements
     : decl_statements decl_statement { $$ = $1; LIST_ADD($$, $2); }
     | %empty { LIST_NEW($$); }
+    | decl_statements error sep_one { $$ = $1; }
     ;
 
 decl_statement
@@ -1915,7 +1893,6 @@ elseif_block
             $$ = IF3($3, TRIVIA_AFTER($7, @$), $8, $10, @$); }
     | KW_ELSEIF "(" expr ")" KW_THEN id_opt sep statements elseif_block {
             $$ = IF3($3, TRIVIA_AFTER($7, @$), $8, $9, @$); }
-    | error { $$ = nullptr; }
     ;
 
 where_statement
@@ -1954,7 +1931,6 @@ elsewhere_block
             $$ = WHERE1($3, TRIVIA_AFTER($5, @$), $6, @$); }
     | KW_ELSE KW_WHERE "(" expr ")" sep statements {
             $$ = WHERE1($4, TRIVIA_AFTER($6, @$), $7, @$); }
-    | error { $$ = nullptr; }
     ;
 
 select_statement
@@ -1967,7 +1943,6 @@ select_statement
 case_statements
     : case_statements case_statement { $$ = $1; LIST_ADD($$, $2); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 case_statement
@@ -2003,7 +1978,6 @@ select_rank
 select_rank_case_stmts
     : select_rank_case_stmts select_rank_case_stmt { $$ = $1; LIST_ADD($$, $2); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 select_rank_case_stmt
@@ -2030,7 +2004,6 @@ select_type_body_statements
     : select_type_body_statements select_type_body_statement {
                         $$ = $1; LIST_ADD($$, $2); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 select_type_body_statement
@@ -2071,7 +2044,6 @@ concurrent_control_list
     : concurrent_control_list "," concurrent_control {
         $$ = $1; LIST_ADD($$, $3); }
     | concurrent_control { LIST_NEW($$); LIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 concurrent_control
@@ -2085,7 +2057,6 @@ concurrent_locality_star
     : concurrent_locality_star concurrent_locality {
         $$ = $1; LIST_ADD($$, $2); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 concurrent_locality
@@ -2153,13 +2124,11 @@ enddo
     | TK_LABEL KW_END_DO
     | KW_ENDDO { WARN_ENDDO(@$); }
     | TK_LABEL KW_ENDDO {}
-    | error
     ;
 
 endforall
     : KW_END_FORALL
     | KW_ENDFORALL
-    | error
     ;
 
 endif
@@ -2273,7 +2242,6 @@ event_wait_spec_list
     : event_wait_spec_list "," sync_stat { $$ = $1; LIST_ADD($$, $3); }
     | event_wait_spec { LIST_NEW($$); LIST_ADD($$, $1); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$); }
     ;
 
 event_wait_spec
@@ -2282,7 +2250,6 @@ event_wait_spec
 
 event_post_stat_list
     : sync_stat { LIST_NEW($$); LIST_ADD($$, $1); }
-    | error { LIST_NEW($$); }
     ;
 
 sync_stat_list
@@ -2325,7 +2292,6 @@ coarray_association_list
     : coarray_association_list "," coarray_association { $$ = $1; LIST_ADD($$, $3); }
     | coarray_association { LIST_NEW($$); LIST_ADD($$, $1); }
     | %empty { LIST_NEW($$); }
-    | error { LIST_NEW($$);}
     ;
 
 coarray_association
@@ -2686,5 +2652,4 @@ id
     | KW_WHERE { $$ = SYMBOL($1, @$); }
     | KW_WHILE { $$ = SYMBOL($1, @$); }
     | KW_WRITE { $$ = SYMBOL($1, @$); }
-    | error { $$ = SYMBOL(LCompilers::Str(), @$); }
     ;


### PR DESCRIPTION
Now we have just one error recovery at the statement level, which is easier to mmaintain and it is able to print AST, since we simply skip the statement.

This provides an improvement over the initial implementation in https://github.com/lfortran/lfortran/pull/4774. The test introduced there still works.