### PR TITLE
feat: propagate location information of name in `unit`

### DIFF
--- a/a.f90
+++ b/a.f90
@@ -1,0 +1,3 @@
+function xyz()
+        print *, "abc"
+end function xyz

--- a/grammar/AST.asdl
+++ b/grammar/AST.asdl
@@ -53,7 +53,7 @@ program_unit
     | Function(identifier name, arg* args, decl_attribute* attributes,
         expr? return_var, bind? bind, trivia? trivia, unit_decl1* use, import_statement* import,
         implicit_statement* implicit, unit_decl2* decl, stmt* body,
-        program_unit* contains, identifier* temp_args)
+        program_unit* contains, identifier* temp_args, Location start_name, Location end_name)
 
 unit_decl1
     = Use(decl_attribute* nature, identifier module, use_symbol* symbols,

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -988,25 +988,28 @@ function
         sep use_statement_star import_statement_star implicit_statement_star decl_statements
         contains_block_opt
         end_function sep {
+            YYLTYPE start_name_loc = @2;
             LLOC(@$, @12); $$ = FUNCTION0($2, $4, nullptr, nullptr,
                 TRIVIA($6, $13, @$), $7, $8, $9, SPLIT_DECL(p.m_a, $10),
-                SPLIT_STMT(p.m_a, $10), $11, $12, @$); }
+                SPLIT_STMT(p.m_a, $10), $11, $12, @$, &start_name_loc, nullptr); }
     | KW_FUNCTION id "(" id_list_opt ")"
         bind
         result_opt
         sep use_statement_star import_statement_star implicit_statement_star decl_statements
         contains_block_opt
         end_function sep {
+            YYLTYPE start_name_loc = @2;
             LLOC(@$, @14); $$ = FUNCTION0($2, $4, $7, $6, TRIVIA($8, $15, @$),
-                $9, $10, $11, SPLIT_DECL(p.m_a, $12), SPLIT_STMT(p.m_a, $12), $13, $14, @$); }
+                $9, $10, $11, SPLIT_DECL(p.m_a, $12), SPLIT_STMT(p.m_a, $12), $13, $14, @$, &start_name_loc, nullptr); }
     | KW_FUNCTION id "(" id_list_opt ")"
         result
         bind_opt
         sep use_statement_star import_statement_star implicit_statement_star decl_statements
         contains_block_opt
         end_function sep {
+            YYLTYPE start_name_loc = @2;
             LLOC(@$, @14); $$ = FUNCTION0($2, $4, $6, $7, TRIVIA($8, $15, @$),
-                $9, $10, $11, SPLIT_DECL(p.m_a, $12), SPLIT_STMT(p.m_a, $12), $13, $14, @$); }
+                $9, $10, $11, SPLIT_DECL(p.m_a, $12), SPLIT_STMT(p.m_a, $12), $13, $14, @$, &start_name_loc, nullptr); }
     | KW_FUNCTION id "{" id_list "}" "(" id_list_opt ")"
         result_opt
         bind_opt
@@ -1018,25 +1021,28 @@ function
         sep use_statement_star import_statement_star implicit_statement_star decl_statements
         contains_block_opt
         end_function sep {
+            YYLTYPE start_name_loc = @2;
             LLOC(@$, @13); $$ = FUNCTION($1, $3, $5, nullptr, nullptr,
                 TRIVIA($7, $14, @$), $8, $9, $10, SPLIT_DECL(p.m_a, $11),
-                SPLIT_STMT(p.m_a, $11), $12, $13, @$); }
+                SPLIT_STMT(p.m_a, $11), $12, $13, @$, &start_name_loc, nullptr); }
     | fn_mod_plus KW_FUNCTION id "(" id_list_opt ")"
         bind
         result_opt
         sep use_statement_star import_statement_star implicit_statement_star decl_statements
         contains_block_opt
         end_function sep {
+            YYLTYPE start_name_loc = @2;
             LLOC(@$, @15); $$ = FUNCTION($1, $3, $5, $8, $7, TRIVIA($9, $16, @$),
-                $10, $11, $12, SPLIT_DECL(p.m_a, $13), SPLIT_STMT(p.m_a, $13), $14, $15, @$); }
+                $10, $11, $12, SPLIT_DECL(p.m_a, $13), SPLIT_STMT(p.m_a, $13), $14, $15, @$, &start_name_loc, nullptr); }
     | fn_mod_plus KW_FUNCTION id "(" id_list_opt ")"
         result
         bind_opt
         sep use_statement_star import_statement_star implicit_statement_star decl_statements
         contains_block_opt
         end_function sep {
+            YYLTYPE start_name_loc = @2;
             LLOC(@$, @15); $$ = FUNCTION($1, $3, $5, $7, $8, TRIVIA($9, $16, @$),
-                $10, $11, $12, SPLIT_DECL(p.m_a, $13), SPLIT_STMT(p.m_a, $13), $14, $15, @$); }
+                $10, $11, $12, SPLIT_DECL(p.m_a, $13), SPLIT_STMT(p.m_a, $13), $14, $15, @$, &start_name_loc, nullptr); }
     | fn_mod_plus KW_FUNCTION id "{" id_list "}" "(" id_list_opt ")"
         result_opt
         bind_opt

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -1356,7 +1356,7 @@ char *str_or_null(Allocator &al, const LCompilers::Str &s) {
     }
 }
 
-#define FUNCTION(fn_type, name, args, return_var, bind, trivia, use, import, implicit, decl, stmts, contains, name_opt, l) make_Function_t(p.m_a, l, \
+#define FUNCTION(fn_type, name, args, return_var, bind, trivia, use, import, implicit, decl, stmts, contains, name_opt, l, s_l, e_l) make_Function_t(p.m_a, l, \
         /*name*/ name2char_with_check(name, name_opt, l, "function"), \
         /*args*/ ARGS(p.m_a, l, args), \
         /*n_args*/ args.size(), \
@@ -1378,8 +1378,10 @@ char *str_or_null(Allocator &al, const LCompilers::Str &s) {
         /*contains*/ CONTAINS(contains), \
         /*n_contains*/ contains.size(), \
         /*temp_args*/ nullptr, \
-        /*n_temp_args*/ 0)
-#define FUNCTION0(name, args, return_var, bind, trivia, use, import, implicit, decl, stmts, contains, name_opt, l) make_Function_t(p.m_a, l, \
+        /*n_temp_args*/ 0, \
+        /*start_name*/ s_l, \
+        /*end_name*/ e_l)
+#define FUNCTION0(name, args, return_var, bind, trivia, use, import, implicit, decl, stmts, contains, name_opt, l, s_l, e_l) make_Function_t(p.m_a, l, \
         /*name*/ name2char_with_check(name, name_opt, l, "function"), \
         /*args*/ ARGS(p.m_a, l, args), \
         /*n_args*/ args.size(), \
@@ -1401,7 +1403,9 @@ char *str_or_null(Allocator &al, const LCompilers::Str &s) {
         /*contains*/ CONTAINS(contains), \
         /*n_contains*/ contains.size(), \
         /*temp_args*/ nullptr, \
-        /*n_temp_args*/ 0)
+        /*n_temp_args*/ 0, \
+        /*start_name*/ s_l, \
+        /*end_name*/ e_l)
 
 #define TEMPLATED_FUNCTION(fn_type, name, temp_args, fn_args, return_var, bind, trivia, decl, stmts, name_opt, l) \
         make_Function_t(p.m_a, l, \

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1299,6 +1299,14 @@ public:
     }
 
     void visit_Function(const AST::Function_t &x) {
+        std::cout<<"Function: "<<x.m_name<<std::endl;
+        if (x.m_start_name != nullptr) {
+            Location* loc = x.m_start_name;
+            std::cout<<"loc->first: "<<loc->first<<std::endl;
+            std::cout<<"loc->last: "<<loc->last<<std::endl;
+        } else {
+            std::cout<<"nullptr hai"<<std::endl;
+        }
         in_Subroutine = true;
         SetChar current_function_dependencies_copy = current_function_dependencies;
         current_function_dependencies.clear(al);

--- a/src/libasr/asdl.py
+++ b/src/libasr/asdl.py
@@ -223,7 +223,9 @@ def tokenize_asdl(buf):
     for lineno, line in enumerate(buf.splitlines(), 1):
         for m in re.finditer(r'\s*(\w+|--.*|.)', line.strip()):
             c = m.group(1)
-            if c[0].isalpha():
+            if c == "Location":
+                yield Token(TokenKind.TypeId, c, lineno)
+            elif c[0].isalpha():
                 # Some kind of identifier
                 if c[0].isupper():
                     yield Token(TokenKind.ConstructorId, c, lineno)


### PR DESCRIPTION
Towards https://github.com/lfortran/lfortran/issues/5558

We have location information but it is incorrect.

```fortran
real function xyz()
        print *, "abc"
end function xyz

```


```console
% lfortran a.f90 --show-asr
Function: xyz
loc->first: 53763168
loc->last: 24576
[...]
```