### PR TITLE
fix : Handling ArrayItem in ArrayConstructor having Descriptor Array ttype

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -576,6 +576,7 @@ RUN(NAME arrays_73 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EX
 RUN(NAME arrays_74 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER)
 RUN(NAME arrays_75 LABELS gfortran llvm)
 RUN(NAME arrays_76 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME arrays_77 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_array_pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)

--- a/integration_tests/arrays_77.f90
+++ b/integration_tests/arrays_77.f90
@@ -1,14 +1,14 @@
-module a 
+module a_arrays_77
   contains 
   function f2() result(res)
     integer(8), allocatable :: res(:)
     allocate(res(10))
     res = [1,2,3,4,5,6,7,8,9,10]
   end function f2
-end module a 
+end module a_arrays_77
 
 program arrays_77
-  use a
+  use a_arrays_77
   integer :: i
   integer :: arr(10)
   integer,allocatable :: arr_res(:)

--- a/integration_tests/arrays_77.f90
+++ b/integration_tests/arrays_77.f90
@@ -1,0 +1,27 @@
+module a 
+  contains 
+  function f2() result(res)
+    integer(8), allocatable :: res(:)
+    allocate(res(10))
+    res = [1,2,3,4,5,6,7,8,9,10]
+  end function f2
+end module a 
+
+program arrays_77
+  use a
+  integer :: i
+  integer :: arr(10)
+  integer,allocatable :: arr_res(:)
+  do i = 1 , 10
+    arr(i) = i + 100
+  end do
+
+  allocate(arr_res(11))
+  arr_res = [arr(f2()),111] ! Error here
+  print *, arr_res
+
+  do i = 1 , 11
+    if (arr_res(i) /= i + 100) error stop
+  end do
+
+end program

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -125,8 +125,18 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
             } else if ( ASR::is_a<ASR::ArrayItem_t>(*element) ) {
                 ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(element);
                 if ( ASR::is_a<ASR::Array_t>(*array_item->m_type) ) {
-                    ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(array_item->m_type);
-                    constant_size += ASRUtils::get_fixed_size_of_array(array_type->m_dims, array_type->n_dims);
+                    if ( ASRUtils::is_fixed_size_array(array_item->m_type) ) {
+                        ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(array_item->m_type);
+                        constant_size += ASRUtils::get_fixed_size_of_array(array_type->m_dims, array_type->n_dims);
+                    } else {
+                        ASR::expr_t* element_array_size = ASRUtils::get_size(element, al, false);
+                        if( array_size == nullptr ) {
+                            array_size = element_array_size;
+                        } else {
+                            array_size = builder.Add(array_size,
+                                            element_array_size);
+                        }
+                    }
                 } else {
                     constant_size += 1;
                 }


### PR DESCRIPTION
Fixes #5990 

MRE :- 
```
module a 
  contains 
  function f2() result(res)
    integer(8), allocatable :: res(:)
    allocate(res(10))
    res = [1,2,3,4,5,6,7,8,9,10]
  end function f2
end module a 

program prog
  use a
  integer :: i
  integer :: arr(10)
  integer,allocatable :: arr_res(:)
  do i = 1 , 10
    arr(i) = i+100
  end do

  allocate(arr_res(11))
  arr_res = [arr(f2()),111] ! Error here
  print *, arr_res

end program prog
```

LFortran Output :- 
```
(lf) lordansh@LordAnsh:~/dev/lfort1/lfortran$ lfortran try.f90
101
102
103
104
105
106
107
108
109
110
111
```

