### PR TITLE
enh: support multiple integer types for `_lfortran_str_item`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1376,6 +1376,7 @@ RUN(NAME string_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME string_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME string_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_43.f90
+++ b/integration_tests/string_43.f90
@@ -1,0 +1,23 @@
+program string_43
+    character(len=5), parameter :: color = "hello"
+    
+    integer(1) :: i = 1
+    integer(2) :: j = 2
+    integer(4) :: k = 3
+    integer(8) :: l = 4
+ 
+    print *, color(i:i)
+    if (color(i:i) /= "h") error stop
+ 
+    print *, color(j:j)
+    if (color(j:j) /= "e") error stop
+ 
+    print *, color(k:k)
+    if (color(k:k) /= "l") error stop
+ 
+    print *, color(l:l)
+    if (color(l:l) /= "l") error stop
+ 
+    print *, color(5:5)
+ end program string_43
+  

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -694,12 +694,14 @@ public:
 
     llvm::Value* lfortran_str_item(llvm::Value* str, llvm::Value* idx1)
     {
-        std::string runtime_func_name = "_lfortran_str_item";
-        llvm::Function *fn = module->getFunction(runtime_func_name);
+        std::string runtime_func_name = std::string("_lfortran_str_item_") + "int"
+                                        + std::to_string(idx1->getType()->getIntegerBitWidth())
+                                        + "_t";
+        llvm::Function* fn = module->getFunction(runtime_func_name);
         if (!fn) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
                     character_type, {
-                        character_type, llvm::Type::getInt32Ty(context)
+                        character_type, idx1->getType()
                     }, false);
             fn = llvm::Function::Create(function_type,
                     llvm::Function::ExternalLinkage, runtime_func_name, *module);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2292,20 +2292,26 @@ LFORTRAN_API char* _lfortran_strrepeat_c(char* s, int32_t n)
 }
 
 // idx starts from 1
-LFORTRAN_API char* _lfortran_str_item(char* s, int32_t idx) {
-
-    int s_len = strlen(s);
-    int original_idx = idx - 1;
-    if (idx < 1) idx += s_len;
-    if (idx < 1 || idx >= s_len + 1) {
-        printf("String index: %d is out of Bounds\n", original_idx);
-        exit(1);
+#define DEFINE_LFORTRAN_STR_ITEM(type)                                                             \
+    LFORTRAN_API char* _lfortran_str_item_##type(char* s, type idx)                                \
+    {                                                                                              \
+        int s_len = strlen(s);                                                                     \
+        int original_idx = idx - 1;                                                                \
+        if (idx < 1) idx += s_len;                                                                 \
+        if (idx < 1 || idx >= s_len + 1) {                                                         \
+            printf("String index: %d is out of Bounds\n", original_idx);                           \
+            exit(1);                                                                               \
+        }                                                                                          \
+        char* res = (char*) malloc(2);                                                             \
+        res[0] = s[idx - 1];                                                                       \
+        res[1] = '\0';                                                                             \
+        return res;                                                                                \
     }
-    char* res = (char*)malloc(2);
-    res[0] = s[idx-1];
-    res[1] = '\0';
-    return res;
-}
+
+DEFINE_LFORTRAN_STR_ITEM(int8_t)
+DEFINE_LFORTRAN_STR_ITEM(int16_t)
+DEFINE_LFORTRAN_STR_ITEM(int32_t)
+DEFINE_LFORTRAN_STR_ITEM(int64_t)
 
 // idx1 and idx2 both start from 1
 LFORTRAN_API char* _lfortran_str_copy(char* s, int32_t idx1, int32_t idx2) {

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -65,6 +65,14 @@ typedef double _Complex double_complex_t;
     }
 #endif
 
+#define DECLARE_LFORTRAN_STR_ITEM(type)                                                            \
+    LFORTRAN_API char* _lfortran_str_item_##type(char* s, type idx);
+
+DECLARE_LFORTRAN_STR_ITEM(int8_t)
+DECLARE_LFORTRAN_STR_ITEM(int16_t)
+DECLARE_LFORTRAN_STR_ITEM(int32_t)
+DECLARE_LFORTRAN_STR_ITEM(int64_t)
+
 LFORTRAN_API double _lfortran_sum(int n, double *v);
 LFORTRAN_API void _lfortran_random_number(int n, double *v);
 LFORTRAN_API void _lfortran_init_random_clock();
@@ -209,7 +217,6 @@ LFORTRAN_API int8_t* _lfortran_calloc(int32_t count, int32_t size);
 LFORTRAN_API void _lfortran_free(char* ptr);
 LFORTRAN_API void _lfortran_alloc(char** ptr, int32_t len, int64_t* size, int64_t* capacity);
 LFORTRAN_API void _lfortran_string_init(int size_plus_one, char *s);
-LFORTRAN_API char* _lfortran_str_item(char* s, int32_t idx);
 LFORTRAN_API char* _lfortran_str_copy(char* s, int32_t idx1, int32_t idx2); // idx1 and idx2 both start from 1
 LFORTRAN_API char* _lfortran_str_slice(char* s, int32_t idx1, int32_t idx2, int32_t step,
                         bool idx1_present, bool idx2_present);

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "817d2ce942971b593fdfe9c0cb8c81b12198602fffc586e5c8062707",
+    "stdout_hash": "fca0809ea0f5ee912930541ae841f31905c70961f19d99808b9652c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -33,7 +33,7 @@ then:                                             ; preds = %.entry
 loop.head:                                        ; preds = %ifcont, %then
   %5 = load i32, i32* %result, align 4
   %6 = load i8*, i8** %str, align 8
-  %7 = call i8* @_lfortran_str_item(i8* %6, i32 %5)
+  %7 = call i8* @_lfortran_str_item_int32_t(i8* %6, i32 %5)
   %8 = alloca i8*, align 8
   store i8* %7, i8** %8, align 8
   %9 = alloca i8*, align 8
@@ -143,7 +143,7 @@ declare void @_lfortran_strcpy_descriptor_string(i8**, i8*, i64*, i64*)
 
 declare i32 @_lfortran_str_len(i8**)
 
-declare i8* @_lfortran_str_item(i8*, i32)
+declare i8* @_lfortran_str_item_int32_t(i8*, i32)
 
 declare i1 @_lpython_str_compare_eq(i8**, i8**)
 


### PR DESCRIPTION
fixes #5839 