### PR TITLE
CMake: Do not use CMAKE_VERBOSE_MAKEFILE in CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -406,7 +406,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DWITH_LLVM=yes \
               -DWITH_LSP=yes \
-              -DCMAKE_VERBOSE_MAKEFILE= yes \
               -DLFORTRAN_BUILD_ALL=yes \
               -DWITH_STACKTRACE=no \
               -DWITH_RUNTIME_STACKTRACE=yes \
@@ -1373,7 +1372,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug \
               -DWITH_LLVM=yes \
               -DWITH_LSP=yes \
-              -DCMAKE_VERBOSE_MAKEFILE= yes \
               -DLFORTRAN_BUILD_ALL=yes \
               -DWITH_STACKTRACE=no \
               -DWITH_RUNTIME_STACKTRACE=yes \


### PR DESCRIPTION
## Description

This PR aims to address the comment left here: https://github.com/lfortran/lfortran/pull/5616#pullrequestreview-2486852946