### PR TITLE
chore: convert 'FLUSH' intrinsic to 'FLUSH' statement

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1523,6 +1523,7 @@ RUN(NAME sign_from_value LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME rewind_inquire_flush LABELS gfortran)
 RUN(NAME flush_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_01_data.txt)
+RUN(NAME flush_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_01_data.txt file_02_data.txt)
 
 RUN(NAME assign_to1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME assign_to2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/flush_02.f90
+++ b/integration_tests/flush_02.f90
@@ -1,0 +1,8 @@
+program flush_02
+    implicit none
+    open(10, file="file_01_data.txt")
+    open(11, file="file_02_data.txt")
+    call FLUSH()
+    close(10)
+    close(11)
+end program flush_02

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3280,13 +3280,6 @@ public:
     */
     void flush_subroutine_to_flush_statement(const AST::SubroutineCall_t &x) {
         LCOMPILERS_ASSERT(to_lower(x.m_name) == "flush")
-        // encourage users to use `FLUSH` statement instead,
-        // as 'FLUSH' subroutine call isn't in Fortran standard
-        diag.semantic_warning_label(
-            "The 'flush' intrinsic function is an LFortran extension",
-            {x.base.base.loc},
-            "help: use the 'flush' statement instead"
-        );
 
         // for FLUSH subroutine call, the only argument 'unit' is optional
         ASR::expr_t* unit_flush = nullptr;
@@ -3318,7 +3311,7 @@ public:
             );
         } else {
             diag.add(Diagnostic(
-                "Expected 0 or 1 argument, instead got " + std::to_string(x.n_args + x.n_keywords) +
+                "Expected 0 or 1 arguments, got " + std::to_string(x.n_args + x.n_keywords) +
                 " arguments instead.",
                 Level::Error, Stage::Semantic, {
                     Label("",{x.base.base.loc})
@@ -3329,6 +3322,13 @@ public:
         tmp = ASR::make_Flush_t(
             al, x.base.base.loc, 0, unit_flush, nullptr,
             nullptr, nullptr
+        );
+        // encourage users to use `FLUSH` statement instead,
+        // as 'FLUSH' subroutine call isn't in Fortran standard
+        diag.semantic_warning_label(
+            "The 'flush' intrinsic function is an LFortran extension",
+            {x.base.base.loc},
+            "help: use the 'flush' statement instead"
         );
     }
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2926,13 +2926,23 @@ LFORTRAN_API int64_t _lfortran_open(int32_t unit_num, char *f_name, char *status
 
 LFORTRAN_API void _lfortran_flush(int32_t unit_num)
 {
-    bool unit_file_bin;
-    FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin);
-    if( filep == NULL ) {
-        printf("Specified UNIT %d in FLUSH is not connected.\n", unit_num);
-        exit(1);
+    // special case: flush all open units
+    if (unit_num == -1) {
+        for (int i = 0; i <= last_index_used; i++) {
+            if (unit_to_file[i].filep != NULL) {
+                fflush(unit_to_file[i].filep);
+            }
+        }
+    } else {
+        bool unit_file_bin;
+        FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin);
+        get_file_pointer_from_unit(unit_num, &unit_file_bin);
+        if( filep == NULL ) {
+            printf("Specified UNIT %d in FLUSH is not connected.\n", unit_num);
+            exit(1);
+        }
+        fflush(filep);
     }
-    fflush(filep);
 }
 
 LFORTRAN_API void _lfortran_inquire(char *f_name, bool *exists, int32_t unit_num, bool *opened, int32_t *size) {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2936,7 +2936,6 @@ LFORTRAN_API void _lfortran_flush(int32_t unit_num)
     } else {
         bool unit_file_bin;
         FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin);
-        get_file_pointer_from_unit(unit_num, &unit_file_bin);
         if( filep == NULL ) {
             printf("Specified UNIT %d in FLUSH is not connected.\n", unit_num);
             exit(1);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -77,5 +77,6 @@ program continue_compilation_1
     !parameter_01
     i1 = 3
     print*,i1
+    call FLUSH(1, 2)
 
 end program

--- a/tests/flush2.f90
+++ b/tests/flush2.f90
@@ -3,4 +3,5 @@ program flush2
     call flush()
     open(10, file="file_01_data.txt")
     call flush(10)
+    call flush()
 end program flush2

--- a/tests/flush2.f90
+++ b/tests/flush2.f90
@@ -1,0 +1,6 @@
+program flush2
+    implicit none
+    call flush()
+    open(10, file="file_01_data.txt")
+    call flush(10)
+end program flush2

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "fe50900b3e871f7dfb599f76e1631b687d811bf374bed4e88c7ace7f",
+    "infile_hash": "37fe3a57bf05fd3bd96144143cf6a32805e5176662dde827403c512d",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "3550f6b34efb3510891e8e632a1cc406e8e31944dc714cfbc2293f23",
+    "stderr_hash": "203afcb2445664843802b7085f6927458dd4d299bf08b7bcca7d07f5",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -130,3 +130,9 @@ semantic error: Cannot assign to a constant variable
    |
 10 |     integer, parameter :: i1 = 2
    |                           ~~~~~~ declared as constant
+
+semantic error: Expected 0 or 1 arguments, got 2 arguments instead.
+  --> tests/errors/continue_compilation_1.f90:80:5
+   |
+80 |     call FLUSH(1, 2)
+   |     ^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-flush2-9767ece.json
+++ b/tests/reference/asr-flush2-9767ece.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-flush2-9767ece.stdout",
-    "stdout_hash": "870e340ce5506e28aad8eb9bab1c23b7ee472f72aaba63a34d7966f9",
+    "stdout_hash": "917455c7f979278a4e1553acb9e357d29b39bd49dbf1b0de9850cafa",
     "stderr": "asr-flush2-9767ece.stderr",
     "stderr_hash": "9a387f3a8657746f5eb56f5e5a03771cfe161a73d9fb1a50cc03e6ae",
     "returncode": 0

--- a/tests/reference/asr-flush2-9767ece.json
+++ b/tests/reference/asr-flush2-9767ece.json
@@ -2,12 +2,12 @@
     "basename": "asr-flush2-9767ece",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/flush2.f90",
-    "infile_hash": "968ed5c55feb6f409c674be79a74ceab43e943d2e9e9d3a05d5e2b50",
+    "infile_hash": "e4912e2bc379b34e493cdd9c89f76794bb32113af915d2ca96793675",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-flush2-9767ece.stdout",
-    "stdout_hash": "93adcc31f59b50101588d6af54585e38985c25428416d72fc1adf8ba",
+    "stdout_hash": "870e340ce5506e28aad8eb9bab1c23b7ee472f72aaba63a34d7966f9",
     "stderr": "asr-flush2-9767ece.stderr",
-    "stderr_hash": "55871963dcd8bad789f6d4fdee3bbc6724dcd802d2bd758b01caadb8",
+    "stderr_hash": "9a387f3a8657746f5eb56f5e5a03771cfe161a73d9fb1a50cc03e6ae",
     "returncode": 0
 }

--- a/tests/reference/asr-flush2-9767ece.json
+++ b/tests/reference/asr-flush2-9767ece.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-flush2-9767ece",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/flush2.f90",
+    "infile_hash": "968ed5c55feb6f409c674be79a74ceab43e943d2e9e9d3a05d5e2b50",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-flush2-9767ece.stdout",
+    "stdout_hash": "93adcc31f59b50101588d6af54585e38985c25428416d72fc1adf8ba",
+    "stderr": "asr-flush2-9767ece.stderr",
+    "stderr_hash": "55871963dcd8bad789f6d4fdee3bbc6724dcd802d2bd758b01caadb8",
+    "returncode": 0
+}

--- a/tests/reference/asr-flush2-9767ece.stderr
+++ b/tests/reference/asr-flush2-9767ece.stderr
@@ -1,11 +1,17 @@
-warning: `FLUSH` statement should be preferred over the `FLUSH` intrinsic
+warning: The 'flush' intrinsic function is an LFortran extension
  --> tests/flush2.f90:3:5
   |
 3 |     call flush()
-  |     ^^^^^^^^^^^^ 
+  |     ^^^^^^^^^^^^ help: use the 'flush' statement instead
 
-warning: `FLUSH` statement should be preferred over the `FLUSH` intrinsic
+warning: The 'flush' intrinsic function is an LFortran extension
  --> tests/flush2.f90:5:5
   |
 5 |     call flush(10)
-  |     ^^^^^^^^^^^^^^ 
+  |     ^^^^^^^^^^^^^^ help: use the 'flush' statement instead
+
+warning: The 'flush' intrinsic function is an LFortran extension
+ --> tests/flush2.f90:6:5
+  |
+6 |     call flush()
+  |     ^^^^^^^^^^^^ help: use the 'flush' statement instead

--- a/tests/reference/asr-flush2-9767ece.stderr
+++ b/tests/reference/asr-flush2-9767ece.stderr
@@ -1,0 +1,11 @@
+warning: `FLUSH` statement should be preferred over the `FLUSH` intrinsic
+ --> tests/flush2.f90:3:5
+  |
+3 |     call flush()
+  |     ^^^^^^^^^^^^ 
+
+warning: `FLUSH` statement should be preferred over the `FLUSH` intrinsic
+ --> tests/flush2.f90:5:5
+  |
+5 |     call flush(10)
+  |     ^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-flush2-9767ece.stdout
+++ b/tests/reference/asr-flush2-9767ece.stdout
@@ -7,10 +7,20 @@
                     (SymbolTable
                         2
                         {
-                            output_unit:
+                            __external_output_unit_flush2:
                                 (ExternalSymbol
                                     2
+                                    __external_output_unit_flush2
+                                    4 output_unit
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
                                     output_unit
+                                    Private
+                                ),
+                            __external_output_unit_flush21:
+                                (ExternalSymbol
+                                    2
+                                    __external_output_unit_flush21
                                     4 output_unit
                                     lfortran_intrinsic_iso_fortran_env
                                     []
@@ -22,7 +32,7 @@
                     []
                     [(Flush
                         0
-                        (Var 2 output_unit)
+                        (Var 2 __external_output_unit_flush2)
                         ()
                         ()
                         ()
@@ -40,6 +50,13 @@
                     (Flush
                         0
                         (IntegerConstant 10 (Integer 4) Decimal)
+                        ()
+                        ()
+                        ()
+                    )
+                    (Flush
+                        0
+                        (Var 2 __external_output_unit_flush21)
                         ()
                         ()
                         ()

--- a/tests/reference/asr-flush2-9767ece.stdout
+++ b/tests/reference/asr-flush2-9767ece.stdout
@@ -1,0 +1,52 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            flush2:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            output_unit:
+                                (ExternalSymbol
+                                    2
+                                    output_unit
+                                    4 output_unit
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    output_unit
+                                    Private
+                                )
+                        })
+                    flush2
+                    []
+                    [(Flush
+                        0
+                        (Var 2 output_unit)
+                        ()
+                        ()
+                        ()
+                    )
+                    (FileOpen
+                        0
+                        (IntegerConstant 10 (Integer 4) Decimal)
+                        (StringConstant
+                            "file_01_data.txt"
+                            (String 1 16 () PointerString)
+                        )
+                        ()
+                        ()
+                    )
+                    (Flush
+                        0
+                        (IntegerConstant 10 (Integer 4) Decimal)
+                        ()
+                        ()
+                        ()
+                    )]
+                ),
+            lfortran_intrinsic_iso_fortran_env:
+                (IntrinsicModule lfortran_intrinsic_iso_fortran_env)
+        })
+    []
+)

--- a/tests/reference/asr-flush2-9767ece.stdout
+++ b/tests/reference/asr-flush2-9767ece.stdout
@@ -7,32 +7,17 @@
                     (SymbolTable
                         2
                         {
-                            __external_output_unit_flush2:
-                                (ExternalSymbol
-                                    2
-                                    __external_output_unit_flush2
-                                    4 output_unit
-                                    lfortran_intrinsic_iso_fortran_env
-                                    []
-                                    output_unit
-                                    Private
-                                ),
-                            __external_output_unit_flush21:
-                                (ExternalSymbol
-                                    2
-                                    __external_output_unit_flush21
-                                    4 output_unit
-                                    lfortran_intrinsic_iso_fortran_env
-                                    []
-                                    output_unit
-                                    Private
-                                )
+                            
                         })
                     flush2
                     []
                     [(Flush
                         0
-                        (Var 2 __external_output_unit_flush2)
+                        (IntegerUnaryMinus
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            (IntegerConstant -1 (Integer 4) Decimal)
+                        )
                         ()
                         ()
                         ()
@@ -56,14 +41,16 @@
                     )
                     (Flush
                         0
-                        (Var 2 __external_output_unit_flush21)
+                        (IntegerUnaryMinus
+                            (IntegerConstant 1 (Integer 4) Decimal)
+                            (Integer 4)
+                            (IntegerConstant -1 (Integer 4) Decimal)
+                        )
                         ()
                         ()
                         ()
                     )]
-                ),
-            lfortran_intrinsic_iso_fortran_env:
-                (IntrinsicModule lfortran_intrinsic_iso_fortran_env)
+                )
         })
     []
 )

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2596,6 +2596,10 @@ ast = true
 ast_f90 = true
 
 [[test]]
+filename = "flush2.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/class_01.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
## Description

'FLUSH' intrinsic and 'FLUSH' statement have identifical effect. Other compilers ifx, ifort, gfortran support 'FLUSH' intrinsic as well

We raise a warning to encourage users to use 'FLUSH' statement instead of 'FLUSH' intrinsic.

Fixes https://github.com/lfortran/lfortran/issues/5709