### PR TITLE
fix: do not deallocate `allocatable` variables local to a function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1456,6 +1456,7 @@ RUN(NAME string_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_48.f90
+++ b/integration_tests/string_48.f90
@@ -1,0 +1,29 @@
+module string_48_mod
+   implicit none
+
+contains
+
+   subroutine split(s)
+      character(len=:), allocatable, intent(out) :: s(:)
+      character(:), allocatable :: tstr
+
+      allocate(character(len=1) :: s(1))
+
+      tstr = "A"
+      s(1) = tstr
+   end subroutine split
+
+end module string_48_mod
+
+program string_48
+   use string_48_mod
+   implicit none
+   character(:), allocatable :: out(:)
+
+   call split(out)
+
+   print *, "out ", out(1)
+   if (out(1) /= "A") error stop
+
+end program string_48
+

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -32,7 +32,8 @@ class InsertDeallocate: public ASR::CallReplacerOnExpressionsVisitor<InsertDeall
                 ASR::is_a<ASR::Allocatable_t>(*ASRUtils::symbol_type(s)) && 
                 (ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_allocatable(ASRUtils::symbol_type(s))) ||
                 ASRUtils::is_array(ASRUtils::symbol_type(s))) &&
-                ASRUtils::symbol_intent(s) == ASRUtils::intent_local){
+                ASRUtils::symbol_intent(s) == ASRUtils::intent_local
+                && !ASR::is_a<ASR::Function_t>(*ASRUtils::get_asr_owner(s))) {
                 return true;
             }
             return false;

--- a/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.json
+++ b/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_insert_deallocate-finalize_01-3efebdd.stdout",
-    "stdout_hash": "49673dd026efa4a62e70830a9a496e0db94cbece1847e1b3b2cee631",
+    "stdout_hash": "7a28e0a2c554edf7fb85657e3575e0b6c34b7e550f03d92481739621",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.stdout
+++ b/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.stdout
@@ -148,16 +148,8 @@
                                             .true.
                                             (Logical 4)
                                         )
-                                        [(ImplicitDeallocate
-                                            [(Var 6 arr_real)
-                                            (Var 6 str)]
-                                        )
-                                        (Return)]
+                                        [(Return)]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 6 arr_real)
-                                        (Var 6 str)]
                                     )]
                                     ()
                                     Public
@@ -301,17 +293,8 @@
                                             .true.
                                             (Logical 4)
                                         )
-                                        [(ImplicitDeallocate
-                                            [(Var 4 arr)]
-                                        )
-                                        (Return)]
-                                        [(ImplicitDeallocate
-                                            [(Var 4 arr)]
-                                        )
-                                        (Return)]
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 4 arr)]
+                                        [(Return)]
+                                        [(Return)]
                                     )]
                                     ()
                                     Public
@@ -386,9 +369,6 @@
                                         ()
                                         ()
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 str)]
                                     )
                                     (Return)
                                     (DoLoop


### PR DESCRIPTION
fixes #6322 

These variables are allocated on the stack using
`alloca` and freed later by LLVM.