### PR TITLE
fix: End function name mismatch with function name generates ast with cc

### DIFF
--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -327,3 +327,20 @@ subroutine try_to_change(y)
     integer, intent(in) :: y
     y = 99  
 end subroutine
+
+module my_module
+    integer :: x = 10
+end module wrong_module_name 
+
+subroutine my_subroutine1()
+    print *, "Inside subroutine"
+end subroutine different_name
+
+function my_function() result(res)
+    integer :: res
+    res = 42
+end function not_my_function
+
+subroutine my_subroutine2()
+    print *, "Inside subroutine"
+end subroutine different_name 

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "c3bc41c72ce233600b096cfd2e1f36a43a1f0aa5c7b1cb055ef29ec9",
+    "infile_hash": "602f7366a335389879deaef940fa56737a2a0f2830e40e6ce30518ba",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "9d7e7791825790d389fb9cf76a719e024dba971af0a35a4e597289b4",
+    "stderr_hash": "6f2fd71c5a40f37eb5f6808990065105c968381db4db0447b7043112",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -4,6 +4,46 @@ syntax error: Invalid syntax for variable initialization (try inserting '::' aft
 34 |     integer init_x = 1
    |     ^^^^^^^^^^^^^^^^^^ 
 
+syntax error: End module name does not match module name
+   --> tests/errors/continue_compilation_2.f90:331:1 - 333:28
+    |
+331 |    module my_module
+    |    ^^^^^^^^^^^^^^^^...
+...
+    |
+333 |    end module wrong_module_name 
+    | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+syntax error: End subroutine name does not match subroutine name
+   --> tests/errors/continue_compilation_2.f90:335:1 - 337:29
+    |
+335 |    subroutine my_subroutine1()
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+    |
+337 |    end subroutine different_name
+    | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+syntax error: End function name does not match function name
+   --> tests/errors/continue_compilation_2.f90:339:1 - 342:28
+    |
+339 |    function my_function() result(res)
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+    |
+342 |    end function not_my_function
+    | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+syntax error: End subroutine name does not match subroutine name
+   --> tests/errors/continue_compilation_2.f90:344:1 - 346:29
+    |
+344 |    subroutine my_subroutine2()
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+    |
+346 |    end subroutine different_name 
+    | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: Duplicate DIMENSION attribute specified
   --> tests/errors/continue_compilation_2.f90:22:12
    |


### PR DESCRIPTION
Towards: #5813 