### PR TITLE
fix: incorrect location information of `ExternalSymbol`

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2754,7 +2754,7 @@ public:
             Str name;
             name.from_str(al, local_sym);
             ASR::asr_t *sub = ASR::make_ExternalSymbol_t(
-                al, msub->base.base.loc,
+                al, loc,
                 /* a_symtab */ current_scope,
                 /* a_name */ name.c_str(al),
                 (ASR::symbol_t*)msub,
@@ -2795,7 +2795,7 @@ public:
             name.from_str(al, local_sym);
             char *cname = name.c_str(al);
             ASR::asr_t *fn = ASR::make_ExternalSymbol_t(
-                al, mfn->base.base.loc,
+                al, loc,
                 /* a_symtab */ current_scope,
                 /* a_name */ cname,
                 (ASR::symbol_t*)mfn,
@@ -2829,7 +2829,7 @@ public:
                 throw SemanticAbort();
             }
             ASR::asr_t *v = ASR::make_ExternalSymbol_t(
-                al, mv->base.base.loc,
+                al, loc,
                 /* a_symtab */ current_scope,
                 /* a_name */ cname,
                 (ASR::symbol_t*)mv,
@@ -2861,7 +2861,7 @@ public:
             name.from_str(al, local_sym);
             char *cname = name.c_str(al);
             ASR::asr_t *v = ASR::make_ExternalSymbol_t(
-                al, mv->base.base.loc,
+                al, loc,
                 /* a_symtab */ current_scope,
                 /* a_name */ cname,
                 (ASR::symbol_t*)mv,
@@ -2872,7 +2872,7 @@ public:
         } else if (ASR::is_a<ASR::Requirement_t>(*t)) {
             ASR::Requirement_t *mreq = ASR::down_cast<ASR::Requirement_t>(t);
             ASR::asr_t *req = ASR::make_ExternalSymbol_t(
-                al, mreq->base.base.loc,
+                al, loc,
                 current_scope,
                 s2c(al, local_sym),
                 (ASR::symbol_t*) mreq,
@@ -2882,7 +2882,7 @@ public:
         } else if (ASR::is_a<ASR::Template_t>(*t)) {
             ASR::Template_t *mtemp = ASR::down_cast<ASR::Template_t>(t);
             ASR::asr_t *temp = ASR::make_ExternalSymbol_t(
-                al, mtemp->base.base.loc,
+                al, loc,
                 current_scope,
                 s2c(al, local_sym),
                 (ASR::symbol_t*) mtemp,
@@ -2892,7 +2892,7 @@ public:
         } else if (ASR::is_a<ASR::ExternalSymbol_t>(*t)) {
             ASR::ExternalSymbol_t* ext_sym = ASR::down_cast<ASR::ExternalSymbol_t>(t);
             ASR::asr_t* temp = ASR::make_ExternalSymbol_t(
-                al, ext_sym->base.base.loc,
+                al, loc,
                 current_scope,
                 s2c(al, local_sym),
                 ext_sym->m_external,
@@ -3019,7 +3019,7 @@ public:
                     local_sym = remote_sym;
                 }
                 import_symbols_util(m, msym, remote_sym, local_sym,
-                                    to_be_imported_later, x.base.base.loc);
+                                    to_be_imported_later, x.m_symbols[i]->base.loc);
             }
 
             // Importing procedures defined for overloaded operators like assignment

--- a/tests/reference/asr-private2-d3a4771.json
+++ b/tests/reference/asr-private2-d3a4771.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-private2-d3a4771.stderr",
-    "stderr_hash": "4c2f89bda14c9decfc88e5a2793f7faa82c2dfc93b0264d7eeb2f1ff",
+    "stderr_hash": "98341ad40f302acd14f7188319321a9b5a620c529f9ce700ff28c1a3",
     "returncode": 2
 }

--- a/tests/reference/asr-private2-d3a4771.stderr
+++ b/tests/reference/asr-private2-d3a4771.stderr
@@ -1,5 +1,5 @@
 semantic error: Private variable `y` cannot be imported
- --> tests/errors/private2.f90:7:5
+ --> tests/errors/private2.f90:7:21
   |
 7 |     use foo2, only: y
-  |     ^^^^^^^^^^^^^^^^^ 
+  |                     ^ 

--- a/tests/reference/asr_json-modules_10-93cd62d.json
+++ b/tests/reference/asr_json-modules_10-93cd62d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_json-modules_10-93cd62d.stdout",
-    "stdout_hash": "650bccaab3e398353670a983c8e994271af380f50e2077bab7ae06bb",
+    "stdout_hash": "a032494d27cd24396c6ae5a5d3a9614143b62f43cdb4483976ceecae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_json-modules_10-93cd62d.stdout
+++ b/tests/reference/asr_json-modules_10-93cd62d.stdout
@@ -22,14 +22,14 @@
                                         "access": "Public"
                                     },
                                     "loc": {
-                                        "first": 38,
-                                        "last": 50,
+                                        "first": 197,
+                                        "last": 205,
                                         "first_filename": "tests/modules_10.f90",
-                                        "first_line": 2,
-                                        "first_column": 16,
+                                        "first_line": 10,
+                                        "first_column": 32,
                                         "last_filename": "tests/modules_10.f90",
-                                        "last_line": 2,
-                                        "last_column": 28
+                                        "last_line": 10,
+                                        "last_column": 40
                                     }
                                 },
                                 "my_proc": {
@@ -50,14 +50,14 @@
                                                         "access": "Public"
                                                     },
                                                     "loc": {
-                                                        "first": 65,
-                                                        "last": 134,
+                                                        "first": 274,
+                                                        "last": 286,
                                                         "first_filename": "tests/modules_10.f90",
-                                                        "first_line": 4,
-                                                        "first_column": 5,
+                                                        "first_line": 13,
+                                                        "first_column": 36,
                                                         "last_filename": "tests/modules_10.f90",
-                                                        "last_line": 6,
-                                                        "last_column": 18
+                                                        "last_line": 13,
+                                                        "last_column": 48
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
Fixes #5802.

```console
$ cat a.f90                                      
module A
implicit none

integer :: x

contains

    subroutine f(b)
    integer, intent(in) :: b
    print *, b
    end subroutine

end module
$ cat expr2.f90 
program expr2
use A, only: x, f
implicit none

x = (2+3)*5
print *, x
call f(x)

end program
$ lfortran -c a.f90
% lfortran expr2.f90 --show-document-symbols | jq             
[
  {
    "kind": 2,
    "location": {
      "range": {
        "start": {
          "character": 1,
          "line": 0
        },
        "end": {
          "character": 10,
          "line": 12
        }
      },
      "uri": "uri"
    },
    "name": "a",
    "filename": "a.f90"
  },
  {
    "kind": 12,
    "location": {
      "range": {
        "start": {
          "character": 5,
          "line": 7
        },
        "end": {
          "character": 18,
          "line": 10
        }
      },
      "uri": "uri"
    },
    "name": "f",
    "filename": "a.f90"
  },
  {
    "kind": 13,
    "location": {
      "range": {
        "start": {
          "character": 28,
          "line": 8
        },
        "end": {
          "character": 28,
          "line": 8
        }
      },
      "uri": "uri"
    },
    "name": "b",
    "filename": "a.f90"
  },
  {
    "kind": 13,
    "location": {
      "range": {
        "start": {
          "character": 12,
          "line": 3
        },
        "end": {
          "character": 12,
          "line": 3
        }
      },
      "uri": "uri"
    },
    "name": "x",
    "filename": "a.f90"
  },
  {
    "kind": 12,
    "location": {
      "range": {
        "start": {
          "character": 1,
          "line": 0
        },
        "end": {
          "character": 11,
          "line": 8
        }
      },
      "uri": "uri"
    },
    "name": "expr2",
    "filename": "expr2.f90"
  },
  {
    "kind": 12,
    "location": {
      "range": {
        "start": {
          "character": 17,
          "line": 1
        },
        "end": {
          "character": 17,
          "line": 1
        }
      },
      "uri": "uri"
    },
    "name": "f",
    "filename": "expr2.f90"
  },
  {
    "kind": 12,
    "location": {
      "range": {
        "start": {
          "character": 14,
          "line": 1
        },
        "end": {
          "character": 14,
          "line": 1
        }
      },
      "uri": "uri"
    },
    "name": "x",
    "filename": "expr2.f90"
  }
]
```