### PR TITLE
Fix : Flush pass_result into the body if we'll overwrite it in `subroutine_from_function_simplifier`.

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -350,7 +350,7 @@ RUN(NAME doloop_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c cpp wasm)
 RUN(NAME doloop_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nested subroutine
 RUN(NAME doloop_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm) # implicit cast loop variable
 RUN(NAME doloop_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm EXTRA_ARGS --use-loop-variable-after-loop)
-RUN(NAME doloop_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME doloop_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME cycle_and_exit1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME cycle_and_exit2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -350,6 +350,7 @@ RUN(NAME doloop_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c cpp wasm)
 RUN(NAME doloop_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # nested subroutine
 RUN(NAME doloop_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm) # implicit cast loop variable
 RUN(NAME doloop_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm EXTRA_ARGS --use-loop-variable-after-loop)
+RUN(NAME doloop_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME cycle_and_exit1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME cycle_and_exit2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/doloop_12.f90
+++ b/integration_tests/doloop_12.f90
@@ -1,0 +1,23 @@
+module gg
+    contains
+    function func_arr3(inp_ref) result(ret_arr)
+        integer, intent(in) :: inp_ref
+        integer,allocatable :: ret_arr(:)
+        allocate(ret_arr(1))
+        ret_arr = [inp_ref]
+        print *, "worked", inp_ref
+    end function
+end module
+
+
+program p
+    use gg
+    implicit none
+    integer, allocatable :: inp(:)
+    integer :: i =77
+    
+    do i= 1, 3
+        inp = func_arr3(i)
+    end do 
+end program  
+  

--- a/src/libasr/pass/subroutine_from_function_simplifier.cpp
+++ b/src/libasr/pass/subroutine_from_function_simplifier.cpp
@@ -7,8 +7,6 @@
 #include <libasr/pass/intrinsic_function_registry.h>
 #include <libasr/pass/intrinsic_array_function_registry.h>
 #include <libasr/pass/pass_utils.h>
-#include<libasr/pickle.h>
-
 
 namespace LCompilers {
 


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/5563

The fix does the same as other passes do, it makes sure to add the statements pushed in `Vec<ASR::stmt_t*> pass_result` in the appropriate body once we make a nested call that will overwrite the `pass_result` as it's shared by all visitors in the class.