### PR TITLE
fix: missing location information of variables

### DIFF
--- a/src/libasr/asdl_cpp.py
+++ b/src/libasr/asdl_cpp.py
@@ -362,7 +362,7 @@ class DefaultLookupNameVisitor(ASDLVisitor):
         self.emit("uint32_t last = loc.last;", 2)
         self.emit("if (first <= pos && pos <= last) {", 2)
         self.emit("uint32_t span = last - first;", 3)
-        self.emit("if (span <= min_span) {", 3)
+        self.emit("if (span < min_span) {", 3)
         self.emit("min_span = span;", 4)
         self.emit("return true;", 4)
         self.emit("}", 3)

--- a/src/libasr/asr_lookup_name.h
+++ b/src/libasr/asr_lookup_name.h
@@ -18,6 +18,16 @@ namespace LCompilers::LFortran {
             LookupNameVisitor(uint16_t pos) {
                 this->pos = pos;
             }
+            void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
+                if ((bool&)x) { } // Suppress unused warning
+                if (test_loc_and_set_span(x.base.base.loc)) {
+                    const ASR::symbol_t* sym = this->symbol_get_past_external_(x.m_external);
+                    this->handle_symbol(sym);
+                    if ( ASR::is_a<ASR::ClassProcedure_t>(*sym) ) {
+                        this->handle_symbol(ASR::down_cast<ASR::ClassProcedure_t>(sym)->m_proc);
+                    }
+                }
+            }
             void visit_FunctionCall(const ASR::FunctionCall_t &x) {
                 for (size_t i=0; i<x.n_args; i++) {
                     this->visit_call_arg(x.m_args[i]);

--- a/tests/lookup_name3.f90
+++ b/tests/lookup_name3.f90
@@ -1,0 +1,8 @@
+MODULE lookup_name3_module
+REAL, ALLOCATABLE, DIMENSION(:,:,:) :: ec
+CONTAINS
+SUBROUTINE sn_expcoeff( ndimen )
+INTEGER, INTENT(IN) :: ndimen
+ec(:,1,5) = 1.0
+END SUBROUTINE sn_expcoeff
+END MODULE lookup_name3_module

--- a/tests/reference/lookup_name-lookup_name3-a06a374.json
+++ b/tests/reference/lookup_name-lookup_name3-a06a374.json
@@ -1,0 +1,13 @@
+{
+    "basename": "lookup_name-lookup_name3-a06a374",
+    "cmd": "lfortran --lookup-name --no-color {infile} -o {outfile}",
+    "infile": "tests/lookup_name3.f90",
+    "infile_hash": "7181224f94a1ed635176c4414c3a6f8a8b82712a2f3834d4f9fb74b3",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "lookup_name-lookup_name3-a06a374.stdout",
+    "stdout_hash": "02bb7c20abdee50648e64e6a5adf4f41c979dd046f57374672809c01",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/lookup_name-lookup_name3-a06a374.stdout
+++ b/tests/reference/lookup_name-lookup_name3-a06a374.stdout
@@ -1,0 +1,1 @@
+[{"kind":13,"location":{"range":{"start":{"character":40,"line":2},"end":{"character":41,"line":2}},"uri":"uri"},"name":"ec","filename":"tests/lookup_name3.f90"}]

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4390,6 +4390,12 @@ line = 5
 column = 11
 
 [[test]]
+filename = "lookup_name3.f90"
+lookup_name = true
+line = 6
+column = 2
+
+[[test]]
 filename = "errors/func_parameter_type.f90"
 asr = true
 


### PR DESCRIPTION
Fixes #5829. Although it introduces a regression where `Go To Definition` of `procedure` takes us to variable declaration and not `Function` itself.