### PR TITLE
fix : Handling Array Asignment in subroutine where Array referrence is Array Constant in both LHS and RHS

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -551,6 +551,7 @@ RUN(NAME arrays_66 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EX
 RUN(NAME arrays_67 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_68 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_69 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME arrays_70 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_array_pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/arrays_70.f90
+++ b/integration_tests/arrays_70.f90
@@ -1,0 +1,12 @@
+program arrays_70
+    integer :: A(4) = [1,2,3,4]
+    call temp(A)
+    print *, A
+    if (A(1) /= 2) error stop
+    if (A(2) /= 1) error stop
+contains
+    subroutine temp(A)
+        integer, intent(inout) :: A(:)
+        A([1,2]) = A([2,1])
+    end subroutine
+end program

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -2282,16 +2282,29 @@ class ArrayOpVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisit
                             ASR::expr_t* itr = PassUtils::create_var(
                                 0, "itr", array_item_target->base.base.loc, integer_type, al, current_scope);
 
-                            ASR::ttype_t* temporary_array_type = ASRUtils::expr_type(array_item_value->m_v);
-                            ASR::dimension_t* m_dims =nullptr;
-                            ASRUtils::extract_dimensions_from_ttype(temporary_array_type, m_dims);
+                            ASR::expr_t* temporary_array_size = ASRUtils::EXPR(ASR::make_ArraySize_t(
+                                al, array_item_value->m_v->base.loc, array_item_value->m_v,
+                                nullptr, integer_type, nullptr));
+
+                            Vec<ASR::dimension_t> temporary_array_dims;
+                            temporary_array_dims.reserve(al, 1);
+
+                            ASR::dimension_t temporary_array_dim;
+                            temporary_array_dim.loc = array_item_value->m_v->base.loc;
+                            temporary_array_dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                al, array_item_value->m_v->base.loc, 1, integer_type));
+                            temporary_array_dim.m_length = temporary_array_size;
+                            temporary_array_dims.push_back(al, temporary_array_dim);
+
+                            ASR::ttype_t* temporary_array_type = ASRUtils::TYPE(ASR::make_Array_t(
+                                al, array_item_value->m_v->base.loc, integer_type,
+                                temporary_array_dims.p, temporary_array_dims.size(),
+                                ASR::array_physical_typeType::PointerToDataArray));
+
                             ASR::expr_t* temporary_array = PassUtils::create_var(
                                 0, "_temporary_value", array_item_value->m_v->base.loc,
                                 ASRUtils::duplicate_type(al, temporary_array_type), al, current_scope);
 
-                            ASR::expr_t* temporary_array_size = ASRUtils::EXPR(ASR::make_ArraySize_t(
-                                al, array_item_value->m_v->base.loc, array_item_value->m_v,
-                                nullptr, integer_type, nullptr));
 
                             Vec<ASR::expr_t*> temporary_idx_vars;
                             PassUtils::create_idx_vars(temporary_idx_vars, 1, array_item_value->m_v->base.loc, al, current_scope);


### PR DESCRIPTION
fixes #5656 

MRE :- 
```
program test
    integer :: A(4) = [1,2,3,4]
    call temp(A)
    print *, A
contains
    subroutine temp(A)
        integer, intent(inout) :: A(:)
        A([1,2]) = A([2,1])
    end subroutine
end program
```

LFortran Output :- 
```
(lf) lordansh@LordAnsh:~/dev/lfort4/lfortran$ ./src/bin/lfortran try.f90 
2    1    3    4
```

Fortran Code after array_op pass :- 
```
! Fortran code after applying the pass: array_op
program test
implicit none
integer(4) :: __1_k
integer(4), dimension(4), save :: a
__1_k = lbound(a, 1)
a(__1_k) = 1
__1_k = __1_k + 1
a(__1_k) = 2
__1_k = __1_k + 1
a(__1_k) = 3
__1_k = __1_k + 1
a(__1_k) = 4
__1_k = __1_k + 1
call temp(a)
print *, a

contains

subroutine temp(a)
    integer(4) :: __1_k
    integer(4) :: __1_k1
    integer(4) :: __1_k2
    integer(4), dimension(2) :: __libasr__created__var__0__array_constant_
    integer(4), dimension(:), intent(inout) :: a
    integer(4), dimension(size(a)) :: __libasr__created__var__0__temporary_value
    integer(4) :: __libasr__created__var__0_itr
    integer(4), dimension(size([1, 2])) :: __libasr__created__var__1_array_constant
    __1_k = lbound(__libasr__created__var__0__array_constant_, 1)
    __libasr__created__var__0__array_constant_(__1_k) = 2
    __1_k = __1_k + 1
    __libasr__created__var__0__array_constant_(__1_k) = 1
    __1_k = __1_k + 1
    do __1_k1 = 1, size(a)
        __libasr__created__var__0__temporary_value(__1_k1) = a(__1_k1)
    end do
    __1_k2 = lbound(__libasr__created__var__1_array_constant, 1)
    __libasr__created__var__1_array_constant(__1_k2) = 1
    __1_k2 = __1_k2 + 1
    __libasr__created__var__1_array_constant(__1_k2) = 2
    __1_k2 = __1_k2 + 1
    do __libasr__created__var__0_itr = 1, size([1, 2])
        a(__libasr__created__var__1_array_constant(__libasr__created__var__0_itr)) = __libasr__created__var__0__temporar&
        y_value(__libasr__created__var__0__array_constant_(__libasr__created__var__0_itr))
    end do
end subroutine temp

end program test
```