### PR TITLE
Parse the new format

### DIFF
--- a/src/libasr/dwarf_convert.py
+++ b/src/libasr/dwarf_convert.py
@@ -92,8 +92,6 @@ class Parser:
             dir_idx = re.compile(r"dir_index: (\d+)").findall(self.line)[0]
             dir_idx = int(dir_idx)
 
-            self.line = self.file.readline()
-            self.line = self.file.readline()
 
             file_names.append(FileName(n, filename, dir_idx))
 


### PR DESCRIPTION
This will however break the old format, so we need to improve this change to work with both old and new formats.

Fixes #5496.