### PR TITLE
fix : Handling Array Size in Function call in Pass array by data using Deep copy

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -469,6 +469,7 @@ RUN(NAME arrays_04_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackA
 RUN(NAME arrays_05_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_06_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_07_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME arrays_08_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME matrix_01_transpose LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME matrix_02_matmul LABELS gfortran fortran)
 RUN(NAME array_01_pack LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/arrays_08_size.f90
+++ b/integration_tests/arrays_08_size.f90
@@ -1,0 +1,30 @@
+program arrays_08_size
+   integer :: y = 2
+   call temp(y)
+
+contains
+   subroutine temp(x)
+        integer, intent(inout) :: x
+        logical :: keep(x)
+        integer :: result(x)
+        keep = [.false., .true.]
+        x = 1
+        result = trueloc(keep)
+        print * , result
+        if (result(1) /= 2) error stop
+   end subroutine
+   function trueloc(x) result(loc)
+        logical, intent(in) :: x(:)
+        integer(4), allocatable :: loc(:)
+        integer :: i, j
+        allocate(loc(count(x)))
+        j = 1
+        do i = 1, size(x)
+            if( x(i) ) then
+                loc(j) = i
+                j = j + 1
+            end if
+        end do
+    end function trueloc
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8901,7 +8901,11 @@ public:
                     ASR::Variable_t *arg = EXPR2VAR(x.m_args[i].m_value);
                     uint32_t h = get_hash((ASR::asr_t*)arg);
                     if (llvm_symtab.find(h) != llvm_symtab.end()) {
-                        tmp = llvm_symtab[h];
+                        if (llvm_symtab_deep_copy.find(h) != llvm_symtab_deep_copy.end()) {
+                            tmp = llvm_symtab_deep_copy[h];
+                        } else {
+                            tmp = llvm_symtab[h];
+                        }
                         if( !ASRUtils::is_array(arg->m_type) ) {
 
                             if (x_abi == ASR::abiType::Source && ASR::is_a<ASR::CPtr_t>(*arg->m_type)) {


### PR DESCRIPTION
fix #6147 

MRE
```console
program arrays_08_size
   integer :: y = 2
   call temp(y)

contains
   subroutine temp(x)
        integer, intent(inout) :: x
        logical :: keep(x)
        integer :: result(x)
        keep = [.false., .true.]
        x = 1
        result = trueloc(keep)
        print * , result
   end subroutine
   function trueloc(x) result(loc)
        logical, intent(in) :: x(:)
        integer(4), allocatable :: loc(:)
        integer :: i, j
        allocate(loc(count(x)))
        j = 1
        do i = 1, size(x)
            if( x(i) ) then
                loc(j) = i
                j = j + 1
            end if
        end do
    end function trueloc

end program
```

LFortran output
```console
(lf) lordansh@LordAnsh:~/dev/lfort3/lfortran$ lfortran try.f90
2
0
```