### PR TITLE
Improve "star" declaration processing in fixed form

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -22,7 +22,7 @@ int position = 0;
 
 namespace LCompilers::LFortran {
 
-std::map<std::string, yytokentype> identifiers_map = {
+const std::unordered_map<std::string, yytokentype> identifiers_map = {
     {"EOF", END_OF_FILE},
     {"\n", TK_NEWLINE},
     {"name", TK_NAME},
@@ -267,7 +267,7 @@ std::map<std::string, yytokentype> identifiers_map = {
 };
 
 // star-forms must appear before non-stars
-std::vector<std::string> declarators{
+const std::vector<std::string> declarators{
             "integer*",
             "integer",
 	    "real*",
@@ -437,7 +437,7 @@ struct FixedFormRecursiveDescent {
     // Push the token_type, YYSTYPE and Location of the token_str at `cur`.
     // (Does not modify `cur`.)
     void push_token_no_advance_token(unsigned char *cur, const std::string &token_str,
-            yytokentype token_type) {
+            yytokentype const token_type) {
         YYSTYPE yy;
         yy.string.from_str(m_a, token_str);
         stypes.push_back(yy);
@@ -450,7 +450,9 @@ struct FixedFormRecursiveDescent {
 
     // token_type automatically determined
     void push_token_no_advance(unsigned char *cur, const std::string &token_str) {
-        push_token_no_advance_token(cur, token_str, identifiers_map[token_str]);
+	auto it = identifiers_map.find(token_str);
+	LCOMPILERS_ASSERT(it != identifiers_map.end());
+        push_token_no_advance_token(cur, token_str, it->second);
     }
 
     void push_integer_no_advance(unsigned char *cur, int32_t n) {

--- a/tests/fixed_form5.f
+++ b/tests/fixed_form5.f
@@ -1,5 +1,7 @@
-        COMPLEX*16 FUNCTION ZDOTC(N,ZX)
+        COMPLEX*16 FUNCTION ZDOTC(N,D1X)
         INTEGER N
-        COMPLEX*16 ZX(*)
+        COMPLEX*16D1X(*)
+        CHARACTER*2D2V
+        D2V="AB"
         RETURN
         END

--- a/tests/reference/ast-fixed_form5-66fddbd.json
+++ b/tests/reference/ast-fixed_form5-66fddbd.json
@@ -2,11 +2,11 @@
     "basename": "ast-fixed_form5-66fddbd",
     "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
     "infile": "tests/fixed_form5.f",
-    "infile_hash": "620d881af257eb1c53b26d138f8f5ba7bbb589226cfe8a9bc7ec351b",
+    "infile_hash": "a40b468e72a8562746dc8711312f496a7635144b26f7cfca248cb16e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form5-66fddbd.stdout",
-    "stdout_hash": "b868e167f02d1a2770e8c976817180814ab3c3e89798114581b36a6f",
+    "stdout_hash": "4dd21115e7fcf6067f1eabb89aa266e4a0317e0d303c1b5428f96e46",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form5-66fddbd.stdout
+++ b/tests/reference/ast-fixed_form5-66fddbd.stdout
@@ -2,7 +2,7 @@
     [(Function
         zdotc
         [(n)
-        (zx)]
+        (d1x)]
         [(AttrType
             TypeComplex
             [(()
@@ -47,7 +47,7 @@
                 None
             )
             []
-            [(zx
+            [(d1x
             [(()
             ()
             DimensionStar)]
@@ -57,8 +57,34 @@
             None
             ())]
             ()
+        )
+        (Declaration
+            (AttrType
+                TypeCharacter
+                [(()
+                2
+                Value)]
+                ()
+                ()
+                None
+            )
+            []
+            [(d2v
+            []
+            []
+            ()
+            ()
+            None
+            ())]
+            ()
         )]
-        [(Return
+        [(Assignment
+            0
+            d2v
+            (String "AB")
+            ()
+        )
+        (Return
             0
             ()
             ()


### PR DESCRIPTION
The previous version would incorrectly parse `CHARACTER*2D1V` as `CHARACTER*2D1 V`, with a `REAL` character length, instead of  the correct `CHARACTER*2 D1V` (by  R723).

Closes #5644