### PR TITLE
[MLIR][OpenMP] Replace DoConcurrentLoop with Parallel construct

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1525,6 +1525,7 @@ jobs:
             python=3.10
             mlir=15.0.7
             llvm=15.0.7
+            llvm-openmp=15.0.7
 
       - uses: hendrikmuhs/ccache-action@main
         with:
@@ -1553,10 +1554,8 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            ./run_tests.py -b mlir -j1
-            ./run_tests.py -b mlir -j1 --no-experimental-simplifier
-
-
+            ./run_tests.py -b mlir mlir_omp -j1
+            ./run_tests.py -b mlir mlir_omp -j1 --no-experimental-simplifier
 
   upload_docs:
     name: Documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,8 @@ if (WITH_LLVM)
                 MLIRIR
                 MLIRLLVMToLLVMIRTranslation
                 MLIRLLVMDialect
+                MLIROpenMPToLLVMIRTranslation
+                MLIROpenMPDialect
             )
         set_property(TARGET p::mlir PROPERTY INTERFACE_LINK_LIBRARIES ${mlir_libs})
         set(HAVE_LFORTRAN_MLIR yes)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -154,6 +154,12 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             execute_process(COMMAND lfortran ${extra_args} --backend=mlir
                 ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.f90 -o ${name})
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
+        elseif (LFORTRAN_BACKEND STREQUAL "mlir_omp")
+            execute_process(COMMAND lfortran ${extra_args} --backend=mlir
+                --openmp --openmp-lib-dir=$ENV{CONDA_PREFIX}/lib
+                --mlir-gpu-offloading
+                ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.f90 -o ${name})
+            add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         else ()
             add_executable(${name} ${file_name}.f90 ${extra_files})
             target_compile_options(${name} PUBLIC ${gfortran_args})
@@ -183,7 +189,7 @@ macro(RUN)
                         "${multiValueArgs}" ${ARGN} )
 
     foreach(b ${RUN_LABELS})
-        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|llvm_wasm|llvm_wasm_emcc|llvm_omp|mlir)$"))
+        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|llvm_wasm|llvm_wasm_emcc|llvm_omp|mlir|mlir_omp)$"))
             message(FATAL_ERROR "Unsupported backend: ${b}")
         endif()
     endforeach()
@@ -257,6 +263,7 @@ endmacro(COMPILE)
 # x86           --- compile to x86 binary directly
 # wasm          --- compile to WASM binary directly
 # mlir          --- generate mlir, convert to llvm ir and compile to binary
+# mlir_omp      --- generate mlir with OpenMP, convert to llvm ir and compile to binary
 
 # `reduce` is not supported by GFortran yet:
 # RUN(NAME doconcurrentloop_02 LABELS gfortran)
@@ -1822,7 +1829,7 @@ RUN(NAME selected_int_kind_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fort
 
 RUN(NAME capital_01 LABELS gfortran llvmImplicit)
 
-RUN(NAME do_concurrent_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc mlir)
+RUN(NAME do_concurrent_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc mlir mlir_omp)
 RUN(NAME do_concurrent_02 LABELS llvm_omp llvm)
 RUN(NAME do_concurrent_03 LABELS llvm_omp)
 RUN(NAME do_concurrent_04 LABELS llvm_omp)

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -9,7 +9,7 @@ NO_OF_THREADS = 8 # default no of threads is 8
 SUPPORTED_BACKENDS = ['llvm', 'llvm2', 'llvm_rtlib', 'c', 'cpp', 'x86', 'wasm',
                       'gfortran', 'llvmImplicit', 'llvmStackArray', 'fortran',
                       'c_nopragma', 'llvm_nopragma', 'llvm_wasm', 'llvm_wasm_emcc',
-                      'llvm_omp', 'mlir']
+                      'llvm_omp', 'mlir', 'mlir_omp']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LFORTRAN_PATH = f"{BASE_DIR}/../src/bin:$PATH"
 

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -37,14 +37,19 @@ class DoLoopVisitor : public ASR::StatementWalkVisitor<DoLoopVisitor>
 {
 public:
     bool use_loop_variable_after_loop = false;
-    DoLoopVisitor(Allocator &al) : StatementWalkVisitor(al) {
-    }
+    PassOptions pass_options;
+    DoLoopVisitor(Allocator &al, PassOptions pass_options_) :
+        StatementWalkVisitor(al), pass_options(pass_options_) { }
 
     void visit_DoLoop(const ASR::DoLoop_t &x) {
         pass_result = PassUtils::replace_doloop(al, x, -1, use_loop_variable_after_loop);
     }
 
     void visit_DoConcurrentLoop(const ASR::DoConcurrentLoop_t &x) {
+        if (pass_options.enable_gpu_offloading) {
+            // DoConcurrentLoop is handled in the MLIR backend
+            return;
+        }
         Vec<ASR::stmt_t*> body;body.reserve(al,1);
         for (int i = 0; i < static_cast<int>(x.n_body); i++) {
             body.push_back(al,x.m_body[i]);
@@ -62,7 +67,7 @@ public:
 
 void pass_replace_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
                            const LCompilers::PassOptions& pass_options) {
-    DoLoopVisitor v(al);
+    DoLoopVisitor v(al, pass_options);
     // Each call transforms only one layer of nested loops, so we call it twice
     // to transform doubly nested loops:
     v.asr_changed = true;


### PR DESCRIPTION
Implementation details:
- Use OpenMPDialect (to use MLIR OpenMP dialect) and
  OpenMPToLLVMIRTranslation (to transform OpenMP dialect
  to LLVM IR)
- Convert DoConcurrentLoop into OpenMP Parallel construct

Towards: https://github.com/lfortran/lfortran/issues/4319