### PR TITLE
Fix : minor fixes in `sign_from_value` pass

### DIFF
--- a/integration_tests/sign_from_value.f90
+++ b/integration_tests/sign_from_value.f90
@@ -4,6 +4,7 @@ program flip_sign
     real(8) :: rxdp = 5.5, epsrdp = 1e-6
     integer :: ixsp = 5, epsisp = 16
     integer(8) :: ixdp = 5, epsidp = 16
+    integer :: a=2, b=-3, c
 
     rxsp = rxsp * sign(1._4, epsrsp)
     print *, rxsp
@@ -28,5 +29,9 @@ program flip_sign
     ixdp = ixdp * sign(1_8, epsidp)
     print *, ixdp
     if (ixdp /= 5) error stop
+
+    c = a*sign(1, b) ! Test that we don't apply sign opt. on integers.
+    print *, c
+    if(c /= -2) error stop
 
 end program

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -1097,7 +1097,7 @@ namespace LCompilers {
             }
             ASRUtils::impl_function instantiate_function =
             ASRUtils::IntrinsicElementalFunctionRegistry::get_instantiate_function(
-                    static_cast<int64_t>(ASRUtils::IntrinsicElementalFunctions::FMA));
+                    static_cast<int64_t>(ASRUtils::IntrinsicElementalFunctions::SignFromValue));
             Vec<ASR::ttype_t*> arg_types;
             arg_types.reserve(al, 2);
             arg_types.push_back(al, ASRUtils::expr_type(arg0));

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -70,8 +70,7 @@ public:
             return nullptr;
         }
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(func_sym);
-        if( ASRUtils::is_intrinsic_procedure(func) &&
-            std::string(func->m_name).find("sign") == std::string::npos ) {
+        if( std::string(func->m_name).find("_lcompilers_sign_") == std::string::npos ) {
             return nullptr;
         }
         ASR::expr_t *arg0 = func_call->m_args[0].m_value, *arg1 = func_call->m_args[1].m_value;

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -98,8 +98,12 @@ public:
             return ;
         }
 
-        from_sign_from_value = true;
         T& x = const_cast<T&>(x_const);
+        if( x.m_op != ASR::binopType::Mul ) {
+            return ;
+        }
+
+        from_sign_from_value = true;
 
         sign_from_value_var = nullptr;
         visit_expr(*x.m_left);
@@ -114,9 +118,6 @@ public:
         }
         sign_from_value_var = nullptr;
 
-        if( x.m_op != ASR::binopType::Mul ) {
-            return ;
-        }
 
         ASR::expr_t *first_arg = nullptr, *second_arg = nullptr;
 

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -53,7 +53,8 @@ public:
 
     bool is_value_one(ASR::expr_t* expr) {
         double value;
-        if( ASRUtils::is_value_constant(expr, value) ) {
+        if( ASRUtils::is_value_constant(expr, value) && 
+            ASRUtils::is_real(*ASRUtils::expr_type(expr)) ) {
             return value == 1.0;
         }
         return false;

--- a/tests/reference/asr-sign_from_value-b974070.json
+++ b/tests/reference/asr-sign_from_value-b974070.json
@@ -2,11 +2,11 @@
     "basename": "asr-sign_from_value-b974070",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/sign_from_value.f90",
-    "infile_hash": "18a4a6ee33509de837af6a678eccfc6e03c235ddc514d79f4b30a8d6",
+    "infile_hash": "7cbc0fb4db075ef92bcc404a8b3bf01eae79238f7d4dd22429b5e2e0",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-sign_from_value-b974070.stdout",
-    "stdout_hash": "bb0cdaefd42e086480ff1304da0d3fb9963b177dd249f70e902a197b",
+    "stdout_hash": "87f7e5aa71a64887e7e0ef6deae48b14346490a4dbdfc44efa30bc62",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-sign_from_value-b974070.stdout
+++ b/tests/reference/asr-sign_from_value-b974070.stdout
@@ -7,6 +7,61 @@
                     (SymbolTable
                         2
                         {
+                            a:
+                                (Variable
+                                    2
+                                    a
+                                    []
+                                    Local
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    Save
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            b:
+                                (Variable
+                                    2
+                                    b
+                                    []
+                                    Local
+                                    (IntegerUnaryMinus
+                                        (IntegerConstant 3 (Integer 4) Decimal)
+                                        (Integer 4)
+                                        (IntegerConstant -3 (Integer 4) Decimal)
+                                    )
+                                    (IntegerConstant -3 (Integer 4) Decimal)
+                                    Save
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            c:
+                                (Variable
+                                    2
+                                    c
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
                             epsidp:
                                 (Variable
                                     2
@@ -528,6 +583,50 @@
                                 IntegerToInteger
                                 (Integer 8)
                                 (IntegerConstant 5 (Integer 8) Decimal)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 c)
+                        (IntegerBinOp
+                            (Var 2 a)
+                            Mul
+                            (IntrinsicElementalFunction
+                                Sign
+                                [(IntegerConstant 1 (Integer 4) Decimal)
+                                (Var 2 b)]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(Var 2 c)]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 2 c)
+                            NotEq
+                            (IntegerUnaryMinus
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                (Integer 4)
+                                (IntegerConstant -2 (Integer 4) Decimal)
                             )
                             (Logical 4)
                             ()

--- a/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.json
+++ b/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.json
@@ -2,11 +2,11 @@
     "basename": "pass_sign_from_value-sign_from_value-ba1c944",
     "cmd": "lfortran --pass=sign_from_value --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/sign_from_value.f90",
-    "infile_hash": "18a4a6ee33509de837af6a678eccfc6e03c235ddc514d79f4b30a8d6",
+    "infile_hash": "7cbc0fb4db075ef92bcc404a8b3bf01eae79238f7d4dd22429b5e2e0",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_sign_from_value-sign_from_value-ba1c944.stdout",
-    "stdout_hash": "bb0cdaefd42e086480ff1304da0d3fb9963b177dd249f70e902a197b",
+    "stdout_hash": "87f7e5aa71a64887e7e0ef6deae48b14346490a4dbdfc44efa30bc62",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.stdout
+++ b/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.stdout
@@ -7,6 +7,61 @@
                     (SymbolTable
                         2
                         {
+                            a:
+                                (Variable
+                                    2
+                                    a
+                                    []
+                                    Local
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    Save
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            b:
+                                (Variable
+                                    2
+                                    b
+                                    []
+                                    Local
+                                    (IntegerUnaryMinus
+                                        (IntegerConstant 3 (Integer 4) Decimal)
+                                        (Integer 4)
+                                        (IntegerConstant -3 (Integer 4) Decimal)
+                                    )
+                                    (IntegerConstant -3 (Integer 4) Decimal)
+                                    Save
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            c:
+                                (Variable
+                                    2
+                                    c
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
                             epsidp:
                                 (Variable
                                     2
@@ -528,6 +583,50 @@
                                 IntegerToInteger
                                 (Integer 8)
                                 (IntegerConstant 5 (Integer 8) Decimal)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (Var 2 c)
+                        (IntegerBinOp
+                            (Var 2 a)
+                            Mul
+                            (IntrinsicElementalFunction
+                                Sign
+                                [(IntegerConstant 1 (Integer 4) Decimal)
+                                (Var 2 b)]
+                                0
+                                (Integer 4)
+                                ()
+                            )
+                            (Integer 4)
+                            ()
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(Var 2 c)]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (If
+                        (IntegerCompare
+                            (Var 2 c)
+                            NotEq
+                            (IntegerUnaryMinus
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                (Integer 4)
+                                (IntegerConstant -2 (Integer 4) Decimal)
                             )
                             (Logical 4)
                             ()


### PR DESCRIPTION
This fix is towards getting PRIMA to compile with `--fast`
***
Example of one issue :
```.f90
program pp
    implicit none
    integer :: a, b, c
    a = 2
    b = -3
    c = a*sign(1, b)
    print *, c

end program pp
```

```console
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ gfortran tt5.f90 && ./a.out 
          -2
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ gfortran tt5.f90 -O3 && ./a.out 
          -2
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ 

```
LFortran before this PR
```Console
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ lfortran tt5.f90 --fast
-2147483646
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ lfortran tt5.f90 
-2
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ 
```
After
```Console
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ lfortran tt5.f90 --fast
-2
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ lfortran tt5.f90 
-2
assem@assem-PC:~/Desktop/fortran/compile_gsnap$ 


```
