### PR TITLE
Fix : Handling Intrinsic Elemental Function by visiting its Arguments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1573,6 +1573,8 @@ RUN(NAME array_op_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArra
 RUN(NAME array_op_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_op_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NOFAST)
 RUN(NAME array_op_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME array_op_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME array_op_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_slice_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray c)
 RUN(NAME array_slice_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_slice_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray c)

--- a/integration_tests/array_op_08.f90
+++ b/integration_tests/array_op_08.f90
@@ -1,0 +1,10 @@
+program test 
+  integer :: A(3) = [1,2,3]
+  logical :: X(3)
+  integer :: tol = 2
+  integer :: i
+  X = abs(A) <= max(tol, tol * maxval(abs(A)))
+  do i = 1, 2, 3
+    if (X(i) .neqv. .true.) error stop
+  end do
+end program

--- a/integration_tests/array_op_09.f90
+++ b/integration_tests/array_op_09.f90
@@ -1,0 +1,7 @@
+program test 
+integer :: A(3,2) = reshape([1,2,3,4,5,6], [3,2])
+integer :: X(2)
+X = abs(sum(A, dim=1))
+if(X(1) /= 6) error stop 
+if(X(2) /= 15) error stop
+end program

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1611,7 +1611,49 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
     }
 
     void replace_IntrinsicElementalFunction(ASR::IntrinsicElementalFunction_t* x) {
-        replace_intrinsic_function(x);
+
+        for (size_t i = 0; i < x->n_args; i++){
+            ASR::expr_t* arg = x->m_args[i];
+
+            if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*arg)) {
+                arg = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg)->m_arg;
+            }
+
+            if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*arg)) {
+                ASR::expr_t** current_expr_copy_9 = current_expr;
+                current_expr = &(x->m_args[i]);
+                ASR::dimension_t* op_dims_copy = op_dims;
+                size_t op_n_dims_copy = op_n_dims;
+                self().replace_expr(x->m_args[i]);
+                x->m_args[i] = *current_expr;
+                op_dims = op_dims_copy;
+                op_n_dims = op_n_dims_copy;
+                current_expr = current_expr_copy_9;
+            } else if (ASR::is_a<ASR::IntrinsicArrayFunction_t>(*arg)) {
+                ASR::expr_t** current_expr_copy_9 = current_expr;
+                current_expr = &(x->m_args[i]);
+                ASR::dimension_t* op_dims_copy = op_dims;
+                size_t op_n_dims_copy = op_n_dims;
+                self().replace_expr(x->m_args[i]);
+                x->m_args[i] = *current_expr;
+                op_dims = op_dims_copy;
+                op_n_dims = op_n_dims_copy;
+                current_expr = current_expr_copy_9;
+            } else if (ASR::is_a<ASR::IntegerBinOp_t>(*arg)) {
+                ASR::expr_t** current_expr_copy_9 = current_expr;
+                current_expr = &(x->m_args[i]);
+                ASR::dimension_t* op_dims_copy = op_dims;
+                size_t op_n_dims_copy = op_n_dims;
+                self().replace_expr(x->m_args[i]);
+                x->m_args[i] = *current_expr;
+                op_dims = op_dims_copy;
+                op_n_dims = op_n_dims_copy;
+                current_expr = current_expr_copy_9;
+            } else {
+                replace_intrinsic_function(x);
+            }
+        }
+        return ;
     }
 
     void replace_IntrinsicArrayFunction(ASR::IntrinsicArrayFunction_t* x) {

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1619,17 +1619,7 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 arg = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg)->m_arg;
             }
 
-            if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*arg)) {
-                ASR::expr_t** current_expr_copy_9 = current_expr;
-                current_expr = &(x->m_args[i]);
-                ASR::dimension_t* op_dims_copy = op_dims;
-                size_t op_n_dims_copy = op_n_dims;
-                self().replace_expr(x->m_args[i]);
-                x->m_args[i] = *current_expr;
-                op_dims = op_dims_copy;
-                op_n_dims = op_n_dims_copy;
-                current_expr = current_expr_copy_9;
-            } else if (ASR::is_a<ASR::IntrinsicArrayFunction_t>(*arg)) {
+            if (ASR::is_a<ASR::IntrinsicArrayFunction_t>(*arg)) {
                 ASR::expr_t** current_expr_copy_9 = current_expr;
                 current_expr = &(x->m_args[i]);
                 ASR::dimension_t* op_dims_copy = op_dims;
@@ -1649,10 +1639,10 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
                 op_dims = op_dims_copy;
                 op_n_dims = op_n_dims_copy;
                 current_expr = current_expr_copy_9;
-            } else {
-                replace_intrinsic_function(x);
             }
         }
+
+        replace_intrinsic_function(x);
         return ;
     }
 


### PR DESCRIPTION
Fixes #5513 

Earlier , we were not visiting arguments of Elemental Function . This PR tries to incorporate this thing in array_op.

MRE 1
```
program test 
  integer :: A(3) = [1,2,3]
  logical :: X(3)
  integer :: tol = 2
  X = abs(A) <= max(tol, tol * maxval(abs(A)))
  print *, X
end program
```

Output 
```
(lf) ansh_mehta@DESKTOP-VJGRLON:/mnt/d/lfortran2/lfortran$ ./src/bin/lfortran try.f90
T    T    T
```

MRE 2
```
program test 
  integer :: A(3) = [1,2,3]
  logical :: X(3)
  integer :: tol = 2
  X = abs(A) <= max(tol,maxval(abs(A)))
  print *, X
end program
```

Output 
```
(lf) lordansh@LordAnsh:~/dev/lfort2/lfortran$ ./src/bin/lfortran try.f90
T    T    T
```

MRE 3
```
program test 
integer :: A(3,2) = reshape([1,2,3,4,5,6], [3,2])
integer :: X(2)
X = abs(sum(A, dim=1))
print *, X
end program
```

Output 
```
(lf) lordansh@LordAnsh:~/dev/lfort2/lfortran$ ./src/bin/lfortran try.f90
6    15
```