### PR TITLE
fix: create temporary when `ArraySection` pointer is passed to funccall 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -439,6 +439,7 @@ RUN(NAME functions_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_33 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_34 LABELS gfortran llvm NO_STD_F23)
+RUN(NAME functions_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_35.f90
+++ b/integration_tests/functions_35.f90
@@ -1,0 +1,21 @@
+module function_33_mod
+contains
+subroutine istril(y)
+    real(8), intent(inout) :: y(:, :)
+    if (y(2,2) /= 0.0) error stop
+    if (y(1,2) /= 2.0) error stop
+end subroutine
+subroutine matprod(y)
+    real(8), intent(inout) :: y(:, :)
+    y(1,2) = 2
+    call istril(y)
+end subroutine 
+end module
+
+program function_33
+    use function_33_mod
+    real(8) :: A(5,3)
+    A = 1.0_8
+    A(2,2) = 0
+    call matprod(A(1:2,1:2))
+end program 

--- a/integration_tests/legacy_array_sections_02.f90
+++ b/integration_tests/legacy_array_sections_02.f90
@@ -13,5 +13,5 @@ integer :: j
 j = 3
 a = 1
 a(2,3) = 2
-call sub(a(1,j))
+! call sub(a(1,j))
 end program

--- a/integration_tests/legacy_array_sections_02.f90
+++ b/integration_tests/legacy_array_sections_02.f90
@@ -13,5 +13,5 @@ integer :: j
 j = 3
 a = 1
 a(2,3) = 2
-! call sub(a(1,j))
+call sub(a(1,j))
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5644,8 +5644,8 @@ public:
                         ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(arg_expr);
                         ASR::expr_t* array_expr = array_item->m_v;
                         LCOMPILERS_ASSERT(array_item->n_args > 0);
-                        ASR::array_index_t last_arg = array_item->m_args[array_item->n_args - 1];
-                        ASR::expr_t* idx = last_arg.m_right;
+                        ASR::array_index_t first_arg = array_item->m_args[0];
+                        ASR::expr_t* idx = first_arg.m_right;
 
                         Vec<ASR::dimension_t> dims;
                         dims.reserve(al, 1);
@@ -5665,14 +5665,13 @@ public:
                         Vec<ASR::array_index_t> array_indices;
                         array_indices.reserve(al, array_item->n_args);
 
-                        for (size_t i = 0; i < array_item->n_args - 1; i++) {
+                        for (size_t i = 0; i < array_item->n_args; i++) {
                             array_indices.push_back(al, array_item->m_args[i]);
                         }
 
-                        ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, compiler_options.po.default_integer_kind));
-                        ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int_type));
+                        ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, ASRUtils::extract_type(ASRUtils::expr_type(idx))));
 
-                        ASR::expr_t* array_bound = ASRUtils::get_bound<SemanticAbort>(array_expr, array_item->n_args, "ubound", al, diag);
+                        ASR::expr_t* array_bound = ASRUtils::get_bound<SemanticAbort>(array_expr, 1, "ubound", al, diag);
 
                         ASR::array_index_t array_idx;
                         array_idx.loc = array_item->base.base.loc;
@@ -5680,7 +5679,7 @@ public:
                         array_idx.m_right = array_bound;
                         array_idx.m_step = one;
 
-                        array_indices.push_back(al, array_idx);
+                        array_indices.p[0] = array_idx;
 
                         ASR::expr_t* array_section = ASRUtils::EXPR(ASR::make_ArraySection_t(al, array_item->base.base.loc,
                                                     array_expr, array_indices.p, array_indices.size(),

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4870,19 +4870,50 @@ public:
             Vec<ASR::dimension_t> array_section_dims;
             array_section_dims.reserve(al, n_args);
             for( size_t i = 0; i < n_args; i++ ) {
-                if( args.p[i].m_step != nullptr &&
-                    args.p[i].m_left == nullptr ) {
-                    args.p[i].m_left = ASRUtils::get_bound<SemanticAbort>(v_Var, i + 1, "lbound", al, diag);
+                ASR::expr_t* start = args.p[i].m_left;
+                ASR::expr_t* end = args.p[i].m_right;
+                ASR::expr_t* step = args.p[i].m_step;
+                bool is_any_kind_8 = false;
+
+                if( step != nullptr &&
+                    start == nullptr ) {
+                    start = ASRUtils::get_bound<SemanticAbort>(v_Var, i + 1, "lbound", al, diag);
                 }
-                if (args.p[i].m_step != nullptr
-                    || (args.p[i].m_step == nullptr && args.p[i].m_right != nullptr
-                        && ASRUtils::is_array(ASRUtils::expr_type(args.p[i].m_right)))) {
+                if ( step != nullptr
+                    || (step == nullptr && end != nullptr
+                        && ASRUtils::is_array(ASRUtils::expr_type(end)))) {
                     ASR::dimension_t empty_dim;
                     empty_dim.loc = loc;
                     empty_dim.m_start = nullptr;
                     empty_dim.m_length = nullptr;
                     array_section_dims.push_back(al, empty_dim);
                 }
+                
+                if( !ASRUtils::is_array(ASRUtils::expr_type(end)) && 
+                    ( (end && ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(end)) == 8) || 
+                    (start && ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(start)) == 8) || 
+                    (step && ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(step)) == 8) )) {
+                        is_any_kind_8 = true;
+                }
+                if( is_any_kind_8 ) {
+                    ASR::expr_t* int_one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                        al, loc, 1, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 8))));
+                    if( end && ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(end)) != 8 ) {
+                        end = ASRUtils::EXPR(ASRUtils::make_Cast_t_value(
+                            al, end->base.loc, end, ASR::cast_kindType::IntegerToInteger, ASRUtils::expr_type(int_one)));
+                    }
+                    if( start && ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(start)) != 8 ) {
+                        start = ASRUtils::EXPR(ASRUtils::make_Cast_t_value(
+                            al, start->base.loc, start, ASR::cast_kindType::IntegerToInteger, ASRUtils::expr_type(int_one)));
+                    }
+                    if( step && ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(step)) != 8 ) {
+                        step = ASRUtils::EXPR(ASRUtils::make_Cast_t_value(
+                            al, step->base.loc, step, ASR::cast_kindType::IntegerToInteger, ASRUtils::expr_type(int_one)));
+                    }
+                }
+                args.p[i].m_left = start;
+                args.p[i].m_right = end;
+                args.p[i].m_step = step;
             }
             type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable(type),
                     &array_section_dims);


### PR DESCRIPTION
Fixes #6214
