### PR TITLE
build: use "find_package" instead of "find_library" for libunwind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,7 @@ if (WITH_LIBUNWIND_FORCE)
     set(WITH_LIBUNWIND yes)
 endif()
 if (WITH_LIBUNWIND)
-    find_library(LIBUNWIND_LIBRARY unwind)
+    find_package(LIBUNWIND_LIBRARY unwind)
 endif()
 
 set(WITH_KOKKOS no CACHE BOOL "Detect Kokkos location for cpp backend")


### PR DESCRIPTION
## Description

Addresses the comment left here: https://github.com/lfortran/lfortran/pull/5031