### PR TITLE
fix: taking order and pad arguments in the reshape intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -512,6 +512,7 @@ RUN(NAME arrays_reshape_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmSta
 RUN(NAME arrays_reshape_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME arrays_reshape_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_elemental_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME arrays_03_func LABELS gfortran cpp llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_03_func_pass_arr_dims LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)

--- a/integration_tests/arrays_reshape_20.f90
+++ b/integration_tests/arrays_reshape_20.f90
@@ -1,0 +1,13 @@
+program arrays_reshape_20
+    integer, dimension(2, 3) :: x1 = reshape([1, 4, 2, 5, 3, 6], [2, 3])
+    integer, dimension(2, 3) :: x2 = reshape([1, 2, 3, 4, 0, 0], [2, 3])
+    integer, dimension(2, 3) :: x3 =reshape([1, 4, 2, 0, 3, 0], [2, 3])
+
+    print *, x1
+    print *, x2
+    print *, x3
+
+    if (any(x1 /= reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 1]))) error stop
+    if (any(x2 /= reshape([1, 2, 3, 4], [2, 3], pad = [0]))) error stop
+    if (any(x3 /= reshape([1, 2, 3, 4], [2, 3], order = [2, 1], pad = [0]))) error stop
+end program arrays_reshape_20

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6300,7 +6300,7 @@ public:
     ASR::asr_t* create_ArrayReshape(const AST::FuncCallOrArray_t& x) {
         if( x.n_args + x.n_keywords < 2 || x.n_args + x.n_keywords > 4 ) {
             diag.add(Diagnostic("reshape expects number at least 2 and at most 4 arguments, got " +
-                                std::to_string(x.n_args) + " arguments instead.",
+                                std::to_string(x.n_args + x.n_keywords) + " arguments instead.",
                                 Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
             throw SemanticAbort();
         }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6298,37 +6298,38 @@ public:
     }
 
     ASR::asr_t* create_ArrayReshape(const AST::FuncCallOrArray_t& x) {
-        if( x.n_args + x.n_keywords != 2) {
-            diag.add(Diagnostic("reshape accepts only 2 arguments, got " +
+        if( x.n_args + x.n_keywords < 2 || x.n_args + x.n_keywords > 4 ) {
+            diag.add(Diagnostic("reshape expects number of arguments to be between, got " +
                                 std::to_string(x.n_args) + " arguments instead.",
                                 Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
             throw SemanticAbort();
         }
         AST::expr_t* source = nullptr;
         AST::expr_t* shape = nullptr;
+        AST::expr_t* order = nullptr;
+        AST::expr_t* pad = nullptr;
         if ( x.n_args > 0 ) {
             source = x.m_args[0].m_end;
         }
         if ( x.n_args > 1 ) {
             shape = x.m_args[1].m_end;
         }
-        if ( x.n_keywords > 0 ) {
-            if ( to_lower(x.m_keywords[0].m_arg) == "source" ) {
-                source = x.m_keywords[0].m_value;
-            } else if ( to_lower(x.m_keywords[0].m_arg) == "shape" ) {
-                shape = x.m_keywords[0].m_value;
-            } else {
-                diag.add(Diagnostic("Unrecognized keyword argument " +
-                                    std::string(x.m_keywords[0].m_arg) + " passed to reshape.",
-                                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-                throw SemanticAbort();
-            }
+        if (x.n_args > 2){
+            pad = x.m_args[2].m_end;
         }
-        if ( x.n_keywords > 1 ) {
-            if ( to_lower(x.m_keywords[1].m_arg) == "source" ) {
-                source = x.m_keywords[1].m_value;
-            } else if ( to_lower(x.m_keywords[1].m_arg) == "shape" ) {
-                shape = x.m_keywords[1].m_value;
+        if (x.n_args > 3){
+            order = x.m_args[2].m_end;
+            pad = x.m_args[2].m_end;
+        }
+        for( size_t i=0;i<x.n_keywords;i++ ) {
+            if( to_lower(x.m_keywords[i].m_arg) == "source" ) {
+                source = x.m_keywords[i].m_value;
+            } else if( to_lower(x.m_keywords[i].m_arg) == "shape" ) {
+                shape = x.m_keywords[i].m_value;
+            } else if( to_lower(x.m_keywords[i].m_arg) == "pad" ) {
+                pad = x.m_keywords[i].m_value;
+            } else if( to_lower(x.m_keywords[i].m_arg) == "order" ) {
+                order = x.m_keywords[i].m_value;
             } else {
                 diag.add(Diagnostic("Unrecognized keyword argument " +
                                     std::string(x.m_keywords[1].m_arg) + " passed to reshape.",


### PR DESCRIPTION
Towards #6157 

Current Status:
- [x] taking the arguments order and pad in the reshape function
- [x] add the validation for order to be the same size as shape and pad to be of same type as array
- [x] stop throwing error when number of elements in array is less than that after reshape if pad argument is given
- [x] implementing the logic for order and pad