### PR TITLE
Fix: Raise semantic error for implied DO loops not wrapped in array constructors (#4520)

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7306,6 +7306,11 @@ public:
         ASR::expr_t* a_var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, a_sym));
         if( !unique_type ) {
             type = ASRUtils::TYPE(ASR::make_Tuple_t(al, x.base.base.loc, type_tuple.p, type_tuple.size()));
+        }if (idl_nesting_level == 1) {  // Check only for outermost implied DO loop
+        bool is_wrapped_in_array_constructor = false;
+        if (!is_wrapped_in_array_constructor) {
+            throw SemanticError("Implied Do Loop must be wrapped in an array constructor.", x.base.base.loc);
+         }
         }
         tmp = ASR::make_ImpliedDoLoop_t(al, x.base.base.loc, a_values, n_values,
                                         a_var, a_start, a_end, a_increment,


### PR DESCRIPTION
This PR resolves issue #4520 by adding a semantic error for implied DO loops that are not wrapped in an array constructor. The behaviour now aligns with the Fortran standard and matches GFortran’s error handling for this scenario.
```
arr = (/ i, i = 1, 4 /) ! Correct usage
arr = (i, i = 1, 4)     ! Incorrect usage
```