### PR TITLE
ci: setup POT3D ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -508,6 +508,20 @@ jobs:
             git checkout b3f5b55c94b3b0b2568fe9af97a8e34a48cac7b4
             FC="$(pwd)/../src/bin/lfortran --cpp --skip-pass=pass_array_by_data" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe
+      
+      - name: Test POT3D
+        shell: bash -e -l {0}
+        if: contains(matrix.llvm-version, '11') && contains(matrix.os, 'macos')
+        run: |
+            git clone https://github.com/gxyd/pot3d.git
+            FC="$(pwd)/src/bin/lfortran"
+            cd pot3d
+            git checkout -t origin/mpi_with_workaround
+            git checkout 9fb077f667e7eef7799cf7f3a7f0a42cd2c5c85e
+            cd src
+            $FC -c mpi.f90
+            $FC -c psi_io.f90
+            $FC pot3d.F --cpp --implicit-interface --fixed-form --show-asr
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}


### PR DESCRIPTION
## Description

The third party repository [predsci/POT3D](https://github.com/predsci/POT3D), which is being tracked at the issue: https://github.com/lfortran/lfortran/issues/2862, now compiles to ASR with LFortran.

This PR ensures that we test it at the CI now.