### PR TITLE
fix: handling correct compile time error message for array intrinsic function

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -624,6 +624,31 @@ static inline ASR::asr_t* create_ArrIntrinsic(
             }
             if (args[2] && is_logical(*ASRUtils::expr_type(args[2]))) {
                 mask = args[2];
+                if (!ASRUtils::is_value_constant(mask)) {
+                    ASR::dimension_t* mask_dims = nullptr;
+                    ASR::dimension_t* array_dims = nullptr;
+                    ASR::ttype_t* mask_type = ASRUtils::expr_type(mask);
+                    int array_n_dims = ASRUtils::extract_dimensions_from_ttype(array_type, array_dims);
+                    int mask_n_dims = ASRUtils::extract_dimensions_from_ttype(mask_type, mask_dims);
+                    if (array_n_dims != mask_n_dims) {
+                        diag.add(diag::Diagnostic("The dimensions of `array` and `mask` arguments of `" + intrinsic_func_name + "` intrinsic must be same", 
+                        diag::Level::Error, 
+                        diag::Stage::Semantic, 
+                        {diag::Label("Incompatible ranks in arguments `array` and `mask` for (" + std::to_string(array_n_dims) + ", " + 
+                                    std::to_string(mask_n_dims) + ")", { args[0]->base.loc, args[2]->base.loc })}));
+                        return nullptr;
+                    }
+                    for (int i = 0; i < array_n_dims; i++) {
+                        if (!(ASRUtils::expr_equal(array_dims[i].m_length, mask_dims[i].m_length) &&
+                            ASRUtils::expr_equal(array_dims[i].m_start, mask_dims[i].m_start))) {
+                                diag.add(diag::Diagnostic("The dimensions of `array` and `mask` arguments of `" + intrinsic_func_name + "` intrinsic must be same", 
+                                diag::Level::Error, 
+                                diag::Stage::Semantic, 
+                                {diag::Label("Different shape for arguments `array` and `mask` on dimension " + std::to_string((i + 1)), { args[0]->base.loc, args[2]->base.loc })}));
+                                return nullptr;
+                        }
+                    }
+                }
             } else if (args[2]) {
                 append_error(diag, "`mask` argument to `" + intrinsic_func_name + "` must be a scalar or array of logical type",
                     args[2]->base.loc);
@@ -631,6 +656,31 @@ static inline ASR::asr_t* create_ArrIntrinsic(
             }
         } else if (is_logical(*ASRUtils::expr_type(args[1]))) {
             mask = args[1];
+            if (!ASRUtils::is_value_constant(mask)) {
+                ASR::dimension_t* mask_dims = nullptr;
+                ASR::dimension_t* array_dims = nullptr;
+                ASR::ttype_t* mask_type = ASRUtils::expr_type(mask);
+                int array_n_dims = ASRUtils::extract_dimensions_from_ttype(array_type, array_dims);
+                int mask_n_dims = ASRUtils::extract_dimensions_from_ttype(mask_type, mask_dims);
+                if (array_n_dims != mask_n_dims) {
+                    diag.add(diag::Diagnostic("The dimensions of `array` and `mask` arguments of `" + intrinsic_func_name + "` intrinsic must be same", 
+                    diag::Level::Error, 
+                    diag::Stage::Semantic, 
+                    {diag::Label("Incompatible ranks in arguments `array` and `mask` for (" + std::to_string(array_n_dims) + ", " + 
+                                std::to_string(mask_n_dims) + ")", { args[0]->base.loc, args[1]->base.loc })}));
+                    return nullptr;
+                }
+                for (int i = 0; i < array_n_dims; i++) {
+                    if (!(ASRUtils::expr_equal(array_dims[i].m_length, mask_dims[i].m_length) &&
+                        ASRUtils::expr_equal(array_dims[i].m_start, mask_dims[i].m_start))) {
+                            diag.add(diag::Diagnostic("The dimensions of `array` and `mask` arguments of `" + intrinsic_func_name + "` intrinsic must be same", 
+                            diag::Level::Error, 
+                            diag::Stage::Semantic, 
+                            {diag::Label("Different shape for arguments `array` and `mask` on dimension " + std::to_string((i + 1)), { args[0]->base.loc, args[1]->base.loc })}));
+                            return nullptr;
+                    }
+                }
+            }
             if (args[2] && is_integer(*ASRUtils::expr_type(args[2]))) {
                 dim = args[2];
                 if ( ASRUtils::is_value_constant(dim) ) {

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -3,7 +3,7 @@ program continue_compilation_1
 
     integer :: a(3), b(3), b1(3, 3), a3(3, 3, 3), b4(3, 3, 3, 3), a5, c5, i, arr1(3), arr2(2, 3), arr3(2, 1, 3)
     character :: a1(3, 3)
-    logical :: a2(3, 3), mask1(3), mask2(2, 3), mask3(2, 1, 3)
+    logical :: a2(3, 3), mask1(3), mask2(2, 3), mask3(2, 1, 3), mask4(3, 2), mask5(2, 3, 1)
     integer(kind=8) :: b5
     real(8) :: y1
     real :: z1
@@ -124,4 +124,12 @@ program continue_compilation_1
     if (q1) q1 = 1
     if (r1) r1 = 1.0
     if (c1) c1 = 'a'
+
+    mask4 = reshape([.true., .false., .true., .true., .false., .true.], [3, 2])
+    mask5 = reshape([.true., .false., .true., .true., .false., .true.], [2, 3, 1])
+
+    print *, sum(arr1, mask2)
+    print *, sum(arr1, mask2, 2)
+    print *, iparity(arr2, mask4)
+    print *, iparity(arr3, mask5, 3)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "8ad101b38d5135d4629d84600f75737af2bcbcbb1c420079695a33a9",
+    "infile_hash": "c0ede332ae72884a91d8951ed00beff22ee647f682e9193d44038a22",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "fe3e61ac6a890e121c49d4dfc7cbbdd6d5131fd0569020a70ed68d80",
+    "stderr_hash": "f1555f90c7a05bc89615ff8f3f7af17a3bbb81babbf700bc5afd1b29",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -286,3 +286,27 @@ semantic error: string expression, expected logical
     |
 126 |     if (c1) c1 = 'a'
     |         ^^ 
+
+semantic error: The dimensions of `array` and `mask` arguments of `Sum` intrinsic must be same
+   --> tests/errors/continue_compilation_1.f90:131:18
+    |
+131 |     print *, sum(arr1, mask2)
+    |                  ^^^^  ^^^^^ Incompatible ranks in arguments `array` and `mask` for (1, 2)
+
+semantic error: The dimensions of `array` and `mask` arguments of `Sum` intrinsic must be same
+   --> tests/errors/continue_compilation_1.f90:132:18
+    |
+132 |     print *, sum(arr1, mask2, 2)
+    |                  ^^^^  ^^^^^ Incompatible ranks in arguments `array` and `mask` for (1, 2)
+
+semantic error: The dimensions of `array` and `mask` arguments of `Iparity` intrinsic must be same
+   --> tests/errors/continue_compilation_1.f90:133:22
+    |
+133 |     print *, iparity(arr2, mask4)
+    |                      ^^^^  ^^^^^ Different shape for arguments `array` and `mask` on dimension 1
+
+semantic error: The dimensions of `array` and `mask` arguments of `Iparity` intrinsic must be same
+   --> tests/errors/continue_compilation_1.f90:134:22
+    |
+134 |     print *, iparity(arr3, mask5, 3)
+    |                      ^^^^  ^^^^^ Different shape for arguments `array` and `mask` on dimension 2


### PR DESCRIPTION
- Adds condition which check for the dimension of the provided array and mask array. And returns the error accordingly.