### PR TITLE
enh : Get subroutine_from_function pass to handle strings (right owner)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1151,6 +1151,7 @@ RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_04 LABELS gfortran llvm)
 RUN(NAME operator_overloading_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_07.f90
+++ b/integration_tests/operator_overloading_07.f90
@@ -1,0 +1,50 @@
+! Overloading the assignment operator `=` with a function call that would be handled by
+! `subroutine_from_function` pass. So we need to make sure that the pass 
+! actually replaces the function call in the overloaded expression.
+module operator_overloading_07_mod1
+    implicit none
+    interface assignment(=)
+        module procedure :: assign_string_char
+    end interface assignment(=)
+
+    type string_type
+        character(:), allocatable :: raw
+    end type
+
+    contains
+
+    subroutine assign_string_char(lhs, rhs)
+        type(string_type), intent(inout) :: lhs
+        character(len=*), intent(in) :: rhs
+        lhs%raw = rhs
+    end subroutine assign_string_char
+
+end module operator_overloading_07_mod1
+
+
+module operator_overloading_07_mod2
+    use operator_overloading_07_mod1
+    implicit none
+
+    type(string_type) :: instance
+    
+    contains
+    function func() result(ret_arr)
+        character(:), allocatable :: ret_arr
+        allocate(character(15) :: ret_arr)
+        ret_arr = "Hello World!"
+    end function
+
+    subroutine ff()
+        character(:), allocatable :: inp
+        instance = func() ! pass `subroutine_from_function` takes action here. It must handle the overloading of `=`. 
+        print *, instance%raw
+    end subroutine ff
+end module
+
+
+program operator_overloading_07
+    use operator_overloading_07_mod2, only : ff
+    implicit none
+    call ff()
+end program  

--- a/integration_tests/operator_overloading_07.f90
+++ b/integration_tests/operator_overloading_07.f90
@@ -39,6 +39,7 @@ module operator_overloading_07_mod2
         character(:), allocatable :: inp
         instance = func() ! pass `subroutine_from_function` takes action here. It must handle the overloading of `=`. 
         print *, instance%raw
+        if(instance%raw /= "Hello World!") error stop
     end subroutine ff
 end module
 

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -157,7 +157,8 @@ namespace LCompilers {
         static inline bool is_aggregate_or_array_type(ASR::expr_t* var) {
             return (ASR::is_a<ASR::StructType_t>(*ASRUtils::expr_type(var)) ||
                     ASRUtils::is_array(ASRUtils::expr_type(var)) ||
-                    ASR::is_a<ASR::SymbolicExpression_t>(*ASRUtils::expr_type(var)));
+                    ASR::is_a<ASR::SymbolicExpression_t>(*ASRUtils::expr_type(var)) || 
+                    ASRUtils::is_descriptorString(ASRUtils::expr_type(var)));
         }
 
         static inline bool is_symbolic_list_type(ASR::expr_t* var) {

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -162,12 +162,17 @@ namespace LCompilers {
             return ASRUtils::is_descriptorString(x);
         }
 
-        static inline bool is_aggregate_or_array_or_nonPrimitive_type(ASR::expr_t* var) {
+        static inline bool is_aggregate_or_array_type(ASR::expr_t* var) {
             return (ASR::is_a<ASR::StructType_t>(*ASRUtils::expr_type(var)) ||
                     ASRUtils::is_array(ASRUtils::expr_type(var)) ||
-                    ASR::is_a<ASR::SymbolicExpression_t>(*ASRUtils::expr_type(var)) || 
-                    is_non_primitive_return_type(ASRUtils::expr_type(var)));
+                    ASR::is_a<ASR::SymbolicExpression_t>(*ASRUtils::expr_type(var)));
         }
+        
+        static inline bool is_aggregate_or_array_or_nonPrimitive_type(ASR::expr_t* var) {
+            return  is_aggregate_or_array_type(var) || 
+                    is_non_primitive_return_type(ASRUtils::expr_type(var));
+        }
+
 
         static inline bool is_symbolic_list_type(ASR::expr_t* var) {
             if (ASR::is_a<ASR::List_t>(*ASRUtils::expr_type(var))) {

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -154,11 +154,19 @@ namespace LCompilers {
             return ASR::is_a<ASR::StructType_t>(*ASRUtils::expr_type(var));
         }
 
-        static inline bool is_aggregate_or_array_type(ASR::expr_t* var) {
+        /*  Checks for any non-primitive-function-return type 
+            like fixed strings or allocatables.
+            allocatable string, allocatable integer, etc.. */
+        static inline bool is_non_primitive_return_type(ASR::ttype_t* x){
+            // TODO : Handle other allocatable types and fixed strings.
+            return ASRUtils::is_descriptorString(x);
+        }
+
+        static inline bool is_aggregate_or_array_or_nonPrimitive_type(ASR::expr_t* var) {
             return (ASR::is_a<ASR::StructType_t>(*ASRUtils::expr_type(var)) ||
                     ASRUtils::is_array(ASRUtils::expr_type(var)) ||
                     ASR::is_a<ASR::SymbolicExpression_t>(*ASRUtils::expr_type(var)) || 
-                    ASRUtils::is_descriptorString(ASRUtils::expr_type(var)));
+                    is_non_primitive_return_type(ASRUtils::expr_type(var)));
         }
 
         static inline bool is_symbolic_list_type(ASR::expr_t* var) {

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -33,7 +33,7 @@ class CreateFunctionFromSubroutine: public PassUtils::PassVisitor<CreateFunction
                 if (is_a<ASR::Function_t>(*item.second)) {
                     PassUtils::handle_fn_return_var(al,
                         ASR::down_cast<ASR::Function_t>(item.second),
-                        PassUtils::is_aggregate_or_array_type);
+                        PassUtils::is_aggregate_or_array_or_nonPrimitive_type);
                 }
             }
 
@@ -58,7 +58,7 @@ class CreateFunctionFromSubroutine: public PassUtils::PassVisitor<CreateFunction
                 if (is_a<ASR::Function_t>(*item.second)) {
                     PassUtils::handle_fn_return_var(al,
                         ASR::down_cast<ASR::Function_t>(item.second),
-                        PassUtils::is_aggregate_or_array_type);
+                        PassUtils::is_aggregate_or_array_or_nonPrimitive_type);
                 }
             }
 
@@ -79,7 +79,7 @@ class CreateFunctionFromSubroutine: public PassUtils::PassVisitor<CreateFunction
                 if (is_a<ASR::Function_t>(*item.second)) {
                     PassUtils::handle_fn_return_var(al,
                         ASR::down_cast<ASR::Function_t>(item.second),
-                        PassUtils::is_aggregate_or_array_type);
+                        PassUtils::is_aggregate_or_array_or_nonPrimitive_type);
                 }
             }
 

--- a/src/libasr/pass/subroutine_from_function_simplifier.cpp
+++ b/src/libasr/pass/subroutine_from_function_simplifier.cpp
@@ -135,27 +135,37 @@ class ReplaceFunctionCallWithSubroutineCallSimplifierVisitor:
             n_body = body.size();
         }
 
-        bool is_function_call_returning_aggregate_or_nonPrimitive_type(ASR::expr_t* m_value) {
+        bool is_function_call_returning_aggregate_type(ASR::expr_t* m_value) {
             bool is_function_call = ASR::is_a<ASR::FunctionCall_t>(*m_value);
             bool is_aggregate_type = (ASRUtils::is_aggregate_type(
                 ASRUtils::expr_type(m_value)) ||
-                PassUtils::is_aggregate_or_array_or_nonPrimitive_type(m_value));
+                PassUtils::is_aggregate_or_array_type(m_value));
             return is_function_call && is_aggregate_type;
         }
 
         void visit_Assignment(const ASR::Assignment_t &x) {
-            if( !is_function_call_returning_aggregate_or_nonPrimitive_type(x.m_value) ) {
-                visit_expr(*x.m_value);
+            ASR::CallReplacerOnExpressionsVisitor \
+            <ReplaceFunctionCallWithSubroutineCallSimplifierVisitor>::visit_Assignment(x);
+            if( !is_function_call_returning_aggregate_type(x.m_value)) {
                 return ;
             }
             ASR::FunctionCall_t* fc = ASR::down_cast<ASR::FunctionCall_t>(x.m_value);
-            if(PassUtils::is_non_primitive_return_type(fc->m_type)){ 
-                /*  
-                RHS functionCalls of type Array or struct is handled beforehand by simplifier,
-                while Non-Primitive functionCall needs to be handled in this pass. 
-                */
-                replacer.traverse_functionCall_args(fc->m_args, fc->n_args); // Check for nested-NonPrimitive functionCall.
-            }
+            // if(PassUtils::is_non_primitive_return_type(fc->m_type)){ 
+            //     /*  
+            //     RHS functionCalls of type Array or struct is handled beforehand by simplifier,
+            //     while Non-Primitive functionCall needs to be handled in this pass. 
+            //     */
+            // //    ASR::Assignment_t& xx = const_cast<ASR::Assignment_t&>(x);
+            // //    ASR::expr_t** cc = current_expr;
+            // //     current_expr = &xx.m_value;
+            // //     call_replacer();
+            // //     current_expr= cc;
+            // //     // visit_expr(*x.m_value);
+            // //     return ;
+
+            //     // replacer.traverse_functionCall_args(fc->m_args, fc->n_args); // Check for nested-NonPrimitive functionCall.
+            //     return;
+            // }
 
             if( PassUtils::is_elemental(fc->m_name) && ASRUtils::is_array(fc->m_type) ) {
                 return ;

--- a/src/libasr/pass/subroutine_from_function_simplifier.cpp
+++ b/src/libasr/pass/subroutine_from_function_simplifier.cpp
@@ -149,24 +149,8 @@ class ReplaceFunctionCallWithSubroutineCallSimplifierVisitor:
             if( !is_function_call_returning_aggregate_type(x.m_value)) {
                 return ;
             }
+
             ASR::FunctionCall_t* fc = ASR::down_cast<ASR::FunctionCall_t>(x.m_value);
-            // if(PassUtils::is_non_primitive_return_type(fc->m_type)){ 
-            //     /*  
-            //     RHS functionCalls of type Array or struct is handled beforehand by simplifier,
-            //     while Non-Primitive functionCall needs to be handled in this pass. 
-            //     */
-            // //    ASR::Assignment_t& xx = const_cast<ASR::Assignment_t&>(x);
-            // //    ASR::expr_t** cc = current_expr;
-            // //     current_expr = &xx.m_value;
-            // //     call_replacer();
-            // //     current_expr= cc;
-            // //     // visit_expr(*x.m_value);
-            // //     return ;
-
-            //     // replacer.traverse_functionCall_args(fc->m_args, fc->n_args); // Check for nested-NonPrimitive functionCall.
-            //     return;
-            // }
-
             if( PassUtils::is_elemental(fc->m_name) && ASRUtils::is_array(fc->m_type) ) {
                 return ;
             }

--- a/src/libasr/pass/subroutine_from_function_simplifier.cpp
+++ b/src/libasr/pass/subroutine_from_function_simplifier.cpp
@@ -26,11 +26,59 @@ class CreateFunctionFromSubroutineSimplifier: public ASR::BaseWalkVisitor<Create
         void visit_Function(const ASR::Function_t& x) {
             ASR::Function_t& xx = const_cast<ASR::Function_t&>(x);
             ASR::Function_t* x_ptr = ASR::down_cast<ASR::Function_t>(&(xx.base));
-            PassUtils::handle_fn_return_var(al, x_ptr, PassUtils::is_aggregate_or_array_type);
+            PassUtils::handle_fn_return_var(al, x_ptr, PassUtils::is_aggregate_or_array_or_nonPrimitive_type);
         }
 
 };
 
+class ReplaceFunctionCallWithSubroutineCallSimplifier:
+    public ASR::BaseExprReplacer<ReplaceFunctionCallWithSubroutineCallSimplifier> {
+private : 
+public :
+    Allocator & al;
+    int result_counter = 0;
+    SymbolTable* current_scope;
+    Vec<ASR::stmt_t*> &pass_result;
+    ReplaceFunctionCallWithSubroutineCallSimplifier(Allocator& al_, Vec<ASR::stmt_t*> &pass_result_) :
+        al(al_),pass_result(pass_result_) {}
+
+    void traverse_functionCall_args(ASR::call_arg_t* call_args, size_t call_args_n){
+        for(size_t i = 0; i < call_args_n; i++){
+            ASR::expr_t** current_expr_copy = current_expr;
+            current_expr = &call_args[i].m_value;
+            replace_expr(call_args[i].m_value);
+            current_expr = current_expr_copy;
+        }
+    }
+
+    void replace_FunctionCall(ASR::FunctionCall_t* x){
+        traverse_functionCall_args(x->m_args, x->n_args);
+        if(PassUtils::is_non_primitive_return_type(x->m_type)){ // Arrays and structs are handled by the simplifier. No need to check for them here.
+            // Create variable in current_scope to be holding the return + Deallocate. 
+            ASR::expr_t* result_var = PassUtils::create_var(result_counter++,
+                "_func_call_res", x->base.base.loc, ASRUtils::duplicate_type(al, x->m_type), al, current_scope);
+            if(ASRUtils::is_allocatable(result_var)){
+                Vec<ASR::expr_t*> to_be_deallocated;
+                to_be_deallocated.reserve(al, 1);
+                to_be_deallocated.push_back(al, result_var);
+                pass_result.push_back(al, ASRUtils::STMT(
+                ASR::make_ImplicitDeallocate_t(al, result_var->base.loc,
+                    to_be_deallocated.p, to_be_deallocated.size())));
+            }
+            // Create new call args with `result_var` as last argument capturing return + Create a `subroutineCall`.
+            Vec<ASR::call_arg_t> new_call_args;
+            new_call_args.reserve(al,1);
+            new_call_args.from_pointer_n_copy(al, x->m_args, x->n_args);
+            new_call_args.push_back(al, {result_var->base.loc, result_var});
+            ASR::stmt_t* subrout_call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, x->base.base.loc,
+                                                x->m_name, nullptr, new_call_args.p, new_call_args.size(), x->m_dt,
+                                                nullptr, false, false));
+            // replace functionCall with `result_var` + push subroutineCall into the body.
+            *current_expr = result_var;
+            pass_result.push_back(al, subrout_call); 
+        }
+    }
+};
 class ReplaceFunctionCallWithSubroutineCallSimplifierVisitor:
     public ASR::CallReplacerOnExpressionsVisitor<ReplaceFunctionCallWithSubroutineCallSimplifierVisitor> {
 
@@ -38,15 +86,23 @@ class ReplaceFunctionCallWithSubroutineCallSimplifierVisitor:
 
         Allocator& al;
         Vec<ASR::stmt_t*> pass_result;
+        ReplaceFunctionCallWithSubroutineCallSimplifier replacer;
+        bool remove_original_statement = false;
         Vec<ASR::stmt_t*>* parent_body = nullptr;
 
 
     public:
 
-        ReplaceFunctionCallWithSubroutineCallSimplifierVisitor(Allocator& al_): al(al_)
+        ReplaceFunctionCallWithSubroutineCallSimplifierVisitor(Allocator& al_): al(al_), replacer(al, pass_result)
         {
             pass_result.n = 0;
             pass_result.reserve(al, 1);
+        }
+
+        void call_replacer(){
+            replacer.current_expr = current_expr;
+            replacer.current_scope = current_scope;
+            replacer.replace_expr(*current_expr);
         }
 
         void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "18f7835fa5939fe9746bd5ac7525dbf65819cf9be6284678712d5444",
+    "stdout_hash": "817d2ce942971b593fdfe9c0cb8c81b12198602fffc586e5c8062707",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "806a91418e9e8ac1f55667ef5587651e151c4bebf1303ad4324e785c",
+    "stdout_hash": "18f7835fa5939fe9746bd5ac7525dbf65819cf9be6284678712d5444",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -170,20 +170,36 @@ define i32 @main(i32 %0, i8** %1) {
   store i64 0, i64* %7, align 4
   %value = alloca double, align 8
   store double 1.000000e+01, double* %value, align 8
-  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__0__func_call_res)
   %8 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %9)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  %9 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %10 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %11 = load i8*, i8** %8, align 8
+  call void @_lfortran_free(i8* %11)
+  store i8* null, i8** %8, align 8
+  store i64 0, i64* %9, align 4
+  store i64 0, i64* %10, align 4
+  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__0__func_call_res)
+  %12 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %13 = load i8*, i8** %12, align 8
+  %14 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %13)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  %15 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
+  %16 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 1
+  %17 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 2
+  %18 = load i8*, i8** %15, align 8
+  call void @_lfortran_free(i8* %18)
+  store i8* null, i8** %15, align 8
+  store i64 0, i64* %16, align 4
+  store i64 0, i64* %17, align 4
   call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__1__func_call_res)
-  %11 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = alloca i8*, align 8
-  store i8* %12, i8** %13, align 8
-  %14 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([19 x i8], [19 x i8]* @7, i32 0, i32 0), i8** %14, align 8
-  %15 = call i1 @_lpython_str_compare_noteq(i8** %13, i8** %14)
-  br i1 %15, label %then, label %else
+  %19 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
+  %20 = load i8*, i8** %19, align 8
+  %21 = alloca i8*, align 8
+  store i8* %20, i8** %21, align 8
+  %22 = alloca i8*, align 8
+  store i8* getelementptr inbounds ([19 x i8], [19 x i8]* @7, i32 0, i32 0), i8** %22, align 8
+  %23 = call i1 @_lpython_str_compare_noteq(i8** %21, i8** %22)
+  br i1 %23, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
@@ -194,22 +210,22 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %16 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %17 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
-  %18 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
-  %19 = load i8*, i8** %16, align 8
-  call void @_lfortran_free(i8* %19)
-  store i8* null, i8** %16, align 8
-  store i64 0, i64* %17, align 4
-  store i64 0, i64* %18, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
-  %21 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 1
-  %22 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 2
-  %23 = load i8*, i8** %20, align 8
-  call void @_lfortran_free(i8* %23)
-  store i8* null, i8** %20, align 8
-  store i64 0, i64* %21, align 4
-  store i64 0, i64* %22, align 4
+  %24 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %25 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %26 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %27 = load i8*, i8** %24, align 8
+  call void @_lfortran_free(i8* %27)
+  store i8* null, i8** %24, align 8
+  store i64 0, i64* %25, align 4
+  store i64 0, i64* %26, align 4
+  %28 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
+  %29 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 1
+  %30 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 2
+  %31 = load i8*, i8** %28, align 8
+  call void @_lfortran_free(i8* %31)
+  store i8* null, i8** %28, align 8
+  store i64 0, i64* %29, align 4
+  store i64 0, i64* %30, align 4
   call void @_lpython_free_argv()
   br label %return
 
@@ -219,6 +235,8 @@ return:                                           ; preds = %ifcont
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
+declare void @_lfortran_free(i8*)
+
 declare void @_lfortran_printf(i8*, ...)
 
 declare i1 @_lpython_str_compare_noteq(i8**, i8**)
@@ -226,7 +244,5 @@ declare i1 @_lpython_str_compare_noteq(i8**, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
-
-declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -94,7 +94,7 @@ return:                                           ; preds = %.entry
   ret i8* %6
 }
 
-define %string_descriptor @__module_testdrive_derived_types_32_real_dp_to_string(double* %val) {
+define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val, %string_descriptor* %string) {
 .entry:
   %buffer = alloca i8*, align 8
   %0 = call i8* @_lfortran_malloc(i32 129)
@@ -103,40 +103,32 @@ define %string_descriptor @__module_testdrive_derived_types_32_real_dp_to_string
   %1 = load i8*, i8** %buffer, align 8
   %buffer_len = alloca i32, align 4
   store i32 128, i32* %buffer_len, align 4
-  %string = alloca %string_descriptor, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  store i8* null, i8** %2, align 8
-  %3 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  store i64 0, i64* %3, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
-  store i64 0, i64* %4, align 4
   %negative_one_constant = alloca i64, align 8
   store i64 -1, i64* %negative_one_constant, align 4
-  %5 = alloca i32*, align 8
-  store i32* null, i32** %5, align 8
-  %6 = load i32*, i32** %5, align 8
-  %7 = load double, double* %val, align 8
-  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 5, double %7)
-  call void (i8**, i64*, i64*, i32*, i8*, ...) @_lfortran_string_write(i8** %buffer, i64* %negative_one_constant, i64* %negative_one_constant, i32* %6, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @3, i32 0, i32 0), i8* %8)
+  %2 = alloca i32*, align 8
+  store i32* null, i32** %2, align 8
+  %3 = load i32*, i32** %2, align 8
+  %4 = load double, double* %val, align 8
+  %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 5, double %4)
+  call void (i8**, i64*, i64*, i32*, i8*, ...) @_lfortran_string_write(i8** %buffer, i64* %negative_one_constant, i64* %negative_one_constant, i32* %3, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @3, i32 0, i32 0), i8* %5)
   %casted_string_ptr_to_desc = alloca %string_descriptor, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
-  %10 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 2
-  %12 = call i8* @_lcompilers_trim_str(i8** %buffer)
-  store i8* %12, i8** %9, align 8
-  store i64 -1, i64* %10, align 4
-  store i64 -1, i64* %11, align 4
-  %13 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %14 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
-  %16 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  call void @_lfortran_strcpy_descriptor_string(i8** %13, i8* %17, i64* %14, i64* %15)
+  %6 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
+  %7 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 1
+  %8 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 2
+  %9 = call i8* @_lcompilers_trim_str(i8** %buffer)
+  store i8* %9, i8** %6, align 8
+  store i64 -1, i64* %7, align 4
+  store i64 -1, i64* %8, align 4
+  %10 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
+  %11 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
+  %12 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 2
+  %13 = getelementptr %string_descriptor, %string_descriptor* %casted_string_ptr_to_desc, i32 0, i32 0
+  %14 = load i8*, i8** %13, align 8
+  call void @_lfortran_strcpy_descriptor_string(i8** %10, i8* %14, i64* %11, i64* %12)
   br label %return
 
 return:                                           ; preds = %.entry
-  %18 = load %string_descriptor, %string_descriptor* %string, align 8
-  ret %string_descriptor %18
+  ret void
 }
 
 declare i8* @_lfortran_malloc(i32)
@@ -162,26 +154,36 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %__libasr__created__var__0__func_call_res = alloca %string_descriptor, align 8
+  %2 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  store i8* null, i8** %2, align 8
+  %3 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  store i64 0, i64* %3, align 4
+  %4 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  store i64 0, i64* %4, align 4
+  %__libasr__created__var__1__func_call_res = alloca %string_descriptor, align 8
+  %5 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
+  store i8* null, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 1
+  store i64 0, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 2
+  store i64 0, i64* %7, align 4
   %value = alloca double, align 8
   store double 1.000000e+01, double* %value, align 8
-  %2 = call %string_descriptor @__module_testdrive_derived_types_32_real_dp_to_string(double* %value)
-  %3 = alloca %string_descriptor, align 8
-  store %string_descriptor %2, %string_descriptor* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %3, i32 0, i32 0
-  %5 = load i8*, i8** %4, align 8
-  %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %5)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  %7 = call %string_descriptor @__module_testdrive_derived_types_32_real_dp_to_string(double* %value)
-  %8 = alloca %string_descriptor, align 8
-  store %string_descriptor %7, %string_descriptor* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %8, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = alloca i8*, align 8
-  store i8* %10, i8** %11, align 8
-  %12 = alloca i8*, align 8
-  store i8* getelementptr inbounds ([19 x i8], [19 x i8]* @7, i32 0, i32 0), i8** %12, align 8
-  %13 = call i1 @_lpython_str_compare_noteq(i8** %11, i8** %12)
-  br i1 %13, label %then, label %else
+  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__0__func_call_res)
+  %8 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %9)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__1__func_call_res)
+  %11 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
+  %12 = load i8*, i8** %11, align 8
+  %13 = alloca i8*, align 8
+  store i8* %12, i8** %13, align 8
+  %14 = alloca i8*, align 8
+  store i8* getelementptr inbounds ([19 x i8], [19 x i8]* @7, i32 0, i32 0), i8** %14, align 8
+  %15 = call i1 @_lpython_str_compare_noteq(i8** %13, i8** %14)
+  br i1 %15, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
@@ -192,6 +194,22 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  %16 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %17 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %18 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %19 = load i8*, i8** %16, align 8
+  call void @_lfortran_free(i8* %19)
+  store i8* null, i8** %16, align 8
+  store i64 0, i64* %17, align 4
+  store i64 0, i64* %18, align 4
+  %20 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
+  %21 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 1
+  %22 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 2
+  %23 = load i8*, i8** %20, align 8
+  call void @_lfortran_free(i8* %23)
+  store i8* null, i8** %20, align 8
+  store i64 0, i64* %21, align 4
+  store i64 0, i64* %22, align 4
   call void @_lpython_free_argv()
   br label %return
 
@@ -208,5 +226,7 @@ declare i1 @_lpython_str_compare_noteq(i8**, i8**)
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "5d834d9b57053d8ba5613200045cabbda315dfc48d60006c9b33b2a1",
+    "stdout_hash": "9257e41c3a38560c9fa6defe529da204d1546254acb31893d5843b32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "80e9cfcddbfffc792ce51e8fffe33f7899b67389e269a3b84b24764e",
+    "stdout_hash": "5d834d9b57053d8ba5613200045cabbda315dfc48d60006c9b33b2a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -2,9 +2,9 @@
 source_filename = "LFortran"
 
 %0 = type { [25 x i8], i32 }
-%string_descriptor = type { i8*, i64, i64 }
 %compiler_t_polymorphic = type { i64, %compiler_t* }
 %compiler_t = type { i32, %string_descriptor, %string_descriptor, %string_descriptor, i1, i1 }
+%string_descriptor = type { i8*, i64, i64 }
 %array = type { %string_t*, i32, %dimension_descriptor*, i1, i32 }
 %string_t = type { %string_descriptor }
 %dimension_descriptor = type { i32, i32, i32 }
@@ -14,31 +14,24 @@ source_filename = "LFortran"
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define %string_descriptor @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %self, i8** %prefix, %array* %libs) {
+define void @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %self, i8** %prefix, %array* %libs, %string_descriptor* %r) {
 .entry:
   %0 = alloca %__vtab_compiler_t, align 8
   %1 = getelementptr %__vtab_compiler_t, %__vtab_compiler_t* %0, i32 0, i32 0
   store i64 0, i64* %1, align 4
-  %r = alloca %string_descriptor, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %r, i32 0, i32 0
-  store i8* null, i8** %2, align 8
-  %3 = getelementptr %string_descriptor, %string_descriptor* %r, i32 0, i32 1
-  store i64 0, i64* %3, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %r, i32 0, i32 2
-  store i64 0, i64* %4, align 4
-  %5 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %self, i32 0, i32 1
-  %6 = load %compiler_t*, %compiler_t** %5, align 8
-  %7 = getelementptr %compiler_t, %compiler_t* %6, i32 0, i32 0
-  %8 = load i32, i32* %7, align 4
-  %9 = icmp eq i32 %8, 1
-  %10 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %self, i32 0, i32 1
-  %11 = load %compiler_t*, %compiler_t** %10, align 8
-  %12 = getelementptr %compiler_t, %compiler_t* %11, i32 0, i32 0
-  %13 = load i32, i32* %12, align 4
-  %14 = icmp eq i32 %13, 2
-  %15 = icmp eq i1 %9, false
-  %16 = select i1 %15, i1 %14, i1 %9
-  br i1 %16, label %then, label %else
+  %2 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %self, i32 0, i32 1
+  %3 = load %compiler_t*, %compiler_t** %2, align 8
+  %4 = getelementptr %compiler_t, %compiler_t* %3, i32 0, i32 0
+  %5 = load i32, i32* %4, align 4
+  %6 = icmp eq i32 %5, 1
+  %7 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %self, i32 0, i32 1
+  %8 = load %compiler_t*, %compiler_t** %7, align 8
+  %9 = getelementptr %compiler_t, %compiler_t* %8, i32 0, i32 0
+  %10 = load i32, i32* %9, align 4
+  %11 = icmp eq i32 %10, 2
+  %12 = icmp eq i1 %6, false
+  %13 = select i1 %12, i1 %11, i1 %6
+  br i1 %13, label %then, label %else
 
 then:                                             ; preds = %.entry
   br label %ifcont
@@ -50,8 +43,7 @@ ifcont:                                           ; preds = %else, %then
   br label %return
 
 return:                                           ; preds = %ifcont
-  %17 = load %string_descriptor, %string_descriptor* %r, align 8
-  ret %string_descriptor %17
+  ret void
 }
 
 define i32 @main(i32 %0, i8** %1) {
@@ -60,96 +52,109 @@ define i32 @main(i32 %0, i8** %1) {
   %i = alloca i32, align 4
   %array_size = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %compiler_arg = alloca %compiler_t, align 8
-  %2 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 2
-  %3 = getelementptr %string_descriptor, %string_descriptor* %2, i32 0, i32 0
-  store i8* null, i8** %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %2, i32 0, i32 1
+  %__libasr__created__var__0__func_call_res = alloca %string_descriptor, align 8
+  %2 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  store i8* null, i8** %2, align 8
+  %3 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  store i64 0, i64* %3, align 4
+  %4 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
   store i64 0, i64* %4, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %2, i32 0, i32 2
-  store i64 0, i64* %5, align 4
-  %6 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 3
-  %7 = getelementptr %string_descriptor, %string_descriptor* %6, i32 0, i32 0
-  store i8* null, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %6, i32 0, i32 1
+  %compiler_arg = alloca %compiler_t, align 8
+  %5 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 2
+  %6 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 0
+  store i8* null, i8** %6, align 8
+  %7 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 1
+  store i64 0, i64* %7, align 4
+  %8 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 2
   store i64 0, i64* %8, align 4
-  %9 = getelementptr %string_descriptor, %string_descriptor* %6, i32 0, i32 2
-  store i64 0, i64* %9, align 4
-  %10 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 4
-  store i1 true, i1* %10, align 1
-  %11 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 1
-  %12 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 0
-  store i8* null, i8** %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 1
-  store i64 0, i64* %13, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 2
-  store i64 0, i64* %14, align 4
-  %15 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 0
-  store i32 0, i32* %15, align 4
-  %16 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 5
-  store i1 true, i1* %16, align 1
+  %9 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 3
+  %10 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 0
+  store i8* null, i8** %10, align 8
+  %11 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 1
+  store i64 0, i64* %11, align 4
+  %12 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 2
+  store i64 0, i64* %12, align 4
+  %13 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 4
+  store i1 true, i1* %13, align 1
+  %14 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 1
+  %15 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 0
+  store i8* null, i8** %15, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 1
+  store i64 0, i64* %16, align 4
+  %17 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 2
+  store i64 0, i64* %17, align 4
+  %18 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 0
+  store i32 0, i32* %18, align 4
+  %19 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 5
+  store i1 true, i1* %19, align 1
   %libs_arg = alloca [4 x %string_t], align 8
   store i32 4, i32* %array_size, align 4
   store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %17 = load i32, i32* %i, align 4
-  %18 = load i32, i32* %array_size, align 4
-  %19 = icmp slt i32 %17, %18
-  br i1 %19, label %loop.body, label %loop.end
+  %20 = load i32, i32* %i, align 4
+  %21 = load i32, i32* %array_size, align 4
+  %22 = icmp slt i32 %20, %21
+  br i1 %22, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %20 = load i32, i32* %i, align 4
-  %21 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 %20
-  %22 = getelementptr %string_t, %string_t* %21, i32 0, i32 0
-  %23 = getelementptr %string_descriptor, %string_descriptor* %22, i32 0, i32 0
-  store i8* null, i8** %23, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %22, i32 0, i32 1
-  store i64 0, i64* %24, align 4
-  %25 = getelementptr %string_descriptor, %string_descriptor* %22, i32 0, i32 2
-  store i64 0, i64* %25, align 4
-  %26 = load i32, i32* %i, align 4
-  %27 = add i32 %26, 1
-  store i32 %27, i32* %i, align 4
+  %23 = load i32, i32* %i, align 4
+  %24 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 %23
+  %25 = getelementptr %string_t, %string_t* %24, i32 0, i32 0
+  %26 = getelementptr %string_descriptor, %string_descriptor* %25, i32 0, i32 0
+  store i8* null, i8** %26, align 8
+  %27 = getelementptr %string_descriptor, %string_descriptor* %25, i32 0, i32 1
+  store i64 0, i64* %27, align 4
+  %28 = getelementptr %string_descriptor, %string_descriptor* %25, i32 0, i32 2
+  store i64 0, i64* %28, align 4
+  %29 = load i32, i32* %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, i32* %i, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   %prefix_arg = alloca i8*, align 8
-  %28 = call i8* @_lfortran_malloc(i32 4)
-  call void @_lfortran_string_init(i32 4, i8* %28)
-  store i8* %28, i8** %prefix_arg, align 8
-  %29 = load i8*, i8** %prefix_arg, align 8
-  %30 = alloca %compiler_t_polymorphic, align 8
-  %31 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %30, i32 0, i32 0
-  store i64 0, i64* %31, align 4
-  %32 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %30, i32 0, i32 1
-  store %compiler_t* %compiler_arg, %compiler_t** %32, align 8
-  %33 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
-  %34 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
-  store %string_t* %33, %string_t** %34, align 8
-  %35 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
-  store i32 0, i32* %35, align 4
-  %36 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
-  %37 = alloca %dimension_descriptor, align 8
-  store %dimension_descriptor* %37, %dimension_descriptor** %36, align 8
-  %38 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
-  store i32 1, i32* %38, align 4
-  %39 = load %dimension_descriptor*, %dimension_descriptor** %36, align 8
-  %40 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %39, i32 0
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 0
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 1
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 2
+  %31 = call i8* @_lfortran_malloc(i32 4)
+  call void @_lfortran_string_init(i32 4, i8* %31)
+  store i8* %31, i8** %prefix_arg, align 8
+  %32 = load i8*, i8** %prefix_arg, align 8
+  %33 = alloca %compiler_t_polymorphic, align 8
+  %34 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %33, i32 0, i32 0
+  store i64 0, i64* %34, align 4
+  %35 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %33, i32 0, i32 1
+  store %compiler_t* %compiler_arg, %compiler_t** %35, align 8
+  %36 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
+  %37 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
+  store %string_t* %36, %string_t** %37, align 8
+  %38 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
+  store i32 0, i32* %38, align 4
+  %39 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
+  %40 = alloca %dimension_descriptor, align 8
+  store %dimension_descriptor* %40, %dimension_descriptor** %39, align 8
+  %41 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
   store i32 1, i32* %41, align 4
-  store i32 1, i32* %42, align 4
-  store i32 4, i32* %43, align 4
-  %44 = call %string_descriptor @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %30, i8** %prefix_arg, %array* %array_descriptor)
-  %45 = alloca %string_descriptor, align 8
-  store %string_descriptor %44, %string_descriptor* %45, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %45, i32 0, i32 0
-  %47 = load i8*, i8** %46, align 8
-  %48 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %47)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %42 = load %dimension_descriptor*, %dimension_descriptor** %39, align 8
+  %43 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 0
+  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 0
+  %45 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 1
+  %46 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 2
+  store i32 1, i32* %44, align 4
+  store i32 1, i32* %45, align 4
+  store i32 4, i32* %46, align 4
+  call void @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %33, i8** %prefix_arg, %array* %array_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res)
+  %47 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %48 = load i8*, i8** %47, align 8
+  %49 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %48)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %50 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %51 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %52 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %53 = load i8*, i8** %50, align 8
+  call void @_lfortran_free(i8* %53)
+  store i8* null, i8** %50, align 8
+  store i64 0, i64* %51, align 4
+  store i64 0, i64* %52, align 4
   call void @_lpython_free_argv()
   br label %return
 
@@ -166,5 +171,7 @@ declare void @_lfortran_string_init(i32, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -119,42 +119,50 @@ loop.end:                                         ; preds = %loop.head
   call void @_lfortran_string_init(i32 4, i8* %31)
   store i8* %31, i8** %prefix_arg, align 8
   %32 = load i8*, i8** %prefix_arg, align 8
-  %33 = alloca %compiler_t_polymorphic, align 8
-  %34 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %33, i32 0, i32 0
+  %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %34 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %36 = load i8*, i8** %33, align 8
+  call void @_lfortran_free(i8* %36)
+  store i8* null, i8** %33, align 8
   store i64 0, i64* %34, align 4
-  %35 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %33, i32 0, i32 1
-  store %compiler_t* %compiler_arg, %compiler_t** %35, align 8
-  %36 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
-  %37 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
-  store %string_t* %36, %string_t** %37, align 8
-  %38 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
-  store i32 0, i32* %38, align 4
-  %39 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
-  %40 = alloca %dimension_descriptor, align 8
-  store %dimension_descriptor* %40, %dimension_descriptor** %39, align 8
-  %41 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
-  store i32 1, i32* %41, align 4
-  %42 = load %dimension_descriptor*, %dimension_descriptor** %39, align 8
-  %43 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %42, i32 0
-  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 0
-  %45 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 1
-  %46 = getelementptr %dimension_descriptor, %dimension_descriptor* %43, i32 0, i32 2
-  store i32 1, i32* %44, align 4
+  store i64 0, i64* %35, align 4
+  %37 = alloca %compiler_t_polymorphic, align 8
+  %38 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %37, i32 0, i32 0
+  store i64 0, i64* %38, align 4
+  %39 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %37, i32 0, i32 1
+  store %compiler_t* %compiler_arg, %compiler_t** %39, align 8
+  %40 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
+  %41 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
+  store %string_t* %40, %string_t** %41, align 8
+  %42 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
+  store i32 0, i32* %42, align 4
+  %43 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
+  %44 = alloca %dimension_descriptor, align 8
+  store %dimension_descriptor* %44, %dimension_descriptor** %43, align 8
+  %45 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
   store i32 1, i32* %45, align 4
-  store i32 4, i32* %46, align 4
-  call void @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %33, i8** %prefix_arg, %array* %array_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res)
-  %47 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %48 = load i8*, i8** %47, align 8
-  %49 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %48)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %50 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %51 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
-  %52 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
-  %53 = load i8*, i8** %50, align 8
-  call void @_lfortran_free(i8* %53)
-  store i8* null, i8** %50, align 8
-  store i64 0, i64* %51, align 4
-  store i64 0, i64* %52, align 4
+  %46 = load %dimension_descriptor*, %dimension_descriptor** %43, align 8
+  %47 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 0
+  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 0
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 1
+  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 2
+  store i32 1, i32* %48, align 4
+  store i32 1, i32* %49, align 4
+  store i32 4, i32* %50, align 4
+  call void @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %37, i8** %prefix_arg, %array* %array_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res)
+  %51 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %52 = load i8*, i8** %51, align 8
+  %53 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %52)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %54 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %55 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %56 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %57 = load i8*, i8** %54, align 8
+  call void @_lfortran_free(i8* %57)
+  store i8* null, i8** %54, align 8
+  store i64 0, i64* %55, align 4
+  store i64 0, i64* %56, align 4
   call void @_lpython_free_argv()
   br label %return
 
@@ -168,10 +176,10 @@ declare i8* @_lfortran_malloc(i32)
 
 declare void @_lfortran_string_init(i32, i8*)
 
+declare void @_lfortran_free(i8*)
+
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
-
-declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()


### PR DESCRIPTION
Towards #2257 (https://github.com/lfortran/lfortran/issues/2257#issuecomment-2041693935) + towards finalization
This handles the descriptorStrings `(character(:), alloctable :: str)` to transform the following code :
```fortran 
program p
    print *, func_str()    

    contains 

    function func_str() result(ret_str)
        character(:), allocatable :: ret_str
    end function
end program  
```
to 
```fortran
! Fortran code after applying the pass: insert_deallocate
program p
implicit none
character(len=:, kind=1), allocatable :: __libasr__created__var__0__func_call_res
call func_str(__libasr__created__var__0__func_call_res)
print *, __libasr__created__var__0__func_call_res
deallocate(__libasr__created__var__0__func_call_res) ! Implicit deallocate

contains

subroutine func_str(ret_str)
    character(len=:, kind=1), allocatable, intent(out) :: ret_str
end subroutine func_str

end program p
```

I think we should do the same with normal strings (pointerString) `character(10) :: str` as it's being heap allocated so it needs to have proper owner then later in `insert_deallocate` pass we can properly deallocate it.