### PR TITLE
enh : Handle `get_global_scope` using this and change module name in test

### DIFF
--- a/integration_tests/arrays_09_size.f90
+++ b/integration_tests/arrays_09_size.f90
@@ -1,13 +1,13 @@
-module moddd
+module mod_arrays_09_size
   contains 
   subroutine sub(xx)
     real :: xx(5)
     real :: buggy(count(xx > 0.0))
     if (size(buggy) /= 3) error stop
   end subroutine sub
-end module moddd
+end module mod_arrays_09_size
 program main
-  use moddd
+  use mod_arrays_09_size
   real :: xx(5) = [1.1, 2.1, -1.3, 3.4, 0.0]
   call sub(xx)
 end program main

--- a/src/libasr/asr_scopes.h
+++ b/src/libasr/asr_scopes.h
@@ -50,8 +50,8 @@ struct SymbolTable {
         return scope[name];
     }
 
-    SymbolTable* get_global_scope(SymbolTable* current_scope) {
-        SymbolTable* global_scope = current_scope;
+    SymbolTable* get_global_scope() {
+        SymbolTable* global_scope = this;
         while (global_scope->parent) {
             global_scope = global_scope->parent;
         }

--- a/src/libasr/pass/function_call_in_declaration.cpp
+++ b/src/libasr/pass/function_call_in_declaration.cpp
@@ -148,7 +148,7 @@ public:
         std::vector<ArgInfo> indicies;
         get_arg_indices_used(x, indicies);
 
-        SymbolTable* global_scope = current_scope->get_global_scope(current_scope);
+        SymbolTable* global_scope = current_scope->get_global_scope();
         SetChar current_function_dependencies; current_function_dependencies.clear(al);
         SymbolTable* new_scope = al.make_new<SymbolTable>(global_scope);
 


### PR DESCRIPTION
Based on comments https://github.com/lfortran/lfortran/pull/6245#discussion_r1946370058 and https://github.com/lfortran/lfortran/pull/6235#discussion_r1946366072