### PR TITLE
Fix : Set arrayPhysicalType of Array constructor to desciptorArray when any arg doesn't have compile time size

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -499,7 +499,7 @@ RUN(NAME arrays_reshape_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
 RUN(NAME arrays_reshape_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME arrays_reshape_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
-RUN(NAME arrays_reshape_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME arrays_reshape_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER)
 RUN(NAME arrays_elemental_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME arrays_03_func LABELS gfortran cpp llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_03_func_pass_arr_dims LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -499,6 +499,7 @@ RUN(NAME arrays_reshape_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
 RUN(NAME arrays_reshape_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME arrays_reshape_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME arrays_reshape_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_elemental_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME arrays_03_func LABELS gfortran cpp llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_03_func_pass_arr_dims LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)

--- a/integration_tests/arrays_reshape_19.f90
+++ b/integration_tests/arrays_reshape_19.f90
@@ -2,9 +2,7 @@ module arrays_reshape_19_mod
     contains 
     subroutine another_func(q)
       integer, intent(in) :: q(:,:)
-      integer,allocatable :: anew(:)
-      allocate(anew(size(q) +2))
-      print *, size(anew)
+      integer :: anew(18)
       anew = reshape([0,q,17], [18])
       print *, anew
       if(any(anew /= [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17])) error stop 

--- a/integration_tests/arrays_reshape_19.f90
+++ b/integration_tests/arrays_reshape_19.f90
@@ -1,0 +1,19 @@
+module arrays_reshape_19_mod
+    contains 
+    subroutine another_func(q)
+      integer, intent(in) :: q(:,:)
+      integer,allocatable :: anew(:)
+      allocate(anew(size(q) +2))
+      print *, size(anew)
+      anew = reshape([0,q,17], [18])
+      print *, anew
+      if(any(anew /= [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17])) error stop 
+    end subroutine another_func
+  end module
+  
+  program arrays_reshape_19
+    use arrays_reshape_19_mod
+    integer :: q(4,4)
+    q = reshape([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16], [4,4])
+    call another_func(q)
+  end program arrays_reshape_19


### PR DESCRIPTION
fixes #5928 
towards #5929 