### PR TITLE
Fix memory issues in lfortran

### DIFF
--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -310,7 +310,7 @@ LineType determine_line_type(const unsigned char *pos)
         }
         if (col <= 6) {
             return LineType::LabeledStatement;
-        } else if (std::string(pos, pos + 7) == "include") {
+        } else if (str_compare(pos, "include")) {
             return LineType::Include;
         } else {
             return LineType::Statement;

--- a/src/libasr/pass/intrinsic_subroutine.cpp
+++ b/src/libasr/pass/intrinsic_subroutine.cpp
@@ -38,6 +38,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
 
         ReplaceIntrinsicSubroutines(Allocator& al_) :
         al(al_), remove_original_statement(false) {
+            parent_body = nullptr;
             pass_result.n = 0;
         }
 

--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -265,4 +265,17 @@ char* str_unescape_fortran(Allocator &al, LCompilers::Str &s, char ch) {
     return LCompilers::s2c(al, x);
 }
 
+bool str_compare(const unsigned char *pos, std::string s) {
+    for (size_t i = 0; i < s.size(); i++) {
+        if (pos[i] == '\0') {
+            return false;
+        }
+
+        if (pos[i] != s[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace LCompilers

--- a/src/libasr/string_utils.h
+++ b/src/libasr/string_utils.h
@@ -16,7 +16,7 @@ bool endswith(const std::string &s, const std::string &e);
 std::string to_lower(const std::string &s);
 std::vector<std::string> string_split(const std::string &s,
     const std::string &split_string, bool strs_to_lower=true);
-std::vector<std::string> string_split_avoid_parentheses(const std::string &s, 
+std::vector<std::string> string_split_avoid_parentheses(const std::string &s,
     bool strs_to_lower=true);
 std::vector<std::string> split(const std::string &s);
 std::string join(const std::string j, const std::vector<std::string> &v);
@@ -47,6 +47,8 @@ char* str_unescape_c(Allocator &al, LCompilers::Str &s);
 // given string must be enclosed in double quotes
 std::string str_escape_fortran_double_quote(const std::string &s);
 char* str_unescape_fortran(Allocator &al, LCompilers::Str &s, char ch);
+
+bool str_compare(const unsigned char *pos, std::string s);
 
 } // namespace LCompilers
 


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/5534

Output from branch:

```fortran
(lf) ubaid@DESKTOP-TEN39M0:~/projects/lfortran$ cat examples/expr2.f90 
      program hello
      end
```

```console
(lf) ubaid@DESKTOP-TEN39M0:~/projects/lfortran$ valgrind gfortran examples/expr2.f90
==133657== Memcheck, a memory error detector
==133657== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==133657== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==133657== Command: gfortran examples/expr2.f90
==133657== 
==133657== 
==133657== HEAP SUMMARY:
==133657==     in use at exit: 180,109 bytes in 123 blocks
==133657==   total heap usage: 522 allocs, 399 frees, 239,868 bytes allocated
==133657== 
==133657== LEAK SUMMARY:
==133657==    definitely lost: 7,040 bytes in 50 blocks
==133657==    indirectly lost: 82 bytes in 5 blocks
==133657==      possibly lost: 0 bytes in 0 blocks
==133657==    still reachable: 172,987 bytes in 68 blocks
==133657==         suppressed: 0 bytes in 0 blocks
==133657== Rerun with --leak-check=full to see details of leaked memory
==133657== 
==133657== For lists of detected and suppressed errors, rerun with: -s
==133657== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```console
(lf) ubaid@DESKTOP-TEN39M0:~/projects/lfortran$ valgrind lfortran examples/expr2.f90 --fixed-form
==133703== Memcheck, a memory error detector
==133703== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==133703== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==133703== Command: lfortran examples/expr2.f90 --fixed-form
==133703== 
==133703== 
==133703== HEAP SUMMARY:
==133703==     in use at exit: 396,663 bytes in 1,619 blocks
==133703==   total heap usage: 31,559 allocs, 29,940 frees, 4,333,827 bytes allocated
==133703== 
==133703== LEAK SUMMARY:
==133703==    definitely lost: 2,435 bytes in 6 blocks
==133703==    indirectly lost: 296,223 bytes in 352 blocks
==133703==      possibly lost: 0 bytes in 0 blocks
==133703==    still reachable: 98,005 bytes in 1,261 blocks
==133703==         suppressed: 0 bytes in 0 blocks
==133703== Rerun with --leak-check=full to see details of leaked memory
==133703== 
==133703== For lists of detected and suppressed errors, rerun with: -s
==133703== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
