### PR TITLE
[LLVM] Use LLVM backend to generate IR for GPU offloading

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1626,8 +1626,8 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            ./run_tests.py -b mlir mlir_omp -j1
-            ./run_tests.py -b mlir mlir_omp -j1 --no-experimental-simplifier
+            ./run_tests.py -b mlir mlir_omp mlir_llvm_omp -j1
+            ./run_tests.py -b mlir mlir_omp mlir_llvm_omp -j1 --no-experimental-simplifier
 
   upload_docs:
     name: Documentation

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -162,6 +162,12 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
                 --mlir-gpu-offloading
                 ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.f90 -o ${name})
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
+        elseif (LFORTRAN_BACKEND STREQUAL "mlir_llvm_omp")
+            execute_process(COMMAND lfortran ${extra_args} --backend=llvm
+                --openmp --openmp-lib-dir=$ENV{CONDA_PREFIX}/lib
+                --mlir-gpu-offloading
+                ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.f90 -o ${name})
+            add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         else ()
             add_executable(${name} ${file_name}.f90 ${extra_files})
             target_compile_options(${name} PUBLIC ${gfortran_args})
@@ -191,7 +197,7 @@ macro(RUN)
                         "${multiValueArgs}" ${ARGN} )
 
     foreach(b ${RUN_LABELS})
-        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|llvm_wasm|llvm_wasm_emcc|llvm_omp|mlir|mlir_omp)$"))
+        if (NOT (b MATCHES "^(llvm|llvm2|llvm_rtlib|c|cpp|x86|wasm|gfortran|llvmImplicit|llvmStackArray|fortran|c_nopragma|llvm_nopragma|llvm_wasm|llvm_wasm_emcc|llvm_omp|mlir|mlir_omp|mlir_llvm_omp)$"))
             message(FATAL_ERROR "Unsupported backend: ${b}")
         endif()
     endforeach()
@@ -271,6 +277,8 @@ endmacro(COMPILE)
 # wasm          --- compile to WASM binary directly
 # mlir          --- generate mlir, convert to llvm ir and compile to binary
 # mlir_omp      --- generate mlir with OpenMP, convert to llvm ir and compile to binary
+# mlir_llvm_omp --- generate mlir for a module with OpenMP, convert and link
+#                   it with the existing llvm ir and compile to binary
 
 # `reduce` is not supported by GFortran yet:
 # RUN(NAME doconcurrentloop_02 LABELS gfortran)
@@ -1879,7 +1887,7 @@ RUN(NAME selected_int_kind_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fort
 
 RUN(NAME capital_01 LABELS gfortran llvmImplicit)
 
-RUN(NAME do_concurrent_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc mlir mlir_omp)
+RUN(NAME do_concurrent_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc mlir mlir_omp mlir_llvm_omp)
 RUN(NAME do_concurrent_02 LABELS llvm_omp llvm)
 RUN(NAME do_concurrent_03 LABELS llvm_omp)
 RUN(NAME do_concurrent_04 LABELS llvm_omp)

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -9,7 +9,7 @@ NO_OF_THREADS = 8 # default no of threads is 8
 SUPPORTED_BACKENDS = ['llvm', 'llvm2', 'llvm_rtlib', 'c', 'cpp', 'x86', 'wasm',
                       'gfortran', 'llvmImplicit', 'llvmStackArray', 'fortran',
                       'c_nopragma', 'llvm_nopragma', 'llvm_wasm', 'llvm_wasm_emcc',
-                      'llvm_omp', 'mlir', 'mlir_omp']
+                      'llvm_omp', 'mlir', 'mlir_omp', 'mlir_llvm_omp']
 SUPPORTED_STANDARDS = ['lf', 'f23', 'legacy']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LFORTRAN_PATH = f"{BASE_DIR}/../src/bin:$PATH"

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1081,7 +1081,7 @@ int compile_src_to_object_file(const std::string &infile,
                     mlir_res = fe.get_mlir((LCompilers::ASR::asr_t &)mod, diagnostics);
 
                 std::cerr << diagnostics.render(lm, compiler_options);
-                if (result.ok) {
+                if (mlir_res.ok) {
                     mlir_res.result->mlir_to_llvm(*mlir_res.result->llvm_ctx);
                     std::string mlir_tmp_o{std::filesystem::path(infile).
                         replace_extension(".mlir.tmp.o").string()};

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -909,7 +909,7 @@ int handle_mlir(const std::string &infile,
     std::unique_ptr<LCompilers::MLIRModule> m;
     diagnostics.diagnostics.clear();
     LCompilers::Result<std::unique_ptr<LCompilers::MLIRModule>>
-        res = fe.get_mlir(*asr, diagnostics);
+        res = fe.get_mlir(*(LCompilers::ASR::asr_t *)asr, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);
     if (res.ok) {
         m = std::move(res.result);

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1069,6 +1069,32 @@ int compile_src_to_object_file(const std::string &infile,
         e.save_object_file(*(m->m_m), outfile);
     }
 
+    if(compiler_options.po.enable_gpu_offloading) {
+#ifdef HAVE_LFORTRAN_MLIR
+        for (auto &item : asr->m_symtab->get_scope()) {
+            if (LCompilers::ASR::is_a<LCompilers::ASR::Module_t>(*item.second) &&
+                    item.first.find("_lcompilers_mlir_gpu_offloading")
+                    != std::string::npos) {
+                LCompilers::ASR::Module_t &mod = *LCompilers::ASR::down_cast
+                    <LCompilers::ASR::Module_t>(item.second);
+                LCompilers::Result<std::unique_ptr<LCompilers::MLIRModule>>
+                    mlir_res = fe.get_mlir((LCompilers::ASR::asr_t &)mod, diagnostics);
+
+                std::cerr << diagnostics.render(lm, compiler_options);
+                if (result.ok) {
+                    mlir_res.result->mlir_to_llvm(*mlir_res.result->llvm_ctx);
+                    std::string mlir_tmp_o{std::filesystem::path(infile).
+                        replace_extension(".mlir.tmp.o").string()};
+                    e.save_object_file(*(mlir_res.result->llvm_m), mlir_tmp_o);
+                } else {
+                    LCOMPILERS_ASSERT(diagnostics.has_error())
+                    return 1;
+                }
+            }
+        }
+#endif
+    }
+
     return has_error_w_cc;
 }
 
@@ -1758,6 +1784,13 @@ int link_executable(const std::vector<std::string> &infiles,
             compile_cmd = CC + options + " -o " + outfile + " ";
             for (auto &s : infiles) {
                 compile_cmd += s + " ";
+                if (backend == Backend::llvm &&
+                        compiler_options.po.enable_gpu_offloading &&
+                        LCompilers::endswith(s, ".tmp.o")) {
+                    std::string mlir_tmp_o{s.substr(0, s.size() - 6) +
+                        ".mlir.tmp.o"};
+                    compile_cmd += mlir_tmp_o + " ";
+                }
             }
             if(!extra_library_flags.empty()) {
                 compile_cmd += extra_library_flags + " ";
@@ -2675,13 +2708,13 @@ int main_app(int argc, char *argv[]) {
                         time_report, compiler_options);
             }
             if (backend == Backend::llvm) {
-    #ifdef HAVE_LFORTRAN_LLVM
+#ifdef HAVE_LFORTRAN_LLVM
                 err = compile_src_to_object_file(arg_file, tmp_o, false,
                     compiler_options, lfortran_pass_manager);
-    #else
+#else
                 std::cerr << "Compiling Fortran files to object files requires the LLVM backend to be enabled. Recompile with `WITH_LLVM=yes`." << std::endl;
                 return 1;
-    #endif
+#endif
             } else if (backend == Backend::cpp) {
                 err = compile_to_object_file_cpp(arg_file, tmp_o, arg_v, false,
                         true, rtlib_header_dir, compiler_options);
@@ -2694,26 +2727,26 @@ int main_app(int argc, char *argv[]) {
                 err = compile_to_binary_wasm(arg_file, outfile,
                         time_report, compiler_options);
             } else if (backend == Backend::mlir) {
-    #ifdef HAVE_LFORTRAN_MLIR
+#ifdef HAVE_LFORTRAN_MLIR
                 err = handle_mlir(arg_file, tmp_o, compiler_options, false, false);
-    #else
+#else
                 std::cerr << "Compiling Fortran files to object files using "
                     "`--backend=mlir` requires the MLIR backend to be enabled. "
                     "Recompile with `WITH_MLIR=yes`." << std::endl;
                 return 1;
-    #endif
+#endif
             } else {
                 throw LCompilers::LCompilersException("Backend not supported");
             }
         } else if (endswith(arg_file, ".ll")) {
             // this way we can execute LLVM IR files directly
-    #ifdef HAVE_LFORTRAN_LLVM
+#ifdef HAVE_LFORTRAN_LLVM
             err = compile_llvm_to_object_file(arg_file, tmp_o, compiler_options);
             if (err) return err;
-    #else
+#else
             std::cerr << "Compiling LLVM IR to object files requires the LLVM backend to be enabled. Recompile with `WITH_LLVM=yes`." << std::endl;
             return 1;
-    #endif
+#endif
         } else {
             // assume it's an object file
             tmp_o = arg_file;

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -535,18 +535,22 @@ Result<std::string> FortranEvaluator::get_julia(const std::string &code,
 
 Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir(
 #ifdef HAVE_LFORTRAN_MLIR
-        ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics
+        ASR::asr_t &asr, diag::Diagnostics &diagnostics
 #else
-        ASR::TranslationUnit_t &/*asr*/, diag::Diagnostics &/*diagnostics*/
+        ASR::asr_t &/*asr*/, diag::Diagnostics &/*diagnostics*/
 #endif
 ) {
 #ifdef HAVE_LFORTRAN_MLIR
     // ASR -> MLIR
     std::unique_ptr<LCompilers::MLIRModule> m;
     LCompilers::PassManager pass_manager;
-    pass_manager.use_default_passes();
-    pass_manager.apply_passes(al, &asr, compiler_options.po, diagnostics);
-    Result<std::unique_ptr<MLIRModule>> res = asr_to_mlir(al, asr, diagnostics);
+    if (asr.type == ASR::unit) {
+        pass_manager.use_default_passes();
+        pass_manager.apply_passes(al, (ASR::TranslationUnit_t *)&asr,
+            compiler_options.po, diagnostics);
+    }
+    Result<std::unique_ptr<MLIRModule>> res = asr_to_mlir(al,
+        (ASR::asr_t &)asr, diagnostics);
     if (res.ok) {
         m = std::move(res.result);
     } else {

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -533,6 +533,7 @@ Result<std::string> FortranEvaluator::get_julia(const std::string &code,
     }
 }
 
+// asr_t &asr accepts only TranslationUnit and Module's type for now
 Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir(
 #ifdef HAVE_LFORTRAN_MLIR
         ASR::asr_t &asr, diag::Diagnostics &diagnostics
@@ -544,7 +545,7 @@ Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir(
     // ASR -> MLIR
     std::unique_ptr<LCompilers::MLIRModule> m;
     LCompilers::PassManager pass_manager;
-    if (asr.type == ASR::unit) {
+    if (ASR::is_a<ASR::unit_t>(asr)) {
         pass_manager.use_default_passes();
         pass_manager.apply_passes(al, (ASR::TranslationUnit_t *)&asr,
             compiler_options.po, diagnostics);

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -559,7 +559,7 @@ Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir(
     }
 
     // MLIR -> LLVM
-    m->mlir_to_llvm();
+    m->mlir_to_llvm(*m->llvm_ctx);
     return m;
 #else
     throw LCompilersException("MLIR is not enabled");

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -108,7 +108,7 @@ public:
     Result<std::string> get_julia(const std::string &code,
         LocationManager &lm, diag::Diagnostics &diagnostics);
     Result<std::unique_ptr<MLIRModule>> get_mlir(
-        ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics);
+        ASR::asr_t &asr, diag::Diagnostics &diagnostics);
     Result<std::string> get_fortran(const std::string &code,
         LocationManager &lm, diag::Diagnostics &diagnostics);
     Result<std::string> get_fmt(const std::string &code, LocationManager &lm,

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -971,6 +971,7 @@ public:
         std::vector<std::string> build_order
             = determine_module_dependencies(x);
         for (auto &item : build_order) {
+            if (!item.compare("_lcompilers_mlir_gpu_offloading")) continue;
             LCOMPILERS_ASSERT(x.m_symtab->get_symbol(item)
                 != nullptr);
             ASR::symbol_t *mod = x.m_symtab->get_symbol(item);

--- a/src/libasr/codegen/asr_to_mlir.cpp
+++ b/src/libasr/codegen/asr_to_mlir.cpp
@@ -875,6 +875,13 @@ public:
 
 Result<std::unique_ptr<MLIRModule>> asr_to_mlir(Allocator &al,
         ASR::asr_t &asr, diag::Diagnostics &diagnostics) {
+    if ( !(ASR::is_a<ASR::unit_t>(asr) ||
+            (ASR::is_a<ASR::Module_t>((ASR::symbol_t &)asr))) ) {
+        diagnostics.diagnostics.push_back(diag::Diagnostic("Unhandled type "
+            "passed as argument: 'asr' to asr_to_mlir(...)",
+            diag::Level::Error, diag::Stage::CodeGen));
+        Error error; return error;
+    }
     ASRToMLIRVisitor v(al);
     try {
         v.visit_asr(asr);

--- a/src/libasr/codegen/asr_to_mlir.cpp
+++ b/src/libasr/codegen/asr_to_mlir.cpp
@@ -874,10 +874,10 @@ public:
 };
 
 Result<std::unique_ptr<MLIRModule>> asr_to_mlir(Allocator &al,
-        ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics) {
+        ASR::asr_t &asr, diag::Diagnostics &diagnostics) {
     ASRToMLIRVisitor v(al);
     try {
-        v.visit_TranslationUnit(asr);
+        v.visit_asr(asr);
     } catch (const CodeGenError &e) {
         diagnostics.diagnostics.push_back(e.d);
         return Error();

--- a/src/libasr/codegen/asr_to_mlir.cpp
+++ b/src/libasr/codegen/asr_to_mlir.cpp
@@ -151,6 +151,11 @@ public:
     }
 
     void visit_Module(const ASR::Module_t &x) {
+        if (!module) {
+            module = std::make_unique<mlir::ModuleOp>(
+                builder->create<mlir::ModuleOp>(loc,
+                llvm::StringRef("LFortran")));
+        }
         // Visit all the Functions
         for (auto &item : x.m_symtab->get_scope()) {
             if (is_a<ASR::Function_t>(*item.second)) {

--- a/src/libasr/codegen/asr_to_mlir.cpp
+++ b/src/libasr/codegen/asr_to_mlir.cpp
@@ -167,6 +167,10 @@ public:
     void visit_Function(const ASR::Function_t &x) {
         ASR::FunctionType_t *fnType = down_cast<ASR::FunctionType_t>(
             x.m_function_signature);
+        if (fnType->m_deftype == ASR::deftypeType::Interface) {
+            // Skip Interface function for now
+            return;
+        }
         Vec<mlir::Type> argsType; argsType.reserve(al, fnType->n_arg_types);
         // Collect all the arguments type
         for (size_t i=0; i<fnType->n_arg_types; i++) {

--- a/src/libasr/codegen/asr_to_mlir.h
+++ b/src/libasr/codegen/asr_to_mlir.h
@@ -8,7 +8,7 @@
 namespace LCompilers {
 
     Result<std::unique_ptr<MLIRModule>> asr_to_mlir(Allocator &al,
-        ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics);
+        ASR::asr_t &asr, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -147,6 +147,7 @@ MLIRModule::MLIRModule(std::unique_ptr<mlir::ModuleOp> m,
         std::unique_ptr<mlir::MLIRContext> ctx) {
     mlir_m = std::move(m);
     mlir_ctx = std::move(ctx);
+    llvm_ctx = std::make_unique<llvm::LLVMContext>();
 }
 
 MLIRModule::~MLIRModule() {
@@ -168,10 +169,9 @@ std::string MLIRModule::llvm_str() {
     return mlir_str;
 }
 
-void MLIRModule::mlir_to_llvm() {
-    llvm_ctx = std::make_unique<llvm::LLVMContext>();
+void MLIRModule::mlir_to_llvm(llvm::LLVMContext &ctx) {
     std::unique_ptr<llvm::Module> llvmModule = mlir::translateModuleToLLVMIR(
-        *mlir_m, *llvm_ctx);
+        *mlir_m, ctx);
     if (llvmModule) {
         llvm_m = std::move(llvmModule);
     } else {

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -53,7 +53,7 @@ public:
     ~MLIRModule();
     std::string mlir_str();
     std::string llvm_str();
-    void mlir_to_llvm();
+    void mlir_to_llvm(llvm::LLVMContext &ctx);
 };
 
 class LLVMEvaluator

--- a/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.json
+++ b/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_openmp-do_concurrent_01-2a6df8c.stdout",
-    "stdout_hash": "e3b274b060f74c8fdb8410d8e137c58313021d165ac1b51be4747175",
+    "stdout_hash": "f5a56ec847f4f34941b6c75aaabd834c888025be1f7f83ca0c0d0d48",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.stdout
+++ b/tests/reference/pass_openmp-do_concurrent_01-2a6df8c.stdout
@@ -57,9 +57,9 @@
                                                     Default
                                                     (Array
                                                         (Real 4)
-                                                        [(()
-                                                        ())]
-                                                        DescriptorArray
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (IntegerConstant 12 (Integer 4) Decimal))]
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     Source
@@ -75,12 +75,12 @@
                                         (Integer 4)
                                         (Array
                                             (Real 4)
-                                            [(()
-                                            ())]
-                                            DescriptorArray
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 12 (Integer 4) Decimal))]
+                                            FixedSizeArray
                                         )]
                                         ()
-                                        Source
+                                        BindC
                                         Implementation
                                         ()
                                         .false.
@@ -178,14 +178,99 @@
                         2
                         {
                             _lcompilers_doconcurrent_replacer_func:
-                                (ExternalSymbol
-                                    2
+                                (Function
+                                    (SymbolTable
+                                        5
+                                        {
+                                            i:
+                                                (Variable
+                                                    5
+                                                    i
+                                                    []
+                                                    InOut
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            n:
+                                                (Variable
+                                                    5
+                                                    n
+                                                    []
+                                                    InOut
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            x:
+                                                (Variable
+                                                    5
+                                                    x
+                                                    []
+                                                    InOut
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 4)
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (IntegerConstant 12 (Integer 4) Decimal))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Private
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
                                     _lcompilers_doconcurrent_replacer_func
-                                    3 _lcompilers_doconcurrent_replacer_func
-                                    _lcompilers_mlir_gpu_offloading
+                                    (FunctionType
+                                        [(Integer 4)
+                                        (Integer 4)
+                                        (Array
+                                            (Real 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 12 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )]
+                                        ()
+                                        BindC
+                                        Interface
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
                                     []
-                                    _lcompilers_doconcurrent_replacer_func
+                                    [(Var 5 i)
+                                    (Var 5 n)
+                                    (Var 5 x)]
+                                    []
+                                    ()
                                     Public
+                                    .false.
+                                    .false.
+                                    ()
                                 ),
                             i:
                                 (Variable


### PR DESCRIPTION
Design details:
- OpenMP pass creates a module `_lcompilers_mlir_gpu_offloading`,
  which has all the items required for GPU offloading. This module will
  contain the functions with `abiType::BindC`, 
  `deftypeType::Implementation`. MLIR backend will generate the 
  required IR and object file.
- The user module will contain the interface function definition with 
  `abiType::BindC`, `deftypeType::Interface`. We call this interface and
  later link it with the correct BindC function. For these modules, LLVM
  backend will generate the IR and object file
- Later, we link both the object files and created an executable.

Towards: https://github.com/lfortran/lfortran/issues/4319