### PR TITLE
fix: 'intrinsic' attribute refers to intrinsic procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1962,4 +1962,4 @@ RUN(NAME array_concat LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # array pas
 
 RUN(NAME multiple_objects_args LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME module_array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
-RUN(NAME attr_intrinsic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME attr_intrinsic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1962,3 +1962,4 @@ RUN(NAME array_concat LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # array pas
 
 RUN(NAME multiple_objects_args LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME module_array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME attr_intrinsic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/attr_intrinsic.f90
+++ b/integration_tests/attr_intrinsic.f90
@@ -43,8 +43,8 @@ program attr_intrinsic
         ! dummy result output
         integer :: i
         intrinsic char
-        ! the 'char' here is the variable 'char' not the intrinsic
-        ! function
+        ! the 'char' here is the intrinsic function 'char' not
+        ! the variable 'char'
         print *, 'intrinsic elemental char(65): ', char(65)
         if (char(65) /= 'A') error stop
     end function fun2

--- a/integration_tests/attr_intrinsic.f90
+++ b/integration_tests/attr_intrinsic.f90
@@ -1,0 +1,51 @@
+! this program tests to make sure that 'intrinsic' attribute
+program attr_intrinsic
+    implicit none
+    ! variable 'abs' with same name as intrinsic elemental
+    ! function 'abs'
+    integer, parameter :: abs = 11
+    integer :: i1, i2
+
+    ! variable 'char' with same name as intrinsic elemental
+    ! function 'char'
+    integer, parameter :: char = 19
+
+    call sub1()
+    i1 = fun1()
+    call sub2()
+    i2 = fun2()
+
+    contains
+
+    subroutine sub1()
+        ! intrinsic 'abs' means, 'abs' used in this subroutine
+        ! is actually the intrinsic elemental function 'abs'
+        intrinsic abs
+        print *, abs(-4)
+        if (abs(-4) /= 4) error stop
+    end subroutine sub1
+
+    function fun1() result(i)
+        ! dummy result output
+        integer :: i
+        ! the 'char' here is the variable 'char' not the intrinsic
+        ! function
+        print *, 'variable char: ', char
+        if (char /= 19) error stop
+    end function fun1
+
+    subroutine sub2()
+        print *, abs
+        if (abs /= 11) error stop
+    end subroutine sub2
+
+    function fun2() result(i)
+        ! dummy result output
+        integer :: i
+        intrinsic char
+        ! the 'char' here is the variable 'char' not the intrinsic
+        ! function
+        print *, 'intrinsic elemental char(65): ', char(65)
+        if (char(65) /= 'A') error stop
+    end function fun2
+end program attr_intrinsic

--- a/integration_tests/attr_intrinsic.f90
+++ b/integration_tests/attr_intrinsic.f90
@@ -1,4 +1,4 @@
-! this program tests to make sure that 'intrinsic' attribute
+! this program tests 'intrinsic' attribute used in declarations
 program attr_intrinsic
     implicit none
     ! variable 'abs' with same name as intrinsic elemental

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -38,17 +38,24 @@ public:
     std::vector<ASR::DoConcurrentLoop_t *> omp_constructs;
 
     BodyVisitor(Allocator &al, ASR::asr_t *unit, diag::Diagnostics &diagnostics,
-            CompilerOptions &compiler_options, std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping,
-            std::map<uint64_t, ASR::symbol_t*>& common_variables_hash, std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
-            std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
-            std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
-            std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-            std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-            std::vector<ASR::stmt_t*> &data_structure,
-            LCompilers::LocationManager &lm)
-        : CommonVisitor(al, nullptr, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, lm),
-        asr{unit}, from_block{false} {}
+        CompilerOptions &compiler_options,
+        std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping,
+        std::map<uint64_t, ASR::symbol_t*>& common_variables_hash,
+        std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
+        std::map<uint64_t, std::vector<std::string>>& explicit_intrinsic_procedures_mapping,
+        std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
+        std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
+        std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+        std::vector<ASR::stmt_t*> &data_structure,
+        LCompilers::LocationManager &lm
+    ) : CommonVisitor(
+            al, nullptr, diagnostics, compiler_options, implicit_mapping,
+            common_variables_hash, external_procedures_mapping,
+            explicit_intrinsic_procedures_mapping, instantiate_types,
+            instantiate_symbols, entry_functions, entry_function_arguments_mapping,
+            data_structure, lm
+        ), asr{unit}, from_block{false} {}
 
     void visit_Declaration(const AST::Declaration_t& x) {
         if( from_block ) {
@@ -4646,6 +4653,7 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::map<uint64_t, std::map<std::string, ASR::ttype_t*>>& implicit_mapping,
         std::map<uint64_t, ASR::symbol_t*>& common_variables_hash,
         std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
+        std::map<uint64_t, std::vector<std::string>>& explicit_intrinsic_procedures_mapping,
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
@@ -4653,8 +4661,12 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::vector<ASR::stmt_t*> &data_structure,
         LCompilers::LocationManager &lm)
 {
-    BodyVisitor b(al, unit, diagnostics, compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-                  instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, lm);
+    BodyVisitor b(al, unit, diagnostics, compiler_options, implicit_mapping,
+        common_variables_hash, external_procedures_mapping,
+        explicit_intrinsic_procedures_mapping,
+        instantiate_types, instantiate_symbols, entry_functions,
+        entry_function_arguments_mapping, data_structure, lm
+    );
     try {
         b.is_body_visitor = true;
         b.visit_TranslationUnit(ast);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1033,9 +1033,15 @@ public:
 
     std::vector<std::map<std::string, ASR::ttype_t*>> implicit_stack;
     std::map<uint64_t, std::vector<std::string>> &external_procedures_mapping;
+    // mapping of hash int's of scope to 'explicit_intrinsic_procedures'
+    std::map<uint64_t, std::vector<std::string>> &explicit_intrinsic_procedures_mapping;
     std::map<std::string, ASR::symbol_t*> changed_external_function_symbol;
     std::map<std::string, std::vector<AST::stmt_t*>> entry_point_mapping;
     std::vector<std::string> external_procedures;
+    // procedures explicitly declared with 'intrinsic' attribute
+    // e.g. a declaration like: 'intrinsic abs' for an intrinsic
+    // elemental function 'abs'
+    std::vector<std::string> explicit_intrinsic_procedures;
     std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions;
     std::map<std::string, std::vector<int>> &entry_function_arguments_mapping;
     Vec<char*> data_member_names;
@@ -1067,22 +1073,26 @@ public:
     int idl_nesting_level = 0;
 
     CommonVisitor(Allocator &al, SymbolTable *symbol_table,
-            diag::Diagnostics &diagnostics, CompilerOptions &compiler_options,
-            std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping,
-            std::map<uint64_t, ASR::symbol_t*>& common_variables_hash,
-            std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
-            std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
-            std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
-            std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
-            std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
-            std::vector<ASR::stmt_t*> &data_structure,
-            LCompilers::LocationManager &lm)
-        : diag{diagnostics}, al{al}, compiler_options{compiler_options},
+        diag::Diagnostics &diagnostics, CompilerOptions &compiler_options,
+        std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping,
+        std::map<uint64_t, ASR::symbol_t*>& common_variables_hash,
+        std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
+        std::map<uint64_t, std::vector<std::string>>& explicit_intrinsic_procedures_mapping,
+        std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
+        std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
+        std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
+        std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
+        std::vector<ASR::stmt_t*> &data_structure,
+            LCompilers::LocationManager &lm
+    ): diag{diagnostics}, al{al}, compiler_options{compiler_options},
           current_scope{symbol_table}, implicit_mapping{implicit_mapping},
-          common_variables_hash{common_variables_hash}, external_procedures_mapping{external_procedures_mapping},
+          common_variables_hash{common_variables_hash},
+          external_procedures_mapping{external_procedures_mapping},
+          explicit_intrinsic_procedures_mapping{explicit_intrinsic_procedures_mapping},
           entry_functions{entry_functions},entry_function_arguments_mapping{entry_function_arguments_mapping},
           current_variable_type_{nullptr}, instantiate_types{instantiate_types},
-          instantiate_symbols{instantiate_symbols}, data_structure{data_structure}, lm{lm} {
+          instantiate_symbols{instantiate_symbols}, data_structure{data_structure}, lm{lm}
+    {
         current_module_dependencies.reserve(al, 4);
         enum_init_val = 0;
     }
@@ -2268,12 +2278,34 @@ public:
         return ( std::find(external_procedures.begin(), external_procedures.end(), sym) != external_procedures.end() );
     }
 
+    bool check_is_explicit_intrinsic(std::string sym, SymbolTable* scope=nullptr) {
+        if (scope) {
+            explicit_intrinsic_procedures = explicit_intrinsic_procedures_mapping[get_hash(scope->asr_owner)];
+        } else if (current_scope->asr_owner) {
+            explicit_intrinsic_procedures = explicit_intrinsic_procedures_mapping[get_hash(current_scope->asr_owner)];
+        }
+        return (
+            std::find(explicit_intrinsic_procedures.begin(), explicit_intrinsic_procedures.end(), sym) != explicit_intrinsic_procedures.end()
+        );
+    }
+
     void erase_from_external_mapping(std::string sym) {
         uint64_t hash = get_hash(current_scope->asr_owner);
         external_procedures_mapping[hash].erase(
             std::remove(external_procedures_mapping[hash].begin(),
             external_procedures_mapping[hash].end(), sym),
             external_procedures_mapping[hash].end());
+    }
+
+    void erase_from_explicit_intrinsic_mapping(std::string sym) {
+        uint64_t hash = get_hash(current_scope->asr_owner);
+        explicit_intrinsic_procedures_mapping[hash].erase(
+            std::remove(
+                explicit_intrinsic_procedures_mapping[hash].begin(),
+                explicit_intrinsic_procedures_mapping[hash].end(),
+                sym
+            )
+        );
     }
 
     // pad (with ' ') or trim character string 'value'
@@ -2507,7 +2539,7 @@ public:
                                     }
                                 } else if(sa->m_attr == AST::simple_attributeType
                                         ::AttrIntrinsic) {
-                                    // Ignore Intrinsic attribute
+                                    explicit_intrinsic_procedures.push_back(sym);
                                 } else if (sa->m_attr == AST::simple_attributeType
                                         ::AttrExternal) {
                                     create_external_function(sym, x.m_syms[i].loc);
@@ -7502,6 +7534,7 @@ public:
         ASR::symbol_t *v = nullptr;
         ASR::expr_t *v_expr = nullptr;
         bool is_external_procedure = check_is_external(var_name);
+        bool is_explicit_intrinsic = check_is_explicit_intrinsic(var_name);
         // If this is a type bound procedure (in a class) it won't be in the
         // main symbol table. Need to check n_member.
         if (x.n_member >= 1) {
@@ -7526,7 +7559,7 @@ public:
         } else {
             v = current_scope->resolve_symbol(var_name);
         }
-        if (!v || (v && is_external_procedure)) {
+        if (!v || (v && (is_external_procedure || is_explicit_intrinsic))) {
             ASR::symbol_t* external_sym = is_external_procedure ? v : nullptr;
             if (var_name == "dble") {
                 Vec<ASR::call_arg_t> args;

--- a/src/lfortran/semantics/ast_to_asr.cpp
+++ b/src/lfortran/semantics/ast_to_asr.cpp
@@ -27,6 +27,7 @@ Result<ASR::asr_t*> symbol_table_visitor(Allocator &al, AST::TranslationUnit_t &
         std::map<uint64_t, std::map<std::string, ASR::ttype_t*>>& implicit_mapping,
         std::map<uint64_t, ASR::symbol_t*>& common_variables_hash,
         std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
+        std::map<uint64_t, std::vector<std::string>>& explicit_intrinsic_procedures_mapping,
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
@@ -42,6 +43,7 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
         std::map<uint64_t, std::map<std::string, ASR::ttype_t*>>& implicit_mapping,
         std::map<uint64_t, ASR::symbol_t*>& common_variables_hash,
         std::map<uint64_t, std::vector<std::string>>& external_procedures_mapping,
+        std::map<uint64_t, std::vector<std::string>>& explicit_intrinsic_procedures_mapping,
         std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> &instantiate_types,
         std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> &instantiate_symbols,
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
@@ -62,6 +64,7 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> implicit_mapping;
     std::map<uint64_t, ASR::symbol_t*> common_variables_hash;
     std::map<uint64_t, std::vector<std::string>> external_procedures_mapping;
+    std::map<uint64_t, std::vector<std::string>> explicit_intrinsic_procedures_mapping;
     std::map<uint32_t, std::map<std::string, ASR::ttype_t*>> instantiate_types;
     std::map<uint32_t, std::map<std::string, ASR::symbol_t*>> instantiate_symbols;
     std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> entry_functions;
@@ -70,7 +73,8 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     ASR::asr_t *unit;
     auto res = symbol_table_visitor(al, ast, diagnostics, symbol_table,
         compiler_options, implicit_mapping, common_variables_hash, external_procedures_mapping,
-        instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, lm);
+        explicit_intrinsic_procedures_mapping, instantiate_types, instantiate_symbols, entry_functions,
+        entry_function_arguments_mapping, data_structure, lm);
     if (res.ok) {
         unit = res.result;
     } else {
@@ -98,9 +102,13 @@ Result<ASR::TranslationUnit_t*> ast_to_asr(Allocator &al,
     };
 #endif
     if (!symtab_only) {
-        auto res = body_visitor(al, ast, diagnostics, unit, compiler_options,
+        auto res = body_visitor(
+            al, ast, diagnostics, unit, compiler_options,
             implicit_mapping, common_variables_hash, external_procedures_mapping,
-            instantiate_types, instantiate_symbols, entry_functions, entry_function_arguments_mapping, data_structure, lm);
+            explicit_intrinsic_procedures_mapping, instantiate_types,
+            instantiate_symbols, entry_functions, entry_function_arguments_mapping,
+            data_structure, lm
+        );
         if (res.ok) {
             tu = res.result;
         } else {


### PR DESCRIPTION
## Description

earlier 'intrinsic' attribute had almost no effect in ASR creation, this PR makes sure that a declaration like 'intrinsic abs' uses the intrinsic procedure 'abs' even in case of an existing declaration of variable 'abs'

Fixes #5857