### PR TITLE
enh: handling of 'dble', 'float', 'dfloat', 'shifta' as intrinsics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -988,6 +988,8 @@ RUN(NAME intrinsics_333 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPER
 RUN(NAME intrinsics_334 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #move_alloc
 RUN(NAME intrinsics_335 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #kind, real
 RUN(NAME intrinsics_336 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER) #any
+RUN(NAME intrinsics_336 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER) #any
+RUN(NAME intrinsics_337 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dble, dfloat, float, shifta
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -988,7 +988,6 @@ RUN(NAME intrinsics_333 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPER
 RUN(NAME intrinsics_334 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #move_alloc
 RUN(NAME intrinsics_335 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #kind, real
 RUN(NAME intrinsics_336 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER) #any
-RUN(NAME intrinsics_336 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER) #any
 RUN(NAME intrinsics_337 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dble, dfloat, float, shifta
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants

--- a/integration_tests/intrinsics_337.f90
+++ b/integration_tests/intrinsics_337.f90
@@ -69,7 +69,7 @@ CONTAINS
 end module intrinsics_337_mod
 
 program intrinsics_337
-    use M_strings
+    use intrinsics_337_mod
     implicit none
     ! this call matches with intrinsic 'dble'
     print *, dble(1)

--- a/integration_tests/intrinsics_337.f90
+++ b/integration_tests/intrinsics_337.f90
@@ -1,4 +1,4 @@
-MODULE M_strings
+MODULE intrinsics_337_mod
 implicit none
 
 ! interface with same name as intrinsic 'dble'
@@ -66,9 +66,9 @@ CONTAINS
     double precision function interface_shifta_fun()
         interface_shifta_fun = 5.0D0
     end function interface_shifta_fun
-end module M_strings
+end module intrinsics_337_mod
 
-program main
+program intrinsics_337
     use M_strings
     implicit none
     ! this call matches with intrinsic 'dble'
@@ -101,4 +101,4 @@ program main
     call sub2()
     call sub3()
     call sub4()
-end program main
+end program intrinsics_337

--- a/integration_tests/intrinsics_337.f90
+++ b/integration_tests/intrinsics_337.f90
@@ -1,0 +1,104 @@
+MODULE M_strings
+implicit none
+
+! interface with same name as intrinsic 'dble'
+interface dble
+    module procedure interface_dble_fun
+end interface
+
+! interface with same name as intrinsic 'float'
+interface float
+    module procedure interface_float_fun
+end interface
+
+! interface with same name as intrinsic 'dfloat'
+interface dfloat
+    module procedure interface_dfloat_fun
+end interface
+
+! interface with same name as intrinsic 'shifta'
+interface shifta
+    module procedure interface_shifta_fun
+end interface
+
+CONTAINS
+
+    subroutine sub1()
+        integer :: intg
+        intg = 1
+        print *, dble(intg)
+        if (abs(dble(intg) - 1.D0) > epsilon(1.D0)) error stop
+    end subroutine sub1
+
+    subroutine sub2()
+        integer :: intg
+        intg = 1
+        print *, float(intg)
+        if (abs(float(intg) - 1.0) > epsilon(1.0)) error stop
+    end subroutine sub2
+
+    subroutine sub3()
+        integer :: intg
+        intg = 1
+        print *, dfloat(intg)
+        if (abs(dfloat(intg) - 1.D0) > epsilon(1.D0)) error stop
+    end subroutine sub3
+
+    subroutine sub4()
+        integer :: intg
+        intg = 1
+        print *, shifta(intg, intg)
+        if (shifta(intg, intg) /= 0) error stop
+    end subroutine sub4
+
+    doubleprecision function interface_dble_fun()
+        interface_dble_fun = 5.0D0
+    end function interface_dble_fun
+
+    double precision function interface_float_fun()
+        interface_float_fun = 5.0D0
+    end function interface_float_fun
+
+    double precision function interface_dfloat_fun()
+        interface_dfloat_fun = 5.0D0
+    end function interface_dfloat_fun
+
+    double precision function interface_shifta_fun()
+        interface_shifta_fun = 5.0D0
+    end function interface_shifta_fun
+end module M_strings
+
+program main
+    use M_strings
+    implicit none
+    ! this call matches with intrinsic 'dble'
+    print *, dble(1)
+    if (abs(dble(1) - 1.D0) > epsilon(1.D0)) error stop
+    ! this call matches with intrinsic 'float'
+    print *, float(1)
+    if (abs(float(1) - 1.0) > epsilon(1.0)) error stop
+    ! this call matches with intrinsic 'dfloat'
+    print *, dfloat(1)
+    if (abs(dfloat(1) - 1.D0) > epsilon(1.D0)) error stop
+    ! this call matches with intrinsic 'shifta'
+    print *, shifta(1, 1)
+    if (shifta(1, 1) /= 0) error stop
+
+    ! this call matches with interface defined in module
+    print *, dble()
+    if (abs(dble() - 5.D0) > epsilon(1.D0)) error stop
+    ! this call matches with interface defined in module
+    print *, float()
+    if (abs(float() - 5.0) > epsilon(1.0)) error stop
+    ! this call matches with interface defined in module
+    print *, dfloat()
+    if (abs(dfloat() - 5.D0) > epsilon(1.D0)) error stop
+    ! this call matches with interface defined in module
+    print *, shifta()
+    if (abs(shifta() - 5.D0) > epsilon(1.D0)) error stop
+
+    call sub1()
+    call sub2()
+    call sub3()
+    call sub4()
+end program main

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7066,6 +7066,9 @@ public:
         return nullptr;
     }
 
+    // special handling of 'dble', 'float', 'dfloat', 'shifta' intrinsics
+    // maybe once those are moved to IntrinsicElementalFunction, this might
+    // not be needed
     ASR::asr_t* handle_intrinsics_dble_float_dfloat_shifta(
         const AST::FuncCallOrArray_t &x,
         Allocator &al
@@ -7664,6 +7667,16 @@ public:
                     throw SemanticAbort();
                 }
             } else if (compiler_options.implicit_interface) {
+
+                bool is_function = true;
+                // NOTE: ideally this shouldn't be needed, this is only to handle
+                // 'dble', 'shifta', 'float', 'dfloat', which aren't currently
+                // implemented as intrinsic elemental function
+                intrinsic_as_node(x, is_function);
+                if (!is_function) {
+                    return;
+                }
+
                 // If implicit interface is allowed, we have to handle the
                 // following case here:
                 // real :: x

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5141,6 +5141,10 @@ public:
                     false);
         if( idx == -1 ) {
             bool is_function = true;
+            if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
+                tmp = result;
+                return tmp;
+            }
             v = intrinsic_as_node(x, is_function);
             if( !is_function ) {
                 return tmp;
@@ -5255,6 +5259,10 @@ public:
                     false);
             if( idx == -1 ) {
                 bool is_function = true;
+                if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
+                    tmp = result;
+                    return tmp;
+                }
                 v = intrinsic_as_node(x, is_function);
                 if( !is_function ) {
                     return tmp;
@@ -7061,6 +7069,29 @@ public:
         return nullptr;
     }
 
+    ASR::asr_t* handle_intrinsics_dble_float_dfloat_shifta(
+        const AST::FuncCallOrArray_t &x,
+        Allocator &al
+    ) {
+        ASR::asr_t* asr_node { nullptr };
+        std::string var_name = to_lower(x.m_func);
+        Vec<ASR::call_arg_t> args;
+        if (var_name == "dble") {
+            visit_expr_list(x.m_args, x.n_args, args);
+            asr_node = handle_intrinsic_dble(al, args, x.base.base.loc);
+        } else if (var_name == "float" ) {
+            visit_expr_list(x.m_args, x.n_args, args);
+            asr_node = handle_intrinsic_float_dfloat(al, args, x.base.base.loc, 4);
+        } else if (var_name == "dfloat" ) {
+            visit_expr_list(x.m_args, x.n_args, args);
+            asr_node = handle_intrinsic_float_dfloat(al, args, x.base.base.loc, 8);
+        } else if (var_name == "shifta") {
+            visit_expr_list(x.m_args, x.n_args, args);
+            asr_node = create_Shifta(x.base.base.loc, args);
+        }
+        return asr_node;
+    }
+
     ASR::asr_t* handle_intrinsic_dble(Allocator &al, Vec<ASR::call_arg_t> args,
                                         const Location &loc) {
         ASR::expr_t *arg = nullptr, *value = nullptr;
@@ -7581,25 +7612,8 @@ public:
         }
         if (!v || (v && (is_external_procedure || is_explicit_intrinsic))) {
             ASR::symbol_t* external_sym = is_external_procedure ? v : nullptr;
-            if (var_name == "dble") {
-                Vec<ASR::call_arg_t> args;
-                visit_expr_list(x.m_args, x.n_args, args);
-                tmp = handle_intrinsic_dble(al, args, x.base.base.loc);
-                return;
-            } else if (var_name == "float" ) {
-                Vec<ASR::call_arg_t> args;
-                visit_expr_list(x.m_args, x.n_args, args);
-                tmp = handle_intrinsic_float_dfloat(al, args, x.base.base.loc, 4);
-                return;
-            } else if (var_name == "dfloat" ) {
-                Vec<ASR::call_arg_t> args;
-                visit_expr_list(x.m_args, x.n_args, args);
-                tmp = handle_intrinsic_float_dfloat(al, args, x.base.base.loc, 8);
-                return;
-            } else if (var_name == "shifta") {
-                Vec<ASR::call_arg_t> args;
-                visit_expr_list(x.m_args, x.n_args, args);
-                tmp = create_Shifta(x.base.base.loc, args);
+            if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
+                tmp = result;
                 return;
             }
             bool is_function = true;
@@ -7657,20 +7671,8 @@ public:
                     throw SemanticAbort();
                 }
             } else if (compiler_options.implicit_interface) {
-                if (var_name == "dble") {
-                    Vec<ASR::call_arg_t> args;
-                    visit_expr_list(x.m_args, x.n_args, args);
-                    tmp = handle_intrinsic_dble(al, args, x.base.base.loc);
-                    return;
-                } else if (var_name == "float" ) {
-                    Vec<ASR::call_arg_t> args;
-                    visit_expr_list(x.m_args, x.n_args, args);
-                    tmp = handle_intrinsic_float_dfloat(al, args, x.base.base.loc, 4);
-                    return;
-                } else if (var_name == "dfloat" ) {
-                    Vec<ASR::call_arg_t> args;
-                    visit_expr_list(x.m_args, x.n_args, args);
-                    tmp = handle_intrinsic_float_dfloat(al, args, x.base.base.loc, 8);
+                if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
+                    tmp = result;
                     return;
                 }
                 // If implicit interface is allowed, we have to handle the

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5141,10 +5141,6 @@ public:
                     false);
         if( idx == -1 ) {
             bool is_function = true;
-            if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
-                tmp = result;
-                return tmp;
-            }
             v = intrinsic_as_node(x, is_function);
             if( !is_function ) {
                 return tmp;
@@ -5259,10 +5255,6 @@ public:
                     false);
             if( idx == -1 ) {
                 bool is_function = true;
-                if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
-                    tmp = result;
-                    return tmp;
-                }
                 v = intrinsic_as_node(x, is_function);
                 if( !is_function ) {
                     return tmp;
@@ -6905,6 +6897,11 @@ public:
     ASR::symbol_t* intrinsic_as_node(const AST::FuncCallOrArray_t &x,
                                      bool& is_function) {
         std::string var_name = to_lower(x.m_func);
+        if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
+            is_function = false;
+            tmp = result;
+            return nullptr;
+        }
         std::string specific_var_name = var_name;
         bool is_specific_type_intrinsic = intrinsic_mapping.count(var_name);
         if( is_intrinsic_registry_function(var_name)) {
@@ -7612,10 +7609,6 @@ public:
         }
         if (!v || (v && (is_external_procedure || is_explicit_intrinsic))) {
             ASR::symbol_t* external_sym = is_external_procedure ? v : nullptr;
-            if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
-                tmp = result;
-                return;
-            }
             bool is_function = true;
             v = intrinsic_as_node(x, is_function);
             if( !is_function ) {
@@ -7671,10 +7664,6 @@ public:
                     throw SemanticAbort();
                 }
             } else if (compiler_options.implicit_interface) {
-                if (ASR::asr_t* result = handle_intrinsics_dble_float_dfloat_shifta(x, al)) {
-                    tmp = result;
-                    return;
-                }
                 // If implicit interface is allowed, we have to handle the
                 // following case here:
                 // real :: x


### PR DESCRIPTION
## Description

Fixes #5923 

