### PR TITLE
Demonstration of using IMPLICIT declaration-type-spec

### DIFF
--- a/grammar/AST.asdl
+++ b/grammar/AST.asdl
@@ -102,7 +102,7 @@ implicit_statement
     | Implicit(implicit_spec* specs, trivia? trivia)
 
 implicit_spec
-    = ImplicitSpec(decl_attribute type, letter_spec* kind, letter_spec* specs)
+    = ImplicitSpec(decl_attribute type, letter_spec* specs)
 
 implicit_none_spec
     = ImplicitNoneExternal(int dummy)

--- a/src/lfortran/ast_to_src.cpp
+++ b/src/lfortran/ast_to_src.cpp
@@ -1228,14 +1228,6 @@ public:
         std::string r;
         visit_decl_attribute(*x.m_type);
         r += s;
-        if (x.n_kind > 0) {
-            r += " (";
-            for (size_t i=0; i<x.n_kind; i++) {
-                visit_letter_spec(*x.m_kind[i]);
-                r += s;
-            }
-            r += ")";
-        }
         if (x.n_specs > 0) {
             r += " (";
             for (size_t i=0; i<x.n_specs; i++) {

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -4,7 +4,7 @@
 %param {LCompilers::LFortran::Parser &p}
 %locations
 %glr-parser
-%expect    227 // shift/reduce conflicts
+%expect    232 // shift/reduce conflicts
 %expect-rr 175 // reduce/reduce conflicts
 
 // Uncomment this to get verbose error messages
@@ -1162,86 +1162,9 @@ implicit_spec_list
     | implicit_spec { LIST_NEW($$); LIST_ADD($$, $1); }
     ;
 
-/*
-   HERE BE DRAGONS!
-
-   The standard gives the rule:
-
-       _implicit-spec_ := _declaration-type-spec_ ( _letter-spec-list_ )
-
-   which allows for full `KIND` specifications on any
-   _intrinsic_type_spec_.  The following grammar rule attempts to
-   approximate that in three ways:
-
-      1. If no KIND parameter is given, an IMPLICIT_SPEC is constructed
-         with an ATTR_TYPE as the first parameter; or
-      2. If an integer is given as an (unlabelled) KIND parameter, then
-         an IMPLICIT_SPEC is constructed with an ATTR_TYPE_INT as the
-	 first parameter; or
-      3. If an expression that matches `letter_spec_list` is passed as
-         an (unlabelled) KIND parameter, then an IMPLICIT_SPEC_KIND
-	 is constructed with an ATTR_TYPE as the first parameter and
-	 the `letter_spec_list` result as the second.
-
-    Note that #3 accepts `id` (and `id - id`), because `letter_spec_list`
-    itself accepts an `id`, rather than just `letter`.
-
-    So, this rule accepts only a portion of the full KIND specification.
-    We should just be using the grammar `declaration_type_spec` rule
-    instead of all of these special cases, but that leads to a fundamental
-    shift/reduce conflict due to the overlap between `( kind_arg_list )`
-    and `( letter_spec_list )`.
-*/
-
 implicit_spec
-    : KW_INTEGER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE(Integer, @$), $3, @$); }
-    | KW_INTEGER "*" TK_INTEGER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Integer, $3, @$), $5, @$); }
-    | KW_INTEGER "(" TK_INTEGER ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Integer, $3, @$), $6, @$); }
-    | KW_INTEGER "(" letter_spec_list ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC_KIND(ATTR_TYPE(Integer, @$), $3, $6, @$); }
-    | KW_CHARACTER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE(Character, @$), $3, @$); }
-    | KW_CHARACTER "*" TK_INTEGER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Character, $3, @$), $5, @$); }
-    | KW_CHARACTER "(" TK_INTEGER ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Character, $3, @$), $6, @$); }
-    | KW_CHARACTER "(" letter_spec_list ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC_KIND(ATTR_TYPE(Character, @$), $3, $6, @$); }
-    | KW_REAL "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE(Real, @$), $3, @$); }
-    | KW_REAL "*" TK_INTEGER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Real, $3, @$), $5, @$); }
-    | KW_REAL "(" TK_INTEGER ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Real, $3, @$), $6, @$); }
-    | KW_REAL "(" letter_spec_list ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC_KIND(ATTR_TYPE(Real, @$), $3, $6, @$); }
-    | KW_COMPLEX "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE(Complex, @$), $3, @$); }
-    | KW_COMPLEX "*" TK_INTEGER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Complex, DIV2($3), @$), $5, @$); }
-    | KW_COMPLEX "(" TK_INTEGER ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Complex, $3, @$), $6, @$); }
-    | KW_COMPLEX "(" letter_spec_list ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC_KIND(ATTR_TYPE(Complex, @$), $3, $6, @$); }
-    | KW_LOGICAL "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE(Logical, @$), $3, @$); }
-    | KW_LOGICAL "*" TK_INTEGER "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Logical, $3, @$), $5, @$); }
-    | KW_LOGICAL "(" TK_INTEGER ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_INT(Logical, $3, @$), $6, @$); }
-    | KW_LOGICAL "(" letter_spec_list ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC_KIND(ATTR_TYPE(Logical, @$), $3, $6, @$); }
-    | KW_DOUBLE KW_PRECISION "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE(DoublePrecision, @$), $4, @$); }
-    | KW_TYPE "(" id ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_NAME(Type, $3, @$), $6, @$); }
-    | KW_PROCEDURE "(" id ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_NAME(Procedure, $3, @$), $6, @$); }
-    | KW_CLASS "(" id ")" "(" letter_spec_list ")" {
-            $$ = IMPLICIT_SPEC(ATTR_TYPE_NAME(Class, $3, @$), $6, @$); }
+    : declaration_type_spec "(" letter_spec_list ")" {
+           $$ = IMPLICIT_SPEC($1, $3, @$); }
     ;
 
 // IMPLICIT NONE [ ( [implicit-none-spec-list] ) ]

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -447,14 +447,10 @@ ast_t* data_implied_do(Allocator &al, Location &loc,
 #define IMPLICIT_NONE_TYPE(l) make_ImplicitNoneType_t(p.m_a, l)
 
 #define IMPLICIT(specs, trivia, l) make_Implicit_t(p.m_a, l, \
-	VEC_CAST(specs, implicit_spec), specs.size(), trivia_cast(trivia))
-#define IMPLICIT_SPEC(t, specs, l) make_ImplicitSpec_t(p.m_a, l, \
-        down_cast<decl_attribute_t>(t), nullptr, 0, \
-	VEC_CAST(specs, letter_spec), specs.size())
-#define IMPLICIT_SPEC_KIND(t, kind, specs, l) make_ImplicitSpec_t(p.m_a, l, \
+        VEC_CAST(specs, implicit_spec), specs.size(), trivia_cast(trivia))
+#define IMPLICIT_SPEC(t, letspecs, l) make_ImplicitSpec_t(p.m_a, l, \
         down_cast<decl_attribute_t>(t), \
-        VEC_CAST(kind, letter_spec), kind.size(), \
-        VEC_CAST(specs, letter_spec), specs.size())
+        VEC_CAST(letspecs, letter_spec), letspecs.size())
 
 #define LETTER_SPEC1(a, l) make_LetterSpec_t(p.m_a, l, \
         nullptr, name2char(a))

--- a/tests/implicit1.f90
+++ b/tests/implicit1.f90
@@ -40,5 +40,4 @@ implicit complex(4) (z)
 
 IMPLICIT TYPE(BLOB) (A)
 IMPLICIT class(X) (A-b)
-IMPLICIT procedure(Y) (A-b)
 end program

--- a/tests/reference/asr-implicit11-95f56fd.json
+++ b/tests/reference/asr-implicit11-95f56fd.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit11-95f56fd.stdout",
     "stdout_hash": "327d454aabab8e0b2d7425d07a4b621b52b48678aed2b37c95a1b6ee",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit11-95f56fd.stderr",
+    "stderr_hash": "a9b344b83292123dafaf10db7d59f06293389e5099ce50a0696cf631",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit11-95f56fd.stderr
+++ b/tests/reference/asr-implicit11-95f56fd.stderr
@@ -1,0 +1,11 @@
+style suggestion: Use complex(16) instead of complex*16
+ --> tests/implicit11.f90:2:10
+  |
+2 | implicit complex*16 (z,i)
+  |          ^^^^^^^^^^ help: write this as 'complex(16)'
+
+style suggestion: Use complex(16) instead of complex*16
+ --> tests/implicit11.f90:8:10
+  |
+8 | implicit complex*16 (z,i)
+  |          ^^^^^^^^^^ help: write this as 'complex(16)'

--- a/tests/reference/asr-implicit12-025d795.json
+++ b/tests/reference/asr-implicit12-025d795.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-implicit12-025d795.stderr",
-    "stderr_hash": "939016af2ad7a036e04f9e64a52901996ed4a89baf4d392178997173",
+    "stderr_hash": "baa5601cf83a8d24fcda9670468bd09a88697d92a5a3735846a7c369",
     "returncode": 2
 }

--- a/tests/reference/asr-implicit12-025d795.stderr
+++ b/tests/reference/asr-implicit12-025d795.stderr
@@ -1,3 +1,39 @@
+style suggestion: Use integer(4) instead of integer*4
+ --> tests/implicit12.f90:3:10
+  |
+3 | implicit integer*4 (d-e)
+  |          ^^^^^^^^^ help: write this as 'integer(4)'
+
+style suggestion: Use integer(8) instead of integer*8
+ --> tests/implicit12.f90:4:10
+  |
+4 | implicit integer*8 (f-g)
+  |          ^^^^^^^^^ help: write this as 'integer(8)'
+
+style suggestion: Use real(4) instead of real*4
+ --> tests/implicit12.f90:6:10
+  |
+6 | implicit real*4 (i-k)
+  |          ^^^^^^ help: write this as 'real(4)'
+
+style suggestion: Use real(8) instead of real*8
+ --> tests/implicit12.f90:7:10
+  |
+7 | implicit real*8 (l)
+  |          ^^^^^^ help: write this as 'real(8)'
+
+style suggestion: Use complex(8) instead of complex*8
+ --> tests/implicit12.f90:9:10
+  |
+9 | implicit complex*8 (o)
+  |          ^^^^^^^^^ help: write this as 'complex(8)'
+
+style suggestion: Use complex(16) instead of complex*16
+  --> tests/implicit12.f90:10:10
+   |
+10 | implicit complex*16 (p)
+   |          ^^^^^^^^^^ help: write this as 'complex(16)'
+
 semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
  --> tests/implicit12.f90:2:1
   |

--- a/tests/reference/asr-implicit12-1826599.json
+++ b/tests/reference/asr-implicit12-1826599.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit12-1826599.stdout",
     "stdout_hash": "a7d368ea611fb14f1060af6dc5a5e61ea74952390603e8277c855fdf",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit12-1826599.stderr",
+    "stderr_hash": "59c1a221cac1cf9580f2011e66835457e82ec2e7a5372e3f9a5c270b",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit12-1826599.stderr
+++ b/tests/reference/asr-implicit12-1826599.stderr
@@ -1,41 +1,35 @@
 style suggestion: Use integer(4) instead of integer*4
- --> tests/implicit9.f90:3:10
+ --> tests/implicit12.f90:3:10
   |
 3 | implicit integer*4 (d-e)
   |          ^^^^^^^^^ help: write this as 'integer(4)'
 
 style suggestion: Use integer(8) instead of integer*8
- --> tests/implicit9.f90:4:10
+ --> tests/implicit12.f90:4:10
   |
 4 | implicit integer*8 (f-g)
   |          ^^^^^^^^^ help: write this as 'integer(8)'
 
 style suggestion: Use real(4) instead of real*4
- --> tests/implicit9.f90:6:10
+ --> tests/implicit12.f90:6:10
   |
 6 | implicit real*4 (i-k)
   |          ^^^^^^ help: write this as 'real(4)'
 
 style suggestion: Use real(8) instead of real*8
- --> tests/implicit9.f90:7:10
+ --> tests/implicit12.f90:7:10
   |
 7 | implicit real*8 (l)
   |          ^^^^^^ help: write this as 'real(8)'
 
 style suggestion: Use complex(8) instead of complex*8
- --> tests/implicit9.f90:9:10
+ --> tests/implicit12.f90:9:10
   |
 9 | implicit complex*8 (o)
   |          ^^^^^^^^^ help: write this as 'complex(8)'
 
 style suggestion: Use complex(16) instead of complex*16
-  --> tests/implicit9.f90:10:10
+  --> tests/implicit12.f90:10:10
    |
 10 | implicit complex*16 (p)
    |          ^^^^^^^^^^ help: write this as 'complex(16)'
-
-semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
- --> tests/implicit9.f90:2:1
-  |
-2 | implicit integer (a,b-c)
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-implicit13-56e851c.json
+++ b/tests/reference/asr-implicit13-56e851c.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit13-56e851c.stdout",
     "stdout_hash": "06f10332171157dd77624ca92dbceabf892703b42652e813040ae709",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit13-56e851c.stderr",
+    "stderr_hash": "f252e47a58cba0186876fa843eb853212afb9b9ea4d5a9f7533d7595",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit13-56e851c.stderr
+++ b/tests/reference/asr-implicit13-56e851c.stderr
@@ -1,0 +1,35 @@
+style suggestion: Use integer(4) instead of integer*4
+ --> tests/implicit13.f90:2:27
+  |
+2 | implicit integer (a,b-c), integer*4 (d-e), integer*8 (f-g), real (h)
+  |                           ^^^^^^^^^ help: write this as 'integer(4)'
+
+style suggestion: Use integer(8) instead of integer*8
+ --> tests/implicit13.f90:2:44
+  |
+2 | implicit integer (a,b-c), integer*4 (d-e), integer*8 (f-g), real (h)
+  |                                            ^^^^^^^^^ help: write this as 'integer(8)'
+
+style suggestion: Use real(4) instead of real*4
+ --> tests/implicit13.f90:3:10
+  |
+3 | implicit real*4 (i-k), real*8 (l), complex (m, n), complex*8 (o)
+  |          ^^^^^^ help: write this as 'real(4)'
+
+style suggestion: Use real(8) instead of real*8
+ --> tests/implicit13.f90:3:24
+  |
+3 | implicit real*4 (i-k), real*8 (l), complex (m, n), complex*8 (o)
+  |                        ^^^^^^ help: write this as 'real(8)'
+
+style suggestion: Use complex(8) instead of complex*8
+ --> tests/implicit13.f90:3:52
+  |
+3 | implicit real*4 (i-k), real*8 (l), complex (m, n), complex*8 (o)
+  |                                                    ^^^^^^^^^ help: write this as 'complex(8)'
+
+style suggestion: Use complex(16) instead of complex*16
+ --> tests/implicit13.f90:4:10
+  |
+4 | implicit complex*16 (p), double precision (q), double precision (r)
+  |          ^^^^^^^^^^ help: write this as 'complex(16)'

--- a/tests/reference/asr-implicit3-ffc1655.json
+++ b/tests/reference/asr-implicit3-ffc1655.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit3-ffc1655.stdout",
     "stdout_hash": "a96ee71467c94ae645f7b62ccf04eaca08689b631f58f93227d92664",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit3-ffc1655.stderr",
+    "stderr_hash": "ceaf6acb8d4c73c60c0b5bea7a74aa0116f4b6c0a37bff9555e47436",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit3-ffc1655.stderr
+++ b/tests/reference/asr-implicit3-ffc1655.stderr
@@ -1,0 +1,5 @@
+style suggestion: Use real(8) instead of real*8
+ --> tests/implicit3.f90:3:10
+  |
+3 | implicit real*8 (k)
+  |          ^^^^^^ help: write this as 'real(8)'

--- a/tests/reference/asr-implicit4-704272e.json
+++ b/tests/reference/asr-implicit4-704272e.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit4-704272e.stdout",
     "stdout_hash": "5e067281b11877bbdc7f558be68e550e9555d83c488535aa1f811b54",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit4-704272e.stderr",
+    "stderr_hash": "cda83d31bd8e01174b2e07e33c06a4d0f33cc32918a349b65613cc3f",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit4-704272e.stderr
+++ b/tests/reference/asr-implicit4-704272e.stderr
@@ -1,0 +1,5 @@
+style suggestion: Use real(8) instead of real*8
+ --> tests/implicit4.f90:2:10
+  |
+2 | implicit real *8 (a-h,o-z)
+  |          ^^^^^^^ help: write this as 'real(8)'

--- a/tests/reference/asr-implicit6-061f8e3.json
+++ b/tests/reference/asr-implicit6-061f8e3.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit6-061f8e3.stdout",
     "stdout_hash": "bd42878345748d9c6ba8bcce578542e107c012f104b4f2f7dddadbf8",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit6-061f8e3.stderr",
+    "stderr_hash": "d46932ae800a3e523fac2dda89c0772a873ffc393f5af0b8e2e88655",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit6-061f8e3.stderr
+++ b/tests/reference/asr-implicit6-061f8e3.stderr
@@ -1,0 +1,5 @@
+style suggestion: Use complex(16) instead of complex*16
+ --> tests/implicit6.f90:3:10
+  |
+3 | IMPLICIT COMPLEX*16 (C,Z)
+  |          ^^^^^^^^^^ help: write this as 'complex(16)'

--- a/tests/reference/asr-implicit7-2fc9cda.json
+++ b/tests/reference/asr-implicit7-2fc9cda.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-implicit7-2fc9cda.stderr",
-    "stderr_hash": "7abfef1aadbe7259622aeca183a017c877b96ca8c42fb652e3640203",
+    "stderr_hash": "3531cc88b9d6ad527f1e3af6e65b390c137f1b4f910c24dc0226add3",
     "returncode": 2
 }

--- a/tests/reference/asr-implicit7-2fc9cda.stderr
+++ b/tests/reference/asr-implicit7-2fc9cda.stderr
@@ -1,3 +1,9 @@
+style suggestion: Use real(8) instead of real*8
+ --> tests/implicit7.f90:4:10
+  |
+4 | implicit real*8 (k)
+  |          ^^^^^^ help: write this as 'real(8)'
+
 semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
  --> tests/implicit7.f90:2:1
   |

--- a/tests/reference/asr-implicit7-9099c07.json
+++ b/tests/reference/asr-implicit7-9099c07.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit7-9099c07.stdout",
     "stdout_hash": "d43f612fa2debf945371ee43a62fd0795707f1e711d4b7de07fffd1e",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit7-9099c07.stderr",
+    "stderr_hash": "6360e3c3c33402bb8d7c1e824b3bad8dbb198c9b79f1162015ba1fe0",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit7-9099c07.stderr
+++ b/tests/reference/asr-implicit7-9099c07.stderr
@@ -1,0 +1,5 @@
+style suggestion: Use real(8) instead of real*8
+ --> tests/implicit7.f90:4:10
+  |
+4 | implicit real*8 (k)
+  |          ^^^^^^ help: write this as 'real(8)'

--- a/tests/reference/asr-implicit9-5318b32.json
+++ b/tests/reference/asr-implicit9-5318b32.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-implicit9-5318b32.stderr",
-    "stderr_hash": "0fbb03ff1a6a80b37f8eb94946215a161238afc70de8a3b8964f9c68",
+    "stderr_hash": "73d4f69f6d8afd30a5af0bfe89d4f3c74642f4aa64280747f9e2698a",
     "returncode": 2
 }

--- a/tests/reference/asr-implicit9-b56b139.json
+++ b/tests/reference/asr-implicit9-b56b139.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit9-b56b139.stdout",
     "stdout_hash": "06f10332171157dd77624ca92dbceabf892703b42652e813040ae709",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit9-b56b139.stderr",
+    "stderr_hash": "0b8f68407a758161c71bb589ab56789a79add7e90f5938e4895f55e8",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit9-b56b139.stderr
+++ b/tests/reference/asr-implicit9-b56b139.stderr
@@ -33,9 +33,3 @@ style suggestion: Use complex(16) instead of complex*16
    |
 10 | implicit complex*16 (p)
    |          ^^^^^^^^^^ help: write this as 'complex(16)'
-
-semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
- --> tests/implicit9.f90:2:1
-  |
-2 | implicit integer (a,b-c)
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-implicit_typing4-c338b90.json
+++ b/tests/reference/asr-implicit_typing4-c338b90.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "asr-implicit_typing4-c338b90.stdout",
     "stdout_hash": "4da3b6ae0e69b1fd84e8adbc98bf6b04e1caa94b47b43a1a99591e88",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "asr-implicit_typing4-c338b90.stderr",
+    "stderr_hash": "b8cbc21d05ce6f91793460871df9544bb5bcadc0f5babdbd81826ec2",
     "returncode": 0
 }

--- a/tests/reference/asr-implicit_typing4-c338b90.stderr
+++ b/tests/reference/asr-implicit_typing4-c338b90.stderr
@@ -1,0 +1,5 @@
+style suggestion: Use complex(16) instead of complex*16
+ --> tests/implicit_typing4.f90:7:14
+  |
+7 |     IMPLICIT COMPLEX*16 (C,Z)
+  |              ^^^^^^^^^^ help: write this as 'complex(16)'

--- a/tests/reference/ast-array7-b9de38f.json
+++ b/tests/reference/ast-array7-b9de38f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-array7-b9de38f.stdout",
-    "stdout_hash": "9b13592a8b987511aa07ea288353b0d96b051ec8cfedd7cbe5f9f4ed",
+    "stdout_hash": "deea556a927bab2a181ab718f525d699a049741fc3c5ef4ac5989a8b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-array7-b9de38f.stdout
+++ b/tests/reference/ast-array7-b9de38f.stdout
@@ -12,7 +12,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     A
                     H
@@ -33,7 +32,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     I
                     N

--- a/tests/reference/ast-block1-ff0f95d.json
+++ b/tests/reference/ast-block1-ff0f95d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-block1-ff0f95d.stdout",
-    "stdout_hash": "2c7784859ce47b778d9e5de807c5c6aac72bd3b356f083a83389a6ea",
+    "stdout_hash": "fe709ed51cbc71ed240d820fd417a0d0bde95b51487e5717fb390a25",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-block1-ff0f95d.stdout
+++ b/tests/reference/ast-block1-ff0f95d.stdout
@@ -27,7 +27,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     z

--- a/tests/reference/ast-block_data1-d563f39.json
+++ b/tests/reference/ast-block_data1-d563f39.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-block_data1-d563f39.stdout",
-    "stdout_hash": "5e3da8c5a14979b47d6e93be6240dc2d034bf5c0dd06d921c88e67b4",
+    "stdout_hash": "fc634818e72b2dee786f5376e781c56c724214c8de2cf931a0b91d0c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-block_data1-d563f39.stdout
+++ b/tests/reference/ast-block_data1-d563f39.stdout
@@ -16,7 +16,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     z
@@ -69,7 +68,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     z

--- a/tests/reference/ast-common1-abbc59b.json
+++ b/tests/reference/ast-common1-abbc59b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-common1-abbc59b.stdout",
-    "stdout_hash": "8d7afdb355ec684972b4e1193a9eaf219d6910423f9679aa0ae353db",
+    "stdout_hash": "faf519067dfcd3a552107a98759269e49520704ade3557e23e87e91c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-common1-abbc59b.stdout
+++ b/tests/reference/ast-common1-abbc59b.stdout
@@ -16,7 +16,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     z

--- a/tests/reference/ast-fixed_form_implicit2-f584754.json
+++ b/tests/reference/ast-fixed_form_implicit2-f584754.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_implicit2-f584754.stdout",
-    "stdout_hash": "daee0e0b4a693383cd33ef037b45aa2f8d7d5070e0e31788af1db02b",
+    "stdout_hash": "ec75ab5349993d3fbd8408b235e5fdd9c2d897b60b7d3d144b6d62d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_implicit2-f584754.stdout
+++ b/tests/reference/ast-fixed_form_implicit2-f584754.stdout
@@ -12,7 +12,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     a
@@ -39,7 +38,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     k

--- a/tests/reference/ast-fixed_form_implicit_check-62ffca3.json
+++ b/tests/reference/ast-fixed_form_implicit_check-62ffca3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_implicit_check-62ffca3.stdout",
-    "stdout_hash": "1f7a42bd0262b4892d94d10febeaf4b3e4465d889cebb49339c5a66a",
+    "stdout_hash": "0623f030fb96bf3fd397948f5c177d108aa3a0990e6602016668cd99",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_implicit_check-62ffca3.stdout
+++ b/tests/reference/ast-fixed_form_implicit_check-62ffca3.stdout
@@ -12,7 +12,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     h

--- a/tests/reference/ast-implicit1-e201262.json
+++ b/tests/reference/ast-implicit1-e201262.json
@@ -2,12 +2,12 @@
     "basename": "ast-implicit1-e201262",
     "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/implicit1.f90",
-    "infile_hash": "8e65affb83e17129305b295736a3a898e9046a8667bb7c089d1ad67f",
+    "infile_hash": "055efd6feee3a318ee48bce964a4223461719dc2c772db80c7440f82",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
+    "stdout": "ast-implicit1-e201262.stdout",
+    "stdout_hash": "c5c32bccd6687c158281ea8e78595f4639a22d1777fdd60ab8021932",
     "stderr": "ast-implicit1-e201262.stderr",
-    "stderr_hash": "98ff09ba3e15d6a0160e3a8f9aad63e98b4c71440d7f7466c6c52ccc",
-    "returncode": 2
+    "stderr_hash": "8fb7cba70f8f53adeb61cebe9b2ec9569553e1c2d1593891217dd169",
+    "returncode": 0
 }

--- a/tests/reference/ast-implicit1-e201262.json
+++ b/tests/reference/ast-implicit1-e201262.json
@@ -5,9 +5,9 @@
     "infile_hash": "8e65affb83e17129305b295736a3a898e9046a8667bb7c089d1ad67f",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": "ast-implicit1-e201262.stdout",
-    "stdout_hash": "f9c1d016379d0d5973542f0154c93aef995cc21b2eece992f0ea8be3",
-    "stderr": null,
-    "stderr_hash": null,
-    "returncode": 0
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-implicit1-e201262.stderr",
+    "stderr_hash": "98ff09ba3e15d6a0160e3a8f9aad63e98b4c71440d7f7466c6c52ccc",
+    "returncode": 2
 }

--- a/tests/reference/ast-implicit1-e201262.stderr
+++ b/tests/reference/ast-implicit1-e201262.stderr
@@ -1,0 +1,35 @@
+style suggestion: Use real(8) instead of real*8
+  --> tests/implicit1.f90:13:10
+   |
+13 | implicit real*8 (a-h,o-z)
+   |          ^^^^^^ help: write this as 'real(8)'
+
+style suggestion: Use integer(8) instead of integer*8
+  --> tests/implicit1.f90:25:10
+   |
+25 | implicit integer*8 (i,j-l,m,n)
+   |          ^^^^^^^^^ help: write this as 'integer(8)'
+
+style suggestion: Use integer(4) instead of integer*4
+  --> tests/implicit1.f90:27:10
+   |
+27 | IMPLICIT INTEGER*4 (C, D-x)
+   |          ^^^^^^^^^ help: write this as 'integer(4)'
+
+style suggestion: Use logical(4) instead of logical*4
+  --> tests/implicit1.f90:32:10
+   |
+32 | implicit logical*4 (l, u-z)
+   |          ^^^^^^^^^ help: write this as 'logical(4)'
+
+style suggestion: Use complex(8) instead of complex*8
+  --> tests/implicit1.f90:38:10
+   |
+38 | implicit complex*8 (z)
+   |          ^^^^^^^^^ help: write this as 'complex(8)'
+
+syntax error: Token 'procedure' is unexpected here
+  --> tests/implicit1.f90:43:10
+   |
+43 | IMPLICIT procedure(Y) (A-b)
+   |          ^^^^^^^^^ 

--- a/tests/reference/ast-implicit1-e201262.stderr
+++ b/tests/reference/ast-implicit1-e201262.stderr
@@ -27,9 +27,3 @@ style suggestion: Use complex(8) instead of complex*8
    |
 38 | implicit complex*8 (z)
    |          ^^^^^^^^^ help: write this as 'complex(8)'
-
-syntax error: Token 'procedure' is unexpected here
-  --> tests/implicit1.f90:43:10
-   |
-43 | IMPLICIT procedure(Y) (A-b)
-   |          ^^^^^^^^^ 

--- a/tests/reference/ast-implicit1-e201262.stdout
+++ b/tests/reference/ast-implicit1-e201262.stdout
@@ -58,7 +58,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     h
@@ -74,15 +73,13 @@
             [(ImplicitSpec
                 (AttrType
                     TypeReal
-                    []
-                    ()
-                    ()
-                    None
-                )
-                [(LetterSpec
-                    ()
+                    [(()
                     dp
-                )]
+                    Value)]
+                    ()
+                    ()
+                    None
+                )
                 [(LetterSpec
                     a
                     h
@@ -105,7 +102,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     h
@@ -128,7 +124,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     h
@@ -153,7 +148,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     a
                     h
@@ -178,7 +172,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     c
@@ -194,15 +187,13 @@
             [(ImplicitSpec
                 (AttrType
                     TypeCharacter
-                    []
+                    [(()
+                    id
+                    Value)]
                     ()
                     ()
                     None
                 )
-                [(LetterSpec
-                    ()
-                    id
-                )]
                 [(LetterSpec
                     a
                     z
@@ -223,7 +214,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     i
                     n
@@ -240,7 +230,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     i
@@ -277,7 +266,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     i
@@ -301,15 +289,13 @@
             [(ImplicitSpec
                 (AttrType
                     TypeInteger
-                    []
+                    [(()
+                    dp
+                    Value)]
                     ()
                     ()
                     None
                 )
-                [(LetterSpec
-                    ()
-                    dp
-                )]
                 [(LetterSpec
                     a
                     h
@@ -332,7 +318,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     i
@@ -361,7 +346,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     A
@@ -384,7 +368,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     C
@@ -407,7 +390,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     C
@@ -432,7 +414,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     l
@@ -448,15 +429,13 @@
             [(ImplicitSpec
                 (AttrType
                     TypeLogical
-                    []
+                    [(()
+                    dp
+                    Value)]
                     ()
                     ()
                     None
                 )
-                [(LetterSpec
-                    ()
-                    dp
-                )]
                 [(LetterSpec
                     a
                     h
@@ -479,7 +458,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     l
@@ -502,7 +480,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     l
@@ -527,7 +504,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     z
@@ -539,15 +515,13 @@
             [(ImplicitSpec
                 (AttrType
                     TypeComplex
-                    []
+                    [(()
+                    dp
+                    Value)]
                     ()
                     ()
                     None
                 )
-                [(LetterSpec
-                    ()
-                    dp
-                )]
                 [(LetterSpec
                     a
                     h
@@ -568,7 +542,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     C
@@ -587,7 +560,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     z
@@ -606,7 +578,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     z
@@ -627,7 +598,6 @@
                     BLOB
                     None
                 )
-                []
                 [(LetterSpec
                     ()
                     A
@@ -644,24 +614,6 @@
                     X
                     None
                 )
-                []
-                [(LetterSpec
-                    A
-                    b
-                )]
-            )]
-            ()
-        )
-        (Implicit
-            [(ImplicitSpec
-                (AttrType
-                    TypeProcedure
-                    []
-                    ()
-                    Y
-                    None
-                )
-                []
                 [(LetterSpec
                     A
                     b

--- a/tests/reference/ast-implicit_check-4f0391f.json
+++ b/tests/reference/ast-implicit_check-4f0391f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-implicit_check-4f0391f.stdout",
-    "stdout_hash": "ea1999e1a6033330554e299116aad5e83e1faf77c724ae29edbccac2",
+    "stdout_hash": "cf1c71b539cc3253680fa426242e31cd3f34bdf3f01d96a66c479b21",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-implicit_check-4f0391f.stdout
+++ b/tests/reference/ast-implicit_check-4f0391f.stdout
@@ -12,7 +12,6 @@
                     ()
                     None
                 )
-                []
                 [(LetterSpec
                     A
                     H

--- a/tests/reference/ast_f90-implicit1-418fb10.json
+++ b/tests/reference/ast_f90-implicit1-418fb10.json
@@ -5,9 +5,9 @@
     "infile_hash": "8e65affb83e17129305b295736a3a898e9046a8667bb7c089d1ad67f",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": "ast_f90-implicit1-418fb10.stdout",
-    "stdout_hash": "0a8b16328ee00f6652a05cc1a0086e87290f6632923521553054233e",
-    "stderr": null,
-    "stderr_hash": null,
-    "returncode": 0
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast_f90-implicit1-418fb10.stderr",
+    "stderr_hash": "98ff09ba3e15d6a0160e3a8f9aad63e98b4c71440d7f7466c6c52ccc",
+    "returncode": 2
 }

--- a/tests/reference/ast_f90-implicit1-418fb10.json
+++ b/tests/reference/ast_f90-implicit1-418fb10.json
@@ -2,12 +2,12 @@
     "basename": "ast_f90-implicit1-418fb10",
     "cmd": "lfortran --show-ast-f90 --no-indent --no-color {infile}",
     "infile": "tests/implicit1.f90",
-    "infile_hash": "8e65affb83e17129305b295736a3a898e9046a8667bb7c089d1ad67f",
+    "infile_hash": "055efd6feee3a318ee48bce964a4223461719dc2c772db80c7440f82",
     "outfile": null,
     "outfile_hash": null,
-    "stdout": null,
-    "stdout_hash": null,
+    "stdout": "ast_f90-implicit1-418fb10.stdout",
+    "stdout_hash": "da90bd9449cc668dc87b7e3b46163c6f97c78649065cafd5d5d2bf68",
     "stderr": "ast_f90-implicit1-418fb10.stderr",
-    "stderr_hash": "98ff09ba3e15d6a0160e3a8f9aad63e98b4c71440d7f7466c6c52ccc",
-    "returncode": 2
+    "stderr_hash": "8fb7cba70f8f53adeb61cebe9b2ec9569553e1c2d1593891217dd169",
+    "returncode": 0
 }

--- a/tests/reference/ast_f90-implicit1-418fb10.stderr
+++ b/tests/reference/ast_f90-implicit1-418fb10.stderr
@@ -1,0 +1,35 @@
+style suggestion: Use real(8) instead of real*8
+  --> tests/implicit1.f90:13:10
+   |
+13 | implicit real*8 (a-h,o-z)
+   |          ^^^^^^ help: write this as 'real(8)'
+
+style suggestion: Use integer(8) instead of integer*8
+  --> tests/implicit1.f90:25:10
+   |
+25 | implicit integer*8 (i,j-l,m,n)
+   |          ^^^^^^^^^ help: write this as 'integer(8)'
+
+style suggestion: Use integer(4) instead of integer*4
+  --> tests/implicit1.f90:27:10
+   |
+27 | IMPLICIT INTEGER*4 (C, D-x)
+   |          ^^^^^^^^^ help: write this as 'integer(4)'
+
+style suggestion: Use logical(4) instead of logical*4
+  --> tests/implicit1.f90:32:10
+   |
+32 | implicit logical*4 (l, u-z)
+   |          ^^^^^^^^^ help: write this as 'logical(4)'
+
+style suggestion: Use complex(8) instead of complex*8
+  --> tests/implicit1.f90:38:10
+   |
+38 | implicit complex*8 (z)
+   |          ^^^^^^^^^ help: write this as 'complex(8)'
+
+syntax error: Token 'procedure' is unexpected here
+  --> tests/implicit1.f90:43:10
+   |
+43 | IMPLICIT procedure(Y) (A-b)
+   |          ^^^^^^^^^ 

--- a/tests/reference/ast_f90-implicit1-418fb10.stderr
+++ b/tests/reference/ast_f90-implicit1-418fb10.stderr
@@ -27,9 +27,3 @@ style suggestion: Use complex(8) instead of complex*8
    |
 38 | implicit complex*8 (z)
    |          ^^^^^^^^^ help: write this as 'complex(8)'
-
-syntax error: Token 'procedure' is unexpected here
-  --> tests/implicit1.f90:43:10
-   |
-43 | IMPLICIT procedure(Y) (A-b)
-   |          ^^^^^^^^^ 

--- a/tests/reference/ast_f90-implicit1-418fb10.stdout
+++ b/tests/reference/ast_f90-implicit1-418fb10.stdout
@@ -9,36 +9,35 @@ implicit none (external, type)
 implicit none (type, external)
 
 implicit real (a-h,o-z)
-implicit real (dp) (a-h,o-z)
+implicit real(dp) (a-h,o-z)
 implicit real(8) (a-h,o-z)
 implicit real(8) (a-h,o-z)
 
 implicit double precision (a-h,o-z)
 
 implicit character (c,o-z)
-implicit character (id) (a-z)
+implicit character(len=id) (a-z)
 
 implicit integer (i-n)
 implicit integer (i,j,k,l,m,n)
 implicit integer (i,j-l,m,n)
-implicit integer (dp) (a-h,o-z)
+implicit integer(dp) (a-h,o-z)
 implicit integer(8) (i,j-l,m,n)
 implicit integer (A,C)
 implicit integer(4) (C,D-x)
 implicit integer(4) (C,D-x)
 
 implicit logical (l,u-z)
-implicit logical (dp) (a-h,o-z)
+implicit logical(dp) (a-h,o-z)
 implicit logical(4) (l,u-z)
 implicit logical(4) (l,u-z)
 
 implicit complex (z)
-implicit complex (dp) (a-h,o-z)
+implicit complex(dp) (a-h,o-z)
 implicit complex (C)
 implicit complex(4) (z)
 implicit complex(4) (z)
 
 implicit type(BLOB) (A)
 implicit class(X) (A-b)
-implicit procedure(Y) (A-b)
 end program implicit1


### PR DESCRIPTION
*DO NOT MERGE*

This is an example of how to use the `declaration_type_spec` rule in the `implicit_spec` to improve parsing of the _kind-selector_.  As discussed in #5549, this code introduces 5 essential shift/reduce conflicts, which need to be addressed.  This PR is intended just for allowing developers to see the complete code.

