### PR TITLE
fix : Empty the dimensions of Array Argument passed in random_number function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1034,6 +1034,8 @@ RUN(NAME intrinsics_353 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_354 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # minval
 
 RUN(NAME intrinsics_355 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # system_clock
+RUN(NAME intrinsics_356 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME intrinsics_357 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/intrinsics_356.f90
+++ b/integration_tests/intrinsics_356.f90
@@ -8,7 +8,7 @@ program intrinsics_356
     
 contains
 
-    function rand1(m) result(x)
+    impure function rand1(m) result(x)
         implicit none
         integer, intent(in) :: m
         real :: x(max(m, 0))

--- a/integration_tests/intrinsics_356.f90
+++ b/integration_tests/intrinsics_356.f90
@@ -1,0 +1,19 @@
+program intrinsics_356
+    implicit none
+    integer :: m
+    real :: A(3)  
+
+    m = 3
+    A = rand1(m)
+    
+contains
+
+    function rand1(m) result(x)
+        implicit none
+        integer, intent(in) :: m
+        real :: x(max(m, 0))
+
+        call random_number(harvest=x)
+    end function
+
+end program

--- a/integration_tests/intrinsics_357.f90
+++ b/integration_tests/intrinsics_357.f90
@@ -1,0 +1,21 @@
+program intrinsics_357
+    implicit none
+    integer :: m, n
+    real :: A(3, 4)  
+
+    m = 3
+    n = 4
+
+    A = rand2(m, n)
+
+contains
+
+    function rand2(m, n) result(x)
+        implicit none
+        integer, intent(in) :: m, n
+        real :: x(max(m, 0), max(n, 0))
+
+        call random_number(harvest=x)
+    end function rand2
+
+end program

--- a/integration_tests/intrinsics_357.f90
+++ b/integration_tests/intrinsics_357.f90
@@ -10,7 +10,7 @@ program intrinsics_357
 
 contains
 
-    function rand2(m, n) result(x)
+    impure function rand2(m, n) result(x)
         implicit none
         integer, intent(in) :: m, n
         real :: x(max(m, 0), max(n, 0))

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -266,7 +266,7 @@ namespace RandomNumber {
         std::string new_name = "_lcompilers_random_number_";
 
         declare_basic_variables(new_name);
-        fill_func_arg_sub("r", arg_types[0], InOut);
+        fill_func_arg_sub("r", ASRUtils::duplicate_type_with_empty_dims(al, arg_types[0]), InOut);
         SymbolTable *fn_symtab_1 = al.make_new<SymbolTable>(fn_symtab);
         Vec<ASR::expr_t*> args_1; args_1.reserve(al, 0);
         ASR::expr_t *return_var_1 = b.Variable(fn_symtab_1, c_func_name,


### PR DESCRIPTION
fix #6270 