### PR TITLE
chore: update funding manifest URL

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,1 +1,1 @@
-https://www.lfortran.org/funding.json
+https://lfortran.org/funding.json


### PR DESCRIPTION
Remove `www` subdomain from URL.