### PR TITLE
Fix : use any variable as unit, not just `ASR::Var` + support different kinds integers to be used as unit arg.

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1439,6 +1439,7 @@ RUN(NAME file_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_
 RUN(NAME file_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_21_data.txt)
 RUN(NAME file_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_22_data.txt)
+RUN(NAME file_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_23_data.txt)
 
 RUN(NAME inquire_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_backspace_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_01_data.txt)

--- a/integration_tests/file_23.f90
+++ b/integration_tests/file_23.f90
@@ -1,0 +1,35 @@
+! Testing different kinds of integer variables as unit number. 
+program file_23
+    type :: file_t
+       integer(1) :: iunit_1
+       integer(2) :: iunit_2
+       integer(4) :: iunit_4
+       integer(8) :: iunit_8
+    end type file_t
+ 
+    type(file_t) :: f
+    character(30) :: str
+    open(newunit=f%iunit_1, file='file_23_data.txt')
+    read(f%iunit_1, *) str 
+    print *, str
+    if(str /= "HelloWorld!") error stop
+    close(f%iunit_1)
+    
+    open(newunit=f%iunit_2, file='file_23_data.txt')
+    read(f%iunit_2, *) str
+    print *, str
+    if(str /= "HelloWorld!") error stop
+    close(f%iunit_2)
+    
+    open(newunit=f%iunit_4, file='file_23_data.txt')
+    read(f%iunit_4, *) str
+    print *, str
+    if(str /= "HelloWorld!") error stop
+    close(f%iunit_4)
+    
+    open(newunit=f%iunit_8, file='file_23_data.txt')
+    read(f%iunit_8, *) str
+    print *, str
+    if(str /= "HelloWorld!") error stop
+    close(f%iunit_8)
+ end program file_23

--- a/integration_tests/file_23_data.txt
+++ b/integration_tests/file_23_data.txt
@@ -1,0 +1,2 @@
+HelloWorld!
+LFortran

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -258,11 +258,11 @@ public:
                 a_newunit = ASRUtils::EXPR(tmp);
                 ASR::ttype_t* a_newunit_type = ASRUtils::expr_type(a_newunit);
                 if( ( m_arg_str == std::string("newunit") &&
-                      a_newunit->type != ASR::exprType::Var ) ||
+                     !ASRUtils::is_variable(a_newunit) ) ||
                     ( !ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(a_newunit_type))
                     ) ) {
                         diag.add(Diagnostic(
-                            "`newunit`/`unit` must be a variable of type, Integer or IntegerPointer",
+                            "`newunit`/`unit` must be a mutable variable of type, Integer or IntegerPointer",
                             Level::Error, Stage::Semantic, {
                                 Label("",{x.base.base.loc})
                             }));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8167,7 +8167,7 @@ public:
     void visit_FileClose(const ASR::FileClose_t &x) {
         llvm::Value *unit_val = nullptr;
         this->visit_expr_wrapper(x.m_unit, true);
-        unit_val = tmp;
+        unit_val = llvm_utils->convert_kind(tmp, llvm::Type::getInt32Ty(context));
         std::string runtime_func_name = "_lfortran_close";
         llvm::Function *fn = module->getFunction(runtime_func_name);
         if (!fn) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7868,6 +7868,10 @@ public:
             is_string = ASRUtils::is_character(*expr_type(x.m_unit));
             this->visit_expr_wrapper(x.m_unit, true);
             unit_val = tmp;
+            if(ASRUtils::is_integer(*ASRUtils::expr_type(x.m_unit))){
+                // Convert the unit to 32 bit integer (We only support unit number up to 1000).
+                unit_val = llvm_utils->convert_kind(tmp, llvm::Type::getInt32Ty(context));
+            }
         }
 
         if (x.m_iostat) {
@@ -8009,7 +8013,7 @@ public:
         llvm::Value *unit_val = nullptr, *f_name = nullptr;
         llvm::Value *status = nullptr, *form = nullptr;
         this->visit_expr_wrapper(x.m_newunit, true);
-        unit_val = tmp;
+        unit_val = llvm_utils->convert_kind(tmp, llvm::Type::getInt32Ty(context));
         int ptr_copy = ptr_loads;
         if (x.m_filename) {
             ptr_loads = 1;
@@ -8094,7 +8098,6 @@ public:
         } else {
             size_val = llvm_utils->CreateAlloca(*builder,
                             llvm::Type::getInt32Ty(context));
-            print_util(size_val);
         }
 
         std::string runtime_func_name = "_lfortran_inquire";

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2197,6 +2197,19 @@ namespace LCompilers {
             }
         }
     }
+    llvm::Value* LLVMUtils::convert_kind(llvm::Value* val, llvm::Type* target_type){
+        LCOMPILERS_ASSERT(
+            (val->getType()->isIntegerTy() && target_type->isIntegerTy()) || 
+            (val->getType()->isFloatingPointTy() && target_type->isFloatingPointTy()));
+
+        if(val->getType()->getPrimitiveSizeInBits() == target_type->getPrimitiveSizeInBits()){
+            return val;
+        } else if(val->getType()->getPrimitiveSizeInBits() > target_type->getPrimitiveSizeInBits()){
+            return builder->CreateTrunc(val, target_type);
+        } else {
+            return builder->CreateSExt(val, target_type);
+        }
+    }
 
     LLVMList::LLVMList(llvm::LLVMContext& context_,
         LLVMUtils* llvm_utils_,

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -378,6 +378,8 @@ namespace LCompilers {
                 ASR::ttype_t* asr_type, llvm::Module* module,
                 std::map<std::string, std::map<std::string, int>>& name2memidx);
 
+            llvm::Value* convert_kind(llvm::Value* val, llvm::Type* target_type);
+
 
             // Note: `llvm_utils->create_if_else` and `create_loop` are optional APIs
             // that do not have to be used. Many times, for more complicated

--- a/src/runtime/custom/lfortran_intrinsic_custom.f90
+++ b/src/runtime/custom/lfortran_intrinsic_custom.f90
@@ -1,24 +1,55 @@
 module lfortran_intrinsic_custom
 implicit none
 
-contains
+interface  newunit
+    procedure :: newunit_int_1
+    procedure :: newunit_int_2
+    procedure :: newunit_int_4
+    procedure :: newunit_int_8
+end interface 
 
-    subroutine newunit(unit)
-        implicit none
+contains
+    function get_valid_newunit() result(lun)
         integer, parameter :: LUN_MIN=0, LUN_MAX=1000
         logical :: opened
-        integer :: lun
-        integer, intent(out) :: unit
-
+        integer(4) :: lun ! no need for kind 8, we have limit of 1000 for now.
         do lun=LUN_MIN,LUN_MAX
             inquire(unit=lun,opened=opened)
             if (.not. opened) then
-                unit = lun
                 return
             end if
         end do
         print *, "All unit numbers are utilized"
         error stop
-    end subroutine newunit
+    end function
+
+    subroutine newunit_int_1(unit)
+        implicit none
+        integer(1), intent(out) :: unit
+        if(get_valid_newunit() >= 2**8) then
+            print *, "integer(KIND=1) & 
+            &is has small limit. Use larger kind for the unit number"
+            error stop
+        end if
+        unit =  INT(get_valid_newunit(),1)
+    end subroutine newunit_int_1
+
+    subroutine newunit_int_2(unit)
+        implicit none
+        integer(2), intent(out) :: unit
+        unit =  INT(get_valid_newunit(),2)
+    end subroutine newunit_int_2
+
+    subroutine newunit_int_4(unit)
+        implicit none
+        integer(4), intent(out) :: unit
+        unit =  INT(get_valid_newunit(),4)
+    end subroutine newunit_int_4
+
+    subroutine newunit_int_8(unit)
+        implicit none
+        integer(8), intent(out) :: unit
+        unit =  INT(get_valid_newunit(),8)
+    end subroutine newunit_int_8
 
 end module

--- a/src/runtime/custom/lfortran_intrinsic_custom.f90
+++ b/src/runtime/custom/lfortran_intrinsic_custom.f90
@@ -9,13 +9,15 @@ interface  newunit
 end interface 
 
 contains
-    function get_valid_newunit() result(lun)
+    function get_valid_newunit() result(unit)
         integer, parameter :: LUN_MIN=0, LUN_MAX=1000
         logical :: opened
-        integer(4) :: lun ! no need for kind 8, we have limit of 1000 for now.
+        integer(4) :: lun 
+        integer(4) :: unit ! no need for kind 8, we have limit of 1000 for now.
         do lun=LUN_MIN,LUN_MAX
             inquire(unit=lun,opened=opened)
             if (.not. opened) then
+                unit = lun
                 return
             end if
         end do


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/5728