### PR TITLE
 fix: cast to `PointerString` when `m_fmt` is a variable with physical type `DescriptorString` in `StringFormat`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1553,6 +1553,7 @@ RUN(NAME write_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME write_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME do_loop_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/write_08.f90
+++ b/integration_tests/write_08.f90
@@ -1,0 +1,9 @@
+program test
+    character(len=20) :: str
+    character(len=:), allocatable :: sformat
+    real :: x = 3.14159
+    sformat = "(F6.2)"
+    write(str, sformat) x
+    print *, str
+    if (trim(str) /= "  3.14") error stop
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -6118,6 +6118,24 @@ static inline void promote_ints_to_kind_8(ASR::expr_t** m_args, size_t n_args,
 static inline ASR::asr_t* make_StringFormat_t_util(Allocator &al, const Location &a_loc,
         ASR::expr_t* a_fmt, ASR::expr_t** a_args, size_t n_args, ASR::string_format_kindType a_kind,
         ASR::ttype_t* a_type, ASR::expr_t* a_value) {
+    if (a_fmt && ASR::is_a<ASR::Var_t>(*a_fmt)) {
+        ASR::Variable_t* fmt_str = ASR::down_cast<ASR::Variable_t>(ASR::down_cast<ASR::Var_t>(a_fmt)->m_v);
+        if (ASR::is_a<ASR::String_t>(
+                *ASRUtils::type_get_past_array_pointer_allocatable(fmt_str->m_type))) {
+            ASR::String_t* str_type = ASR::down_cast<ASR::String_t>(
+                ASRUtils::type_get_past_array_pointer_allocatable(fmt_str->m_type));
+            if (str_type->m_physical_type != ASR::string_physical_typeType::PointerString) {
+                a_fmt = ASRUtils::EXPR(ASR::make_StringPhysicalCast_t(
+                    al,
+                    a_fmt->base.loc,
+                    a_fmt,
+                    str_type->m_physical_type,
+                    ASR::string_physical_typeType::PointerString,
+                    a_type,
+                    nullptr));
+            }
+        }
+    }
     return ASR::make_StringFormat_t(al, a_loc, a_fmt, a_args, n_args, a_kind, a_type, a_value);
 }
 


### PR DESCRIPTION
fixes #5554 