### PR TITLE
fix: set `ArrayPhysicalCast` type correctly when passing an `allocatable`  array as argument to a fixed-size array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -428,6 +428,7 @@ RUN(NAME functions_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME functions_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_29.f90
+++ b/integration_tests/functions_29.f90
@@ -1,0 +1,19 @@
+program function_29
+   implicit none
+
+   integer, allocatable :: x(:)
+
+   allocate(x(2))
+   x = [1, 2]
+   call my_func(x)
+
+contains
+
+   subroutine my_func(arr)
+      integer, intent(in) :: arr(2)
+      print *, arr
+      if (any(arr /= [1, 2])) error stop
+   end subroutine my_func
+
+end program function_29
+

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5893,10 +5893,23 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                     "Incompatible dimensions passed to " + (std::string)(ASR::down_cast<ASR::Function_t>(a_name_)->m_name)
                     + "(" + std::to_string(get_fixed_size_of_array(arg_array_t->m_dims,arg_array_t->n_dims)) + "/" + std::to_string(get_fixed_size_of_array(orig_arg_array_t->m_dims,orig_arg_array_t->n_dims))+")");
 
-                physical_cast_arg.m_value = ASRUtils::EXPR(ASRUtils::make_ArrayPhysicalCast_t_util(
-                    al, arg->base.loc, arg, arg_array_t->m_physical_type, orig_arg_array_t->m_physical_type,
-                    ASRUtils::duplicate_type(al, ASRUtils::expr_type(arg), dimensions, orig_arg_array_t->m_physical_type, true),
-                    nullptr));
+                physical_cast_arg.m_value = ASRUtils::EXPR(
+                                            ASRUtils::make_ArrayPhysicalCast_t_util(
+                                                al,
+                                                arg->base.loc,
+                                                arg,
+                                                arg_array_t->m_physical_type,
+                                                orig_arg_array_t->m_physical_type,
+                                                ASRUtils::duplicate_type(
+                                                    al,
+                                                    use_experimental_simplifier
+                                                        ? ASRUtils::type_get_past_allocatable(
+                                                            ASRUtils::expr_type(arg))
+                                                        : ASRUtils::expr_type(arg),
+                                                    dimensions,
+                                                    orig_arg_array_t->m_physical_type,
+                                                    true),
+                                                nullptr));
                 a_args[i] = physical_cast_arg;
             }
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5893,23 +5893,23 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                     "Incompatible dimensions passed to " + (std::string)(ASR::down_cast<ASR::Function_t>(a_name_)->m_name)
                     + "(" + std::to_string(get_fixed_size_of_array(arg_array_t->m_dims,arg_array_t->n_dims)) + "/" + std::to_string(get_fixed_size_of_array(orig_arg_array_t->m_dims,orig_arg_array_t->n_dims))+")");
 
+                ASR::ttype_t* physical_cast_type = use_experimental_simplifier
+                                                    ? ASRUtils::type_get_past_allocatable(
+                                                        ASRUtils::expr_type(arg))
+                                                    : ASRUtils::expr_type(arg);
                 physical_cast_arg.m_value = ASRUtils::EXPR(
-                                            ASRUtils::make_ArrayPhysicalCast_t_util(
-                                                al,
-                                                arg->base.loc,
-                                                arg,
-                                                arg_array_t->m_physical_type,
-                                                orig_arg_array_t->m_physical_type,
-                                                ASRUtils::duplicate_type(
+                                                ASRUtils::make_ArrayPhysicalCast_t_util(
                                                     al,
-                                                    use_experimental_simplifier
-                                                        ? ASRUtils::type_get_past_allocatable(
-                                                            ASRUtils::expr_type(arg))
-                                                        : ASRUtils::expr_type(arg),
-                                                    dimensions,
+                                                    arg->base.loc,
+                                                    arg,
+                                                    arg_array_t->m_physical_type,
                                                     orig_arg_array_t->m_physical_type,
-                                                    true),
-                                                nullptr));
+                                                    ASRUtils::duplicate_type(al,
+                                                                            physical_cast_type,
+                                                                            dimensions,
+                                                                            orig_arg_array_t->m_physical_type,
+                                                                            true),
+                                                    nullptr));
                 a_args[i] = physical_cast_arg;
             }
         }

--- a/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.json
+++ b/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface_allocatable_array-38d4afe.stdout",
-    "stdout_hash": "bfad2011393bb9fa83e1d0639e5f8c586efd1387e2fdc40e337d416e",
+    "stdout_hash": "b13790d6023fce54a443d01721f0f8726351bc06bf977863750609e0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.stdout
+++ b/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.stdout
@@ -241,13 +241,11 @@
                             (Var 2 r_g)
                             DescriptorArray
                             PointerToDataArray
-                            (Allocatable
-                                (Array
-                                    (Real 4)
-                                    [(()
-                                    ())]
-                                    PointerToDataArray
-                                )
+                            (Array
+                                (Real 4)
+                                [(()
+                                ())]
+                                PointerToDataArray
                             )
                             ()
                         ))]


### PR DESCRIPTION
fixes #5933

Looking at the `asr_verify` code for `Allocatable_t` with the `simplifier` pass, we see that it requires an `allocatable` type to have a deferred length to work. This is the required behavior also, but for `ArrayPhysicalCast`, we were setting the `ttype` wrapped inside `Allocatable_t` causing issues. As it turns out, the implementation before the `simplifier` pass had handled this with `Allocatable_t`, but `simplifier` pass is stricter in this regard.