### PR TITLE
preprocessing: use `in_string` only when position has moved forward

### DIFF
--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -688,7 +688,7 @@ std::string prescan(const std::string &s, LocationManager &lm,
                 process_include(out, s, lm, pos, fixed_form, include_dirs, col);
             }
             newline = false;
-            if (s[pos] == '!') in_comment = true;
+            if (s[pos] == '!' && !in_string) in_comment = true;
             if (in_comment && s[pos] == '\n') in_comment = false;
             if (!in_comment && s[pos] == '&') {
                 size_t pos2=pos+1;


### PR DESCRIPTION
## Description

This PR has the changes from https://github.com/lfortran/lfortran/pull/5569 and then builds on top of it, this is definitely not intended to be reviewed until https://github.com/lfortran/lfortran/pull/5569 has been reviewed and merged.


## TODO

I'll add test cases as well for this PR