### PR TITLE
CI: fix version of cmake to use

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -20,5 +20,5 @@ dependencies:
   - ninja
   - zlib
   - zstd-static
-  - cmake
+  - cmake=3.29.1
   - make


### PR DESCRIPTION
## Description

Currently, we've a failure in *main* for the run here: https://github.com/lfortran/lfortran/actions/runs/11966322550/job/33361766770.

Ondřej in a message here: https://lfortran.zulipchat.com/#narrow/channel/197339-General/topic/CI.20failure.20in.20main/near/483842225, mentioned that:

> Use the same version that we use at the CI

This PR fixes the version of `cmake` to 3.29.1