### PR TITLE
enh:Fortran Backend: Nullify Visitor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1917,6 +1917,9 @@ RUN(NAME openmp_39 LABELS gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_40 LABELS llvm_omp llvm)
 RUN(NAME openmp_41 LABELS llvm_omp llvm)
 
+RUN(NAME nullify_01 LABELS gfortran fortran llvm)
+RUN(NAME nullify_02 LABELS gfortran fortran llvm)
+
 RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME fortran_02 LABELS gfortran fortran)
 

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1275,11 +1275,10 @@ public:
         std::string r = indent;
         r += "nullify (";
         for (int i = 0; i < static_cast<int>(x.n_vars); i++) {
-            if(x.m_vars[i]->type == ASR::Variable) {
-                r += ASRUtils::symbol_name(x.m_vars[i]);
-                if(i != static_cast<int>(x.n_vars-1)) {
-                    r += ", ";
-                }
+            visit_expr(*x.m_vars[i]);
+            r += src;
+            if(i != static_cast<int>(x.n_vars-1)) {
+                r += ", ";
             }
         }
         r += ")";

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -721,6 +721,9 @@ public:
         if (x.m_value_attr) {
             r += ", value";
         }
+        if (x.m_target_attr) {
+            r += ", target";
+        }
         r += " :: ";
         r.append(x.m_name);
         if (x.m_symbolic_value && x.m_value && ASR::is_a<ASR::StringChr_t>(*x.m_symbolic_value) && ASR::is_a<ASR::StringConstant_t>(*x.m_value)) {

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1271,7 +1271,22 @@ public:
         src = r;
     }
 
-    // void visit_Nullify(const ASR::Nullify_t &x) {}
+    void visit_Nullify(const ASR::Nullify_t &x) {
+        std::string r = indent;
+        r += "nullify (";
+        for (int i = 0; i < static_cast<int>(x.n_vars); i++) {
+            if(x.m_vars[i]->type == ASR::Variable) {
+                r += ASRUtils::symbol_name(x.m_vars[i]);
+                if(i != static_cast<int>(x.n_vars-1)) {
+                    r += ", ";
+                }
+            }
+        }
+        r += ")";
+        handle_line_truncation(r, 2);
+        r += "\n";
+        src = r;
+    }
 
     // void visit_Flush(const ASR::Flush_t &x) {}
 


### PR DESCRIPTION
This PR adds a Nullify visitor in the fortran backend
```fortran
 aditya-trivedi   lfortran    fortran ≢    cat ./integration_tests/nullify_02.f90 
program nullify_02
implicit none

   real, pointer :: p1
   real, target :: t1 
   integer, pointer :: p2
   integer, target :: t2
   
   p1=>t1
   p1 = 1
   p2=>t2
   p2 = 2.
   nullify(p1, p2) 
   
   
end program nullify_02
 aditya-trivedi   lfortran    fortran ≢    lfortran ./integration_tests/nullify_02.f90 --show-fortran --show-stacktrace
program nullify_02
implicit none
real(4), pointer :: p1
integer(4), pointer :: p2
real(4) :: t1
integer(4) :: t2
p1 => t1
p1 = real(1, kind=4)
p2 => t2
p2 = int(2.00000000e+00, kind=4)
nullify (p1, p2)
end program nullify_02
 aditya-trivedi   lfortran    fortran ≢   
```