### PR TITLE
Fix operator overloading 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1231,6 +1231,7 @@ RUN(NAME operator_overloading_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_04 LABELS gfortran llvm)
 RUN(NAME operator_overloading_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
+RUN(NAME operator_overloading_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_08.f90
+++ b/integration_tests/operator_overloading_08.f90
@@ -1,0 +1,24 @@
+module operator_overloading_08_mod1
+    type :: custom_int
+        integer :: value
+    end type custom_int
+
+    interface operator(/)
+        module procedure custom_div
+    end interface
+ contains
+    function custom_div(a, b) result(res)
+        type(custom_int), intent(in) :: a
+        integer, intent(in) :: b
+        type(custom_int) :: res
+        res%value = a%value / (b + 1)
+    end function custom_div
+ end module operator_overloading_08_mod1
+
+ program operator_overloading_08
+    use operator_overloading_08_mod1
+
+    type(custom_int) :: a
+    a%value = 1
+    print *, a / 0 ! Yields 1
+ end program operator_overloading_08

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8307,7 +8307,7 @@ public:
             ASRUtils::is_integer(*right_type)) {
             // Don't Check.
         } else if (!ASRUtils::check_equal_type(ASRUtils::expr_type(left),
-                                    ASRUtils::expr_type(right))) {
+                                    ASRUtils::expr_type(right)) && overloaded == nullptr) {
             std::string ltype = ASRUtils::type_to_str(ASRUtils::expr_type(left));
             std::string rtype = ASRUtils::type_to_str(ASRUtils::expr_type(right));
             diag.add(Diagnostic(

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -977,6 +977,7 @@ public:
         {AST::operatorType::Mul, "~mul"},
         {AST::operatorType::Add, "~add"},
         {AST::operatorType::Sub, "~sub"},
+        {AST::operatorType::Div, "~div"},
     };
 
     std::map<AST::cmpopType, std::string> cmpop2str = {
@@ -991,6 +992,7 @@ public:
     std::map<AST::intrinsicopType, std::string> intrinsic2str = {
         {AST::intrinsicopType::STAR, "~mul"},
         {AST::intrinsicopType::PLUS, "~add"},
+        {AST::intrinsicopType::DIV, "~div"},
         {AST::intrinsicopType::EQ, "~eq"},
         {AST::intrinsicopType::NOTEQ, "~noteq"},
         {AST::intrinsicopType::LT, "~lt"},

--- a/tests/reference/asr-operator_overloading_08-52825a6.json
+++ b/tests/reference/asr-operator_overloading_08-52825a6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-operator_overloading_08-52825a6",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/operator_overloading_08.f90",
+    "infile_hash": "5acb071582afc132942154d54a27349e2c92072962ccc8e3699a6187",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-operator_overloading_08-52825a6.stdout",
+    "stdout_hash": "bcbcaa03e76bac8b211680356f88c9bc6bf88839f8e0dcb466d75fbe",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-operator_overloading_08-52825a6.stdout
+++ b/tests/reference/asr-operator_overloading_08-52825a6.stdout
@@ -1,0 +1,290 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            operator_overloading_08:
+                (Program
+                    (SymbolTable
+                        5
+                        {
+                            1_custom_int_value:
+                                (ExternalSymbol
+                                    5
+                                    1_custom_int_value
+                                    3 value
+                                    custom_int
+                                    []
+                                    value
+                                    Public
+                                ),
+                            a:
+                                (Variable
+                                    5
+                                    a
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (StructType
+                                        5 custom_int
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            custom_div:
+                                (ExternalSymbol
+                                    5
+                                    custom_div
+                                    2 custom_div
+                                    operator_overloading_08_mod1
+                                    []
+                                    custom_div
+                                    Public
+                                ),
+                            custom_int:
+                                (ExternalSymbol
+                                    5
+                                    custom_int
+                                    2 custom_int
+                                    operator_overloading_08_mod1
+                                    []
+                                    custom_int
+                                    Public
+                                ),
+                            ~div:
+                                (ExternalSymbol
+                                    5
+                                    ~div
+                                    2 ~div
+                                    operator_overloading_08_mod1
+                                    []
+                                    ~div
+                                    Public
+                                )
+                        })
+                    operator_overloading_08
+                    [operator_overloading_08_mod1]
+                    [(Assignment
+                        (StructInstanceMember
+                            (Var 5 a)
+                            5 1_custom_int_value
+                            (Integer 4)
+                            ()
+                        )
+                        (IntegerConstant 1 (Integer 4) Decimal)
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(OverloadedBinOp
+                                (Var 5 a)
+                                Div
+                                (IntegerConstant 0 (Integer 4) Decimal)
+                                (Integer 4)
+                                ()
+                                (FunctionCall
+                                    5 custom_div
+                                    5 ~div
+                                    [((Var 5 a))
+                                    ((IntegerConstant 0 (Integer 4) Decimal))]
+                                    (StructType
+                                        5 custom_int
+                                    )
+                                    ()
+                                    ()
+                                )
+                            )]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )]
+                ),
+            operator_overloading_08_mod1:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            custom_div:
+                                (Function
+                                    (SymbolTable
+                                        4
+                                        {
+                                            1_custom_int_value:
+                                                (ExternalSymbol
+                                                    4
+                                                    1_custom_int_value
+                                                    3 value
+                                                    custom_int
+                                                    []
+                                                    value
+                                                    Public
+                                                ),
+                                            a:
+                                                (Variable
+                                                    4
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (StructType
+                                                        2 custom_int
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    4
+                                                    b
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            res:
+                                                (Variable
+                                                    4
+                                                    res
+                                                    []
+                                                    ReturnVar
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (StructType
+                                                        2 custom_int
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    custom_div
+                                    (FunctionType
+                                        [(StructType
+                                            2 custom_int
+                                        )
+                                        (Integer 4)]
+                                        (StructType
+                                            2 custom_int
+                                        )
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 4 a)
+                                    (Var 4 b)]
+                                    [(Assignment
+                                        (StructInstanceMember
+                                            (Var 4 res)
+                                            4 1_custom_int_value
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        (IntegerBinOp
+                                            (StructInstanceMember
+                                                (Var 4 a)
+                                                4 1_custom_int_value
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            Div
+                                            (IntegerBinOp
+                                                (Var 4 b)
+                                                Add
+                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            (Integer 4)
+                                            ()
+                                        )
+                                        ()
+                                    )]
+                                    (Var 4 res)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            custom_int:
+                                (Struct
+                                    (SymbolTable
+                                        3
+                                        {
+                                            value:
+                                                (Variable
+                                                    3
+                                                    value
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    custom_int
+                                    []
+                                    [value]
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
+                                ),
+                            ~div:
+                                (CustomOperator
+                                    2
+                                    ~div
+                                    [2 custom_div]
+                                    Public
+                                )
+                        })
+                    operator_overloading_08_mod1
+                    []
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2769,6 +2769,10 @@ filename = "../integration_tests/operator_overloading_04.f90"
 asr = true
 
 [[test]]
+filename = "../integration_tests/operator_overloading_08.f90"
+asr = true
+
+[[test]]
 filename = "team1.f90"
 ast = true
 ast_f90 = true


### PR DESCRIPTION
Fix #6195 

Add `"~div"` to `binop2str` and `intrinsic2str`.

Also don't check equal types when operator is overloaded.