### PR TITLE
Add implicit deallocate before creating a `subroutine_call` in `subroutine_from_function`pass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -403,6 +403,7 @@ RUN(NAME functions_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --fixed-form)
 RUN(NAME functions_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME functions_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_27.f90
+++ b/integration_tests/functions_27.f90
@@ -1,0 +1,21 @@
+module functions_27_mod
+    contains
+    function func_arr3() result(ret_arr)
+        integer,allocatable :: ret_arr(:)
+        print *, allocated(ret_arr)
+        ! ret_arr should always be not allocated by the begining of the function call.
+        if(allocated(ret_arr) .eqv. .true.) error stop
+        allocate(ret_arr(1))
+    end function
+end module
+
+
+program functions_27
+    use functions_27_mod
+    implicit none
+    integer, allocatable :: inp(:)
+    integer :: i
+    do i= 1, 3
+        inp = func_arr3()
+    end do 
+end program  

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -297,6 +297,14 @@ class ReplaceFunctionCallWithSubroutineCall:
                     current_expr = current_expr_copy_9;
                     s_args.push_back(al, x->m_args[i]);
                 }
+                if(is_func_call_allocatable){ //Make sure to deallocate the argument that will hold the return of function.
+                    Vec<ASR::expr_t*> to_be_deallocated;
+                    to_be_deallocated.reserve(al, 1);
+                    to_be_deallocated.push_back(al, *current_expr);
+                    pass_result.push_back(al, ASRUtils::STMT(
+                        ASR::make_ImplicitDeallocate_t(al, (*current_expr)->base.loc,
+                        to_be_deallocated.p, to_be_deallocated.size())));
+                }
                 ASR::call_arg_t result_arg;
                 result_arg.loc = loc;
                 result_arg.m_value = *current_expr;

--- a/src/libasr/pass/subroutine_from_function_simplifier.cpp
+++ b/src/libasr/pass/subroutine_from_function_simplifier.cpp
@@ -89,6 +89,14 @@ class ReplaceFunctionCallWithSubroutineCallSimplifierVisitor:
             for( size_t i = 0; i < fc->n_args; i++ ) {
                 s_args.push_back(al, fc->m_args[i]);
             }
+            if(ASRUtils::is_allocatable(x.m_value)){ // Make sure to deallocate the argument that will hold the return of function.
+                Vec<ASR::expr_t*> to_be_deallocated;
+                to_be_deallocated.reserve(al, 1);
+                to_be_deallocated.push_back(al, x.m_target);
+                pass_result.push_back(al, ASRUtils::STMT(
+                    ASR::make_ImplicitDeallocate_t(al, x.m_target->base.loc,
+                    to_be_deallocated.p, to_be_deallocated.size())));
+            }
             ASR::call_arg_t result_arg;
             result_arg.loc = x.m_target->base.loc;
             result_arg.m_value = x.m_target;


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/5564