### PR TITLE
fix: update error message for reshape intrinsic

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6392,20 +6392,20 @@ public:
         }
         if( !ASRUtils::is_array(ASRUtils::expr_type(array)) ) {
             diag.add(Diagnostic("reshape accepts arrays for `source` argument, found " +
-                ASRUtils::type_to_str_python(ASRUtils::expr_type(array)) +
+                ASRUtils::type_to_str(ASRUtils::expr_type(array)) +
                 " instead.", Level::Error, Stage::Semantic, {Label("", {array->base.loc})}));
             throw SemanticAbort();
         }
         if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
             diag.add(Diagnostic("reshape accepts arrays for `shape` argument, found " +
-                ASRUtils::type_to_str_python(ASRUtils::expr_type(newshape)) +
+                ASRUtils::type_to_str(ASRUtils::expr_type(newshape)) +
                 " instead.", Level::Error, Stage::Semantic, {Label("", {shape->base.loc})}));
             throw SemanticAbort();
         }
         if (order_expr) {
             if (!ASRUtils::is_array(ASRUtils::expr_type(order_expr))){
                 diag.add(Diagnostic("reshape accepts arrays for `order` argument, found " +
-                    ASRUtils::type_to_str_python(ASRUtils::expr_type(order_expr)) +
+                    ASRUtils::type_to_str(ASRUtils::expr_type(order_expr)) +
                     " instead.", Level::Error, Stage::Semantic, {Label("", {order->base.loc})}));
                 throw SemanticAbort();
             }
@@ -6413,13 +6413,14 @@ public:
         if (pad_expr) {
             if (!ASRUtils::is_array(ASRUtils::expr_type(pad_expr))){
                 diag.add(Diagnostic("reshape accepts arrays for `pad` argument, found " +
-                    ASRUtils::type_to_str_python(ASRUtils::expr_type(pad_expr)) +
+                    ASRUtils::type_to_str(ASRUtils::expr_type(pad_expr)) +
                     " instead.", Level::Error, Stage::Semantic, {Label("", {pad->base.loc})}));
                 throw SemanticAbort();
             } else if ( (ASRUtils::type_to_str(ASRUtils::expr_type(pad_expr)) != ASRUtils::type_to_str(ASRUtils::expr_type(array)))|| 
             (ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(pad_expr)) != ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(array))) ){
                 diag.add(Diagnostic("`pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type " +
-                    ASRUtils::type_to_str_python(ASRUtils::expr_type(pad_expr)) + " source type " + ASRUtils::type_to_str_python(ASRUtils::expr_type(array)) +
+                    ASRUtils::type_to_str(ASRUtils::expr_type(pad_expr)) + " and kind " + std::to_string(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(pad_expr)))
+                     + " source type " + ASRUtils::type_to_str(ASRUtils::expr_type(array)) + " and kind " + std::to_string(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(array))) +
                     " instead.", Level::Error, Stage::Semantic, {Label("", {pad->base.loc})}));
                 throw SemanticAbort();
             }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "bdacf194bab49f6d52602d674f6c87a65d802e5fc57973478ce5f056",
+    "stderr_hash": "877a83f73eb5a3c5bd47c1f0dbc90407c668b9b57bdd6dc1437bc6ee",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -335,25 +335,25 @@ semantic error: Different shape for arguments `array` and `mask` for pack intrin
 144 |     print *, pack([1, 2, 3], [.true., .true., .true., .true.])
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: reshape accepts arrays for `source` argument, found str instead.
+semantic error: reshape accepts arrays for `source` argument, found string instead.
    --> tests/errors/continue_compilation_1.f90:146:22
     |
 146 |     print *, reshape("hello", [2, 3])
     |                      ^^^^^^^ 
 
-semantic error: reshape accepts arrays for `source` argument, found bool instead.
+semantic error: reshape accepts arrays for `source` argument, found logical instead.
    --> tests/errors/continue_compilation_1.f90:147:22
     |
 147 |     print *, reshape(.true., [2, 3])
     |                      ^^^^^^ 
 
-semantic error: reshape accepts arrays for `shape` argument, found str instead.
+semantic error: reshape accepts arrays for `shape` argument, found string instead.
    --> tests/errors/continue_compilation_1.f90:148:36
     |
 148 |     print *, reshape([1, 2, 3, 4], "hello")
     |                                    ^^^^^^^ 
 
-semantic error: reshape accepts arrays for `shape` argument, found bool instead.
+semantic error: reshape accepts arrays for `shape` argument, found logical instead.
    --> tests/errors/continue_compilation_1.f90:149:36
     |
 149 |     print *, reshape([1, 2, 3, 4], .false.)
@@ -485,25 +485,25 @@ semantic error: Type mismatch in assignment, the types must be compatible
 182 |     z1 = y 
     |     ^^   ^ type mismatch (real and logical)
 
-semantic error: reshape accepts arrays for `pad` argument, found i32 instead.
+semantic error: reshape accepts arrays for `pad` argument, found integer instead.
    --> tests/errors/continue_compilation_1.f90:184:50
     |
 184 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], 0)
     |                                                  ^ 
 
-semantic error: reshape accepts arrays for `order` argument, found i32 instead.
+semantic error: reshape accepts arrays for `order` argument, found integer instead.
    --> tests/errors/continue_compilation_1.f90:185:55
     |
 185 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0], 0)
     |                                                       ^ 
 
-semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type f32[1] source type i32[6] instead.
+semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type real[:] and kind 4 source type integer[:] and kind 4 instead.
    --> tests/errors/continue_compilation_1.f90:186:50
     |
 186 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [1.2])
     |                                                  ^^^^^ 
 
-semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type i64[1] source type i32[6] instead.
+semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type integer[:] and kind 8 source type integer[:] and kind 4 instead.
    --> tests/errors/continue_compilation_1.f90:187:50
     |
 187 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0_8])


### PR DESCRIPTION
Update error message to use `type_to_str` instead of `type_to_str_python` for array reshape.
Apply suggestion from https://github.com/lfortran/lfortran/pull/6311#discussion_r1956010433