### PR TITLE
Refactor `Sign_from_value` pass

### DIFF
--- a/integration_tests/sign_from_value.f90
+++ b/integration_tests/sign_from_value.f90
@@ -2,9 +2,8 @@ program flip_sign
     implicit none
     real :: rxsp = 5.5, epsrsp = 1e-6
     real(8) :: rxdp = 5.5, epsrdp = 1e-6
-    integer :: ixsp = 5, epsisp = 16
     integer(8) :: ixdp = 5, epsidp = 16
-    integer :: a=2, b=-3, c
+    real :: x=-2, y=-3, z, arr(5)
 
     rxsp = rxsp * sign(1._4, epsrsp)
     print *, rxsp
@@ -22,16 +21,14 @@ program flip_sign
     print *, rxdp
     if (abs(rxdp + 5.5) > epsrdp) error stop
 
-    ixsp = ixsp * sign(1_4, epsisp)
-    print *, ixsp
-    if (ixsp /= 5) error stop
-
-    ixdp = ixdp * sign(1_8, epsidp)
+    ixdp = ixdp * sign(1_8, epsidp) ! Test that we don't apply sign opt. on integers.
     print *, ixdp
     if (ixdp /= 5) error stop
 
-    c = a*sign(1, b) ! Test that we don't apply sign opt. on integers.
-    print *, c
-    if(c /= -2) error stop
+
+    arr = [1.0, 2.0, 3.0, 4.0, 5.0]
+    z = arr(int(x*sign(1.0,y), 4)) ! Test nested `sign` expression
+    print *, z
+    if(z /= arr(2)) error stop
 
 end program

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -30,30 +30,16 @@ to:
     c = sign_from_value(a, b)
 
 */
-class SignFromValueVisitor : public PassUtils::SkipOptimizationFunctionVisitor<SignFromValueVisitor>
-{
+
+class SignFromValueReplacer : public ASR::BaseExprReplacer<SignFromValueReplacer>{
 private:
+    Allocator &al;
     ASR::TranslationUnit_t &unit;
-
-    LCompilers::PassOptions pass_options;
-
-    ASR::expr_t* sign_from_value_var;
-
-    // To make sure that SignFromValue is applied only for
-    // the nodes implemented in this class
-    bool from_sign_from_value;
-
-public:
-    SignFromValueVisitor(Allocator &al_, ASR::TranslationUnit_t &unit_,
-                         const LCompilers::PassOptions& pass_options_) : SkipOptimizationFunctionVisitor(al_),
-    unit(unit_), pass_options(pass_options_), sign_from_value_var(nullptr), from_sign_from_value(false)
-    {
-        pass_result.reserve(al, 1);
-    }
+    const LCompilers::PassOptions& pass_options;
 
     bool is_value_one(ASR::expr_t* expr) {
         double value;
-        if( ASRUtils::is_value_constant(expr, value) && 
+        if( ASRUtils::is_value_constant(ASRUtils::expr_value(expr), value) && 
             ASRUtils::is_real(*ASRUtils::expr_type(expr)) ) {
             return value == 1.0;
         }
@@ -61,100 +47,70 @@ public:
     }
 
     ASR::expr_t* is_extract_sign(ASR::expr_t* expr) {
-        if( !ASR::is_a<ASR::FunctionCall_t>(*expr) ) {
-            return nullptr;
+        if( ASR::is_a<ASR::RealCopySign_t>(*expr) ) {
+            ASR::RealCopySign_t *real_cpy_sign = ASR::down_cast<ASR::RealCopySign_t>(expr);
+            if( !is_value_one(real_cpy_sign->m_target) ) {return nullptr;}
+            return real_cpy_sign->m_source;
         }
-        ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(expr);
-        ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external(func_call->m_name);
-        if( !ASR::is_a<ASR::Function_t>(*func_sym) ) {
-            return nullptr;
-        }
-        ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(func_sym);
-        if( std::string(func->m_name).find("_lcompilers_sign_") == std::string::npos ) {
-            return nullptr;
-        }
-        ASR::expr_t *arg0 = func_call->m_args[0].m_value, *arg1 = func_call->m_args[1].m_value;
-        if( !is_value_one(arg0) ) {
-            return nullptr;
-        }
-        return arg1;
+        return nullptr;
     }
 
-    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
-        handle_BinOp(x);
-    }
 
-    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
-        handle_BinOp(x);
-    }
+public:
 
-    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
-        handle_BinOp(x);
-    }
-
-    template <typename T>
-    void handle_BinOp(const T& x_const) {
-        if( !from_sign_from_value ) {
-            return ;
-        }
-
-        T& x = const_cast<T&>(x_const);
-        if( x.m_op != ASR::binopType::Mul ) {
-            return ;
-        }
-
-        from_sign_from_value = true;
-
-        sign_from_value_var = nullptr;
-        visit_expr(*x.m_left);
-        if( sign_from_value_var ) {
-            x.m_left = sign_from_value_var;
-        }
-
-        sign_from_value_var = nullptr;
-        visit_expr(*x.m_right);
-        if( sign_from_value_var ) {
-            x.m_right = sign_from_value_var;
-        }
-        sign_from_value_var = nullptr;
+    SignFromValueReplacer(Allocator &al, ASR::TranslationUnit_t &unit,
+                                  const LCompilers::PassOptions& pass_options) 
+                            :al(al),unit(unit), pass_options(pass_options){}
 
 
+    void replace_RealBinOp(ASR::RealBinOp_t* x) {
+        BaseExprReplacer::replace_RealBinOp(x);
+
+        if( x->m_op != ASR::binopType::Mul ) { return; }
         ASR::expr_t *first_arg = nullptr, *second_arg = nullptr;
-
-        first_arg = is_extract_sign(x.m_left);
-        second_arg = is_extract_sign(x.m_right);
+        first_arg = is_extract_sign(x->m_left);
+        second_arg = is_extract_sign(x->m_right);
 
         if( second_arg ) {
-            first_arg = x.m_left;
+            first_arg = x->m_left;
         } else if( first_arg ) {
-            second_arg = x.m_right;
+            second_arg = x->m_right;
         } else {
             return ;
         }
-
-        sign_from_value_var = PassUtils::get_sign_from_value(first_arg, second_arg,
-                                     al, unit, x.base.base.loc, pass_options);
-        from_sign_from_value = false;
+        *current_expr = PassUtils::get_sign_from_value(first_arg, second_arg,
+                                     al, unit, x->base.base.loc,
+                                    const_cast<LCompilers::PassOptions&>(pass_options));
     }
-
-    void visit_Assignment(const ASR::Assignment_t& x) {
-        from_sign_from_value = true;
-        ASR::Assignment_t& xx = const_cast<ASR::Assignment_t&>(x);
-        sign_from_value_var = nullptr;
-        visit_expr(*x.m_value);
-        if( sign_from_value_var ) {
-            xx.m_value = sign_from_value_var;
-        }
-        sign_from_value_var = nullptr;
-        from_sign_from_value = false;
-    }
-
+    
 };
 
+class SignFromValueVisitor : public ASR::CallReplacerOnExpressionsVisitor<SignFromValueVisitor>{
+private:
+    SignFromValueReplacer replacer;
+public:
+    SignFromValueVisitor(Allocator &al, ASR::TranslationUnit_t &unit,
+                                  const LCompilers::PassOptions& pass_options)
+                        :replacer{al, unit, pass_options}{}
+                        
+    void call_replacer(){
+        if( is_a<ASR::RealBinOp_t>(**current_expr) ){
+            replacer.current_expr = current_expr;
+            replacer.replace_expr(*current_expr);
+        }
+    }
+    void visit_Function(const ASR::Function_t &x){
+        if(std::string(x.m_name).find("_lcompilers_optimization_")
+            !=std::string::npos){ // Don't visit the optimization functions.
+            return;
+        }
+    }
+};
 void pass_replace_sign_from_value(Allocator &al, ASR::TranslationUnit_t &unit,
                                   const LCompilers::PassOptions& pass_options) {
-    SignFromValueVisitor v(al, unit, pass_options);
-    v.visit_TranslationUnit(unit);
+    SignFromValueVisitor sign_from_value_visitor(al, unit, pass_options);
+    sign_from_value_visitor.visit_TranslationUnit(unit);
+    
 }
 
 

--- a/tests/reference/asr-sign_from_value-b974070.json
+++ b/tests/reference/asr-sign_from_value-b974070.json
@@ -2,11 +2,11 @@
     "basename": "asr-sign_from_value-b974070",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/sign_from_value.f90",
-    "infile_hash": "7cbc0fb4db075ef92bcc404a8b3bf01eae79238f7d4dd22429b5e2e0",
+    "infile_hash": "7437cc00f75f54ea619e0dd72d2c4777e332b6128cc89903c0cea4fc",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-sign_from_value-b974070.stdout",
-    "stdout_hash": "87f7e5aa71a64887e7e0ef6deae48b14346490a4dbdfc44efa30bc62",
+    "stdout_hash": "e913ed57f00403985fa2fb2be78f9b4aa5271578298413eda3be0213",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-sign_from_value-b974070.stdout
+++ b/tests/reference/asr-sign_from_value-b974070.stdout
@@ -7,54 +7,21 @@
                     (SymbolTable
                         2
                         {
-                            a:
+                            arr:
                                 (Variable
                                     2
-                                    a
-                                    []
-                                    Local
-                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
-                            b:
-                                (Variable
-                                    2
-                                    b
-                                    []
-                                    Local
-                                    (IntegerUnaryMinus
-                                        (IntegerConstant 3 (Integer 4) Decimal)
-                                        (Integer 4)
-                                        (IntegerConstant -3 (Integer 4) Decimal)
-                                    )
-                                    (IntegerConstant -3 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
-                            c:
-                                (Variable
-                                    2
-                                    c
+                                    arr
                                     []
                                     Local
                                     ()
                                     ()
                                     Default
-                                    (Integer 4)
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 5 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
                                     ()
                                     Source
                                     Public
@@ -77,23 +44,6 @@
                                     (IntegerConstant 16 (Integer 8) Decimal)
                                     Save
                                     (Integer 8)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
-                            epsisp:
-                                (Variable
-                                    2
-                                    epsisp
-                                    []
-                                    Local
-                                    (IntegerConstant 16 (Integer 4) Decimal)
-                                    (IntegerConstant 16 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
                                     ()
                                     Source
                                     Public
@@ -177,23 +127,6 @@
                                     .false.
                                     .false.
                                 ),
-                            ixsp:
-                                (Variable
-                                    2
-                                    ixsp
-                                    []
-                                    Local
-                                    (IntegerConstant 5 (Integer 4) Decimal)
-                                    (IntegerConstant 5 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
                             rxdp:
                                 (Variable
                                     2
@@ -240,6 +173,87 @@
                                         (Real 4)
                                     )
                                     Save
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    (Cast
+                                        (IntegerUnaryMinus
+                                            (IntegerConstant 2 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -2 (Integer 4) Decimal)
+                                        )
+                                        IntegerToReal
+                                        (Real 4)
+                                        (RealConstant
+                                            -2.000000
+                                            (Real 4)
+                                        )
+                                    )
+                                    (RealConstant
+                                        -2.000000
+                                        (Real 4)
+                                    )
+                                    Save
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    (Cast
+                                        (IntegerUnaryMinus
+                                            (IntegerConstant 3 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -3 (Integer 4) Decimal)
+                                        )
+                                        IntegerToReal
+                                        (Real 4)
+                                        (RealConstant
+                                            -3.000000
+                                            (Real 4)
+                                        )
+                                    )
+                                    (RealConstant
+                                        -3.000000
+                                        (Real 4)
+                                    )
+                                    Save
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
                                     (Real 4)
                                     ()
                                     Source
@@ -508,46 +522,6 @@
                         []
                     )
                     (Assignment
-                        (Var 2 ixsp)
-                        (IntegerBinOp
-                            (Var 2 ixsp)
-                            Mul
-                            (IntrinsicElementalFunction
-                                Sign
-                                [(IntegerConstant 1 (Integer 4) Decimal)
-                                (Var 2 epsisp)]
-                                0
-                                (Integer 4)
-                                ()
-                            )
-                            (Integer 4)
-                            ()
-                        )
-                        ()
-                    )
-                    (Print
-                        (StringFormat
-                            ()
-                            [(Var 2 ixsp)]
-                            FormatFortran
-                            (String -1 0 () PointerString)
-                            ()
-                        )
-                    )
-                    (If
-                        (IntegerCompare
-                            (Var 2 ixsp)
-                            NotEq
-                            (IntegerConstant 5 (Integer 4) Decimal)
-                            (Logical 4)
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (Assignment
                         (Var 2 ixdp)
                         (IntegerBinOp
                             (Var 2 ixdp)
@@ -593,19 +567,51 @@
                         []
                     )
                     (Assignment
-                        (Var 2 c)
-                        (IntegerBinOp
-                            (Var 2 a)
-                            Mul
+                        (Var 2 arr)
+                        (ArrayConstant
+                            20
+                            [1.00000000e+00, 2.00000000e+00, 3.00000000e+00, 4.00000000e+00, 5.00000000e+00]
+                            (Array
+                                (Real 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 5 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 z)
+                        (ArrayItem
+                            (Var 2 arr)
+                            [(()
                             (IntrinsicElementalFunction
-                                Sign
-                                [(IntegerConstant 1 (Integer 4) Decimal)
-                                (Var 2 b)]
+                                Int
+                                [(RealBinOp
+                                    (Var 2 x)
+                                    Mul
+                                    (IntrinsicElementalFunction
+                                        Sign
+                                        [(RealConstant
+                                            1.000000
+                                            (Real 4)
+                                        )
+                                        (Var 2 y)]
+                                        0
+                                        (Real 4)
+                                        ()
+                                    )
+                                    (Real 4)
+                                    ()
+                                )]
                                 0
                                 (Integer 4)
                                 ()
                             )
-                            (Integer 4)
+                            ())]
+                            (Real 4)
+                            ColMajor
                             ()
                         )
                         ()
@@ -613,20 +619,24 @@
                     (Print
                         (StringFormat
                             ()
-                            [(Var 2 c)]
+                            [(Var 2 z)]
                             FormatFortran
                             (String -1 0 () PointerString)
                             ()
                         )
                     )
                     (If
-                        (IntegerCompare
-                            (Var 2 c)
+                        (RealCompare
+                            (Var 2 z)
                             NotEq
-                            (IntegerUnaryMinus
+                            (ArrayItem
+                                (Var 2 arr)
+                                [(()
                                 (IntegerConstant 2 (Integer 4) Decimal)
-                                (Integer 4)
-                                (IntegerConstant -2 (Integer 4) Decimal)
+                                ())]
+                                (Real 4)
+                                ColMajor
+                                ()
                             )
                             (Logical 4)
                             ()

--- a/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.json
+++ b/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.json
@@ -2,11 +2,11 @@
     "basename": "pass_sign_from_value-sign_from_value-ba1c944",
     "cmd": "lfortran --pass=sign_from_value --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/sign_from_value.f90",
-    "infile_hash": "7cbc0fb4db075ef92bcc404a8b3bf01eae79238f7d4dd22429b5e2e0",
+    "infile_hash": "7437cc00f75f54ea619e0dd72d2c4777e332b6128cc89903c0cea4fc",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_sign_from_value-sign_from_value-ba1c944.stdout",
-    "stdout_hash": "87f7e5aa71a64887e7e0ef6deae48b14346490a4dbdfc44efa30bc62",
+    "stdout_hash": "e913ed57f00403985fa2fb2be78f9b4aa5271578298413eda3be0213",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.stdout
+++ b/tests/reference/pass_sign_from_value-sign_from_value-ba1c944.stdout
@@ -7,54 +7,21 @@
                     (SymbolTable
                         2
                         {
-                            a:
+                            arr:
                                 (Variable
                                     2
-                                    a
-                                    []
-                                    Local
-                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
-                            b:
-                                (Variable
-                                    2
-                                    b
-                                    []
-                                    Local
-                                    (IntegerUnaryMinus
-                                        (IntegerConstant 3 (Integer 4) Decimal)
-                                        (Integer 4)
-                                        (IntegerConstant -3 (Integer 4) Decimal)
-                                    )
-                                    (IntegerConstant -3 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
-                            c:
-                                (Variable
-                                    2
-                                    c
+                                    arr
                                     []
                                     Local
                                     ()
                                     ()
                                     Default
-                                    (Integer 4)
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 5 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
                                     ()
                                     Source
                                     Public
@@ -77,23 +44,6 @@
                                     (IntegerConstant 16 (Integer 8) Decimal)
                                     Save
                                     (Integer 8)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
-                            epsisp:
-                                (Variable
-                                    2
-                                    epsisp
-                                    []
-                                    Local
-                                    (IntegerConstant 16 (Integer 4) Decimal)
-                                    (IntegerConstant 16 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
                                     ()
                                     Source
                                     Public
@@ -177,23 +127,6 @@
                                     .false.
                                     .false.
                                 ),
-                            ixsp:
-                                (Variable
-                                    2
-                                    ixsp
-                                    []
-                                    Local
-                                    (IntegerConstant 5 (Integer 4) Decimal)
-                                    (IntegerConstant 5 (Integer 4) Decimal)
-                                    Save
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                ),
                             rxdp:
                                 (Variable
                                     2
@@ -240,6 +173,87 @@
                                         (Real 4)
                                     )
                                     Save
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            x:
+                                (Variable
+                                    2
+                                    x
+                                    []
+                                    Local
+                                    (Cast
+                                        (IntegerUnaryMinus
+                                            (IntegerConstant 2 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -2 (Integer 4) Decimal)
+                                        )
+                                        IntegerToReal
+                                        (Real 4)
+                                        (RealConstant
+                                            -2.000000
+                                            (Real 4)
+                                        )
+                                    )
+                                    (RealConstant
+                                        -2.000000
+                                        (Real 4)
+                                    )
+                                    Save
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            y:
+                                (Variable
+                                    2
+                                    y
+                                    []
+                                    Local
+                                    (Cast
+                                        (IntegerUnaryMinus
+                                            (IntegerConstant 3 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -3 (Integer 4) Decimal)
+                                        )
+                                        IntegerToReal
+                                        (Real 4)
+                                        (RealConstant
+                                            -3.000000
+                                            (Real 4)
+                                        )
+                                    )
+                                    (RealConstant
+                                        -3.000000
+                                        (Real 4)
+                                    )
+                                    Save
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                ),
+                            z:
+                                (Variable
+                                    2
+                                    z
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
                                     (Real 4)
                                     ()
                                     Source
@@ -508,46 +522,6 @@
                         []
                     )
                     (Assignment
-                        (Var 2 ixsp)
-                        (IntegerBinOp
-                            (Var 2 ixsp)
-                            Mul
-                            (IntrinsicElementalFunction
-                                Sign
-                                [(IntegerConstant 1 (Integer 4) Decimal)
-                                (Var 2 epsisp)]
-                                0
-                                (Integer 4)
-                                ()
-                            )
-                            (Integer 4)
-                            ()
-                        )
-                        ()
-                    )
-                    (Print
-                        (StringFormat
-                            ()
-                            [(Var 2 ixsp)]
-                            FormatFortran
-                            (String -1 0 () PointerString)
-                            ()
-                        )
-                    )
-                    (If
-                        (IntegerCompare
-                            (Var 2 ixsp)
-                            NotEq
-                            (IntegerConstant 5 (Integer 4) Decimal)
-                            (Logical 4)
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (Assignment
                         (Var 2 ixdp)
                         (IntegerBinOp
                             (Var 2 ixdp)
@@ -593,19 +567,51 @@
                         []
                     )
                     (Assignment
-                        (Var 2 c)
-                        (IntegerBinOp
-                            (Var 2 a)
-                            Mul
+                        (Var 2 arr)
+                        (ArrayConstant
+                            20
+                            [1.00000000e+00, 2.00000000e+00, 3.00000000e+00, 4.00000000e+00, 5.00000000e+00]
+                            (Array
+                                (Real 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 5 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (Assignment
+                        (Var 2 z)
+                        (ArrayItem
+                            (Var 2 arr)
+                            [(()
                             (IntrinsicElementalFunction
-                                Sign
-                                [(IntegerConstant 1 (Integer 4) Decimal)
-                                (Var 2 b)]
+                                Int
+                                [(RealBinOp
+                                    (Var 2 x)
+                                    Mul
+                                    (IntrinsicElementalFunction
+                                        Sign
+                                        [(RealConstant
+                                            1.000000
+                                            (Real 4)
+                                        )
+                                        (Var 2 y)]
+                                        0
+                                        (Real 4)
+                                        ()
+                                    )
+                                    (Real 4)
+                                    ()
+                                )]
                                 0
                                 (Integer 4)
                                 ()
                             )
-                            (Integer 4)
+                            ())]
+                            (Real 4)
+                            ColMajor
                             ()
                         )
                         ()
@@ -613,20 +619,24 @@
                     (Print
                         (StringFormat
                             ()
-                            [(Var 2 c)]
+                            [(Var 2 z)]
                             FormatFortran
                             (String -1 0 () PointerString)
                             ()
                         )
                     )
                     (If
-                        (IntegerCompare
-                            (Var 2 c)
+                        (RealCompare
+                            (Var 2 z)
                             NotEq
-                            (IntegerUnaryMinus
+                            (ArrayItem
+                                (Var 2 arr)
+                                [(()
                                 (IntegerConstant 2 (Integer 4) Decimal)
-                                (Integer 4)
-                                (IntegerConstant -2 (Integer 4) Decimal)
+                                ())]
+                                (Real 4)
+                                ColMajor
+                                ()
                             )
                             (Logical 4)
                             ()


### PR DESCRIPTION
It's utilizing the `BaseExprReplacer` class to efficiently replace `RealBinOp` expression.
