### PR TITLE
feat: add parser errors in diagnostics

### DIFF
--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -1803,8 +1803,8 @@ void add_ws_warning(const Location &loc,
                         {loc},
                         "help: write this as 'integer(8)'");
                 } else {
-                        throw LCompilers::LFortran::parser_local::ParserError(
-                        "kind " + std::to_string(a_kind) + " is not supported yet.", {loc});
+                        diagnostics.add(LCompilers::LFortran::parser_local::ParserError(
+                                "kind " + std::to_string(a_kind) + " is not supported yet.", {loc}).d);
                 }
         } else if (end_token == yytokentype::KW_CHARACTER) {
                 std::string msg1 = "Use character("+std::to_string(a_kind)+") instead of character*"+std::to_string(a_kind);

--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -306,6 +306,9 @@ program continue_compilation_2
     real(3) :: x
     !kind2
     real(*) kind2_a
+    !type_conflict1
+    integer, parameter, target :: foo=4
+    print *,foo
 
     contains
     logical function f(x)

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "9931599f732e3fe226a196d167337724c00c443cb0f18997008ec0de",
+    "infile_hash": "7ce55f8b446d9eb6c082a13b828fbdbb8edcbdb8ffe81e77fc44e578",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "c8589e608d32dd3cb089b3d2013f14e408db22387db5397de6762bad",
+    "stderr_hash": "ab2434ddc76881d183094599beb3405d0e193d629e84f54dcf1ba68d",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -85,6 +85,12 @@ semantic error: Expected initialization expression for kind
 308 |     real(*) kind2_a
     |          ^ 
 
+semantic error: Parameter attribute cannot be used with Target attribute
+   --> tests/errors/continue_compilation_2.f90:310:5
+    |
+310 |     integer, parameter, target :: foo=4
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: Unexpected args, SetExponent expects (real, int) as arguments
   --> tests/errors/continue_compilation_2.f90:23:14
    |
@@ -568,8 +574,14 @@ semantic error: Type mismatch in assignment, the types must be compatible
 280 |     tm2_x = 5 + "x"
     |     ^^^^^       ^^^ type mismatch (integer and string)
 
-semantic error: Cannot assign to an intent(in) variable `y`
-   --> tests/errors/continue_compilation_2.f90:321:5
+semantic error: Variable 'foo' is not declared
+   --> tests/errors/continue_compilation_2.f90:311:13
     |
-321 |     y = 99  
+311 |     print *,foo
+    |             ^^^ 'foo' is undeclared
+
+semantic error: Cannot assign to an intent(in) variable `y`
+   --> tests/errors/continue_compilation_2.f90:324:5
+    |
+324 |     y = 99  
     |     ^ 


### PR DESCRIPTION
I was trying a small POC to get the following file working using continue-compilation flag that had declaration statement. And this is what I discovered. 

File integer16.f90
```
cat integer16.f90
program integer16
        integer*16 x
end
```

Following is the behaviour after this fix.
```
lfortran integer16.f90 --continue-compilation --show-ast
syntax error: kind 16 is not supported yet.
 --> integer16.f90:2:2
  |
2 |  integer*16 x
  |  ^^^^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
(TranslationUnit
    [(Program
        integer16
        ()
        []
        []
        [(Declaration
            (AttrType
                TypeInteger
                [(()
                16
                Value)]
                ()
                ()
                None
            )
            []
            [(x
            []
            []
            ()
            ()
            None
            ())]
            ()
        )]
        []
        []
    )]
)
```


Current behaviour (latest main)
```
lfortran integer16.f90 --continue-compilation --show-ast
syntax error: kind 16 is not supported yet.
 --> /Users/parth1211/repos/lfortran/tests/errors/integer16.f90:2:2
  |
2 |  integer*16 x
  |  ^^^^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```


Also I am not really sure if this is the correct approach.