### PR TITLE
fix: extract value from first argument in findloc and use it

### DIFF
--- a/integration_tests/intrinsics_301.f90
+++ b/integration_tests/intrinsics_301.f90
@@ -16,6 +16,9 @@ program intrinsics_301
     integer(4), parameter :: i13 = findloc([1, 3, 2, 3], 3, 1, mask = [.true., .true., .false., .true.], back = .true., kind = 4)
 
     integer :: x1(5) = [1, 3, 2, 4, 2], y1 = 2
+    integer, parameter :: x1_param(5) = [1, 3, 2, 4, 2]
+    integer, parameter :: y1_param = 2
+    integer, parameter :: i14(1) = findloc(x1_param, y1_param)
     real :: x2(5) = [1.0, 3.0, 2.0, 4.0, 2.0], y2 = 2.0
     character(len=2) :: x3(3) = ["aa", "db", "ca"], y3 = "aa"
     logical :: mask1(5) = [.true., .true., .false., .true., .true.]
@@ -78,5 +81,8 @@ program intrinsics_301
     
     print *, kind(findloc(["aa", "db", "ca"], "aa", 1, mask = [.false., .false., .false.], kind = 8))
     if (kind(findloc(["aa", "db", "ca"], "db", 1, mask = [.false., .false., .false.], kind = 8)) /= 8) error stop
+
+    print *, i14
+    if (any(i14 /= 3)) error stop
     
 end program intrinsics_301

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3304,11 +3304,12 @@ namespace FindLoc {
         ASR::expr_t* dim = args[2];
         if (!array) return nullptr;
         if (!value) return nullptr;
-        if (extract_n_dims_from_ttype(expr_type(args[0])) == 1) {
+        if (extract_n_dims_from_ttype(expr_type(array)) == 1) {
             int arr_size = 0;
+            ASR::expr_t* array_value = ASRUtils::expr_value(array);
             ASR::ArrayConstant_t *arr = nullptr;
-            if (ASR::is_a<ASR::ArrayConstant_t>(*array)) {
-                arr = ASR::down_cast<ASR::ArrayConstant_t>(array);
+            if (array_value && ASR::is_a<ASR::ArrayConstant_t>(*array_value)) {
+                arr = ASR::down_cast<ASR::ArrayConstant_t>(array_value);
                 arr_size = ASRUtils::get_fixed_size_of_array(arr->m_type);
             } else {
                 return nullptr;
@@ -3345,11 +3346,11 @@ namespace FindLoc {
             } else {
                 double ele = 0;
                 if (is_integer(*ASRUtils::expr_type(args[1]))) {
-                    ele = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+                    ele = ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::expr_value(args[1]))->m_n;
                 } else if (is_real(*ASRUtils::expr_type(args[1]))) {
-                    ele = ASR::down_cast<ASR::RealConstant_t>(args[1])->m_r;
+                    ele = ASR::down_cast<ASR::RealConstant_t>(ASRUtils::expr_value(args[1]))->m_r;
                 } else if (is_logical(*ASRUtils::expr_type(args[1]))) {
-                    ele = ASR::down_cast<ASR::LogicalConstant_t>(args[1])->m_value;
+                    ele = ASR::down_cast<ASR::LogicalConstant_t>(ASRUtils::expr_value(args[1]))->m_value;
                 }
                 for (int i = element_idx; i < arr_size; i++) {
                     if (((bool*)mask->m_data)[i] != 0) {


### PR DESCRIPTION
## Description

The below Fortran program doesn't work in *main*, this PR fixes it:
```f90
program main
    implicit none
    integer, parameter :: x1(5) = [1, 3, 2, 4, 2]
    integer, parameter :: y1 = 2
    integer, parameter :: i14(1) = findloc(x1, y1)
end program main

```