### PR TITLE
CI: Workaround for allocatable structs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -535,7 +535,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 79585cc94cb9fa40400b0e6447871eb477e17292
+            git checkout 1aba062ac90c39e171f722c15b2bc6fafaaff251
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang


### PR DESCRIPTION
With this CI update LFortran compiles POT3D with the correct workaround

Hence this PR https://github.com/lfortran/lfortran/pull/6232 can be closed.