### PR TITLE
enh: add support for automatic allocation for `allocatable` with `--std=f23`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1280,6 +1280,9 @@ RUN(NAME allocate_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --realloc-lhs)
 RUN(NAME allocate_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
+RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
+
 RUN(NAME block_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME block_02 LABELS gfortran llvm)
 RUN(NAME block_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/automatic_allocation_01.f90
+++ b/integration_tests/automatic_allocation_01.f90
@@ -1,0 +1,6 @@
+program main
+   integer,allocatable:: x(:)
+   x = [1,2,3,4]
+   print *,x
+end program
+

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2340,6 +2340,7 @@ int main_app(int argc, char *argv[]) {
         compiler_options.implicit_interface = true;
         compiler_options.print_leading_space = true;
         compiler_options.logical_casting = false;
+        compiler_options.po.realloc_lhs = true;
     } else if (arg_standard == "legacy") {
         // f23
         compiler_options.disable_style = true;


### PR DESCRIPTION
As seen in https://wg5-fortran.org/N2201-N2250/N2212.pdf.

'The new features of Fortran 2023' paper linked above talks about the introduction of automatic allocation of character variables but GFortran seems to support this for all variables.