### PR TITLE
fix: Use variable in Subroutinecall instead its `m_type_declaration` and create load when function variable is local

### DIFF
--- a/integration_tests/procedure_08.f90
+++ b/integration_tests/procedure_08.f90
@@ -1,3 +1,4 @@
+!! Test to check if actual function is called instead of its m_type_declaration 
 module procedure_08_module
 contains
     subroutine cb(x)
@@ -36,5 +37,17 @@ contains
     subroutine temp2(call_back)
         implicit none
         procedure(cb), optional :: call_back
+        if(present(call_back)) then
+            call temp3(call_back) 
+        end if 
     end subroutine
+    subroutine temp3(call_back)
+        implicit none
+        procedure(cb) :: call_back
+        integer :: x(4) 
+        call call_back(x) 
+        print *, x
+        if(x(1) /= 2) error stop
+    end subroutine
+
 end program procedure_08

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8854,18 +8854,9 @@ public:
                                     tmp = llvm_utils->CreateLoad2(arg->m_type, tmp);
                                 }
                             } else {
-                                if(arg->m_type_declaration && ASR::is_a<ASR::Function_t>(
-                                        *ASRUtils::symbol_get_past_external(arg->m_type_declaration))){
-                                    // (FunctionType)** --> (FunctionType)*
-                                    ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(
-                                        symbol_get_past_external(arg->m_type_declaration));
-                                    uint32_t h = get_hash((ASR::asr_t*)fn);
-                                    if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Implementation) {
-                                        LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
-                                        tmp = llvm_symtab_fn[h];
-                                    } else if(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end()) {
-                                        tmp = llvm_symtab_fn_arg[h];
-                                    }
+                                if( arg->m_intent == intent_local && ASR::is_a<ASR::FunctionType_t>(*arg->m_type) ) {
+                                    // (FunctionType**) --> (FunctionType*)
+                                    tmp = llvm_utils->CreateLoad2(arg->m_type, tmp);
                                 }
                                 if( orig_arg &&
                                     !LLVM::is_llvm_pointer(*orig_arg->m_type) &&


### PR DESCRIPTION
Fixes #5868 