### PR TITLE
fix: support nullifying procedure pointer variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2027,7 +2027,7 @@ RUN(NAME openmp_43 LABELS llvm_omp llvm)
 
 RUN(NAME nullify_01 LABELS gfortran fortran llvm)
 RUN(NAME nullify_02 LABELS gfortran fortran llvm)
-RUN(NAME nullify_05 LABELS gfortran fortran llvm)
+RUN(NAME nullify_05 LABELS gfortran llvm)
 
 RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME fortran_02 LABELS gfortran fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2027,6 +2027,7 @@ RUN(NAME openmp_43 LABELS llvm_omp llvm)
 
 RUN(NAME nullify_01 LABELS gfortran fortran llvm)
 RUN(NAME nullify_02 LABELS gfortran fortran llvm)
+RUN(NAME nullify_05 LABELS gfortran fortran llvm)
 
 RUN(NAME fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME fortran_02 LABELS gfortran fortran)

--- a/integration_tests/nullify_05.f90
+++ b/integration_tests/nullify_05.f90
@@ -1,0 +1,11 @@
+program nullify_05
+   procedure(OBJ), pointer :: calfun
+   nullify(calfun)
+
+   if (associated(calfun)) error stop
+
+contains
+
+   subroutine OBJ()
+   end subroutine
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4501,7 +4501,7 @@ public:
         for( size_t i = 0; i < x.n_args; i++ ) {
             this->visit_expr(*(x.m_args[i]));
             ASR::expr_t* tmp_expr = ASRUtils::EXPR(tmp);
-            if (ASRUtils::is_pointer(ASRUtils::expr_type(tmp_expr))) {
+            if (ASRUtils::is_pointer(ASRUtils::expr_type(tmp_expr)) || ASR::is_a<ASR::FunctionType_t>(*ASRUtils::expr_type(tmp_expr))) {
                 if(ASR::is_a<ASR::StructInstanceMember_t>(*tmp_expr) || ASR::is_a<ASR::Var_t>(*tmp_expr)) {
                     arg_vec.push_back(al, tmp_expr);
                 }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1149,9 +1149,14 @@ public:
                 ASRUtils::type_get_past_pointer(
                 ASRUtils::type_get_past_allocatable(
                 ASRUtils::symbol_type(tmp_sym))), module.get());
+
+            llvm::Type* dest_type = tp->getPointerTo();
+            if (ASR::is_a<ASR::FunctionType_t>(*ASRUtils::symbol_type(tmp_sym))) {
+                // functions are pointers in LLVM, so we do not need to get the pointer to it
+                dest_type = tp;
+            }
             llvm::Value* np = builder->CreateIntToPtr(
-                llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
-                tp->getPointerTo());
+                llvm::ConstantInt::get(context, llvm::APInt(32, 0)), dest_type);
             builder->CreateStore(np, target);
         }
     }


### PR DESCRIPTION
resolves #6215 

With the changes in this PR, we wrap `FunctionType` with `Pointer` for procedure pointers. I am not sure why, but the changes are causing unexpected failures. I cross-checked the changes here. I request a careful review from other developers.

If we find that the changes here are not right, a fix for this issue would be to allow procedure pointers in `nullify` as a special case, but this would also incorrectly allow non-pointer procedure variables.