### PR TITLE
Better modfile errors

### DIFF
--- a/src/libasr/modfile.cpp
+++ b/src/libasr/modfile.cpp
@@ -77,11 +77,13 @@ inline void load_serialised_asr(const std::string &s, std::string& asr_binary) {
 #endif
     std::string file_type = b.read_string();
     if (file_type != lfortran_modfile_type_string) {
-        throw LCompilersException("LCompilers Modfile format not recognized");
+        std::cerr << "LCompilers Modfile format not recognized" << std::endl;
+        exit(1);
     }
     std::string version = b.read_string();
     if (version != LFORTRAN_VERSION) {
-        throw LCompilersException("Incompatible format: LFortran Modfile was generated using version '" + version + "', but current LFortran version is '" + LFORTRAN_VERSION + "'");
+        std::cerr << "Incompatible format: LFortran Modfile was generated using version '" + version + "', but current LFortran version is '" + LFORTRAN_VERSION + "'" << std::endl;
+        exit(1);
     }
     asr_binary = b.read_string();
 }


### PR DESCRIPTION
Now we print an error an exit. This should be further improved to propagate the error to the main program and exit there, and it should print the name and path of the mod file.