### PR TITLE
Added ``replace_with_compile_time_values`` pass for replacing expressions with their compile time values

### DIFF
--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "b20c2bd6981a514817950b10ce3721a1e33066979c78462977bd1b53",
+    "stdout_hash": "8f62d45e1c30066cad28a73dc1df90f1a0236be93461b5cdcc35ed5e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -20,31 +20,571 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %array_bound153 = alloca i32, align 4
+  %array_bound149 = alloca i32, align 4
+  %array_bound143 = alloca i32, align 4
+  %array_bound137 = alloca i32, align 4
+  %array_bound131 = alloca i32, align 4
+  %array_bound125 = alloca i32, align 4
+  %array_bound115 = alloca i32, align 4
+  %array_bound105 = alloca i32, align 4
+  %array_bound95 = alloca i32, align 4
+  %array_bound85 = alloca i32, align 4
+  %array_bound75 = alloca i32, align 4
+  %array_bound65 = alloca i32, align 4
+  %array_bound55 = alloca i32, align 4
+  %array_bound45 = alloca i32, align 4
+  %array_bound37 = alloca i32, align 4
+  %array_bound29 = alloca i32, align 4
+  %array_bound21 = alloca i32, align 4
+  %array_bound13 = alloca i32, align 4
+  %array_bound5 = alloca i32, align 4
+  %array_bound = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [196 x i32], align 4
   %b = alloca [96 x i32], align 4
   %c = alloca [35 x i32], align 4
   %d = alloca [4 x i32], align 4
-  %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 2, i32 2, i64 3, i32 2, i64 1)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 5, i32 2, i64 9, i32 2, i64 7)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 2, i64 1, i32 2, i64 2, i32 2, i64 3, i32 2, i64 4)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 2, i64 2, i32 2, i64 4, i32 2, i64 6, i32 2, i64 7)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 6, i32 2, i64 1)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 10, i32 2, i64 7)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 1)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 4)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  br i1 true, label %then, label %else
+
+then:                                             ; preds = %.entry
+  store i32 2, i32* %array_bound, align 4
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br i1 false, label %then1, label %else2
+
+then1:                                            ; preds = %else
+  store i32 3, i32* %array_bound, align 4
+  br label %ifcont
+
+else2:                                            ; preds = %else
+  br i1 false, label %then3, label %else4
+
+then3:                                            ; preds = %else2
+  store i32 1, i32* %array_bound, align 4
+  br label %ifcont
+
+else4:                                            ; preds = %else2
+  br label %ifcont
+
+ifcont:                                           ; preds = %else4, %then3, %then1, %then
+  %2 = load i32, i32* %array_bound, align 4
+  %3 = sext i32 %2 to i64
+  br i1 false, label %then6, label %else7
+
+then6:                                            ; preds = %ifcont
+  store i32 2, i32* %array_bound5, align 4
+  br label %ifcont12
+
+else7:                                            ; preds = %ifcont
+  br i1 true, label %then8, label %else9
+
+then8:                                            ; preds = %else7
+  store i32 3, i32* %array_bound5, align 4
+  br label %ifcont12
+
+else9:                                            ; preds = %else7
+  br i1 false, label %then10, label %else11
+
+then10:                                           ; preds = %else9
+  store i32 1, i32* %array_bound5, align 4
+  br label %ifcont12
+
+else11:                                           ; preds = %else9
+  br label %ifcont12
+
+ifcont12:                                         ; preds = %else11, %then10, %then8, %then6
+  %4 = load i32, i32* %array_bound5, align 4
+  %5 = sext i32 %4 to i64
+  br i1 false, label %then14, label %else15
+
+then14:                                           ; preds = %ifcont12
+  store i32 2, i32* %array_bound13, align 4
+  br label %ifcont20
+
+else15:                                           ; preds = %ifcont12
+  br i1 false, label %then16, label %else17
+
+then16:                                           ; preds = %else15
+  store i32 3, i32* %array_bound13, align 4
+  br label %ifcont20
+
+else17:                                           ; preds = %else15
+  br i1 true, label %then18, label %else19
+
+then18:                                           ; preds = %else17
+  store i32 1, i32* %array_bound13, align 4
+  br label %ifcont20
+
+else19:                                           ; preds = %else17
+  br label %ifcont20
+
+ifcont20:                                         ; preds = %else19, %then18, %then16, %then14
+  %6 = load i32, i32* %array_bound13, align 4
+  %7 = sext i32 %6 to i64
+  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %3, i32 2, i64 %5, i32 2, i64 %7)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  br i1 true, label %then22, label %else23
+
+then22:                                           ; preds = %ifcont20
+  store i32 5, i32* %array_bound21, align 4
+  br label %ifcont28
+
+else23:                                           ; preds = %ifcont20
+  br i1 false, label %then24, label %else25
+
+then24:                                           ; preds = %else23
+  store i32 9, i32* %array_bound21, align 4
+  br label %ifcont28
+
+else25:                                           ; preds = %else23
+  br i1 false, label %then26, label %else27
+
+then26:                                           ; preds = %else25
+  store i32 7, i32* %array_bound21, align 4
+  br label %ifcont28
+
+else27:                                           ; preds = %else25
+  br label %ifcont28
+
+ifcont28:                                         ; preds = %else27, %then26, %then24, %then22
+  %9 = load i32, i32* %array_bound21, align 4
+  %10 = sext i32 %9 to i64
+  br i1 false, label %then30, label %else31
+
+then30:                                           ; preds = %ifcont28
+  store i32 5, i32* %array_bound29, align 4
+  br label %ifcont36
+
+else31:                                           ; preds = %ifcont28
+  br i1 true, label %then32, label %else33
+
+then32:                                           ; preds = %else31
+  store i32 9, i32* %array_bound29, align 4
+  br label %ifcont36
+
+else33:                                           ; preds = %else31
+  br i1 false, label %then34, label %else35
+
+then34:                                           ; preds = %else33
+  store i32 7, i32* %array_bound29, align 4
+  br label %ifcont36
+
+else35:                                           ; preds = %else33
+  br label %ifcont36
+
+ifcont36:                                         ; preds = %else35, %then34, %then32, %then30
+  %11 = load i32, i32* %array_bound29, align 4
+  %12 = sext i32 %11 to i64
+  br i1 false, label %then38, label %else39
+
+then38:                                           ; preds = %ifcont36
+  store i32 5, i32* %array_bound37, align 4
+  br label %ifcont44
+
+else39:                                           ; preds = %ifcont36
+  br i1 false, label %then40, label %else41
+
+then40:                                           ; preds = %else39
+  store i32 9, i32* %array_bound37, align 4
+  br label %ifcont44
+
+else41:                                           ; preds = %else39
+  br i1 true, label %then42, label %else43
+
+then42:                                           ; preds = %else41
+  store i32 7, i32* %array_bound37, align 4
+  br label %ifcont44
+
+else43:                                           ; preds = %else41
+  br label %ifcont44
+
+ifcont44:                                         ; preds = %else43, %then42, %then40, %then38
+  %13 = load i32, i32* %array_bound37, align 4
+  %14 = sext i32 %13 to i64
+  %15 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %10, i32 2, i64 %12, i32 2, i64 %14)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  br i1 true, label %then46, label %else47
+
+then46:                                           ; preds = %ifcont44
+  store i32 1, i32* %array_bound45, align 4
+  br label %ifcont54
+
+else47:                                           ; preds = %ifcont44
+  br i1 false, label %then48, label %else49
+
+then48:                                           ; preds = %else47
+  store i32 2, i32* %array_bound45, align 4
+  br label %ifcont54
+
+else49:                                           ; preds = %else47
+  br i1 false, label %then50, label %else51
+
+then50:                                           ; preds = %else49
+  store i32 3, i32* %array_bound45, align 4
+  br label %ifcont54
+
+else51:                                           ; preds = %else49
+  br i1 false, label %then52, label %else53
+
+then52:                                           ; preds = %else51
+  store i32 4, i32* %array_bound45, align 4
+  br label %ifcont54
+
+else53:                                           ; preds = %else51
+  br label %ifcont54
+
+ifcont54:                                         ; preds = %else53, %then52, %then50, %then48, %then46
+  %16 = load i32, i32* %array_bound45, align 4
+  %17 = sext i32 %16 to i64
+  br i1 false, label %then56, label %else57
+
+then56:                                           ; preds = %ifcont54
+  store i32 1, i32* %array_bound55, align 4
+  br label %ifcont64
+
+else57:                                           ; preds = %ifcont54
+  br i1 true, label %then58, label %else59
+
+then58:                                           ; preds = %else57
+  store i32 2, i32* %array_bound55, align 4
+  br label %ifcont64
+
+else59:                                           ; preds = %else57
+  br i1 false, label %then60, label %else61
+
+then60:                                           ; preds = %else59
+  store i32 3, i32* %array_bound55, align 4
+  br label %ifcont64
+
+else61:                                           ; preds = %else59
+  br i1 false, label %then62, label %else63
+
+then62:                                           ; preds = %else61
+  store i32 4, i32* %array_bound55, align 4
+  br label %ifcont64
+
+else63:                                           ; preds = %else61
+  br label %ifcont64
+
+ifcont64:                                         ; preds = %else63, %then62, %then60, %then58, %then56
+  %18 = load i32, i32* %array_bound55, align 4
+  %19 = sext i32 %18 to i64
+  br i1 false, label %then66, label %else67
+
+then66:                                           ; preds = %ifcont64
+  store i32 1, i32* %array_bound65, align 4
+  br label %ifcont74
+
+else67:                                           ; preds = %ifcont64
+  br i1 false, label %then68, label %else69
+
+then68:                                           ; preds = %else67
+  store i32 2, i32* %array_bound65, align 4
+  br label %ifcont74
+
+else69:                                           ; preds = %else67
+  br i1 true, label %then70, label %else71
+
+then70:                                           ; preds = %else69
+  store i32 3, i32* %array_bound65, align 4
+  br label %ifcont74
+
+else71:                                           ; preds = %else69
+  br i1 false, label %then72, label %else73
+
+then72:                                           ; preds = %else71
+  store i32 4, i32* %array_bound65, align 4
+  br label %ifcont74
+
+else73:                                           ; preds = %else71
+  br label %ifcont74
+
+ifcont74:                                         ; preds = %else73, %then72, %then70, %then68, %then66
+  %20 = load i32, i32* %array_bound65, align 4
+  %21 = sext i32 %20 to i64
+  br i1 false, label %then76, label %else77
+
+then76:                                           ; preds = %ifcont74
+  store i32 1, i32* %array_bound75, align 4
+  br label %ifcont84
+
+else77:                                           ; preds = %ifcont74
+  br i1 false, label %then78, label %else79
+
+then78:                                           ; preds = %else77
+  store i32 2, i32* %array_bound75, align 4
+  br label %ifcont84
+
+else79:                                           ; preds = %else77
+  br i1 false, label %then80, label %else81
+
+then80:                                           ; preds = %else79
+  store i32 3, i32* %array_bound75, align 4
+  br label %ifcont84
+
+else81:                                           ; preds = %else79
+  br i1 true, label %then82, label %else83
+
+then82:                                           ; preds = %else81
+  store i32 4, i32* %array_bound75, align 4
+  br label %ifcont84
+
+else83:                                           ; preds = %else81
+  br label %ifcont84
+
+ifcont84:                                         ; preds = %else83, %then82, %then80, %then78, %then76
+  %22 = load i32, i32* %array_bound75, align 4
+  %23 = sext i32 %22 to i64
+  %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 2, i64 %17, i32 2, i64 %19, i32 2, i64 %21, i32 2, i64 %23)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  br i1 true, label %then86, label %else87
+
+then86:                                           ; preds = %ifcont84
+  store i32 2, i32* %array_bound85, align 4
+  br label %ifcont94
+
+else87:                                           ; preds = %ifcont84
+  br i1 false, label %then88, label %else89
+
+then88:                                           ; preds = %else87
+  store i32 4, i32* %array_bound85, align 4
+  br label %ifcont94
+
+else89:                                           ; preds = %else87
+  br i1 false, label %then90, label %else91
+
+then90:                                           ; preds = %else89
+  store i32 6, i32* %array_bound85, align 4
+  br label %ifcont94
+
+else91:                                           ; preds = %else89
+  br i1 false, label %then92, label %else93
+
+then92:                                           ; preds = %else91
+  store i32 7, i32* %array_bound85, align 4
+  br label %ifcont94
+
+else93:                                           ; preds = %else91
+  br label %ifcont94
+
+ifcont94:                                         ; preds = %else93, %then92, %then90, %then88, %then86
+  %25 = load i32, i32* %array_bound85, align 4
+  %26 = sext i32 %25 to i64
+  br i1 false, label %then96, label %else97
+
+then96:                                           ; preds = %ifcont94
+  store i32 2, i32* %array_bound95, align 4
+  br label %ifcont104
+
+else97:                                           ; preds = %ifcont94
+  br i1 true, label %then98, label %else99
+
+then98:                                           ; preds = %else97
+  store i32 4, i32* %array_bound95, align 4
+  br label %ifcont104
+
+else99:                                           ; preds = %else97
+  br i1 false, label %then100, label %else101
+
+then100:                                          ; preds = %else99
+  store i32 6, i32* %array_bound95, align 4
+  br label %ifcont104
+
+else101:                                          ; preds = %else99
+  br i1 false, label %then102, label %else103
+
+then102:                                          ; preds = %else101
+  store i32 7, i32* %array_bound95, align 4
+  br label %ifcont104
+
+else103:                                          ; preds = %else101
+  br label %ifcont104
+
+ifcont104:                                        ; preds = %else103, %then102, %then100, %then98, %then96
+  %27 = load i32, i32* %array_bound95, align 4
+  %28 = sext i32 %27 to i64
+  br i1 false, label %then106, label %else107
+
+then106:                                          ; preds = %ifcont104
+  store i32 2, i32* %array_bound105, align 4
+  br label %ifcont114
+
+else107:                                          ; preds = %ifcont104
+  br i1 false, label %then108, label %else109
+
+then108:                                          ; preds = %else107
+  store i32 4, i32* %array_bound105, align 4
+  br label %ifcont114
+
+else109:                                          ; preds = %else107
+  br i1 true, label %then110, label %else111
+
+then110:                                          ; preds = %else109
+  store i32 6, i32* %array_bound105, align 4
+  br label %ifcont114
+
+else111:                                          ; preds = %else109
+  br i1 false, label %then112, label %else113
+
+then112:                                          ; preds = %else111
+  store i32 7, i32* %array_bound105, align 4
+  br label %ifcont114
+
+else113:                                          ; preds = %else111
+  br label %ifcont114
+
+ifcont114:                                        ; preds = %else113, %then112, %then110, %then108, %then106
+  %29 = load i32, i32* %array_bound105, align 4
+  %30 = sext i32 %29 to i64
+  br i1 false, label %then116, label %else117
+
+then116:                                          ; preds = %ifcont114
+  store i32 2, i32* %array_bound115, align 4
+  br label %ifcont124
+
+else117:                                          ; preds = %ifcont114
+  br i1 false, label %then118, label %else119
+
+then118:                                          ; preds = %else117
+  store i32 4, i32* %array_bound115, align 4
+  br label %ifcont124
+
+else119:                                          ; preds = %else117
+  br i1 false, label %then120, label %else121
+
+then120:                                          ; preds = %else119
+  store i32 6, i32* %array_bound115, align 4
+  br label %ifcont124
+
+else121:                                          ; preds = %else119
+  br i1 true, label %then122, label %else123
+
+then122:                                          ; preds = %else121
+  store i32 7, i32* %array_bound115, align 4
+  br label %ifcont124
+
+else123:                                          ; preds = %else121
+  br label %ifcont124
+
+ifcont124:                                        ; preds = %else123, %then122, %then120, %then118, %then116
+  %31 = load i32, i32* %array_bound115, align 4
+  %32 = sext i32 %31 to i64
+  %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 2, i64 %26, i32 2, i64 %28, i32 2, i64 %30, i32 2, i64 %32)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  br i1 true, label %then126, label %else127
+
+then126:                                          ; preds = %ifcont124
+  store i32 6, i32* %array_bound125, align 4
+  br label %ifcont130
+
+else127:                                          ; preds = %ifcont124
+  br i1 false, label %then128, label %else129
+
+then128:                                          ; preds = %else127
+  store i32 1, i32* %array_bound125, align 4
+  br label %ifcont130
+
+else129:                                          ; preds = %else127
+  br label %ifcont130
+
+ifcont130:                                        ; preds = %else129, %then128, %then126
+  %34 = load i32, i32* %array_bound125, align 4
+  %35 = sext i32 %34 to i64
+  br i1 false, label %then132, label %else133
+
+then132:                                          ; preds = %ifcont130
+  store i32 6, i32* %array_bound131, align 4
+  br label %ifcont136
+
+else133:                                          ; preds = %ifcont130
+  br i1 true, label %then134, label %else135
+
+then134:                                          ; preds = %else133
+  store i32 1, i32* %array_bound131, align 4
+  br label %ifcont136
+
+else135:                                          ; preds = %else133
+  br label %ifcont136
+
+ifcont136:                                        ; preds = %else135, %then134, %then132
+  %36 = load i32, i32* %array_bound131, align 4
+  %37 = sext i32 %36 to i64
+  %38 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %35, i32 2, i64 %37)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %38, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  br i1 true, label %then138, label %else139
+
+then138:                                          ; preds = %ifcont136
+  store i32 10, i32* %array_bound137, align 4
+  br label %ifcont142
+
+else139:                                          ; preds = %ifcont136
+  br i1 false, label %then140, label %else141
+
+then140:                                          ; preds = %else139
+  store i32 7, i32* %array_bound137, align 4
+  br label %ifcont142
+
+else141:                                          ; preds = %else139
+  br label %ifcont142
+
+ifcont142:                                        ; preds = %else141, %then140, %then138
+  %39 = load i32, i32* %array_bound137, align 4
+  %40 = sext i32 %39 to i64
+  br i1 false, label %then144, label %else145
+
+then144:                                          ; preds = %ifcont142
+  store i32 10, i32* %array_bound143, align 4
+  br label %ifcont148
+
+else145:                                          ; preds = %ifcont142
+  br i1 true, label %then146, label %else147
+
+then146:                                          ; preds = %else145
+  store i32 7, i32* %array_bound143, align 4
+  br label %ifcont148
+
+else147:                                          ; preds = %else145
+  br label %ifcont148
+
+ifcont148:                                        ; preds = %else147, %then146, %then144
+  %41 = load i32, i32* %array_bound143, align 4
+  %42 = sext i32 %41 to i64
+  %43 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %40, i32 2, i64 %42)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  br i1 true, label %then150, label %else151
+
+then150:                                          ; preds = %ifcont148
+  store i32 1, i32* %array_bound149, align 4
+  br label %ifcont152
+
+else151:                                          ; preds = %ifcont148
+  br label %ifcont152
+
+ifcont152:                                        ; preds = %else151, %then150
+  %44 = load i32, i32* %array_bound149, align 4
+  %45 = sext i32 %44 to i64
+  %46 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %45)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  br i1 true, label %then154, label %else155
+
+then154:                                          ; preds = %ifcont152
+  store i32 4, i32* %array_bound153, align 4
+  br label %ifcont156
+
+else155:                                          ; preds = %ifcont152
+  br label %ifcont156
+
+ifcont156:                                        ; preds = %else155, %then154
+  %47 = load i32, i32* %array_bound153, align 4
+  %48 = sext i32 %47 to i64
+  %49 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %48)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %.entry
+return:                                           ; preds = %ifcont156
   ret i32 0
 }
 

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "ad4617c79b9076b9faeb41c1d14b514d60cdfe44c8cbd468ba53c1a2",
+    "stdout_hash": "e50a994bb07d778e2f2b0dc61434a7b4069126b7454bb74c1ea07e3c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -3,9 +3,9 @@ source_filename = "LFortran"
 
 %complex_4 = type { float, float }
 
-@0 = private unnamed_addr constant [5 x i8] c"left\00", align 1
-@1 = private unnamed_addr constant [2 x i8] c"l\00", align 1
-@2 = private unnamed_addr constant [4 x i8] c"eft\00", align 1
+@0 = private unnamed_addr constant [2 x i8] c"l\00", align 1
+@1 = private unnamed_addr constant [4 x i8] c"eft\00", align 1
+@2 = private unnamed_addr constant [5 x i8] c"left\00", align 1
 @3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @4 = private unnamed_addr constant [6 x i8] c"False\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"True\00", align 1
@@ -23,8 +23,14 @@ define i32 @main(i32 %0, i8** %1) {
   %j = alloca i32, align 4
   store i32 2, i32* %j, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a1 = alloca i32, align 4
-  store i32 3, i32* %a1, align 4
+  %i1 = alloca i32, align 4
+  store i32 1, i32* %i1, align 4
+  %j2 = alloca i32, align 4
+  store i32 2, i32* %j2, align 4
+  %a3 = alloca i32, align 4
+  store i32 3, i32* %a3, align 4
+  %l = alloca i1, align 1
+  store i1 true, i1* %l, align 1
   %b = alloca i1, align 1
   store i1 true, i1* %b, align 1
   %c = alloca %complex_4, align 8
@@ -35,34 +41,28 @@ define i32 @main(i32 %0, i8** %1) {
   store float 4.000000e+00, float* %4, align 4
   %5 = load %complex_4, %complex_4* %2, align 4
   store %complex_4 %5, %complex_4* %c, align 4
-  %i2 = alloca i32, align 4
-  store i32 1, i32* %i2, align 4
-  %j3 = alloca i32, align 4
-  store i32 2, i32* %j3, align 4
-  %l = alloca i1, align 1
-  store i1 true, i1* %l, align 1
   %r = alloca float, align 4
   store float 4.000000e+00, float* %r, align 4
   %r_minus = alloca float, align 4
   store float -4.000000e+00, float* %r_minus, align 4
-  %s = alloca i8*, align 8
-  %6 = call i8* @_lfortran_malloc(i32 5)
-  call void @_lfortran_string_init(i32 5, i8* %6)
-  store i8* %6, i8** %s, align 8
-  call void @_lfortran_strcpy_pointer_string(i8** %s, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @0, i32 0, i32 0))
-  %7 = load i8*, i8** %s, align 8
   %s1 = alloca i8*, align 8
-  %8 = call i8* @_lfortran_malloc(i32 2)
-  call void @_lfortran_string_init(i32 2, i8* %8)
-  store i8* %8, i8** %s1, align 8
-  call void @_lfortran_strcpy_pointer_string(i8** %s1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  %9 = load i8*, i8** %s1, align 8
+  %6 = call i8* @_lfortran_malloc(i32 2)
+  call void @_lfortran_string_init(i32 2, i8* %6)
+  store i8* %6, i8** %s1, align 8
+  call void @_lfortran_strcpy_pointer_string(i8** %s1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %7 = load i8*, i8** %s1, align 8
   %s2 = alloca i8*, align 8
-  %10 = call i8* @_lfortran_malloc(i32 4)
-  call void @_lfortran_string_init(i32 4, i8* %10)
-  store i8* %10, i8** %s2, align 8
-  call void @_lfortran_strcpy_pointer_string(i8** %s2, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @2, i32 0, i32 0))
-  %11 = load i8*, i8** %s2, align 8
+  %8 = call i8* @_lfortran_malloc(i32 4)
+  call void @_lfortran_string_init(i32 4, i8* %8)
+  store i8* %8, i8** %s2, align 8
+  call void @_lfortran_strcpy_pointer_string(i8** %s2, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @1, i32 0, i32 0))
+  %9 = load i8*, i8** %s2, align 8
+  %s = alloca i8*, align 8
+  %10 = call i8* @_lfortran_malloc(i32 5)
+  call void @_lfortran_string_init(i32 5, i8* %10)
+  store i8* %10, i8** %s, align 8
+  call void @_lfortran_strcpy_pointer_string(i8** %s, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0))
+  %11 = load i8*, i8** %s, align 8
   %12 = alloca %complex_4, align 8
   %13 = getelementptr %complex_4, %complex_4* %12, i32 0, i32 0
   %14 = getelementptr %complex_4, %complex_4* %12, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "866ef06f0571649d7214d730628b7398c75be260c7a5f620964199e7",
+    "stdout_hash": "0c70f54389e895a362fa931f1b0a3840ee9f87f193d5a44f9d3e5398",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -92,76 +92,44 @@ return:                                           ; preds = %.entry
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value15 = alloca i1, align 1
-  %call_arg_value14 = alloca i1, align 1
-  %call_arg_value13 = alloca i1, align 1
-  %call_arg_value12 = alloca i1, align 1
-  %call_arg_value11 = alloca i1, align 1
-  %call_arg_value10 = alloca i1, align 1
-  %call_arg_value9 = alloca i1, align 1
-  %call_arg_value8 = alloca i1, align 1
-  %call_arg_value7 = alloca i1, align 1
-  %call_arg_value6 = alloca i1, align 1
-  %call_arg_value5 = alloca i1, align 1
-  %call_arg_value4 = alloca i1, align 1
-  %call_arg_value3 = alloca i1, align 1
-  %call_arg_value2 = alloca i1, align 1
-  %call_arg_value1 = alloca i1, align 1
-  %call_arg_value = alloca i1, align 1
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i1, align 1
   store i1 false, i1* %f, align 1
   %t = alloca i1, align 1
   store i1 true, i1* %t, align 1
-  store i1 true, i1* %call_arg_value, align 1
-  store i1 true, i1* %call_arg_value1, align 1
-  %2 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %call_arg_value, i1* %call_arg_value1)
+  %2 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %t)
   %3 = icmp eq i1 %2, false
   %4 = select i1 %3, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 8, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  store i1 true, i1* %call_arg_value2, align 1
-  store i1 false, i1* %call_arg_value3, align 1
-  %6 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %call_arg_value2, i1* %call_arg_value3)
+  %6 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %f)
   %7 = icmp eq i1 %6, false
   %8 = select i1 %7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 8, i8* %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  store i1 false, i1* %call_arg_value4, align 1
-  store i1 true, i1* %call_arg_value5, align 1
-  %10 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %call_arg_value4, i1* %call_arg_value5)
+  %10 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %t)
   %11 = icmp eq i1 %10, false
   %12 = select i1 %11, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0)
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 8, i8* %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  store i1 false, i1* %call_arg_value6, align 1
-  store i1 false, i1* %call_arg_value7, align 1
-  %14 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %call_arg_value6, i1* %call_arg_value7)
+  %14 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %f)
   %15 = icmp eq i1 %14, false
   %16 = select i1 %15, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0)
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i32 8, i8* %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0))
-  store i1 true, i1* %call_arg_value8, align 1
-  store i1 true, i1* %call_arg_value9, align 1
-  %18 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %call_arg_value8, i1* %call_arg_value9)
+  %18 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %t)
   %19 = sext i32 %18 to i64
   %20 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i32 2, i64 %19)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @22, i32 0, i32 0), i8* %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  store i1 true, i1* %call_arg_value10, align 1
-  store i1 false, i1* %call_arg_value11, align 1
-  %21 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %call_arg_value10, i1* %call_arg_value11)
+  %21 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %f)
   %22 = sext i32 %21 to i64
   %23 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @24, i32 0, i32 0), i32 2, i64 %22)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0))
-  store i1 false, i1* %call_arg_value12, align 1
-  store i1 true, i1* %call_arg_value13, align 1
-  %24 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %call_arg_value12, i1* %call_arg_value13)
+  %24 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %t)
   %25 = sext i32 %24 to i64
   %26 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i32 2, i64 %25)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @28, i32 0, i32 0), i8* %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
-  store i1 false, i1* %call_arg_value14, align 1
-  store i1 false, i1* %call_arg_value15, align 1
-  %27 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %call_arg_value14, i1* %call_arg_value15)
+  %27 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %f)
   %28 = sext i32 %27 to i64
   %29 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @30, i32 0, i32 0), i32 2, i64 %28)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "03f311ed0e1d591a0b8a18f9badfcbd724c317a429ddfa5191c0d702",
+    "stdout_hash": "2bceb0d24bc20a28931cb5c39115c7170dd65ca7efdf8d778eb5a6b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -42,6 +42,66 @@ source_filename = "LFortran"
 @38 = private unnamed_addr constant [5 x i8] c"True\00", align 1
 @39 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
+define i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %log1, i1* %log2) {
+.entry:
+  %greater_than_inverse = alloca i1, align 1
+  %0 = load i1, i1* %log1, align 1
+  %1 = load i1, i1* %log2, align 1
+  %2 = select i1 false, i1 true, i1 %1
+  %3 = icmp eq i1 %0, false
+  %4 = xor i1 %0, %2
+  %5 = xor i1 %4, true
+  %6 = icmp eq i1 %5, false
+  %7 = xor i1 %5, false
+  %8 = xor i1 %7, true
+  br i1 %8, label %then, label %else
+
+then:                                             ; preds = %.entry
+  store i1 true, i1* %greater_than_inverse, align 1
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  store i1 false, i1* %greater_than_inverse, align 1
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
+  %9 = load i1, i1* %greater_than_inverse, align 1
+  ret i1 %9
+}
+
+define i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %log1, i1* %log2) {
+.entry:
+  %less_than_inverse = alloca i1, align 1
+  %0 = load i1, i1* %log1, align 1
+  %1 = load i1, i1* %log2, align 1
+  %2 = select i1 true, i1 false, i1 %1
+  %3 = icmp eq i1 %0, false
+  %4 = xor i1 %0, %2
+  %5 = xor i1 %4, true
+  %6 = icmp eq i1 %5, false
+  %7 = xor i1 %5, true
+  %8 = xor i1 %7, true
+  br i1 %8, label %then, label %else
+
+then:                                             ; preds = %.entry
+  store i1 true, i1* %less_than_inverse, align 1
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  store i1 false, i1* %less_than_inverse, align 1
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  br label %return
+
+return:                                           ; preds = %ifcont
+  %9 = load i1, i1* %less_than_inverse, align 1
+  ret i1 %9
+}
+
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -49,22 +109,46 @@ define i32 @main(i32 %0, i8** %1) {
   store i1 false, i1* %f, align 1
   %t = alloca i1, align 1
   store i1 true, i1* %t, align 1
-  %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @12, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @17, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0))
-  %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @22, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @24, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @27, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
-  %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @34, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
-  %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @36, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @37, i32 0, i32 0))
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0))
+  %2 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %t)
+  %3 = icmp eq i1 %2, false
+  %4 = select i1 %3, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
+  %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 8, i8* %4)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %6 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %f)
+  %7 = icmp eq i1 %6, false
+  %8 = select i1 %7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
+  %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 8, i8* %8)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  %10 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %t)
+  %11 = icmp eq i1 %10, false
+  %12 = select i1 %11, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0)
+  %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 8, i8* %12)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  %14 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %f)
+  %15 = icmp eq i1 %14, false
+  %16 = select i1 %15, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0)
+  %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i32 8, i8* %16)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0))
+  %18 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %t)
+  %19 = icmp eq i1 %18, false
+  %20 = select i1 %19, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @22, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0)
+  %21 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i32 8, i8* %20)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @24, i32 0, i32 0), i8* %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  %22 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %f)
+  %23 = icmp eq i1 %22, false
+  %24 = select i1 %23, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @28, i32 0, i32 0)
+  %25 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i32 8, i8* %24)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
+  %26 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %t)
+  %27 = icmp eq i1 %26, false
+  %28 = select i1 %27, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0)
+  %29 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i32 8, i8* %28)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @34, i32 0, i32 0), i8* %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  %30 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %f)
+  %31 = icmp eq i1 %30, false
+  %32 = select i1 %31, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0)
+  %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @36, i32 0, i32 0), i32 8, i8* %32)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0))
   call void @_lpython_free_argv()
   br label %return
 


### PR DESCRIPTION
One example with `integration_tests/parameter_13.f90`,

```zsh
[(If (IntegerCompare (TypeInquiry Kind (Real 4) (Var 2 y) (Integer 4) (IntegerConstant 4 (Integer 4) Decimal)) NotEq (Var 2 sp) (Logical 4) (LogicalConstant .false. (Logical 4))) [(ErrorStop ())] []) (Print (StringFormat () [(Var 2 s)] FormatFortran (String -1 0 () PointerString) ())) (If (RealCompare (IntrinsicElementalFunction Abs [(RealBinOp (Var 2 s) Sub (RealConstant 2.000000 (Real 8)) (Real 8) (RealConstant 0.000000 (Real 8)))] 0 (Real 8) (RealConstant 0.000000 (Real 8))) Gt (RealConstant 0.000000 (Real 8)) (Logical 4) (LogicalConstant .false. (Logical 4))) [(ErrorStop ())] [])])}) [])
```

is reduced to,

```zsh
[(If (LogicalConstant .false. (Logical 4)) [(ErrorStop ())] []) (Print (StringFormat () [(RealConstant 2.000000 (Real 8))] FormatFortran (String -1 0 () PointerString) ())) (If (LogicalConstant .false. (Logical 4)) [(ErrorStop ())] [])])}) [])
```

This helps the latter passes to not process unnecessary information in the ASR.

I will apply it only in `--fast` mode. Just testing without `--fast` mode to cover corner cases.