### PR TITLE
Properly detect re2c and bison when building under LFORTRAN_BUILD_ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,10 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
 # We don't execute this if we have a tarball
 if (LFORTRAN_BUILD_ALL)
-    find_program(BASH_BIN bash)
-    execute_process(COMMAND "${BASH_BIN}" "-e" "build0.sh" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} RESULT_VARIABLE _BUILD0_EXIT)
+    find_program(RE2C re2c REQUIRED)
+    find_program(BISON bison REQUIRED)
+    find_program(BASH_BIN bash REQUIRED)
+    execute_process(COMMAND "env" "RE2C=${RE2C}" "BISON=${BISON}" "${BASH_BIN}" "-e" "build0.sh" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} RESULT_VARIABLE _BUILD0_EXIT)
     if (NOT _BUILD0_EXIT EQUAL 0)
         message(FATAL_ERROR "Running build0.sh failed (see error above)")
     endif ()

--- a/build0.sh
+++ b/build0.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+RE2C=${RE2C:-re2c}
+BISON=${BISON:-bison}
+
 # Generate the `version` file
 ci/version.sh
 
@@ -16,9 +19,9 @@ python src/libasr/wasm_instructions_visitor.py
 python src/libasr/intrinsic_func_registry_util_gen.py
 
 # Generate the tokenizer and parser
-(cd src/lfortran && re2c -W -b parser/tokenizer.re -o parser/tokenizer.cpp)
-(cd src/lfortran && re2c -W -b parser/preprocessor.re -o parser/preprocessor.cpp)
-(cd src/lfortran/parser && bison -Wall -d -r all parser.yy)
+(cd src/lfortran && ${RE2C} -W -b parser/tokenizer.re -o parser/tokenizer.cpp)
+(cd src/lfortran && ${RE2C} -W -b parser/preprocessor.re -o parser/preprocessor.cpp)
+(cd src/lfortran/parser && ${BISON} -Wall -d -r all parser.yy)
 
 grep -n "'" src/lfortran/parser/parser.yy && echo "Single quote not allowed" && exit 1
 echo "OK"


### PR DESCRIPTION
This was extracted from #4183.

I benchmarked the speed of compilation, didn't notice any slowdown.