### PR TITLE
chore: throw semantic error for invalid arguments to intrinsic `present`

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -132,4 +132,10 @@ program continue_compilation_1
     print *, sum(arr2, mask3, 2)
     print *, iparity(arr2, mask4)
     print *, iparity(arr3, mask5, 3)
+
+    ! argument_not_a_variable
+    print *, present(a + 1)
+
+    ! argument_not_optional
+    print *, present(a)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "eed08a3cd2877a6eda3bbda31b70d5a16124190caee1da55b57bd246",
+    "infile_hash": "f9862cd9093623b800e65965bd7433316bcb835ed84ef329c9189db8",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "7d038f42ad4e03c7c5cd658b6334f3fd1a2a621118cbdc56459cab33",
+    "stderr_hash": "62019bc1207ab781e1915a2e904a972bcc85025ea56adc370f384bd1",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -310,3 +310,15 @@ semantic error: The shapes of the `array` and `mask` arguments of the `Iparity` 
     |
 134 |     print *, iparity(arr3, mask5, 3)
     |                      ^^^^  ^^^^^ `array` has shape [2,1,3], but `mask` has shape [2,3,1]
+
+semantic error: Argument to 'present' must be a variable, but got an expression
+   --> tests/errors/continue_compilation_1.f90:137:14
+    |
+137 |     print *, present(a + 1)
+    |              ^^^^^^^^^^^^^^ 
+
+semantic error: Argument to 'present' must be an optional dummy argument
+   --> tests/errors/continue_compilation_1.f90:140:14
+    |
+140 |     print *, present(a)
+    |              ^^^^^^^^^^ 


### PR DESCRIPTION
fixes #6074 

```
program main
  call a()
  contains
  subroutine a(ii)
    integer ,optional :: ii
    integer :: mm
    if(present(mm)) print *, "bug"
  end subroutine a

end program main
```

Output:
```
semantic error: Argument to 'present' must be an optional dummy argument
 --> temp.f90:7:8
  |
7 |     if(present(mm)) print *, "bug"
  |        ^^^^^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```