### PR TITLE
fix: bad_implicit typing generates ast and asr with cc flag

### DIFF
--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -78,8 +78,6 @@ static inline char* name2char_with_check(const ast_t *n1, const ast_t *n2,
     if(n2) {
         char* n2c = name2char(n2);
         if (!streql(n1c, n2c)) {
-        //     throw LCompilers::LFortran::parser_local::ParserError(
-        //         "End " + unit + " name does not match " + unit + " name", loc);
             diagnostics.add(LCompilers::LFortran::parser_local::ParserError(
                 "End " + unit + " name does not match " + unit + " name", {loc}).d);
         }
@@ -458,7 +456,7 @@ static inline char * id_if_Name_t(expr_t const * exprNode) {
   return id;
 }
 
-Vec<ast_t*> vec_kind_item2ast(Allocator &al, const Vec<kind_item_t> &kind_items) {
+Vec<ast_t*> vec_kind_item2ast(Allocator &al, const Vec<kind_item_t> &kind_items, LCompilers::diag::Diagnostics &diagnostics) {
     Vec<ast_t*> ast_nodes;
     ast_nodes.reserve(al, kind_items.size());
 
@@ -488,8 +486,8 @@ Vec<ast_t*> vec_kind_item2ast(Allocator &al, const Vec<kind_item_t> &kind_items)
       if (ls_node) {
 	ast_nodes.push_back(al, ls_node);
       } else {
-	throw LCompilers::LFortran::parser_local::ParserError(
-           "Bad implicit letter specification", loc);
+        diagnostics.add(LCompilers::LFortran::parser_local::ParserError(
+            "Bad implicit letter specification", {loc}).d);
       }
     }
 
@@ -499,7 +497,7 @@ Vec<ast_t*> vec_kind_item2ast(Allocator &al, const Vec<kind_item_t> &kind_items)
 	VEC_CAST(specs, implicit_spec), specs.size(), trivia_cast(trivia))
 #define IMPLICIT_SPEC(t, specs, l) make_ImplicitSpec_t(p.m_a, l, \
         down_cast<decl_attribute_t>(t), \
-        VEC_CAST(vec_kind_item2ast(p.m_a, specs), letter_spec), specs.size())
+        VEC_CAST(vec_kind_item2ast(p.m_a, specs, p.diag), letter_spec), specs.size())
 
 static inline var_sym_t* VARSYM(Allocator &al, Location &l,
         char* name, dimension_t* dim, size_t n_dim,

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -521,6 +521,7 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    throw SemanticAbort();
                 }
             }
         }
@@ -571,6 +572,7 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    if ( !compiler_options.continue_compilation ) throw SemanticAbort();
                 }
             }
         }
@@ -981,6 +983,7 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    throw SemanticAbort();
                 }
             }
         }
@@ -1375,6 +1378,7 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    throw SemanticAbort();
                 }
             }
         }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -521,7 +521,6 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
                 }
             }
         }
@@ -572,7 +571,6 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
                 }
             }
         }
@@ -983,7 +981,6 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
                 }
             }
         }
@@ -1378,7 +1375,6 @@ public:
                         "Implicit typing is not allowed, enable it by using --implicit-typing ",
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
                 }
             }
         }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1,5 +1,5 @@
 program continue_compilation_1
-    implicit none
+    implicit integer(a-f), real(e-z)
 
     integer :: a(3), b(3), b1(3, 3), a3(3, 3, 3), b4(3, 3, 3, 3), a5, c5, i
     character :: a1(3, 3)

--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -27,7 +27,7 @@ program continue_compilation_2
     use iso_fortran_env
     use iso_c_binding, only: c_ptr, c_f_pointer
     use Geometry
-    implicit none
+    implicit real(a-z)
 
     integer, pointer, parameter :: v => null()
     integer, allocatable, parameter :: v=1
@@ -313,6 +313,10 @@ program continue_compilation_2
     !type_conflict1
     integer, parameter, target :: foo=4
     print *,foo
+
+    integer :: x_bad_implicit
+    x_bad_implicit = 10
+    print *, x_bad_implicit
 
     contains
     logical function f(x)

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "a71fcc9e485b0040897b1a0aa0bae3e23560aece699750eb19d3536a",
+    "infile_hash": "fe50900b3e871f7dfb599f76e1631b687d811bf374bed4e88c7ace7f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "135703d0a73dfccc52d850e2242bdf6a50423c1f0bd66205dafd0bbb",
+    "stderr_hash": "3550f6b34efb3510891e8e632a1cc406e8e31944dc714cfbc2293f23",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -4,6 +4,16 @@ syntax error: Token 'print' is unexpected here
 73 |     print*, nint(1e12_8)
    |     ^^^^^ 
 
+semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
+ --> tests/errors/continue_compilation_1.f90:2:5 - 3:1
+  |
+2 |        implicit integer(a-f), real(e-z)
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+  |
+3 |    
+  | ...^ 
+
 semantic error: Assignment to loop variable `i` is not allowed
   --> tests/errors/continue_compilation_1.f90:18:8
    |

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "602f7366a335389879deaef940fa56737a2a0f2830e40e6ce30518ba",
+    "infile_hash": "86c24b0fa8ba584382001ded62f890090d348e771014a893faf279d0",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "6f2fd71c5a40f37eb5f6808990065105c968381db4db0447b7043112",
+    "stderr_hash": "c9346f44957a7e1b33f07d4c650f16b00a2b5627e4df7cd74031c5d5",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -5,43 +5,43 @@ syntax error: Invalid syntax for variable initialization (try inserting '::' aft
    |     ^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End module name does not match module name
-   --> tests/errors/continue_compilation_2.f90:331:1 - 333:28
+   --> tests/errors/continue_compilation_2.f90:335:1 - 337:28
     |
-331 |    module my_module
+335 |    module my_module
     |    ^^^^^^^^^^^^^^^^...
 ...
     |
-333 |    end module wrong_module_name 
+337 |    end module wrong_module_name 
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End subroutine name does not match subroutine name
-   --> tests/errors/continue_compilation_2.f90:335:1 - 337:29
+   --> tests/errors/continue_compilation_2.f90:339:1 - 341:29
     |
-335 |    subroutine my_subroutine1()
+339 |    subroutine my_subroutine1()
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-337 |    end subroutine different_name
+341 |    end subroutine different_name
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End function name does not match function name
-   --> tests/errors/continue_compilation_2.f90:339:1 - 342:28
+   --> tests/errors/continue_compilation_2.f90:343:1 - 346:28
     |
-339 |    function my_function() result(res)
+343 |    function my_function() result(res)
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-342 |    end function not_my_function
+346 |    end function not_my_function
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End subroutine name does not match subroutine name
-   --> tests/errors/continue_compilation_2.f90:344:1 - 346:29
+   --> tests/errors/continue_compilation_2.f90:348:1 - 350:29
     |
-344 |    subroutine my_subroutine2()
+348 |    subroutine my_subroutine2()
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-346 |    end subroutine different_name 
+350 |    end subroutine different_name 
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Duplicate DIMENSION attribute specified
@@ -49,6 +49,16 @@ semantic error: Duplicate DIMENSION attribute specified
    |
 22 |     common /rowns/ rowns(209)
    |            ^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
+  --> tests/errors/continue_compilation_2.f90:30:5 - 31:1
+   |
+30 |        implicit real(a-z)
+   |        ^^^^^^^^^^^^^^^^^^...
+...
+   |
+31 |    
+   | ...^ 
 
 semantic error: `parameter` attribute conflicts with `pointer` attribute
   --> tests/errors/continue_compilation_2.f90:32:5
@@ -639,7 +649,7 @@ semantic error: Variable 'foo' is not declared
     |             ^^^ 'foo' is undeclared
 
 semantic error: Cannot assign to an intent(in) variable `y`
-   --> tests/errors/continue_compilation_2.f90:328:5
+   --> tests/errors/continue_compilation_2.f90:332:5
     |
-328 |     y = 99  
+332 |     y = 99  
     |     ^ 


### PR DESCRIPTION
Towards: #5813 