### PR TITLE
enh: add support for handling `ASR::ClassProcedure_t` for functions with string parameters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1437,6 +1437,8 @@ RUN(NAME class_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
+RUN(NAME class_procedure_args_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
 RUN(NAME kwargs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME kwargs_02 LABELS gfortran)
 

--- a/integration_tests/class_procedure_args_01.f90
+++ b/integration_tests/class_procedure_args_01.f90
@@ -1,39 +1,40 @@
 module class_procedure_args_01
 
-    type,public :: clock
-    contains
-       procedure,public :: toc => clock_end
-    end type clock
- 
-    type(clock),public :: clk
- 
- contains
- 
-    subroutine clock_end(me, case_str)
-       class(clock),intent(inout) :: me
-       character(len=*),intent(in) :: case_str
-       print *, case_str
-       if (case_str /= "5") stop
-    end subroutine clock_end
- 
-    subroutine sub(case_str)
-       character(len=*),intent(in) :: case_str
-       print *, case_str
-       if (case_str /= "6") error stop
-    end subroutine sub
- 
- end module class_procedure_args_01
- 
- 
- program main
- 
-    use class_procedure_args_01
- 
-    procedure(sub), pointer :: toc
-    call clk%toc("5")
- 
-    toc => sub
-    call toc("6")
- 
- end program main
- 
+   type,public :: clock
+   contains
+      procedure,public :: toc => clock_end
+   end type clock
+
+   type(clock),public :: clk
+
+contains
+
+   subroutine clock_end(me, case_str)
+      class(clock),intent(inout) :: me
+      character(len=*),intent(in) :: case_str
+      print *, case_str
+      if (case_str /= "5") stop
+   end subroutine clock_end
+
+   subroutine sub(case_str)
+      character(len=*),intent(in) :: case_str
+      print *, case_str
+      if (case_str /= "6") error stop
+   end subroutine sub
+
+end module class_procedure_args_01
+
+
+program main
+
+   use class_procedure_args_01
+
+   !  TODO: Uncomment test case after fixing #5741
+   !  procedure(sub), pointer :: toc
+   call clk%toc("5")
+
+   !  toc => sub
+   !  call toc("6")
+
+end program main
+

--- a/integration_tests/class_procedure_args_01.f90
+++ b/integration_tests/class_procedure_args_01.f90
@@ -1,0 +1,39 @@
+module class_procedure_args_01
+
+    type,public :: clock
+    contains
+       procedure,public :: toc => clock_end
+    end type clock
+ 
+    type(clock),public :: clk
+ 
+ contains
+ 
+    subroutine clock_end(me, case_str)
+       class(clock),intent(inout) :: me
+       character(len=*),intent(in) :: case_str
+       print *, case_str
+       if (case_str /= "5") stop
+    end subroutine clock_end
+ 
+    subroutine sub(case_str)
+       character(len=*),intent(in) :: case_str
+       print *, case_str
+       if (case_str /= "6") error stop
+    end subroutine sub
+ 
+ end module class_procedure_args_01
+ 
+ 
+ program main
+ 
+    use class_procedure_args_01
+ 
+    procedure(sub), pointer :: toc
+    call clk%toc("5")
+ 
+    toc => sub
+    call toc("6")
+ 
+ end program main
+ 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8986,6 +8986,19 @@ public:
                         if( func_subrout->type == ASR::symbolType::Function ) {
                             ASR::Function_t* func = down_cast<ASR::Function_t>(func_subrout);
                             orig_arg = ASRUtils::EXPR2VAR(func->m_args[i]);
+                        } else if (func_subrout->type == ASR::symbolType::ClassProcedure) {
+                            ASR::ClassProcedure_t* class_proc = down_cast<ASR::ClassProcedure_t>(func_subrout);
+                            ASR::symbol_t* func_sym = class_proc->m_proc;
+                            if (func_sym->type == ASR::symbolType::Function) {
+                                ASR::Function_t* func = down_cast<ASR::Function_t>(func_sym);
+                                orig_arg = EXPR2VAR(func->m_args[i]);
+                            } else {
+                                LCOMPILERS_ASSERT(false)
+                            }
+                        } else if( func_subrout->type == ASR::symbolType::Variable ) {
+                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(func_subrout);
+                            ASR::Function_t* func = down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(v->m_type_declaration));
+                            orig_arg = EXPR2VAR(func->m_args[i]);
                         } else {
                             throw CodeGenError("ICE: expected func_subrout->type == ASR::symbolType::Function.");
                         }


### PR DESCRIPTION
fixes #5734 