### PR TITLE
Allow for array constants in array item calls

### DIFF
--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -33,6 +33,10 @@ program array_indices_array_item
     print *, rank_val
     if (rank_val /= 1) error stop
 
+    rank_val = rank(arr_3(1, [2, 1], 2))
+    print *, rank_val
+    if (rank_val /= 1) error stop
+
     arr_2 = arr_1(arr_idx2, 1)
     arr_2_reshape = reshape([3.0, 1.0], shape(arr_2_reshape));
     print *, rank(arr_2)

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4314,8 +4314,7 @@ public:
                         throw SemanticAbort();
                     }
                     res_dims_vec.push_back(al, arg_dim[0]);
-                }
-                if( all_args_eval ) {
+                } else if( all_args_eval ) {
                     flag = true;
                     ASR::expr_t* m_right_expr = ASRUtils::expr_value(a.m_right);
                     if(!ASR::is_a<ASR::IntegerConstant_t>(*m_right_expr)) {


### PR DESCRIPTION
Fixes #5518 

Essentially fixes calls of:
```fortran
print *, arr([1, 2])
```