### PR TITLE
fix: consider only `intent(in)` scalar argument while creating dimension for temporary

### DIFF
--- a/integration_tests/functions_32.f90
+++ b/integration_tests/functions_32.f90
@@ -18,17 +18,20 @@ program function_32
     use function_32_mod
     real(8) :: x(5,2)
     integer :: iact(2)
+    integer :: nact
     real(8) :: full_size(10)
     iact = [2,1]
+    nact = -1
     full_size = return_type_check(x(:,iact)) + 1.0_8
     if(any(full_size /= 2.0_8)) error stop
     x = matprod(x(:,iact), x(:, iact)) + 1.0_8
     if(any(x /= 2.0_8)) error stop
-    call func(x, iact)
+    call func(x, iact, nact)
 contains 
-subroutine func(x, iact)
+subroutine func(x, iact, nact)
     real(8), intent(in) :: x(:,:)
     integer, intent(inout) :: iact(:)
+    integer, intent(inout) :: nact
     real(8) :: bmat(2, 2 + size(x,1))
     real(8) :: yzmat_c(2, size(x,2))
     real(8) :: tmp_x(size(x,1) * size(x,2))
@@ -40,5 +43,8 @@ subroutine func(x, iact)
     if(any(tmp_x /= 2.0_8)) error stop
     yzmat_c = matprod(x(iact, :), x(:, iact)) + 1.0_8
     if(any(yzmat_c /= 2.0_8)) error stop
+    nact = 2
+    bmat(:, 1:nact) = -matprod(yzmat_c, x(:, 1:nact))
+    if(any(bmat(:,1:nact) /= -1.0_8)) error stop
 end subroutine
 end program 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2401,6 +2401,11 @@ static inline bool is_only_upper_bound_empty(ASR::dimension_t& dim) {
     return (dim.m_start != nullptr && dim.m_length == nullptr);
 }
 
+inline bool is_array(ASR::ttype_t *x) {
+    ASR::dimension_t* dims = nullptr;
+    return extract_dimensions_from_ttype(x, dims) > 0;
+}
+
 class ExprDependentOnlyOnArguments: public ASR::BaseWalkVisitor<ExprDependentOnlyOnArguments> {
 
     public:
@@ -2413,7 +2418,11 @@ class ExprDependentOnlyOnArguments: public ASR::BaseWalkVisitor<ExprDependentOnl
         void visit_Var(const ASR::Var_t& x) {
             if( ASR::is_a<ASR::Variable_t>(*x.m_v) ) {
                 ASR::Variable_t* x_m_v = ASR::down_cast<ASR::Variable_t>(x.m_v);
-                is_dependent_only_on_argument = is_dependent_only_on_argument && ASRUtils::is_arg_dummy(x_m_v->m_intent);
+                if ( ASRUtils::is_array(x_m_v->m_type) ) {
+                    is_dependent_only_on_argument = is_dependent_only_on_argument && ASRUtils::is_arg_dummy(x_m_v->m_intent);
+                } else {
+                    is_dependent_only_on_argument = is_dependent_only_on_argument && (x_m_v->m_intent == ASR::intentType::In);
+                }
             } else {
                 is_dependent_only_on_argument = false;
             }
@@ -2439,11 +2448,6 @@ static inline bool is_dimension_dependent_only_on_arguments(ASR::ttype_t* type) 
     ASR::dimension_t* m_dims;
     size_t n_dims = ASRUtils::extract_dimensions_from_ttype(type, m_dims);
     return is_dimension_dependent_only_on_arguments(m_dims, n_dims);
-}
-
-inline bool is_array(ASR::ttype_t *x) {
-    ASR::dimension_t* dims = nullptr;
-    return extract_dimensions_from_ttype(x, dims) > 0;
 }
 
 static inline bool is_binop_expr(ASR::expr_t* x) {

--- a/tests/reference/asr-template_04-f41dd3e.json
+++ b/tests/reference/asr-template_04-f41dd3e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_04-f41dd3e.stdout",
-    "stdout_hash": "0a303d98de91848f20a76e2308c1469e3dc53d15b5b647572ed90c4c",
+    "stdout_hash": "5e83202d6ba4154df9579869f060f23af1012a16406108b1b05a7478",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_04-f41dd3e.stdout
+++ b/tests/reference/asr-template_04-f41dd3e.stdout
@@ -16416,7 +16416,7 @@
                                                                                                         )
                                                                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                         (Var 113 n))]
-                                                                                                        PointerToDataArray
+                                                                                                        DescriptorArray
                                                                                                     )
                                                                                                     ()
                                                                                                     ()
@@ -18050,7 +18050,7 @@
                                                                                 (Var 113 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 113 n))]
-                                                                                PointerToDataArray
+                                                                                DescriptorArray
                                                                             )
                                                                             ()
                                                                             ()

--- a/tests/reference/asr-template_array_05-ae2710a.json
+++ b/tests/reference/asr-template_array_05-ae2710a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_05-ae2710a.stdout",
-    "stdout_hash": "d71406cf3259d9ad20b054599bdbef369092394b4c7b5740b1f390bf",
+    "stdout_hash": "36d8194507dd4d635351490861f0bafa52a54595ff32b2295d336e00",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_array_05-ae2710a.stdout
+++ b/tests/reference/asr-template_array_05-ae2710a.stdout
@@ -1109,7 +1109,7 @@
                                                                 (Var 9 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 9 n))]
-                                                                PointerToDataArray
+                                                                DescriptorArray
                                                             )
                                                             ()
                                                             ()
@@ -1584,7 +1584,7 @@
                                                                 )
                                                                 [((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 5 n))]
-                                                                PointerToDataArray
+                                                                DescriptorArray
                                                             )
                                                             ()
                                                             ()

--- a/tests/reference/asr-template_matrix_01-65b17ae.json
+++ b/tests/reference/asr-template_matrix_01-65b17ae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_matrix_01-65b17ae.stdout",
-    "stdout_hash": "e1e6cb75a2c6ecc06ce99366fc7c240caa58c8da505c0ff91ff6fb14",
+    "stdout_hash": "e07d6554cc08a56e41f48d9b4476a41d77ec8c38b29b5749b8e2e092",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_matrix_01-65b17ae.stdout
+++ b/tests/reference/asr-template_matrix_01-65b17ae.stdout
@@ -1620,7 +1620,7 @@
                                                                 (Var 5 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 5 n))]
-                                                                PointerToDataArray
+                                                                DescriptorArray
                                                             )
                                                             ()
                                                             ()


### PR DESCRIPTION
Fixes #6205 

Removes : https://github.com/Pranavchiku/prima/commit/c79a877e98ffc6c9b9bd33d77ff5024e01d92716
Removes : https://github.com/Pranavchiku/prima/commit/99dbeb7fd7ee5e5635df08d3510bc41cf91437f9
