### PR TITLE
fix: raise error when expression in if is not of logical type

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3883,6 +3883,14 @@ public:
     void visit_If(const AST::If_t &x) {
         visit_expr(*x.m_test);
         ASR::expr_t *test = ASRUtils::EXPR(tmp);
+        ASR::ttype_t *test_type = ASRUtils::expr_type(test);
+        if (!ASR::is_a<ASR::Logical_t>(*test_type)) {
+            diag.add(diag::Diagnostic(
+                "If statement requires a logical expression",
+                diag::Level::Error, diag::Stage::Semantic, {
+                    diag::Label("", {test->base.loc})}));
+            throw SemanticAbort();
+        }
         Vec<ASR::stmt_t*> body;
         body.reserve(al, x.n_body);
         transform_stmts(body, x.n_body, x.m_body);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -116,4 +116,12 @@ program continue_compilation_1
     print *, iparity(arr3, dim = -1)
     print *, iparity(arr3, mask = mask3, dim = 4)
     print *, iparity(arr3, mask = mask3, dim = -1)
+
+    integer :: q1
+    real :: r1
+    character :: c1
+
+    if (q1) q1 = 1
+    if (r1) r1 = 1.0
+    if (c1) c1 = 'a'
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "811e768b22327c634d115675ba541df781fe7cf3ec3fe74f74dc6540",
+    "infile_hash": "8ad101b38d5135d4629d84600f75737af2bcbcbb1c420079695a33a9",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2aef1341c55267857ff863568ca37193567ee71d4fea5688a469a21b",
+    "stderr_hash": "4b6953fadb168e6e59e064625ec6b0b4b769e1f62234bf6ea18c450d",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -268,3 +268,21 @@ semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
     |
 118 |     print *, iparity(arr3, mask = mask3, dim = -1)
     |                                                ^^ Must have 0 < dim <= 3 for array of rank 3
+
+semantic error: If statement requires a logical expression
+   --> tests/errors/continue_compilation_1.f90:124:9
+    |
+124 |     if (q1) q1 = 1
+    |         ^^ 
+
+semantic error: If statement requires a logical expression
+   --> tests/errors/continue_compilation_1.f90:125:9
+    |
+125 |     if (r1) r1 = 1.0
+    |         ^^ 
+
+semantic error: If statement requires a logical expression
+   --> tests/errors/continue_compilation_1.f90:126:9
+    |
+126 |     if (c1) c1 = 'a'
+    |         ^^ 


### PR DESCRIPTION
Fix: #6096 