### PR TITLE
Speed up `dftatom` execution time

### DIFF
--- a/integration_tests/intrinsics_16.f90
+++ b/integration_tests/intrinsics_16.f90
@@ -46,7 +46,7 @@ if (abs(r64-7) > 1e-10) error stop
 print *, aimag(arr1)
 if (any(aimag(arr1) - [7.0_sp, 7.11999989e+00_sp, 3.40000010e+00_sp] > 1e-6)) error stop
 
-! print *, aimag(arr2) ! Does not work yet #4542
-! if (any(aimag(arr2) - [7.00000000000000000e+00_dp, 7.12000000000000011e+00_dp, 3.39999999999999991e+00_dp] > 1e-10)) error stop
+print *, aimag(arr2) ! Does not work yet #4542
+if (any(aimag(arr2) - [7.00000000000000000e+00_dp, 7.12000000000000011e+00_dp, 3.39999999999999991e+00_dp] > 1e-10)) error stop
 
 end program

--- a/integration_tests/logical_not_01.f90
+++ b/integration_tests/logical_not_01.f90
@@ -8,7 +8,7 @@ subroutine test_falseloc_pack()
     print *, lvec
     if (any(.not. lvec)) error stop
 end subroutine
-    
+
 program logical_not_01
     call test_falseloc_pack()
 end program

--- a/src/libasr/pass/array_op_simplifier.cpp
+++ b/src/libasr/pass/array_op_simplifier.cpp
@@ -123,6 +123,7 @@ class FixTypeVisitor: public ASR::CallReplacerOnExpressionsVisitor<FixTypeVisito
     }
 
     void visit_Cast(const ASR::Cast_t& x) {
+        ASR::CallReplacerOnExpressionsVisitor<FixTypeVisitor>::visit_Cast(x);
         ASR::Cast_t& xx = const_cast<ASR::Cast_t&>(x);
         if( !ASRUtils::is_array(ASRUtils::expr_type(x.m_arg)) &&
              ASRUtils::is_array(x.m_type) ) {
@@ -633,8 +634,8 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
         if( index2var[do_loop_head.m_v].second == IndexType::ArrayIndex ) {
             bound_dim = 1;
         }
-        if( n_array_indices_args > -1 && array_indices_args[n_array_indices_args].m_right != nullptr && 
-                array_indices_args[n_array_indices_args].m_left != nullptr && 
+        if( n_array_indices_args > -1 && array_indices_args[n_array_indices_args].m_right != nullptr &&
+                array_indices_args[n_array_indices_args].m_left != nullptr &&
                 array_indices_args[n_array_indices_args].m_step != nullptr) {
             do_loop_head.m_start = array_indices_args[n_array_indices_args].m_left;
             do_loop_head.m_end = array_indices_args[n_array_indices_args].m_right;
@@ -673,8 +674,8 @@ class ArrayOpSimplifierVisitor: public ASR::CallReplacerOnExpressionsVisitor<Arr
             if( index2var[do_loop_head.m_v].second == IndexType::ArrayIndex ) {
                 bound_dim = 1;
             }
-            if( n_array_indices_args > -1 && array_indices_args[n_array_indices_args].m_right != nullptr && 
-                    array_indices_args[n_array_indices_args].m_left != nullptr && 
+            if( n_array_indices_args > -1 && array_indices_args[n_array_indices_args].m_right != nullptr &&
+                    array_indices_args[n_array_indices_args].m_left != nullptr &&
                     array_indices_args[n_array_indices_args].m_step != nullptr) {
                 do_loop_head.m_start = array_indices_args[n_array_indices_args].m_left;
                 do_loop_head.m_end = array_indices_args[n_array_indices_args].m_right;

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -393,7 +393,9 @@ static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x,
     ASR::ttype_t* input_type = ASRUtils::expr_type(x.m_args[0]);
     ASR::ttype_t* output_type = x.m_type;
     ASRUtils::require_impl(ASRUtils::check_equal_type(input_type, output_type, true),
-        "The input and output type of elemental intrinsics must exactly match, input type: " +
+        "The input and output type of elemental intrinsic, " +
+        std::to_string(static_cast<int64_t>(x.m_intrinsic_id)) +
+        " must exactly match, input type: " +
         ASRUtils::get_type_code(input_type) + " output type: " + ASRUtils::get_type_code(output_type),
         loc, diagnostics);
 }
@@ -765,7 +767,7 @@ namespace Abs {
                 loc, diagnostics);
         } else {
             ASRUtils::require_impl(ASRUtils::check_equal_type(input_type, output_type, true),
-                "The input and output type of elemental intrinsics must exactly match, input type: " +
+                "The input and output type of Abs intrinsic must exactly match, input type: " +
                 input_type_str + " output type: " + output_type_str, loc, diagnostics);
         }
     }
@@ -5961,7 +5963,7 @@ static inline ASR::asr_t* create_SetRemove(Allocator& al, const Location& loc,
 
 } // namespace SetRemove
 
-static inline void promote_arguments_kinds(Allocator &al, const Location &loc, 
+static inline void promote_arguments_kinds(Allocator &al, const Location &loc,
         Vec<ASR::expr_t*> &args, diag::Diagnostics &diag) {
     int target_kind = -1;
     for (size_t i = 0; i < args.size(); i++) {
@@ -6242,7 +6244,7 @@ namespace Min {
         if (!all_args_same_kind){
             promote_arguments_kinds(al, loc, args, diag);
         }
-        
+
         Vec<ASR::expr_t*> arg_values;
         arg_values.reserve(al, args.size());
         ASR::expr_t *arg_value;

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1280,6 +1280,15 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
             ASRUtils::symbol_name(x.m_dt_sym));
     }
 
+    void visit_TypeInquiry(const ASR::TypeInquiry_t& x) {
+        Vec<ASR::expr_t*> x_m_args_; x_m_args_.reserve(al, 1);
+        x_m_args_.push_back(al, x.m_arg);
+        Vec<ASR::expr_t*> x_m_args; x_m_args.reserve(al, 1);
+        traverse_args(x_m_args, x_m_args_.p, x_m_args_.size(), std::string("_type_inquiry_"));
+        ASR::TypeInquiry_t& xx = const_cast<ASR::TypeInquiry_t&>(x);
+        xx.m_arg = x_m_args[0];
+    }
+
     void visit_ArrayConstructor(const ASR::ArrayConstructor_t& x) {
         Vec<ASR::expr_t*> x_m_args; x_m_args.reserve(al, x.n_args);
         traverse_args(x_m_args, x.m_args, x.n_args, std::string("_array_constructor_"));


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/5836

`./tests/atom_U/F_atom_U  0.76s user 0.01s system 99% cpu 0.774 total` (this PR)

`./tests/atom_U/F_atom_U  0.83s user 0.02s system 99% cpu 0.847 total` (with `--no-experimental-simplifier`)

Let's see what happens with tests. :D. Will rewrite git history before merging.