### PR TITLE
fix (AST -> ASR): import `ExternalSymbol` with `m_name` instead of `m_original_name`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -298,6 +298,7 @@ RUN(NAME include_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran
 RUN(NAME include_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran INCLUDE_PATH include_03)
 
 RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c wasm fortran)
+RUN(NAME use_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c wasm fortran)
 
 RUN(NAME cond_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME cond_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)

--- a/integration_tests/use_02.f90
+++ b/integration_tests/use_02.f90
@@ -1,0 +1,11 @@
+module use_02_module
+    use iso_fortran_env, only: dp => real64
+ end module
+ 
+ program use_02
+    use use_02_module
+    integer(dp) :: i
+    i = 1234567890123456789_dp
+    if (i /= 1234567890123456789_dp) error stop
+ end program
+ 

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2534,22 +2534,16 @@ public:
                 // We have to "repack" the ExternalSymbol so that it lives in the
                 // local symbol table
                 ASR::ExternalSymbol_t *es0 = ASR::down_cast<ASR::ExternalSymbol_t>(item.second);
-                std::string sym;
-                if( in_submodule || ASR::is_a<ASR::Function_t>(*es0->m_external)) {
-                    sym = item.first;
-                } else {
-                    sym = to_lower(es0->m_original_name);
-                }
                 ASR::asr_t *es = ASR::make_ExternalSymbol_t(
                     al, es0->base.base.loc,
                     /* a_symtab */ current_scope,
-                    /* a_name */ s2c(al, sym),
+                    /* a_name */ s2c(al, item.first),
                     es0->m_external,
                     es0->m_module_name, nullptr, 0,
                     es0->m_original_name,
                     dflt_access
                     );
-                current_scope->add_or_overwrite_symbol(sym, ASR::down_cast<ASR::symbol_t>(es));
+                current_scope->add_or_overwrite_symbol(item.first, ASR::down_cast<ASR::symbol_t>(es));
             } else if( ASR::is_a<ASR::Struct_t>(*item.second) ) {
                 ASR::Struct_t *mv = ASR::down_cast<ASR::Struct_t>(item.second);
                 // `mv` is the Variable in a module. Now we construct

--- a/tests/reference/asr-derived_types_11-c169ea7.json
+++ b/tests/reference/asr-derived_types_11-c169ea7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_11-c169ea7.stdout",
-    "stdout_hash": "3ccf91b481fc0952d30d7077585663fa27169b808ca4c6e6ad6e69dc",
+    "stdout_hash": "731640f5e615e47c9e6246d13da8910a1f1309913891f9e3b36d9b13",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_11-c169ea7.stdout
+++ b/tests/reference/asr-derived_types_11-c169ea7.stdout
@@ -143,16 +143,6 @@
                                     backslash
                                     Public
                                 ),
-                            backslash:
-                                (ExternalSymbol
-                                    4
-                                    backslash
-                                    3 backslash
-                                    y
-                                    []
-                                    backslash
-                                    Public
-                                ),
                             type_y:
                                 (ExternalSymbol
                                     4

--- a/tests/reference/asr-modules_31-cd9bfef.json
+++ b/tests/reference/asr-modules_31-cd9bfef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_31-cd9bfef.stdout",
-    "stdout_hash": "8ec26e61e2873df44fb38ba8bd6b613646e1e34493c87853fe9e2c53",
+    "stdout_hash": "2ec1a659261277dac579ef6fe7e822918b1228e011324f4d5b429da9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_31-cd9bfef.stdout
+++ b/tests/reference/asr-modules_31-cd9bfef.stdout
@@ -847,6 +847,16 @@
                     (SymbolTable
                         2
                         {
+                            1_dependency_config_t:
+                                (ExternalSymbol
+                                    2
+                                    1_dependency_config_t
+                                    9 dependency_config_t
+                                    fpm_dependency_modules_31
+                                    []
+                                    dependency_config_t
+                                    Public
+                                ),
                             cmd_update:
                                 (ExternalSymbol
                                     2
@@ -855,16 +865,6 @@
                                     fpm_cmd_update_modules_31
                                     []
                                     cmd_update
-                                    Public
-                                ),
-                            dependency_config_t:
-                                (ExternalSymbol
-                                    2
-                                    dependency_config_t
-                                    9 dependency_config_t
-                                    fpm_dependency_modules_31
-                                    []
-                                    dependency_config_t
                                     Public
                                 ),
                             dependency_tree_t:

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "ceb81887312ecf22eb84789106a9075dcb46a40f51eea201418a8bda",
+    "stdout_hash": "2536c98324324bc5f3ef60e244f63b27c22515ed83cbe08a9c1b46d8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -520,6 +520,16 @@
                     (SymbolTable
                         2
                         {
+                            1_enum_stat:
+                                (ExternalSymbol
+                                    2
+                                    1_enum_stat
+                                    11 enum_stat
+                                    class_default_select_type
+                                    []
+                                    enum_stat
+                                    Public
+                                ),
                             check_table:
                                 (ExternalSymbol
                                     2
@@ -528,16 +538,6 @@
                                     class_default_select_type_user
                                     []
                                     check_table
-                                    Public
-                                ),
-                            enum_stat:
-                                (ExternalSymbol
-                                    2
-                                    enum_stat
-                                    11 enum_stat
-                                    class_default_select_type
-                                    []
-                                    enum_stat
                                     Public
                                 ),
                             get_table:

--- a/tests/reference/asr-use_02-fe85e54.json
+++ b/tests/reference/asr-use_02-fe85e54.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-use_02-fe85e54",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/use_02.f90",
+    "infile_hash": "2465d081695b10647ab035f666d8e103185c17953126f0aacfcc3ce3",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-use_02-fe85e54.stdout",
+    "stdout_hash": "629864273e08fbe71543979ac3e21b5e443740c3aa98f146299f23a5",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-use_02-fe85e54.stdout
+++ b/tests/reference/asr-use_02-fe85e54.stdout
@@ -1,0 +1,84 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env),
+            use_02:
+                (Program
+                    (SymbolTable
+                        5
+                        {
+                            dp:
+                                (ExternalSymbol
+                                    5
+                                    dp
+                                    4 real64
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    real64
+                                    Public
+                                ),
+                            i:
+                                (Variable
+                                    5
+                                    i
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 8)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                )
+                        })
+                    use_02
+                    [use_02_module]
+                    [(Assignment
+                        (Var 5 i)
+                        (IntegerConstant 1234567890123456789 (Integer 8) Decimal)
+                        ()
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 5 i)
+                            NotEq
+                            (IntegerConstant 1234567890123456789 (Integer 8) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )]
+                ),
+            use_02_module:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            dp:
+                                (ExternalSymbol
+                                    2
+                                    dp
+                                    4 real64
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    real64
+                                    Public
+                                )
+                        })
+                    use_02_module
+                    [iso_fortran_env]
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4412,3 +4412,7 @@ extrafiles = "document_symbols1_module.f90"
 filename = "../integration_tests/loop_var_use_after_loop.f90"
 pass = "do_loops"
 options = "--use-loop-variable-after-loop"
+
+[[test]]
+filename = "../integration_tests/use_02.f90"
+asr = true


### PR DESCRIPTION
fixes #5870 

Using `m_original_name` causes incorrect variable names for aliases.