### PR TITLE
fix: retain symbol name for `ExternalSymbol` during import if `m_external` is `ASR::Function_t`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1042,6 +1042,7 @@ RUN(NAME modules_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST)
 RUN(NAME modules_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES modules_58_module.f90)
 RUN(NAME modules_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME modules_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
         operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES

--- a/integration_tests/modules_60.f90
+++ b/integration_tests/modules_60.f90
@@ -1,0 +1,25 @@
+module inf_mod_1
+    interface is_finite
+       module procedure is_finite_1
+    end interface is_finite
+ contains
+    subroutine is_finite_1()
+    end subroutine is_finite_1
+ end module inf_mod_1
+ 
+ module infnan_mod_1
+    use inf_mod_1, only : is_finite
+ contains
+    subroutine is_finite_1(x)
+       integer , intent(in) :: x
+       print *, x
+       if (x /= 1) error stop
+    end subroutine is_finite_1
+ end module infnan_mod_1
+ 
+ 
+ program bobyqa_exmp
+    use infnan_mod_1
+    call is_finite_1(1)
+ end program bobyqa_exmp
+ 

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2442,7 +2442,7 @@ public:
                 // local symbol table
                 ASR::ExternalSymbol_t *es0 = ASR::down_cast<ASR::ExternalSymbol_t>(item.second);
                 std::string sym;
-                if( in_submodule ) {
+                if( in_submodule || ASR::is_a<ASR::Function_t>(*es0->m_external)) {
                     sym = item.first;
                 } else {
                     sym = to_lower(es0->m_original_name);

--- a/tests/reference/asr-modules_60-baa1105.json
+++ b/tests/reference/asr-modules_60-baa1105.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-modules_60-baa1105",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/modules_60.f90",
+    "infile_hash": "568155f82ef97833e2766041c53cec7324de6bf8d2c418af15782fa3",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-modules_60-baa1105.stdout",
+    "stdout_hash": "263525b56d83a23981960c2209b504dac462e45d7bca21166d3b12e9",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-modules_60-baa1105.stdout
+++ b/tests/reference/asr-modules_60-baa1105.stdout
@@ -1,0 +1,199 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            bobyqa_exmp:
+                (Program
+                    (SymbolTable
+                        6
+                        {
+                            is_finite:
+                                (ExternalSymbol
+                                    6
+                                    is_finite
+                                    2 is_finite
+                                    inf_mod_1
+                                    []
+                                    is_finite
+                                    Public
+                                ),
+                            is_finite_1:
+                                (ExternalSymbol
+                                    6
+                                    is_finite_1
+                                    4 is_finite_1
+                                    infnan_mod_1
+                                    []
+                                    is_finite_1
+                                    Public
+                                ),
+                            is_finite_1@is_finite:
+                                (ExternalSymbol
+                                    6
+                                    is_finite_1@is_finite
+                                    2 is_finite_1
+                                    inf_mod_1
+                                    []
+                                    is_finite_1
+                                    Public
+                                )
+                        })
+                    bobyqa_exmp
+                    [infnan_mod_1]
+                    [(SubroutineCall
+                        6 is_finite_1
+                        ()
+                        [((IntegerConstant 1 (Integer 4) Decimal))]
+                        ()
+                    )]
+                ),
+            inf_mod_1:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            is_finite:
+                                (GenericProcedure
+                                    2
+                                    is_finite
+                                    [2 is_finite_1]
+                                    Public
+                                ),
+                            is_finite_1:
+                                (Function
+                                    (SymbolTable
+                                        3
+                                        {
+                                            
+                                        })
+                                    is_finite_1
+                                    (FunctionType
+                                        []
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    []
+                                    []
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                )
+                        })
+                    inf_mod_1
+                    []
+                    .false.
+                    .false.
+                ),
+            infnan_mod_1:
+                (Module
+                    (SymbolTable
+                        4
+                        {
+                            is_finite:
+                                (ExternalSymbol
+                                    4
+                                    is_finite
+                                    2 is_finite
+                                    inf_mod_1
+                                    []
+                                    is_finite
+                                    Public
+                                ),
+                            is_finite_1:
+                                (Function
+                                    (SymbolTable
+                                        5
+                                        {
+                                            x:
+                                                (Variable
+                                                    5
+                                                    x
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    is_finite_1
+                                    (FunctionType
+                                        [(Integer 4)]
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 5 x)]
+                                    [(Print
+                                        (StringFormat
+                                            ()
+                                            [(Var 5 x)]
+                                            FormatFortran
+                                            (String -1 0 () PointerString)
+                                            ()
+                                        )
+                                    )
+                                    (If
+                                        (IntegerCompare
+                                            (Var 5 x)
+                                            NotEq
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Logical 4)
+                                            ()
+                                        )
+                                        [(ErrorStop
+                                            ()
+                                        )]
+                                        []
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            is_finite_1@is_finite:
+                                (ExternalSymbol
+                                    4
+                                    is_finite_1@is_finite
+                                    2 is_finite_1
+                                    inf_mod_1
+                                    []
+                                    is_finite_1
+                                    Public
+                                )
+                        })
+                    infnan_mod_1
+                    [inf_mod_1]
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2273,6 +2273,10 @@ asr = true
 extrafiles = "../integration_tests/modules_52_module3.f90, ../integration_tests/modules_52_module2.f90, ../integration_tests/modules_52_module1.f90"
 
 [[test]]
+filename = "../integration_tests/modules_60.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/modules_36.f90"
 llvm = true
 


### PR DESCRIPTION
fixes #5366
