### PR TITLE
fix: replace arguments of `Arrayitem` first before creating temporary in `simplifier` pass

### DIFF
--- a/integration_tests/array_indices_array_item_assignment_2.f90
+++ b/integration_tests/array_indices_array_item_assignment_2.f90
@@ -1,17 +1,22 @@
 program array_indices_array_item_assignment_2
 
-real :: Q(4), R(4), S(4)
+real :: Q(4), R(4), S(4), X(2,2)
+logical, save :: mask(2) = [.true.,.false.]
 
 R = [1, 4, 2, 3]
 S = [3, 2, 1, 4]
 
 Q = 5.0
+X = reshape(R, shape(X))
 
 Q(trueloc(R < S)) = Q(trueloc(R < S)) + 1.0
 Q(trueloc(R >= S)) = -Q(trueloc(R >= S)) - 1.0
-
 print *, Q
 if( any(Q /= [6.0, -6.0, -6.0, 6.0]) ) error stop
+
+X([1,2], trueloc(mask)) = X([2,1], trueloc(mask))
+print *, X
+if( X(1,1) /= 4.0 .or. X(2,1) /= 1.0 .or. X(1,2) /= 2.0 .or. X(2,2) /= 3.0 ) error stop
 
 contains
 

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1749,6 +1749,7 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
 
     void replace_ArrayItem(ASR::ArrayItem_t* x) {
         if( ASRUtils::is_array_indexed_with_array_indices(x) ) {
+            ASR::BaseExprReplacer<ReplaceExprWithTemporary>::replace_ArrayItem(x);
             if( (exprs_with_target.find(*current_expr) == exprs_with_target.end() &&
                 !is_assignment_target_array_section_item) || 
                 (lhs_var && is_common_symbol_present_in_lhs_and_rhs(lhs_var, x->m_v))) {
@@ -1756,7 +1757,6 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
                     *current_expr, "_array_item_", al, current_body,
                     current_scope, exprs_with_target);
             }
-            ASR::BaseExprReplacer<ReplaceExprWithTemporary>::replace_ArrayItem(x);
             return ;
         }
 


### PR DESCRIPTION
Fixes #6095