### PR TITLE
chore: rename `type_to_str` to `type_to_str_fortran`

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2728,8 +2728,8 @@ public:
                                         ASRUtils::expr_type(value),ASRUtils::expr_type(to_return), diag);
         if (!ASRUtils::check_equal_type(ASRUtils::expr_type(to_return),
                                     ASRUtils::expr_type(value))) {
-            std::string ltype = ASRUtils::type_to_str(ASRUtils::expr_type(to_return));
-            std::string rtype = ASRUtils::type_to_str(ASRUtils::expr_type(value));
+            std::string ltype = ASRUtils::type_to_str_fortran(ASRUtils::expr_type(to_return));
+            std::string rtype = ASRUtils::type_to_str_fortran(ASRUtils::expr_type(value));
             diag.semantic_error_label(
                 "Type mismatch in statement function, the types must be compatible",
                 {to_return->base.loc, value->base.loc},
@@ -3037,8 +3037,8 @@ public:
             }
             if (!ASRUtils::check_equal_type(ASRUtils::expr_type(target),
                                         ASRUtils::expr_type(value))) {
-                std::string ltype = ASRUtils::type_to_str(ASRUtils::expr_type(target));
-                std::string rtype = ASRUtils::type_to_str(ASRUtils::expr_type(value));
+                std::string ltype = ASRUtils::type_to_str_fortran(ASRUtils::expr_type(target));
+                std::string rtype = ASRUtils::type_to_str_fortran(ASRUtils::expr_type(value));
                 if(value->type == ASR::exprType::ArrayConstant) {
                     ASR::ArrayConstant_t *ac = ASR::down_cast<ASR::ArrayConstant_t>(value);
                     for (size_t i = 0; i < (size_t) ASRUtils::get_fixed_size_of_array(ac->m_type); i++) {
@@ -3896,9 +3896,9 @@ public:
         ASR::ttype_t *test_type = ASRUtils::expr_type(test);
         if (!ASR::is_a<ASR::Logical_t>(*test_type)) {
             diag.add(diag::Diagnostic("Expected logical expression in if statement, but recieved " +
-                ASRUtils::type_to_str(test_type) + " instead",
+                ASRUtils::type_to_str_fortran(test_type) + " instead",
                 diag::Level::Error, diag::Stage::Semantic, {
-                diag::Label(ASRUtils::type_to_str(test_type) + " expression, expected logical", {test->base.loc})}));
+                diag::Label(ASRUtils::type_to_str_fortran(test_type) + " expression, expected logical", {test->base.loc})}));
             throw SemanticAbort();
         }
         Vec<ASR::stmt_t*> body;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -602,8 +602,8 @@ inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
                 default:
                     LCOMPILERS_ASSERT(false);
             }
-            diag.add(Diagnostic("Operator `" + op_str + "` undefined for the types in the expression `" + ASRUtils::type_to_str(left_type)
-                                + " " +  op_str + " " + ASRUtils::type_to_str(right_type) + "`", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+            diag.add(Diagnostic("Operator `" + op_str + "` undefined for the types in the expression `" + ASRUtils::type_to_str_fortran(left_type)
+                                + " " +  op_str + " " + ASRUtils::type_to_str_fortran(right_type) + "`", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
             throw SemanticAbort();
         }
     }
@@ -981,7 +981,7 @@ inline static void visit_BoolOp(Allocator &al, const AST::BoolOp_t &x,
         else {
             diag.add(diag::Diagnostic(
                 "Operand of .not. operator is "+
-                std::string(ASRUtils::type_to_str(operand_type)),
+                std::string(ASRUtils::type_to_str_fortran(operand_type)),
                 Level::Error, Stage::Semantic, {
                 diag::Label("", {x.base.base.loc})}));
             throw SemanticAbort();
@@ -5609,8 +5609,8 @@ public:
                 }
 
                 if(!ASRUtils::check_equal_type(arg_type,orig_arg_type)){
-                    std::string arg_str = ASRUtils::type_to_str(arg_type);
-                    std::string orig_arg_str = ASRUtils::type_to_str(orig_arg_type);
+                    std::string arg_str = ASRUtils::type_to_str_fortran(arg_type);
+                    std::string orig_arg_str = ASRUtils::type_to_str_fortran(orig_arg_type);
                     diag.add(Diagnostic("Type mismatch in argument at argument (" + std::to_string(i+1) +
                                         "); passed `" + arg_str + "` to `" + orig_arg_str + "`.",
                                         Level::Error, Stage::Semantic, {Label("", {args.p[i].loc})}));
@@ -6392,20 +6392,20 @@ public:
         }
         if( !ASRUtils::is_array(ASRUtils::expr_type(array)) ) {
             diag.add(Diagnostic("reshape accepts arrays for `source` argument, found " +
-                ASRUtils::type_to_str(ASRUtils::expr_type(array)) +
+                ASRUtils::type_to_str_fortran(ASRUtils::expr_type(array)) +
                 " instead.", Level::Error, Stage::Semantic, {Label("", {array->base.loc})}));
             throw SemanticAbort();
         }
         if( !ASRUtils::is_array(ASRUtils::expr_type(newshape)) ) {
             diag.add(Diagnostic("reshape accepts arrays for `shape` argument, found " +
-                ASRUtils::type_to_str(ASRUtils::expr_type(newshape)) +
+                ASRUtils::type_to_str_fortran(ASRUtils::expr_type(newshape)) +
                 " instead.", Level::Error, Stage::Semantic, {Label("", {shape->base.loc})}));
             throw SemanticAbort();
         }
         if (order_expr) {
             if (!ASRUtils::is_array(ASRUtils::expr_type(order_expr))){
                 diag.add(Diagnostic("reshape accepts arrays for `order` argument, found " +
-                    ASRUtils::type_to_str(ASRUtils::expr_type(order_expr)) +
+                    ASRUtils::type_to_str_fortran(ASRUtils::expr_type(order_expr)) +
                     " instead.", Level::Error, Stage::Semantic, {Label("", {order->base.loc})}));
                 throw SemanticAbort();
             }
@@ -6413,14 +6413,14 @@ public:
         if (pad_expr) {
             if (!ASRUtils::is_array(ASRUtils::expr_type(pad_expr))){
                 diag.add(Diagnostic("reshape accepts arrays for `pad` argument, found " +
-                    ASRUtils::type_to_str(ASRUtils::expr_type(pad_expr)) +
+                    ASRUtils::type_to_str_fortran(ASRUtils::expr_type(pad_expr)) +
                     " instead.", Level::Error, Stage::Semantic, {Label("", {pad->base.loc})}));
                 throw SemanticAbort();
-            } else if ( (ASRUtils::type_to_str(ASRUtils::expr_type(pad_expr)) != ASRUtils::type_to_str(ASRUtils::expr_type(array)))|| 
+            } else if ( (ASRUtils::type_to_str_fortran(ASRUtils::expr_type(pad_expr)) != ASRUtils::type_to_str_fortran(ASRUtils::expr_type(array)))|| 
             (ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(pad_expr)) != ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(array))) ){
                 diag.add(Diagnostic("`pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type " +
-                    ASRUtils::type_to_str(ASRUtils::expr_type(pad_expr)) + " and kind " + std::to_string(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(pad_expr)))
-                     + " source type " + ASRUtils::type_to_str(ASRUtils::expr_type(array)) + " and kind " + std::to_string(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(array))) +
+                    ASRUtils::type_to_str_fortran(ASRUtils::expr_type(pad_expr)) + " and kind " + std::to_string(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(pad_expr)))
+                     + " source type " + ASRUtils::type_to_str_fortran(ASRUtils::expr_type(array)) + " and kind " + std::to_string(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(array))) +
                     " instead.", Level::Error, Stage::Semantic, {Label("", {pad->base.loc})}));
                 throw SemanticAbort();
             }
@@ -6939,14 +6939,14 @@ public:
                     int kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                     if (arg_type != required_type || kind != required_kind) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of " + ASRUtils::type_to_str(required_type) + " type with kind " + std::to_string(required_kind),
+                                            " must be of " + ASRUtils::type_to_str_fortran(required_type) + " type with kind " + std::to_string(required_kind),
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
                 } else {
                     if (arg_type != required_type) {
                         diag.add(Diagnostic("Argument " + std::to_string(i + 1) + " of " + intrinsic_name +
-                                            " must be of " + ASRUtils::type_to_str(required_type) + " type",
+                                            " must be of " + ASRUtils::type_to_str_fortran(required_type) + " type",
                                             Level::Error, Stage::Semantic, {Label("", {loc})}));
                         throw SemanticAbort();
                     }
@@ -7417,7 +7417,7 @@ public:
                     al, loc, arg, ASR::cast_kindType::ComplexToReal,
                     to_type, value));
         } else {
-            std::string stype = ASRUtils::type_to_str(type);
+            std::string stype = ASRUtils::type_to_str_fortran(type);
             diag.add(Diagnostic("Conversion of '" + stype + "' to float is not Implemented",
                                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
@@ -8166,8 +8166,8 @@ public:
                         ASR::ttype_t *source_type = ASRUtils::expr_type(source);
 
                         if (!ASRUtils::check_equal_type(dest_type, source_type)) {
-                            std::string dtype = ASRUtils::type_to_str(dest_type);
-                            std::string stype = ASRUtils::type_to_str(source_type);
+                            std::string dtype = ASRUtils::type_to_str_fortran(dest_type);
+                            std::string stype = ASRUtils::type_to_str_fortran(source_type);
                             diag.add(Diagnostic(
                                 "Type mismatch in function call, the function expects '" + dtype + "' but '" + stype + "' was provided",
                                 Level::Error, Stage::Semantic, {
@@ -8488,8 +8488,8 @@ public:
             // Don't Check.
         } else if (!ASRUtils::check_equal_type(ASRUtils::expr_type(left),
                                     ASRUtils::expr_type(right)) && overloaded == nullptr) {
-            std::string ltype = ASRUtils::type_to_str(ASRUtils::expr_type(left));
-            std::string rtype = ASRUtils::type_to_str(ASRUtils::expr_type(right));
+            std::string ltype = ASRUtils::type_to_str_fortran(ASRUtils::expr_type(left));
+            std::string rtype = ASRUtils::type_to_str_fortran(ASRUtils::expr_type(right));
             diag.add(Diagnostic(
                 "Type mismatch in binary operator, the types must be compatible",
                 Level::Error, Stage::Semantic, {
@@ -8560,8 +8560,8 @@ public:
                     default:
                         LCOMPILERS_ASSERT(false);
                 }
-            diag.add(Diagnostic("Operator `" + op_str + "` undefined for the types in the expression `" + ASRUtils::type_to_str(left_type)
-                                + " " +  op_str + " " + ASRUtils::type_to_str(right_type) + "`", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+            diag.add(Diagnostic("Operator `" + op_str + "` undefined for the types in the expression `" + ASRUtils::type_to_str_fortran(left_type)
+                                + " " +  op_str + " " + ASRUtils::type_to_str_fortran(right_type) + "`", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
                 throw SemanticAbort();
             }
         } else if( overloaded == nullptr ) {
@@ -8616,7 +8616,7 @@ public:
                     args[i], false, false, dims, type_declaration, current_procedure_abi_type);
                 ASR::ttype_t *param_type = ASRUtils::symbol_type(param_sym);
                 if (!ASRUtils::is_type_parameter(*param_type)) {
-                    diag.add(Diagnostic("The type " + ASRUtils::type_to_str(arg_type) +
+                    diag.add(Diagnostic("The type " + ASRUtils::type_to_str_fortran(arg_type) +
                         " cannot be applied to non-type parameter " + param, Level::Error, Stage::Semantic, {Label("", {loc})}));
                     throw SemanticAbort();
                 }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -432,7 +432,7 @@ public:
         std::cout << "Implicit Dictionary: " << std::endl;
         for (auto it: implicit_dictionary) {
             if (it.second) {
-                std::cout << it.first << " " << ASRUtils::type_to_str(it.second) << std::endl;
+                std::cout << it.first << " " << ASRUtils::type_to_str_fortran(it.second) << std::endl;
             } else {
                 std::cout << it.first << " " << "NULL" << std::endl;
             }
@@ -3230,7 +3230,7 @@ public:
                 ASR::ttype_t *ttype = determine_type(attr->base.loc, req_param,
                     attr, false, false, dims, type_declaration, current_procedure_abi_type);
 
-                req_arg = ASRUtils::type_to_str(ttype);
+                req_arg = ASRUtils::type_to_str_fortran(ttype);
                 type_subs[req_param] = ttype;
             } else {
                 diag.add(diag::Diagnostic(
@@ -3396,7 +3396,7 @@ public:
                 ASR::ttype_t *param_type = ASRUtils::symbol_type(param_sym);
                 if (!ASRUtils::is_type_parameter(*param_type)) {
                     diag.add(diag::Diagnostic(
-                        "The type " + ASRUtils::type_to_str(arg_type) +
+                        "The type " + ASRUtils::type_to_str_fortran(arg_type) +
                         " cannot be applied to non-type parameter " + param,
                         diag::Level::Error, diag::Stage::Semantic, {
                             diag::Label("", {x.m_args[i]->base.loc})}));
@@ -3566,7 +3566,7 @@ public:
                         args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, var)));
                     }
 
-                    //std::string func_name = op_name + "_intrinsic_" + ASRUtils::type_to_str(ltype);
+                    //std::string func_name = op_name + "_intrinsic_" + ASRUtils::type_to_str_fortran(ltype);
                     std::string func_name = parent_scope->get_unique_name(op_name + "_intrinsic");
 
                     ASR::ttype_t *return_type = nullptr;

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -928,12 +928,12 @@ void process_overloaded_assignment_function(ASR::symbol_t* proc, ASR::expr_t* ta
                 }
                 if( (arg0_name == pass_arg_str && target != expr_dt) ) {
                     err(std::string(subrout->m_name) + " is not a procedure of " +
-                        ASRUtils::type_to_str(target_type),
+                        ASRUtils::type_to_str_fortran(target_type),
                         loc);
                 }
                 if( (arg1_name == pass_arg_str && value != expr_dt) ) {
                     err(std::string(subrout->m_name) + " is not a procedure of " +
-                        ASRUtils::type_to_str(value_type),
+                        ASRUtils::type_to_str_fortran(value_type),
                         loc);
                 }
             }
@@ -1036,7 +1036,7 @@ void process_overloaded_read_write_function(std::string &read_write, ASR::symbol
             std::string pass_arg_str = std::string(pass_arg);
             if( (arg0_name == pass_arg_str && args[0] != expr_dt) ) {
                 err(std::string(subrout->m_name) + " is not a procedure of " +
-                    ASRUtils::type_to_str(arg_type),
+                    ASRUtils::type_to_str_fortran(arg_type),
                     loc);
             }
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -593,7 +593,7 @@ static inline void encode_dimensions(size_t n_dims, std::string& res,
     }
 }
 
-static inline std::string type_to_str(const ASR::ttype_t *t)
+static inline std::string type_to_str_fortran(const ASR::ttype_t *t)
 {
     switch (t->type) {
         case ASR::ttypeType::Integer: {
@@ -639,16 +639,16 @@ static inline std::string type_to_str(const ASR::ttype_t *t)
             return "type(c_ptr)";
         }
         case ASR::ttypeType::Pointer: {
-            return type_to_str(ASRUtils::type_get_past_pointer(
+            return type_to_str_fortran(ASRUtils::type_get_past_pointer(
                         const_cast<ASR::ttype_t*>(t))) + " pointer";
         }
         case ASR::ttypeType::Allocatable: {
-            return type_to_str(ASRUtils::type_get_past_allocatable(
+            return type_to_str_fortran(ASRUtils::type_get_past_allocatable(
                         const_cast<ASR::ttype_t*>(t))) + " allocatable";
         }
         case ASR::ttypeType::Array: {
             ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(t);
-            std::string res = type_to_str(array_t->m_type);
+            std::string res = type_to_str_fortran(array_t->m_type);
             encode_dimensions(array_t->n_dims, res, false);
             return res;
         }
@@ -663,11 +663,11 @@ static inline std::string type_to_str(const ASR::ttype_t *t)
             ASR::FunctionType_t* ftp = ASR::down_cast<ASR::FunctionType_t>(t);
             std::string result = "(";
             for( size_t i = 0; i < ftp->n_arg_types; i++ ) {
-                result += type_to_str(ftp->m_arg_types[i]) + ", ";
+                result += type_to_str_fortran(ftp->m_arg_types[i]) + ", ";
             }
             result += "return_type: ";
             if( ftp->m_return_var_type ) {
-                result += type_to_str(ftp->m_return_var_type);
+                result += type_to_str_fortran(ftp->m_return_var_type);
             } else {
                 result += "void";
             }
@@ -679,7 +679,7 @@ static inline std::string type_to_str(const ASR::ttype_t *t)
 }
 
 static inline std::string type_to_str_with_type(const ASR::ttype_t *t) {
-    std::string type = type_to_str(t);
+    std::string type = type_to_str_fortran(t);
     std::string kind = std::to_string(extract_kind_from_ttype_t(t));
     return type + "(" + kind + ")";
 }
@@ -721,7 +721,7 @@ static inline std::string type_to_str_with_substitution(const ASR::ttype_t *t,
             result += ")";
             return result;
         }
-        default : return type_to_str(t);
+        default : return type_to_str_fortran(t);
     }
 }
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7850,7 +7850,7 @@ public:
             case (ASR::cast_kindType::ListToArray) : {
                 if( !ASR::is_a<ASR::List_t>(*ASRUtils::expr_type(x.m_arg)) ) {
                     throw CodeGenError("The argument of ListToArray cast should "
-                        "be a list/std::vector, found, " + ASRUtils::type_to_str(
+                        "be a list/std::vector, found, " + ASRUtils::type_to_str_fortran(
                             ASRUtils::expr_type(x.m_arg)));
                 }
                 int64_t ptr_loads_copy = ptr_loads;
@@ -7983,7 +7983,7 @@ public:
                 break;
             }
             default: {
-                std::string s_type = ASRUtils::type_to_str(type);
+                std::string s_type = ASRUtils::type_to_str_fortran(type);
                 throw CodeGenError("Read function not implemented for: " + s_type);
             }
         }
@@ -8736,7 +8736,7 @@ public:
             }
         } else {
             throw CodeGenError("Printing support is not available for `" +
-                ASRUtils::type_to_str(t) + "` type.", loc);
+                ASRUtils::type_to_str_fortran(t) + "` type.", loc);
         }
 
         if(is_array){
@@ -9198,7 +9198,7 @@ public:
                         break;
                     }
                     default :
-                        throw CodeGenError("Type " + ASRUtils::type_to_str(arg_type) + " not implemented yet.");
+                        throw CodeGenError("Type " + ASRUtils::type_to_str_fortran(arg_type) + " not implemented yet.");
                 }
                 if( ASR::is_a<ASR::EnumValue_t>(*x.m_args[i].m_value) ) {
                     target_type = llvm::Type::getInt32Ty(context);

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -705,7 +705,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             }
             default: {
                 diag.codegen_warning_label("Declare Global: Type "
-                 + ASRUtils::type_to_str(v_m_type) + " not yet supported", {v->base.base.loc}, "");
+                 + ASRUtils::type_to_str_fortran(v_m_type) + " not yet supported", {v->base.base.loc}, "");
                 global_var_idx = m_wa.declare_global_var(i32, 0);
             }
         }
@@ -963,7 +963,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 }
             } else {
                 diag.codegen_warning_label("Unsupported variable type: " +
-                        ASRUtils::type_to_str(v->m_type), {v->base.base.loc},
+                        ASRUtils::type_to_str_fortran(v->m_type), {v->base.base.loc},
                         "Only integer, floats, logical and complex supported currently");
                 type_vec.push_back(i32);
             }
@@ -1296,7 +1296,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             }
             default: {
                 throw CodeGenError("MemoryStore: Type " +
-                                   ASRUtils::type_to_str(ttype) +
+                                   ASRUtils::type_to_str_fortran(ttype) +
                                    " not yet supported");
             }
         }
@@ -1397,7 +1397,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             }
             default: {
                 throw CodeGenError("MemoryStore: Type " +
-                                   ASRUtils::type_to_str(ttype) +
+                                   ASRUtils::type_to_str_fortran(ttype) +
                                    " not yet supported");
             }
         }
@@ -1485,7 +1485,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             }
             default: {
                 throw CodeGenError("MemoryLoad: Type " +
-                                   ASRUtils::type_to_str(ttype) +
+                                   ASRUtils::type_to_str_fortran(ttype) +
                                    " not yet supported");
             }
         }
@@ -2690,7 +2690,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             }
             default: {
                 throw CodeGenError("temp_value_set: Type " +
-                                   ASRUtils::type_to_str(ttype) +
+                                   ASRUtils::type_to_str_fortran(ttype) +
                                    " not yet supported");
             }
         }
@@ -2739,7 +2739,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             }
             default: {
                 throw CodeGenError("temp_value_get: Type " +
-                                   ASRUtils::type_to_str(ttype) +
+                                   ASRUtils::type_to_str_fortran(ttype) +
                                    " not yet supported");
             }
         }

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1519,7 +1519,7 @@ namespace LCompilers {
                 break;
             }
             default :
-                throw CodeGenError("Support for type " + ASRUtils::type_to_str(asr_type) +
+                throw CodeGenError("Support for type " + ASRUtils::type_to_str_fortran(asr_type) +
                                    " not yet implemented.");
         }
         return llvm_type;
@@ -2193,7 +2193,7 @@ namespace LCompilers {
             }
             default: {
                 throw LCompilersException("LLVMUtils::deepcopy isn't implemented for " +
-                                          ASRUtils::type_to_str(asr_type));
+                                          ASRUtils::type_to_str_fortran(asr_type));
             }
         }
     }

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -842,10 +842,10 @@ void report_check_restriction(std::map<std::string, ASR::ttype_t*> type_subs,
                 = ASR::down_cast<ASR::TypeParameter_t>(f_param);
             if (!ASRUtils::check_equal_type(type_subs[f_tp->m_param],
                                             arg_param)) {
-                std::string rtype = ASRUtils::type_to_str(type_subs[f_tp->m_param]);
+                std::string rtype = ASRUtils::type_to_str_fortran(type_subs[f_tp->m_param]);
                 std::string rvar = ASRUtils::symbol_name(
                                     ASR::down_cast<ASR::Var_t>(f->m_args[i])->m_v);
-                std::string atype = ASRUtils::type_to_str(arg_param);
+                std::string atype = ASRUtils::type_to_str_fortran(arg_param);
                 std::string avar = ASRUtils::symbol_name(
                                     ASR::down_cast<ASR::Var_t>(arg->m_args[i])->m_v);
                 diagnostics.add(diag::Diagnostic(
@@ -877,8 +877,8 @@ void report_check_restriction(std::map<std::string, ASR::ttype_t*> type_subs,
             ASR::TypeParameter_t *return_tp
                 = ASR::down_cast<ASR::TypeParameter_t>(f_ret);
             if (!ASRUtils::check_equal_type(type_subs[return_tp->m_param], arg_ret)) {
-                std::string rtype = ASRUtils::type_to_str(type_subs[return_tp->m_param]);
-                std::string atype = ASRUtils::type_to_str(arg_ret);
+                std::string rtype = ASRUtils::type_to_str_fortran(type_subs[return_tp->m_param]);
+                std::string atype = ASRUtils::type_to_str_fortran(arg_ret);
                 diagnostics.add(diag::Diagnostic(
                     "Restriction type mismatch with provided function argument",
                     diag::Level::Error, diag::Stage::Semantic, {
@@ -1891,7 +1891,7 @@ bool check_restriction(std::map<std::string, ASR::ttype_t*> type_subs,
                 std::string rtype = ASRUtils::type_to_str_with_substitution(f_param, type_subs);
                 std::string rvar = ASRUtils::symbol_name(
                                     ASR::down_cast<ASR::Var_t>(f->m_args[i])->m_v);
-                std::string atype = ASRUtils::type_to_str(arg_param);
+                std::string atype = ASRUtils::type_to_str_fortran(arg_param);
                 std::string avar = ASRUtils::symbol_name(
                                     ASR::down_cast<ASR::Var_t>(arg->m_args[i])->m_v);
                 diagnostics.add(diag::Diagnostic(
@@ -1925,7 +1925,7 @@ bool check_restriction(std::map<std::string, ASR::ttype_t*> type_subs,
         if (!ASRUtils::types_equal_with_substitution(f_ret, arg_ret, type_subs)) {
             if (report) {
                 std::string rtype = ASRUtils::type_to_str_with_substitution(f_ret, type_subs);
-                std::string atype = ASRUtils::type_to_str(arg_ret);
+                std::string atype = ASRUtils::type_to_str_fortran(arg_ret);
                 diagnostics.add(diag::Diagnostic(
                     "Restriction type mismatch with provided function argument",
                     diag::Level::Error, diag::Stage::Semantic, {

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -636,7 +636,7 @@ static inline ASR::asr_t* create_ArrIntrinsic(
     ASR::expr_t *mask = nullptr;
     ASR::ttype_t* array_type = ASRUtils::expr_type(array);
     if (!is_array(array_type)){
-        append_error(diag, "Argument to intrinsic `" + intrinsic_func_name + "` is expected to be an array, found: " + type_to_str(array_type), loc);
+        append_error(diag, "Argument to intrinsic `" + intrinsic_func_name + "` is expected to be an array, found: " + type_to_str_fortran(array_type), loc);
         return nullptr;
     }
     if (args[1]) {
@@ -3095,7 +3095,7 @@ namespace Sum {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_complex(*array_type)) {
             diag.add(diag::Diagnostic("Input to `Sum` is expected to be numeric, but got " +
-                type_to_str(array_type), 
+                type_to_str_fortran(array_type), 
                 diag::Level::Error, 
                 diag::Stage::Semantic, 
                 {diag::Label("must be integer, real or complex type", { args[0]->base.loc })}));
@@ -3136,7 +3136,7 @@ namespace Product {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_complex(*array_type)) {
             diag.add(diag::Diagnostic("Input to `Product` is expected to be numeric, but got " +
-                type_to_str(array_type), 
+                type_to_str_fortran(array_type), 
                 diag::Level::Error, 
                 diag::Stage::Semantic, 
                 {diag::Label("must be integer, real or complex type", { args[0]->base.loc })}));
@@ -3210,7 +3210,7 @@ namespace MaxVal {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_character(*array_type)) {
             diag.add(diag::Diagnostic("Input to `MaxVal` is expected to be of integer, real or character type, but got " +
-                type_to_str(array_type), 
+                type_to_str_fortran(array_type), 
                 diag::Level::Error, 
                 diag::Stage::Semantic, 
                 {diag::Label("must be integer, real or character type", { args[0]->base.loc })}));
@@ -3647,7 +3647,7 @@ namespace MinVal {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_character(*array_type)) {
             diag.add(diag::Diagnostic("Input to `MinVal` is expected to be of integer, real or character type, but got " +
-                type_to_str(array_type), 
+                type_to_str_fortran(array_type), 
                 diag::Level::Error, 
                 diag::Stage::Semantic, 
                 {diag::Label("must be integer, real or character type", { args[0]->base.loc })}));

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -129,9 +129,9 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
                 }
                 if( std::find(indices.begin(), indices.end(), i) != indices.end() ) {
                     if( arg_func ) {
-                        suffix += "_" + ASRUtils::type_to_str(arg_func->m_function_signature);
+                        suffix += "_" + ASRUtils::type_to_str_fortran(arg_func->m_function_signature);
                     } else {
-                        suffix += "_" + ASRUtils::type_to_str(arg->m_type);
+                        suffix += "_" + ASRUtils::type_to_str_fortran(arg->m_type);
                     }
                     suffix += "_" + std::to_string(i);
                 }


### PR DESCRIPTION
Fixes #6325 