### PR TITLE
build: fix dependencies version in yml file

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -5,22 +5,22 @@ dependencies:
   - llvmdev=11
   # Enable for OpenMP:
   #- llvm-openmp=11
-  - toml
-  - pytest
-  - jupyter
+  - toml=0.10.2
+  - pytest=8.3.4
+  - jupyter=1.1.1
   - xeus=5.1.0
   - xeus-zmq=3.0.0
   - nlohmann_json=3.11.3
   - jupyter_kernel_test
   - xonsh=0.16.0
-  - re2c
-  - numpy
+  - re2c=4.0.1
+  - numpy=2.2.0
   - bison=3.4
-  - rapidjson
-  - ninja
-  - zlib
-  - zstd-static
+  - rapidjson=1.1.0
+  - ninja=1.11.1
+  - zlib=1.3.1
+  - zstd-static=1.5.6
   - cmake=3.29.1
-  - make
-  # install libunwind if building with llvmdev > 11
-  # - libunwind
+  - make=4.3
+  # install libunwind if building with llvmdev > 11 only on Linux
+  # - libunwind=1.7.2


### PR DESCRIPTION
## Description

Fix versions of dependencies by getting versions often used in other .yml files or in `.github/workflows/CI.yml`.

Also, added a note that `libunwind` is only need for building on Linux and not on macOS.

I tested with this file by creating a new conda environment and running the integration tests to make sure that things work fine with these changes in environment_linux.yml