### PR TITLE
fix: implementation of `dshiftr` for different kind value

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -999,6 +999,8 @@ RUN(NAME intrinsics_342 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPER
 RUN(NAME intrinsics_343 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER) # cshift
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 
+RUN(NAME test_dshiftr LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
 RUN(NAME passing_array_01 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME passing_array_02 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME passing_array_03 LABELS gfortran fortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/test_dshiftr.f90
+++ b/integration_tests/test_dshiftr.f90
@@ -1,0 +1,6 @@
+program test_dshiftr
+  integer, parameter:: ik1 = selected_int_kind(1)
+  integer(ik1), parameter:: i0 = 0, i1 = 1
+  integer(ik1):: expected = 64
+  if (abs(dshiftr(i1, i0, 2) - expected) > 1e-6) error stop
+end program test_dshiftr

--- a/integration_tests/test_dshiftr.f90
+++ b/integration_tests/test_dshiftr.f90
@@ -2,5 +2,5 @@ program test_dshiftr
   integer, parameter:: ik1 = selected_int_kind(1)
   integer(ik1), parameter:: i0 = 0, i1 = 1
   integer(ik1):: expected = 64
-  if (abs(dshiftr(i1, i0, 2) - expected) > 1e-6) error stop
+  if (dshiftr(i1, i0, 2) /= expected) error stop
 end program test_dshiftr

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1516,7 +1516,7 @@ namespace Dshiftr {
             append_error(diag, "The shift argument of 'dshiftr' intrinsic must be non-negative integer", loc);
             return nullptr;
         }
-        int64_t k_val = (kind1 == 8) ? 64 : 32;
+        int64_t k_val = kind1 * 8;
         if (shift > k_val) {
             append_error(diag, "The shift argument of 'dshiftr' intrinsic must be less than or equal to the bit size of the integer", loc);
             return nullptr;
@@ -1525,9 +1525,9 @@ namespace Dshiftr {
         int64_t result = rightmostI << (k_val - shift);
         int64_t leftmostJ;
         if (val2 < 0) {
-            leftmostJ = (val2 >> (k_val - shift)) & ((1LL << (k_val - shift)) - 1LL);
+            leftmostJ = (val2 >> shift) & ((1LL << (k_val - shift)) - 1LL);
         } else {
-            leftmostJ = val2 >> (k_val - shift);
+            leftmostJ = val2 >> shift;
         }
         result |= leftmostJ;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);


### PR DESCRIPTION
Fixes: #4002

- Change the `k_val` variable for different kind of integer as `k_val = kind * 8` to ensure it's correctness with gfortran results.
- Updated the `dshiftr` evaluation implementation.