### PR TITLE
fix: support all the arguments of system_clock correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1029,7 +1029,7 @@ RUN(NAME intrinsics_351 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_352 LABELS gfortran llvm) # random_seed
 RUN(NAME intrinsics_353 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # random_number
 
-RUN(NAME intrinsics_355 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # system_clock
+RUN(NAME intrinsics_355 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # system_clock
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1029,6 +1029,8 @@ RUN(NAME intrinsics_351 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_352 LABELS gfortran llvm) # random_seed
 RUN(NAME intrinsics_353 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # random_number
 
+RUN(NAME intrinsics_355 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # system_clock
+
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 
 RUN(NAME test_dshiftr LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_355.f90
+++ b/integration_tests/intrinsics_355.f90
@@ -1,0 +1,18 @@
+module timerm
+    implicit none
+    private
+    public  print_time
+    contains
+      subroutine print_time(rate)
+        integer rate
+        call system_clock(count_rate=rate)
+      end subroutine print_time
+end module timerm
+program intrinsic_355
+use timerm
+integer :: rate
+call print_time(rate)
+print *, rate
+if (rate /= 1000) error stop
+end
+  


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/6018