### PR TITLE
Feat: Multiple Headed DoConcurrentLoop: Update of each loop variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1859,6 +1859,7 @@ RUN(NAME openmp_37 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_38 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_39 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_40 LABELS llvm_omp)
+RUN(NAME openmp_41 LABELS llvm_omp)
 
 RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME fortran_02 LABELS gfortran fortran)

--- a/integration_tests/openmp_41.f90
+++ b/integration_tests/openmp_41.f90
@@ -1,0 +1,21 @@
+program openmp_41
+integer :: i, j, k, res=0, resi=0, resj=0, resk=0
+print *,"----","i","j","k"
+do concurrent (i = 1:4 ,j = 1:3 ,k = 1:2) reduce(+:res,resi,resj,resk)
+    print *, "----" ,i,j,k
+    res=res+1
+    resi=resi+i
+    resj=resj+j
+    resk=resk+k
+end do 
+print *,"res = ",res
+print *,"resi = ",resi
+print *,"resj = ",resj
+print *,"resk = ",resk
+
+! Check the result
+if ( resi /= 60 ) error stop ! (1+2+3+4) * 3 * 2=60
+if ( resj /= 48 ) error stop ! (1+2+3) * 4 * 2  = 48
+if ( resk /= 36 ) error stop ! (1+2) * 4* 3 = 36
+if ( res /= 24 ) error stop  ! Total iterations = 4 * 3 * 2 = 24
+end program


### PR DESCRIPTION
This PR aims to correctly update the loop variables for each head of DoConcurrentLoop,  continuing #5542 and hence moving towards #4900 and #4818 completion