### PR TITLE
macOS: Use system dsymutil first

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -25,10 +25,15 @@ if (WITH_STACKTRACE AND APPLE AND CMAKE_CXX_COMPILER_ID MATCHES Clang)
     # On macOS we have to call dsymutil to create the dSYM bundle so that the
     # stacktrace can find debugging information corresponding to the lfortran
     # binary
+    find_program(DSYMUTIL NAMES dsymutil PATHS /usr/bin NO_DEFAULT_PATH)
+    if(NOT DSYMUTIL)
+        find_program(DSYMUTIL NAMES dsymutil)
+    endif()
+    message("DSYMUTIL: ${DSYMUTIL}")
     add_custom_command(
         TARGET lfortran
         POST_BUILD
-        COMMAND dsymutil lfortran
+        COMMAND ${DSYMUTIL} lfortran
     )
     if (WITH_DWARFDUMP)
         add_custom_command(


### PR DESCRIPTION
Now the llvm-dwarfdump outputs debugging information.

Fixes #5492.