### PR TITLE
[Pass] Modify ASR to generate a module for MLIR GPU offloading

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -76,6 +76,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     fast = is_included("fast")
     print_leading_space = is_included("print_leading_space")
     interactive = is_included("interactive")
+    options = test.get("options", "")
     pass_ = test.get("pass", None)
     extrafiles = test.get("extrafiles", "").split(",")
     run = test.get("run")
@@ -94,7 +95,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
                         "array_op", "select_case",
                         "class_constructor", "implied_do_loops",
                         "pass_array_by_data", "init_expr", "where",
-                        "nested_vars", "insert_deallocate"] and
+                        "nested_vars", "insert_deallocate", "openmp"] and
                 _pass not in optimization_passes):
                 raise Exception(f"Unknown pass: {_pass}")
     if update_reference:
@@ -115,6 +116,8 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
         extra_args += " --line=" + line
     if column:
         extra_args += " --column=" + column
+    if options:
+        extra_args += " " + options
 
     if tokens:
         run_test(
@@ -341,14 +344,14 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
                 update_reference,
                 verify_hash,
                 extra_args)
-            
+
     if semantics_only_cc:
         run_test(filename, "asr", "lfortran --semantics-only --continue-compilation --no-color {infile}",
             filename,
             update_reference,
             verify_hash,
             extra_args)
-    
+
     if continue_compilation:
         if no_llvm:
             log.info(f"{filename} * obj    SKIPPED as requested")
@@ -439,7 +442,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
             update_reference,
             verify_hash,
             extra_args)
-        
+
     if mod_to_asr:
         run_test(
             filename,

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2264,6 +2264,7 @@ int main_app(int argc, char *argv[]) {
     app.add_flag("--wasm-html", compiler_options.wasm_html, "Generate HTML file using emscripten for LLVM->WASM");
     app.add_flag("--experimental-simplifier", compiler_options.po.experimental_simplifier, "Use experimental simplifier pass");
     app.add_option("--emcc-embed", compiler_options.emcc_embed, "Embed a given file/directory using emscripten for LLVM->WASM");
+    app.add_flag("--mlir-gpu-offloading", compiler_options.po.enable_gpu_offloading, "Enables gpu offloading using MLIR backend");
 
     // LSP specific options
     app.add_flag("--show-errors", show_errors, "Show errors when LSP is running in the background");
@@ -2475,6 +2476,12 @@ int main_app(int argc, char *argv[]) {
         compiler_options.c_preprocessor = true;
     } else {
         compiler_options.c_preprocessor = false;
+    }
+
+    if(compiler_options.po.enable_gpu_offloading && !compiler_options.openmp) {
+        std::cerr << "The option `--mlir-gpu-offloading` requires openmp pass "
+            "to be applied. Rerun with `--openmp` option\n";
+        return 1;
     }
 
     std::string outfile;

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -60,6 +60,7 @@ struct PassOptions {
     bool c_mangling = false;
     bool openmp = false;
     bool experimental_simplifier = false;
+    bool enable_gpu_offloading = false;
 };
 
 struct CompilerOptions {

--- a/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.json
+++ b/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "pass_openmp-do_concurrent_01-2a6df8c",
+    "cmd": "lfortran --pass=openmp --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/do_concurrent_01.f90",
+    "infile_hash": "6a7684b3e2ff6bfd0e1eb6c1095feb666304732379d06a99405e0aa6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "pass_openmp-do_concurrent_01-2a6df8c.stdout",
+    "stdout_hash": "4bf3416f6f4b4d4a1fbc783a6209e7a7a4160dfe345e8b6b73ca9f5c",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.stdout
+++ b/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.stdout
@@ -1,0 +1,297 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            _lcompilers_mlir_gpu_offloading:
+                (Module
+                    (SymbolTable
+                        3
+                        {
+                            _lcompilers_doconcurrent_replacer_func:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            i:
+                                                (Variable
+                                                    4
+                                                    i
+                                                    []
+                                                    InOut
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            n:
+                                                (Variable
+                                                    4
+                                                    n
+                                                    []
+                                                    InOut
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                ),
+                                            x:
+                                                (Variable
+                                                    4
+                                                    x
+                                                    []
+                                                    InOut
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    _lcompilers_doconcurrent_replacer_func
+                                    (FunctionType
+                                        [(Integer 4)
+                                        (Integer 4)
+                                        (Array
+                                            (Real 4)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )]
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 4 i)
+                                    (Var 4 n)
+                                    (Var 4 x)]
+                                    [(DoConcurrentLoop
+                                        [((Var 4 i)
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        (Var 4 n)
+                                        ())]
+                                        []
+                                        []
+                                        []
+                                        [(Print
+                                            (StringFormat
+                                                ()
+                                                [(ArrayItem
+                                                    (Var 4 x)
+                                                    [(()
+                                                    (Var 4 i)
+                                                    ())]
+                                                    (Real 4)
+                                                    ColMajor
+                                                    ()
+                                                )]
+                                                FormatFortran
+                                                (String -1 0 () PointerString)
+                                                ()
+                                            )
+                                        )
+                                        (If
+                                            (RealCompare
+                                                (IntrinsicElementalFunction
+                                                    Abs
+                                                    [(RealBinOp
+                                                        (ArrayItem
+                                                            (Var 4 x)
+                                                            [(()
+                                                            (Var 4 i)
+                                                            ())]
+                                                            (Real 4)
+                                                            ColMajor
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (RealConstant
+                                                            0.490000
+                                                            (Real 4)
+                                                        )
+                                                        (Real 4)
+                                                        ()
+                                                    )]
+                                                    0
+                                                    (Real 4)
+                                                    ()
+                                                )
+                                                Gt
+                                                (RealConstant
+                                                    0.000001
+                                                    (Real 4)
+                                                )
+                                                (Logical 4)
+                                                ()
+                                            )
+                                            [(ErrorStop
+                                                ()
+                                            )]
+                                            []
+                                        )]
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    _lcompilers_mlir_gpu_offloading
+                    []
+                    .false.
+                    .false.
+                ),
+            do_concurrent_01:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            _lcompilers_doconcurrent_replacer_func:
+                                (ExternalSymbol
+                                    2
+                                    _lcompilers_doconcurrent_replacer_func
+                                    3 _lcompilers_doconcurrent_replacer_func
+                                    _lcompilers_mlir_gpu_offloading
+                                    []
+                                    _lcompilers_doconcurrent_replacer_func
+                                    Public
+                                ),
+                            i:
+                                (Variable
+                                    2
+                                    i
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            n:
+                                (Variable
+                                    2
+                                    n
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                ),
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 12 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                )
+                        })
+                    do_concurrent_01
+                    []
+                    [(Assignment
+                        (Var 2 n)
+                        (IntegerConstant 12 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 x)
+                        (ArrayBroadcast
+                            (RealConstant
+                                0.490000
+                                (Real 4)
+                            )
+                            (ArrayConstant
+                                4
+                                [12]
+                                (Array
+                                    (Integer 4)
+                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 1 (Integer 4) Decimal))]
+                                    FixedSizeArray
+                                )
+                                ColMajor
+                            )
+                            (Array
+                                (Real 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 12 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            (ArrayConstant
+                                48
+                                [4.90000010e-01, 4.90000010e-01, 4.90000010e-01, ...., 4.90000010e-01, 4.90000010e-01, 4.90000010e-01]
+                                (Array
+                                    (Real 4)
+                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 12 (Integer 4) Decimal))]
+                                    FixedSizeArray
+                                )
+                                ColMajor
+                            )
+                        )
+                        ()
+                    )
+                    (SubroutineCall
+                        2 _lcompilers_doconcurrent_replacer_func
+                        2 _lcompilers_doconcurrent_replacer_func
+                        [((Var 2 i))
+                        ((Var 2 n))
+                        ((Var 2 x))]
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1753,6 +1753,11 @@ filename = "../integration_tests/doconcurrentloop_01.f90"
 ast_f90 = true
 
 [[test]]
+filename = "../integration_tests/do_concurrent_01.f90"
+pass = "openmp"
+options = "--mlir-gpu-offloading --openmp"
+
+[[test]]
 filename = "subroutine9.f90"
 ast = true
 ast_f90 = true


### PR DESCRIPTION
This a first step for GPU offloading.

Let's take do concurrent as the ASR node for offloading.
The node has to be moved into a separate module, which will be 
converted into a MLIR openmp dialect and transform the generated
MLIR to LLVM module and link it with the LLVM module generated by
the LLVM backend. 
Only `do concurrent` is handled by MLIR, rest all the nodes will be
handled by the LLVM backend.