### PR TITLE
fix: handle compile time values correctly in `pack` intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1037,6 +1037,7 @@ RUN(NAME intrinsics_355 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # system_
 RUN(NAME intrinsics_356 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_357 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_358 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # getseed
+RUN(NAME intrinsics_359 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # pack
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NOFAST) # LAPACK constants
 

--- a/integration_tests/intrinsics_359.f90
+++ b/integration_tests/intrinsics_359.f90
@@ -1,0 +1,6 @@
+program intrinsics_359
+    implicit none
+    integer :: k
+    print *, pack( [(k, k = 1, 2)] , [.true., .true.] )
+    if (any(pack( [(k, k = 1, 2)] , [.true., .true.] ) /= [1, 2])) error stop
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -4818,15 +4818,18 @@ namespace Pack {
         if (is_type_allocatable) {
             ret_type = TYPE(ASRUtils::make_Allocatable_t_util(al, loc, ret_type));
         }
-        Vec<ASR::expr_t*> m_args; m_args.reserve(al, 2);
+        Vec<ASR::expr_t*> arg_values; arg_values.reserve(al, 3);
+        arg_values.push_back(al, expr_value(array)); arg_values.push_back(al, expr_value(mask));
+        Vec<ASR::expr_t*> m_args; m_args.reserve(al, 3);
         m_args.push_back(al, array); m_args.push_back(al, mask);
         if (is_vector_present) {
+            arg_values.push_back(al, expr_value(vector));
             m_args.push_back(al, vector);
             overload_id = 3;
         }
         ASR::expr_t *value = nullptr;
         if (all_args_evaluated(m_args)) {
-            value = eval_Pack(al, loc, ret_type, m_args, diag);
+            value = eval_Pack(al, loc, ret_type, arg_values, diag);
         }
         return make_IntrinsicArrayFunction_t_util(al, loc,
             static_cast<int64_t>(IntrinsicArrayFunctions::Pack),


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/6313