### PR TITLE
fix: get_past_allocatable for return_type in cshift intrinsic

### DIFF
--- a/integration_tests/intrinsics_331.f90
+++ b/integration_tests/intrinsics_331.f90
@@ -1,3 +1,12 @@
+subroutine shift_allocatable_array ()
+    real(4), dimension(:), allocatable :: dc
+    allocate (dc(2))
+    dc = [1, 2]
+    print *, cshift(dc,-1)
+    deallocate(dc)
+    return
+end
+
 program intrinsics_331
     implicit none
     real :: arr1(2) = [1., 2.]
@@ -6,6 +15,9 @@ program intrinsics_331
 
     print *, arr2
     if (any(arr2 /= [2., 1.])) error stop
+
+    ! TODO: this causes segmentation fault currently
+    ! call shift_allocatable_array()
     contains
 
     ! shifts the elements present in 'in_arr' by one index

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -226,6 +226,12 @@ static inline ASR::ttype_t* extract_type(ASR::ttype_t *f) {
                 type_get_past_pointer(f)));
 }
 
+static inline ASR::ttype_t* type_get_past_allocatable_pointer(ASR::ttype_t* f) {
+    return type_get_past_allocatable(
+        type_get_past_pointer(f)
+    );
+}
+
 static inline int extract_kind_from_ttype_t(const ASR::ttype_t* type) {
     if (type == nullptr) {
         return -1;

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1603,9 +1603,9 @@ namespace Cshift {
             is_dim_present = true;
         }
 
-        ASR::ttype_t *type_array = expr_type(array);
-        ASR::ttype_t *type_shift = expr_type(shift);
-        ASR::ttype_t *ret_type = expr_type(array);
+        ASR::ttype_t *type_array = ASRUtils::type_get_past_allocatable_pointer(expr_type(array));
+        ASR::ttype_t *type_shift = ASRUtils::type_get_past_allocatable_pointer(expr_type(shift));
+        ASR::ttype_t *ret_type = ASRUtils::type_get_past_allocatable_pointer(expr_type(array));
         if ( !is_array(type_array) ) {
             append_error(diag, "The argument `array` in `cshift` must be of type Array", array->base.loc);
             return nullptr;

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -521,6 +521,26 @@ bool set_allocation_size(
                     }
                     break;
                 }
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Cshift): {
+                    size_t n_dims = ASRUtils::extract_n_dims_from_ttype(intrinsic_array_function->m_type);
+                    allocate_dims.reserve(al, n_dims);
+                    for (size_t i = 0; i < n_dims; i++) {
+                        ASR::dimension_t allocate_dim;
+                        allocate_dim.loc = loc;
+                        allocate_dim.m_start = int32_one;
+
+                        ASR::expr_t* size_i = ASRUtils::EXPR(ASR::make_ArraySize_t(
+                            al, loc, intrinsic_array_function->m_args[0],
+                            ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                al, loc, i + 1, ASRUtils::expr_type(int32_one))),
+                            ASRUtils::expr_type(int32_one), nullptr));
+
+                        allocate_dim.m_length = size_i;
+                        allocate_dims.push_back(al, allocate_dim);
+                    }
+                    break;
+                }
+
                 default: {
                     LCOMPILERS_ASSERT_MSG(false, "ASR::IntrinsicArrayFunctions::" +
                         ASRUtils::get_array_intrinsic_name(intrinsic_array_function->m_arr_intrinsic_id)


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5689

Currently in *main*, the ttype for allocatable `return_type` of cshift looks like:
```clj
                                (Allocatable
                                    (Allocatable
                                        (Array
                                            (Real 4)
                                            [(()
                                            ())]
                                            DescriptorArray
                                        )
                                    )
                                )
```

With this branch, that is fixed:
```clj
(Allocatable
                                    (Array
                                        (Real 4)
                                        [(()
                                        ())]
                                        DescriptorArray
                                    )
                                )
```

## Other work

There are few more things which need to be done:
* fixes in `cshift`, currently the code for `cshift` has a lot of bugs, like the `n_dims` calculation etc. (I'll open issues and fix them separately)
* asr_verify check can be used for `Allocatable` ttype to ensure that there is no underlying `Allocatable` ttype right under that, will create a separate PR for it, might reveal other issues as well