### PR TITLE
Allow parser to accept `IMPLICIT NONE ()`

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -554,7 +554,7 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %type <ast> implicit_statement
 %type <vec_ast> implicit_statement_star
 %type <ast> implicit_none_spec
-%type <vec_ast> implicit_none_spec_list
+%type <vec_ast> implicit_none_spec_star
 %type <ast> letter_spec
 %type <vec_ast> letter_spec_list
 %type <ast> procedure_decl
@@ -1149,7 +1149,7 @@ implicit_statement_star
 
 implicit_statement
     : KW_IMPLICIT KW_NONE sep { $$ = IMPLICIT_NONE(TRIVIA_AFTER($3, @$), @$); }
-    | KW_IMPLICIT KW_NONE "(" implicit_none_spec_list ")" sep {
+    | KW_IMPLICIT KW_NONE "(" implicit_none_spec_star ")" sep {
             $$ = IMPLICIT_NONE2($4, TRIVIA_AFTER($6, @$), @$); }
     | KW_IMPLICIT KW_INTEGER "(" letter_spec_list ")" sep {
             $$ = IMPLICIT(ATTR_TYPE(Integer, @$), $4, TRIVIA_AFTER($6, @$), @$); }
@@ -1206,9 +1206,11 @@ implicit_statement
             $$ = IMPLICIT(ATTR_TYPE_NAME(Class, $4, @$), $7, TRIVIA_AFTER($9, @$), @$); }
     ;
 
-implicit_none_spec_list
-    : implicit_none_spec_list "," implicit_none_spec { $$ = $1; LIST_ADD($$, $3); }
+// IMPLICIT NONE [ ( [implicit-none-spec-list] ) ]
+implicit_none_spec_star
+    : implicit_none_spec_star "," implicit_none_spec { $$ = $1; LIST_ADD($$, $3); }
     | implicit_none_spec { LIST_NEW($$); LIST_ADD($$, $1); }
+    | %empty { LIST_NEW($$); }	 
     ;
 
 implicit_none_spec

--- a/tests/implicit1.f90
+++ b/tests/implicit1.f90
@@ -2,6 +2,7 @@ program implicit1
 ! AST only
 implicit none
 IMPLICIT NONE
+implicit none ()
 implicit none (external)
 implicit none (type)
 implicit none (external, type)

--- a/tests/reference/ast-implicit1-e201262.json
+++ b/tests/reference/ast-implicit1-e201262.json
@@ -2,11 +2,11 @@
     "basename": "ast-implicit1-e201262",
     "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/implicit1.f90",
-    "infile_hash": "a132a47983d74e3a4188c28159fe6a65fba4da5e525b1147958c6de6",
+    "infile_hash": "8e65affb83e17129305b295736a3a898e9046a8667bb7c089d1ad67f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-implicit1-e201262.stdout",
-    "stdout_hash": "952a9686a8a3cfc91350abdd91254c228bb404149bbb68c02e025227",
+    "stdout_hash": "e6b96686fbdc855b92612eb637ac72b45451dae4c441318e9826239f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-implicit1-e201262.stdout
+++ b/tests/reference/ast-implicit1-e201262.stdout
@@ -18,6 +18,10 @@
             ()
         )
         (ImplicitNone
+            []
+            ()
+        )
+        (ImplicitNone
             [(ImplicitNoneExternal
                 0
             )]

--- a/tests/reference/ast_f90-implicit1-418fb10.json
+++ b/tests/reference/ast_f90-implicit1-418fb10.json
@@ -2,11 +2,11 @@
     "basename": "ast_f90-implicit1-418fb10",
     "cmd": "lfortran --show-ast-f90 --no-indent --no-color {infile}",
     "infile": "tests/implicit1.f90",
-    "infile_hash": "a132a47983d74e3a4188c28159fe6a65fba4da5e525b1147958c6de6",
+    "infile_hash": "8e65affb83e17129305b295736a3a898e9046a8667bb7c089d1ad67f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast_f90-implicit1-418fb10.stdout",
-    "stdout_hash": "7e9c557a0cd5c1871f8ee826f6b9f69cea3aae51bab7b9cf4b149c89",
+    "stdout_hash": "0a8b16328ee00f6652a05cc1a0086e87290f6632923521553054233e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast_f90-implicit1-418fb10.stdout
+++ b/tests/reference/ast_f90-implicit1-418fb10.stdout
@@ -2,6 +2,7 @@ program implicit1
 ! AST only
 implicit none
 implicit none
+implicit none
 implicit none (external)
 implicit none (type)
 implicit none (external, type)


### PR DESCRIPTION
Simple parser change to allow `IMPLICIT NONE ()` to be accepted.  AST->ASR already handles this case.

* Rename `implicit_none_spec_list` to `implicit_none_spec_star`
* Add `%empty` branch to `implicit_none_spec_star`
* Update `implicit1` test to cover this case.

This closes #5522 