### PR TITLE
fix: allocate space for null terminator in string allocations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -398,13 +398,6 @@ jobs:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
 
-      - name: Install GCC and G++ version 11
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-11 g++-11
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
-
       - name: Build Linux
         shell: bash -e -l {0}
         run: |

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2409,7 +2409,7 @@ LFORTRAN_API char* _lfortran_str_slice_assign(char* s, char *r, int32_t idx1, in
         return s;
     }
 
-    char* dest_char = (char*)malloc(s_len);
+    char* dest_char = (char*)malloc(s_len + 1);
     strcpy(dest_char, s);
     int s_i = idx1, d_i = 0;
     while((step > 0 && s_i >= idx1 && s_i < idx2) ||
@@ -3539,7 +3539,7 @@ LFORTRAN_API void _lfortran_string_write(char **str_holder, int64_t* size, int64
         }
     }
 
-    char *s = (char *) malloc(strlen(str)*sizeof(char) + strlen(end)*sizeof(char));
+    char *s = (char *) malloc(strlen(str)*sizeof(char) + strlen(end)*sizeof(char) + 1);
     sprintf(s, format, str, end);
 
     if(((*size) == -1) && ((*capacity) == -1)){ 
@@ -3870,7 +3870,7 @@ uint32_t get_file_size(int64_t fp) {
 void get_local_info_dwarfdump(struct Stacktrace *d) {
     // TODO: Read the contents of lines.dat from here itself.
     char *base_name = get_base_name(source_filename);
-    char *filename = malloc(strlen(base_name) + 14);
+    char *filename = malloc(strlen(base_name) + 15);
     strcpy(filename, base_name);
     strcat(filename, "_lines.dat.txt");
     int64_t fd = _lpython_open(filename, "r");


### PR DESCRIPTION
Part of #5998