### PR TITLE
Raise error for LOGICAL to REAL conversion

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3556,7 +3556,13 @@ public:
                         value = init_expr;
                     }
                     ASR::ttype_t *init_type = ASRUtils::expr_type(init_expr);
-
+                    // if (type=real and init_type=logical) Raise a semantic error
+                    diag.add(Diagnostic(
+                        "Cannot convert LOGICAL to REAL at assignment",
+                        Level::Error, Stage::Semantic, {
+                            Label("", {init_expr->base.loc})
+                        }));
+                    throw SemanticAbort();
                     size_t rhs_rank = ASRUtils::extract_n_dims_from_ttype(init_type);
                     size_t lhs_rank = ASRUtils::extract_n_dims_from_ttype(type);
 


### PR DESCRIPTION
Fixed -#5431
- This PR modifies the error handling for invalid LOGICAL to REAL assignments.