### PR TITLE
throw correct error message for `shiftl`, `shiftr` and `rshift`

### DIFF
--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1351,9 +1351,21 @@ namespace Sign {
 namespace Shiftr {
 
     static ASR::expr_t *eval_Shiftr(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int64_t val1 = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
         int64_t val2 = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+        int kind = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
+        if(val2 < 0) {
+            append_error(diag, "The shift argument of 'shiftr' intrinsic must be non-negative integer", args[1]->base.loc);
+            return nullptr;
+        }
+        int k_val = kind * 8;
+        if (val2 > k_val) {
+            diag.add(diag::Diagnostic("The shift argument of 'shiftr' intrinsic must be less than or equal to the bit size of the integer", diag::Level::Error,
+            diag::Stage::Semantic, {diag::Label("Shift value is " + std::to_string(val2) +
+            ", but bit size of integer is " + std::to_string(k_val), { args[1]->base.loc })}));
+            return nullptr;
+        }
         int64_t val = val1 >> val2;
         return make_ConstantWithType(make_IntegerConstant_t, val, t1, loc);
     }
@@ -1387,9 +1399,21 @@ namespace Shiftr {
 namespace Rshift {
 
     static ASR::expr_t *eval_Rshift(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int64_t val1 = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
         int64_t val2 = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+        int kind = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
+        if(val2 < 0) {
+            append_error(diag, "The shift argument of 'rshift' intrinsic must be non-negative integer", args[1]->base.loc);
+            return nullptr;
+        }
+        int k_val = kind * 8;
+        if (val2 > k_val) {
+            diag.add(diag::Diagnostic("The shift argument of 'rshift' intrinsic must be less than or equal to the bit size of the integer", diag::Level::Error,
+            diag::Stage::Semantic, {diag::Label("Shift value is " + std::to_string(val2) +
+            ", but bit size of integer is " + std::to_string(k_val), { args[1]->base.loc })}));
+            return nullptr;
+        }
         int64_t val = val1 >> val2;
         return make_ConstantWithType(make_IntegerConstant_t, val, t1, loc);
     }
@@ -1419,9 +1443,21 @@ namespace Rshift {
 namespace Shiftl {
 
     static ASR::expr_t *eval_Shiftl(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         int64_t val1 = ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
         int64_t val2 = ASR::down_cast<ASR::IntegerConstant_t>(args[1])->m_n;
+        int kind = ASRUtils::extract_kind_from_ttype_t(ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_type);
+        if(val2 < 0) {
+            append_error(diag, "The shift argument of 'shiftl' intrinsic must be non-negative integer", args[1]->base.loc);
+            return nullptr;
+        }
+        int k_val = kind * 8;
+        if (val2 > k_val) {
+            diag.add(diag::Diagnostic("The shift argument of 'shiftl' intrinsic must be less than or equal to the bit size of the integer", diag::Level::Error,
+            diag::Stage::Semantic, {diag::Label("Shift value is " + std::to_string(val2) +
+            ", but bit size of integer is " + std::to_string(k_val), { args[1]->base.loc })}));
+            return nullptr;
+        }
         int64_t val = val1 << val2;
         return make_ConstantWithType(make_IntegerConstant_t, val, t1, loc);
     }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -157,4 +157,11 @@ program continue_compilation_1
     character(10) :: str
     print *, v**str
     print *, str**v
+
+    print *, shiftl(2, 34)
+    print *, shiftl(2, -3)
+    print *, shiftr(2, 34)
+    print *, shiftr(2, -3)
+    print *, rshift(2, 34)
+    print *, rshift(2, -3)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "fa82abca610c72ff5e5886c74b988a6fa71435907bd11193d99e65db",
+    "infile_hash": "68c06eaf0ab2044751a642861b0df7a9d2d3c0d8699a293dff4f3bb6",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "e970b6ecb7a35920f32a3c38fc0371030ea77124b3a992d2b3a91470",
+    "stderr_hash": "07ad574662f740308121e921d44afe3107f250bc82526c0876082810",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -382,3 +382,39 @@ semantic error: Type mismatch in binary operator, the types must be compatible
     |
 159 |     print *, str**v
     |              ^^^  ^ type mismatch (string and real)
+
+semantic error: The shift argument of 'shiftl' intrinsic must be less than or equal to the bit size of the integer
+   --> tests/errors/continue_compilation_1.f90:161:24
+    |
+161 |     print *, shiftl(2, 34)
+    |                        ^^ Shift value is 34, but bit size of integer is 32
+
+semantic error: The shift argument of 'shiftl' intrinsic must be non-negative integer
+   --> tests/errors/continue_compilation_1.f90:162:24
+    |
+162 |     print *, shiftl(2, -3)
+    |                        ^^ 
+
+semantic error: The shift argument of 'shiftr' intrinsic must be less than or equal to the bit size of the integer
+   --> tests/errors/continue_compilation_1.f90:163:24
+    |
+163 |     print *, shiftr(2, 34)
+    |                        ^^ Shift value is 34, but bit size of integer is 32
+
+semantic error: The shift argument of 'shiftr' intrinsic must be non-negative integer
+   --> tests/errors/continue_compilation_1.f90:164:24
+    |
+164 |     print *, shiftr(2, -3)
+    |                        ^^ 
+
+semantic error: The shift argument of 'rshift' intrinsic must be less than or equal to the bit size of the integer
+   --> tests/errors/continue_compilation_1.f90:165:24
+    |
+165 |     print *, rshift(2, 34)
+    |                        ^^ Shift value is 34, but bit size of integer is 32
+
+semantic error: The shift argument of 'rshift' intrinsic must be non-negative integer
+   --> tests/errors/continue_compilation_1.f90:166:24
+    |
+166 |     print *, rshift(2, -3)
+    |                        ^^ 


### PR DESCRIPTION
Fixes: #6202 

- Throw correct error message for `shiftl`, `shiftr` and `rshift` intrinsic when provided incorrect `shift` value.