### PR TITLE
fix: handling correct error message for `dshiftl` and `dshiftr`

### DIFF
--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1461,12 +1461,12 @@ namespace Dshiftl {
         int64_t shift = ASR::down_cast<ASR::IntegerConstant_t>(args[2])->m_n;
         int kind = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
         if(shift < 0){
-            append_error(diag, "The shift argument of 'dshiftl' intrinsic must be non-negative integer", loc);
+            append_error(diag, "The shift argument of 'dshiftl' intrinsic must be non-negative integer", args[2]->base.loc);
             return nullptr;
         }
         int k_val = kind * 8;
         if (shift > k_val) {
-            append_error(diag, "The shift argument of 'dshiftl' intrinsic must be less than or equal to the bit size of the integer", loc);
+            append_error(diag, "The shift argument of 'dshiftl' intrinsic must be less than or equal to the bit size of the integer", args[2]->base.loc);
             return nullptr;
         }
         int64_t val = (val1 << shift) | (val2 >> (k_val - shift));
@@ -1517,12 +1517,12 @@ namespace Dshiftr {
             return nullptr;
         }
         if(shift < 0){
-            append_error(diag, "The shift argument of 'dshiftr' intrinsic must be non-negative integer", loc);
+            append_error(diag, "The shift argument of 'dshiftr' intrinsic must be non-negative integer", args[2]->base.loc);
             return nullptr;
         }
         int64_t k_val = kind1 * 8;
         if (shift > k_val) {
-            append_error(diag, "The shift argument of 'dshiftr' intrinsic must be less than or equal to the bit size of the integer", loc);
+            append_error(diag, "The shift argument of 'dshiftr' intrinsic must be less than or equal to the bit size of the integer", args[2]->base.loc);
             return nullptr;
         }
         int64_t rightmostI = val1 & ((1LL << shift) - 1);

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1464,7 +1464,11 @@ namespace Dshiftl {
             append_error(diag, "The shift argument of 'dshiftl' intrinsic must be non-negative integer", loc);
             return nullptr;
         }
-        int k_val = (kind == 8) ? 64: 32;
+        int k_val = kind * 8;
+        if (shift > k_val) {
+            append_error(diag, "The shift argument of 'dshiftl' intrinsic must be less than or equal to the bit size of the integer", loc);
+            return nullptr;
+        }
         int64_t val = (val1 << shift) | (val2 >> (k_val - shift));
         return make_ConstantWithType(make_IntegerConstant_t, val, t1, loc);
     }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -84,4 +84,10 @@ program continue_compilation_1
     print*, verify(string, set, kind= [4, 4] )
     print *, and([1, 2, 3], [1, 2, 3])
     character(3), parameter :: ar1 = repeat(["abc", "#^1", "123"], [1, 2, 3])
+
+    print *, dshiftl(1, 2, 34)
+    print *, dshiftl(1, 2, -2)
+
+    print *, dshiftr(1, 2, 34)
+    print *, dshiftr(1, 2, -2)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "718a9bab25e37caff504bbdf1fb26ae0c45b47ba7697f523e822d9cd",
+    "infile_hash": "a42afb3bcef6cc93f66dd52698e6e60dc930ec79f18780eb3474e85d",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2eafb21cf0815ad174ae9fd4382a7b25e2485a7ed4b0b1de790dce88",
+    "stderr_hash": "43877644f0771c7e755fdcdff1d198ced24a2f698d397ef817d0c5ad",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -154,3 +154,27 @@ semantic error: arguments of `and` intrinsic must be scalar
    |
 85 |     print *, and([1, 2, 3], [1, 2, 3])
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: The shift argument of 'dshiftl' intrinsic must be less than or equal to the bit size of the integer
+  --> tests/errors/continue_compilation_1.f90:88:28
+   |
+88 |     print *, dshiftl(1, 2, 34)
+   |                            ^^ 
+
+semantic error: The shift argument of 'dshiftl' intrinsic must be non-negative integer
+  --> tests/errors/continue_compilation_1.f90:89:28
+   |
+89 |     print *, dshiftl(1, 2, -2)
+   |                            ^^ 
+
+semantic error: The shift argument of 'dshiftr' intrinsic must be less than or equal to the bit size of the integer
+  --> tests/errors/continue_compilation_1.f90:91:28
+   |
+91 |     print *, dshiftr(1, 2, 34)
+   |                            ^^ 
+
+semantic error: The shift argument of 'dshiftr' intrinsic must be non-negative integer
+  --> tests/errors/continue_compilation_1.f90:92:28
+   |
+92 |     print *, dshiftr(1, 2, -2)
+   |                            ^^ 


### PR DESCRIPTION
Fixes: #6044 

- Updates the implementation of `dshiftl` such that it gives correct error message
- Updates the error squiggle position for `dshiftr` and `dshiftl`