### PR TITLE
Fix: Use Var name in SubCall instead type_decl name

### DIFF
--- a/integration_tests/procedure_08.f90
+++ b/integration_tests/procedure_08.f90
@@ -2,16 +2,17 @@ module procedure_08_module
 contains
     subroutine cb(x)
         implicit none
-        integer, intent(in), optional :: x(:)
+        integer, intent(inout), optional :: x(:)
     end subroutine cb
 
     subroutine calfun(x)
         implicit none
-        integer, intent(in), optional :: x(:)
+        integer, intent(inout), optional :: x(:)
         logical :: y
+        x = 2
         y = present(x)
         print *, y
-        if (y) error stop
+        if (.not. y) error stop
     end subroutine calfun
 end module procedure_08_module
 
@@ -25,7 +26,12 @@ contains
     subroutine temp(call_back)
         implicit none
         procedure(cb), optional :: call_back
-        if(present(call_back)) call call_back()   
+        integer :: x(4) 
+        if(present(call_back)) then
+            call call_back(x) 
+            print *, x
+            if(x(1) /= 2) error stop
+        end if  
     end subroutine temp
     subroutine temp2(call_back)
         implicit none

--- a/integration_tests/procedure_08.f90
+++ b/integration_tests/procedure_08.f90
@@ -10,6 +10,7 @@ contains
         integer, intent(in), optional :: x(:)
         logical :: y
         y = present(x)
+        print *, y
         if (y) error stop
     end subroutine calfun
 end module procedure_08_module

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3938,7 +3938,7 @@ public:
 
     bool is_function_variable(const ASR::Variable_t &v) {
         if (v.m_type_declaration) {
-            return ASR::is_a<ASR::Function_t>(*v.m_type_declaration);
+            return ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(v.m_type_declaration));
         } else {
             return false;
         }
@@ -3966,7 +3966,7 @@ public:
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(s);
                 if (is_function_variable(*v)) {
                     // * Function (callback) Variable (`procedure(fn) :: x`)
-                    s = v->m_type_declaration;
+                    s = ASRUtils::symbol_get_past_external(v->m_type_declaration);
                 } else {
                     // * Variable (`integer :: x`)
                     ASR::Variable_t *arg = EXPR2VAR(x.m_args[i]);
@@ -9289,13 +9289,8 @@ public:
             proc_sym = clss_proc->m_proc;
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym)) {
             ASR::symbol_t *type_decl = ASR::down_cast<ASR::Variable_t>(proc_sym)->m_type_declaration;
-            LCOMPILERS_ASSERT(type_decl);
-            if (ASR::is_a<ASR::Function_t>(*type_decl)) {
-                s = ASR::down_cast<ASR::Function_t>(type_decl);
-            } else {
-                proc_sym = ASRUtils::symbol_get_past_external(type_decl);
-                s = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(type_decl));
-            }
+            LCOMPILERS_ASSERT(type_decl && ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(type_decl)));
+            s = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(type_decl));
         } else {
             throw CodeGenError("SubroutineCall: Symbol type not supported");
         }


### PR DESCRIPTION
Fixes #5603 
Refer https://github.com/lfortran/lfortran/issues/5603#issuecomment-2525200055.