### PR TITLE
fix: decrement loop variable to retain correct value when using loop variable after loop

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1493,6 +1493,8 @@ RUN(NAME div_to_mul LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME fma LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME loop_unroll_small LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME loop_unroll_large LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME loop_var_use_after_loop LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm
+        EXTRA_ARGS --use-loop-variable-after-loop)
 RUN(NAME sign_from_value LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME rewind_inquire_flush LABELS gfortran)

--- a/integration_tests/loop_var_use_after_loop.f90
+++ b/integration_tests/loop_var_use_after_loop.f90
@@ -1,0 +1,58 @@
+program main
+   implicit none
+
+   integer :: i
+
+   ! Loop 1
+   do i = 1, 2
+      print *,'In loop 1 i =', i
+      if (i < 2) exit
+   end do
+   print *,'After loop 1 i = ', i
+   if (i /= 1) error stop
+
+   ! Loop 2
+   print *
+   do i = 1, 3
+      print *,'In loop 2 i = ', i
+      if (i < 2) then
+         print *, "if (i < 2) then"
+      else
+         exit
+      end if
+   end do
+   print *,'After loop 2 i = ', i
+   if (i /= 2) error stop
+
+
+   ! Loop 3
+   print *
+   do i = 1, 6
+      print *,'In loop 3 i = ', i
+      if (i <= 4) then
+         if (i - 1 == 3) then
+            if (i - 1 == 2) exit
+            exit
+         end if
+      end if
+   end do
+   print *,'After loop 3 i = ', i
+   if (i /= 4) error stop
+
+   ! Loop 4
+   print *
+   do i = 1, 6
+      print *,'In loop 4 i = ', i
+      if (i <= 4) then
+         if (i - 1 == 3) then
+            if (i - 1 == 2) exit
+            exit
+         else
+            print *, "i - 1 /= 3"
+         end if
+      end if
+   end do
+   print *,'After loop 4 i = ', i
+   if (i /= 4) error stop
+
+end program

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -1121,6 +1121,101 @@ namespace LCompilers {
             }
         }
 
+        Vec<ASR::stmt_t*> insert_if_stmts_in_loop_body(Allocator& al,
+                                                       ASR::If_t* if_stmt,
+                                                       ASR::stmt_t* decrement_stmt)
+        {
+            Vec<ASR::stmt_t*> body; body.reserve(al, 0);
+            Vec<ASR::stmt_t*> if_stmt_body; if_stmt_body.reserve(al, 0);
+            Vec<ASR::stmt_t*> else_stmt_body; else_stmt_body.reserve(al, 0);
+
+            for (size_t i = 0; i < if_stmt->n_body; i++) {
+                if (ASR::is_a<ASR::If_t>(*if_stmt->m_body[i])) {
+                    Vec<ASR::stmt_t*> nested_if_stmt_body = insert_if_stmts_in_loop_body(al,
+                                                 ASR::down_cast<ASR::If_t>(if_stmt->m_body[i]),
+                                                 decrement_stmt);
+                    for (size_t j = 0; j < nested_if_stmt_body.size(); j++) {
+                        if_stmt_body.push_back(al, nested_if_stmt_body[j]);
+                    }
+                } else if (ASR::is_a<ASR::Exit_t>(*if_stmt->m_body[i])) {
+                    if_stmt_body.push_back(al, decrement_stmt);
+                    if_stmt_body.push_back(al, if_stmt->m_body[i]);
+                    break;  // dead code ahead, skip it
+                } else {
+                    if_stmt_body.push_back(al, if_stmt->m_body[i]);
+                }
+            }
+
+            if_stmt->m_body = if_stmt_body.p;
+            if_stmt->n_body = if_stmt_body.n;
+
+            for (size_t i = 0; i < if_stmt->n_orelse; i++) {
+                if (ASR::is_a<ASR::If_t>(*if_stmt->m_orelse[i])) {
+                    Vec<ASR::stmt_t*> nested_if_stmt_body = insert_if_stmts_in_loop_body(al,
+                                                 ASR::down_cast<ASR::If_t>(if_stmt->m_orelse[i]),
+                                                 decrement_stmt);
+                    for (size_t j = 0; j < nested_if_stmt_body.size(); j++) {
+                        else_stmt_body.push_back(al, nested_if_stmt_body[j]);
+                    }
+                } else if (ASR::is_a<ASR::Exit_t>(*if_stmt->m_orelse[i])) {
+                    else_stmt_body.push_back(al, decrement_stmt);
+                    else_stmt_body.push_back(al, if_stmt->m_orelse[i]);
+                    break;  // dead code ahead, skip it
+                } else {
+                    else_stmt_body.push_back(al, if_stmt->m_orelse[i]);
+                }
+            }
+            
+            if_stmt->m_orelse = else_stmt_body.p;
+            if_stmt->n_orelse = else_stmt_body.n;
+
+            body.push_back(al, ASRUtils::STMT(&if_stmt->base.base));
+            return body;
+        }
+
+        void insert_stmts_in_loop_body(Allocator& al,
+                                       const ASR::DoLoop_t& loop,
+                                       Vec<ASR::stmt_t*>& body,
+                                       ASR::expr_t* increment)
+        {
+            Vec<ASR::stmt_t*> new_body;
+            new_body.from_pointer_n_copy(al, body.p, body.n);
+            Location loc = loop.base.base.loc;
+
+            ASR::expr_t* target = loop.m_head.m_v;
+            int a_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(target));
+            ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, a_kind));
+
+            ASR::stmt_t* decrement_stmt = ASRUtils::STMT(
+                                            ASR::make_Assignment_t(
+                                                al,
+                                                loc,
+                                                target,
+                                                ASRUtils::EXPR(
+                                                    ASR::make_IntegerBinOp_t(
+                                                    al, loc, target, ASR::binopType::Sub,
+                                                    increment, type, nullptr)),
+                                                nullptr));
+
+            for (size_t i = 0; i < loop.n_body; i++) {
+                if (ASR::is_a<ASR::Exit_t>(*loop.m_body[i])) {
+                    new_body.push_back(al, decrement_stmt);
+                    new_body.push_back(al, loop.m_body[i]);
+                    break;  // dead code ahead, skip it
+                } else if (ASR::is_a<ASR::If_t>(*loop.m_body[i])) {
+                    Vec<ASR::stmt_t*> if_body = insert_if_stmts_in_loop_body(
+                        al, ASR::down_cast<ASR::If_t>(loop.m_body[i]), decrement_stmt);
+                    for (size_t j = 0; j < if_body.size(); j++) {
+                        new_body.push_back(al, if_body[j]);
+                    }
+                } else {
+                    new_body.push_back(al, loop.m_body[i]);
+                }
+            }
+
+            body = new_body;
+        }
+
         Vec<ASR::stmt_t*> replace_doloop(Allocator &al, const ASR::DoLoop_t &loop,
                                          int comp, bool use_loop_variable_after_loop) {
             Location loc = loop.base.base.loc;
@@ -1259,9 +1354,15 @@ namespace LCompilers {
             if( inc_stmt ) {
                 body.push_back(al, inc_stmt);
             }
-            for (size_t i=0; i<loop.n_body; i++) {
-                body.push_back(al, loop.m_body[i]);
+
+            if (use_loop_variable_after_loop) {
+                insert_stmts_in_loop_body(al, loop, body, c);
+            } else {
+                for (size_t i = 0; i < loop.n_body; i++) {
+                    body.push_back(al, loop.m_body[i]);
+                }
             }
+
             ASR::stmt_t *while_loop_stmt = ASRUtils::STMT(ASR::make_WhileLoop_t(al, loc,
                 loop.m_name, cond, body.p, body.size(), loop.m_orelse, loop.n_orelse));
             Vec<ASR::stmt_t*> result;

--- a/tests/reference/pass_do_loops-loop_var_use_after_loop-e26183c.json
+++ b/tests/reference/pass_do_loops-loop_var_use_after_loop-e26183c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "pass_do_loops-loop_var_use_after_loop-e26183c",
+    "cmd": "lfortran --pass=do_loops --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/loop_var_use_after_loop.f90",
+    "infile_hash": "7155c67c016a79ec0de4c65637bdec02203cd567e2d20a7676393d09",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "pass_do_loops-loop_var_use_after_loop-e26183c.stdout",
+    "stdout_hash": "47f1ce19be62d9e8aa8c26c1460e90647b534ae1a7620ea8032c5a88",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/pass_do_loops-loop_var_use_after_loop-e26183c.stdout
+++ b/tests/reference/pass_do_loops-loop_var_use_after_loop-e26183c.stdout
@@ -1,0 +1,614 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            main:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            i:
+                                (Variable
+                                    2
+                                    i
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                )
+                        })
+                    main
+                    []
+                    [(Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            Sub
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (WhileLoop
+                        ()
+                        (IntegerCompare
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            LtE
+                            (IntegerConstant 2 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(Assignment
+                            (Var 2 i)
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            ()
+                        )
+                        (Print
+                            (StringFormat
+                                ()
+                                [(StringConstant
+                                    "In loop 1 i ="
+                                    (String 1 13 () PointerString)
+                                )
+                                (Var 2 i)]
+                                FormatFortran
+                                (String -1 0 () PointerString)
+                                ()
+                            )
+                        )
+                        (If
+                            (IntegerCompare
+                                (Var 2 i)
+                                Lt
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                (Logical 4)
+                                ()
+                            )
+                            [(Assignment
+                                (Var 2 i)
+                                (IntegerBinOp
+                                    (Var 2 i)
+                                    Sub
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    (Integer 4)
+                                    ()
+                                )
+                                ()
+                            )
+                            (Exit
+                                ()
+                            )]
+                            []
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (Var 2 i)
+                            Add
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(StringConstant
+                                "After loop 1 i = "
+                                (String 1 17 () PointerString)
+                            )
+                            (Var 2 i)]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 2 i)
+                            NotEq
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            []
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            Sub
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (WhileLoop
+                        ()
+                        (IntegerCompare
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            LtE
+                            (IntegerConstant 3 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(Assignment
+                            (Var 2 i)
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            ()
+                        )
+                        (Print
+                            (StringFormat
+                                ()
+                                [(StringConstant
+                                    "In loop 2 i = "
+                                    (String 1 14 () PointerString)
+                                )
+                                (Var 2 i)]
+                                FormatFortran
+                                (String -1 0 () PointerString)
+                                ()
+                            )
+                        )
+                        (If
+                            (IntegerCompare
+                                (Var 2 i)
+                                Lt
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                (Logical 4)
+                                ()
+                            )
+                            [(Print
+                                (StringConstant
+                                    "if (i < 2) then"
+                                    (String 1 15 () PointerString)
+                                )
+                            )]
+                            [(Assignment
+                                (Var 2 i)
+                                (IntegerBinOp
+                                    (Var 2 i)
+                                    Sub
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    (Integer 4)
+                                    ()
+                                )
+                                ()
+                            )
+                            (Exit
+                                ()
+                            )]
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (Var 2 i)
+                            Add
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(StringConstant
+                                "After loop 2 i = "
+                                (String 1 17 () PointerString)
+                            )
+                            (Var 2 i)]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 2 i)
+                            NotEq
+                            (IntegerConstant 2 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            []
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            Sub
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (WhileLoop
+                        ()
+                        (IntegerCompare
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            LtE
+                            (IntegerConstant 6 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(Assignment
+                            (Var 2 i)
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            ()
+                        )
+                        (Print
+                            (StringFormat
+                                ()
+                                [(StringConstant
+                                    "In loop 3 i = "
+                                    (String 1 14 () PointerString)
+                                )
+                                (Var 2 i)]
+                                FormatFortran
+                                (String -1 0 () PointerString)
+                                ()
+                            )
+                        )
+                        (If
+                            (IntegerCompare
+                                (Var 2 i)
+                                LtE
+                                (IntegerConstant 4 (Integer 4) Decimal)
+                                (Logical 4)
+                                ()
+                            )
+                            [(If
+                                (IntegerCompare
+                                    (IntegerBinOp
+                                        (Var 2 i)
+                                        Sub
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        (Integer 4)
+                                        ()
+                                    )
+                                    Eq
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    (Logical 4)
+                                    ()
+                                )
+                                [(If
+                                    (IntegerCompare
+                                        (IntegerBinOp
+                                            (Var 2 i)
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        Eq
+                                        (IntegerConstant 2 (Integer 4) Decimal)
+                                        (Logical 4)
+                                        ()
+                                    )
+                                    [(Assignment
+                                        (Var 2 i)
+                                        (IntegerBinOp
+                                            (Var 2 i)
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (Exit
+                                        ()
+                                    )]
+                                    []
+                                )
+                                (Assignment
+                                    (Var 2 i)
+                                    (IntegerBinOp
+                                        (Var 2 i)
+                                        Sub
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        (Integer 4)
+                                        ()
+                                    )
+                                    ()
+                                )
+                                (Exit
+                                    ()
+                                )]
+                                []
+                            )]
+                            []
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (Var 2 i)
+                            Add
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(StringConstant
+                                "After loop 3 i = "
+                                (String 1 17 () PointerString)
+                            )
+                            (Var 2 i)]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 2 i)
+                            NotEq
+                            (IntegerConstant 4 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            []
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            Sub
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (WhileLoop
+                        ()
+                        (IntegerCompare
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            LtE
+                            (IntegerConstant 6 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(Assignment
+                            (Var 2 i)
+                            (IntegerBinOp
+                                (Var 2 i)
+                                Add
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                            )
+                            ()
+                        )
+                        (Print
+                            (StringFormat
+                                ()
+                                [(StringConstant
+                                    "In loop 4 i = "
+                                    (String 1 14 () PointerString)
+                                )
+                                (Var 2 i)]
+                                FormatFortran
+                                (String -1 0 () PointerString)
+                                ()
+                            )
+                        )
+                        (If
+                            (IntegerCompare
+                                (Var 2 i)
+                                LtE
+                                (IntegerConstant 4 (Integer 4) Decimal)
+                                (Logical 4)
+                                ()
+                            )
+                            [(If
+                                (IntegerCompare
+                                    (IntegerBinOp
+                                        (Var 2 i)
+                                        Sub
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        (Integer 4)
+                                        ()
+                                    )
+                                    Eq
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    (Logical 4)
+                                    ()
+                                )
+                                [(If
+                                    (IntegerCompare
+                                        (IntegerBinOp
+                                            (Var 2 i)
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        Eq
+                                        (IntegerConstant 2 (Integer 4) Decimal)
+                                        (Logical 4)
+                                        ()
+                                    )
+                                    [(Assignment
+                                        (Var 2 i)
+                                        (IntegerBinOp
+                                            (Var 2 i)
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (Exit
+                                        ()
+                                    )]
+                                    []
+                                )
+                                (Assignment
+                                    (Var 2 i)
+                                    (IntegerBinOp
+                                        (Var 2 i)
+                                        Sub
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        (Integer 4)
+                                        ()
+                                    )
+                                    ()
+                                )
+                                (Exit
+                                    ()
+                                )]
+                                [(Print
+                                    (StringConstant
+                                        "i - 1 /= 3"
+                                        (String 1 10 () PointerString)
+                                    )
+                                )]
+                            )]
+                            []
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 i)
+                        (IntegerBinOp
+                            (Var 2 i)
+                            Add
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(StringConstant
+                                "After loop 4 i = "
+                                (String 1 17 () PointerString)
+                            )
+                            (Var 2 i)]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 2 i)
+                            NotEq
+                            (IntegerConstant 4 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4461,3 +4461,8 @@ show_errors = true
 filename = "document_symbols1.f90"
 document_symbols = true
 extrafiles = "document_symbols1_module.f90"
+
+[[test]]
+filename = "../integration_tests/loop_var_use_after_loop.f90"
+pass = "do_loops"
+options = "--use-loop-variable-after-loop"


### PR DESCRIPTION
fixes #5761 

When breaking from the loop, we decrement the loop variable by the loop increment value, so when we break out of loop, the default increment by `--use-loop-variable-after-loop` fixes the value.