### PR TITLE
feat: support `PointerToDataArray` in array reshape

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1611,6 +1611,8 @@ RUN(NAME array_section_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStac
 RUN(NAME array_section_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME array_section_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 
+RUN(NAME pointer_to_data_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+
 RUN(NAME pass_array_by_data_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME pass_array_by_data_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME pass_array_by_data_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/pointer_to_data_array_01.f90
+++ b/integration_tests/pointer_to_data_array_01.f90
@@ -1,0 +1,66 @@
+! Fortran code after applying the pass: simplifier
+program pointer_to_data_array_01
+implicit none
+integer(4) :: k1
+real(4), dimension(2) :: array_constant
+integer(4), dimension(2) :: ac1
+real(4), dimension(4) :: array_reshape
+real(4), dimension(2, 2) :: a
+real(4) :: d
+real(4), dimension(2) :: g
+array_reshape = [1.00000000e+00, 2.00000000e+00, 3.00000000e+00, 4.00000000e+00]
+ac1 = [2, 2]
+a = reshape(array_reshape, ac1)
+k1 = lbound(array_constant, 1)
+array_constant(k1) = 5.00000000e+00
+k1 = k1 + 1
+array_constant(k1) = 6.00000000e+00
+k1 = k1 + 1
+g = array_constant
+d = trstlp(a, g)
+print *, d
+
+contains
+
+real(4) function trstlp(a, g) result(d)
+    integer(4) :: i1
+    integer(4) :: t2
+    integer(4) :: t1
+    integer(4) :: t3
+    real(4), dimension(:), allocatable :: ac
+    integer(4), dimension(2) :: ac2
+    real(4), dimension(:, :) :: a
+    real(4), dimension(:) :: g
+    real(4), dimension(size(a) + size(g)) :: array_reshape
+    real(4), dimension(size(a, 1), size(a, 2) + 1) :: a_aug
+    integer(4) :: m
+    integer(4) :: n
+    print *, "A = ", a
+    print *, "g = ", g
+    ! deallocate(ac)
+    allocate(ac(size(a) + size(g)))
+    i1 = lbound(ac, 1)
+    do t3 = lbound(a, 2), ubound(a, 2)
+        do t2 = lbound(a, 1), ubound(a, 1)
+            ac(i1) = a(t2, t3)
+            i1 = i1 + 1
+        end do
+    end do
+    do t1 = lbound(g, 1), ubound(g, 1)
+        ac(i1) = g(t1)
+        i1 = i1 + 1
+    end do
+    print *, "[A, g] = ", ac
+    m = size(a, 2)
+    n = size(a, 1)
+    array_reshape = [a, g]
+    ac2 = [n, m + 1]
+    print *, "array_reshape = ", array_reshape
+    a_aug = reshape(array_reshape, ac2)
+    print *, "A_aug = ", a_aug
+    d = Sum(a_aug)
+    print *, d
+end function trstlp
+
+end program pointer_to_data_array_01
+

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2526,6 +2526,31 @@ public:
                 tmp = target;
                 break;
             }
+            case ASR::array_physical_typeType::PointerToDataArray: {
+                ASR::dimension_t* m_dims = nullptr;
+                size_t n_dims = ASRUtils::extract_dimensions_from_ttype(x_m_array_type, m_dims);
+                llvm::Value* llvm_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), llvm::APInt(32, 1));
+                llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(x_m_array_type, module.get());
+                llvm::Value *target = llvm_utils->CreateAlloca(
+                    target_type, nullptr, "pointer_to_data_array");
+                int ptr_loads_copy = ptr_loads;
+                ptr_loads = 2;
+                for( size_t i = 0; i < n_dims; i++ ) {
+                    visit_expr_wrapper(m_dims[i].m_length, true);
+                    llvm_size = builder->CreateMul(tmp, llvm_size);
+                }
+                ptr_loads = ptr_loads_copy;
+                llvm::Value* target_ = llvm_utils->create_gep(target, 0);
+                llvm::Type* llvm_data_type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::type_get_past_array(
+                    ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(x_m_array_type))), module.get());
+                llvm::DataLayout data_layout(module.get());
+                uint64_t data_size = data_layout.getTypeAllocSize(llvm_data_type);
+                llvm_size = builder->CreateMul(llvm_size,
+                    llvm::ConstantInt::get(context, llvm::APInt(32, data_size)));
+                builder->CreateMemCpy(target_, llvm::MaybeAlign(), array, llvm::MaybeAlign(), llvm_size);
+                tmp = target_;
+                break;
+            }
             default: {
                 LCOMPILERS_ASSERT(false);
             }


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/5926#issuecomment-2577929635. Output still diverges.