### PR TITLE
Fix `ArrayPhysicalCast` in `pass_array_by_data` pass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -405,6 +405,7 @@ RUN(NAME functions_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS -
 RUN(NAME functions_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME functions_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_28.f90
+++ b/integration_tests/functions_28.f90
@@ -1,0 +1,28 @@
+program test 
+    implicit none
+    real(8) :: y(2,2)
+    real(8) :: x(2) = [1,2]
+    real(8) :: z(size(y,2))
+    integer :: j = 1
+    z = matprod12(x, y)
+    print *, z
+
+contains
+function matprod12(x, y) result(z)
+    implicit none
+    real(8), intent(in) :: x(:)
+    real(8), intent(in) :: y(:, :)
+    real(8) :: z(size(y, 2))
+    integer :: j 
+    j = size(y,2)
+    z(j) = inprod(x, y(:, j))
+end function matprod12
+
+function inprod(x, y) result(z)
+    implicit none
+    real(8), intent(in) :: x(:)
+    real(8), intent(in) :: y(:)
+    real(8) :: z 
+end function inprod
+end program
+

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -341,15 +341,21 @@ class EditProcedureReplacer: public ASR::BaseExprReplacer<EditProcedureReplacer>
         ASR::BaseExprReplacer<EditProcedureReplacer>::replace_ArrayPhysicalCast(x);
         // TODO: Allow for DescriptorArray to DescriptorArray physical cast for allocatables
         // later on
+        x->m_old = ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg));
         if( (x->m_old == x->m_new &&
              x->m_old != ASR::array_physical_typeType::DescriptorArray) ||
             (x->m_old == x->m_new && x->m_old == ASR::array_physical_typeType::DescriptorArray &&
             (ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(x->m_arg)) ||
-             ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x->m_arg)))) ||
-             x->m_old != ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg)) ) {
+             ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x->m_arg))))) {
             *current_expr = x->m_arg;
         } else {
-            x->m_old = ASRUtils::extract_physical_type(ASRUtils::expr_type(x->m_arg));
+            ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_pointer(
+                  ASRUtils::type_get_past_allocatable(x->m_type)));
+            if (ASRUtils::is_dimension_empty(arr->m_dims, arr->n_dims)) {
+              arr->m_dims = ASR::down_cast<ASR::Array_t>(
+                  ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(
+                      ASRUtils::expr_type(x->m_arg))))->m_dims;
+            }
         }
     }
 


### PR DESCRIPTION
1. Set the `m_old` parameter to the new physical type of the array.
2. Set the dimensions to the array dimensions if necessary.

Creates valid ASR instead of wrong type being passed.

Fixes #5521 