### PR TITLE
fix :Visit internals of the symbol instead of passing it if it's identified as classProcedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1614,6 +1614,7 @@ RUN(NAME pass_array_by_data_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llv
 RUN(NAME pass_array_by_data_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME pass_array_by_data_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME pass_array_by_data_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+RUN(NAME pass_array_by_data_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 
 RUN(NAME implicit_deallocate_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/pass_array_by_data_09.f90
+++ b/integration_tests/pass_array_by_data_09.f90
@@ -1,0 +1,40 @@
+module pass_array_by_data_09_mod
+    interface interface_1
+    procedure :: ff
+    end interface interface_1
+    contains 
+    function ff(inp) result(oout)
+      integer, intent(in) :: inp(:)
+      integer :: oout
+      print *, inp
+      if(any(inp /= [1,2,3,4,5])) error stop 
+      oout = 11
+    end function
+  end module pass_array_by_data_09_mod
+  
+  
+  
+  
+  program pass_array_by_data_09
+    use pass_array_by_data_09_mod
+    
+    type :: tt
+      integer :: i
+    end type tt
+
+    integer, allocatable :: ll(:)
+    type(tt) :: inst_tt
+    call ffo(inst_tt)
+
+    contains
+
+    subroutine ffo(dummy) 
+        class(tt), intent(in):: dummy ! This shouldn't idenify this function `ffo` as classProcedure. It's a normal function.
+        integer :: r
+        integer, dimension(5) :: rr
+        rr = [1,2,3,4,5]
+        r = interface_1(rr)
+        print *, r
+        if(r /= 11) error stop
+    end subroutine ffo
+  end program pass_array_by_data_09

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -707,6 +707,9 @@ class RemoveArrayByDescriptorProceduresVisitor : public PassUtils::PassVisitor<R
             for( auto& item: current_scope->get_scope() ) {
                 if (ASR::is_a<ASR::Function_t>(*item.second)) {
                     ASR::FunctionType_t* func_type = ASRUtils::get_FunctionType(item.second);
+                    SymbolTable* current_scope_copy = current_scope;
+                    visit_symbol(*item.second);
+                    current_scope = current_scope_copy;
                     if (func_type->n_arg_types >= 1 && ASR::is_a<ASR::ClassType_t>(*func_type->m_arg_types[0])) {
                         continue;
                     }


### PR DESCRIPTION
fixes #5844 