### PR TITLE
rem: unnecessary granular catch at `visit_Name`

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9157,12 +9157,8 @@ public:
     void visit_NameUtil(AST::struct_member_t* x_m_member, size_t x_n_member,
                         char* x_m_id, const Location& loc) {
         if (x_n_member == 0) {
-            try {
-                ASR::expr_t* expr = ASRUtils::EXPR(resolve_variable(loc, to_lower(x_m_id)));
-                tmp = (ASR::asr_t*) replace_with_common_block_variables(expr);
-            } catch (const SemanticAbort &a) {
-                if (!compiler_options.continue_compilation) throw a;
-            }
+            ASR::expr_t* expr = ASRUtils::EXPR(resolve_variable(loc, to_lower(x_m_id)));
+            tmp = (ASR::asr_t*) replace_with_common_block_variables(expr);
         } else if (x_n_member == 1) {
             if (x_m_member[0].n_args == 0) {
                 SymbolTable* scope = current_scope;

--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -86,11 +86,12 @@ x = "x"
 x = 5 + "x"
 !subroutine1, subroutine2, subroutine3, subroutine5
 call bpe()
-    i = bpe()
-    contains
-    subroutine bpe()
-        print *, size(bpe)
-        bpe = d
-    end subroutine
+i = bpe()
+print *, xx
+contains
+subroutine bpe()
+    print *, size(bpe)
+    bpe = d
+end subroutine
     
 end program

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "2bf81cf1328e6352facfffe9604bf8413a6448d926ed53e523594cc5",
+    "infile_hash": "4da9ce3cdee93614875cd831e6826cc94b76e5b4fe0df59d6d7bb866",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "c56db9b45a76f39c6c3e7d457d82d59c0d5bd24b5fc5cdb90939f5b5",
+    "stderr_hash": "49e1fefdb7d4b7c2db9b853af658ec20a76eb4bcc94979f08aa8c180",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -212,25 +212,31 @@ semantic error: Type mismatch in assignment, the types must be compatible
    | ^       ^^^ type mismatch (integer and string)
 
 semantic error: Subroutine `bpe` called as a function
-  --> tests/errors/continue_compilation_3.f90:89:9
+  --> tests/errors/continue_compilation_3.f90:89:5
    |
-89 |     i = bpe()
-   |         ^^^^^ 
+89 | i = bpe()
+   |     ^^^^^ 
+
+semantic error: Variable 'xx' is not declared
+  --> tests/errors/continue_compilation_3.f90:90:10
+   |
+90 | print *, xx
+   |          ^^ 'xx' is undeclared
 
 semantic error: Argument of `size` must be an array
-  --> tests/errors/continue_compilation_3.f90:92:18
+  --> tests/errors/continue_compilation_3.f90:93:14
    |
-92 |         print *, size(bpe)
-   |                  ^^^^^^^^^ 
+93 |     print *, size(bpe)
+   |              ^^^^^^^^^ 
 
 semantic error: Variable 'd' is not declared
-  --> tests/errors/continue_compilation_3.f90:93:15
+  --> tests/errors/continue_compilation_3.f90:94:11
    |
-93 |         bpe = d
-   |               ^ 'd' is undeclared
+94 |     bpe = d
+   |           ^ 'd' is undeclared
 
 semantic error: Assignment to subroutine is not allowed
-  --> tests/errors/continue_compilation_3.f90:93:9
+  --> tests/errors/continue_compilation_3.f90:94:5
    |
-93 |         bpe = d
-   |         ^^^ 
+94 |     bpe = d
+   |     ^^^ 


### PR DESCRIPTION
I think this should fix https://github.com/lfortran/lfortran-lsp/issues/21