### PR TITLE
Modify return type for `BinOp` after `where` pass itemize the array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1083,6 +1083,7 @@ RUN(NAME where_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 RUN(NAME forall_01 LABELS gfortran llvm NOFAST)

--- a/integration_tests/where_14.f90
+++ b/integration_tests/where_14.f90
@@ -1,16 +1,27 @@
+! Test that `BinOp` on arrays inside `where` works and result in correct `BinOp` after indexing.  
 program where_14
     real :: A(4)
     call temp(A)
     
     contains
     subroutine temp(A)
-    real, intent(in) :: A(:)
-    integer :: xbdi(size(A))
-    integer :: ssq(size(A))
-    xbdi = [212334,0,212121,0]
-    ssq = [1,10,1,-1]
-    where (xbdi == 0) ssq = max(0, ssq - xbdi)
-    print *, ssq
-    if(any(ssq /= [1, 10, 1, 0])) error stop
+        real, intent(in) :: A(:)
+        integer :: xbdi(size(A))
+        integer :: ssq(size(A))
+        xbdi = [212334,0,212121,0]
+        ssq = [1,10,1,-1]
+        where (xbdi == 0) ssq = max(0, ssq - xbdi)
+        print *, ssq
+        if(any(ssq /= [1, 10, 1, 0])) error stop
+        
+        ssq = [100,0,100,3]
+        where (xbdi == 0) ssq = max(0, 2 - ssq)
+        print *, ssq
+        if(any(ssq /= [100, 2, 100, 0])) error stop
+        
+        ssq = [100,0,100,3]
+        where (xbdi == 0) ssq = max(0,ssq - 2)
+        print *, ssq
+        if(any(ssq /= [100, 0, 100, 1])) error stop
     end subroutine
 end program

--- a/integration_tests/where_14.f90
+++ b/integration_tests/where_14.f90
@@ -1,0 +1,16 @@
+program where_14
+    real :: A(4)
+    call temp(A)
+    
+    contains
+    subroutine temp(A)
+    real, intent(in) :: A(:)
+    integer :: xbdi(size(A))
+    integer :: ssq(size(A))
+    xbdi = [212334,0,212121,0]
+    ssq = [1,10,1,-1]
+    where (xbdi == 0) ssq = max(0, ssq - xbdi)
+    print *, ssq
+    if(any(ssq /= [1, 10, 1, 0])) error stop
+    end subroutine
+end program

--- a/src/libasr/pass/where.cpp
+++ b/src/libasr/pass/where.cpp
@@ -86,7 +86,7 @@ public:
         ASR::expr_t* right = *current_expr; \
         current_expr = current_expr_copy; \
         ASR::ttype_t* return_type;\
-        /* Both sides are primtives, OR one side is primitve and the other is ArrayBroadCast, OR both arrays*/ \
+        /* Both sides are primitives, OR one side is primitive and the other is ArrayBroadCast, OR both arrays*/ \
         bool return_is_primitve =!ASRUtils::is_array(ASRUtils::expr_type(x->m_left)) || \
             !ASRUtils::is_array(ASRUtils::expr_type(x->m_right)); \
         return_type = return_is_primitve? ASRUtils::type_get_past_array(ASRUtils::expr_type(x->m_left)) : x->m_type;\

--- a/src/libasr/pass/where.cpp
+++ b/src/libasr/pass/where.cpp
@@ -85,8 +85,13 @@ public:
         this->replace_expr(x->m_right); \
         ASR::expr_t* right = *current_expr; \
         current_expr = current_expr_copy; \
+        ASR::ttype_t* return_type;\
+        /* Both sides are primtives, OR one side is primitve and the other is ArrayBroadCast, OR both arrays*/ \
+        bool return_is_primitve =!ASRUtils::is_array(ASRUtils::expr_type(x->m_left)) || \
+            !ASRUtils::is_array(ASRUtils::expr_type(x->m_right)); \
+        return_type = return_is_primitve? ASRUtils::type_get_past_array(ASRUtils::expr_type(x->m_left)) : x->m_type;\
         *current_expr = ASRUtils::EXPR(ASR::Constructor(al, x->base.base.loc, \
-            left, x->m_op, right, x->m_type, nullptr)); \
+            left, x->m_op, right, return_type, nullptr)); \
 
     void replace_IntegerBinOp(ASR::IntegerBinOp_t* x) {
         BinOpReplacement(make_IntegerBinOp_t)

--- a/tests/reference/pass_where-where_03-00685f9.json
+++ b/tests/reference/pass_where-where_03-00685f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_where-where_03-00685f9.stdout",
-    "stdout_hash": "c7c8da8785919fabb409a378f4209c4a3ae3e725c2f33c1b126d8d42",
+    "stdout_hash": "a508ce57caf6d0be8588720a0df9ddd3e13289e65e3571ccd01f7dd4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_where-where_03-00685f9.stdout
+++ b/tests/reference/pass_where-where_03-00685f9.stdout
@@ -336,12 +336,7 @@
                                                         ColMajor
                                                     )
                                                 )
-                                                (Array
-                                                    (Real 4)
-                                                    [((IntegerConstant 1 (Integer 4) Decimal)
-                                                    (IntegerConstant 4 (Integer 4) Decimal))]
-                                                    FixedSizeArray
-                                                )
+                                                (Real 4)
                                                 ()
                                             )
                                             Div
@@ -354,12 +349,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            (Array
-                                                (Real 4)
-                                                [((IntegerConstant 1 (Integer 4) Decimal)
-                                                (IntegerConstant 4 (Integer 4) Decimal))]
-                                                FixedSizeArray
-                                            )
+                                            (Real 4)
                                             ()
                                         )
                                         Mul
@@ -397,12 +387,7 @@
                                                 ColMajor
                                             )
                                         )
-                                        (Array
-                                            (Real 4)
-                                            [((IntegerConstant 1 (Integer 4) Decimal)
-                                            (IntegerConstant 4 (Integer 4) Decimal))]
-                                            FixedSizeArray
-                                        )
+                                        (Real 4)
                                         ()
                                     )
                                     ()


### PR DESCRIPTION
Fixes #5433
It changes the ASR for the example `where (xbdi == 0) ssq = max(0, ssq - xbdi)` from 
```Clojure
(IntegerBinOp
    (ArrayItem
        (Var 3 ssq)
        [(()
        (Var 3 __1_k)
        ())]
        (Integer 4)
        RowMajor
        ()
    )
    Sub
    (ArrayItem
        (Var 3 xbdi)
        [(()
        (Var 3 __1_k)
        ())]
        (Integer 4)
        RowMajor
        ()
    )
    (Array
        (Integer 4)
        [((IntegerConstant 1 (Integer 4) Decimal)
        (ArraySize
            (Var 3 a)
            ()
            (Integer 4)
            ()
        ))]
        PointerToDataArray
    )
    ()
)
```
To
```Clojure
(IntegerBinOp
    (ArrayItem
        (Var 3 ssq)
        [(()
        (Var 3 __1_k)
        ())]
        (Integer 4)
        RowMajor
        ()
    )
    Sub
    (ArrayItem
        (Var 3 xbdi)
        [(()
        (Var 3 __1_k)
        ())]
        (Integer 4)
        RowMajor
        ()
    )
    (Integer 4)  ;; HERE IS THE CHANGE
    ()
)
```