### PR TITLE
refactor: use function instead of macros

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -437,6 +437,7 @@ RUN(NAME functions_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME functions_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER)
+RUN(NAME functions_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1163,6 +1163,7 @@ RUN(NAME where_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NOFAST)
+RUN(NAME where_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 RUN(NAME forall_01 LABELS gfortran llvm NOFAST)
@@ -1684,7 +1685,7 @@ RUN(NAME do_loop_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME do_loop_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
-RUN(NAME array_op_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm) #TODO: fix mlir, commented in PR: #6060 
+RUN(NAME array_op_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm) #TODO: fix mlir, commented in PR: #6060
 RUN(NAME array_op_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_op_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME array_op_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1565,7 +1565,7 @@ RUN(NAME conv_complex2real LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME template_02 LABELS llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME template_03 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
-RUN(NAME template_04 LABELS llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
+RUN(NAME template_04 LABELS llvm llvm_wasm llvm_wasm_emcc NO_STD_F23 ONLY_EXPERIMENTAL_SIMPLIFIER)
 RUN(NAME template_05 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME template_add_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm NO_STD_F23)
 RUN(NAME template_add_01b LABELS llvm llvm_wasm llvm_wasm_emcc wasm NO_STD_F23)
@@ -1583,7 +1583,7 @@ RUN(NAME template_array_02 LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray w
 RUN(NAME template_array_03 LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME template_array_04 LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm NO_STD_F23)
 RUN(NAME template_array_04b LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
-RUN(NAME template_matrix_01 LABELS llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
+RUN(NAME template_matrix_01 LABELS llvm llvm_wasm llvm_wasm_emcc NO_STD_F23 ONLY_EXPERIMENTAL_SIMPLIFIER)
 RUN(NAME template_matrix_test LABELS llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
     template_semigroup.f90
     template_semiring.f90
@@ -1719,6 +1719,7 @@ RUN(NAME procedure_13 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME procedure_14 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME procedure_15 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME procedure_16 LABELS gfortran llvm NO_STD_F23)
+RUN(NAME procedure_17 LABELS gfortran llvm NO_STD_F23)
 
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1011,6 +1011,7 @@ RUN(NAME intrinsics_341 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # trailz
 RUN(NAME intrinsics_342 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER) # spread
 RUN(NAME intrinsics_343 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc ONLY_EXPERIMENTAL_SIMPLIFIER) # cshift
 RUN(NAME intrinsics_344 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskl
+RUN(NAME intrinsics_345 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # findloc
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 
 RUN(NAME test_dshiftr LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/functions_31.f90
+++ b/integration_tests/functions_31.f90
@@ -1,0 +1,18 @@
+program function_31
+    integer :: x(2,3) = reshape([1, 2, 3, 4, 5, 6], [2,3])
+    call func(x)
+  contains 
+    subroutine func(x)
+        integer, intent(in) :: x(:, :)
+        integer :: y2(size(x, 2), size(x, 1) + 1)
+        y2 = reshape([allocate_return_type_func(x), x(1,:)], shape(y2))
+        print *, y2
+        if(any(y2(:, 1) /= [1,2,3]) .or. any(y2(:, 2) /= [4,5,6]) .or. any(y2(:, 3) /= [1,3,5])) error stop
+    end subroutine
+    function allocate_return_type_func(x) result(z)
+        integer, intent(in) :: x(:, :)
+        integer, allocatable :: z(:, :) 
+        allocate(z(size(x,1), size(x,2)))
+        z = x
+    end function
+end program 

--- a/integration_tests/intrinsics_345.f90
+++ b/integration_tests/intrinsics_345.f90
@@ -1,0 +1,35 @@
+program intrinsics_345
+    implicit none
+    integer, dimension(2, 3) :: array1 = reshape([1, 1, 0, 1, 5, 1], [2, 3])
+    integer, dimension(2, 3) :: array2 = reshape([2, 1, 0, 1, 5, 1], [2, 3])
+    integer, dimension(2, 3) :: array3 = reshape([2, 2, 0, 1, 5, 1], [2, 3])
+    integer, dimension(2, 3) :: array4 = reshape([1, 1, 1, 1, 1, 1], [2, 3])
+    integer, dimension(2, 3) :: array5 = reshape([2, 2, 1, 0, 1, 0], [2, 3])
+    integer, dimension(2, 3) :: array6 = reshape([0, 1, 1, 1, 1, 2], [2, 3])
+    integer :: value = 1
+
+    if (any(findloc(array1, value, dim=1) /= [1, 2, 2])) error stop
+    if (any(findloc(array1, value, dim=1, back=.true.) /= [2, 2, 2])) error stop
+    if (any(findloc(array1, value, dim=2) /= [1, 1])) error stop
+    if (any(findloc(array1, value, dim=2, back=.true.) /= [1, 3])) error stop
+    if (any(findloc(array2, value, dim=1) /= [2, 2, 2])) error stop
+    if (any(findloc(array2, value, dim=1, back=.true.) /= [2, 2, 2])) error stop
+    if (any(findloc(array2, value, dim=2) /= [0, 1])) error stop
+    if (any(findloc(array2, value, dim=2, back=.true.) /= [0, 3])) error stop
+    if (any(findloc(array3, value, dim=1) /= [0, 2, 2])) error stop
+    if (any(findloc(array3, value, dim=1, back=.true.) /= [0, 2, 2])) error stop
+    if (any(findloc(array3, value, dim=2) /= [0, 2])) error stop
+    if (any(findloc(array3, value, dim=2, back=.true.) /= [0, 3])) error stop
+    if (any(findloc(array4, value, dim=1) /= [1, 1, 1])) error stop
+    if (any(findloc(array4, value, dim=1, back=.true.) /= [2, 2, 2])) error stop
+    if (any(findloc(array4, value, dim=2) /= [1, 1])) error stop
+    if (any(findloc(array4, value, dim=2, back=.true.) /= [3, 3])) error stop
+    if (any(findloc(array5, value, dim=1) /= [0, 1, 1])) error stop
+    if (any(findloc(array5, value, dim=1, back=.true.) /= [0, 1, 1])) error stop
+    if (any(findloc(array5, value, dim=2) /= [2, 0])) error stop
+    if (any(findloc(array5, value, dim=2, back=.true.) /= [3, 0])) error stop
+    if (any(findloc(array6, value, dim=1) /= [2, 1, 1])) error stop
+    if (any(findloc(array6, value, dim=1, back=.true.) /= [2, 2, 1])) error stop
+    if (any(findloc(array6, value, dim=2) /= [2, 1])) error stop
+    if (any(findloc(array6, value, dim=2, back=.true.) /= [3, 2])) error stop
+end program

--- a/integration_tests/procedure_17.f90
+++ b/integration_tests/procedure_17.f90
@@ -1,0 +1,29 @@
+module proc_type_procedure_17
+contains
+ subroutine cb()
+   implicit none
+end subroutine
+end module
+
+module cobylb_mod_procedure_17
+contains
+    subroutine cobylb(call_back)
+        use proc_type_procedure_17
+        procedure(cb) :: call_back
+        integer, save :: x = 3
+        call calcfc_internal()
+    contains
+        subroutine calcfc_internal()
+            implicit none
+            integer :: y(x)
+            print *, 'x = ', x
+            if ( x /= 3 ) error stop
+        end subroutine calcfc_internal
+    end subroutine cobylb
+end module
+
+program procedure_17
+use cobylb_mod_procedure_17
+use proc_type_procedure_17
+call cobylb(cb)
+end program

--- a/integration_tests/where_16.f90
+++ b/integration_tests/where_16.f90
@@ -1,0 +1,39 @@
+module update
+
+contains
+   subroutine updateres(b, delta, rescon)
+      implicit none
+
+      real, intent(in) :: b(:)
+      real, intent(in) :: delta
+      real, intent(inout) :: rescon(:)
+
+      real :: ax(size(b))
+      integer :: idx(size(b))    ! Comment out to avoid abort
+      logical :: mask(size(b))
+
+      ax = 1.0
+
+      mask = (abs(rescon) < delta)
+
+      where (mask)
+         rescon = max(b - ax, 0.0)
+      end where
+
+   end subroutine updateres
+end module update
+
+program where_16
+   use update
+   implicit none
+
+   real :: delta = 2.33
+
+   real :: b(2) = [5.4, 3.6]
+   real :: rescon(2) = [2.3, 8.6]
+
+   call updateres(b, delta, rescon)
+   print *, rescon
+   if( any(abs(rescon - [4.4, 8.6]) > 1e-6) ) error stop
+
+end program where_16

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3582,8 +3582,11 @@ namespace FindLoc {
     }
     ASR::ttype_t *type = ASRUtils::extract_type(return_type);
     ASR::expr_t *i = declare("i", type, Local);
+    ASR::expr_t *j = declare("j", type, Local);
+    ASR::expr_t *found_value = declare("found_value", logical, Local);
     ASR::expr_t *array = args[0];
     ASR::expr_t *value = args[1];
+    ASR::expr_t* dim = args[2];
     ASR::expr_t *mask = args[3];
     ASR::expr_t *back = args[5];
     if (overload_id == 1) {
@@ -3604,15 +3607,52 @@ namespace FindLoc {
             }, {})
         }));
     } else {
-        body.push_back(al, b.Assignment(result, b.i_t(0, use_experimental_simplifier ? ASRUtils::type_get_past_array(return_type) : return_type)));
-        body.push_back(al, b.DoLoop(i, b.i_t(1, type), UBound(array, 1), {
-            b.If(b.Eq(ArrayItem_02(array, i), value), {
-                b.Assignment(result, i),
-                b.If(b.NotEq(back, b.bool_t(1, logical)), {
-                    b.Return()
+        int array_rank = ASRUtils::extract_n_dims_from_ttype(array_type);
+        ASR::ttype_t* ret_type = use_experimental_simplifier ? ASRUtils::type_get_past_array(return_type) : return_type;
+        if (array_rank == 1) {
+            body.push_back(al, b.Assignment(result, b.i_t(0, ret_type)));
+            body.push_back(al, b.DoLoop(i, b.i_t(1, type), UBound(array, 1), {
+                b.If(b.Eq(ArrayItem_02(array, i), value), {
+                    b.Assignment(result, i),
+                    b.If(b.NotEq(back, b.bool_t(1, logical)), {
+                        b.Return()
+                    }, {})
                 }, {})
-            }, {})
-        }));
+            }));
+        } else if (array_rank == 2) {
+            Vec<ASR::expr_t*> idx_vars_ij; idx_vars_ij.reserve(al, 2);
+            Vec<ASR::expr_t*> idx_vars_ji; idx_vars_ji.reserve(al, 2);
+            idx_vars_ij.push_back(al, i); idx_vars_ij.push_back(al, j);
+            idx_vars_ji.push_back(al, j); idx_vars_ji.push_back(al, i);
+            body.push_back(al, b.Assignment(result, b.i_t(0, ret_type)));
+            body.push_back(al, b.If(b.Eq(dim, b.i_t(1, ret_type)), {
+                b.DoLoop(i, b.i_t(1, ret_type), UBound(array, 2), {
+                    b.Assignment(found_value, b.bool_t(0, logical)),
+                    b.DoLoop(j, b.i_t(1, ret_type), UBound(array, 1), {
+                        b.If(b.Eq(ArrayItem_02(array, idx_vars_ji), value), {
+                            b.Assignment(b.ArrayItem_01(result, {i}), j),
+                            b.Assignment(found_value, b.bool_t(1, logical)),
+                        }, {}),
+                        b.If(b.And(found_value, b.Not(back)), {
+                            b.Exit()
+                        }, {})
+                    })
+                })
+            }, {
+                b.DoLoop(i, b.i_t(1, ret_type), UBound(array, 1), {
+                    b.Assignment(found_value, b.bool_t(0, logical)),
+                    b.DoLoop(j, b.i_t(1, ret_type), UBound(array, 2), {
+                        b.If(b.Eq(ArrayItem_02(array, idx_vars_ij), value), {
+                            b.Assignment(b.ArrayItem_01(result, {i}), j),
+                            b.Assignment(found_value, b.bool_t(1, logical)),
+                        }, {}),
+                        b.If(b.And(found_value, b.Not(back)), {
+                            b.Exit()
+                        }, {})
+                    })
+                })
+            }));
+        }
     }
 
     body.push_back(al, b.Return());

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -304,58 +304,69 @@ namespace LCompilers {
                 new_m_dims.push_back(al, new_m_dim);
             }
             return PassUtils::set_dim_rank(sibling_type, new_m_dims.p, ndims, true, &al);
-    }
+        }
 
-    ASR::expr_t* create_var(int counter, std::string suffix, const Location& loc,
+        bool is_args_contains_allocatable(ASR::expr_t* x) {
+            if( ASR::is_a<ASR::ArrayConstructor_t>(*x) ) {
+                ASR::ArrayConstructor_t* arr_constructor = ASR::down_cast<ASR::ArrayConstructor_t>(x);
+                for(size_t i = 0; i < arr_constructor->n_args; i++) {
+                    if( ASRUtils::is_allocatable(ASRUtils::expr_type(arr_constructor->m_args[i])) ) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        ASR::expr_t* create_var(int counter, std::string suffix, const Location& loc,
                             ASR::ttype_t* var_type, Allocator& al, SymbolTable*& current_scope) {
-        ASR::dimension_t* m_dims = nullptr;
-        int ndims = 0;
-        PassUtils::get_dim_rank(var_type, m_dims, ndims);
-        if( !ASRUtils::is_fixed_size_array(m_dims, ndims) &&
-            !ASRUtils::is_dimension_dependent_only_on_arguments(m_dims, ndims) &&
-            !(ASR::is_a<ASR::Allocatable_t>(*var_type) || ASR::is_a<ASR::Pointer_t>(*var_type)) ) {
-            var_type = ASRUtils::TYPE(ASRUtils::make_Allocatable_t_util(al, var_type->base.loc,
-                ASRUtils::type_get_past_allocatable(
-                    ASRUtils::duplicate_type_with_empty_dims(al, var_type))));
+            ASR::dimension_t* m_dims = nullptr;
+            int ndims = 0;
+            PassUtils::get_dim_rank(var_type, m_dims, ndims);
+            if( !ASRUtils::is_fixed_size_array(m_dims, ndims) &&
+                !ASRUtils::is_dimension_dependent_only_on_arguments(m_dims, ndims) &&
+                !(ASR::is_a<ASR::Allocatable_t>(*var_type) || ASR::is_a<ASR::Pointer_t>(*var_type)) ) {
+                var_type = ASRUtils::TYPE(ASRUtils::make_Allocatable_t_util(al, var_type->base.loc,
+                    ASRUtils::type_get_past_allocatable(
+                        ASRUtils::duplicate_type_with_empty_dims(al, var_type))));
+            }
+            ASR::expr_t* idx_var = nullptr;
+            std::string str_name = "__libasr__created__var__" + std::to_string(counter) + "_" + suffix;
+
+            if( current_scope->get_symbol(str_name) == nullptr ||
+                !ASRUtils::check_equal_type(
+                    ASRUtils::symbol_type(current_scope->get_symbol(str_name)),
+                    var_type, true
+                ) ) {
+                str_name = current_scope->get_unique_name(str_name);
+                ASR::asr_t* idx_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, s2c(al, str_name), nullptr, 0,
+                                                        ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
+                                                        var_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
+                                                        ASR::presenceType::Required, false);
+                current_scope->add_symbol(str_name, ASR::down_cast<ASR::symbol_t>(idx_sym));
+                idx_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, ASR::down_cast<ASR::symbol_t>(idx_sym)));
+            } else {
+                ASR::symbol_t* idx_sym = current_scope->get_symbol(str_name);
+                idx_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, idx_sym));
+            }
+
+            return idx_var;
         }
-        ASR::expr_t* idx_var = nullptr;
-        std::string str_name = "__libasr__created__var__" + std::to_string(counter) + "_" + suffix;
 
-        if( current_scope->get_symbol(str_name) == nullptr ||
-            !ASRUtils::check_equal_type(
-                ASRUtils::symbol_type(current_scope->get_symbol(str_name)),
-                var_type, true
-            ) ) {
-            str_name = current_scope->get_unique_name(str_name);
-            ASR::asr_t* idx_sym = ASRUtils::make_Variable_t_util(al, loc, current_scope, s2c(al, str_name), nullptr, 0,
-                                                    ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
-                                                    var_type, nullptr, ASR::abiType::Source, ASR::accessType::Public,
-                                                    ASR::presenceType::Required, false);
-            current_scope->add_symbol(str_name, ASR::down_cast<ASR::symbol_t>(idx_sym));
-            idx_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, ASR::down_cast<ASR::symbol_t>(idx_sym)));
-        } else {
-            ASR::symbol_t* idx_sym = current_scope->get_symbol(str_name);
-            idx_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, idx_sym));
+        ASR::expr_t* create_var(int counter, std::string suffix, const Location& loc,
+                                ASR::expr_t* sibling, Allocator& al, SymbolTable*& current_scope) {
+            ASR::ttype_t* var_type = nullptr;
+            var_type = get_matching_type(sibling, al);
+            return create_var(counter, suffix, loc, var_type, al, current_scope);
         }
 
-        return idx_var;
-    }
-
-    ASR::expr_t* create_var(int counter, std::string suffix, const Location& loc,
-                            ASR::expr_t* sibling, Allocator& al, SymbolTable*& current_scope) {
-        ASR::ttype_t* var_type = nullptr;
-        var_type = get_matching_type(sibling, al);
-        return create_var(counter, suffix, loc, var_type, al, current_scope);
-    }
-
-    void fix_dimension(ASR::Cast_t* x, ASR::expr_t* arg_expr) {
-        ASR::ttype_t* x_type = const_cast<ASR::ttype_t*>(x->m_type);
-        ASR::ttype_t* arg_type = ASRUtils::expr_type(arg_expr);
-        ASR::dimension_t* m_dims;
-        int ndims;
-        PassUtils::get_dim_rank(arg_type, m_dims, ndims);
-        PassUtils::set_dim_rank(x_type, m_dims, ndims);
-    }
+        void fix_dimension(ASR::Cast_t* x, ASR::expr_t* arg_expr) {
+            ASR::ttype_t* x_type = const_cast<ASR::ttype_t*>(x->m_type);
+            ASR::ttype_t* arg_type = ASRUtils::expr_type(arg_expr);
+            ASR::dimension_t* m_dims;
+            int ndims;
+            PassUtils::get_dim_rank(arg_type, m_dims, ndims);
+            PassUtils::set_dim_rank(x_type, m_dims, ndims);
+        }
 
         void create_vars(Vec<ASR::expr_t*>& vars, int n_vars, const Location& loc,
                          Allocator& al, SymbolTable*& current_scope, std::string suffix,

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -44,6 +44,7 @@ namespace LCompilers {
                 ASR::down_cast<ASR::Function_t>(x))->m_elemental;
         }
 
+        bool is_args_contains_allocatable(ASR::expr_t* x);
         void fix_dimension(ASR::Cast_t* x, ASR::expr_t* arg_expr);
 
         ASR::ttype_t* get_matching_type(ASR::expr_t* sibling, Allocator& al);

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -81,7 +81,6 @@ namespace LCompilers {
         ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim, std::string bound,
                                 Allocator& al);
 
-
         ASR::expr_t* get_flipsign(ASR::expr_t* arg0, ASR::expr_t* arg1,
                              Allocator& al, ASR::TranslationUnit_t& unit, const Location& loc,
                              PassOptions& pass_options);

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -168,7 +168,8 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al,
     }
     // dimensions can be different for an ArrayConstructor e.g. [1, a], where `a` is an
     // ArrayConstructor like [5, 2, 1]
-    if (ASR::is_a<ASR::ArrayConstructor_t>(*value)) {
+    if (ASR::is_a<ASR::ArrayConstructor_t>(*value) && 
+           !PassUtils::is_args_contains_allocatable(value)) {
         ASR::ArrayConstructor_t* arr_constructor = ASR::down_cast<ASR::ArrayConstructor_t>(value);
         value_m_dims->m_length = ASRUtils::get_ArrayConstructor_size(al, arr_constructor);
     }

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -1420,73 +1420,75 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
         ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>::visit_FunctionCall(x);
     }
 
-    #define replace_expr_with_temporary_variable(member, name_hint) if( var_check(x.m_##member)) { \
-        visit_expr(*x.m_##member); \
-        xx.m_##member = create_and_allocate_temporary_variable_for_array( \
-            x.m_##member, name_hint, al, current_body, current_scope, exprs_with_target); \
+    void replace_expr_with_temporary_variable(ASR::expr_t* &xx_member, ASR::expr_t* x_member, const std::string& name_hint) {
+        if( var_check(x_member)) {
+            visit_expr(*x_member);
+            xx_member = create_and_allocate_temporary_variable_for_array(x_member,
+                name_hint, al, current_body, current_scope, exprs_with_target);
         }
+    }
 
     void visit_ArrayReshape(const ASR::ArrayReshape_t& x) {
         ASR::ArrayReshape_t& xx = const_cast<ASR::ArrayReshape_t&>(x);
-        replace_expr_with_temporary_variable(array, "_array_reshape_array")
+        replace_expr_with_temporary_variable(xx.m_array, x.m_array, "_array_reshape_array");
     }
 
     void visit_ComplexConstructor(const ASR::ComplexConstructor_t& x) {
         ASR::ComplexConstructor_t& xx = const_cast<ASR::ComplexConstructor_t&>(x);
 
-        replace_expr_with_temporary_variable(re, "_complex_constructor_re")
+        replace_expr_with_temporary_variable(xx.m_re, x.m_re, "_complex_constructor_re");
 
-        replace_expr_with_temporary_variable(im, "_complex_constructor_im")
+        replace_expr_with_temporary_variable(xx.m_im, xx.m_im, "_complex_constructor_im");
     }
 
     void visit_ArrayTranspose(const ASR::ArrayTranspose_t& x) {
         ASR::ArrayTranspose_t& xx = const_cast<ASR::ArrayTranspose_t&>(x);
 
-        replace_expr_with_temporary_variable(matrix, "_array_transpose_matrix_")
+        replace_expr_with_temporary_variable(xx.m_matrix, x.m_matrix, "_array_transpose_matrix_");
     }
 
     void visit_ArrayPack(const ASR::ArrayPack_t& x) {
         ASR::ArrayPack_t& xx = const_cast<ASR::ArrayPack_t&>(x);
 
-        replace_expr_with_temporary_variable(array, "_array_pack_array_")
+        replace_expr_with_temporary_variable(xx.m_array, x.m_array, "_array_pack_array_");
 
-        replace_expr_with_temporary_variable(mask, "_array_pack_mask_")
+        replace_expr_with_temporary_variable(xx.m_mask, x.m_mask, "_array_pack_mask_");
 
         if( x.m_vector ) {
-            replace_expr_with_temporary_variable(vector, "_array_pack_vector_")
+            replace_expr_with_temporary_variable(xx.m_vector, x.m_vector, "_array_pack_vector_");
         }
     }
 
     void visit_ComplexRe(const ASR::ComplexRe_t& x) {
         ASR::ComplexRe_t& xx = const_cast<ASR::ComplexRe_t&>(x);
 
-        replace_expr_with_temporary_variable(arg, "_complex_re_")
+        replace_expr_with_temporary_variable(xx.m_arg, x.m_arg, "_complex_re_");
     }
 
     void visit_ComplexIm(const ASR::ComplexIm_t& x) {
         ASR::ComplexIm_t& xx = const_cast<ASR::ComplexIm_t&>(x);
 
-        replace_expr_with_temporary_variable(arg, "_complex_im_")
+        replace_expr_with_temporary_variable(xx.m_arg, x.m_arg, "_complex_im_");
     }
 
     void visit_RealSqrt(const ASR::RealSqrt_t& x) {
         ASR::RealSqrt_t& xx = const_cast<ASR::RealSqrt_t&>(x);
 
-        replace_expr_with_temporary_variable(arg, "_real_sqrt_")
+        replace_expr_with_temporary_variable(xx.m_arg, x.m_arg, "_real_sqrt_");
     }
 
     void visit_ArrayBound(const ASR::ArrayBound_t& x) {
         ASR::ArrayBound_t& xx = const_cast<ASR::ArrayBound_t&>(x);
 
         if( is_temporary_needed(xx.m_v) ) {
-            replace_expr_with_temporary_variable(v, "_array_bound_v")
+            replace_expr_with_temporary_variable(xx.m_v, x.m_v, "_array_bound_v");
         }
     }
 
     void visit_ArraySize(const ASR::ArraySize_t& x) {
         ASR::ArraySize_t& xx = const_cast<ASR::ArraySize_t&>(x);
         if( is_temporary_needed(xx.m_v) ) {
-            replace_expr_with_temporary_variable(v, "_array_size_v")
+            replace_expr_with_temporary_variable(xx.m_v, x.m_v, "_array_size_v");
         }
     }
 };
@@ -1529,27 +1531,40 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             return ; \
         }
 
-    #define force_replace_current_expr_for_array(name_hint) *current_expr = create_and_allocate_temporary_variable_for_array( \
-                *current_expr, name_hint, al, current_body, \
-                current_scope, exprs_with_target, is_assignment_target_array_section_item); \
+    void force_replace_current_expr_for_array(ASR::expr_t** &current_expr, const std::string& name_hint, Allocator& al,
+        Vec<ASR::stmt_t*>* &current_body, SymbolTable* &current_scope, ExprsWithTargetType& exprs_with_target,
+        bool is_assignment_target_array_section_item) {
+        *current_expr = create_and_allocate_temporary_variable_for_array(
+                *current_expr, name_hint, al, current_body,
+                current_scope, exprs_with_target, is_assignment_target_array_section_item);
+    }
 
-    #define force_replace_current_expr_for_struct(name_hint) *current_expr = create_and_allocate_temporary_variable_for_struct( \
-            *current_expr, name_hint, al, current_body, \
-            current_scope, exprs_with_target); \
+    void force_replace_current_expr_for_struct(ASR::expr_t** &current_expr, const std::string& name_hint, Allocator& al,
+        Vec<ASR::stmt_t*>* &current_body, SymbolTable* &current_scope, ExprsWithTargetType& exprs_with_target) {
+        *current_expr = create_and_allocate_temporary_variable_for_struct(
+                *current_expr, name_hint, al, current_body,
+                current_scope, exprs_with_target);
+    }
 
-    #define force_replace_current_expr_for_scalar(name_hint) *current_expr = create_and_declare_temporary_variable_for_scalar( \
-                *current_expr, name_hint, al, current_body, \
-                current_scope, exprs_with_target); \
+    void force_replace_current_expr_for_scalar(ASR::expr_t** &current_expr, const std::string& name_hint, Allocator& al,
+        Vec<ASR::stmt_t*>* &current_body, SymbolTable* &current_scope, ExprsWithTargetType& exprs_with_target) {
+        *current_expr = create_and_declare_temporary_variable_for_scalar(
+                *current_expr, name_hint, al, current_body,
+                current_scope, exprs_with_target);
+    }
 
-    #define replace_current_expr(name_hint) is_current_expr_linked_to_target_then_return \
-        if( ASRUtils::is_array(x->m_type) ) { \
-            force_replace_current_expr_for_array(name_hint) \
-        } else if( ASRUtils::is_struct(*x->m_type) ) { \
-            force_replace_current_expr_for_struct(name_hint) \
+    template <typename T>
+    void replace_current_expr(T* &x, const std::string& name_hint) {
+        is_current_expr_linked_to_target_then_return
+        if( ASRUtils::is_array(x->m_type) ) {
+            force_replace_current_expr_for_array(current_expr, name_hint, al, current_body, current_scope, exprs_with_target, is_assignment_target_array_section_item);
+        } else if( ASRUtils::is_struct(*x->m_type) ) {
+            force_replace_current_expr_for_struct(current_expr, name_hint, al, current_body, current_scope, exprs_with_target);
         }
+    }
 
     void replace_ComplexConstructor(ASR::ComplexConstructor_t* x) {
-        replace_current_expr("_complex_constructor_")
+        replace_current_expr(x, "_complex_constructor_");
     }
 
     ASR::symbol_t* extract_symbol(ASR::expr_t* expr) {
@@ -1606,26 +1621,27 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
                    is_common_symbol_present_in_lhs_and_rhs(target, *current_expr))) ) ||
                  target_Type == targetType::GeneratedTargetPointerForArraySection ||
                 (!ASRUtils::is_allocatable(target) && ASRUtils::is_allocatable(x->m_type)) ) {
-                force_replace_current_expr_for_array(std::string("_function_call_") +
-                                           ASRUtils::symbol_name(x->m_name))
+                force_replace_current_expr_for_array(current_expr, std::string("_function_call_") +
+                                           ASRUtils::symbol_name(x->m_name), al, current_body, current_scope, 
+                                           exprs_with_target, is_assignment_target_array_section_item);
                 return ;
             }
         }
         if( !ASRUtils::is_array(x->m_type) && lhs_var &&
                is_common_symbol_present_in_lhs_and_rhs(lhs_var, *current_expr) ) {
-            force_replace_current_expr_for_scalar(std::string("_function_call_") +
-                                           ASRUtils::symbol_name(x->m_name))
+            force_replace_current_expr_for_scalar(current_expr, std::string("_function_call_") +
+                                           ASRUtils::symbol_name(x->m_name), al, current_body, current_scope, exprs_with_target);
             return ;
         }
 
-        replace_current_expr(std::string("_function_call_") +
-            ASRUtils::symbol_name(x->m_name))
+        replace_current_expr(x, std::string("_function_call_") +
+            ASRUtils::symbol_name(x->m_name));
     }
 
     void replace_IntrinsicArrayFunction(ASR::IntrinsicArrayFunction_t* x) {
         std::string name_hint = std::string("_intrinsic_array_function_") + ASRUtils::get_array_intrinsic_name(x->m_arr_intrinsic_id);
         if (!(is_current_expr_linked_to_target(exprs_with_target, current_expr) || ASRUtils::is_array(x->m_type))) {
-            force_replace_current_expr_for_scalar(name_hint)
+            force_replace_current_expr_for_scalar(current_expr, name_hint, al, current_body, current_scope, exprs_with_target);
         } else if ((is_current_expr_linked_to_target(exprs_with_target, current_expr) &&
             static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Transpose) == x->m_arr_intrinsic_id &&
             exprs_with_target[*current_expr].second == targetType::OriginalTarget) ||
@@ -1640,55 +1656,56 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             // x = transpose(x), where 'x' is user-variable
             // needs have a temporary, there might be more
             // intrinsic array functions needing this
-            force_replace_current_expr_for_array(name_hint)
+            force_replace_current_expr_for_array(current_expr, name_hint, al, current_body, current_scope, 
+                                                exprs_with_target, is_assignment_target_array_section_item);
         } else {
-            replace_current_expr(name_hint)
+            replace_current_expr(x, name_hint);
         }
     }
 
     void replace_IntrinsicImpureFunction(ASR::IntrinsicImpureFunction_t* x) {
-        replace_current_expr(std::string("_intrinsic_impure_function_") +
-            ASRUtils::get_impure_intrinsic_name(x->m_impure_intrinsic_id))
+        replace_current_expr(x, std::string("_intrinsic_impure_function_") +
+            ASRUtils::get_impure_intrinsic_name(x->m_impure_intrinsic_id));
     }
 
     void replace_StructConstructor(ASR::StructConstructor_t* x) {
-        replace_current_expr("_struct_constructor_")
+        replace_current_expr(x, "_struct_constructor_");
     }
 
     void replace_EnumConstructor(ASR::EnumConstructor_t* x) {
-        replace_current_expr("_enum_constructor_")
+        replace_current_expr(x, "_enum_constructor_");
     }
 
     void replace_UnionConstructor(ASR::UnionConstructor_t* x) {
-        replace_current_expr("_union_constructor_")
+        replace_current_expr(x, "_union_constructor_");
     }
 
     void replace_ImpliedDoLoop(ASR::ImpliedDoLoop_t* x) {
-        replace_current_expr("_implied_do_loop_")
+        replace_current_expr(x, "_implied_do_loop_");
     }
 
     void replace_ListConstant(ASR::ListConstant_t* x) {
-        replace_current_expr("_list_constant_")
+        replace_current_expr(x, "_list_constant_");
     }
 
     void replace_SetConstant(ASR::SetConstant_t* x) {
-        replace_current_expr("_set_constant_")
+        replace_current_expr(x, "_set_constant_");
     }
 
     void replace_TupleConstant(ASR::TupleConstant_t* x) {
-        replace_current_expr("_tuple_constant_")
+        replace_current_expr(x, "_tuple_constant_");
     }
 
     void replace_StringSection(ASR::StringSection_t* x) {
-        replace_current_expr("_string_section_")
+        replace_current_expr(x, "_string_section_");
     }
 
     void replace_DictConstant(ASR::DictConstant_t* x) {
-        replace_current_expr("_dict_constant_")
+        replace_current_expr(x, "_dict_constant_");
     }
 
     void replace_ArrayConstructor(ASR::ArrayConstructor_t* x) {
-        replace_current_expr("_array_constructor_")
+        replace_current_expr(x, "_array_constructor_");
     }
 
     void replace_ArrayConstant(ASR::ArrayConstant_t* /*x*/) {
@@ -1697,8 +1714,23 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         // (b). there is an OriginalTarget and realloc_lhs is true e.g. `x = [1, 2, 3, 4]`
         if (exprs_with_target.find(*current_expr) == exprs_with_target.end() ||
             (exprs_with_target[*current_expr].second == targetType::OriginalTarget && realloc_lhs)) {
-            force_replace_current_expr_for_array("_array_constant_")
+            force_replace_current_expr_for_array(current_expr, "_array_constant_", al, current_body, current_scope, 
+                                                exprs_with_target, is_assignment_target_array_section_item);
         }
+    }
+
+    ASR::expr_t* generate_associate_for_array_section(ASR::expr_t** &current_expr, Allocator& al, const Location &loc,
+        SymbolTable* &current_scope, Vec<ASR::stmt_t*>* &current_body) {
+        size_t value_n_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(*current_expr));
+        ASR::ttype_t* tmp_type = ASRUtils::create_array_type_with_empty_dims(
+                al, value_n_dims, ASRUtils::expr_type(*current_expr));
+        tmp_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc, tmp_type));
+        ASR::expr_t* array_expr_ptr = create_temporary_variable_for_array(
+                al, loc, current_scope, "_array_section_pointer_", tmp_type);
+        current_body->push_back(al, ASRUtils::STMT(ASR::make_Associate_t(
+                al, loc, array_expr_ptr, *current_expr)));
+        *current_expr = array_expr_ptr;
+        return array_expr_ptr;
     }
 
     void replace_ArraySection(ASR::ArraySection_t* x) {
@@ -1714,24 +1746,14 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             return ;
         }
 
-        #define generate_associate_for_array_section size_t value_n_dims = \
-            ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(*current_expr)); \
-            ASR::ttype_t* tmp_type = ASRUtils::create_array_type_with_empty_dims( \
-                al, value_n_dims, ASRUtils::expr_type(*current_expr)); \
-            tmp_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc, tmp_type)); \
-            ASR::expr_t* array_expr_ptr = create_temporary_variable_for_array( \
-                al, loc, current_scope, "_array_section_pointer_", tmp_type); \
-            current_body->push_back(al, ASRUtils::STMT(ASR::make_Associate_t( \
-                al, loc, array_expr_ptr, *current_expr))); \
-            *current_expr = array_expr_ptr;
-
         const Location& loc = x->base.base.loc;
         if( is_simd_expression ) {
             if( is_current_expr_linked_to_target(exprs_with_target, current_expr) ) {
                 return ;
             }
 
-            generate_associate_for_array_section
+            ASR::expr_t* array_expr_ptr = generate_associate_for_array_section(current_expr, 
+                al, loc, current_scope, current_body);
 
             array_expr_ptr = create_temporary_variable_for_array(
                 al, loc, current_scope, "_array_section_copy_", simd_type);
@@ -1742,23 +1764,23 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         }
 
         if( exprs_with_target.find(*current_expr) != exprs_with_target.end() ) {
-            generate_associate_for_array_section
+            generate_associate_for_array_section(current_expr, al, loc, current_scope, current_body);
             return ;
         }
 
-        replace_current_expr("_array_section_")
+        replace_current_expr(x, "_array_section_");
     }
 
     void replace_ArrayTranspose(ASR::ArrayTranspose_t* x) {
-        replace_current_expr("_array_transpose_")
+        replace_current_expr(x, "_array_transpose_");
     }
 
     void replace_ArrayPack(ASR::ArrayPack_t* x) {
-        replace_current_expr("_array_pack_")
+        replace_current_expr(x, "_array_pack_");
     }
 
     void replace_ArrayReshape(ASR::ArrayReshape_t* x) {
-        replace_current_expr("_array_reshape_")
+        replace_current_expr(x, "_array_reshape_");
     }
 
     void replace_ArrayItem(ASR::ArrayItem_t* x) {
@@ -1790,24 +1812,24 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         ASR::BaseExprReplacer<ReplaceExprWithTemporary>::replace_IntegerBinOp(x);
         parent_expr = parent_expr_copy;
         if( parent_expr == nullptr ) {
-            replace_current_expr("_integer_binop_")
+            replace_current_expr(x, "_integer_binop_");
         }
     }
 
     void replace_StructStaticMember(ASR::StructStaticMember_t* x) {
-        replace_current_expr("_struct_static_member_")
+        replace_current_expr(x, "_struct_static_member_");
     }
 
     void replace_EnumStaticMember(ASR::EnumStaticMember_t* x) {
-        replace_current_expr("_enum_static_member_")
+        replace_current_expr(x, "_enum_static_member_");
     }
 
     void replace_UnionInstanceMember(ASR::UnionInstanceMember_t* x) {
-        replace_current_expr("_union_instance_member_")
+        replace_current_expr(x, "_union_instance_member_");
     }
 
     void replace_OverloadedCompare(ASR::OverloadedCompare_t* x) {
-        replace_current_expr("_overloaded_compare_")
+        replace_current_expr(x, "_overloaded_compare_");
     }
 
     template <typename T>
@@ -1838,38 +1860,39 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
     }
 
     void replace_ComplexRe(ASR::ComplexRe_t* x) {
-        replace_current_expr("_complex_re_")
+        replace_current_expr(x, "_complex_re_");
     }
 
     void replace_ComplexIm(ASR::ComplexIm_t* x) {
-        replace_current_expr("_complex_im_")
+        replace_current_expr(x, "_complex_im_");
     }
 
     void replace_ListSection(ASR::ListSection_t* x) {
-        replace_current_expr("_list_section_")
+        replace_current_expr(x, "_list_section_");
     }
 
     void replace_ListRepeat(ASR::ListRepeat_t* x) {
-        replace_current_expr("_list_repeat_")
+        replace_current_expr(x, "_list_repeat_");
     }
 
     void replace_DictPop(ASR::DictPop_t* x) {
-        replace_current_expr("_dict_pop_")
+        replace_current_expr(x, "_dict_pop_");
     }
 
     void replace_SetPop(ASR::SetPop_t* x) {
-        replace_current_expr("_set_pop_")
+        replace_current_expr(x, "_set_pop_");
     }
 
     void replace_RealSqrt(ASR::RealSqrt_t* x) {
-        replace_current_expr("_real_sqrt_")
+        replace_current_expr(x, "_real_sqrt_");
     }
 
     void replace_ArrayBound(ASR::ArrayBound_t* x) {
         ASR::expr_t** current_expr_copy_149 = current_expr;
         current_expr = &(x->m_v);
         if( is_temporary_needed(x->m_v) ) {
-            force_replace_current_expr_for_array("_array_bound_v")
+            force_replace_current_expr_for_array(current_expr, "_array_bound_v", al, current_body, current_scope, 
+                                                    exprs_with_target, is_assignment_target_array_section_item);    
         }
         current_expr = current_expr_copy_149;
     }
@@ -1878,7 +1901,8 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         ASR::expr_t** current_expr_copy_149 = current_expr;
         current_expr = &(x->m_v);
         if( is_temporary_needed(x->m_v) ) {
-            force_replace_current_expr_for_array("_array_size_v")
+            force_replace_current_expr_for_array(current_expr, "_array_size_v", al, current_body, current_scope, 
+                                                    exprs_with_target, is_assignment_target_array_section_item); 
         }
         current_expr = current_expr_copy_149;
     }
@@ -2014,7 +2038,8 @@ class ReplaceExprWithTemporaryVisitor:
             ASRUtils::is_array(ASRUtils::expr_type(x.m_value)) &&
             !is_elemental_expr(x.m_value) ) {
             bool is_assignment_target_array_section_item = true;
-            force_replace_current_expr_for_array("_assignment_value_")
+            replacer.force_replace_current_expr_for_array(current_expr, "_assignment_value_", al, current_body, current_scope, 
+                                                exprs_with_target, is_assignment_target_array_section_item);
         }
         current_expr = current_expr_copy_9;
         replacer.is_simd_expression = is_simd_expr_copy;
@@ -2283,14 +2308,17 @@ class VerifySimplifierASROutput:
         return ;
     }
 
-    #define check_for_var_if_array(expr) if( is_temporary_needed(expr) ) { \
-            LCOMPILERS_ASSERT(ASR::is_a<ASR::Var_t>(*ASRUtils::get_past_array_physical_cast(expr))); \
-        } \
+    void check_for_var_if_array(ASR::expr_t* expr) {
+        if ( is_temporary_needed(expr) ) {
+            LCOMPILERS_ASSERT(ASR::is_a<ASR::Var_t>(*ASRUtils::get_past_array_physical_cast(expr)));
+        }
+    }
 
-    #define check_if_linked_to_target(expr, type) if( ASRUtils::is_aggregate_type(type) \
-        && ASRUtils::is_simd_array(type) ) { \
-         LCOMPILERS_ASSERT( exprs_with_target.find(&(const_cast<ASR::expr_t&>(expr))) != \
-                            exprs_with_target.end()); \
+    void check_if_linked_to_target(ASR::expr_t expr, ASR::ttype_t* type) {
+        if( ASRUtils::is_aggregate_type(type) &&
+            ASRUtils::is_simd_array(type) ) {
+            LCOMPILERS_ASSERT(exprs_with_target.find(&expr) != exprs_with_target.end());
+        }
     }
 
     template <typename T>
@@ -2301,7 +2329,7 @@ class VerifySimplifierASROutput:
     }
 
     void visit_Print(const ASR::Print_t& x) {
-        check_for_var_if_array(x.m_text)
+        check_for_var_if_array(x.m_text);
     }
 
     void visit_FileWrite(const ASR::FileWrite_t& x) {

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -2314,7 +2314,7 @@ class VerifySimplifierASROutput:
         }
     }
 
-    void check_if_linked_to_target(ASR::expr_t expr, ASR::ttype_t* type) {
+    void check_if_linked_to_target([[maybe_unused]] ASR::expr_t expr, ASR::ttype_t* type) {
         if( ASRUtils::is_aggregate_type(type) &&
             ASRUtils::is_simd_array(type) ) {
             LCOMPILERS_ASSERT(exprs_with_target.find(&expr) != exprs_with_target.end());

--- a/src/libasr/pass/simplifier.cpp
+++ b/src/libasr/pass/simplifier.cpp
@@ -764,17 +764,24 @@ void insert_allocate_stmt_for_struct(Allocator& al, ASR::expr_t* temporary_var,
 }
 
 void transform_stmts_impl(Allocator& al, ASR::stmt_t**& m_body, size_t& n_body,
-    Vec<ASR::stmt_t*>*& current_body, std::function<void(const ASR::stmt_t&)> visit_stmt) {
-    Vec<ASR::stmt_t*>* current_body_copy = current_body;
-    Vec<ASR::stmt_t*> current_body_vec; current_body_vec.reserve(al, 1);
-    current_body_vec.reserve(al, n_body);
-    current_body = &current_body_vec;
-    for (size_t i = 0; i < n_body; i++) {
-        visit_stmt(*m_body[i]);
-        current_body->push_back(al, m_body[i]);
+    Vec<ASR::stmt_t*>*& current_body, bool inside_where,
+    std::function<void(const ASR::stmt_t&)> visit_stmt) {
+    if( inside_where ) {
+        for (size_t i = 0; i < n_body; i++) {
+            visit_stmt(*m_body[i]);
+        }
+    } else {
+        Vec<ASR::stmt_t*>* current_body_copy = current_body;
+        Vec<ASR::stmt_t*> current_body_vec; current_body_vec.reserve(al, 1);
+        current_body_vec.reserve(al, n_body);
+        current_body = &current_body_vec;
+        for (size_t i = 0; i < n_body; i++) {
+            visit_stmt(*m_body[i]);
+            current_body->push_back(al, m_body[i]);
+        }
+        m_body = current_body_vec.p; n_body = current_body_vec.size();
+        current_body = current_body_copy;
     }
-    m_body = current_body_vec.p; n_body = current_body_vec.size();
-    current_body = current_body_copy;
 }
 
 ASR::expr_t* create_and_declare_temporary_variable_for_scalar(
@@ -893,10 +900,10 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
         al(al_), current_body(nullptr), parent_body_for_where(nullptr),
             exprs_with_target(exprs_with_target_), realloc_lhs(realloc_lhs_),
             inside_where(false) {(void)realloc_lhs; /*Silence-Warning*/}
-    
+
 
     void transform_stmts(ASR::stmt_t**& m_body, size_t& n_body) {
-        transform_stmts_impl(al, m_body, n_body, current_body,
+        transform_stmts_impl(al, m_body, n_body, current_body, inside_where,
             [this](const ASR::stmt_t& stmt) { visit_stmt(stmt); });
     }
 
@@ -1697,7 +1704,7 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         ASR::BaseExprReplacer<ReplaceExprWithTemporary>::replace_ArraySection(x);
         if( ASRUtils::is_array_indexed_with_array_indices(x) ) {
             if( (exprs_with_target.find(*current_expr) == exprs_with_target.end() &&
-                !is_assignment_target_array_section_item) || 
+                !is_assignment_target_array_section_item) ||
                 (lhs_var && is_common_symbol_present_in_lhs_and_rhs(lhs_var, x->m_v))) {
                 *current_expr = create_and_allocate_temporary_variable_for_array(
                     *current_expr, "_array_section_", al, current_body,
@@ -1757,7 +1764,7 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
         if( ASRUtils::is_array_indexed_with_array_indices(x) ) {
             ASR::BaseExprReplacer<ReplaceExprWithTemporary>::replace_ArrayItem(x);
             if( (exprs_with_target.find(*current_expr) == exprs_with_target.end() &&
-                !is_assignment_target_array_section_item) || 
+                !is_assignment_target_array_section_item) ||
                 (lhs_var && is_common_symbol_present_in_lhs_and_rhs(lhs_var, x->m_v))) {
                 *current_expr = create_and_allocate_temporary_variable_for_array(
                     *current_expr, "_array_item_", al, current_body,
@@ -1885,11 +1892,14 @@ class ReplaceExprWithTemporaryVisitor:
     ExprsWithTargetType& exprs_with_target;
     Vec<ASR::stmt_t*>* current_body;
     ReplaceExprWithTemporary replacer;
+    Vec<ASR::stmt_t*>* parent_body_for_where;
+    bool inside_where;
 
     public:
 
     ReplaceExprWithTemporaryVisitor(Allocator& al_, ExprsWithTargetType& exprs_with_target_, bool realloc_lhs_):
-        al(al_), exprs_with_target(exprs_with_target_), replacer(al, exprs_with_target, realloc_lhs_) {
+        al(al_), exprs_with_target(exprs_with_target_), replacer(al, exprs_with_target, realloc_lhs_),
+        parent_body_for_where(nullptr), inside_where(false) {
         replacer.call_replacer_on_value = false;
         call_replacer_on_value = false;
     }
@@ -1910,9 +1920,36 @@ class ReplaceExprWithTemporaryVisitor:
     }
 
     void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {
-        transform_stmts_impl(al, m_body, n_body, current_body,
+        transform_stmts_impl(al, m_body, n_body, current_body, inside_where,
             [this](const ASR::stmt_t& stmt) { visit_stmt(stmt); });
     }
+
+    void visit_Where(const ASR::Where_t &x) {
+        bool inside_where_copy = inside_where;
+        if( !inside_where ) {
+            inside_where = true;
+            parent_body_for_where = current_body;
+        }
+        Vec<ASR::stmt_t*>* current_body_copy_ = current_body;
+        current_body = parent_body_for_where;
+        ASR::expr_t** current_expr_copy_86 = current_expr;
+        current_expr = const_cast<ASR::expr_t**>(&(x.m_test));
+        call_replacer();
+        current_expr = current_expr_copy_86;
+        if( x.m_test && visit_expr_after_replacement )
+        visit_expr(*x.m_test);
+        current_body = current_body_copy_;
+
+        ASR::Where_t& xx = const_cast<ASR::Where_t&>(x);
+        transform_stmts(xx.m_body, xx.n_body);
+        transform_stmts(xx.m_orelse, xx.n_orelse);
+
+        if( !inside_where_copy ) {
+            inside_where = false;
+            parent_body_for_where = nullptr;
+        }
+    }
+
 
     void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t &x) {
         ASR::expr_t** current_expr_copy_273 = current_expr;


### PR DESCRIPTION
Towards #6084 

- Removes following macros:
1. `replace_expr_with_temporary_variable`
2. `force_replace_current_expr_for_array`
3. `force_replace_current_expr_for_struct`
4. `force_replace_current_expr_for_scalar`
5. `replace_current_expr`
6. `generate_associate_for_array_section`
7. `check_for_var_if_array`
8. `check_if_linked_to_target`