### PR TITLE
fix: correct `--show-prescan` documentation and add prescan explanation

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2107,6 +2107,7 @@ int main_app(int argc, char *argv[]) {
     std::vector<std::string> arg_files;
     std::string arg_standard;
     bool arg_version = false;
+    // see parser.prescan function for what 'prescanning' does
     bool show_prescan = false;
     bool show_tokens = false;
     bool show_ast = false;
@@ -2193,7 +2194,7 @@ int main_app(int argc, char *argv[]) {
     app.add_flag("--fixed-form-infer", fixed_form_infer, "Use heuristics to infer if a file is in fixed form");
     app.add_option("--std", arg_standard, "Select standard conformance (lf, f23, legacy)");
     app.add_flag("--no-prescan", arg_no_prescan, "Turn off prescanning");
-    app.add_flag("--show-prescan", show_prescan, "Show tokens for the given file and exit");
+    app.add_flag("--show-prescan", show_prescan, "Show the source code after prescanning and exit");
     app.add_flag("--show-tokens", show_tokens, "Show tokens for the given file and exit");
     app.add_flag("--show-ast", show_ast, "Show AST for the given file and exit");
     app.add_flag("--show-asr", show_asr, "Show ASR for the given file and exit");

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -507,6 +507,15 @@ bool is_include(const std::string &s, uint32_t pos) {
     }
 }
 
+/*
+The prescan phase includes:
+- Removal of whitespace (fixed-form only)
+- Joining of continuation lines
+- Removal of comments and empty lines
+- Handling of include statements
+- Conversion to lowercase (fixed-form only)
+- Handling of fixed-form column rules (columns 1–6 for labels/comments)
+*/
 std::string prescan(const std::string &s, LocationManager &lm,
         bool fixed_form, std::vector<std::filesystem::path> &include_dirs)
 {


### PR DESCRIPTION
## Description

This PR fixes `--show-prescan` compiler flag's short description, and adds a short explanation for it.