### PR TITLE
refactor: perform scoped duplication of function body and arguments while duplicating `ASR::Function_t`

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4133,7 +4133,10 @@ class ExprStmtWithScopeDuplicator: public ASR::BaseExprStmtDuplicator<ExprStmtWi
 
     ASR::asr_t* duplicate_Var(ASR::Var_t* x) {
         ASR::symbol_t* m_v = current_scope->get_symbol(ASRUtils::symbol_name(x->m_v));
-        LCOMPILERS_ASSERT(m_v != nullptr);
+        if (m_v == nullptr) {
+            // we are dealing with an external/statement function, duplicate node with same symbol
+            return ASR::make_Var_t(al, x->base.base.loc, x->m_v);
+        }
         return ASR::make_Var_t(al, x->base.base.loc, m_v);
     }
 


### PR DESCRIPTION
The duplication of `ASR::stmt_t` nodes like `ASR::Assignment_t` was done incorrectly before causing expressions like `ASR::Var_t` to point to the original scope. We fix it using scoped duplication. Rest of the change is cleanup due to the use of new method.