### PR TITLE
fix: throw error in array intrinsic if argument is not of the required type

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -635,6 +635,26 @@ static inline ASR::asr_t* create_ArrIntrinsic(
     ASR::expr_t *dim = nullptr;
     ASR::expr_t *mask = nullptr;
     ASR::ttype_t* array_type = ASRUtils::expr_type(array);
+    if (intrinsic_func_name == "Sum" || intrinsic_func_name == "Product"){
+        if (!is_integer(*array_type) && !is_real(*array_type) && !is_complex(*array_type)) {
+            diag.add(diag::Diagnostic("Input to `" + intrinsic_func_name + "EXpected to be numeric, but got " +
+            type_to_str(array_type), 
+            diag::Level::Error, 
+            diag::Stage::Semantic, 
+            {diag::Label("Input to `" + intrinsic_func_name + "` intrinsic must be of integer, real or complex type", { args[0]->base.loc })}));
+            return nullptr;
+        }
+    }
+    if (intrinsic_func_name == "MinVal" || intrinsic_func_name == "MaxVal"){
+        if (!is_integer(*array_type) && !is_real(*array_type) && !is_character(*array_type)) {
+            diag.add(diag::Diagnostic("Input to `" + intrinsic_func_name + "EXpected to be integer, real or string type but got " +
+            type_to_str(array_type), 
+            diag::Level::Error, 
+            diag::Stage::Semantic, 
+            {diag::Label("Input to `" + intrinsic_func_name + "` intrinsic must be of integer, real or complex type", { args[0]->base.loc })}));
+            return nullptr;
+        }
+    }
     if (args[1]) {
         if (is_integer(*ASRUtils::expr_type(args[1]))) {
             dim = args[1];

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -145,4 +145,10 @@ program continue_compilation_1
     print *, reshape(.true., [2, 3])
     print *, reshape([1, 2, 3, 4], "hello")
     print *, reshape([1, 2, 3, 4], .false.)
+
+    complex :: c = (1.0, 2.0)
+    print *, sum([c1])
+    print *, product([c1])
+    print *, minval(c)
+    print *, maxval(c)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "22e9c04b575fcb2f1cd796447b1ce85404c920c6d6029c25738167a3",
+    "infile_hash": "b8b45f7f46fecbee0c485c97c8d194ad204ab061283a075b47c075ff",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "faa5a134351502eda91f5151f241ed51cbc025129f838b5f770da832",
+    "stderr_hash": "5cdb86823a2b49038d8ffcdab5d2050f736336c6d1e1c625f2be2757",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -352,3 +352,27 @@ semantic error: reshape accepts arrays for `shape` argument, found bool instead.
     |
 147 |     print *, reshape([1, 2, 3, 4], .false.)
     |                                    ^^^^^^^ 
+
+semantic error: Input to `SumEXpected to be numeric, but got string[:]
+   --> tests/errors/continue_compilation_1.f90:150:18
+    |
+150 |     print *, sum([c1])
+    |                  ^^^^ Input to `Sum` intrinsic must be of integer, real or complex type
+
+semantic error: Input to `ProductEXpected to be numeric, but got string[:]
+   --> tests/errors/continue_compilation_1.f90:151:22
+    |
+151 |     print *, product([c1])
+    |                      ^^^^ Input to `Product` intrinsic must be of integer, real or complex type
+
+semantic error: Input to `MinValEXpected to be integer, real or string type but got complex
+   --> tests/errors/continue_compilation_1.f90:152:21
+    |
+152 |     print *, minval(c)
+    |                     ^ Input to `MinVal` intrinsic must be of integer, real or complex type
+
+semantic error: Input to `MaxValEXpected to be integer, real or string type but got complex
+   --> tests/errors/continue_compilation_1.f90:153:21
+    |
+153 |     print *, maxval(c)
+    |                     ^ Input to `MaxVal` intrinsic must be of integer, real or complex type


### PR DESCRIPTION
Towards #6187 
Fix for intrinsic function `Sum`, `Product`, `Minval`, `Maxval`