### PR TITLE
Speeding up compile time evaluation of ImpliedDoLoop

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -492,7 +492,7 @@ inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
                                    const CompilerOptions &compiler_options, diag::Diagnostics &diag) {
     if(ASRUtils::is_descriptorString(ASRUtils::expr_type(left))){
         left = ASRUtils::cast_string_descriptor_to_pointer(al, left);
-    }                                
+    }
     if (ASRUtils::is_descriptorString(ASRUtils::expr_type(right))){
         right = ASRUtils::cast_string_descriptor_to_pointer(al, right);
     }
@@ -541,7 +541,7 @@ inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
         intrinsic_op_name, curr_scope, asr, al,
         x.base.base.loc, current_function_dependencies,
         current_module_dependencies,
-        [&](const std::string &msg, const Location &loc) { 
+        [&](const std::string &msg, const Location &loc) {
                 diag.add(diag::Diagnostic(
                     msg,
                     Level::Error, Stage::Semantic, {
@@ -872,7 +872,7 @@ inline static void visit_BoolOp(Allocator &al, const AST::BoolOp_t &x,
                 x.base.base.loc, current_function_dependencies,
                 current_module_dependencies,
                 [&](const std::string &msg, const Location &loc)
-                { 
+                {
                     diag.add(diag::Diagnostic(
                         msg,
                         Level::Error, Stage::Semantic, {
@@ -1576,7 +1576,7 @@ public:
                         return true;
                     }
                 }
-            } 
+            }
         } else {
 
             ASR::ttype_t* dim_expr_type = ASRUtils::expr_type(dim_expr);
@@ -3207,10 +3207,10 @@ public:
                             throw SemanticAbort();
                         }
                     }
-                    
+
 
                     if (is_allocatable && storage_type == ASR::storage_typeType::Parameter) {
-                        diag.add((Diagnostic( 
+                        diag.add((Diagnostic(
                             "`parameter` attribute conflicts with `allocatable` attribute",
                             Level::Error, Stage::Semantic, {
                                 Label("",{x.base.base.loc})
@@ -3218,7 +3218,7 @@ public:
                         )));
                         throw SemanticAbort();
                     } else if (is_pointer && storage_type == ASR::storage_typeType::Parameter) {
-                        diag.add((Diagnostic( 
+                        diag.add((Diagnostic(
                             "`parameter` attribute conflicts with `pointer` attribute",
                             Level::Error, Stage::Semantic, {
                                 Label("",{x.base.base.loc})
@@ -3505,7 +3505,7 @@ public:
                     // when lhs_rank > rhs_rank it can broadcast
                     if( lhs_rank != rhs_rank && lhs_rank < rhs_rank ){
                         diag.add(Diagnostic(
-                            "Incompatible ranks `"+ std::to_string(lhs_rank) + "` and `" 
+                            "Incompatible ranks `"+ std::to_string(lhs_rank) + "` and `"
                                                                   + std::to_string(rhs_rank) + "` in assignment",
                             Level::Error, Stage::Semantic, {
                                 Label("",{x.base.base.loc})
@@ -3516,7 +3516,7 @@ public:
                      if ( ASR::is_a<ASR::Array_t>(*init_type) && ASR::is_a<ASR::ArrayReshape_t>(*init_expr) ){
                         ASR::Array_t* arr_rhs = ASR::down_cast<ASR::Array_t>(init_type);
                         ASR::Array_t* arr_lhs = ASR::down_cast<ASR::Array_t>(type);
-                        
+
                     for (size_t i = 0; i < arr_lhs->n_dims; i++) {
                            std::string lhs_dim = ASRUtils::extract_dim_value(arr_lhs->m_dims[i].m_length);
                            std::string rhs_dim = ASRUtils::extract_dim_value(arr_rhs->m_dims[i].m_length);
@@ -4032,7 +4032,7 @@ public:
                 a_len = 1; // The default len of "character :: x" is 1
             }
             LCOMPILERS_ASSERT(a_len != -10)
-            type = ASRUtils::TYPE(ASR::make_String_t(al, loc, a_kind, a_len, len_expr, 
+            type = ASRUtils::TYPE(ASR::make_String_t(al, loc, a_kind, a_len, len_expr,
                 (is_allocatable && dims.size() == 0) ? ASR::string_physical_typeType::DescriptorString : ASR::string_physical_typeType::PointerString));
             type = ASRUtils::make_Array_t_util(
                 al, loc, type, dims.p, dims.size(), abi, is_argument,
@@ -4198,9 +4198,9 @@ public:
         visit_expr_list(m_args, n_args, vals);
         if(ASR::is_a<ASR::Struct_t>(*ASRUtils::symbol_get_past_external(v))){
             ASR::Struct_t* struct_= ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(v));
-            size_t iter = 0 ; 
+            size_t iter = 0 ;
             for (auto item : struct_->m_symtab->get_scope()){
-                if(iter >= vals.size()) break;  
+                if(iter >= vals.size()) break;
                     // TO DO :: check type match. Use code below as reference.
                     // if(!ASRUtils::check_equal_type(
                     //     ASRUtils::symbol_type(item.second), ASRUtils::expr_type(vals[iter].m_value))){
@@ -4211,17 +4211,17 @@ public:
                 // Cast RHS and LHS to have the same string physical type (LHS rules).
                 if(ASR::is_a<ASR::Variable_t>(*item.second)){
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(item.second);
-                    if( ASRUtils::is_descriptorString(var->m_type) && 
+                    if( ASRUtils::is_descriptorString(var->m_type) &&
                         ASRUtils::is_character(*ASRUtils::expr_type(vals[iter].m_value)) &&
                         !ASRUtils::is_descriptorString(ASRUtils::expr_type(vals[iter].m_value))){ // DescriptorString(LHS), PointerString (RHS)
-                        ASR::call_arg_t* passed_arg = const_cast<ASR::call_arg_t*>(&vals[iter]); 
-                        passed_arg->m_value = ASRUtils::cast_string_pointer_to_descriptor(al, passed_arg->m_value);      
+                        ASR::call_arg_t* passed_arg = const_cast<ASR::call_arg_t*>(&vals[iter]);
+                        passed_arg->m_value = ASRUtils::cast_string_pointer_to_descriptor(al, passed_arg->m_value);
                     }
                     if( ASRUtils::is_character(*var->m_type) &&
-                        !ASRUtils::is_descriptorString(var->m_type) && 
+                        !ASRUtils::is_descriptorString(var->m_type) &&
                         ASRUtils::is_descriptorString(ASRUtils::expr_type(vals[iter].m_value))){ // PointerString(LHS), DescriptorString (RHS)
-                        ASR::call_arg_t* passed_arg = const_cast<ASR::call_arg_t*>(&vals[iter]); 
-                        passed_arg->m_value = ASRUtils::cast_string_descriptor_to_pointer(al, passed_arg->m_value);      
+                        ASR::call_arg_t* passed_arg = const_cast<ASR::call_arg_t*>(&vals[iter]);
+                        passed_arg->m_value = ASRUtils::cast_string_descriptor_to_pointer(al, passed_arg->m_value);
                     }
                 }
                 ++iter;
@@ -4697,7 +4697,7 @@ public:
                         }
                         if ( a_value != nullptr ) {
                             int64_t a = ASR::down_cast<ASR::IntegerConstant_t>(a_value)->m_n;
-                            if ( a < 0 ) { 
+                            if ( a < 0 ) {
                                 diag.add(Diagnostic("The first index in string section is less than 1",
                                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                                 throw SemanticAbort();
@@ -4725,9 +4725,9 @@ public:
                             a_len = -3;
                         }
                         if(!l && !r){
-                            // No runtime slicing is required. 
+                            // No runtime slicing is required.
                             // Use the actual type of lhs as the type of the resulting expr from string slicing operation.
-                            char_type = ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, a_len, a_len_expr, 
+                            char_type = ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, a_len, a_len_expr,
                                 ASR::down_cast<ASR::String_t>(
                                 ASRUtils::extract_type(v_type))->m_physical_type));
                         } else { // resulting string is of pointerString physical type
@@ -4773,7 +4773,7 @@ public:
             // e.g. [character(len=*) :: "a", "apple"], this isn't allowed
             if (char_type_spec->m_len == -1) {
                 diag.add(Diagnostic("Type-spec cannot contain an asterisk for a type "
-                    "parameter", Level::Error, Stage::Semantic, 
+                    "parameter", Level::Error, Stage::Semantic,
                     {Label("",{char_type_spec->base.base.loc})}));
                 throw SemanticAbort();
             }
@@ -5062,7 +5062,7 @@ public:
         ASR::symbol_t *f2 = ASR::down_cast<ASR::ExternalSymbol_t>(v)->m_external;
         ASR::GenericProcedure_t *g = ASR::down_cast<ASR::GenericProcedure_t>(f2);
         int idx = ASRUtils::select_generic_procedure(args, *g, loc,
-                    [&](const std::string &msg, const Location &loc) { 
+                    [&](const std::string &msg, const Location &loc) {
                             diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                             throw SemanticAbort();
                         });
@@ -5077,7 +5077,7 @@ public:
         ASR::symbol_t *f2 = ASR::down_cast<ASR::ExternalSymbol_t>(v)->m_external;
         ASR::GenericProcedure_t *g = ASR::down_cast<ASR::GenericProcedure_t>(f2);
         int idx = ASRUtils::select_generic_procedure(args, *g, loc,
-                    [&](const std::string &msg, const Location &loc) { 
+                    [&](const std::string &msg, const Location &loc) {
                         diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     },
@@ -5137,7 +5137,7 @@ public:
         } else {
             ASR::GenericProcedure_t *p = ASR::down_cast<ASR::GenericProcedure_t>(v);
             int idx = ASRUtils::select_generic_procedure(args, *p, loc,
-                    [&](const std::string &msg, const Location &loc) { 
+                    [&](const std::string &msg, const Location &loc) {
                             diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                             throw SemanticAbort();
                         },
@@ -5191,7 +5191,7 @@ public:
         } else {
             ASR::GenericProcedure_t *p = ASR::down_cast<ASR::GenericProcedure_t>(v);
             int idx = ASRUtils::select_generic_procedure(args, *p, loc,
-                    [&](const std::string &msg, const Location &loc) { 
+                    [&](const std::string &msg, const Location &loc) {
                             diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                             throw SemanticAbort();
                         },
@@ -5372,14 +5372,14 @@ public:
             }
         }
     }
-    
+
     void validate_create_function_arguments(Vec<ASR::call_arg_t>& args, ASR::symbol_t *v){
         ASR::symbol_t *f2 = ASRUtils::symbol_get_past_external(v);
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(f2);
         ASR::FunctionType_t* func_type = ASRUtils::get_FunctionType(v);
 
         // Currently present function is supporting only integer arguments
-        // After implementing present below if condition should be removed 
+        // After implementing present below if condition should be removed
         if( to_lower(func->m_name) != "present" ){
             for( size_t i = 0; i < args.size(); i++ ) {
                 if( args.p[i].m_value == nullptr ) {
@@ -5390,7 +5390,7 @@ public:
                         ASRUtils::type_get_past_pointer(ASRUtils::expr_type(arg)));
                 ASR::ttype_t* orig_arg_type = ASRUtils::type_get_past_allocatable(
                         ASRUtils::type_get_past_pointer(func_type->m_arg_types[i]));
-                
+
                 if( ASR::is_a<ASR::FunctionType_t>(*arg_type) ) continue;
 
                 bool is_compile_time = true;
@@ -5446,11 +5446,11 @@ public:
                         }
                     }
                 }
-                
+
                 if(!ASRUtils::check_equal_type(arg_type,orig_arg_type)){
                     std::string arg_str = ASRUtils::type_to_str(arg_type);
                     std::string orig_arg_str = ASRUtils::type_to_str(orig_arg_type);
-                    diag.add(Diagnostic("Type mismatch in argument at argument (" + std::to_string(i+1) + 
+                    diag.add(Diagnostic("Type mismatch in argument at argument (" + std::to_string(i+1) +
                                         "); passed `" + arg_str + "` to `" + orig_arg_str + "`.",
                                         Level::Error, Stage::Semantic, {Label("", {args.p[i].loc})}));
                     throw SemanticAbort();
@@ -5929,7 +5929,7 @@ public:
             this->visit_expr(*x.m_args[i].m_end);
             args.p[i] = ASRUtils::EXPR(tmp);
             if(ASRUtils::is_descriptorString(ASRUtils::expr_type(args.p[i]))){
-                // Any compile-time intrinsic function doesn't need a cast from 
+                // Any compile-time intrinsic function doesn't need a cast from
                 // descriptorString to pointerString. Only runtime ones need a cast.
                 if(intrinsic_name != "present" && intrinsic_name != "len"){
                     args.p[i] = ASRUtils::cast_string_descriptor_to_pointer(al, args.p[i]);
@@ -6516,7 +6516,7 @@ public:
     }
 
     void scalar_kind_arg(std::string &name, Vec<ASR::expr_t*> &args) {
-        std::vector<std::string> optional_kind_arg = {"logical", "storage_size", "anint", "nint", "aint", "floor", 
+        std::vector<std::string> optional_kind_arg = {"logical", "storage_size", "anint", "nint", "aint", "floor",
             "ceiling", "aimag", "maskl", "maskr", "ichar", "char", "achar", "real", "int"};
         if (std::find(optional_kind_arg.begin(), optional_kind_arg.end(), name) != optional_kind_arg.end()) {
             if (args[1]) {
@@ -6628,7 +6628,7 @@ public:
         if(intrinsic_name == "dint" || intrinsic_name == "dnint") {
             arg_size = 1;
             if (args[1]) {
-                diag.add(Diagnostic("Too many arguments to call `" + intrinsic_name + "`", 
+                diag.add(Diagnostic("Too many arguments to call `" + intrinsic_name + "`",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
@@ -6642,7 +6642,7 @@ public:
                 if(i < intrinsic_mapping[intrinsic_name].second.size()){
                     argument_type = intrinsic_mapping[intrinsic_name].second[i];
                 } else {
-                    diag.add(Diagnostic("Too many arguments to call `" + intrinsic_name + "`", 
+                    diag.add(Diagnostic("Too many arguments to call `" + intrinsic_name + "`",
                         Level::Error, Stage::Semantic, {Label("", {loc})}));
                     throw SemanticAbort();
                 }
@@ -6652,7 +6652,7 @@ public:
                     ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     if (!is_integer(*arg_type)) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of integer type", 
+                                            " must be of integer type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6662,7 +6662,7 @@ public:
                     ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     if (!is_real(*arg_type)) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of real type", 
+                                            " must be of real type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6673,7 +6673,7 @@ public:
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_real(*arg_type) || kind != 4) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of single precision real type", 
+                                            " must be of single precision real type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6684,7 +6684,7 @@ public:
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_real(*arg_type) || kind != 8) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of double precision real type", 
+                                            " must be of double precision real type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6694,7 +6694,7 @@ public:
                     ASR::ttype_t *arg_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(args[i]));
                     if (!is_complex(*arg_type)) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of complex type", 
+                                            " must be of complex type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6705,7 +6705,7 @@ public:
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_complex(*arg_type) || kind != 4) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of single precision complex type", 
+                                            " must be of single precision complex type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6716,7 +6716,7 @@ public:
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (!is_complex(*arg_type) || kind != 8) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of double precision complex type", 
+                                            " must be of double precision complex type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -6899,13 +6899,13 @@ public:
                         ASR::expr_t *matrix_a = args[0], *matrix_b = args[1];
                         ASR::ttype_t *type_a = ASRUtils::expr_type(matrix_a);
                         ASR::ttype_t *type_b = ASRUtils::expr_type(matrix_b);
-                        if((ASRUtils::is_real(*type_b) && ASRUtils::is_integer(*type_a)) || 
-                            (ASRUtils::is_complex(*type_b) && ASRUtils::is_integer(*type_a)) || 
+                        if((ASRUtils::is_real(*type_b) && ASRUtils::is_integer(*type_a)) ||
+                            (ASRUtils::is_complex(*type_b) && ASRUtils::is_integer(*type_a)) ||
                             (ASRUtils::is_complex(*type_b) && ASRUtils::is_real(*type_a)) ){
                             ImplicitCastRules::set_converted_value(al, x.base.base.loc, &matrix_a,
                                             type_a, ASRUtils::type_get_past_allocatable(type_b), diag);
-                        } else if((ASRUtils::is_real(*type_a) && ASRUtils::is_integer(*type_b)) || 
-                                   (ASRUtils::is_complex(*type_a) && ASRUtils::is_integer(*type_b)) || 
+                        } else if((ASRUtils::is_real(*type_a) && ASRUtils::is_integer(*type_b)) ||
+                                   (ASRUtils::is_complex(*type_a) && ASRUtils::is_integer(*type_b)) ||
                                     (ASRUtils::is_complex(*type_a) && ASRUtils::is_real(*type_b)) ){
                             ImplicitCastRules::set_converted_value(al, x.base.base.loc, &matrix_b,
                                             type_b, ASRUtils::type_get_past_allocatable(type_a), diag);
@@ -7002,7 +7002,7 @@ public:
                 al, loc, arg, ASR::cast_kindType::IntegerToReal,
                 to_type, value));
         } else {
-            diag.add(Diagnostic("Argument of intrinsic must be an integer", 
+            diag.add(Diagnostic("Argument of intrinsic must be an integer",
                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
         }
@@ -7209,9 +7209,9 @@ public:
         ASR::symbol_t* a_sym = current_scope->resolve_symbol(to_lower(x.m_var));
         if (a_sym == nullptr) {
             diag.add(Diagnostic("The implied do loop variable '" +
-                to_lower(x.m_var) + "' is not declared", 
+                to_lower(x.m_var) + "' is not declared",
                 Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-            throw SemanticAbort();        
+            throw SemanticAbort();
         }
         ASR::expr_t* a_var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, a_sym));
         if( !unique_type ) {
@@ -7410,7 +7410,7 @@ public:
         ASR::symbol_t* a_sym = current_scope->resolve_symbol(to_lower(x.m_var));
         if (a_sym == nullptr) {
             diag.add(Diagnostic("The implied do loop variable '" +
-                to_lower(x.m_var) + "' is not declared", 
+                to_lower(x.m_var) + "' is not declared",
                 Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
             throw SemanticAbort();
         }
@@ -7792,7 +7792,7 @@ public:
                             continue ;
                         }
                         int idx = ASRUtils::select_generic_procedure(args_copy, *gp, x.base.base.loc,
-                                        [&](const std::string &msg, const Location &loc) { 
+                                        [&](const std::string &msg, const Location &loc) {
                                                 diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                                                 throw SemanticAbort();
                                             },
@@ -7867,7 +7867,7 @@ public:
             }
             case(ASR::symbolType::ClassProcedure):
                 tmp = create_ClassProcedure(x.base.base.loc, x.m_args, x.n_args, v, v_expr); break;
-            default: {   
+            default: {
                 diag.add(Diagnostic("Symbol '" + var_name
                             + "' is not a function or an array",
                             Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
@@ -7895,7 +7895,7 @@ public:
 
         ASR::Module_t *m = ASRUtils::load_module(al, tu_symtab, module_name,
                 loc, true, compiler_options.po, true,
-                [&](const std::string &msg, const Location &loc) { 
+                [&](const std::string &msg, const Location &loc) {
                         diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }, lm
@@ -8090,7 +8090,7 @@ public:
                     x.base.base.loc, current_function_dependencies,
                     current_module_dependencies,
                     [&](const std::string &msg, const Location &loc)
-                    { 
+                    {
                         diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }) ) {
@@ -8346,7 +8346,7 @@ public:
                     case (AST::GTE):
                         is_cmpop = true; cmpop = ASR::GtE; op_name = "~gte"; break;
                     default:
-                        diag.add(Diagnostic("Unsupported binary operator", 
+                        diag.add(Diagnostic("Unsupported binary operator",
                             Level::Error, Stage::Semantic, {Label("", {args[i]->base.loc})}));
                         throw SemanticAbort();
                 }
@@ -8722,7 +8722,7 @@ public:
             ASR::call_arg_t arg2; arg2.loc = x.base.base.loc; arg2.m_value = right;
             args.push_back(al, arg2);
             int i = ASRUtils::select_generic_procedure(args, *custom_op, x.base.base.loc,
-                [&](const std::string &msg, const Location &loc) { 
+                [&](const std::string &msg, const Location &loc) {
                         diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }, true);
@@ -9269,7 +9269,7 @@ public:
             if( is_tmp_array ) {
                 if( ASRUtils::is_array(tmp2_mem_type) ) {
                     diag.add(Diagnostic(
-                        "The expression with derived types contains two or more arrays.", 
+                        "The expression with derived types contains two or more arrays.",
                         Level::Error, Stage::Semantic, {Label("", {loc})}));
                     throw SemanticAbort();
                 }
@@ -9305,7 +9305,7 @@ public:
                     ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(ASRUtils::symbol_type(tmp2_m_m_ext->m_external)))){
                     if(array_found){
                         diag.add(Diagnostic(
-                            "The expression with derived types contains two or more arrays.", 
+                            "The expression with derived types contains two or more arrays.",
                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -9318,7 +9318,7 @@ public:
                 if(ASR::is_a<ASR::Array_t>(*ASRUtils::type_get_past_allocatable(var_type))){
                     if(array_found){
                         diag.add(Diagnostic(
-                            "The expression with derived types contains two or more arrays.", 
+                            "The expression with derived types contains two or more arrays.",
                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -624,7 +624,7 @@ public:
             current_module_dependencies.p,
             current_module_dependencies.size(),
             /* a_body */ nullptr,
-            /* n_body */ 0, 
+            /* n_body */ 0,
             /* m_start_name */ x.m_start_name ? x.m_start_name : nullptr,
             /* m_end_name */ x.m_end_name ? x.m_end_name : nullptr);
         std::string sym_name = to_lower(x.m_name);
@@ -1064,7 +1064,7 @@ public:
                 if ( !compiler_options.continue_compilation ) throw e;
             }
         }
-        Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0); 
+        Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);
         for (size_t i=0; i<x.n_decl; i++) {
             is_Function = true;
             if(x.m_decl[i]->type == AST::unit_decl2Type::Declaration) {
@@ -1233,7 +1233,7 @@ public:
         handle_save();
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
 
-        // Self referencing procedure declarations 
+        // Self referencing procedure declarations
         for (size_t i : procedure_decl_indices) {
             try {
                 visit_unit_decl2(*x.m_decl[i]);
@@ -1459,7 +1459,7 @@ public:
                 if ( !compiler_options.continue_compilation ) throw e;
             }
         }
-        Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0); 
+        Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);
         for (size_t i=0; i<x.n_decl; i++) {
             is_Function = true;
             if(x.m_decl[i]->type == AST::unit_decl2Type::Declaration) {
@@ -1735,8 +1735,8 @@ public:
             x.m_end_name ? x.m_end_name : nullptr);
         handle_save();
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
-        
-        // Self referencing procedure declarations 
+
+        // Self referencing procedure declarations
         for (size_t i : procedure_decl_indices) {
             try {
                 visit_unit_decl2(*x.m_decl[i]);


### PR DESCRIPTION
https://github.com/lfortran/lfortran/issues/5890

The problem was this below line,

https://github.com/lfortran/lfortran/blob/c219981e5502807afab4ab963b11b7171516176f/src/lfortran/semantics/ast_common_visitor.h#L7333

The above line is executed inside a loop (which is of size `65535`). So in each iteration the `visitor` object gets created and destroyed leading to slow down. I moved the class out, and the `visitor` object creation out of the loop. Then it speeds up.

On my system,

**Before**

`lfortran ../debug.f90 -o a.out  12.52s user 0.24s system 100% cpu 12.745 total`

**After**

`lfortran ../debug.f90 -o a.out  0.37s user 0.11s system 86% cpu 0.557 total`

**Code**

```fortran
program compile_time
implicit none
integer, parameter :: N = 65535
integer, parameter :: sp = kind(1.0)
integer, parameter :: dp = kind(1.d0)
real(dp), parameter :: pi = 2*asin(1._dp)
real(dp), parameter :: a = 0, b = pi
real(dp), parameter :: dx = (b-a)/N
integer :: i
real(dp), parameter :: X(*) = [(sin(a+(b-a)*i/N), i = 1, N)]
real(dp), parameter :: S = sum(X)*dx
logical, parameter :: l = S < 2
real(kind=merge(sp, dp, l)) :: y
if (kind(y) == sp) then
print *, "true"
else
print *, "false"
end if
print *, S
end program
```