### PR TITLE
Fixes issue #2863: Repeated use of ASR verify

### DIFF
--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -80,19 +80,19 @@ public:
                         // The symbol table was found and the symbol `sym` is in it
                         return true;
                     } else {
-                        diagnostics.message_label("ASR verify: The symbol table was found and the symbol in it shares the name, but is not equal to `sym`",
+                        diagnostics.message_label("The symbol table was found and the symbol in it shares the name, but is not equal to `sym`",
                         {sym->base.loc}, "failed here", diag::Level::Error, diag::Stage::ASRVerify);
                         return false;
                     }
                 } else {
-                    diagnostics.message_label("ASR verify: The symbol table was found, but the symbol `sym` is not in it",
+                    diagnostics.message_label("The symbol table was found, but the symbol `sym` is not in it",
                         {sym->base.loc}, "failed here", diag::Level::Error, diag::Stage::ASRVerify);
                     return false;
                 }
             }
             s = s->parent;
         }
-        diagnostics.message_label("ASR verify: The symbol table was not found in the scope of `symtab`.",
+        diagnostics.message_label("The symbol table was not found in the scope of `symtab`.",
                         {sym->base.loc}, "failed here", diag::Level::Error, diag::Stage::ASRVerify);
         return false;
     }

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -450,7 +450,7 @@ namespace ObjectType {
 
      static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args == 1,
-            "ASR Verify: type() takes only 1 argument `object`",
+            "type() takes only 1 argument `object`",
             x.base.base.loc, diagnostics);
     }
 
@@ -1192,7 +1192,7 @@ namespace CompilerVersion {
 
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args == 0,
-            "ASR Verify: compiler_version() takes no argument",
+            "compiler_version() takes no argument",
             x.base.base.loc, diagnostics);
     }
 
@@ -1219,7 +1219,7 @@ namespace CommandArgumentCount {
 
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
         ASRUtils::require_impl(x.n_args == 0,
-            "ASR Verify: command_argument_count() takes no argument",
+            "command_argument_count() takes no argument",
             x.base.base.loc, diagnostics);
     }
 


### PR DESCRIPTION
Removed the repeated use of `ASR Verify:` from 2 different files - `asr_verify.cpp ` and `intrinsic_functions.h` . Fixes #2863 