### PR TITLE
CI: Revert "[CI] Fix the command to initialize SHELL for mamba"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN apt install curl git build-essential binutils-dev zlib1g-dev clang libunwind
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b
 
-ENV MAMBA_ROOT_PREFIX="/root/miniforge3"
-RUN /root/miniforge3/bin/mamba shell hook --shell bash --root-prefix "$MAMBA_ROOT_PREFIX"
+RUN /root/miniforge3/bin/mamba init bash
 
 WORKDIR /lfortran
 


### PR DESCRIPTION
## Description

The CI job *build-and-push-image* seems to be failing again, yesterday the fix was made here https://github.com/lfortran/lfortran/pull/5704 and merged.

with this PR I attempt to see if reverting that change fix it now or not. This reverts commit 2f3fe4c0a1cebbed4faca30100b790fdf51c1af9.

