### PR TITLE
Fix: raise error on improper use of `class` keyword in declarations

### DIFF
--- a/integration_tests/template_vector.f90
+++ b/integration_tests/template_vector.f90
@@ -59,7 +59,7 @@ contains
 
     subroutine main()
         instantiate vector_t(integer), only: IntVector => Vector
-        class(IntVector) :: v
+        type(IntVector) :: v
         integer :: i
         v = IntVector()
         ! call v%push_back(v, 1)

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3303,6 +3303,21 @@ public:
                         throw SemanticAbort();
                     }
                 }
+
+                bool is_class_type = sym_type->m_type == AST::decl_typeType::TypeClass; 
+                // Assert class declaration variable is dummy, pointer or allocatable
+                if (is_class_type) {
+                    if (!(is_argument | is_pointer | is_allocatable)) {
+                        diag.add((Diagnostic(
+                            "Class variable must be a dummy argument, allocatable, or pointer.",
+                            Level::Error, Stage::Semantic, {
+                                Label("",{x.base.base.loc})
+                            }
+                        )));
+                        throw SemanticAbort();
+                    }
+                }
+
                 if (s.n_dim > 0) {
                     if (dims.size() > 0) {
                         // This happens for:

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -2,11 +2,11 @@
     "basename": "asr-template_vector-140858c",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/template_vector.f90",
-    "infile_hash": "23c3387fefdedf9e792fc7b6ddfec9102541f4501a300a3641871023",
+    "infile_hash": "c90086bccd7acd20362f5bcb800e4030a60fc54abf4ba105cc7ceef6",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "7d84da782c723456ced90da045b54ed65335ba698ba443e6909d6bac",
+    "stdout_hash": "89d5560d4d7cafae90ddffccb0aff6019cfe25e5565fc2f6e9e8ed63",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -639,7 +639,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (ClassType
+                                                    (StructType
                                                         7 intvector
                                                     )
                                                     ()


### PR DESCRIPTION
Fix #5872

Todo:

- [ ] Add test in `tests/errors`