### PR TITLE
fix: find return_type from attribute only when return var is null

### DIFF
--- a/integration_tests/intrinsics_358.f90
+++ b/integration_tests/intrinsics_358.f90
@@ -6,7 +6,7 @@ integer, intent(out) :: seed(:)
 call random_seed(get=seed)
 end subroutine getseed
 
-impure function rand0() result(x)
+function rand0() result(x)
 use iso_fortran_env, only: RP => REAL64
 real(RP) :: x
 call random_number(harvest=x)

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1305,10 +1305,10 @@ public:
     }
 
     AST::AttrType_t* find_return_type(AST::decl_attribute_t** attributes,
-            size_t n, const Location &loc, std::string &return_var_name) {
+            size_t n, const Location &loc, std::string &return_var_name, ASR::symbol_t* return_var_sym) {
         AST::AttrType_t* r = nullptr;
         bool found = false;
-        if (n == 0 && compiler_options.implicit_interface && compiler_options.implicit_typing) {
+        if (n == 0 && compiler_options.implicit_interface && compiler_options.implicit_typing && !return_var_sym) {
             std::string first_letter = to_lower(std::string(1,return_var_name[0]));
             ASR::ttype_t* t = implicit_dictionary[first_letter];
             AST::decl_typeType ttype;
@@ -1545,8 +1545,9 @@ public:
         // or in local variables as
         //     integer :: f
         ASR::asr_t *return_var;
+        ASR::symbol_t* return_var_sym = current_scope->get_symbol(return_var_name);
         AST::AttrType_t *return_type = find_return_type(x.m_attributes,
-            x.n_attributes, x.base.base.loc, return_var_name);
+            x.n_attributes, x.base.base.loc, return_var_name, return_var_sym);
         if (current_scope->get_symbol(return_var_name) == nullptr) {
             // The variable is not defined among local variables, extract the
             // type from "integer function f()" and add the variable.


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/6291