### PR TITLE
Fix: Handle if array initializer is zero

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1887,6 +1887,8 @@ RUN(NAME openmp_41 LABELS llvm_omp llvm)
 RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME fortran_02 LABELS gfortran fortran)
 
+RUN(NAME array_init_with_scalar_main LABELS gfortran llvm)
+
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME exit_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/array_init_with_scalar.f90
+++ b/integration_tests/array_init_with_scalar.f90
@@ -1,0 +1,9 @@
+module array_init_with_scalar_0
+    implicit none
+    integer, dimension(2) :: drratio=0
+    real, dimension(2) :: drratior=0.0
+end module
+
+program array_init_with_scalar_main
+implicit none
+end program array_init_with_scalar_main


### PR DESCRIPTION
Towards #5690 
In this PR i have changed 
```fortran
integer, dimension(2) :: drratio=0 --------> integer,dimension(2) :: drratio
real, dimension(2) :: drratior=0.0 ---------> real, dimension(2) :: drratior
```
On ASR level 
Which prevents this llvm error 
```clojure
aditya-trivedi   lfortran    main ≡    lfortran integration_tests/array_init_with_scalar.f90 --show-llvm
; ModuleID = 'LFortran'
source_filename = "LFortran"

@drratio = global [2 x i32] zeroinitializer
@drratior = global [2 x float] zeroinitializer

define i32 @main(i32 %0, i8** %1) {
.entry:
  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
  call void @_lpython_free_argv()
  br label %return

return:                                           ; preds = %.entry
  ret i32 0
}

declare void @_lpython_call_initial_functions(i32, i8**)

declare void @_lpython_free_argv()
asr_to_llvm: module failed verification. Error:
Global variable initializer type does not match global variable type!
[2 x i32]* @drratio
Global variable initializer type does not match global variable type!
[2 x float]* @drratior

code generation error: asr_to_llvm: module failed verification. Error:
Global variable initializer type does not match global variable type!
[2 x i32]* @drratio
Global variable initializer type does not match global variable type!
[2 x float]* @drratior



Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.

```
