### PR TITLE
CI: fix version of miniforge in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ USER root
 RUN apt update
 RUN apt install curl git build-essential binutils-dev zlib1g-dev clang libunwind-dev -y
 
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+# fix version of miniforge to 24.11.0-0 as that fixes the version of mamba
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/download/24.11.0-0/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b
 
 RUN /root/miniforge3/bin/mamba init bash


### PR DESCRIPTION
## Description

This is an attempt to fix the version of miniforge to use and hence the version of mamba installed to make sure that we don't get CI failure of *build-and-push* CI job, like we got in https://github.com/lfortran/lfortran/pull/5730.

I'll first check to see if the tests pass or not