### PR TITLE
Handling Assignment for Array with Array Argument to represent Array index

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1687,6 +1687,7 @@ RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+RUN(NAME array_indices_array_item_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME implicit_argument_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-argument-casting

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1687,7 +1687,7 @@ RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
-RUN(NAME array_indices_array_item_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME array_indices_array_item_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_EXPERIMENTAL_SIMPLIFIER)
 
 RUN(NAME implicit_argument_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-argument-casting

--- a/integration_tests/array_indices_array_item_assignment.f90
+++ b/integration_tests/array_indices_array_item_assignment.f90
@@ -1,0 +1,8 @@
+program array_indices_array_item_assignment 
+integer :: A(3) = [1,2,3]
+integer :: X(2) = [1,2]
+integer :: Y = 2
+A(X) = Y
+if (A(1) /= 2) error stop
+if (A(2) /= 2) error stop
+end program

--- a/try.f90
+++ b/try.f90
@@ -1,0 +1,7 @@
+program array_indices_array_item_assignment 
+integer :: A(3) = [1,2,3]
+integer :: X(2) = [1,2]
+integer :: Y = 2
+A(X) = Y
+print * , A
+end program

--- a/try.f90
+++ b/try.f90
@@ -1,7 +1,0 @@
-program array_indices_array_item_assignment 
-integer :: A(3) = [1,2,3]
-integer :: X(2) = [1,2]
-integer :: Y = 2
-A(X) = Y
-print * , A
-end program


### PR DESCRIPTION
Towards #5516 

Tries to make assignment with Array Item as Array reference.

MRE 
```
program array_indices_array_item_assignment 
integer :: A(3) = [1,2,3]
integer :: X(2) = [1,2]
integer :: Y = 2
A(X) = Y
print * , A
end program
```

LFortran result
```
(lf) lordansh@LordAnsh:~/dev/lfort3/lfortran$ ./src/bin/lfortran try.f90
2    2    3
```

Still Array Section (like A(X(:)) = Y ) is not addressed in this PR , which I will address in subsequent PR.