### PR TITLE
CI: update CI for `bobyqa_example_2`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -503,12 +503,13 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
-            git checkout -t origin/lf-bobyqa_1-newuoa_1-newuoa_2-1
-            git checkout 35795f35387d0d0301d97cc550dc76b2fe5dd348
+            git checkout -t origin/lf-bobyqa_1-newuoa_1-newuoa_2-bobyqa_2-2
+            git checkout 5c55fbbdec8135d8f9d997717b69b18f4a4451af
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe
             ./build/fortran/example_newuoa_fortran_1_exe
             ./build/fortran/example_newuoa_fortran_2_exe
+            ./build/fortran/example_bobyqa_fortran_2_exe
 
       - name: Test POT3D
         shell: bash -e -l {0}


### PR DESCRIPTION
With this, 

**Examples giving exact same output as Gfortran** : 
-->`bobyqa_example_1`
-->`newuoa_example_1`

**Examples very close to Gfortran output (maybe precision bug because of more iterations)** : 
-->`bobyqa_example_2`
-->`newuoa_example_2`