### PR TITLE
fix: Add a new option --linker-path

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1741,11 +1741,15 @@ int link_executable(const std::vector<std::string> &infiles,
             } else if (char *env_CC = std::getenv("LFORTRAN_CC")) {
                  CC = env_CC;
             } else {
+#ifdef __clang__
+                CC = "clang";
+#else
                 std::cerr << "Error: linker not specified, "
                     "use --linker-path=<CC> or create an environment variable "
                     "`export LFORTRAN_CC=<CC>`, where CC is path to "
                     "clang or gcc ";
                 return 1;
+#endif
             }
 
             if (compiler_options.target != "" &&

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1741,8 +1741,10 @@ int link_executable(const std::vector<std::string> &infiles,
             } else if (char *env_CC = std::getenv("LFORTRAN_CC")) {
                  CC = env_CC;
             } else {
-#ifdef __clang__
+#if defined(__clang__)
                 CC = "clang";
+#elif defined(__GNUC__)
+                CC = "gcc";
 #else
                 std::cerr << "Error: linker not specified, "
                     "use --linker-path=<CC> or create an environment variable "
@@ -2715,7 +2717,7 @@ int main_app(int argc, char *argv[]) {
         err_ = err;
         if (!err) object_files.push_back(tmp_o);
     }
-    if (object_files.size() == 0) { 
+    if (object_files.size() == 0) {
         return err_;
     } else {
         return err_ + link_executable(object_files, outfile, runtime_library_dir, backend, static_link, shared_link,

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1736,6 +1736,12 @@ int link_executable(const std::vector<std::string> &infiles,
             std::string options;
             std::string runtime_lib = "lfortran_runtime";
 
+std::cout << system("which clang");
+#ifndef __clang__
+#define __clang__ 0
+#endif
+std::cout << __clang__ << ": __clang__\n";
+std::cout << __GNUC__ << ": __GNUC__\n";
             if (!linker_path.empty()) {
                 CC = linker_path;
             } else if (char *env_CC = std::getenv("LFORTRAN_CC")) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1736,28 +1736,20 @@ int link_executable(const std::vector<std::string> &infiles,
             std::string options;
             std::string runtime_lib = "lfortran_runtime";
 
-std::cout << system("which clang");
-#ifndef __clang__
-#define __clang__ 0
-#endif
-std::cout << __clang__ << ": __clang__\n";
-std::cout << __GNUC__ << ": __GNUC__\n";
             if (!linker_path.empty()) {
                 CC = linker_path;
             } else if (char *env_CC = std::getenv("LFORTRAN_CC")) {
                  CC = env_CC;
             } else {
-#if defined(__clang__)
-                CC = "clang";
-#elif defined(__GNUC__)
-                CC = "gcc";
-#else
-                std::cerr << "Error: linker not specified, "
-                    "use --linker-path=<CC> or create an environment variable "
-                    "`export LFORTRAN_CC=<CC>`, where CC is path to "
-                    "clang or gcc ";
-                return 1;
-#endif
+                if (std::ifstream c_path{"/usr/bin/clang"}) {
+                    CC = "clang";
+                } else {
+                    std::cerr << "Error: linker not specified, "
+                        "use --linker-path=<CC> or create an environment variable "
+                        "`export LFORTRAN_CC=<CC>`, where CC is path to "
+                        "clang or gcc ";
+                    return 1;
+                }
             }
 
             if (compiler_options.target != "" &&


### PR DESCRIPTION
Now, the user has two option to specify linker path:
- create an environment variable LFORTRAN_CC with the path
  to the linker, gcc or clang
- pass an option `--linker-path` with the path

Towards: https://github.com/lfortran/lfortran/issues/5526