### PR TITLE
enh: free memory allocated to command-line arguments at program termination

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3296,6 +3296,17 @@ public:
         }
         call_lcompilers_free_strings();
 
+        {
+            llvm::Function *fn = module->getFunction("_lpython_free_argv");
+            if(!fn) {
+                llvm::FunctionType *function_type = llvm::FunctionType::get(
+                    llvm::Type::getVoidTy(context), {}, false);
+                fn = llvm::Function::Create(function_type,
+                    llvm::Function::ExternalLinkage, "_lpython_free_argv", *module);
+            }
+            builder->CreateCall(fn, {});
+        }
+
         start_new_block(proc_return);
         llvm::Value *ret_val2 = llvm::ConstantInt::get(context,
             llvm::APInt(32, 0));

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3517,6 +3517,16 @@ LFORTRAN_API void _lpython_set_argv(int32_t argc_1, char *argv_1[]) {
     _argc = argc_1;
 }
 
+LFORTRAN_API void _lpython_free_argv() {
+    if (_argv != NULL) {
+        for (size_t i = 0; i < _argc; i++) {
+            free(_argv[i]);
+        }
+        free(_argv);
+        _argv = NULL;
+    }
+}
+
 LFORTRAN_API int32_t _lpython_get_argc() {
     return _argc;
 }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -258,6 +258,7 @@ LFORTRAN_API void _lfortran_close(int32_t unit_num);
 LFORTRAN_API int32_t _lfortran_ichar(char *c);
 LFORTRAN_API int32_t _lfortran_iachar(char *c);
 LFORTRAN_API void _lpython_set_argv(int32_t argc_1, char *argv_1[]);
+LFORTRAN_API void _lpython_free_argv();
 LFORTRAN_API int32_t _lpython_get_argc();
 LFORTRAN_API char *_lpython_get_argv(int32_t index);
 LFORTRAN_API void _lpython_call_initial_functions(int32_t argc_1, char *argv_1[]);

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "1a168dfb939e76b287b131f3bb42fd0dee9b7678d65f3e0cdb3b52ea",
+    "stdout_hash": "3b613569cf3f2c95b34c727ef0e1868ea96ca557d0eb6007c2978778",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -288,6 +288,7 @@ else13:                                           ; preds = %ifcont11
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont14
@@ -804,3 +805,5 @@ declare void @exit(i32)
 declare void @_lfortran_free(i8*)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-array2-4254183.json
+++ b/tests/reference/llvm-array2-4254183.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array2-4254183.stdout",
-    "stdout_hash": "925eef131605b22eb13aabc93aefb3d05a162b500b4868ad90aee806",
+    "stdout_hash": "defc303856a2a6c2f7561a63b0af81fa6ada6a3afee8d4e4a531a339",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array2-4254183.stdout
+++ b/tests/reference/llvm-array2-4254183.stdout
@@ -14,6 +14,7 @@ define i32 @main(i32 %0, i8** %1) {
   %h = alloca [24 x float], align 4
   %i = alloca [36 x i32], align 4
   %j = alloca [20 x i1], align 1
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -21,3 +22,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "1bc702a5c67ea1dd5a61528d6969f7484da780f83bc2fd9735203851",
+    "stdout_hash": "8f62d45e1c30066cad28a73dc1df90f1a0236be93461b5cdcc35ed5e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -581,6 +581,7 @@ ifcont156:                                        ; preds = %else155, %then154
   %48 = sext i32 %47 to i64
   %49 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %48)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont156
@@ -592,3 +593,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_01-91893af.json
+++ b/tests/reference/llvm-arrays_01-91893af.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01-91893af.stdout",
-    "stdout_hash": "0e42673de4da6a07e4282bf89ffa332b930fd8349648a284cffdd9c4",
+    "stdout_hash": "4ed6f07a4fc595742011a711eeb3cae278a96e320b5c55055d9bda17",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01-91893af.stdout
+++ b/tests/reference/llvm-arrays_01-91893af.stdout
@@ -307,6 +307,7 @@ else39:                                           ; preds = %ifcont37
   br label %ifcont40
 
 ifcont40:                                         ; preds = %else39, %then38
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont40
@@ -318,3 +319,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.json
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_complex-c90dbdd.stdout",
-    "stdout_hash": "eb30752ca40b45929345d63968a2d2781ddd6060442a0ed85f1c5d27",
+    "stdout_hash": "d57267a22760d2df52d5e68fb638bec06d5040addb2071aaf56b9ac0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
@@ -861,6 +861,7 @@ else58:                                           ; preds = %ifcont56
   br label %ifcont59
 
 ifcont59:                                         ; preds = %else58, %then57
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont59
@@ -876,3 +877,5 @@ declare void @exit(i32)
 declare void @_lfortran_complex_sub_32(%complex_4*, %complex_4*, %complex_4*)
 
 declare void @_lfortran_complex_add_32(%complex_4*, %complex_4*, %complex_4*)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "0b1c63e088b79f96df299b8a57ec5edef151161fe2b642dca993acfe",
+    "stdout_hash": "f6c16a2a63bfb3cb1a77e83bcae796794c88504c191f76b90b0ba063",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -463,6 +463,7 @@ else61:                                           ; preds = %ifcont59
   br label %ifcont62
 
 ifcont62:                                         ; preds = %else61, %then60
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont62
@@ -474,3 +475,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_01_real-6c5e850.json
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_real-6c5e850.stdout",
-    "stdout_hash": "64d2d7476348b4393ac12bb67b70f87dc55faccf91d20f2ca2550bca",
+    "stdout_hash": "76aa758e8b4feec258bf6679b337e26417a2aafa44e7225481027378",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_real-6c5e850.stdout
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.stdout
@@ -427,6 +427,7 @@ else58:                                           ; preds = %ifcont56
   br label %ifcont59
 
 ifcont59:                                         ; preds = %else58, %then57
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont59
@@ -438,3 +439,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_01_size-aaed99f.json
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_size-aaed99f.stdout",
-    "stdout_hash": "e4893a0e1a74dfcfb7fed93fc2a0a23ad36b8d94e6caba71e7cf77dc",
+    "stdout_hash": "4a30b61567a79c661d180068b4469ba6ed0b6a5fc46a28ceae670c74",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_size-aaed99f.stdout
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.stdout
@@ -349,6 +349,7 @@ else47:                                           ; preds = %ifcont45
   br label %ifcont48
 
 ifcont48:                                         ; preds = %else47, %then46
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont48
@@ -360,3 +361,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_03_func-98941b2.json
+++ b/tests/reference/llvm-arrays_03_func-98941b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_03_func-98941b2.stdout",
-    "stdout_hash": "ee2870b789172e0ce7fc97ffcdd6a78c28510d758c15bce91f8d60a1",
+    "stdout_hash": "9f7ff73b939a5bcfdaff6bf059adfdf15a1e25381346ee9be8678a30",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_03_func-98941b2.stdout
+++ b/tests/reference/llvm-arrays_03_func-98941b2.stdout
@@ -62,6 +62,7 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -119,3 +120,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_04_func-2aa342e.json
+++ b/tests/reference/llvm-arrays_04_func-2aa342e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_04_func-2aa342e.stdout",
-    "stdout_hash": "ebfc182ed2bae60e7172b473bf08dfbcf89837adea20bfbaefc8a91d",
+    "stdout_hash": "f8fdd50c799d571cfa78c967f49b43b4ff90334a5c53471adad2ca23",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_04_func-2aa342e.stdout
+++ b/tests/reference/llvm-arrays_04_func-2aa342e.stdout
@@ -46,6 +46,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -129,3 +130,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_06-538e67d.json
+++ b/tests/reference/llvm-arrays_06-538e67d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_06-538e67d.stdout",
-    "stdout_hash": "11e1a50a33deea081bd043e4b09b4f9a01fc28c2c1debbe077767d20",
+    "stdout_hash": "72627eababe8c821ee06ce39ea1ebc53e6c3bd859ffd77527aa59bbb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_06-538e67d.stdout
+++ b/tests/reference/llvm-arrays_06-538e67d.stdout
@@ -904,6 +904,7 @@ loop.end150:                                      ; preds = %ifcont110
   %365 = sext i32 %364 to i64
   %366 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 18, i8* null, i32 2, i64 %341, i32 2, i64 %344, i32 2, i64 %347, i32 2, i64 %350, i32 2, i64 %353, i32 2, i64 %356, i32 2, i64 %359, i32 2, i64 %362, i32 2, i64 %365)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %366, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end150
@@ -918,5 +919,7 @@ declare void @_lfortran_printf(i8*, ...)
 
 ; Function Attrs: nounwind readnone speculatable willreturn
 declare float @llvm.pow.f32(float, float) #0
+
+declare void @_lpython_free_argv()
 
 attributes #0 = { nounwind readnone speculatable willreturn }

--- a/tests/reference/llvm-arrays_08_func-85e526b.json
+++ b/tests/reference/llvm-arrays_08_func-85e526b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_08_func-85e526b.stdout",
-    "stdout_hash": "9c51448c24ddbce7ecb4bde081f6349eccb279513f4650f304b563cb",
+    "stdout_hash": "add211034d40df770ae8e68183401d44857bc63b74ce6b5954c43b86",
     "stderr": "llvm-arrays_08_func-85e526b.stderr",
     "stderr_hash": "d70481e5625f20fa12d3e8bdad4a5dfa6912ac62ade8fc840a5da64b",
     "returncode": 0

--- a/tests/reference/llvm-arrays_08_func-85e526b.stdout
+++ b/tests/reference/llvm-arrays_08_func-85e526b.stdout
@@ -81,6 +81,7 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -194,3 +195,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_13-8ff7d44.json
+++ b/tests/reference/llvm-arrays_13-8ff7d44.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_13-8ff7d44.stdout",
-    "stdout_hash": "e168cf7227ea62123a152c5d50410dd3325b790e06ed32a337d48def",
+    "stdout_hash": "65ed9584ba2d953abfe68183a9fa1d97339f2a8115526a7f61cf9077",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_13-8ff7d44.stdout
+++ b/tests/reference/llvm-arrays_13-8ff7d44.stdout
@@ -295,6 +295,7 @@ loop.end13:                                       ; preds = %loop.head
   call void @check_real(%array** %r)
   %173 = load %array*, %array** %r, align 8
   call void @check_real_without_pointer(%array* %173)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end13
@@ -541,3 +542,5 @@ declare void @_lcompilers_print_error(i8*, ...)
 declare void @exit(i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_25-5b87ac7.json
+++ b/tests/reference/llvm-arrays_25-5b87ac7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_25-5b87ac7.stdout",
-    "stdout_hash": "5a727c7b69111f990f38d0b53b61d72a94464459672985ecb5352bd6",
+    "stdout_hash": "972259292c6f4daf18aba1daec9af2bcaa9615c5fdbc77878cc1aa96",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_25-5b87ac7.stdout
+++ b/tests/reference/llvm-arrays_25-5b87ac7.stdout
@@ -240,6 +240,7 @@ loop.end5:                                        ; preds = %loop.head3
   %159 = load i32, i32* %158, align 4
   store i32 %159, i32* %call_arg_value6, align 4
   call void @decode_integer____0(i32* %145, i32* %call_arg_value, i32* %call_arg_value6)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end5
@@ -305,3 +306,5 @@ declare i8* @_lfortran_malloc(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_op_1-636d572.json
+++ b/tests/reference/llvm-arrays_op_1-636d572.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_1-636d572.stdout",
-    "stdout_hash": "2d5898d447926e753721cdbef210f47287e8c1cbfaaf665894d80009",
+    "stdout_hash": "07cd978f440e4b467397c35cd3e10529d71e6ab103d9dac56af18ff9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_1-636d572.stdout
+++ b/tests/reference/llvm-arrays_op_1-636d572.stdout
@@ -1870,6 +1870,7 @@ else329:                                          ; preds = %ifcont327
   br label %ifcont330
 
 ifcont330:                                        ; preds = %else329, %then328
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont330
@@ -1885,3 +1886,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_op_2-c36ad8d.json
+++ b/tests/reference/llvm-arrays_op_2-c36ad8d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_2-c36ad8d.stdout",
-    "stdout_hash": "bc459b553587cceeacbf0d732376216ca508d63eee6ae14127af435a",
+    "stdout_hash": "caaa604b9cb7fd7c6488de3821066676804724df3674e6de8e712d1b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_2-c36ad8d.stdout
+++ b/tests/reference/llvm-arrays_op_2-c36ad8d.stdout
@@ -2203,6 +2203,7 @@ else481:                                          ; preds = %ifcont479
   br label %ifcont482
 
 ifcont482:                                        ; preds = %else481, %then480
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont482
@@ -2218,3 +2219,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_op_4-df4e84d.json
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_4-df4e84d.stdout",
-    "stdout_hash": "757212bc390102a9118ed16c7c593ea926c3c0738d91c9fc829c74a4",
+    "stdout_hash": "0a9382f1df0a81a23ae4f43dc17aa905564ca5b6f6734c8a0da76486",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_4-df4e84d.stdout
+++ b/tests/reference/llvm-arrays_op_4-df4e84d.stdout
@@ -1592,6 +1592,7 @@ else75:                                           ; preds = %ifcont73
   br label %ifcont76
 
 ifcont76:                                         ; preds = %else75, %then74
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont76
@@ -2021,3 +2022,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lfortran_malloc(i32)
 
 declare void @_lfortran_free(i8*)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_op_5-8426b5a.json
+++ b/tests/reference/llvm-arrays_op_5-8426b5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_5-8426b5a.stdout",
-    "stdout_hash": "9305d756748441ed7f103308176559b98447ee4e28606186a4ca74dd",
+    "stdout_hash": "0e966e857b14e7b98000450a39f31fabd94219b927e2d0bc624e0773",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_5-8426b5a.stdout
+++ b/tests/reference/llvm-arrays_op_5-8426b5a.stdout
@@ -3700,6 +3700,7 @@ loop.end878:                                      ; preds = %ifcont806
   store i32 1, i32* %call_arg_value884, align 4
   store i32 1, i32* %call_arg_value885, align 4
   call void @check_complex__________0(%complex_4* %748, i32* %call_arg_value879, i32* %call_arg_value880, i32* %call_arg_value881, i32* %call_arg_value882, i32* %call_arg_value883, i32* %call_arg_value884, i32* %call_arg_value885)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end878
@@ -4021,3 +4022,5 @@ declare void @exit(i32)
 declare void @_lfortran_complex_sub_32(%complex_4*, %complex_4*, %complex_4*)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_op_7-aeeda6d.json
+++ b/tests/reference/llvm-arrays_op_7-aeeda6d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_op_7-aeeda6d.stdout",
-    "stdout_hash": "8a36625fe99f38efa79ef20010cfa2ceee4e72701f3e5bc1608997c1",
+    "stdout_hash": "1b6ec32a6409d277c46f1a94b78f80db097423b0a54f4b4f5c648bfc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_op_7-aeeda6d.stdout
+++ b/tests/reference/llvm-arrays_op_7-aeeda6d.stdout
@@ -82,6 +82,7 @@ loop.end:                                         ; preds = %ifcont6
   %25 = sext i32 %24 to i64
   %26 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %19, i32 2, i64 %22, i32 2, i64 %25)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -148,3 +149,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "711eae1ef4cd10c7181e9435cbc1ec95ac09f5e40252e74308e37599",
+    "stdout_hash": "52ef7778e567a9cf955b899386eb0401b0ec69e71c89cca3e1d557a2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -113,6 +113,7 @@ define i32 @main(i32 %0, i8** %1) {
   %55 = fpext float %54 to double
   %56 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %51, i32 6, double %55)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -126,3 +127,5 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 declare void @_lfortran_printf(i8*, ...)
 
 declare void @_lfortran_complex_mul_32(%complex_4*, %complex_4*, %complex_4*)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "556a0c239256b26591e9df2a3ab9ff512c1a3bd3c8ebca24f852daec",
+    "stdout_hash": "4e329e2657253e10d7a4d975880c030e5f608d84d3a05f1c2d2e610e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -59,6 +59,7 @@ else3:                                            ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %then2
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont4
@@ -74,3 +75,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "6ba3237808da85690b7b739c4afa653123d6131761ed1ed591874a85",
+    "stdout_hash": "2a2a74b5293ce0894a5267cbe36634085a1a06fe4e2eea2db341e264",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -90,6 +90,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -105,3 +106,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "e1c4266e6bc3869e0e488d5ee430d977a6a8a0c3d0db95158f204a39",
+    "stdout_hash": "ee5137cf06625f3c5840345068e85272b39bb846f4acd0ebafda6f22",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -84,6 +84,7 @@ define i32 @main(i32 %0, i8** %1) {
   %49 = load double, double* %48, align 8
   %50 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 16, i8* null, i32 6, double %22, i32 6, double %26, i32 5, double %30, i32 5, double %33, i32 6, double %38, i32 6, double %42, i32 5, double %46, i32 5, double %49)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %50, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -95,3 +96,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "5f51912d3b7692050c034e1bc2062a3bbdbaeb90591569ef44abe604",
+    "stdout_hash": "9b785734ef2268081b2b4c794f852055161a9e60e75d6db779037dfb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -23,6 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load double, double* %u, align 8
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 6, double %3, i32 5, double %4, i32 6, double %6, i32 5, double %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -34,3 +35,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bindc1-345b88c.json
+++ b/tests/reference/llvm-bindc1-345b88c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc1-345b88c.stdout",
-    "stdout_hash": "ed62e79c0e5a0784b1a8ea7aca98a9b2f74fadb88da3a623f1907edd",
+    "stdout_hash": "60bb22c43f976ce381416b358c870701c96a925818ed808f2a02d73f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc1-345b88c.stdout
+++ b/tests/reference/llvm-bindc1-345b88c.stdout
@@ -10,6 +10,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32*, i32** %x, align 8
   %3 = bitcast i32* %2 to void*
   store void* %3, void** %p, align 8
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -17,3 +18,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "eb5faa0ae27ec41db86e157465b6943cf0f4e31b6e266311ad4d920c",
+    "stdout_hash": "30e3e865406efd2bd044d8b9f08d80b504b27dba0d4d996de29994ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -33,6 +33,7 @@ define i32 @main(i32 %0, i8** %1) {
   %14 = ptrtoint void* %13 to i64
   %15 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 19, i64 %12, i32 19, i64 %14)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -44,3 +45,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "c2d213d63231bd76ac04a9053d24f5ae58e9a1e080be49cc8d61afdb",
+    "stdout_hash": "5c0ded04ac0a6c3774c0fcd7f4397625bb831793bab548869fd215c3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -29,6 +29,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 1, i64 -1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -40,3 +41,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "2c17e045098f9ea8b0a019d35018c32c5d78bf42244760c5c6c1e433",
+    "stdout_hash": "64d65fa2fb9a5bcd15ccec22e56f36b6d6285c166e69bf242ff73c9e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -24,6 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %3, i32 2, i64 %5, i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -35,3 +36,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "ddd61d076347569599c90b8d7c95aed81b45a46a64c78b90ed550365",
+    "stdout_hash": "0c87509549cbc7c9185c3fecdd736798d1365a7c5cac0af58861aa4d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -61,6 +61,7 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.500000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_callback_01_foo(float* %call_arg_value, float* %call_arg_value1)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -68,3 +69,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "08f21e63b075a27a8cb59b6bf665a1ea612a57672071792e3a2128d1",
+    "stdout_hash": "b9e98f4495321dd2b0a024e9573dd40df8a9236a1ea6acd720fa2c5f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -76,6 +76,7 @@ define i32 @main(i32 %0, i8** %1) {
   store float 2.000000e+00, float* %call_arg_value1, align 4
   %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @main.res)
   store float %2, float* @main.res, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -83,3 +84,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "6fb03c62fba95f3b1d56acf1bcc55354e5cd8a59a2517cf0730e0513",
+    "stdout_hash": "f947ee54e3902e86b2001ccdd73b9bfdc61fbb7cb7c916060a8c57bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -91,6 +91,7 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.500000e+00, float* %call_arg_value2, align 4
   store float 2.000000e+00, float* %call_arg_value3, align 4
   call void @__module_callback_03_foo2(float* %call_arg_value2, float* %call_arg_value3)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -98,3 +99,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-callback_04-0d9515f.json
+++ b/tests/reference/llvm-callback_04-0d9515f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_04-0d9515f.stdout",
-    "stdout_hash": "f926eec526671258a8344aaa3c172213d84bbc9248367e95a8e505fa",
+    "stdout_hash": "899e1d6de1fb2fa7e85947f4a0500c760800055ddabb1d92e79be138",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_04-0d9515f.stdout
+++ b/tests/reference/llvm-callback_04-0d9515f.stdout
@@ -44,6 +44,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_dr)
   call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_fortran)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -51,3 +52,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "df28cfe8b46cdffb478ece027b15aa4522e1faeef68305c99da2a0cb",
+    "stdout_hash": "26e735c124158eaa7d0e48e4d137cbe70c2cb36646eff9903c235907",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -56,6 +56,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_callback_05_px_call1(i32* @main.x)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -63,3 +64,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "a3379c92e1b5d9badb6e05d56a98b8d6f83c45d084a271cc2b7e08a2",
+    "stdout_hash": "a7f53c503e96886029f07bd627d3fa94867c4b2442f08b604c1cfc62",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -146,6 +146,7 @@ else22:                                           ; preds = %ifcont20
   br label %ifcont23
 
 ifcont23:                                         ; preds = %else22, %then21
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont23
@@ -159,3 +160,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "09bfdfa4aea5ee1f602a224be036bf6ba08aba937490fd739f02421a",
+    "stdout_hash": "48a65410628baadb8028e3b3c2cea382b8c504adfbadc9f513d09bbe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -396,6 +396,7 @@ ifcont56:                                         ; preds = %ifcont55, %then39
   %107 = sext i32 %106 to i64
   %108 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @73, i32 0, i32 0), i32 2, i64 %107)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @74, i32 0, i32 0), i8* %108, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont56
@@ -411,3 +412,5 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "ae0f3b7627baeecbc0ea648fb7cee2ad0510eab1aab13323a2c9422f",
+    "stdout_hash": "1c1adc037c0322af96e1b6d6df1aba83f959c1be0f369ff17e08c1ee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -103,6 +103,7 @@ ifcont12:                                         ; preds = %ifcont11, %then7
   %18 = sext i32 %17 to i64
   %19 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @22, i32 0, i32 0), i32 2, i64 %18)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont12
@@ -114,3 +115,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lfortran_printf(i8*, ...)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "8503fe67b963ea2f187f04ae1a52bff24ee34bf2941b46d1a7859076",
+    "stdout_hash": "beb1a00607b66c79258c2e10f5b339d262670c0d811067f5fedb6a91",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -83,6 +83,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %circle_polymorphic, %circle_polymorphic* %8, i32 0, i32 1
   store %circle* %c, %circle** %10, align 8
   call void @__module_class_circle1_circle_print(%circle_polymorphic* %8)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -90,5 +91,7 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()
 
 attributes #0 = { nounwind readnone speculatable willreturn }

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "b641549ce87652c5f3b5418d70fa4d20d898c48494b7cf7fa36e7ed4",
+    "stdout_hash": "837475bdf133930e2709a571c69de657fd8331f0db66ee3b9a363110",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -86,6 +86,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_class_circle2__xx_lcompilers_changed_main_xx()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -93,5 +94,7 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()
 
 attributes #0 = { nounwind readnone speculatable willreturn }

--- a/tests/reference/llvm-class_03-d370451.json
+++ b/tests/reference/llvm-class_03-d370451.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_03-d370451.stdout",
-    "stdout_hash": "702c901c7b68db888dcb02360753e2e4b982ceeafde00b0647d3c946",
+    "stdout_hash": "21c3f1b1fbedf5846639cb2f6e5c6af1bfee5a8ad78886c7d1b1f518",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_03-d370451.stdout
+++ b/tests/reference/llvm-class_03-d370451.stdout
@@ -87,6 +87,7 @@ define i32 @main(i32 %0, i8** %1) {
   %54 = sext i32 %53 to i64
   %55 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 12, i8* null, i32 7, i8* %39, i32 7, i8* %42, i32 2, i64 %46, i32 7, i8* %49, i32 7, i8* %51, i32 2, i64 %54)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -98,3 +99,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "c9923be008019008f38211111c62cea04dcb9d15cbfd1e0fb5b88e3c",
+    "stdout_hash": "ed76f7fda931739ac472ecd15616a339eb087b7189a1b856e06f2967",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -83,6 +83,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -98,3 +99,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex1-0e93fa9.json
+++ b/tests/reference/llvm-complex1-0e93fa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex1-0e93fa9.stdout",
-    "stdout_hash": "1d30668182ca63bc6ea30e5f72241811d021cc77d0c3b0bded3071d8",
+    "stdout_hash": "3925130b5b9a02c339beb9786cde93b51b79414c4ae49474232b430f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex1-0e93fa9.stdout
+++ b/tests/reference/llvm-complex1-0e93fa9.stdout
@@ -14,6 +14,7 @@ define i32 @main(i32 %0, i8** %1) {
   store float 4.000000e+00, float* %4, align 4
   %5 = load %complex_4, %complex_4* %2, align 4
   store %complex_4 %5, %complex_4* %x, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -21,3 +22,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "653b852a4a4868f0feeeb7ff040cebda50633a58a74cf3181db5bc48",
+    "stdout_hash": "8aec8183db9d36021c766491a07f7fd00b0ce4fbc048fcc02920a7e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -118,6 +118,7 @@ define i32 @main(i32 %0, i8** %1) {
   %69 = fpext float %68 to double
   %70 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %65, i32 6, double %69)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %70, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -131,3 +132,5 @@ declare void @_lfortran_complex_add_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "0f5f11092d70af6b7f95b63847e35ff8d70e6b6b021a1c2ee1a290ed",
+    "stdout_hash": "9a9a67bd0b2ca04363db69d97a0e0b0f0f7b7af752dce9400bfe3c2b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -118,6 +118,7 @@ define i32 @main(i32 %0, i8** %1) {
   %69 = fpext float %68 to double
   %70 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %65, i32 6, double %69)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %70, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -133,3 +134,5 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 declare void @_lfortran_printf(i8*, ...)
 
 declare void @_lfortran_complex_add_32(%complex_4*, %complex_4*, %complex_4*)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "c870405d43a0b65f6ef8929bad621a38c88c3b660764adcb4eca19ea",
+    "stdout_hash": "76e81414758c708664e11576e71153183d2674038ff02618874e11f6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -67,6 +67,7 @@ define i32 @main(i32 %0, i8** %1) {
   %38 = fpext float %37 to double
   %39 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 12, i8* null, i32 5, double %17, i32 5, double %20, i32 6, double %25, i32 6, double %29, i32 6, double %34, i32 6, double %38)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %39, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -78,3 +79,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "c5fa6bd1eefa84c8a92fa5ee09d4c994f218723d01391927061820c7",
+    "stdout_hash": "6007f71cce4729863cb9e18a1947c82ca3cb36d3afc247b2b69dbc74",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -73,6 +73,7 @@ define i32 @main(i32 %0, i8** %1) {
   %36 = load double, double* %35, align 8
   %37 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 12, i8* null, i32 6, double %18, i32 6, double %22, i32 5, double %26, i32 5, double %29, i32 5, double %33, i32 5, double %36)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -84,3 +85,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "78f6585d5621143cbfab66274fb81579a6ae5c4333f4b4fec325b6e8",
+    "stdout_hash": "8b74de2549e513b80b0b24d3c8e9b53ae62215e58c3b63eae0a02952",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -105,6 +105,7 @@ define i32 @main(i32 %0, i8** %1) {
   %61 = fpext float %60 to double
   %62 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %57, i32 6, double %61)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -118,3 +119,5 @@ declare void @_lfortran_complex_mul_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "beba49fcb97b341bfcaade890f19be3586ab6ca7a181ad8ed057e078",
+    "stdout_hash": "69e13467b95d1424712c7494cd672a94ad5f8a0ddca5ede574e70365",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -49,6 +49,7 @@ define i32 @main(i32 %0, i8** %1) {
   %24 = fpext float %23 to double
   %25 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %20, i32 6, double %24)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -62,3 +63,5 @@ declare void @_lfortran_complex_pow_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "24a5d79a80b65d898a0b5caf4ce16d0b543e187025d3b6fb3c073f7d",
+    "stdout_hash": "836b222ae3c71e655a15c522ce1dbc25b980cfc24b423dd697d070f6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -120,6 +120,7 @@ define i32 @main(i32 %0, i8** %1) {
   %70 = fpext float %69 to double
   %71 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %66, i32 6, double %70)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %71, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -133,3 +134,5 @@ declare void @_lfortran_complex_sub_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "fb9901b79ae74938c00b537a0c7f683124d2ff2e14f2c668252c79b3",
+    "stdout_hash": "724af9934cbeb8643d8b1e1bfde3bea1b0a7c2b7cc5bf650bd0f83ee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -23,6 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load double, double* %u, align 8
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 6, double %3, i32 5, double %4, i32 6, double %6, i32 5, double %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -34,3 +35,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-derived_types_01-ca40b30.json
+++ b/tests/reference/llvm-derived_types_01-ca40b30.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_01-ca40b30.stdout",
-    "stdout_hash": "bf991da10bf50201ee4ab760858eed645fa0099ddc21d05e754a66e6",
+    "stdout_hash": "9b95165b60e9800078117aa03ddd73b8b394c7d4daadf48b72cdc84b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_01-ca40b30.stdout
+++ b/tests/reference/llvm-derived_types_01-ca40b30.stdout
@@ -128,6 +128,7 @@ define i32 @main(i32 %0, i8** %1) {
   %79 = fpext float %78 to double
   %80 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 6, double %64, i32 2, i64 %69, i32 6, double %75, i32 6, double %79)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %80, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -139,3 +140,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "bc97c72b9c4ff36c734cbcfb7bebd919a74fe3cfd7539702a37e149c",
+    "stdout_hash": "806a91418e9e8ac1f55667ef5587651e151c4bebf1303ad4324e785c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -192,6 +192,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -207,3 +208,5 @@ declare i1 @_lpython_str_compare_noteq(i8**, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-do7-8069d7a.json
+++ b/tests/reference/llvm-do7-8069d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-do7-8069d7a.stdout",
-    "stdout_hash": "182aa13417390d3ad92f7023d09500c4119ce7c694a34be5da2bab41",
+    "stdout_hash": "4969ae7ba9289a80087d2ddf35a2f4f68e993ab2ebc67c7ccceff4e8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-do7-8069d7a.stdout
+++ b/tests/reference/llvm-do7-8069d7a.stdout
@@ -28,6 +28,7 @@ loop.body:                                        ; preds = %loop.head
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -48,3 +49,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "a67ab9df94c71b9e64f10a11227c1941a0f090e063f92d06e75fde33",
+    "stdout_hash": "b7a9de9bf3d220152dbcafe58c65cb6ce642128abc1955e275440e31",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -482,6 +482,7 @@ ifcont62:                                         ; preds = %else61, %then60
   %143 = sext i32 %142 to i64
   %144 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %143)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @54, i32 0, i32 0), i8* %144, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @53, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont62
@@ -497,3 +498,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "9c6aa3a7be27bdaee7a308e538a3771502d11d3ff99d2b8ff74fbee9",
+    "stdout_hash": "412d2079f0ff5356a59dbb6c621b51d415f232f65f5cb891531cae37",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -184,6 +184,7 @@ ifcont22:                                         ; preds = %else21, %then20
   %57 = sext i32 %56 to i64
   %58 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %57)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont22
@@ -199,3 +200,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "c40585cb742405146ec30090fe7bb61a8873f8ee47008bb8087f0c92",
+    "stdout_hash": "57f3071a75e2368941a24e44bac62cb8b4640d9c3d887213de1ebc21",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -191,6 +191,7 @@ ifcont27:                                         ; preds = %else26, %then25
   %47 = sext i32 %46 to i64
   %48 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %47)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont27
@@ -206,3 +207,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "fa97764b01a76a31e6a3ccc0c80e6afd781f1dc22704d1e6a20f13ea",
+    "stdout_hash": "e8577242dd5f8437fc5e01e29d755add08be6dc3c109c5766970f65b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -323,6 +323,7 @@ goto_target:                                      ; preds = %loop.body31
   br label %loop.head30
 
 loop.end32:                                       ; preds = %loop.head30
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end32
@@ -338,3 +339,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-expr5-00f7fd9.json
+++ b/tests/reference/llvm-expr5-00f7fd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr5-00f7fd9.stdout",
-    "stdout_hash": "7410f9543bd52f9672fade2394b70eb451809a93c56f7f6d5df09bfe",
+    "stdout_hash": "72a26738d69f3fd63ffb8d9f44f25ee7788c1f8c17f2e024428f5a10",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr5-00f7fd9.stdout
+++ b/tests/reference/llvm-expr5-00f7fd9.stdout
@@ -24,6 +24,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -35,3 +36,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "a672405caa791699633f33e2cc121a4080e489c8389b0f9df9aa4c79",
+    "stdout_hash": "d77a9ff9d8371fc7c52920bca1d6ad24ad6f09e40f57a580e2afe33c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -42,6 +42,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @b()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -49,3 +50,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "82ebbb5116cbe76a09ada0392cf7e7b9c1421ad6cba48d8936d82c98",
+    "stdout_hash": "b32fa95cbbd9b38d30f7179c9646d4ed277a8dc5c23538154f2ffb8e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -14,6 +14,7 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0), i32 2, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -25,3 +26,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-functions_14-f13c087.json
+++ b/tests/reference/llvm-functions_14-f13c087.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-functions_14-f13c087.stdout",
-    "stdout_hash": "25d72f2e9f126730dbb3e52d0bd997c52ed85b481ed9fba1f1df4398",
+    "stdout_hash": "3b049067cb150f2de34272b21bd261bfdb66a6bec1de68347a2735f1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-functions_14-f13c087.stdout
+++ b/tests/reference/llvm-functions_14-f13c087.stdout
@@ -14,6 +14,7 @@ declare i32 @expr()
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -21,3 +22,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "347dab187ded4b07079c383db6ffbac869da1d883f68a70e05dd1da4",
+    "stdout_hash": "f57f57f7c1cbad3e8e73b9b98ee7f571b8e68499f5ea9b2f31ed2bbe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -201,6 +201,7 @@ else10:                                           ; preds = %ifcont8
   br label %ifcont11
 
 ifcont11:                                         ; preds = %else10, %then9
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont11
@@ -214,3 +215,5 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "468527cd471d61862f20307823efc9aa0b706bef534f321c5db34bfd",
+    "stdout_hash": "197e123e3b9daf77e3fab2dab859bf8c812115c33b648951d884a95d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -67,6 +67,7 @@ ifcont:                                           ; preds = %else, %then
   %23 = add i32 %22, 1
   store i32 %23, i32* %__1_k1, align 4
   call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -180,3 +181,5 @@ declare void @_lcompilers_print_error(i8*, ...)
 declare void @exit(i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "5f5561adeb9315fe194b7288c3e6436063373f3f3c2548d15b0e0878",
+    "stdout_hash": "e50a994bb07d778e2f2b0dc61434a7b4069126b7454bb74c1ea07e3c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -81,6 +81,7 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fpext float %22 to double
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 20, i8* null, i32 2, i64 1, i32 2, i64 2, i32 6, double 4.000000e+00, i32 6, double %19, i32 6, double %23, i32 2, i64 3, i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i32 6, double -4.000000e+00, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -98,3 +99,5 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "f3742de07c20f668f77749078520b4d358756efcf517bae039dae734",
+    "stdout_hash": "b1cd0eb1366927c0457fe9f7e864ae7fdc28e2fd5d19d07dce44d014",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -14,6 +14,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i64, i64* @int_dp.v, align 4
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %3, i32 1, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -25,3 +26,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "934c21fb555ad8c712a6bef0ea55c373651fdf5f9b586e96e21c9efb",
+    "stdout_hash": "14643b4a5d36999a724e0d14b2bdd4ccc7152b4e855c62785045ef02",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -22,6 +22,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i64, i64* @int_dp_param.v, align 4
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %3, i32 1, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -33,3 +34,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "ab64d935b4475d40fe1b8d463031d961867486202cfd0565c6f5a927",
+    "stdout_hash": "c65f7b00e8606c994e77c7cab7cc610b5902bf6706bb7d5a09f3969d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -47,6 +47,7 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0.000000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_dflt_intent_foo(float* %call_arg_value, float* %call_arg_value1)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -54,3 +55,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-interface_12-2e5ecb8.json
+++ b/tests/reference/llvm-interface_12-2e5ecb8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-interface_12-2e5ecb8.stdout",
-    "stdout_hash": "043caad821da06a524ff4b468e80444493791a272a2f660fdac49803",
+    "stdout_hash": "da5c938dbaf2504e529d93d4487e1d959369d18c3da4eaccf62891ae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-interface_12-2e5ecb8.stdout
+++ b/tests/reference/llvm-interface_12-2e5ecb8.stdout
@@ -15,6 +15,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @find_fit(void ([1 x float]*)* @expression)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -30,3 +31,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "890e6c60de6fd5392015ee705546c85688281880d9e7e2aadc9c093c",
+    "stdout_hash": "447564f7a95be544175fa61d57c0651d2a65f7a440661872079fa498",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -202,6 +202,7 @@ else16:                                           ; preds = %ifcont11
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %then15
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont17
@@ -217,3 +218,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "bb65dfbe378f817b09c80861e35bd584441c9408183e462387dd7676",
+    "stdout_hash": "04fa3affb1332167b1371e4846902e41f5943f7e491644756b4b7724",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -220,6 +220,7 @@ else16:                                           ; preds = %ifcont14
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %then15
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont17
@@ -235,3 +236,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "7da5b9f083cba5bfe5b1a2d66b7a68fb7edb9a99b21afd7c90b4c7be",
+    "stdout_hash": "8cee087e003c5eb0a0006a6ce94be897b8e6b183144f62faebc2bcd3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -27,6 +27,7 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = fpext float %8 to double
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -38,3 +39,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "c4e13e72a460c33bc8f8e63e373da41a873aa646545b2ef5c774f89d",
+    "stdout_hash": "621e2710551e38fd09f28ed37e4ebeae4d9fe6fb1bff8ac748bbd4a7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -59,6 +59,7 @@ define i32 @main(i32 %0, i8** %1) {
   %21 = fpext float %20 to double
   %22 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %21)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -70,3 +71,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-issue532-d63b703.json
+++ b/tests/reference/llvm-issue532-d63b703.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-issue532-d63b703.stdout",
-    "stdout_hash": "3610f6bb1a4dc4e9951706f66f7f2976cb3ec5d83f77017197126069",
+    "stdout_hash": "294c108a27d359c1cd4416c4375d214a45e4c0b46a6957a76248a539",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-issue532-d63b703.stdout
+++ b/tests/reference/llvm-issue532-d63b703.stdout
@@ -4,6 +4,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -11,3 +12,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "535dc17664df467ebc5702d0bcf57b2567ff987feccd2b2e134ba28a",
+    "stdout_hash": "befb276ce716e14fe05b62fd52747411c650ab8f33993c686adb0d7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -23,6 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = select i1 %6, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0)
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 8, i8* %4, i32 8, i8* %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -34,3 +35,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-logical2-94a2259.json
+++ b/tests/reference/llvm-logical2-94a2259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical2-94a2259.stdout",
-    "stdout_hash": "885d7299c027a3dfa81ebc2ccf6e64fcfe19f36acf0bf549fc810fda",
+    "stdout_hash": "ae176910779c4380b52751da983d2acf88b76ebe3598980140c055ae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical2-94a2259.stdout
+++ b/tests/reference/llvm-logical2-94a2259.stdout
@@ -30,6 +30,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -39,3 +40,5 @@ return:                                           ; preds = %ifcont
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-logical3-4bbf8ea.json
+++ b/tests/reference/llvm-logical3-4bbf8ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical3-4bbf8ea.stdout",
-    "stdout_hash": "cfe00f6a92cdfb74bbc4e27ae8af3024eeae5b67424c53335b842a5f",
+    "stdout_hash": "e57dfc025ae5a97bf6b4107ea86103d6f1f7f449718b35c608d6c5e6",
     "stderr": "llvm-logical3-4bbf8ea.stderr",
     "stderr_hash": "d7e28e54d198e14f86c18ab4c4ad128018b9bc6523fb945b05607a57",
     "returncode": 0

--- a/tests/reference/llvm-logical3-4bbf8ea.stdout
+++ b/tests/reference/llvm-logical3-4bbf8ea.stdout
@@ -249,6 +249,7 @@ else23:                                           ; preds = %ifcont21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont24
@@ -262,3 +263,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "863b11c30f01a2cb1e9f143f35e46a8961aadfc3874c100a2f07db25",
+    "stdout_hash": "4fe159e7369504dc2c34bef29da817332b9be1c67e69490debdb04c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -30,6 +30,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = select i1 %9, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0)
   %11 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 8, i8* %4, i32 8, i8* %7, i32 8, i8* %10)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -41,3 +42,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_01-1b129c3.json
+++ b/tests/reference/llvm-modules_01-1b129c3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_01-1b129c3.stdout",
-    "stdout_hash": "5e2a084fec76304cb0fe72fc72bd59cbbd438ab7dfbc6e4e9bf4e0a3",
+    "stdout_hash": "cf2d441bde9aa52fd8dc7e9f0b5716a6e320cfc9c22cf96d71e4b486",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_01-1b129c3.stdout
+++ b/tests/reference/llvm-modules_01-1b129c3.stdout
@@ -20,6 +20,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_modules_01_a_b()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -27,3 +28,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "f89f5cec48715020240bc9c3f9215cdf409ff2806424f1afbb16070e",
+    "stdout_hash": "dbf2fc82588e75e9f79e6b53be9f8b5ac6169969c3c0d8a9b3ddde2a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -32,6 +32,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -41,3 +42,5 @@ return:                                           ; preds = %.entry
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "364da759f11c437016faf2b68e1c72b26901a44510f90a0ab83cd79a",
+    "stdout_hash": "25d445b0243f1878d58cca433331ff45d4177812d12105738ccc657a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -34,6 +34,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i32 2, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
   call void @__module_modules_11_module11_access_internally()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -41,3 +42,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "85bb2e25be42ed4c6ce0f87a5e7239143be6d42561232cedbb9ed490",
+    "stdout_hash": "5f234ca431489b881665a21a4ced57a6ed7eedff578daa9198d982dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -38,6 +38,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -49,3 +50,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "d4f9ed9312bfb7b471510a0070363c29fa0f579928a7fde2102f466d",
+    "stdout_hash": "f3f8b9aed72c2bd6f16260c4769e3b1321d6f4464ee89de4204d70dd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -203,6 +203,7 @@ define i32 @main(i32 %0, i8** %1) {
   store %fpm_run_settings* %settings, %fpm_run_settings** %8, align 8
   store i1 true, i1* %call_arg_value, align 1
   call void @__module_modules_36_fpm_main_01_cmd_run(%fpm_run_settings_polymorphic* %6, i1* %call_arg_value)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -210,3 +211,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "1c3ee7431281afd62a90ebebbcee3ccc35cbb189bd2d10fee1686f24",
+    "stdout_hash": "80e9cfcddbfffc792ce51e8fffe33f7899b67389e269a3b84b24764e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -150,6 +150,7 @@ loop.end:                                         ; preds = %loop.head
   %47 = load i8*, i8** %46, align 8
   %48 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %47)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -165,3 +166,5 @@ declare void @_lfortran_string_init(i32, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "cbf95ac5ea2a4fa47994949e75c6afb8b687bfea06fb089ea864d87b",
+    "stdout_hash": "2e7d602516ab9478647b6fdb460623dc74f1a801d8fb238925b82ecc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -44,6 +44,7 @@ define i32 @main(i32 %0, i8** %1) {
   %c1 = alloca i32, align 4
   %2 = call i32 @__module_nested_01_a_b()
   store i32 %2, i32* %c1, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -51,3 +52,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "b997d31fb93f0a55b5f3441e80946f66e67168016788af1eccd89767",
+    "stdout_hash": "da0f85cc381d9f8cbb6757ab37546a7def2a057a9456fce56cb38fc5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -35,6 +35,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_02_a_b()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -42,3 +43,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "e603edb550c179a6454d5ceb03956b4fd77ad8359a79aacd0b907d8d",
+    "stdout_hash": "9620fb547ca9cda7bf55dcbd9275c8de39699a9ea0e29f96cf53939d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -48,6 +48,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_03_a_b()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -55,3 +56,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "201549d3ab60304e00a7590dae5254cd5ed1c5b46f782cedbcc14228",
+    "stdout_hash": "38f2c5f4130d4887b6d7b90953a5ea7a772b8eead15b69c2c3dabe73",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -78,6 +78,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 5, i32* %call_arg_value, align 4
   %2 = call i32 @__module_nested_04_a_b(i32* %call_arg_value)
   store i32 %2, i32* %test1, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -85,3 +86,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "1c70e89ab147736b11636e2dc3a06e119f9885511ec20142b96d7cf1",
+    "stdout_hash": "45da14814f9775d2a8982b7acf5b59c2361ae17671bdf5976fdc00c4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -79,6 +79,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_05_a_b()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -86,3 +87,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "2c7326839bd6717c99f18eddfbe48e9fdf77e6a8febe7925a48d4582",
+    "stdout_hash": "dc6743a37623b4afde0021a776be475cea112aaea8ec8fb1d3ae6338",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -48,6 +48,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store float 6.000000e+00, float* %call_arg_value, align 4
   call void @__module_nested_06_a_b(float* %call_arg_value)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -55,3 +56,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nullify_01-810c9d3.json
+++ b/tests/reference/llvm-nullify_01-810c9d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_01-810c9d3.stdout",
-    "stdout_hash": "fecc2ccb0b3eada59719b1840a9a48fb0f449b3f26c4bb41c5cb1faa",
+    "stdout_hash": "4acc4db9257637a0ef29b3cbd0107c14f9a68e5eed0073542e18d32e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_01-810c9d3.stdout
+++ b/tests/reference/llvm-nullify_01-810c9d3.stdout
@@ -16,6 +16,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %2, align 4
   store i32* null, i32** %p1, align 8
   store i32* null, i32** %p2, align 8
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -23,3 +24,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-nullify_02-3c7ee61.json
+++ b/tests/reference/llvm-nullify_02-3c7ee61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_02-3c7ee61.stdout",
-    "stdout_hash": "9a9bd2d2c73fdfafc5e33c803d39cfed93e58c5fc43ef3589ec5d3ef",
+    "stdout_hash": "3fb35e8a1a32b6acd885ba2db008db6a631fab1fd7a2696b610426c8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_02-3c7ee61.stdout
+++ b/tests/reference/llvm-nullify_02-3c7ee61.stdout
@@ -19,6 +19,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 2, i32* %3, align 4
   store float* null, float** %p1, align 8
   store i32* null, i32** %p2, align 8
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -26,3 +27,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "0d2fa51d35a141d2a64a093c7baf96f908ffba99c5efbe71b25595cd",
+    "stdout_hash": "0c70f54389e895a362fa931f1b0a3840ee9f87f193d5a44f9d3e5398",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -133,6 +133,7 @@ define i32 @main(i32 %0, i8** %1) {
   %28 = sext i32 %27 to i64
   %29 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @30, i32 0, i32 0), i32 2, i64 %28)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -144,3 +145,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "bc70e0187dab143fe2d2ab054d4ef9ed09c82c031f51d1c94ce3605c",
+    "stdout_hash": "b60c7035611c750402e9b141155f0c8314009cf3e6c80e440f105d84",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -43,6 +43,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = select i1 %7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0), i32 8, i8* %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -54,3 +55,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "c1610cba8d4e8041562451ebd3b8ddcd7e5223df6de4884d2ed80dec",
+    "stdout_hash": "2bceb0d24bc20a28931cb5c39115c7170dd65ca7efdf8d778eb5a6b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -149,6 +149,7 @@ define i32 @main(i32 %0, i8** %1) {
   %32 = select i1 %31, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0)
   %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @36, i32 0, i32 0), i32 8, i8* %32)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -160,3 +161,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "307cbeef32484abf39368fb21b0e666222b59f2ab3626a5e5e74e04a",
+    "stdout_hash": "d706a512957673cc3800f444d6d7bff6f186300f8c281aa0b2428a6f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -30,6 +30,7 @@ define i32 @main(i32 %0, i8** %1) {
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 10, i8* null, i32 2, i64 %11, i32 2, i64 1, i32 2, i64 3, i32 2, i64 %13, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -41,3 +42,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "f9d7e2477fff46d54c15f4fd9a7b465616675ea7d37cd6000985d835",
+    "stdout_hash": "73accb75d769a175f2edaec351c18c6d65783224dbb6a0aeeb66a806",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -21,6 +21,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -32,3 +33,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "e942c2bafc52b99d52355b1e342eaa40cccd9ccdd81c6eefce0dd66d",
+    "stdout_hash": "1ca6b0c449476a8654fa11abbd72d43b3f9d7f86c6da6cc67604625f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -40,6 +40,7 @@ loop.body:                                        ; preds = %loop.head
 loop.end:                                         ; preds = %loop.head
   %13 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
   store i32 %13, i32* %z1, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -79,3 +80,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-program_cmake_01-caf8f48.json
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_cmake_01-caf8f48.stdout",
-    "stdout_hash": "72abad902a2561fa567f948a81a010ffbd4de9a3c4811e015bb5a0fb",
+    "stdout_hash": "82fe65273d747a157d83d1660819933fc9ec424e16653a398de4cd3c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_cmake_01-caf8f48.stdout
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.stdout
@@ -9,6 +9,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -18,3 +19,5 @@ return:                                           ; preds = %.entry
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "20bf16133f6d2058bd818c885d990e72d01dd1348162b483467ce9de",
+    "stdout_hash": "08858183540767253c9aa2ed2a0b5fcf6f305a713b9584a8fa9b3d6d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -20,6 +20,7 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = fpext float %5 to double
   %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 6, double %3, i32 5, double %4, i32 6, double %6)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -31,3 +32,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "a72982549c2d47ea66d05101d19eb46ba377f92c270eb97ab064121e",
+    "stdout_hash": "6addddae6cc6e9303345d03ec97522920aa93409bce44311f97fecb4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -24,6 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = load double, double* @real_dp_param.zero, align 8
   %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 6, double %3, i32 5, double %4, i32 5, double %5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -35,3 +36,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "cb87ebc6408d9b734bb79e65882cb0fe8d54643c0ca12fdb4879d23d",
+    "stdout_hash": "c508f5de185c08c57f5bab312119ad967be1b8df8289284f9175179a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -76,6 +76,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 10, i32* @n, align 4
   call void @__module_recursion_01_sub1(i32* @x)
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -83,3 +84,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "09d158edba46de009cba06467918f9c6774b006d4c39ae3f5723f442",
+    "stdout_hash": "f8a1f6ddcf075433c292c6138bbd29f9d9a21769e83b2417e69e74d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -128,6 +128,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @13, i32 0, i32 0), i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -135,3 +136,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "cacddb3836a85bb7c432f5ca44678fd74767ad59abb9d2fe07ab5c55",
+    "stdout_hash": "90d78a8c1af353dd40143b8be09e7844b8444ead4fb36677d037abcc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -142,6 +142,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @13, i32 0, i32 0), i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -149,3 +150,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "d5e848f984b627e5fc9e0885c4ddf808797ba6ff1fe064aedbee516f",
+    "stdout_hash": "705a10d6e8e3067d9e147b15116b8d8dbcef53e2be2f372bfd441cee",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -19,6 +19,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i32 @main1()
   store i32 %2, i32* %main_out1, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -60,3 +61,5 @@ return:                                           ; preds = %ifcont, %then
 declare void @_lfortran_printf(i8*, ...)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "9fd12d2f1ce9277aa2becb2c88651b0c755fd5d40b855953da505fae",
+    "stdout_hash": "5e27debbf408dd751229b64b8ff82eea490ae161307653da8a5024dc",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -122,6 +122,7 @@ define i32 @main(i32 %0, i8** %1) {
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -131,3 +132,5 @@ return:                                           ; preds = %.entry
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "bb541f6fe44cae6a15fbb234d3087a9a499316024bf62f9a7d598746",
+    "stdout_hash": "56081ab45fe7ef7b7064e99e6540af8e304bd80185105fb8f969cb9e",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -17,6 +17,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @main1(i32* @main.main_out)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -56,3 +57,5 @@ return:                                           ; preds = %ifcont, %then
 declare void @_lfortran_printf(i8*, ...)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-return_05-b1ab26b.json
+++ b/tests/reference/llvm-return_05-b1ab26b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_05-b1ab26b.stdout",
-    "stdout_hash": "6cdf898461c9b1ddf62be1b84c01869dd2f04654f4827edc64ecf042",
+    "stdout_hash": "8626b55880672d15b8a19dd72fa4bd0a832e476fa3a7606ccf0a9408",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_05-b1ab26b.stdout
+++ b/tests/reference/llvm-return_05-b1ab26b.stdout
@@ -20,6 +20,7 @@ define i32 @main(i32 %0, i8** %1) {
 
 unreachable_after_return:                         ; No predecessors!
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %.entry
@@ -29,3 +30,5 @@ return:                                           ; preds = %unreachable_after_r
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-return_06-ec98b0b.json
+++ b/tests/reference/llvm-return_06-ec98b0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_06-ec98b0b.stdout",
-    "stdout_hash": "4f47823a6ab6e6f0c28f21e4bc3d18dbe1e2fed2592ad716b7dfec02",
+    "stdout_hash": "4f914270779b6a6a8ec0029bc2f6b5fc59707ae7f5beec300029d68e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_06-ec98b0b.stdout
+++ b/tests/reference/llvm-return_06-ec98b0b.stdout
@@ -7,6 +7,7 @@ define i32 @main(i32 %0, i8** %1) {
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %.entry
@@ -14,3 +15,5 @@ return:                                           ; preds = %unreachable_after_r
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "64604af401f18579a836979167fef7b215bcd9af68ca2bba94ab0d13",
+    "stdout_hash": "2df99a76c52323cc80f7f35738592cea7349ac8fcc85b40d8621cd9a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -12,6 +12,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load double, double* %x, align 8
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 5, double %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -23,3 +24,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-stop-866225f.json
+++ b/tests/reference/llvm-stop-866225f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-stop-866225f.stdout",
-    "stdout_hash": "eb4d642ab1fe920ef37d112678c16fcda293dab703816f36674b4f78",
+    "stdout_hash": "87badab56429b29e8fd1a8965f986d2d9147980835a92ca067da195e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-stop-866225f.stdout
+++ b/tests/reference/llvm-stop-866225f.stdout
@@ -24,6 +24,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -35,3 +36,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "2101943ebd7dca5cb89121b0c0011e1958267a16d5f5afd5b5299229",
+    "stdout_hash": "98a0520faba6db392ada7bdcfc24dcb90a30a2b6a6292baa6663dc00",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -18,6 +18,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i8*, i8** @print_01.my_name, align 8
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i32 7, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -35,3 +36,5 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "68b5eedf917496f4063f137bc71e1d4ad1c611d15863a2279fb5de5c",
+    "stdout_hash": "cb2afbbea6488d72b26a902c2a6d1cd3c4897a25c90efc78b57beaab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -45,6 +45,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   %14 = load i8*, i8** %greetings, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -62,3 +63,5 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "1a65d06fb78dbab1090fc3510fbcec79d1d30ea19c1d643427aedca1",
+    "stdout_hash": "b1048f4b974c34500f7ecb351e481ca4a3f051db96c46a2802ee823e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -89,6 +89,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i8* %40, i8** %combined, align 8
   %41 = load i8*, i8** %combined, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -106,3 +107,5 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare void @_lfortran_strcat(i8**, i8**, i8**)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "b7674c39524dcb48532962fb8d296a4156e891f5487dfefae3c25224",
+    "stdout_hash": "4b48d8f4a71a62c339b67f55e9a1f9bf1a4dde684f8cf1fd7ef55405",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -179,6 +179,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -208,3 +209,5 @@ declare i1 @_lpython_str_compare_noteq(i8**, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "926f9214a6cf64347f1f57a05ed8ef122afe7f2517c79151ca7ee68d",
+    "stdout_hash": "5ca4341a4fbd7f264271a84d09c30a32bd770f701d6b3cb9eb33dcd8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -325,6 +325,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -342,3 +343,5 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare void @_lfortran_printf(i8*, ...)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "ac8a7da6091cf4dd256f9ee4986e8e483b6ad5074f47b88a1d12668e",
+    "stdout_hash": "60acce42a2406caf65425fdebbd963bb91a776e81813e11f3f87cb2f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -63,6 +63,7 @@ else8:                                            ; preds = %ifcont6
 ifcont9:                                          ; preds = %else8, %then7
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 48, i32 2, i64 53, i32 2, i64 57)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont9
@@ -78,3 +79,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "ca47294781f6cbd97fcaf8c3f6a147e0534cee5d159dd2548b13f7a1",
+    "stdout_hash": "3c645699ad43bfe32734a0ba2a70934501a106fc1bd07c7c5cae10c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -196,6 +196,7 @@ else27:                                           ; preds = %ifcont24
   br label %ifcont28
 
 ifcont28:                                         ; preds = %else27, %then26
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont28
@@ -222,3 +223,5 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "e3bfdf4cbadc25f0c02046c47e02fd1c98204cda3c02ead87e45db8c",
+    "stdout_hash": "907e6fbb2021dddc337ad31c7d3a7b3ac2bcb971888d58ba63c53549",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -134,6 +134,7 @@ else16:                                           ; preds = %ifcont14
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %then15
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont17
@@ -180,3 +181,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "38e5ef9e8e06369a86f88d62396768154cc023d2c24f66da7f54dbd6",
+    "stdout_hash": "a8f1a476353eb78be069c1b51e7519841d5c54b9317533d5058bac83",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -8,6 +8,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @print_int()
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -33,3 +34,5 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 declare void @_lfortran_printf(i8*, ...)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-sum_02-43f30ca.json
+++ b/tests/reference/llvm-sum_02-43f30ca.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sum_02-43f30ca.stdout",
-    "stdout_hash": "c0bdb144da2bf22a4a24b1b36efa5eb5edf26de477bd02c0a34b4cb3",
+    "stdout_hash": "b5a3894a6bf7c0847e7195da7026a862461a8a40995e1216fb783416",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sum_02-43f30ca.stdout
+++ b/tests/reference/llvm-sum_02-43f30ca.stdout
@@ -196,6 +196,7 @@ else:                                             ; preds = %loop.end6
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -211,3 +212,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-types_01-642cab3.json
+++ b/tests/reference/llvm-types_01-642cab3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_01-642cab3.stdout",
-    "stdout_hash": "c35662de8ece33395abcc550828dd8f5eec3bcc38e940c763be4d7fd",
+    "stdout_hash": "e3a59ca46f949e06ae1a4740ad977aa1fa472dd12d41baf113663ad8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_01-642cab3.stdout
+++ b/tests/reference/llvm-types_01-642cab3.stdout
@@ -10,6 +10,7 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.000000e+00, float* %r, align 4
   store float 2.000000e+00, float* %r, align 4
   store float 3.000000e+00, float* %r, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -17,3 +18,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-types_02-b5bfe0b.json
+++ b/tests/reference/llvm-types_02-b5bfe0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_02-b5bfe0b.stdout",
-    "stdout_hash": "6baaa53fa30e3bd77e44a6cd2b3e0e4c9690b7a6d95d721e589638c4",
+    "stdout_hash": "1f1c3f2bcf1843300bccb6a2e44628bb53e55139f48c9258666fb296",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_02-b5bfe0b.stdout
+++ b/tests/reference/llvm-types_02-b5bfe0b.stdout
@@ -12,6 +12,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* %i1, align 4
   %3 = sitofp i32 %2 to float
   store float %3, float* %r, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -19,3 +20,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "9ae470be48299aeb9068c6703c92de5064699993d8490aaa62f61cc8",
+    "stdout_hash": "4d9080d35eb589d59ce4335657d17e012df8bab5d2b7478509da1fe1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -24,6 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = sext i32 %7 to i64
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -35,3 +36,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-types_04-92449d7.json
+++ b/tests/reference/llvm-types_04-92449d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_04-92449d7.stdout",
-    "stdout_hash": "ba035f7bd898558291dc9e1f485fe4cfd835e095a1aa090d4c0fbdea",
+    "stdout_hash": "7c0c5e2a1f20275d4e263e2a7f086e34b9787e6cb122b2c11270346f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_04-92449d7.stdout
+++ b/tests/reference/llvm-types_04-92449d7.stdout
@@ -86,6 +86,7 @@ define i32 @main(i32 %0, i8** %1) {
   %60 = sitofp i32 %59 to float
   %61 = fdiv float %58, %60
   store float %61, float* %x, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -93,3 +94,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
-    "stdout_hash": "aecb7de0edbb57bedbb871ad4d98e19a152e9762cb8528b19cc47cce",
+    "stdout_hash": "526487454ea550d2d5dce16d48e2a572fbd1c8b297140be5cb85879a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_05-aa71aa9.stdout
+++ b/tests/reference/llvm-types_05-aa71aa9.stdout
@@ -21,6 +21,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 0, i32* %i1, align 4
   store i32 0, i32* %i1, align 4
   store i32 0, i32* %i1, align 4
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -28,3 +29,5 @@ return:                                           ; preds = %.entry
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-types_06-6f66d2c.json
+++ b/tests/reference/llvm-types_06-6f66d2c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_06-6f66d2c.stdout",
-    "stdout_hash": "b955ed3e8f5cc9eebf2adce4b32b558961908fda5d5b35d5572acd5b",
+    "stdout_hash": "12f4e259b702dc09a735123e801f49d950241799dd661ddf4c8495cf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_06-6f66d2c.stdout
+++ b/tests/reference/llvm-types_06-6f66d2c.stdout
@@ -442,6 +442,7 @@ else69:                                           ; preds = %ifcont67
   br label %ifcont70
 
 ifcont70:                                         ; preds = %else69, %then68
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont70
@@ -453,3 +454,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-variables_03-4ba9d62.json
+++ b/tests/reference/llvm-variables_03-4ba9d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-variables_03-4ba9d62.stdout",
-    "stdout_hash": "4c04ce9a124b9d84aa6f68f45e6c334db995127027d49af83a2e5a71",
+    "stdout_hash": "6fc46a22d7d9256fb6d82b86caaaaab4fd86474db84b01c6274f5976",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-variables_03-4ba9d62.stdout
+++ b/tests/reference/llvm-variables_03-4ba9d62.stdout
@@ -86,6 +86,7 @@ else9:                                            ; preds = %ifcont7
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont10
@@ -97,3 +98,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-while_01-3496096.json
+++ b/tests/reference/llvm-while_01-3496096.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_01-3496096.stdout",
-    "stdout_hash": "475ff439d20a378a27311333d830151171ff08e3dd5807ca07314a4b",
+    "stdout_hash": "9aa625a111c4927b572795d93e3ef7ed9d38ba493d2c13d6118b5b80",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_01-3496096.stdout
+++ b/tests/reference/llvm-while_01-3496096.stdout
@@ -165,6 +165,7 @@ else22:                                           ; preds = %ifcont20
   br label %ifcont23
 
 ifcont23:                                         ; preds = %else22, %then21
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont23
@@ -176,3 +177,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-while_02-3db2b04.json
+++ b/tests/reference/llvm-while_02-3db2b04.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_02-3db2b04.stdout",
-    "stdout_hash": "c563afa92a33a2c2063d48a383bc38979e9f21e4af989b934804a99d",
+    "stdout_hash": "f7813f5da8a2607244506dbd2fadee8a097a9955e81999ea998c4d0d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_02-3db2b04.stdout
+++ b/tests/reference/llvm-while_02-3db2b04.stdout
@@ -193,6 +193,7 @@ else28:                                           ; preds = %ifcont26
   br label %ifcont29
 
 ifcont29:                                         ; preds = %else28, %then27
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont29
@@ -204,3 +205,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/llvm-write3-49c0266.json
+++ b/tests/reference/llvm-write3-49c0266.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-write3-49c0266.stdout",
-    "stdout_hash": "971aa189b9308e2f91331bdd9bb222f204c147b5ddcc61910c9001c9",
+    "stdout_hash": "7b84c4118f4d6e4b333fb5b81f6e77ed55f94d4a444b500dc7bee3b1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-write3-49c0266.stdout
+++ b/tests/reference/llvm-write3-49c0266.stdout
@@ -19,6 +19,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32* null, i32** %3, align 8
   %4 = load i32*, i32** %3, align 8
   call void (i32, i32*, i8*, ...) @_lfortran_file_write(i32 %2, i32* %4, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -28,3 +29,5 @@ return:                                           ; preds = %.entry
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_file_write(i32, i32*, i8*, ...)
+
+declare void @_lpython_free_argv()

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run_dbg-runtime_stacktrace_01-dcc746e.stdout",
-    "stdout_hash": "12afa408d6d499403f90c5c0de560313b6c465f5fdcbfed108a68ae2",
+    "stdout_hash": "3cbac67824df4a7f5d34a6c972039cfef6d42c038439792177b26622",
     "stderr": "run_dbg-runtime_stacktrace_01-dcc746e.stderr",
     "stderr_hash": "d7b2063ee2384904c7372e603b621a3e739faa954e5cc144f17d9b08",
     "returncode": 5

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stdout
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stdout
@@ -18,6 +18,7 @@ define i32 @main(i32 %0, i8** %1) !dbg !3 {
   %3 = sext i32 %2 to i64, !dbg !9
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %3), !dbg !9
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0)), !dbg !9
+  call void @_lpython_free_argv(), !dbg !9
   br label %return, !dbg !9
 
 return:                                           ; preds = %.entry
@@ -87,6 +88,8 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 declare void @_lfortran_printf(i8*, ...)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare void @_lpython_free_argv()
 
 attributes #0 = { nounwind readnone speculatable willreturn }
 


### PR DESCRIPTION
Added `_lpython_free_argv()` to deallocate memory allocated by `_lpython_set_argv()` when program ends.

For a simple hello-world program:
```fortran
program main
   print *, "hello, world"
end program
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lfortran$ valgrind -s --leak-check=full --show-leak-kinds=all ./examples/example.o
==13265== Memcheck, a memory error detector
==13265== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==13265== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==13265== Command: ./examples/example.o
==13265== 
hello, world
==13265== 
==13265== HEAP SUMMARY:
==13265==     in use at exit: 0 bytes in 0 blocks
==13265==   total heap usage: 3 allocs, 3 frees, 1,053 bytes allocated
==13265== 
==13265== All heap blocks were freed -- no leaks are possible
==13265== 
==13265== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```