### PR TITLE
enh: udpate function variable when `m_type_declaration` is updated

### DIFF
--- a/integration_tests/procedure_07.f90
+++ b/integration_tests/procedure_07.f90
@@ -12,6 +12,7 @@ end module procedure_07_module
 program procedure_07
     use procedure_07_module
     call temp(cb)
+    call temp2(cb)
 contains
     subroutine temp(call_back)
         implicit none
@@ -19,4 +20,9 @@ contains
         logical :: terminate_var
         call call_back()   
     end subroutine temp
+    subroutine temp2(call_back)
+        implicit none
+        procedure(cb) :: call_back
+        logical :: terminate_var
+    end subroutine
 end program procedure_07

--- a/integration_tests/procedure_08.f90
+++ b/integration_tests/procedure_08.f90
@@ -17,10 +17,15 @@ end module procedure_08_module
 program procedure_08
     use procedure_08_module
     call temp(calfun)
+    call temp2(calfun)
 contains
     subroutine temp(call_back)
         implicit none
         procedure(cb) :: call_back
         call call_back()   
     end subroutine temp
+    subroutine temp2(call_back)
+        implicit none
+        procedure(cb) :: call_back
+    end subroutine
 end program procedure_08


### PR DESCRIPTION
Towards #4397
Previously function Variable was only updating when call is made but now it updates when we declare `procedure(cb) :: call_back`.