### PR TITLE
DRAFT: Fix issue with COMMON and ASR verify

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2316,39 +2316,65 @@ public:
         struct_type->n_members = members.size();
     }
 
-    ASR::Variable_t * get_symtab_var_for_common(AST::var_sym_t const &s) {
-	std::string const sym {to_lower(s.m_name)};
-	ASR::symbol_t *get_sym = current_scope->get_symbol(sym);
-	if (get_sym == nullptr) {
-	    if (compiler_options.implicit_typing) {
-		ASR::intentType intent = ASRUtils::intent_local;
-		get_sym = declare_implicit_variable2(s.loc, sym, intent, implicit_dictionary[std::string(1,sym[0])]);
-	    } else {
-		diag.add(Diagnostic(
-			     "Cannot implicitly declare variable in COMMON block",
-			     Level::Error, Stage::Semantic, {
-				 Label("",{s.loc})
-			     }));
-		throw SemanticAbort();
-	    }
-	}
 
-	ASR::Variable_t* var_{nullptr};
-	if (ASR::is_a<ASR::Variable_t>(*get_sym)) {
-	    var_ = ASR::down_cast<ASR::Variable_t>(get_sym);
-	} else {
-	    diag.add(Diagnostic(
-			 "Can only add variables to COMMON blocks",
-			 Level::Error, Stage::Semantic, {
-			     Label("",{s.loc})
-			 }));
-	    throw SemanticAbort();
-	}
-	return var_;
+    ASR::Variable_t* extract_common_variable(AST::expr_t const* expr, Location loc, Location var_loc) {
+        this->visit_expr(*expr);
+        ASR::Variable_t* var_{nullptr};
+        if (ASR::is_a<ASR::ArrayItem_t>(*ASRUtils::EXPR(tmp))) {
+            ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(ASRUtils::EXPR(tmp));
+            ASR::expr_t* array = array_item->m_v;
+            var_ = ASRUtils::EXPR2VAR(array);
+            if (ASRUtils::is_array(ASRUtils::expr_type(array))) {
+                diag.add(diag::Diagnostic(
+                    "Duplicate DIMENSION attribute specified",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {var_loc})}));
+                throw SemanticAbort();
+            } else {
+                if (array_item->n_args == 1) {
+                    ASR::array_index_t arg = array_item->m_args[0];
+                    ASR::expr_t* arg_right = arg.m_right;
+                    ASR::ttype_t* type = array_item->m_type;
+                    ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc,
+							    compiler_options.po.default_integer_kind));
+                    ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int_type));
+
+                    Vec<ASR::dimension_t> dims;
+                    dims.reserve(al, 1);
+                    ASR::dimension_t dim; dim.m_length = nullptr; dim.m_start = nullptr;
+                    dim.loc = loc;
+                    dim.m_start = one;
+                    dim.m_length = arg_right;
+                    dims.push_back(al, dim);
+
+                    if (ASR::is_a<ASR::Real_t>(*type)) {
+                        ASR::Real_t* real_type = ASR::down_cast<ASR::Real_t>(type);
+                        int64_t kind = real_type->m_kind;
+                        var_->m_type = ASRUtils::TYPE(ASR::make_Real_t(al, var_->base.base.loc, kind));
+                    } else if (ASR::is_a<ASR::Integer_t>(*type)) {
+                        ASR::Integer_t* int_type = ASR::down_cast<ASR::Integer_t>(type);
+                        int64_t kind = int_type->m_kind;
+                        var_->m_type = ASRUtils::TYPE(ASR::make_Integer_t(al, var_->base.base.loc, kind));
+                    } else {
+                        diag.add(diag::Diagnostic(
+                            "Type not supported yet",
+                            diag::Level::Error, diag::Stage::Semantic, {
+                                diag::Label("", {loc})}));
+                        throw SemanticAbort();
+                    }
+                    var_->m_type = ASRUtils::make_Array_t_util(
+                        al, var_->base.base.loc, var_->m_type,
+                        dims.p, dims.size(), var_->m_abi);
+                }
+            }
+        } else {
+            var_ = ASRUtils::EXPR2VAR(ASRUtils::EXPR(tmp));
+        }
+        return var_;
     }
 
-
     void populate_common_dictionary(const AST::Declaration_t &x, common_block_varsyms const & objs_by_blk) {
+
 	for (auto const & blk : objs_by_blk) {
 	    std::string const & common_block_name = blk.first;
 	    ASR::symbol_t* common_block_struct_sym = create_common_module(x.base.base.loc,
@@ -2366,8 +2392,7 @@ public:
 		// Add all the block variables
 		for (auto const &s : blk.second) {
 		    AST::expr_t* expr = s.m_initializer;
-		    this->visit_expr(*expr);
-		    ASR::Variable_t* var_ = get_symtab_var_for_common(s);
+		    ASR::Variable_t* var_ = extract_common_variable(expr, x.base.base.loc, s.loc);
 		    uint64_t hash = get_hash((ASR::asr_t*) var_);
 		    common_block_variables.push_back(ASRUtils::EXPR(tmp));
 		    // add variable to struct
@@ -2388,7 +2413,7 @@ public:
 		    for (auto const &s : blk.second) {
 			AST::expr_t* expr = s.m_initializer;
 			this->visit_expr(*expr);
-			ASR::Variable_t* var_ = get_symtab_var_for_common(s);
+			ASR::Variable_t* var_ = ASRUtils::EXPR2VAR(ASRUtils::EXPR(tmp));
 			uint64_t hash = get_hash((ASR::asr_t*) var_);
 			common_block_variables.push_back(ASRUtils::EXPR(tmp));
 			common_variables_hash[hash] = common_block_struct_sym;
@@ -2931,7 +2956,7 @@ public:
 			    objs_by_blk[common_block_name].push_back(vs);
 			    if (vs.n_dim) {
 				/* Treat this as a dimension statement. */
-				dimension_variable(vs, x.base.base.loc);
+				// dimension_variable(vs, x.base.base.loc);
 			    }
 			}
 		    }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1223,6 +1223,7 @@ public:
     bool is_current_procedure_templated = false;
     bool is_Function = false;
     bool in_Subroutine = false;
+    bool is_common_variable = false;
     bool _processing_dimensions = false;
     bool _declaring_variable = false;
     bool is_implicit_interface = false;
@@ -2382,6 +2383,7 @@ public:
 	    ASR::Struct_t* struct_type = ASR::down_cast<ASR::Struct_t>(common_block_struct_sym);
 	    size_t const num_cb_var = blk.second.size();
 
+	    is_common_variable = true;  // This changes the behavior of visit_FuncCallOrArray
 	    auto cbd_it = common_block_dictionary.find(common_block_name);
 
 	    if (cbd_it == common_block_dictionary.end()) {
@@ -2486,6 +2488,7 @@ public:
 		    }
 		}
 	    }
+	    is_common_variable = false;
 	}
     }
 
@@ -7737,7 +7740,8 @@ public:
                 throw SemanticAbort();
             }
         }
-        if (( ASR::is_a<ASR::Variable_t>(*v) || is_external_procedure )
+        if (!is_common_variable
+	    && (ASR::is_a<ASR::Variable_t>(*v) || is_external_procedure )
             && (!ASRUtils::is_array(ASRUtils::symbol_type(v)))
             && (!ASRUtils::is_character(*ASRUtils::symbol_type(v)))) {
             if (intrinsic_procedures.is_intrinsic(var_name) || is_intrinsic_registry_function(var_name)) {


### PR DESCRIPTION
Attempting to compile the code in #5701 leads to a ICE in the ASR verify pass:
```
ASR verify pass error: ExternalSymbol::m_external cannot be an ExternalSymbol
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/phenning/LFortran/devel/src/bin/lfortran.cpp", line 2774, in main
    return main_app(argc, argv);
  File "/Users/phenning/LFortran/devel/src/bin/lfortran.cpp", line 2712, in main_app(int, char**)
    err = compile_src_to_object_file(arg_file, tmp_o, false,
  File "/Users/phenning/LFortran/devel/src/bin/lfortran.cpp", line 1052, in (anonymous namespace)::compile_src_to_object_file(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, LCompilers::CompilerOptions&, LCompilers::PassManager&)
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile);
  File "/Users/phenning/LFortran/devel/src/lfortran/fortran_evaluator.cpp", line 380, in LCompilers::FortranEvaluator::get_llvm3(LCompilers::ASR::TranslationUnit_t&, LCompilers::PassManager&, LCompilers::diag::Diagnostics&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
    = asr_to_llvm(asr, diagnostics,
  File "/Users/phenning/LFortran/devel/src/libasr/codegen/asr_to_llvm.cpp", line 10596, in LCompilers::asr_to_llvm(LCompilers::ASR::TranslationUnit_t&, LCompilers::diag::Diagnostics&, llvm::LLVMContext&, Allocator&, LCompilers::PassManager&, LCompilers::CompilerOptions&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
    pass_manager.apply_passes(al, &asr, co.po, diagnostics);
  File "/Users/phenning/LFortran/devel/src/libasr/pass/pass_manager.h", line 403, in LCompilers::PassManager::apply_passes(Allocator&, LCompilers::ASR::TranslationUnit_t*, LCompilers::PassOptions&, LCompilers::diag::Diagnostics&)
    apply_passes(al, asr, _passes_with_experimental_simplifier, pass_options, diagnostics);
  File "/Users/phenning/LFortran/devel/src/libasr/pass/pass_manager.h", line 184, in LCompilers::PassManager::apply_passes(Allocator&, LCompilers::ASR::TranslationUnit_t*, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, LCompilers::PassOptions&, LCompilers::diag::Diagnostics&)
    throw LCompilersException("Verify failed in the pass: "
LCompilersException: Verify failed in the pass: nested_vars
```

This reverts commit b6233f3d0c4e815ea60798f0c75ce334a950d628 until I have time to properly fix #5701