### PR TITLE
fix: `is_statement_function` to not consider scalar constants arguments

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2560,11 +2560,20 @@ public:
                             return false;
                         } else {
                             bool no_array_sections = true;
+                            bool constant_args = false;
                             for (size_t i = 0; i < func_call_or_array->n_args; i++) {
                                 if (func_call_or_array->m_args[i].m_step != nullptr) {
                                     no_array_sections = false;
                                     break;
                                 }
+                                if ( func_call_or_array->m_args[i].m_end != nullptr &&
+                                     AST::is_a<AST::Num_t>(*func_call_or_array->m_args[i].m_end) ) {
+                                    constant_args = true;
+                                    break;
+                                }
+                            }
+                            if (constant_args) {
+                                return false;
                             }
                             if (no_array_sections) {
                                 return true;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4449,6 +4449,13 @@ public:
                   final_type = ASRUtils::type_get_past_pointer(
                         ASRUtils::type_get_past_allocatable(type));
                 }
+                if ( current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner) &&
+                    !ASR::is_a<ASR::Block_t>(*ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner)) &&
+                    !ASRUtils::is_array(ASRUtils::expr_type(v_Var))) {
+                    diag.add(Diagnostic("Array reference is not allowed on scalar variable",
+                        Level::Error, Stage::Semantic, {Label("", {loc})}));
+                    throw SemanticAbort();
+                }
                 return (ASR::asr_t*) replace_with_common_block_variables(ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc,
                     v_Var, args.p, args.size(), final_type,
                     ASR::arraystorageType::ColMajor, arr_ref_val)));

--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -93,6 +93,8 @@ call bpe()
 i = bpe()
 print *, xx
 test_re = 1245.13
+c(1) = 1
+
 contains
 subroutine bpe()
     print *, size(bpe)

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "b3efc6fbd42260be3987efd72e10acc8b9b8994b9e8575f75cb3c343",
+    "infile_hash": "62b1ba3219e6c357f0f311ff9583c76d9c8e3a773c11b2fc1b201c1d",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "ec104f49e948299a0309a618cd5b2754439c4bb17a73b2205fb1d27d",
+    "stderr_hash": "449f8fceab9310445e1d27777667c1e321cbf3f4571ebc8e107cb3ba",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -247,20 +247,26 @@ semantic error: Variable 'test_re' is not declared
 95 | test_re = 1245.13
    | ^^^^^^^ 'test_re' is undeclared
 
-semantic error: Argument of `size` must be an array
-  --> tests/errors/continue_compilation_3.f90:98:14
+semantic error: Array reference is not allowed on scalar variable
+  --> tests/errors/continue_compilation_3.f90:96:1
    |
-98 |     print *, size(bpe)
-   |              ^^^^^^^^^ 
+96 | c(1) = 1
+   | ^^^^ 
+
+semantic error: Argument of `size` must be an array
+   --> tests/errors/continue_compilation_3.f90:100:14
+    |
+100 |     print *, size(bpe)
+    |              ^^^^^^^^^ 
 
 semantic error: Variable 'd' is not declared
-  --> tests/errors/continue_compilation_3.f90:99:11
-   |
-99 |     bpe = d
-   |           ^ 'd' is undeclared
+   --> tests/errors/continue_compilation_3.f90:101:11
+    |
+101 |     bpe = d
+    |           ^ 'd' is undeclared
 
 semantic error: Assignment to subroutine is not allowed
-  --> tests/errors/continue_compilation_3.f90:99:5
-   |
-99 |     bpe = d
-   |     ^^^ 
+   --> tests/errors/continue_compilation_3.f90:101:5
+    |
+101 |     bpe = d
+    |     ^^^ 


### PR DESCRIPTION
While experimenting on examples with error resiliency, I found:


```fortran
program main
integer :: xy
xy(1) = 1
end program
```

Not working with `--continue-compilation` and `xy` being treated as `statement` function. This PR strengthens the logic for checking `statement` function, and makes the example error resilient.