### PR TITLE
test: Add tests for error  in array reshape with `pad` and `order` arguments

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6326,8 +6326,8 @@ public:
             pad = x.m_args[2].m_end;
         }
         if (x.n_args > 3){
-            order = x.m_args[2].m_end;
-            pad = x.m_args[3].m_end;
+            pad = x.m_args[2].m_end;
+            order = x.m_args[3].m_end;
         }
         for( size_t i=0;i<x.n_keywords;i++ ) {
             if( to_lower(x.m_keywords[i].m_arg) == "source" ) {

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -180,4 +180,12 @@ program continue_compilation_1
     
     print *, sum([1, 2, 3], mask = [1, 2, 3])
     z1 = y 
+
+    print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], 0)
+    print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0], 0)
+    print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [1.2])
+    print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0_8])
+
+    print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [1.0, 2.0])
+    print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 3])
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "bccb17a444654905dd6c6bc431e2a5322ea5d908d91a983c850c84a9",
+    "infile_hash": "ea071acd3d1a29e0eff9a2c595b6504fe0cb124fded0d6ff1f86c431",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "a5fe9a25fe6b019288fd9787b40b36d9474d3ddbd180cc7e7ba64d0c",
+    "stderr_hash": "bdacf194bab49f6d52602d674f6c87a65d802e5fc57973478ce5f056",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -484,3 +484,39 @@ semantic error: Type mismatch in assignment, the types must be compatible
     |
 182 |     z1 = y 
     |     ^^   ^ type mismatch (real and logical)
+
+semantic error: reshape accepts arrays for `pad` argument, found i32 instead.
+   --> tests/errors/continue_compilation_1.f90:184:50
+    |
+184 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], 0)
+    |                                                  ^ 
+
+semantic error: reshape accepts arrays for `order` argument, found i32 instead.
+   --> tests/errors/continue_compilation_1.f90:185:55
+    |
+185 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0], 0)
+    |                                                       ^ 
+
+semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type f32[1] source type i32[6] instead.
+   --> tests/errors/continue_compilation_1.f90:186:50
+    |
+186 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [1.2])
+    |                                                  ^^^^^ 
+
+semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type i64[1] source type i32[6] instead.
+   --> tests/errors/continue_compilation_1.f90:187:50
+    |
+187 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0_8])
+    |                                                  ^^^^^ 
+
+semantic error: reshape accepts `order` array with integer elements
+   --> tests/errors/continue_compilation_1.f90:189:58
+    |
+189 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [1.0, 2.0])
+    |                                                          ^^^^^^^^^^ 
+
+semantic error: reshape accepts `order` array as a permutation of elements from 1 to 2
+   --> tests/errors/continue_compilation_1.f90:190:58
+    |
+190 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 3])
+    |                                                          ^^^^^^ 


### PR DESCRIPTION
Apply suggestion from https://github.com/lfortran/lfortran/pull/6254#issuecomment-2654254370