### PR TITLE
[MLIR] Support building with MLIR 19

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1523,9 +1523,9 @@ jobs:
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             python=3.10
-            mlir=15.0.7
-            llvm=15.0.7
-            llvm-openmp=15.0.7
+            mlir=19.1.6
+            llvm=19.1.6
+            llvm-openmp=19.1.6
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ if (WITH_LLVM)
         set(mlir_libs
                 MLIRIR
                 MLIRLLVMToLLVMIRTranslation
+                MLIRBuiltinToLLVMIRTranslation
                 MLIRLLVMDialect
                 MLIROpenMPToLLVMIRTranslation
                 MLIROpenMPDialect

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -175,7 +175,7 @@ void MLIRModule::mlir_to_llvm() {
     if (llvmModule) {
         llvm_m = std::move(llvmModule);
     } else {
-        throw std::runtime_error("Failed to generate LLVM IR");
+        throw LCompilersException("Failed to generate LLVM IR");
     }
 }
 #endif


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/5863

Issues fixed:
- LLVMPointerType::get(<mlir::Type>) => LLVMPointerType::get(*context)
- We need to specify the element_type for LoadOp, AllocaOp, GEPOp
- addEntryBlock requires builderOp as argument
- Register BuiltinDialectTranslation to fix the error:
   "cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface`
   registration for dialect for op: builtin.module"