### PR TITLE
throw correct error message for reshape intrinsic

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6322,11 +6322,16 @@ public:
         ASR::expr_t* array = ASRUtils::EXPR(tmp);
         this->visit_expr(*shape);
         ASR::expr_t* newshape = ASRUtils::EXPR(tmp);
+        if( !ASRUtils::is_array(ASRUtils::expr_type(array)) ) {
+            diag.add(Diagnostic("reshape accepts arrays for `source` argument, found " +
+                ASRUtils::type_to_str_python(ASRUtils::expr_type(array)) +
+                " instead.", Level::Error, Stage::Semantic, {Label("", {x.m_args[0].loc})}));
+            throw SemanticAbort();
+        }
         if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
-            diag.add(Diagnostic("reshape only accept arrays for shape "
-                "arguments, found " +
+            diag.add(Diagnostic("reshape accepts arrays for `shape` argument, found " +
                 ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
-                " instead.", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                " instead.", Level::Error, Stage::Semantic, {Label("", {x.m_args[1].loc})}));
             throw SemanticAbort();
         }
         ASR::array_physical_typeType array_physical_type = ASRUtils::extract_physical_type(

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -140,4 +140,9 @@ program continue_compilation_1
     print *, present(a)
 
     print *, pack([1, 2, 3], [.true., .true., .true., .true.])
+
+    print *, reshape("hello", [2, 3])
+    print *, reshape(.true., [2, 3])
+    print *, reshape([1, 2, 3, 4], "hello")
+    print *, reshape([1, 2, 3, 4], .false.)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "e9368752aa076dccdc25709ca2585de5a4923824517c66ebf697fd90",
+    "infile_hash": "22e9c04b575fcb2f1cd796447b1ce85404c920c6d6029c25738167a3",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "0c7c49ad630aeb5280c8e5cd563b12cdd85b0f77498da9400ff91d93",
+    "stderr_hash": "faa5a134351502eda91f5151f241ed51cbc025129f838b5f770da832",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -328,3 +328,27 @@ semantic error: Different shape for arguments `array` and `mask` for pack intrin
     |
 142 |     print *, pack([1, 2, 3], [.true., .true., .true., .true.])
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: reshape accepts arrays for `source` argument, found str instead.
+   --> tests/errors/continue_compilation_1.f90:144:22
+    |
+144 |     print *, reshape("hello", [2, 3])
+    |                      ^^^^^^^ 
+
+semantic error: reshape accepts arrays for `source` argument, found bool instead.
+   --> tests/errors/continue_compilation_1.f90:145:22
+    |
+145 |     print *, reshape(.true., [2, 3])
+    |                      ^^^^^^ 
+
+semantic error: reshape accepts arrays for `shape` argument, found str instead.
+   --> tests/errors/continue_compilation_1.f90:146:36
+    |
+146 |     print *, reshape([1, 2, 3, 4], "hello")
+    |                                    ^^^^^^^ 
+
+semantic error: reshape accepts arrays for `shape` argument, found bool instead.
+   --> tests/errors/continue_compilation_1.f90:147:36
+    |
+147 |     print *, reshape([1, 2, 3, 4], .false.)
+    |                                    ^^^^^^^ 


### PR DESCRIPTION
Fixes: #6158 

- Handles correct error squiggles and throwing error when provided source argument which is not a array