### PR TITLE
Improve handling of `ArrayItem`/`ArraySection` with array indices

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -541,7 +541,7 @@ RUN(NAME pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-RUN(NAME array_indices_array_section_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_EXPERIMENTAL_SIMPLIFIER)
+RUN(NAME array_indices_array_section_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # GFortran
 RUN(NAME arrays_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -28,7 +28,7 @@ message("FAST: ${FAST}")
 message("EXPERIMENTAL_SIMPLIFIER: ${EXPERIMENTAL_SIMPLIFIER}")
 
 
-macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
+macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS RUN_ONLY_EXPERIMENTAL_SIMPLIFIER)
     set(fail ${${RUN_FAIL}})
     set(name ${${RUN_NAME}})
     set(file_name ${${RUN_FILE_NAME}})
@@ -43,7 +43,12 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
     endif()
 
     if (LFORTRAN_BACKEND)
-        if (${LFORTRAN_BACKEND} IN_LIST labels)
+        if (RUN_ONLY_EXPERIMENTAL_SIMPLIFIER AND (NOT EXPERIMENTAL_SIMPLIFIER))
+            # Do not run this test because this only works with simplifier pass
+            # We need to run it for simplifier pass to make sure there is no regression
+            # there.
+            set(ADD_TEST OFF)
+        elseif (${LFORTRAN_BACKEND} IN_LIST labels)
             # Test is supported by the given LFortran backend
             set(ADD_TEST ON)
         else()
@@ -168,7 +173,7 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
 endmacro(RUN_UTIL)
 
 macro(RUN)
-    set(options FAIL NOFAST NO_EXPERIMENTAL_SIMPLIFIER)
+    set(options FAIL NOFAST NO_EXPERIMENTAL_SIMPLIFIER ONLY_EXPERIMENTAL_SIMPLIFIER)
     set(oneValueArgs NAME INCLUDE_PATH  COPY_TO_BIN)
     set(multiValueArgs LABELS EXTRAFILES EXTRA_ARGS GFORTRAN_ARGS)
     cmake_parse_arguments(RUN "${options}" "${oneValueArgs}"
@@ -195,15 +200,16 @@ macro(RUN)
     endif()
 
     if (NOT FAST)
-        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
+        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS RUN_ONLY_EXPERIMENTAL_SIMPLIFIER)
     endif()
 
     if ((FAST) AND (NOT RUN_NOFAST))
         set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} --fast)
         set(RUN_NAME "${RUN_NAME}_FAST")
         list(REMOVE_ITEM RUN_LABELS gfortran) # remove gfortran from --fast test
-        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
+        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS RUN_ONLY_EXPERIMENTAL_SIMPLIFIER)
     endif()
+
 endmacro(RUN)
 
 # only compiles till object file
@@ -1691,6 +1697,7 @@ RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_indices_array_item_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_EXPERIMENTAL_SIMPLIFIER)
+RUN(NAME array_indices_array_item_assignment_1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER)
 
 RUN(NAME implicit_argument_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-argument-casting

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1696,7 +1696,7 @@ RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
-RUN(NAME array_indices_array_item_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_EXPERIMENTAL_SIMPLIFIER)
+RUN(NAME array_indices_array_item_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_item_assignment_1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER)
 
 RUN(NAME implicit_argument_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/array_indices_array_item.f90
+++ b/integration_tests/array_indices_array_item.f90
@@ -11,23 +11,22 @@ program array_indices_array_item
 
     ! Initialize the matrices and arrays
     arr_1 = reshape([1.0, 2.0, 3.0, 4.0], shape(arr_1))
-    arr_3 = reshape([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 5.0], shape(arr_3))
+    arr_3 = reshape([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0], shape(arr_3))
     arr_idx = [2, 1]
     allocate(arr_idx2(2))
     arr_idx2 = [2, 1]
 
      !Slicing
     arr_2 = arr_1(arr_idx, 1)
-    arr_2_reshape = reshape([3.0, 1.0], shape(arr_2_reshape));
+    arr_2_reshape = reshape([2.0, 1.0], shape(arr_2_reshape));
     print *, rank(arr_2)
     if (rank(arr_2) /= 1) error stop
-    if (all(arr_2 /= arr_2_reshape)) error stop
+    if (any(arr_2 /= arr_2_reshape)) error stop
 
     arr_4 = arr_3(1, arr_idx, arr_idx)
-    arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
-    print *, rank(arr_4)
+    arr_4_reshape = reshape([3.0, 1.0, 3.0, 1.0], shape(arr_4_reshape));
     if (rank(arr_4) /= 2) error stop
-    if (all(arr_4 /= arr_4_reshape)) error stop
+    if (any(arr_4 /= arr_4_reshape)) error stop
 
     rank_val = rank(arr_3(1, arr_idx, 2))
     print *, rank_val
@@ -38,16 +37,16 @@ program array_indices_array_item
     if (rank_val /= 1) error stop
 
     arr_2 = arr_1(arr_idx2, 1)
-    arr_2_reshape = reshape([3.0, 1.0], shape(arr_2_reshape));
+    arr_2_reshape = reshape([2.0, 1.0], shape(arr_2_reshape));
     print *, rank(arr_2)
     if (rank(arr_2) /= 1) error stop
-    if (all(arr_2 /= arr_2_reshape)) error stop
+    if (any(arr_2 /= arr_2_reshape)) error stop
 
     arr_4 = arr_3(1, arr_idx2, arr_idx2)
-    arr_4_reshape = reshape([4.0, 2.0, 3.0, 1.0], shape(arr_4_reshape));
+    arr_4_reshape = reshape([3.0, 1.0, 3.0, 1.0], shape(arr_4_reshape));
     print *, rank(arr_4)
     if (rank(arr_4) /= 2) error stop
-    if (all(arr_4 /= arr_4_reshape)) error stop
+    if (any(arr_4 /= arr_4_reshape)) error stop
 
     rank_val = rank(arr_3(1, arr_idx2, 2))
     print *, rank_val
@@ -58,6 +57,6 @@ program array_indices_array_item
     rank_val = rank(arr(arr_idx, 1))
     print *, rank_val
     if (rank_val /= 1) error stop
-    if (all(arr(arr_idx, 1) /= [3, 1])) error stop
+    if (any(arr(arr_idx, 1) /= [2, 1])) error stop
 
 end program array_indices_array_item

--- a/integration_tests/array_indices_array_item_assignment.f90
+++ b/integration_tests/array_indices_array_item_assignment.f90
@@ -1,8 +1,8 @@
-program array_indices_array_item_assignment 
+program array_indices_array_item_assignment
 integer :: A(3) = [1,2,3]
 integer :: X(2) = [1,2]
 integer :: Y = 2
 A(X) = Y
-if (A(1) /= 2) error stop
-if (A(2) /= 2) error stop
+print *, A
+if( any(A /= [2, 2, 3]) ) error stop
 end program

--- a/integration_tests/array_indices_array_item_assignment_1.f90
+++ b/integration_tests/array_indices_array_item_assignment_1.f90
@@ -1,0 +1,14 @@
+program array_indices_array_item_assignment
+integer :: A(3, 2) = reshape([1, 2, 3, 4, 5, 6], [3, 2]), Acorrect(6)
+integer :: B(3, 2)
+integer :: X(2) = [1,2]
+integer, allocatable :: Y(:)
+! integer :: i, j, k
+allocate(Y(2))
+Y = 2
+B = 2
+A(X, X) = B(X, Y)
+Acorrect = reshape(A, [6])
+print *, Acorrect
+if( any(Acorrect /= [2, 2, 3, 2, 2, 6]) ) error stop
+end program

--- a/integration_tests/array_indices_array_section.f90
+++ b/integration_tests/array_indices_array_section.f90
@@ -16,18 +16,18 @@ program array_indices_array_section
     arr_2_reshape = reshape([2.0, 1.0, 4.0, 3.0], shape(arr_2_reshape));
     print *, rank(arr_2)
     if (rank(arr_2) /= 2) error stop
-    if (all(arr_2 /= arr_2_reshape)) error stop
+    if (any(arr_2 /= arr_2_reshape)) error stop
 
     arr_4 = arr_3(:, :, arr_idx)
     arr_4_reshape = reshape([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0], shape(arr_4_reshape));
     print *, rank(arr_4)
     if (rank(arr_4) /= 3) error stop
-    if (all(arr_4 /= arr_4_reshape)) error stop
+    if (any(arr_4 /= arr_4_reshape)) error stop
 
     arr_4 = arr_3(:, arr_idx, :)
     arr_4_reshape = reshape([3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0], shape(arr_4_reshape));
     print *, rank(arr_4)
     if (rank(arr_4) /= 3) error stop
-    if (all(arr_4 /= arr_4_reshape)) error stop
+    if (any(arr_4 /= arr_4_reshape)) error stop
 
 end program array_indices_array_section

--- a/integration_tests/array_indices_array_section_assignment.f90
+++ b/integration_tests/array_indices_array_section_assignment.f90
@@ -1,8 +1,8 @@
-program test 
+program test
 integer :: A(3) = [1,2,3]
 integer :: X(2) = [1,2]
 integer :: Y = 2
 A(X(:)) = Y
-if (A(1) /= 2) error stop
-if (A(2) /= 2) error stop
+print *, A
+if( any(A /= [2, 2, 3]) ) error stop
 end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -6253,11 +6253,25 @@ static inline ASR::expr_t* extract_array_variable(ASR::expr_t* x) {
         return ASR::down_cast<ASR::ArrayItem_t>(x)->m_v;
     } else if( x->type == ASR::exprType::ArraySection ) {
         return ASR::down_cast<ASR::ArraySection_t>(x)->m_v;
-    } else {
-        LCOMPILERS_ASSERT(false);
     }
 
-    return nullptr;
+    return x;
+}
+
+static inline void extract_indices(ASR::expr_t* x,
+    ASR::array_index_t*& m_args, size_t& n_args) {
+    if( x->type == ASR::exprType::ArrayItem ) {
+        m_args = ASR::down_cast<ASR::ArrayItem_t>(x)->m_args;
+        n_args = ASR::down_cast<ASR::ArrayItem_t>(x)->n_args;
+        return ;
+    } else if( x->type == ASR::exprType::ArraySection ) {
+        m_args = ASR::down_cast<ASR::ArraySection_t>(x)->m_args;
+        n_args = ASR::down_cast<ASR::ArraySection_t>(x)->n_args;
+        return ;
+    }
+
+    m_args = nullptr;
+    n_args = 0;
 }
 
 static inline bool is_array_indexed_with_array_indices(ASR::array_index_t* m_args, size_t n_args) {

--- a/src/libasr/pass/array_op_simplifier.cpp
+++ b/src/libasr/pass/array_op_simplifier.cpp
@@ -456,6 +456,34 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
         }
     }
 
+    enum IndexType {
+        ScalarIndex, ArrayIndex
+    };
+
+    void set_index_variables(std::unordered_map<size_t, Vec<ASR::expr_t*>>& var2indices,
+                             std::unordered_map<ASR::expr_t*, std::pair<ASR::expr_t*, IndexType>>& index2var,
+                             size_t var_with_maxrank, size_t max_rank, int64_t loop_depth,
+                             Vec<ASR::stmt_t*>& dest_vec, const Location& loc) {
+        for( size_t i = 0; i < var2indices.size(); i++ ) {
+            if( i == var_with_maxrank ) {
+                continue;
+            }
+            ASR::expr_t* index_var = at(var2indices[i], loop_depth);
+            if( index_var == nullptr ) {
+                continue;
+            }
+            size_t bound_dim = loop_depth + max_rank + 1;
+            if( index2var[index_var].second == IndexType::ArrayIndex ) {
+                bound_dim = 1;
+            }
+            ASR::expr_t* lbound = PassUtils::get_bound(
+                index2var[index_var].first, bound_dim, "lbound", al);
+            ASR::stmt_t* set_index_var = ASRUtils::STMT(ASR::make_Assignment_t(
+                al, loc, index_var, lbound, nullptr));
+            dest_vec.push_back(al, set_index_var);
+        }
+    }
+
     template <typename T>
     void generate_loop_for_array_indexed_with_array_indices(const T& x,
         ASR::expr_t** target_address, ASR::expr_t** value_address,
@@ -464,15 +492,54 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
         ASR::expr_t* value = *value_address;
         size_t var_rank = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(target));
         Vec<ASR::expr_t*> vars_expr; vars_expr.reserve(al, 2);
-        vars_expr.push_back(al, target);
-        vars_expr.push_back(al, ASRUtils::extract_array_variable(value));
+        bool is_target_array = ASRUtils::is_array(ASRUtils::expr_type(target));
+        bool is_value_array = ASRUtils::is_array(ASRUtils::expr_type(value));
+
+        if( is_target_array )
+            vars_expr.push_back(al, ASRUtils::extract_array_variable(target));
+        if( is_value_array )
+            vars_expr.push_back(al, ASRUtils::extract_array_variable(value));
+
+        size_t offset_for_array_indices = 0;
+
+        ASR::array_index_t* m_args; size_t n_args;
+        if( is_target_array ) {
+            ASRUtils::extract_indices(target, m_args, n_args);
+            for( size_t i = 0; i < n_args; i++ ) {
+                if( m_args[i].m_left == nullptr &&
+                    m_args[i].m_right != nullptr &&
+                    m_args[i].m_step == nullptr ) {
+                    if( ASRUtils::is_array(ASRUtils::expr_type(
+                            m_args[i].m_right)) ) {
+                        vars_expr.push_back(al, m_args[i].m_right);
+                    }
+                }
+            }
+            offset_for_array_indices++;
+        }
+
+        if( is_value_array ) {
+            ASRUtils::extract_indices(value, m_args, n_args);
+            for( size_t i = 0; i < n_args; i++ ) {
+                if( m_args[i].m_left == nullptr &&
+                    m_args[i].m_right != nullptr &&
+                    m_args[i].m_step == nullptr ) {
+                    if( ASRUtils::is_array(ASRUtils::expr_type(
+                            m_args[i].m_right)) ) {
+                        vars_expr.push_back(al, m_args[i].m_right);
+                    }
+                }
+            }
+            offset_for_array_indices++;
+        }
 
         std::unordered_map<size_t, Vec<ASR::expr_t*>> var2indices;
+        std::unordered_map<ASR::expr_t*, std::pair<ASR::expr_t*, IndexType>> index2var;
         ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
-        for( size_t i = 0; i < 2; i++ ) {
+        for( size_t i = 0; i < vars_expr.size(); i++ ) {
             Vec<ASR::expr_t*> indices;
             indices.reserve(al, var_rank);
-            for( size_t j = 0; j < var_rank; j++ ) {
+            for( size_t j = 0; j < (i >= offset_for_array_indices ? 1 : var_rank); j++ ) {
                 std::string index_var_name = current_scope->get_unique_name(
                     "__libasr_index_" + std::to_string(j) + "_");
                 ASR::symbol_t* index = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
@@ -481,86 +548,126 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
                     ASR::abiType::Source, ASR::accessType::Public, ASR::presenceType::Required, false));
                 current_scope->add_symbol(index_var_name, index);
                 ASR::expr_t* index_expr = ASRUtils::EXPR(ASR::make_Var_t(al, loc, index));
+                index2var[index_expr] = std::make_pair(vars_expr[i],
+                    i >= offset_for_array_indices ? IndexType::ArrayIndex : IndexType::ScalarIndex);
                 indices.push_back(al, index_expr);
             }
             var2indices[i] = indices;
         }
 
-        Vec<ASR::array_index_t> indices;
-        indices.reserve(al, var_rank);
-        for( size_t j = 0; j < var_rank; j++ ) {
-            ASR::array_index_t array_index;
-            array_index.loc = loc;
-            array_index.m_left = nullptr;
-            array_index.m_right = var2indices[0][j];
-            array_index.m_step = nullptr;
-            indices.push_back(al, array_index);
-        }
-        ASR::ttype_t* var_i_type = ASRUtils::type_get_past_array_pointer_allocatable(
-            ASRUtils::expr_type(target));
-        *target_address = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc, target, indices.p,
-            indices.size(), var_i_type, ASR::arraystorageType::ColMajor, nullptr));
-
-        LCOMPILERS_ASSERT(ASR::is_a<ASR::ArraySection_t>(*value) ||
-                          ASR::is_a<ASR::ArrayItem_t>(*value));
-        ASR::array_index_t* m_args = nullptr;
-        size_t n_args = 0;
-        if( ASR::is_a<ASR::ArraySection_t>(*value) ) {
-            m_args = ASR::down_cast<ASR::ArraySection_t>(value)->m_args;
-            n_args = ASR::down_cast<ASR::ArraySection_t>(value)->n_args;
-        } else if( ASR::is_a<ASR::ArrayItem_t>(*value) ) {
-            m_args = ASR::down_cast<ASR::ArrayItem_t>(value)->m_args;
-            n_args = ASR::down_cast<ASR::ArrayItem_t>(value)->n_args;
-        }
-        LCOMPILERS_ASSERT(m_args != nullptr)
-        Vec<ASR::array_index_t> array_item_args;
-        array_item_args.reserve(al, n_args);
-        for( size_t i = 0, j = 0; i < n_args; i++ ) {
-            if( m_args[i].m_left == nullptr &&
-                m_args[i].m_right != nullptr &&
-                m_args[i].m_step == nullptr ) {
-                if( ASRUtils::is_array(ASRUtils::expr_type(
-                        m_args[i].m_right)) ) {
-                    ASR::array_index_t array_index;
-                    array_index.loc = loc;
-                    array_index.m_left = nullptr;
-                    Vec<ASR::array_index_t> indices1; indices1.reserve(al, 1);
-                    ASR::array_index_t index1; index1.loc = loc; index1.m_left = nullptr;
-                    // TODO: Create seprate indices for vector indices in array section
-                    index1.m_right = var2indices[0][j]; j++; index1.m_step = nullptr;
-                    indices1.push_back(al, index1);
-                    array_index.m_right = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc,
-                        m_args[i].m_right, indices1.p, 1, int32_type,
-                        ASR::arraystorageType::ColMajor, nullptr));
-                    array_index.m_step = nullptr;
-                    array_item_args.push_back(al, array_index);
+        size_t j = offset_for_array_indices;
+        if( is_target_array ) {
+            Vec<ASR::array_index_t> target_array_item_args;
+            target_array_item_args.reserve(al, n_args);
+            ASRUtils::extract_indices(target, m_args, n_args);
+            ASRUtils::ExprStmtDuplicator expr_duplicator(al);
+            Vec<ASR::expr_t*> new_target_indices; new_target_indices.reserve(al, n_args);
+            for( size_t i = 0; i < (n_args == 0 ? var_rank : n_args); i++ ) {
+                if( m_args && m_args[i].m_left == nullptr &&
+                    m_args[i].m_right != nullptr &&
+                    m_args[i].m_step == nullptr ) {
+                    if( ASRUtils::is_array(ASRUtils::expr_type(
+                            m_args[i].m_right)) ) {
+                        ASR::array_index_t array_index;
+                        array_index.loc = loc;
+                        array_index.m_left = nullptr;
+                        Vec<ASR::array_index_t> indices1; indices1.reserve(al, 1);
+                        ASR::array_index_t index1; index1.loc = loc; index1.m_left = nullptr;
+                        index1.m_right = var2indices[j][0]; index1.m_step = nullptr;
+                        new_target_indices.push_back(al, index1.m_right);
+                        indices1.push_back(al, index1);
+                        array_index.m_right = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc,
+                            m_args[i].m_right, indices1.p, 1, int32_type,
+                            ASR::arraystorageType::ColMajor, nullptr));
+                        array_index.m_step = nullptr;
+                        target_array_item_args.push_back(al, array_index);
+                        j++;
+                    } else {
+                        target_array_item_args.push_back(al, m_args[i]);
+                    }
                 } else {
-                    array_item_args.push_back(al, m_args[i]);
+                    ASR::array_index_t index1; index1.loc = loc; index1.m_left = nullptr;
+                    index1.m_right = var2indices[0][i]; index1.m_step = nullptr;
+                    target_array_item_args.push_back(al, index1);
+                    new_target_indices.push_back(al, var2indices[0][i]);
                 }
-            } else {
-                ASR::array_index_t index1; index1.loc = loc; index1.m_left = nullptr;
-                index1.m_right = var2indices[1][i]; index1.m_step = nullptr;
-                array_item_args.push_back(al, index1);
             }
+            var2indices[0] = new_target_indices;
+
+            ASR::ttype_t* target_type = ASRUtils::type_get_past_array_pointer_allocatable(
+                    ASRUtils::expr_type(target));
+            *target_address = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(
+                al, loc, ASRUtils::extract_array_variable(target), target_array_item_args.p,
+                target_array_item_args.size(), target_type, ASR::arraystorageType::ColMajor, nullptr));
         }
 
-        ASR::ttype_t* value_type = ASRUtils::type_get_past_array_pointer_allocatable(
-                ASRUtils::expr_type(value));
-        *value_address = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc, ASRUtils::extract_array_variable(value),
-            array_item_args.p, array_item_args.size(), value_type,
-            ASR::arraystorageType::ColMajor, nullptr));
+        if( is_value_array ) {
+            Vec<ASR::array_index_t> value_array_item_args;
+            value_array_item_args.reserve(al, n_args);
+            ASRUtils::extract_indices(value, m_args, n_args);
+            Vec<ASR::expr_t*> new_value_indices; new_value_indices.reserve(al, n_args);
+            for( size_t i = 0; i < (n_args == 0 ? var_rank : n_args); i++ ) {
+                if( m_args && m_args[i].m_left == nullptr &&
+                    m_args[i].m_right != nullptr &&
+                    m_args[i].m_step == nullptr ) {
+                    if( ASRUtils::is_array(ASRUtils::expr_type(
+                            m_args[i].m_right)) ) {
+                        ASR::array_index_t array_index;
+                        array_index.loc = loc;
+                        array_index.m_left = nullptr;
+                        Vec<ASR::array_index_t> indices1; indices1.reserve(al, 1);
+                        ASR::array_index_t index1; index1.loc = loc; index1.m_left = nullptr;
+                        index1.m_right = var2indices[j][0]; index1.m_step = nullptr;
+                        new_value_indices.push_back(al, index1.m_right);
+                        indices1.push_back(al, index1);
+                        array_index.m_right = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc,
+                            m_args[i].m_right, indices1.p, 1, int32_type,
+                            ASR::arraystorageType::ColMajor, nullptr));
+                        array_index.m_step = nullptr;
+                        value_array_item_args.push_back(al, array_index);
+                        j++;
+                    } else {
+                        value_array_item_args.push_back(al, m_args[i]);
+                    }
+                } else {
+                    ASR::array_index_t index1; index1.loc = loc; index1.m_left = nullptr;
+                    index1.m_right = var2indices[1][i]; index1.m_step = nullptr;
+                    value_array_item_args.push_back(al, index1);
+                    new_value_indices.push_back(al, var2indices[1][i]);
+                }
+            }
+            var2indices[1] = new_value_indices;
+
+            ASR::ttype_t* value_type = ASRUtils::type_get_past_array_pointer_allocatable(
+                    ASRUtils::expr_type(value));
+            *value_address = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(
+                al, loc, ASRUtils::extract_array_variable(value), value_array_item_args.p,
+                value_array_item_args.size(), value_type, ASR::arraystorageType::ColMajor, nullptr));
+        }
+
+        size_t vars_expr_size = vars_expr.size();
+        for( size_t i = offset_for_array_indices; i < vars_expr_size; i++ ) {
+            var2indices.erase(i);
+        }
+        vars_expr.n = offset_for_array_indices;
 
         size_t var_with_maxrank = 0;
 
         ASR::do_loop_head_t do_loop_head;
         do_loop_head.loc = loc;
         do_loop_head.m_v = at(var2indices[var_with_maxrank], -1);
-        do_loop_head.m_start = PassUtils::get_bound(target, var_rank, "lbound", al);
-        do_loop_head.m_end = PassUtils::get_bound(target, var_rank, "ubound", al);
+        size_t bound_dim = var_rank;
+        if( index2var[do_loop_head.m_v].second == IndexType::ArrayIndex ) {
+            bound_dim = 1;
+        }
+        do_loop_head.m_start = PassUtils::get_bound(
+            index2var[do_loop_head.m_v].first, bound_dim, "lbound", al);
+        do_loop_head.m_end = PassUtils::get_bound(
+            index2var[do_loop_head.m_v].first, bound_dim, "ubound", al);
         do_loop_head.m_increment = nullptr;
         Vec<ASR::stmt_t*> parent_do_loop_body; parent_do_loop_body.reserve(al, 1);
         Vec<ASR::stmt_t*> do_loop_body; do_loop_body.reserve(al, 1);
-        set_index_variables(var2indices, vars_expr, var_with_maxrank,
+        set_index_variables(var2indices, index2var, var_with_maxrank,
                             var_rank, -1, parent_do_loop_body, loc);
         do_loop_body.push_back(al, const_cast<ASR::stmt_t*>(&(x.base)));
         increment_index_variables(var2indices, var_with_maxrank, -1,
@@ -572,17 +679,21 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
         parent_do_loop_body.reserve(al, 1);
 
         for( int64_t i = -2; i >= -static_cast<int64_t>(var_rank); i-- ) {
-            set_index_variables(var2indices, vars_expr, var_with_maxrank,
+            set_index_variables(var2indices, index2var, var_with_maxrank,
                                 var_rank, i, parent_do_loop_body, loc);
             increment_index_variables(var2indices, var_with_maxrank, i,
                                       do_loop_body, loc);
             ASR::do_loop_head_t do_loop_head;
             do_loop_head.loc = loc;
             do_loop_head.m_v = at(var2indices[var_with_maxrank], i);
+            bound_dim = var_rank;
+            if( index2var[do_loop_head.m_v].second == IndexType::ArrayIndex ) {
+                bound_dim = 1;
+            }
             do_loop_head.m_start = PassUtils::get_bound(
-                vars_expr[var_with_maxrank], var_rank + i + 1, "lbound", al);
+                index2var[do_loop_head.m_v].first, bound_dim, "lbound", al);
             do_loop_head.m_end = PassUtils::get_bound(
-                vars_expr[var_with_maxrank], var_rank + i + 1, "ubound", al);
+                index2var[do_loop_head.m_v].first, bound_dim, "ubound", al);
             do_loop_head.m_increment = nullptr;
             ASR::stmt_t* do_loop = ASRUtils::STMT(ASR::make_DoLoop_t(al, loc, nullptr,
                 do_loop_head, do_loop_body.p, do_loop_body.size(), nullptr, 0));
@@ -784,10 +895,14 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
         }
         xx.m_value = ASRUtils::get_past_array_broadcast(xx.m_value);
         const Location loc = x.base.base.loc;
-        if( ASR::is_a<ASR::ArraySection_t>(*xx.m_value) || (
-            ASR::is_a<ASR::ArrayItem_t>(*xx.m_value) &&
-            ASRUtils::is_array_indexed_with_array_indices(
-                ASR::down_cast<ASR::ArrayItem_t>(xx.m_value))) ) {
+
+        #define is_array_indexed_with_array_indices_check(expr) \
+            ASR::is_a<ASR::ArraySection_t>(*expr) || ( \
+            ASR::is_a<ASR::ArrayItem_t>(*expr) && \
+            ASRUtils::is_array_indexed_with_array_indices( \
+                ASR::down_cast<ASR::ArrayItem_t>(expr)))
+        if( ( is_array_indexed_with_array_indices_check(xx.m_value) ) ||
+            ( is_array_indexed_with_array_indices_check(xx.m_target) ) ) {
             generate_loop_for_array_indexed_with_array_indices(
                 x, &(xx.m_target), &(xx.m_value), loc);
             return ;

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -431,19 +431,19 @@ create_unary_function(Erf, erf, erf)
 create_unary_function(Erfc, erfc, erfc)
 
 namespace Isnan{
-    static inline ASR::expr_t *eval_Isnan(Allocator &al, const Location &loc,     
-            ASR::ttype_t *t, Vec<ASR::expr_t*> &args,                           
-            diag::Diagnostics& /*diag*/) {                                      
-        double rv = ASR::down_cast<ASR::RealConstant_t>(args[0])->m_r;          
-        ASRUtils::ASRBuilder b(al, loc);                                        
-        return b.bool_t(std::isnan(rv), t);                                       
-    }  
-    static inline ASR::expr_t* instantiate_Isnan(Allocator &al,                  
-            const Location &loc, SymbolTable *scope,                            
-            Vec<ASR::ttype_t*> &arg_types, ASR::ttype_t *return_type,           
-            Vec<ASR::call_arg_t> &new_args, int64_t overload_id) {              
-        return UnaryIntrinsicFunction::instantiate_functions(al, loc, scope,    
-            "is_nan", arg_types[0], return_type, new_args, overload_id);     
+    static inline ASR::expr_t *eval_Isnan(Allocator &al, const Location &loc,
+            ASR::ttype_t *t, Vec<ASR::expr_t*> &args,
+            diag::Diagnostics& /*diag*/) {
+        double rv = ASR::down_cast<ASR::RealConstant_t>(args[0])->m_r;
+        ASRUtils::ASRBuilder b(al, loc);
+        return b.bool_t(std::isnan(rv), t);
+    }
+    static inline ASR::expr_t* instantiate_Isnan(Allocator &al,
+            const Location &loc, SymbolTable *scope,
+            Vec<ASR::ttype_t*> &arg_types, ASR::ttype_t *return_type,
+            Vec<ASR::call_arg_t> &new_args, int64_t overload_id) {
+        return UnaryIntrinsicFunction::instantiate_functions(al, loc, scope,
+            "is_nan", arg_types[0], return_type, new_args, overload_id);
     }
 }
 
@@ -3318,7 +3318,7 @@ namespace Mod {
         */
         int kind = ASRUtils::extract_kind_from_ttype_t(arg_types[1]);
         int kind2 = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
-        int upper_kind = std::max(kind, kind2); 
+        int upper_kind = std::max(kind, kind2);
         if (is_real(*arg_types[1])) {
             ASR::ttype_t* new_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, upper_kind));
             ASR::expr_t* arg0 = b.r2r_t(args[0], new_type);
@@ -3336,7 +3336,7 @@ namespace Mod {
 
             body.push_back(al, b.Assignment(result, b.Sub(arg0, b.Mul(arg1, b.Div(arg0, arg1)))));
         }
-        
+
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);


### PR DESCRIPTION
@advikkabra I have fixed the tests which we discussed today. `any` should be used instead of `all` to make sure that each and every element of the output is correct. Using `all` passes even if one element is correct. Please approve if you agree.