### PR TITLE
Update installation.md

### DIFF
--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -213,7 +213,7 @@ cd lfortran
 ```bash
 conda activate lf
 ./build0.sh
-cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DCMAKE_INSTALL_PREFIX=`pwd`/inst .\
+cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DCMAKE_INSTALL_PREFIX=`pwd`/inst .
 make -j8
 ```
 


### PR DESCRIPTION
The extra `\` is causing the command to fail when it is run immediately after being copied.