### PR TITLE
CI: link object files into POT3D executable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,6 +547,8 @@ jobs:
             ${FC} -c mpi.f90
             ${FC} -c psi_io.f90
             ${FC} -c --cpp --implicit-interface pot3d.F90
+            ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi
+            cp pot3d ../bin/
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}


### PR DESCRIPTION
## Description

This will currently fail with the below error on macOS:
```console
+ lfortran mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L/Users/gxyd/miniforge3/envs/pot3d_build/lib -lmpi
Undefined symbols for architecture arm64:
  "_ffopen", referenced from:
      _read_input_file in pot3d.o
      _write_timing in pot3d.o
      _main in pot3d.o
  "_rdhdf_2d", referenced from:
      _readbr in pot3d.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
The command 'clang -o pot3d mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o  -L/Users/gxyd/miniforge3/envs/pot3d_build/lib -lmpi  -L"/Users/gxyd/OpenSource/lfortran/src/bin/../runtime" -Wl,-rpath,"/Users/gxyd/OpenSource/lfortran/src/bin/../runtime" -llfortran_runtime -lm' failed.
Tip: If there is a linker issue, switch the linker using --linker=<CC> option or create an environment variable `export LFORTRAN_LINKER=<CC>`, where CC is clang or gcc
Also, if required use --linker-path=<PATH>, where PATH has location to look for the linker execuatable
```