### PR TITLE
feat: Support `ArraySection` with array indices inside `ArrayConstructor`

### DIFF
--- a/integration_tests/arrays_71.f90
+++ b/integration_tests/arrays_71.f90
@@ -12,4 +12,9 @@ y = [z, x2([1,2],1)]
 if(y(1) /= 2 .or. y(2) /= 1 .or. y(3) /= 10) error stop
 y2 = [z, x2([1,2],[1,2])]
 if(y2(1) /= 2 .or. y2(2) /= 1 .or. y2(3) /= 10 .or. y2(4) /= 22 .or. y2(5) /= 1) error stop
+y2 = [z, x2(2:3,2:3)]
+if(y2(1) /= 2 .or. y2(2) /= 1 .or. y2(3) /= 2 .or. y2(4) /= 1 .or. y2(5) /= 2) error stop
+y2 = [z, x2(1:2,[1,2])]
+if(y2(1) /= 2 .or. y2(2) /= 1 .or. y2(3) /= 10 .or. y2(4) /= 22 .or. y2(5) /= 1) error stop
+
 end program

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -346,10 +346,12 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
             pass_result.push_back(al, allocate_stmt);
         }
         for (size_t i = 0; i < x->n_args; i++) {
-            ASR::expr_t** temp = current_expr;
-            current_expr = &(x->m_args[i]);
-            self().replace_expr(x->m_args[i]);
-            current_expr = temp;
+            if(ASR::is_a<ASR::ArrayItem_t>(*x->m_args[i]) || ASR::is_a<ASR::ArraySection_t>(*x->m_args[i])){
+                ASR::expr_t** temp = current_expr;
+                current_expr = &(x->m_args[i]);
+                self().replace_expr(x->m_args[i]);
+                current_expr = temp;
+            }
         }
         LCOMPILERS_ASSERT(result_var != nullptr);
         Vec<ASR::stmt_t*>* result_vec = &pass_result;

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -346,12 +346,10 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
             pass_result.push_back(al, allocate_stmt);
         }
         for (size_t i = 0; i < x->n_args; i++) {
-            if(ASR::is_a<ASR::ArrayItem_t>(*x->m_args[i])){
-                ASR::expr_t** temp = current_expr;
-                current_expr = &(x->m_args[i]);
-                self().replace_expr(x->m_args[i]);
-                current_expr = temp;
-            }
+            ASR::expr_t** temp = current_expr;
+            current_expr = &(x->m_args[i]);
+            self().replace_expr(x->m_args[i]);
+            current_expr = temp;
         }
         LCOMPILERS_ASSERT(result_var != nullptr);
         Vec<ASR::stmt_t*>* result_vec = &pass_result;

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -1458,18 +1458,18 @@ namespace LCompilers {
                 } else if( ASR::is_a<ASR::ArraySection_t>(*curr_init) ) {
                     ASR::ArraySection_t* array_section = ASR::down_cast<ASR::ArraySection_t>(curr_init);
                     Vec<ASR::expr_t*> idx_vars;
+                    Vec<ASR::expr_t*> temp_idx_vars;
                     Vec<ASR::stmt_t*> doloop_body;
-                    create_do_loop(al, loc, array_section, idx_vars, doloop_body,
-                        [=, &idx_vars, &doloop_body, &builder, &al] () {
-                        ASR::expr_t* ref = PassUtils::create_array_ref(array_section, idx_vars,
+                    create_do_loop(al, loc, array_section, idx_vars, temp_idx_vars, doloop_body,
+                        [=, &temp_idx_vars, &doloop_body, &builder, &al] () {
+                        ASR::expr_t* ref = PassUtils::create_array_ref(array_section->m_v, temp_idx_vars,
                             al, current_scope, perform_cast, cast_kind, casted_type);
                         ASR::expr_t* res = PassUtils::create_array_ref(arr_var, idx_var, al, current_scope);
                         ASR::stmt_t* assign = builder.Assignment(res, ref);
                         doloop_body.push_back(al, assign);
                         increment_by_one(idx_var, (&doloop_body))
                     }, current_scope, result_vec);
-                }
-                else if (ASR::is_a<ASR::ArrayItem_t>(*curr_init) ) {
+                } else if (ASR::is_a<ASR::ArrayItem_t>(*curr_init) ) { 
                     bool contains_array = false;
                     ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(curr_init);
                     for(size_t i = 0; i < array_item->n_args; i++) {


### PR DESCRIPTION
Transforms : 
```fortran
y2 = [z, x2(1:2,[1,2])]
```
To : 
```fortran
itr = lbound(y2, 1)
y2(itr) = z
itr = itr + 1
do i = lbound(arr_const, 1), ubound(arr_const, 1)
     do j = 1, 2, 1
          y2(itr) = x2(j, arr_const(i)) 
          itr = itr + 1
     end do
end do
```

