### PR TITLE
fix : don't use allocatable return in `move_alloc` intrinsic.

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -972,6 +972,7 @@ RUN(NAME intrinsics_330 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #amax0, m
 RUN(NAME intrinsics_331 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # cshift
 RUN(NAME intrinsics_332 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER)
 RUN(NAME intrinsics_333 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER)
+RUN(NAME intrinsics_334 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #move_alloc
 
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants

--- a/integration_tests/intrinsics_334.f90
+++ b/integration_tests/intrinsics_334.f90
@@ -1,0 +1,19 @@
+program intrinsics_334
+    implicit none
+
+    integer, allocatable :: from(:), to(:)
+
+    allocate(from(5))
+    from = [1, 2, 3, 4, 5]
+
+    allocate(to(5))
+    call move_alloc(from, to)
+    print *, to
+    if(any(to /= [1,2,3,4,5])) error stop
+
+    ! this check doesn't return correct value for now, as we don't deallocte `from` variable yet.
+
+    ! print *, allocated(from)
+    ! if(allocated(from) .neqv. .false.) error stop 
+
+end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4052,10 +4052,7 @@ namespace MoveAlloc {
         declare_basic_variables(new_name);
         fill_func_arg("from", arg_types[0]);
         fill_func_arg("to", arg_types[1]);
-        auto result = declare(new_name, ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc, arg_types[0])), ReturnVar);
-        LCompilers::ASR::dimension_t *m_dims = nullptr;
-        int n_dims = extract_dimensions_from_ttype(arg_types[0], m_dims);
-        body.push_back(al, b.Allocate(result, m_dims, n_dims));
+        auto result = declare(new_name, arg_types[0], ReturnVar);
         body.push_back(al, b.Assignment(result, args[0]));
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,


### PR DESCRIPTION
fixes #5634

I think `move_alloc` should be handled as a standalone ASR node, as we can't move the array pointer using ASR statements; It should be handled by the backend explicitly for efficiency.  