### PR TITLE
Adds support for looking up symbols from just right of their word boundaries

### DIFF
--- a/src/libasr/lsp.cpp
+++ b/src/libasr/lsp.cpp
@@ -344,6 +344,14 @@ int get_errors(const std::string &infile, CompilerOptions &compiler_options)
     return 0;
 }
 
+bool is_id_chr(const char c)
+{
+    return (('a' <= c) && (c <= 'z'))
+        || (('A' <= c) && (c <= 'Z'))
+        || (('0' <= c) && (c <= '9'))
+        || (c == '_');
+}
+
 int get_definitions(const std::string &infile, LCompilers::CompilerOptions &compiler_options)
 {
     std::string input = read_file(infile);
@@ -366,6 +374,10 @@ int get_definitions(const std::string &infile, LCompilers::CompilerOptions &comp
             uint16_t l = std::stoi(compiler_options.line);
             uint16_t c = std::stoi(compiler_options.column);
             uint64_t pos = lm.linecol_to_pos(l, c);
+            if (c > 0 && !is_id_chr(input[pos]) && is_id_chr(input[pos - 1])) {
+                // pos is to the right of the word boundary
+                pos--;
+            }
             LCompilers::ASR::asr_t* asr = fe.handle_lookup_name(x.result, pos);
             LCompilers::document_symbols loc;
             if (!ASR::is_a<ASR::symbol_t>(*asr)) {

--- a/src/libasr/lsp.cpp
+++ b/src/libasr/lsp.cpp
@@ -374,7 +374,7 @@ int get_definitions(const std::string &infile, LCompilers::CompilerOptions &comp
             uint16_t l = std::stoi(compiler_options.line);
             uint16_t c = std::stoi(compiler_options.column);
             uint64_t pos = lm.linecol_to_pos(l, c);
-            if (c > 0 && !is_id_chr(input[pos]) && is_id_chr(input[pos - 1])) {
+            if (c > 0 && pos > 0 && !is_id_chr(input[pos]) && is_id_chr(input[pos - 1])) {
                 // pos is to the right of the word boundary
                 pos--;
             }

--- a/tests/lookup_name2.f90
+++ b/tests/lookup_name2.f90
@@ -1,0 +1,6 @@
+program lookup_name1
+implicit none
+integer :: x
+x = (2+3)*5
+print *, x
+end program

--- a/tests/reference/lookup_name-lookup_name2-458b8c9.json
+++ b/tests/reference/lookup_name-lookup_name2-458b8c9.json
@@ -1,0 +1,13 @@
+{
+    "basename": "lookup_name-lookup_name2-458b8c9",
+    "cmd": "lfortran --lookup-name --no-color {infile} -o {outfile}",
+    "infile": "tests/lookup_name2.f90",
+    "infile_hash": "6040a3665d4455ccb812ccc763c7d458221ef5b0eb639ed341de0618",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "lookup_name-lookup_name2-458b8c9.stdout",
+    "stdout_hash": "72914321b0ec49b432ce8f222354a5a7c73e70b2e41061ca43fa7720",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/lookup_name-lookup_name2-458b8c9.stdout
+++ b/tests/reference/lookup_name-lookup_name2-458b8c9.stdout
@@ -1,0 +1,1 @@
+[{"kind":13,"location":{"range":{"start":{"character":12,"line":2},"end":{"character":12,"line":2}},"uri":"uri"},"name":"x"}]

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4361,6 +4361,12 @@ line = 3
 column = 12
 
 [[test]]
+filename = "lookup_name2.f90"
+lookup_name = true
+line = 5
+column = 11
+
+[[test]]
 filename = "errors/func_parameter_type.f90"
 asr = true
 


### PR DESCRIPTION
Migrates the corresponding logic from lfortran-lsp to here: https://github.com/lfortran/lfortran-lsp/pull/31