### PR TITLE
Fix the issue of throwing error in count intrinsic

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3941,7 +3941,10 @@ namespace Count {
             Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
         int64_t id_mask = 0, id_mask_dim = 1;
         int64_t overload_id = id_mask;
-
+        if (!is_array(expr_type(args[0])) || !is_logical(*expr_type(args[0]))){
+            append_error(diag, "`mask` argument to `count` intrinsic must be a logical array",
+                args[0]->base.loc);
+        }
         ASR::expr_t *mask = args[0], *dim_ = nullptr, *kind = nullptr;
 
         if (args.size() == 2) {

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3944,6 +3944,7 @@ namespace Count {
         if (!is_array(expr_type(args[0])) || !is_logical(*expr_type(args[0]))){
             append_error(diag, "`mask` argument to `count` intrinsic must be a logical array",
                 args[0]->base.loc);
+            return nullptr;
         }
         ASR::expr_t *mask = args[0], *dim_ = nullptr, *kind = nullptr;
 


### PR DESCRIPTION
Fix #6234 
It seems that the issue is named 'throw error if arg to cshift is not logical,' but the concern is actually related to the 'count' function, not 'cshift.' Could you please confirm if the issue title should be updated accordingly?

```fortran
program main
  integer :: x(2)
  call sub(x)
  contains
  subroutine sub(x)
    integer :: x(2)
    integer :: arr(count([2]))
  end subroutine sub
end program main
```
```console
(lf) chaitanya@Chaitanyas-MacBook-Air-10 lfortran % src/bin/lfortran examples/expr2.f90        
semantic error: `mask` argument to `count` intrinsic must be a logical array
 --> examples/expr2.f90:7:26
  |
7 |     integer :: arr(count([2]))
  |                          ^^^ 
```

```fortran
program main
  integer :: x(2)
  call sub(x)
  contains
  subroutine sub(x)
    integer :: x(2)
    integer :: arr(count(1))
  end subroutine sub
end program main
```
```console
(lf) chaitanya@Chaitanyas-MacBook-Air-10 lfortran % src/bin/lfortran examples/expr2.f90
semantic error: `mask` argument to `count` intrinsic must be a logical array
 --> examples/expr2.f90:7:26
  |
7 |     integer :: arr(count(1))
  |                          ^ 

```