### PR TITLE
CI: run validation script for POT3D with MPI rank 1 & MPI rank 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -548,7 +548,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 8679e59f3010a2696cc3fd99f9770dd210db654c
+            git checkout b863ed59cf7ea7c716d64837a4802be4e4877f25
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -548,7 +548,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 1aba062ac90c39e171f722c15b2bc6fafaaff251
+            git checkout 299c5fea41a3fc9bff395ebbba59c7ca9c649f9c
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -548,7 +548,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 299c5fea41a3fc9bff395ebbba59c7ca9c649f9c
+            git checkout 8679e59f3010a2696cc3fd99f9770dd210db654c
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -560,7 +560,7 @@ jobs:
             ${FC} -c mpi.f90
             ${FC} -c psi_io.f90
             ${FC} -c --cpp --implicit-interface pot3d.F90
-            ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi
+            ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
             cp pot3d ../bin/
             cd ..
             ./validate_lf.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -563,7 +563,9 @@ jobs:
             ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
             cp pot3d ../bin/
             cd ..
-            ./validate.sh
+            if [[ "${{matrix.os}}" == "ubuntu-latest" ]]; then
+              ./validate.sh
+            fi
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -562,6 +562,7 @@ jobs:
             ${FC} -c --cpp --implicit-interface pot3d.F90
             ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi
             cp pot3d ../bin/
+            ./validate_lf.sh
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -548,7 +548,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 432ee83a1a33f0e066063c3c4082eee2b80b6e48
+            git checkout 242397c88284e6cdce2bbff8f94374944fd262af
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang
@@ -563,7 +563,7 @@ jobs:
             ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
             cp pot3d ../bin/
             cd ..
-            ./validate_lf.sh
+            ./validate.sh
 
       - name: Test Legacy Minpack (SciPy)
         shell: bash -e -x -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -562,6 +562,7 @@ jobs:
             ${FC} -c --cpp --implicit-interface pot3d.F90
             ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi
             cp pot3d ../bin/
+            cd ..
             ./validate_lf.sh
 
       - name: Test Legacy Minpack (SciPy)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -548,7 +548,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout b863ed59cf7ea7c716d64837a4802be4e4877f25
+            git checkout 432ee83a1a33f0e066063c3c4082eee2b80b6e48
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang


### PR DESCRIPTION
## Description

I think this will fail currently, even though we are running without comparison with the saved output file.

Locally, I initially got an error:
```console
dyld[94016]: Library not loaded: @rpath/libmpi.40.dylib
  Referenced from: <9CECF745-6079-3DDC-8425-592ACBD39F46> /Users/gxyd/OpenSource/lfortran/pot3d/bin/pot3d
  Reason: tried: '/Users/gxyd/OpenSource/lfortran/src/bin/../runtime/libmpi.40.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/gxyd/OpenSource/lfortran/src/bin/../runtime/libmpi.40.dylib' (no such file), '/Users/gxyd/OpenSource/lfortran/src/bin/../runtime/libmpi.40.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/gxyd/OpenSource/lfortran/src/bin/../runtime/libmpi.40.dylib' (no such file)
--------------------------------------------------------------------------
prterun noticed that process rank 0 with PID 94016 on node Gauravs-MacBook-Air exited on
signal 9 (Killed: 9).
--------------------------------------------------------------------------
```

and to fix that I had to run:
```console
$ install_name_tool -add_rpath $CONDA_PREFIX/lib ./bin/pot3d
```

which added rpath as `$CONDA_PREFIX/lib` for `./bin/pot3d` binary.

Let's see how the things go at CI first.


**[EDIT]**: adding the rpath in the build explicitly helped, and probably should be fixed now.