### PR TITLE
fix: set return_type dimensions of 'cshift' intrinsic correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -955,6 +955,7 @@ RUN(NAME intrinsics_327 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_328 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_329 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #idnint
 RUN(NAME intrinsics_330 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #amax0, max1
+RUN(NAME intrinsics_331 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # cshift
 
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants

--- a/integration_tests/intrinsics_331.f90
+++ b/integration_tests/intrinsics_331.f90
@@ -1,0 +1,20 @@
+program intrinsics_331
+    implicit none
+    real :: arr1(2) = [1., 2.]
+    real :: arr2(2)
+    call shift_elemements(2, arr1, arr2)
+
+    print *, arr2
+    if (any(arr2 /= [2., 1.])) error stop
+    contains
+
+    ! shifts the elements present in 'in_arr' by one index
+    ! and outputs it in 'out_arr'
+    subroutine shift_elemements(nc, in_arr, out_arr)
+        implicit none
+        integer, intent(in) :: nc
+        real, dimension(nc), intent(in) :: in_arr
+        real, dimension(nc), intent(out) :: out_arr
+        out_arr = cshift(in_arr, shift=1)
+    end
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1668,10 +1668,11 @@ namespace Cshift {
             end do
         */
         if( !ASRUtils::is_fixed_size_array(return_type) ) {
+            int64_t n_dims_return_type = ASRUtils::extract_n_dims_from_ttype(return_type);
             bool is_allocatable = ASRUtils::is_allocatable(return_type);
             Vec<ASR::dimension_t> empty_dims;
             empty_dims.reserve(al, 2);
-            for( int idim = 0; idim < 2; idim++ ) {
+            for( int idim = 0; idim < n_dims_return_type; idim++ ) {
                 ASR::dimension_t empty_dim;
                 empty_dim.loc = loc;
                 empty_dim.m_start = nullptr;


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5653

Currently in *main*, the node for `result` set in `intrinsic_function` pass is (always set as `2`):
```clj
                                (Variable
                                    4
                                    result
                                    []
                                    Out
                                    ()
                                    ()
                                    Default
                                    (Array
                                        (Real 4)
                                        [(()
                                        ())
                                        (()
                                        ())]
                                        DescriptorArray
                                    )
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                ),
```

this PR fixes the dimensions to set it to same as the number of dimension of the input array (in the given set it's `1`):
```clj
                                (Variable
                                    4
                                    result
                                    []
                                    Out
                                    ()
                                    ()
                                    Default
                                    (Array
                                        (Real 4)
                                        [(()
                                        ())]
                                        DescriptorArray
                                    )
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                ),
```