### PR TITLE
fix: use 1 as length of newline character in `new_line()` intrinsic

### DIFF
--- a/integration_tests/intrinsics_218.f90
+++ b/integration_tests/intrinsics_218.f90
@@ -1,8 +1,15 @@
-program main
-implicit none
-
-integer, parameter :: new_len = len(new_line('a'))
-print *, new_len
-if (new_len /= 1) error stop
-print*, "Hello, World!", new_line('a')
-end
+program intrinsics_218
+    implicit none
+    integer, parameter :: new_len = len(new_line('a'))
+    character(len=*), parameter :: str = new_line('')
+    print *, new_len
+    if (new_len /= 1) error stop
+    print*, "Hello, World!", new_line('a')
+    call temp(str)
+contains 
+   subroutine temp(str)
+      character(len=*) :: str
+      print *, len(str)
+      if(len(str) /= 1) error stop
+    end subroutine
+end program

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1640,7 +1640,11 @@ public:
 
     void visit_StringConstant(const ASR::StringConstant_t &x) {
         src = "\"";
-        src.append(x.m_s);
+        if(std::strcmp(x.m_s, "\n") == 0) {
+            src.append("\\n");
+        } else {
+            src.append(x.m_s);
+        }
         src += "\"";
         last_expr_precedence = Precedence::Ext;
     }

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4563,7 +4563,7 @@ namespace NewLine {
     static ASR::expr_t *eval_NewLine(Allocator &al, const Location &loc,
             ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
         char* new_line_str = (char*)"\n";
-        return make_ConstantWithType(make_StringConstant_t, new_line_str, ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 0, nullptr, ASR::string_physical_typeType::PointerString)), loc);
+        return make_ConstantWithType(make_StringConstant_t, new_line_str, ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 1, nullptr, ASR::string_physical_typeType::PointerString)), loc);
     }
 
 } // namespace NewLine

--- a/tests/reference/asr-intrinsics_33-816caef.json
+++ b/tests/reference/asr-intrinsics_33-816caef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_33-816caef.stdout",
-    "stdout_hash": "3feeac601a83be92b6972f17b88860a177a1adc665d69bcdfa9e1c9a",
+    "stdout_hash": "5b1e0a94e94f2c2b605d514aa9f28f838830b6c15d5fee69f197f487",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_33-816caef.stdout
+++ b/tests/reference/asr-intrinsics_33-816caef.stdout
@@ -28,7 +28,7 @@
                                     (String 1 -1 () PointerString)
                                     (StringConstant
                                         "\n"
-                                        (String 1 0 () PointerString)
+                                        (String 1 1 () PointerString)
                                     )
                                 )
                                 (String 1 -1 () PointerString)


### PR DESCRIPTION
Fixes #5869 