### PR TITLE
Handling Assignment for Array having Array Section for Array Indexing

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -541,6 +541,7 @@ RUN(NAME pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME array_indices_array_section_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_EXPERIMENTAL_SIMPLIFIER)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran llvm)

--- a/integration_tests/array_indices_array_section_assignment.f90
+++ b/integration_tests/array_indices_array_section_assignment.f90
@@ -1,0 +1,8 @@
+program test 
+integer :: A(3) = [1,2,3]
+integer :: X(2) = [1,2]
+integer :: Y = 2
+A(X(:)) = Y
+if (A(1) /= 2) error stop
+if (A(2) /= 2) error stop
+end program

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -2038,7 +2038,57 @@ class ArrayOpVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisit
                     if (ASR::is_a<ASR::ArrayItem_t>(*x.m_target)) {
                         ASR::ArrayItem_t *array_item = ASR::down_cast<ASR::ArrayItem_t>(x.m_target);
                         for (size_t i=0;i<array_item->n_args;i++) {
-                            if (ASRUtils::is_array(ASRUtils::expr_type(array_item->m_args[i].m_right))){
+                            if (ASR::is_a<ASR::ArraySection_t>(*array_item->m_args->m_right)){
+                                ASR::ArraySection_t* array_section = ASR::down_cast<ASR::ArraySection_t>(array_item->m_args->m_right);
+                                ASRUtils::ASRBuilder b(al, array_section->base.base.loc);
+
+                                ASR::ttype_t* integer_type = ASR::down_cast<ASR::ttype_t>(
+                                    ASR::make_Integer_t(al, array_section->base.base.loc, 4));
+                                ASR::expr_t* itr = PassUtils::create_var(
+                                    0, "itr", array_section->base.base.loc, integer_type, al, current_scope);
+
+                                ASR::expr_t* lbound = array_section->m_args->m_left;
+                                ASR::expr_t* ubound = array_section->m_args->m_right;
+
+                                Vec<ASR::array_index_t> inner_arr_dims;
+                                inner_arr_dims.reserve(al, 1);
+
+                                ASR::array_index_t inner_ai;
+                                inner_ai.loc = array_section->base.base.loc;
+                                inner_ai.m_left = nullptr;
+                                inner_ai.m_right = itr;
+                                inner_ai.m_step = nullptr;
+                                inner_arr_dims.push_back(al, inner_ai);
+
+                                ASR::expr_t* inner_index = ASRUtils::EXPR(ASR::make_ArrayItem_t(
+                                    al, array_section->base.base.loc, array_section->m_v, inner_arr_dims.p,
+                                    inner_arr_dims.n, ASRUtils::type_get_past_array_pointer_allocatable(
+                                        ASRUtils::expr_type(array_section->m_v)),
+                                    ASR::arraystorageType::ColMajor, nullptr));
+
+                                Vec<ASR::array_index_t> outer_arr_dims;
+                                outer_arr_dims.reserve(al, 1);
+
+                                ASR::array_index_t outer_ai;
+                                outer_ai.loc = array_item->m_v->base.loc;
+                                outer_ai.m_left = nullptr;
+                                outer_ai.m_right = inner_index;
+                                outer_ai.m_step = nullptr;
+                                outer_arr_dims.push_back(al, outer_ai);
+
+                                ASR::expr_t* outer_index = ASRUtils::EXPR(ASR::make_ArrayItem_t(
+                                    al, array_item->m_v->base.loc, array_item->m_v, outer_arr_dims.p,
+                                    outer_arr_dims.n, ASRUtils::type_get_past_array_pointer_allocatable(
+                                        ASRUtils::expr_type(array_item->m_v)),
+                                    ASR::arraystorageType::ColMajor, nullptr));
+                                
+                                // multidimensional - array section is yet to handled using a recursive code with similar logic.
+                                pass_result.push_back(al,
+                                    b.DoLoop(itr, lbound, ubound, {
+                                        b.Assignment(outer_index, array_broadcast->m_array),
+                                    }, nullptr)
+                                );
+                            } else if (ASRUtils::is_array(ASRUtils::expr_type(array_item->m_args[i].m_right))){
                                 ASRUtils::ASRBuilder b(al, array_item->base.base.loc);
 
                                 ASR::ttype_t* integer_type = ASR::down_cast<ASR::ttype_t>(


### PR DESCRIPTION
Fixes #5516 

Enables Assignment with ArraySection as Array Reference.

MRE 1 :- 
```
program test 
integer :: A(3) = [1,2,3]
integer :: X(2) = [1,2]
integer :: Y = 2
A(X(:)) = Y
print * , A
end program
```

LFortran output :- 
```
(lf) lordansh@LordAnsh:~/dev/lfort3/lfortran$ ./src/bin/lfortran try.f90
2    2    3
```

MRE 2 :-
```
program test 
integer :: A(4) = [1,2,3,4]
integer :: X(3) = [1,2,3]
integer :: Y = 0
A(X(1:2)) = Y
print * , A
end program
```

LFortran output :- 
```
(lf) lordansh@LordAnsh:~/dev/lfort3/lfortran$ ./src/bin/lfortran try.f90
0    0    3    4
```