### PR TITLE
fix: throw error for non scalar args in or/and/xor and non scalar kind arg

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -8,6 +8,8 @@ program continue_compilation_1
     real(8) :: y1
     real :: z1
     integer, parameter :: i1 = 2
+    character(len=5) :: string = "hello"
+	character(len=1) :: set(2) = ["l", "h"]
 
     a5 = 8
     b5 = 12_8
@@ -79,4 +81,6 @@ program continue_compilation_1
     print*,i1
     call FLUSH(1, 2)
 
+    print*, verify(string, set, kind= [4, 4] )
+    print *, and([1, 2, 3], [1, 2, 3])
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "37fe3a57bf05fd3bd96144143cf6a32805e5176662dde827403c512d",
+    "infile_hash": "1d3830cbc8a58d20d6da612b5ba4155c6cf60e015b49c967d9c9af9f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "203afcb2445664843802b7085f6927458dd4d299bf08b7bcca7d07f5",
+    "stderr_hash": "e22ec8c26918a9ef3199699a6ea15b47e065330d0e0f5c7304e76198",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1,7 +1,7 @@
 syntax error: Token 'print' is unexpected here
-  --> tests/errors/continue_compilation_1.f90:73:5
+  --> tests/errors/continue_compilation_1.f90:75:5
    |
-73 |     print*, nint(1e12_8)
+75 |     print*, nint(1e12_8)
    |     ^^^^^ 
 
 semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
@@ -15,124 +15,136 @@ semantic error: Implicit typing is not allowed, enable it by using --implicit-ty
   | ...^ 
 
 semantic error: Assignment to loop variable `i` is not allowed
-  --> tests/errors/continue_compilation_1.f90:18:8
+  --> tests/errors/continue_compilation_1.f90:20:8
    |
-18 |        i = i + 1
+20 |        i = i + 1
    |        ^ 
 
 semantic error:  first argument of `maskl` must be less than or equal to the BIT_SIZE of INTEGER(KIND=4)
-  --> tests/errors/continue_compilation_1.f90:22:13
+  --> tests/errors/continue_compilation_1.f90:24:13
    |
-22 |     print*, maskl(63)
+24 |     print*, maskl(63)
    |             ^^^^^^^^^ 
 
 semantic error: first argument of `maskr` must be less than or equal to the BIT_SIZE of INTEGER(KIND=4)
-  --> tests/errors/continue_compilation_1.f90:24:13
+  --> tests/errors/continue_compilation_1.f90:26:13
    |
-24 |     print*, maskr(63)
+26 |     print*, maskr(63)
    |             ^^^^^^^^^ 
 
 semantic error: first argument of `maskl` must be nonnegative
-  --> tests/errors/continue_compilation_1.f90:26:13
+  --> tests/errors/continue_compilation_1.f90:28:13
    |
-26 |     print*, maskl(-24)
+28 |     print*, maskl(-24)
    |             ^^^^^^^^^^ 
 
 semantic error: first argument of `maskr` must be nonnegative
-  --> tests/errors/continue_compilation_1.f90:28:13
+  --> tests/errors/continue_compilation_1.f90:30:13
    |
-28 |     print*, maskr(-24)
+30 |     print*, maskr(-24)
    |             ^^^^^^^^^^ 
 
 semantic error: The argument `matrix_a` in `matmul` must be of type Integer, Real, Complex or Logical
-  --> tests/errors/continue_compilation_1.f90:30:21
+  --> tests/errors/continue_compilation_1.f90:32:21
    |
-30 |     print *, matmul(a1, b1)
+32 |     print *, matmul(a1, b1)
    |                     ^^ 
 
 semantic error: The argument `matrix_b` in `matmul` must be of type Integer, Real or Complex if first matrix is of numeric type
-  --> tests/errors/continue_compilation_1.f90:32:25
+  --> tests/errors/continue_compilation_1.f90:34:25
    |
-32 |     print *, matmul(b1, a1)
+34 |     print *, matmul(b1, a1)
    |                         ^^ 
 
 semantic error: The `matmul` intrinsic doesn't handle logical type yet
-  --> tests/errors/continue_compilation_1.f90:34:14
+  --> tests/errors/continue_compilation_1.f90:36:14
    |
-34 |     print *, matmul(a2, b1)
+36 |     print *, matmul(a2, b1)
    |              ^^^^^^^^^^^^^^ 
 
 semantic error: `matmul` accepts arrays of rank 1 or 2 only, provided an array with rank, 3
-  --> tests/errors/continue_compilation_1.f90:36:21
+  --> tests/errors/continue_compilation_1.f90:38:21
    |
-36 |     print *, matmul(a3, b1)
+38 |     print *, matmul(a3, b1)
    |                     ^^ 
 
 semantic error: `matmul` accepts arrays of rank 1 or 2 only, provided an array with rank, 4
-  --> tests/errors/continue_compilation_1.f90:38:25
+  --> tests/errors/continue_compilation_1.f90:40:25
    |
-38 |     print *, matmul(b1, b4)
+40 |     print *, matmul(b1, b4)
    |                         ^^ 
 
 semantic error: The argument `matrix_b` in `matmul` must be of rank 2, provided an array with rank, 1
-  --> tests/errors/continue_compilation_1.f90:40:24
+  --> tests/errors/continue_compilation_1.f90:42:24
    |
-40 |     print *, matmul(a, b)
+42 |     print *, matmul(a, b)
    |                        ^ 
 
 semantic error: `transpose` accepts arrays of rank 2 only, provided an array with rank, 1
-  --> tests/errors/continue_compilation_1.f90:42:24
+  --> tests/errors/continue_compilation_1.f90:44:24
    |
-42 |     print *, transpose(a)
+44 |     print *, transpose(a)
    |                        ^ 
-
-semantic error: Kind of all the arguments of Mergebits must be the same
-  --> tests/errors/continue_compilation_1.f90:44:14
-   |
-44 |     print *, merge_bits(8, 12_8, 2)
-   |              ^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Kind of all the arguments of Mergebits must be the same
   --> tests/errors/continue_compilation_1.f90:46:14
    |
-46 |     print *, merge_bits(a5, b5, c5)
+46 |     print *, merge_bits(8, 12_8, 2)
+   |              ^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Kind of all the arguments of Mergebits must be the same
+  --> tests/errors/continue_compilation_1.f90:48:14
+   |
+48 |     print *, merge_bits(a5, b5, c5)
    |              ^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Second argument of modulo cannot be 0
-  --> tests/errors/continue_compilation_1.f90:62:14
+  --> tests/errors/continue_compilation_1.f90:64:14
    |
-62 |     print *, modulo(1, 0)
+64 |     print *, modulo(1, 0)
    |              ^^^^^^^^^^^^ 
 
 semantic error: Function 'my_func' not found (not user defined nor intrinsic)
-  --> tests/errors/continue_compilation_1.f90:64:5
+  --> tests/errors/continue_compilation_1.f90:66:5
    |
-64 |     call my_func(y=1, x=2, z=1)
+66 |     call my_func(y=1, x=2, z=1)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Result of `nint` overflows its kind(4)
-  --> tests/errors/continue_compilation_1.f90:74:13
+  --> tests/errors/continue_compilation_1.f90:76:13
    |
-74 |     print*, nint(1000000000000.0000000000000000d0)
+76 |     print*, nint(1000000000000.0000000000000000d0)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Invalid argument `hello` supplied
-  --> tests/errors/continue_compilation_1.f90:76:5
+  --> tests/errors/continue_compilation_1.f90:78:5
    |
-76 |     OPEN(file="numbers", hello="world")
+78 |     OPEN(file="numbers", hello="world")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Cannot assign to a constant variable
-  --> tests/errors/continue_compilation_1.f90:78:5
+  --> tests/errors/continue_compilation_1.f90:80:5
    |
-78 |     i1 = 3
+80 |     i1 = 3
    |     ^^^^^^ assignment here
    |
 10 |     integer, parameter :: i1 = 2
    |                           ~~~~~~ declared as constant
 
 semantic error: Expected 0 or 1 arguments, got 2 arguments instead.
-  --> tests/errors/continue_compilation_1.f90:80:5
+  --> tests/errors/continue_compilation_1.f90:82:5
    |
-80 |     call FLUSH(1, 2)
+82 |     call FLUSH(1, 2)
    |     ^^^^^^^^^^^^^^^^ 
+
+semantic error: `kind` argument of `verify` intrinsic must be a scalar
+  --> tests/errors/continue_compilation_1.f90:84:39
+   |
+84 |     print*, verify(string, set, kind= [4, 4] )
+   |                                       ^^^^^^ 
+
+semantic error: arguments of `and` intrinsic must be scalar
+  --> tests/errors/continue_compilation_1.f90:85:14
+   |
+85 |     print *, and([1, 2, 3], [1, 2, 3])
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "11d8319ba06900b804a9ea16fef180f2500fc27427d99dd64167c23f",
+    "stderr_hash": "8aba6897b82344dc6656b72c1b358e8081d65b33f1e411e28c1e345f",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -78,13 +78,13 @@ semantic error: `parameter` attribute conflicts with `allocatable` attribute
 33 |     integer, allocatable, parameter :: v=1
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: kind argument of `int` intrinsic must be a scalar
+semantic error: `kind` argument of `int` intrinsic must be a scalar
    --> tests/errors/continue_compilation_2.f90:286:54
     |
 286 |     integer(8), parameter :: ar1(3) = int([1, 2, 3], [8, 8, 8])
     |                                                      ^^^^^^^^^ 
 
-semantic error: kind argument of `int` intrinsic must be a scalar
+semantic error: `kind` argument of `int` intrinsic must be a scalar
    --> tests/errors/continue_compilation_2.f90:288:54
     |
 288 |     integer(8), parameter :: ar2(3) = int([1, 2, 3], [8, 8, 8])
@@ -630,7 +630,7 @@ semantic error: The first argument of `cmplx` intrinsic is of complex type, the 
 276 |     print *, cmplx(complex_z , 1)
     |              ^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: kind argument of `aint` intrinsic must be a scalar
+semantic error: `kind` argument of `aint` intrinsic must be a scalar
    --> tests/errors/continue_compilation_2.f90:278:36
     |
 278 |     print *, aint([1.0, 2.0, 3.0], [4, 4])

--- a/tests/reference/asr-int_01-9bf3eb9.json
+++ b/tests/reference/asr-int_01-9bf3eb9.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-int_01-9bf3eb9.stderr",
-    "stderr_hash": "5a627fb0f74fc80baf2d78276ff8db8d9ace30e87afcd8792bfaa150",
+    "stderr_hash": "c9e39d59ade877d2ab7ac42be2b43f28bfecc44ab58b204ffd1ab5ab",
     "returncode": 2
 }

--- a/tests/reference/asr-int_01-9bf3eb9.stderr
+++ b/tests/reference/asr-int_01-9bf3eb9.stderr
@@ -1,4 +1,4 @@
-semantic error: kind argument of `int` intrinsic must be a scalar
+semantic error: `kind` argument of `int` intrinsic must be a scalar
  --> tests/errors/int_01.f90:2:54
   |
 2 |     integer(8), parameter :: ar1(3) = int([1, 2, 3], [8, 8, 8])

--- a/tests/reference/asr-kind_01-6c675be.json
+++ b/tests/reference/asr-kind_01-6c675be.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-kind_01-6c675be.stderr",
-    "stderr_hash": "4bc9ff76a1e7679e9845bed8dcb2cbfb4fc43d733673cab01066e6b2",
+    "stderr_hash": "a4f46f313141003cd8a07b34744cfb6be4d780ac89b7bef22e149f74",
     "returncode": 2
 }

--- a/tests/reference/asr-kind_01-6c675be.stderr
+++ b/tests/reference/asr-kind_01-6c675be.stderr
@@ -1,4 +1,4 @@
-semantic error: kind argument of `aint` intrinsic must be a scalar
+semantic error: `kind` argument of `aint` intrinsic must be a scalar
  --> tests/errors/kind_01.f90:3:36
   |
 3 |     print *, aint([1.0, 2.0, 3.0], [4, 4])


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/4379
Fixes: https://github.com/lfortran/lfortran/issues/5494