### PR TITLE
CI: update branch and commit for 'Test POT3D' testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,8 +515,8 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             FC="$(pwd)/src/bin/lfortran"
             cd pot3d
-            git checkout -t origin/lf2
-            git checkout db7edd3a493ae4650c1942f257a60dd29958b6c1
+            git checkout -t origin/lf3
+            git checkout 81ff23264eb31860dbc0e156050e877f03696d2d
             cd src
             $FC -c mpi.f90
             $FC -c psi_io.f90


### PR DESCRIPTION
## Description

the new workaround (see: https://github.com/gxyd/POT3D/commit/fe44c91df5d96856b87dc5df92ce0818948155ea) now uses `FLUSH` as a statement instead of as an intrinsic

the older workaround (see: https://github.com/gxyd/POT3D/commit/4a85416220bfe18150b4a0d76d747b1bfbfd0ffa) which just commented out `call FLUSH(...)`