### PR TITLE
fix: handle correct compile time error message for array intrinsic function

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -615,10 +615,10 @@ static inline ASR::asr_t* create_ArrIntrinsic(
                 int dim_val = extract_dim_value_int(dim);
                 int n_dims = ASRUtils::extract_n_dims_from_ttype(array_type);
                 if (dim_val <= 0 || dim_val > n_dims) {
-                    diag.add(diag::Diagnostic("`dim` argument of the `" + intrinsic_func_name + "` is out of bounds", 
+                    diag.add(diag::Diagnostic("`dim` argument of the `" + intrinsic_func_name + "` intrinsic is out of bounds", 
                     diag::Level::Error, 
                     diag::Stage::Semantic, 
-                    {diag::Label("array argument is rank " + std::to_string(n_dims) + ", so must have 1 <= dim <= " + std::to_string(n_dims), { args[1]->base.loc })}));
+                    {diag::Label("Must have 0 < dim <= " + std::to_string(n_dims) + " for array of rank " + std::to_string(n_dims), { args[1]->base.loc })}));
                     return nullptr;
                 }
             }
@@ -637,10 +637,10 @@ static inline ASR::asr_t* create_ArrIntrinsic(
                     int dim_val = extract_dim_value_int(dim);
                     int n_dims = ASRUtils::extract_n_dims_from_ttype(array_type);
                     if (dim_val <= 0 || dim_val > n_dims) {
-                        diag.add(diag::Diagnostic("`dim` argument of the `" + intrinsic_func_name + "` is out of bounds", 
+                        diag.add(diag::Diagnostic("`dim` argument of the `" + intrinsic_func_name + "` intrinsic is out of bounds", 
                         diag::Level::Error, 
                         diag::Stage::Semantic, 
-                        {diag::Label("array argument is rank " + std::to_string(n_dims) + ", so must have 1 <= dim <= " + std::to_string(n_dims), { args[2]->base.loc })}));
+                        {diag::Label("Must have 0 < dim <= " + std::to_string(n_dims) + " for array of rank " + std::to_string(n_dims), { args[2]->base.loc })}));
                         return nullptr;
                     }
                 }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1,9 +1,9 @@
 program continue_compilation_1
     implicit integer(a-f), real(e-z)
 
-    integer :: a(3), b(3), b1(3, 3), a3(3, 3, 3), b4(3, 3, 3, 3), a5, c5, i
+    integer :: a(3), b(3), b1(3, 3), a3(3, 3, 3), b4(3, 3, 3, 3), a5, c5, i, arr1(3), arr2(2, 3), arr3(2, 1, 3)
     character :: a1(3, 3)
-    logical :: a2(3, 3)
+    logical :: a2(3, 3), mask1(3), mask2(2, 3), mask3(2, 1, 3)
     integer(kind=8) :: b5
     real(8) :: y1
     real :: z1
@@ -95,9 +95,25 @@ program continue_compilation_1
     print *, selected_real_kind([1,2,3])
     print *, selected_char_kind(['c', 'a', 'b'])
 
-    print *, sum(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    print *, product(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    print *, minval(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    print *, maxval(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    print *, iparity(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
+    arr1 = reshape([1, 2, 3], [3])
+    arr2 = reshape([1, 2, 3, 4, 5, 6], [2, 3])
+    arr3 = reshape([1, 2, 3, 4, 5, 6], [2, 1, 3])
+    mask1 = reshape([.true., .false., .true.], [3])
+    mask2 = reshape([.true., .false., .true., .true., .false., .true.], [2, 3])
+    mask3 = reshape([.true., .false., .true., .true., .false., .true.], [2, 1, 3])
+
+    print *, sum(arr1, dim = 2)
+    print *, sum(arr1, dim = -1)
+    print *, sum(arr1, mask = mask1, dim = 2)
+    print *, sum(arr1, mask = mask1, dim = -1)
+
+    print *, product(arr2, dim = 3)
+    print *, product(arr2, dim = -1)
+    print *, product(arr2, mask = mask2, dim = 3)
+    print *, product(arr2, mask = mask2, dim = -1)
+
+    print *, iparity(arr3, dim = 4)
+    print *, iparity(arr3, dim = -1)
+    print *, iparity(arr3, mask = mask3, dim = 4)
+    print *, iparity(arr3, mask = mask3, dim = -1)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "bc8f87ed36a56b021f614bad64cd0d667ec6bd10a976719dc701697d",
+    "infile_hash": "811e768b22327c634d115675ba541df781fe7cf3ec3fe74f74dc6540",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "049a3293e7d5e6d89ec2ac4fb20e841df18d1d38393bbff203a233d7",
+    "stderr_hash": "2aef1341c55267857ff863568ca37193567ee71d4fea5688a469a21b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -197,32 +197,74 @@ semantic error: arguments of `selected_char_kind` intrinsic must be scalar
 96 |     print *, selected_char_kind(['c', 'a', 'b'])
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: `dim` argument of the `Sum` is out of bounds
-  --> tests/errors/continue_compilation_1.f90:98:61
-   |
-98 |     print *, sum(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-   |                                                             ^ array argument is rank 2, so must have 1 <= dim <= 2
-
-semantic error: `dim` argument of the `Product` is out of bounds
-  --> tests/errors/continue_compilation_1.f90:99:65
-   |
-99 |     print *, product(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-   |                                                                 ^ array argument is rank 2, so must have 1 <= dim <= 2
-
-semantic error: `dim` argument of the `MinVal` is out of bounds
-   --> tests/errors/continue_compilation_1.f90:100:64
+semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:105:30
     |
-100 |     print *, minval(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    |                                                                ^ array argument is rank 2, so must have 1 <= dim <= 2
+105 |     print *, sum(arr1, dim = 2)
+    |                              ^ Must have 0 < dim <= 1 for array of rank 1
 
-semantic error: `dim` argument of the `MaxVal` is out of bounds
-   --> tests/errors/continue_compilation_1.f90:101:64
+semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:106:30
     |
-101 |     print *, maxval(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    |                                                                ^ array argument is rank 2, so must have 1 <= dim <= 2
+106 |     print *, sum(arr1, dim = -1)
+    |                              ^^ Must have 0 < dim <= 1 for array of rank 1
 
-semantic error: `dim` argument of the `Iparity` is out of bounds
-   --> tests/errors/continue_compilation_1.f90:102:65
+semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:107:44
     |
-102 |     print *, iparity(reshape([1, 2, 3, 4, 5, 6], [2, 3]), dim = 3)
-    |                                                                 ^ array argument is rank 2, so must have 1 <= dim <= 2
+107 |     print *, sum(arr1, mask = mask1, dim = 2)
+    |                                            ^ Must have 0 < dim <= 1 for array of rank 1
+
+semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:108:44
+    |
+108 |     print *, sum(arr1, mask = mask1, dim = -1)
+    |                                            ^^ Must have 0 < dim <= 1 for array of rank 1
+
+semantic error: `dim` argument of the `Product` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:110:34
+    |
+110 |     print *, product(arr2, dim = 3)
+    |                                  ^ Must have 0 < dim <= 2 for array of rank 2
+
+semantic error: `dim` argument of the `Product` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:111:34
+    |
+111 |     print *, product(arr2, dim = -1)
+    |                                  ^^ Must have 0 < dim <= 2 for array of rank 2
+
+semantic error: `dim` argument of the `Product` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:112:48
+    |
+112 |     print *, product(arr2, mask = mask2, dim = 3)
+    |                                                ^ Must have 0 < dim <= 2 for array of rank 2
+
+semantic error: `dim` argument of the `Product` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:113:48
+    |
+113 |     print *, product(arr2, mask = mask2, dim = -1)
+    |                                                ^^ Must have 0 < dim <= 2 for array of rank 2
+
+semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:115:34
+    |
+115 |     print *, iparity(arr3, dim = 4)
+    |                                  ^ Must have 0 < dim <= 3 for array of rank 3
+
+semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:116:34
+    |
+116 |     print *, iparity(arr3, dim = -1)
+    |                                  ^^ Must have 0 < dim <= 3 for array of rank 3
+
+semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:117:48
+    |
+117 |     print *, iparity(arr3, mask = mask3, dim = 4)
+    |                                                ^ Must have 0 < dim <= 3 for array of rank 3
+
+semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
+   --> tests/errors/continue_compilation_1.f90:118:48
+    |
+118 |     print *, iparity(arr3, mask = mask3, dim = -1)
+    |                                                ^^ Must have 0 < dim <= 3 for array of rank 3


### PR DESCRIPTION
Fixes: #6058 

- Handle the correct error message for the array intrinsic function (`sum`, `product`, `minval`, `maxval` and `iparity`) when incorrect `dim` value is provided. 