### PR TITLE
CI: Update PRIMA CI for `uobyqa_example_1` and `uobyqa_example_2`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -503,13 +503,15 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
-            git checkout -t origin/lf-bobyqa_1-newuoa_1-newuoa_2-bobyqa_2-2
-            git checkout 5c55fbbdec8135d8f9d997717b69b18f4a4451af
+            git checkout -t origin/lf-b_1-b_2-n_1-n_2-u_1-u_2-1
+            git checkout 6d8e0a560db09312122f43cb98248ae571f88133
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe
             ./build/fortran/example_newuoa_fortran_1_exe
             ./build/fortran/example_newuoa_fortran_2_exe
             ./build/fortran/example_bobyqa_fortran_2_exe
+            ./build/fortran/example_uobyqa_fortran_1_exe
+            ./build/fortran/example_uobyqa_fortran_2_exe
 
       - name: Test POT3D
         shell: bash -e -l {0}


### PR DESCRIPTION
With this, 

**Examples giving exact same output as Gfortran** : 
-->`bobyqa_example_1`
-->`newuoa_example_1`
-->`uobyqa_example_1`

**Examples very close to Gfortran output (maybe precision bug because of more iterations)** : 
-->`bobyqa_example_2`
-->`newuoa_example_2`
-->`uobyqa_example_2`