### PR TITLE
ci: Use micromamba 2.0 via setup-micromamba 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,9 +38,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment.yml
           create-args: >-
             python=${{ matrix.python-version }}
@@ -123,9 +123,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
@@ -245,9 +245,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
@@ -384,9 +384,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
@@ -457,9 +457,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=${{ matrix.python-version }}
@@ -880,10 +880,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         if: contains(matrix.llvm-version, '19')
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=${{ matrix.python-version }}
@@ -894,10 +894,10 @@ jobs:
             make=4.3
             nodejs=18.20.4
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         if: contains(matrix.llvm-version, '10')
         with:
-          micromamba-version: '1.5.10-0'
+          microconda-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=${{ matrix.python-version }}
@@ -908,10 +908,10 @@ jobs:
             make=4.3
             nodejs=18.20.2
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         if: "!(contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19'))"
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=${{ matrix.python-version }}
@@ -1313,9 +1313,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
           create-args: >-
             llvm-openmp
@@ -1454,9 +1454,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
@@ -1474,9 +1474,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=3.10
@@ -1523,9 +1523,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_docs_linux.yml
 
       - uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -245,7 +245,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -384,7 +384,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -457,7 +457,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
@@ -880,7 +880,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         if: contains(matrix.llvm-version, '19')
         with:
           micromamba-version: '2.0.4-0'
@@ -894,10 +894,10 @@ jobs:
             make=4.3
             nodejs=18.20.4
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         if: contains(matrix.llvm-version, '10')
         with:
-          microconda-version: '2.0.4-0'
+          micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=${{ matrix.python-version }}
@@ -908,7 +908,7 @@ jobs:
             make=4.3
             nodejs=18.20.2
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         if: "!(contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19'))"
         with:
           micromamba-version: '2.0.4-0'
@@ -1313,7 +1313,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -1454,7 +1454,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -1474,7 +1474,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
@@ -1523,7 +1523,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_docs_linux.yml


### PR DESCRIPTION
Alternative to https://github.com/lfortran/lfortran/pull/5013 with unaltered changes and thus caches for the "Check Out-of-Source Debug build" workflow.