### PR TITLE
feat: OMPDirective in ASR  [OPENMP]

### DIFF
--- a/integration_tests/openmp_43.f90
+++ b/integration_tests/openmp_43.f90
@@ -1,0 +1,27 @@
+program parallel_example  
+  use omp_lib  
+  implicit none  
+
+  integer :: i  
+  real :: result(10)  
+
+  ! Initialize the result array  
+  do i = 1, 10  
+     result(i) = 0.0  
+  end do  
+
+  ! Parallel region without a DO loop  
+  !$omp parallel private(i)  
+  i = omp_get_thread_num() + 1  ! Get the thread number (0-based)  
+  if (i <= 10) then  
+     result(i) = i * 2.0          ! Perform some computation  
+  end if  
+  !$omp end parallel  
+
+  ! Output the result  
+  print *, "Result array:"  
+  do i = 1, 10  
+     print *, result(i)  
+  end do  
+
+end program parallel_example

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -37,7 +37,7 @@ stmt
     | ImplicitDeallocate(expr* vars)
     | DoConcurrentLoop(do_loop_head* head, expr* shared, expr* local, reduction_expr* reduction, stmt* body)
     | DoLoop(identifier? name, do_loop_head head, stmt* body, stmt* orelse)
-    | OMPDirective(expr* constructs, expr* shared, expr* local, stmt* body)
+    | OMPDirective(expr* constructs, expr* shared, reduction_expr* reduction, expr* local, stmt* body)
     | ErrorStop(expr? code)
     | Exit(identifier? stmt_name)
     | ForAllSingle(do_loop_head head, stmt assign_stmt)

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -37,6 +37,7 @@ stmt
     | ImplicitDeallocate(expr* vars)
     | DoConcurrentLoop(do_loop_head* head, expr* shared, expr* local, reduction_expr* reduction, stmt* body)
     | DoLoop(identifier? name, do_loop_head head, stmt* body, stmt* orelse)
+    | OMPDirective(expr* constructs, expr* shared, expr* local, stmt* body)
     | ErrorStop(expr? code)
     | Exit(identifier? stmt_name)
     | ForAllSingle(do_loop_head head, stmt assign_stmt)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -166,6 +166,10 @@ filename = "../integration_tests/openmp_39.f90"
 asr_openmp = true
 
 [[test]]
+filename = "../integration_tests/openmp_43.f90"
+asr_openmp = true
+
+[[test]]
 filename = "subroutine2.f90"
 ast = true
 


### PR DESCRIPTION
Towards https://github.com/lfortran/lfortran/issues/5887 and #4147

Design Approach :

- OMPDirective would contain `constructs` expr which would indicate various constructs as listed in #5887 and also we would have `shared`, `local` clauses by default in it, which would incorporate #4147.

- We would extend it further to take in `map` clause as well after which `OMPDirective` itself would contain all data variables' scope information.

- `omp parallel do` would be translated to DoConcurrentLoop
Whereas `omp parallel` , `omp target` would be converted to `OMPDirective` 

Note:- I didn't named it as `OMPParallel` as it would only correspond to parallel construct but apart from it, there can be many constructs. or nested constructs in the parallel region.

Now the main question remains is that how to I take in the body of that block?
@Pranavchiku @certik 