### PR TITLE
feat: Add an option to print LLVM using the generated MLIR

### DIFF
--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -533,32 +533,7 @@ Result<std::string> FortranEvaluator::get_julia(const std::string &code,
     }
 }
 
-Result<std::string> FortranEvaluator::get_mlir(const std::string &code,
-    LocationManager &lm, diag::Diagnostics &diagnostics)
-{
-    // Src -> AST -> ASR -> MLIR
-    SymbolTable *old_symbol_table = symbol_table;
-    symbol_table = nullptr;
-    Result<ASR::TranslationUnit_t*> asr = get_asr2(code, lm, diagnostics);
-    symbol_table = old_symbol_table;
-    if (!asr.ok) {
-        return asr.error;
-    }
-#ifdef HAVE_LFORTRAN_MLIR
-    Result<std::unique_ptr<MLIRModule>> res = asr_to_mlir(al, *asr.result,
-        diagnostics);
-    if (res.ok) {
-        return res.result->str();
-    } else {
-        LCOMPILERS_ASSERT(diagnostics.has_error())
-        return res.error;
-    }
-#else
-    throw LCompilersException("MLIR is not enabled");
-#endif
-}
-
-Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir2(
+Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir(
 #ifdef HAVE_LFORTRAN_MLIR
         ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics
 #else

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -107,9 +107,7 @@ public:
         int64_t default_lower_bound);
     Result<std::string> get_julia(const std::string &code,
         LocationManager &lm, diag::Diagnostics &diagnostics);
-    Result<std::string> get_mlir(const std::string &code,
-        LocationManager &lm, diag::Diagnostics &diagnostics);
-    Result<std::unique_ptr<MLIRModule>> get_mlir2(
+    Result<std::unique_ptr<MLIRModule>> get_mlir(
         ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics);
     Result<std::string> get_fortran(const std::string &code,
         LocationManager &lm, diag::Diagnostics &diagnostics);

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -154,10 +154,17 @@ MLIRModule::~MLIRModule() {
     llvm_ctx.reset();
 };
 
-std::string MLIRModule::str() {
+std::string MLIRModule::mlir_str() {
     std::string mlir_str;
     llvm::raw_string_ostream raw_os(mlir_str);
     mlir_m->print(raw_os);
+    return mlir_str;
+}
+
+std::string MLIRModule::llvm_str() {
+    std::string mlir_str;
+    llvm::raw_string_ostream raw_os(mlir_str);
+    llvm_m->print(raw_os, nullptr);
     return mlir_str;
 }
 

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -51,7 +51,8 @@ public:
     MLIRModule(std::unique_ptr<mlir::ModuleOp> m,
         std::unique_ptr<mlir::MLIRContext> ctx);
     ~MLIRModule();
-    std::string str();
+    std::string mlir_str();
+    std::string llvm_str();
     void mlir_to_llvm();
 };
 


### PR DESCRIPTION
Changes in this PR:
- Simplify the code for handling the MLIR
- Add a new member function `llvm_str` in MLIRModule
- Add a new option `--show-mlir-to-llvm`