### PR TITLE
fix: return type of `spread` by not making it allocatable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1028,6 +1028,7 @@ RUN(NAME intrinsics_348 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ON
 
 RUN(NAME intrinsics_349 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran ONLY_EXPERIMENTAL_SIMPLIFIER) # pack
 RUN(NAME intrinsics_350 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # spread
+RUN(NAME intrinsics_351 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # spread
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/intrinsics_351.f90
+++ b/integration_tests/intrinsics_351.f90
@@ -1,0 +1,9 @@
+program intrinsics_351
+integer, allocatable :: i(:)
+integer :: ii(4,4)
+allocate(i(4))
+i = [1,2,3,4]
+ii = spread(i, dim = 2, ncopies=4)
+print *, sum(ii)
+if ( sum(ii) /= 40 ) error stop
+end program intrinsics_351

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1972,12 +1972,7 @@ namespace Spread {
     static inline ASR::asr_t* create_Spread(Allocator& al, const Location& loc,
             Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
         ASR::expr_t *source = args[0], *dim = args[1], *ncopies = args[2];
-        bool is_type_allocatable = false;
         bool is_scalar = false;
-
-        if (ASRUtils::is_allocatable(source)) {
-            is_type_allocatable = true;
-        }
         ASR::ttype_t *type_source = ASRUtils::type_get_past_allocatable_pointer(expr_type(source));
         ASR::ttype_t *type_dim = ASRUtils::type_get_past_allocatable_pointer(expr_type(dim));
         ASR::ttype_t *type_ncopies = ASRUtils::type_get_past_allocatable_pointer(expr_type(ncopies));
@@ -2045,13 +2040,6 @@ namespace Spread {
                 result_dims.push_back(al, dim);
             }
             ret_type = ASRUtils::duplicate_type(al, ret_type, &result_dims);
-        }
-        if (is_type_allocatable) {
-            if ( use_experimental_simplifier ) {
-                ret_type = TYPE(ASRUtils::make_Allocatable_t_util(al, loc, ret_type));
-            } else {
-                ret_type = TYPE(ASR::make_Allocatable_t(al, loc, ret_type));
-            }
         }
         Vec<ASR::expr_t*> m_args; m_args.reserve(al, 3);
         m_args.push_back(al, source); m_args.push_back(al, dim);


### PR DESCRIPTION
Fixes #5938