### PR TITLE
ci: enable LLVM19 for PRIMA

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -500,7 +500,6 @@ jobs:
 
       - name: Test PRIMA
         shell: bash -e -l {0}
-        if: contains(matrix.llvm-version, '11')
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima


### PR DESCRIPTION
This PR checks if PRIMA works with `llvm19` or not.