### PR TITLE
throw correct error message for reshape intrinsic 

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6323,15 +6323,13 @@ public:
         this->visit_expr(*shape);
         ASR::expr_t* newshape = ASRUtils::EXPR(tmp);
         if( !ASRUtils::is_array(ASRUtils::expr_type(array)) ) {
-            diag.add(Diagnostic("reshape only accept arrays for source "
-                "arguments, found " +
+            diag.add(Diagnostic("reshape accepts arrays for `source` argument, found " +
                 ASRUtils::type_to_str_python(ASRUtils::expr_type(array)) +
                 " instead.", Level::Error, Stage::Semantic, {Label("", {x.m_args[0].loc})}));
             throw SemanticAbort();
         }
         if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
-            diag.add(Diagnostic("reshape only accept arrays for shape "
-                "arguments, found " +
+            diag.add(Diagnostic("reshape accepts arrays for `shape` argument, found " +
                 ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
                 " instead.", Level::Error, Stage::Semantic, {Label("", {x.m_args[1].loc})}));
             throw SemanticAbort();

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6322,11 +6322,18 @@ public:
         ASR::expr_t* array = ASRUtils::EXPR(tmp);
         this->visit_expr(*shape);
         ASR::expr_t* newshape = ASRUtils::EXPR(tmp);
+        if( !ASRUtils::is_array(ASRUtils::expr_type(array)) ) {
+            diag.add(Diagnostic("reshape only accept arrays for source "
+                "arguments, found " +
+                ASRUtils::type_to_str_python(ASRUtils::expr_type(array)) +
+                " instead.", Level::Error, Stage::Semantic, {Label("", {x.m_args[0].loc})}));
+            throw SemanticAbort();
+        }
         if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
             diag.add(Diagnostic("reshape only accept arrays for shape "
                 "arguments, found " +
                 ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
-                " instead.", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                " instead.", Level::Error, Stage::Semantic, {Label("", {x.m_args[1].loc})}));
             throw SemanticAbort();
         }
         ASR::array_physical_typeType array_physical_type = ASRUtils::extract_physical_type(

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -138,4 +138,9 @@ program continue_compilation_1
 
     ! argument_not_optional
     print *, present(a)
+
+    print *, reshape("hello", [2, 3])
+    print *, reshape(.true., [2, 3])
+    print *, reshape([1, 2, 3, 4], "hello")
+    print *, reshape([1, 2, 3, 4], .false.)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "f9862cd9093623b800e65965bd7433316bcb835ed84ef329c9189db8",
+    "infile_hash": "75d2e702563a89d2e022394b4186a695ba0d5fe2758ce52a42d97d27",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "62019bc1207ab781e1915a2e904a972bcc85025ea56adc370f384bd1",
+    "stderr_hash": "fc595097992bbf508ee9b62e8d9dd88b8881fcf093a21503df28f044",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "fc595097992bbf508ee9b62e8d9dd88b8881fcf093a21503df28f044",
+    "stderr_hash": "e3d3bdfb741a61da8936e91244acb6331c375a4728812707a599364e",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -323,25 +323,25 @@ semantic error: Argument to 'present' must be an optional dummy argument
 140 |     print *, present(a)
     |              ^^^^^^^^^^ 
 
-semantic error: reshape only accept arrays for source arguments, found str instead.
+semantic error: reshape accepts arrays for `source` argument, found str instead.
    --> tests/errors/continue_compilation_1.f90:142:22
     |
 142 |     print *, reshape("hello", [2, 3])
     |                      ^^^^^^^ 
 
-semantic error: reshape only accept arrays for source arguments, found bool instead.
+semantic error: reshape accepts arrays for `source` argument, found bool instead.
    --> tests/errors/continue_compilation_1.f90:143:22
     |
 143 |     print *, reshape(.true., [2, 3])
     |                      ^^^^^^ 
 
-semantic error: reshape only accept arrays for shape arguments, found str instead.
+semantic error: reshape accepts arrays for `shape` argument, found str instead.
    --> tests/errors/continue_compilation_1.f90:144:36
     |
 144 |     print *, reshape([1, 2, 3, 4], "hello")
     |                                    ^^^^^^^ 
 
-semantic error: reshape only accept arrays for shape arguments, found bool instead.
+semantic error: reshape accepts arrays for `shape` argument, found bool instead.
    --> tests/errors/continue_compilation_1.f90:145:36
     |
 145 |     print *, reshape([1, 2, 3, 4], .false.)

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -322,3 +322,27 @@ semantic error: Argument to 'present' must be an optional dummy argument
     |
 140 |     print *, present(a)
     |              ^^^^^^^^^^ 
+
+semantic error: reshape only accept arrays for source arguments, found str instead.
+   --> tests/errors/continue_compilation_1.f90:142:22
+    |
+142 |     print *, reshape("hello", [2, 3])
+    |                      ^^^^^^^ 
+
+semantic error: reshape only accept arrays for source arguments, found bool instead.
+   --> tests/errors/continue_compilation_1.f90:143:22
+    |
+143 |     print *, reshape(.true., [2, 3])
+    |                      ^^^^^^ 
+
+semantic error: reshape only accept arrays for shape arguments, found str instead.
+   --> tests/errors/continue_compilation_1.f90:144:36
+    |
+144 |     print *, reshape([1, 2, 3, 4], "hello")
+    |                                    ^^^^^^^ 
+
+semantic error: reshape only accept arrays for shape arguments, found bool instead.
+   --> tests/errors/continue_compilation_1.f90:145:36
+    |
+145 |     print *, reshape([1, 2, 3, 4], .false.)
+    |                                    ^^^^^^^ 


### PR DESCRIPTION
Fixes: #6158 

- Handles correct error squiggles and throwing error when provided source argument which is not a array