### PR TITLE
Create temporary for function call returning arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1399,6 +1399,7 @@ RUN(NAME string_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER NOFAST)
 RUN(NAME string_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_46.f90
+++ b/integration_tests/string_46.f90
@@ -1,0 +1,28 @@
+program string_46
+
+type :: string
+    character(:), allocatable :: s
+end type
+
+type(string), allocatable :: x(:)
+allocate(x(2))
+allocate(character(len("fix")) :: x(1)%s)
+x(1)%s = "fix"
+allocate(character(len("lfortran")) :: x(2)%s)
+x(2)%s = "lfortran"
+x = g(x)
+print *, x(1)%s, x(2)%s
+if( x(1)%s /= "fix" ) error stop
+if( x(2)%s /= "lfortran" ) error stop
+
+
+contains
+
+    function g(intokens) result(tokens)
+    type(string), intent(in) :: intokens(:)
+    type(string), allocatable :: tokens(:)
+    allocate(tokens(size(intokens)))
+    tokens = intokens
+    end function
+
+end program

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1506,7 +1506,8 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             ASR::array_index_t* m_args = nullptr; size_t n_args = 0;
             ASRUtils::extract_indices(target, m_args, n_args);
             if( (target_Type == targetType::OriginalTarget && (realloc_lhs ||
-                 ASRUtils::is_array_indexed_with_array_indices(m_args, n_args))) ||
+                 ASRUtils::is_array_indexed_with_array_indices(m_args, n_args) ||
+                 ASRUtils::is_array(x->m_type))) ||
                  target_Type == targetType::GeneratedTargetPointerForArraySection ||
                 (!ASRUtils::is_allocatable(target) && ASRUtils::is_allocatable(x->m_type)) ) {
                 force_replace_current_expr_for_array(std::string("_function_call_") +


### PR DESCRIPTION
For now helps in handling `x = g(x)` case. In future, we will only create temporary if LHS and RHS has at least one common symbol.