### PR TITLE
Add environments to pixi.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -826,18 +826,37 @@ jobs:
 #    strategy:
 #      fail-fast: false
 #      matrix:
-#        os: ["macos-latest", "ubuntu-latest"]
+#        os: ["ubuntu-latest"]
 #    steps:
 #      - uses: actions/checkout@v4
 #        with:
 #          fetch-depth: 0
-#      - uses: prefix-dev/setup-pixi@v0.5.1
-#      - name: Run tasks
+#      - uses: prefix-dev/setup-pixi@v0.8.1
+#        with:
+#          pixi-version: v0.37.0
+#          cache: true
+#      - name: LLVM 10
 #        run: |
-#          pixi run build
+#          pixi run -e llvm10 build
 #          pixi run start --version
-#          pixi run start examples/expr2.f90
-#          pixi run test
+#          pixi run ctest
+#          pixi run integration_tests
+#          pixi run clean
+#      - name: LLVM 11
+#        run: |
+#          pixi run -e llvm11 build
+#          pixi run start --version
+#          pixi run ctest
+#          pixi run tests # Only run for LLVM 11
+#          pixi run integration_tests
+#          pixi run clean
+#      - name: LLVM 19
+#        run: |
+#          pixi run -e llvm19 build
+#          pixi run start --version
+#          pixi run ctest
+#          pixi run integration_tests
+#          pixi run clean
 
   test_llvm:
     name: Test LLVM ${{ matrix.llvm-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ _CPack_Packages
 /CMakeSettings.json
 .cmake
 
+## Pixi
+.pixi/
+
 ## libraries
 *.a
 *.a.*

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,17 +6,56 @@ authors = ["LFortran Maintainers <lfortran@groups.io>"]
 channels = ["conda-forge"]
 platforms = ["osx-arm64", "win-64", "linux-64"]
 
+# feature.default.tasks
 [tasks]
 start = "src/bin/lfortran"
-test = "cmake --build . --parallel --target test && ./run_tests.py && cd integration_tests && ./run_tests.py -j16"
+clean = "git clean -dfx -e '.pixi'"
 
-[feature.host.tasks]
-# an empty task to make sure the dependencies are installed
-setup = "echo 'host dependencies installed'"
+[feature.test.tasks]
+ctest = "cmake --build . --parallel --target test"
+tests = "./run_tests.py"
+integration_tests = "cd integration_tests && ./run_tests.py -j16"
 
-[host-dependencies]
+[feature.llvm10.host-dependencies]
+llvmdev = "10.0.1"
+[feature.llvm11.host-dependencies]
 llvmdev = "11.1.0"
-toml = "0.10.2"
+[feature.llvm12.host-dependencies]
+llvmdev = "12.0.1"
+[feature.llvm13.host-dependencies]
+llvmdev = "13.0.1"
+[feature.llvm14.host-dependencies]
+llvmdev = "14.0.6"
+[feature.llvm15.host-dependencies]
+llvmdev = "15.0.7"
+[feature.llvm16.host-dependencies]
+llvmdev = "16.0.6"
+[feature.llvm17.host-dependencies]
+llvmdev = "17.0.6"
+[feature.llvm18.host-dependencies]
+llvmdev = "18.1.8"
+[feature.llvm19.host-dependencies]
+llvmdev = "19.1.4"
+[feature.llvm12.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm13.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm14.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm15.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm16.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm17.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm18.target.linux.host-dependencies]
+libunwind = "1.7.2"
+[feature.llvm19.target.linux.host-dependencies]
+libunwind = "1.7.2"
+
+# Dependencies to build the project to be installed for the target architecture.
+# host == target
+[feature.build.host-dependencies]
 pytest = "8.1.1"
 jupyter = "1.0.0"
 xeus = "5.1.0"
@@ -29,22 +68,42 @@ rapidjson = "1.1.0"
 zlib = "*"
 zstd-static = ">=1.5.6,<2"
 
+# Dependencies to build the project to be installed on the build machine.
+# feature.default.build-dependencies
 [build-dependencies]
+python = "3.12"
+
+[feature.build.build-dependencies]
 python = "3.12"
 cmake = "3.29.1"
 ninja = "1.11.1"
 #cxx-compiler = "*"
 re2c = "3.1"
 
-[target.unix.build-dependencies]
+[feature.test.build-dependencies]
+python = "3.12"
+toml = "0.10.2"
+cmake = "3.29.1"
+ninja = "1.11.1"
+
+[feature.build.target.unix.build-dependencies]
 bison = "3.4"
 
-[target.win.build-dependencies]
+[feature.build.target.win.build-dependencies]
 m2-bison = "3.0.4"
 
 [feature.build.tasks]
-build = { cmd = "bash ./build1.sh", env = { CMAKE_PREFIX_PATH_LFORTRAN = "$PIXI_PROJECT_ROOT/.pixi/envs/host/" }, depends-on = ["setup"]}
+build = "bash ./build1.sh"
 
 [environments]
-build = ["build"]
-host = ["host"]
+llvm10 = {features = ["llvm10", "build"]}
+llvm11 = {features = ["llvm11", "build"]}
+llvm12 = {features = ["llvm12", "build"]}
+llvm13 = {features = ["llvm13", "build"]}
+llvm14 = {features = ["llvm14", "build"]}
+llvm15 = {features = ["llvm15", "build"]}
+llvm16 = {features = ["llvm16", "build"]}
+llvm17 = {features = ["llvm17", "build"]}
+llvm18 = {features = ["llvm18", "build"]}
+llvm19 = {features = ["llvm19", "build"]}
+test = {features = ["test"]}


### PR DESCRIPTION
The CI works, but I left it disabled for now to save runners. Once we can replace some existing jobs, then we'll switch.

This ports changes from #5489, except `pixi.lock`, since it's a huge file.