### PR TITLE
fix: Handling of multiple_heads in DoLoopVisitor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1856,12 +1856,12 @@ RUN(NAME openmp_32 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_33 LABELS gfortran llvm_omp NO_EXPERIMENTAL_SIMPLIFIER GFORTRAN_ARGS -fopenmp) # mandelbrot
 RUN(NAME openmp_34 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # Ensure uniform load distribution over threads
 RUN(NAME openmp_35 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
-RUN(NAME openmp_36 LABELS gfortran GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_36 LABELS gfortran GFORTRAN_ARGS -fopenmp llvm)
 RUN(NAME openmp_37 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_38 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_39 LABELS gfortran GFORTRAN_ARGS -fopenmp)
-RUN(NAME openmp_40 LABELS llvm_omp)
-RUN(NAME openmp_41 LABELS llvm_omp)
+RUN(NAME openmp_40 LABELS llvm_omp llvm)
+RUN(NAME openmp_41 LABELS llvm_omp llvm)
 
 RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME fortran_02 LABELS gfortran fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1856,7 +1856,7 @@ RUN(NAME openmp_32 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_33 LABELS gfortran llvm_omp NO_EXPERIMENTAL_SIMPLIFIER GFORTRAN_ARGS -fopenmp) # mandelbrot
 RUN(NAME openmp_34 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp) # Ensure uniform load distribution over threads
 RUN(NAME openmp_35 LABELS gfortran llvm_omp GFORTRAN_ARGS -fopenmp)
-RUN(NAME openmp_36 LABELS gfortran GFORTRAN_ARGS -fopenmp llvm)
+RUN(NAME openmp_36 LABELS gfortran llvm GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_37 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_38 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_39 LABELS gfortran GFORTRAN_ARGS -fopenmp)

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -46,10 +46,10 @@ public:
 
     void visit_DoConcurrentLoop(const ASR::DoConcurrentLoop_t &x) {
         Vec<ASR::stmt_t*> body;body.reserve(al,1);
-        for (int i = 0; i < x.n_body; i++) {
+        for (int i = 0; i < static_cast<int>(x.n_body); i++) {
             body.push_back(al,x.m_body[i]);
         }
-        for (int i = x.n_head - 1; i > 0; i--) {
+        for (int i = static_cast<int>(x.n_head) - 1; i > 0; i--) {
             ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[i], body.p, body.n, nullptr, 0);
             body={};body.reserve(al,1);
             body.push_back(al,ASRUtils::STMT(do_loop));

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -45,8 +45,16 @@ public:
     }
 
     void visit_DoConcurrentLoop(const ASR::DoConcurrentLoop_t &x) {
-        LCOMPILERS_ASSERT(x.n_head == 1);
-        ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[0], x.m_body, x.n_body, nullptr, 0);
+        Vec<ASR::stmt_t*> body;body.reserve(al,1);
+        for (size_t i = 0; i < x.n_body; i++) {
+            body.push_back(al,x.m_body[i]);
+        }
+        for (size_t i = x.n_head - 1; i > 0; i--) {
+            ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[i], body.p, body.n, nullptr, 0);
+            body={};body.reserve(al,1);
+            body.push_back(al,ASRUtils::STMT(do_loop));
+        }
+        ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[0], body.p, body.n, nullptr, 0);
         const ASR::DoLoop_t &do_loop_ref = (const ASR::DoLoop_t&)(*do_loop);
         pass_result = PassUtils::replace_doloop(al, do_loop_ref, -1, use_loop_variable_after_loop);
     }

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -46,10 +46,10 @@ public:
 
     void visit_DoConcurrentLoop(const ASR::DoConcurrentLoop_t &x) {
         Vec<ASR::stmt_t*> body;body.reserve(al,1);
-        for (size_t i = 0; i < x.n_body; i++) {
+        for (int i = 0; i < x.n_body; i++) {
             body.push_back(al,x.m_body[i]);
         }
-        for (size_t i = x.n_head - 1; i > 0; i--) {
+        for (int i = x.n_head - 1; i > 0; i--) {
             ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[i], body.p, body.n, nullptr, 0);
             body={};body.reserve(al,1);
             body.push_back(al,ASRUtils::STMT(do_loop));


### PR DESCRIPTION
 As Do_loop only contains one head we need to convert the multiple_headed DoConcurrentLoops to nested Do_loops , if not using `--openmp` flag 
 As pointed out here in [comment](https://github.com/lfortran/lfortran/pull/5582#issuecomment-2518550810)