### PR TITLE
CI: Test POT3D with LLVM backend with a few workarounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,12 +515,12 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             FC="$(pwd)/src/bin/lfortran"
             cd pot3d
-            git checkout -t origin/lf1
-            git checkout 64f542d8ba3a58114fd1e995a1cd639965374b37
+            git checkout -t origin/lf2
+            git checkout db7edd3a493ae4650c1942f257a60dd29958b6c1
             cd src
             $FC -c mpi.f90
             $FC -c psi_io.f90
-            $FC pot3d.F --cpp --implicit-interface --fixed-form --show-asr
+            $FC pot3d.F --cpp --implicit-interface --fixed-form --show-llvm
 
             cd ..
             git clean -fdx
@@ -529,7 +529,7 @@ jobs:
             cd src
             $FC --experimental-simplifier -c mpi.f90
             $FC --experimental-simplifier -c psi_io.f90
-            $FC --experimental-simplifier pot3d.F --cpp --implicit-interface --fixed-form --show-asr
+            $FC --experimental-simplifier pot3d.F --cpp --implicit-interface --fixed-form --show-llvm
 
 
       - name: Test Legacy Minpack (SciPy)


### PR DESCRIPTION
## Description

There are two main workarounds which have been made use of in this:
* First is https://github.com/gxyd/POT3D/commit/4a85416220bfe18150b4a0d76d747b1bfbfd0ffa, the issue for this is already reported here: https://github.com/lfortran/lfortran/issues/5709, we'll try to fix this as well soon
* second is: https://github.com/gxyd/POT3D/commit/db7edd3a493ae4650c1942f257a60dd29958b6c1, uncommenting all calls to write subroutines for HDF5 format, we should be able to fix this well, I'll report an issue for this soon.