### PR TITLE
CMake enhancements - file generation, out of source, presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,7 @@ MANIFEST
 *~
 
 ## Build Files
+build/
 */bin/lfortran
 output
 *.o
@@ -238,3 +239,6 @@ build.ninja
 doc/man/lfortran.1
 !doc/src/javascripts/*.js
 !pass_array_by_data_*.f90
+
+## CMake user presets
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
+# Do we still need this?
 # We don't execute this if we have a tarball
 if (LFORTRAN_BUILD_ALL)
     find_program(RE2C re2c REQUIRED)
@@ -13,7 +14,15 @@ if (LFORTRAN_BUILD_ALL)
     endif ()
 endif()
 
-file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/version" LFORTRAN_VERSION)
+
+# generate version from git
+find_package(Git)
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
+                OUTPUT_VARIABLE GIT_WORKDIR_VERSION
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ECHO_OUTPUT_VARIABLE)
+# removing 'v' prefix
+string(SUBSTRING ${GIT_WORKDIR_VERSION} 1 -1 LFORTRAN_VERSION)
 string(REGEX MATCH "^[^-]*" LFORTRAN_NO_TAG_VERSION ${LFORTRAN_VERSION})
 
 project(lfortran
@@ -23,6 +32,9 @@ project(lfortran
         LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+# As we generate a lot of files, we set some variables
+set(LFORTRAN_GENERATED_FILES_PATH "${CMAKE_BINARY_DIR}/generated")
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release
@@ -113,15 +125,15 @@ if (LFORTRAN_BUILD_TO_WASM)
     SET(WITH_ZLIB no)
     SET(WITH_RUNTIME_LIBRARY no)
     SET(WITH_LCOMPILERS_FAST_ALLOC no)
-    add_definitions("-DHAVE_BUILD_TO_WASM=1")
+    add_compile_definitions("HAVE_BUILD_TO_WASM=1")
 endif()
 
 if (WITH_WHEREAMI)
-    add_definitions("-DHAVE_WHEREAMI=1")
+    add_compile_definitions("HAVE_WHEREAMI=1")
 endif()
 
 if (WITH_ZLIB)
-    add_definitions("-DHAVE_ZLIB=1")
+    add_compile_definitions("HAVE_ZLIB=1")
 
     # Find ZLIB with our custom finder before including LLVM since the finder for LLVM
     # might search for ZLIB again and find the shared libraries instead of the static ones
@@ -129,7 +141,7 @@ if (WITH_ZLIB)
 endif()
 
 if (WITH_LCOMPILERS_FAST_ALLOC)
-    add_definitions("-DLCOMPILERS_FAST_ALLOC=1")
+    add_compile_definitions("LCOMPILERS_FAST_ALLOC=1")
 endif()
 
 
@@ -236,7 +248,7 @@ if (WITH_LLVM)
         endif()
 
         list(APPEND LFORTRAN_LLVM_COMPONENTS aarch64info aarch64utils aarch64desc aarch64asmparser aarch64codegen aarch64disassembler)
-        add_definitions("-DHAVE_TARGET_AARCH64=1")
+        add_compile_definitions("HAVE_TARGET_AARCH64=1")
     endif()
 
     if (WITH_TARGET_X86)
@@ -245,7 +257,7 @@ if (WITH_LLVM)
         endif()
 
         list(APPEND LFORTRAN_LLVM_COMPONENTS x86info x86desc x86codegen x86asmparser x86disassembler)
-        add_definitions("-DHAVE_TARGET_X86=1")
+        add_compile_definitions("HAVE_TARGET_X86=1")
     endif()
 
     if (WITH_TARGET_WASM)
@@ -254,7 +266,7 @@ if (WITH_LLVM)
         endif()
 
         list(APPEND LFORTRAN_LLVM_COMPONENTS webassemblyasmparser webassemblycodegen webassemblydesc webassemblydisassembler webassemblyinfo)
-        add_definitions("-DHAVE_TARGET_WASM=1")
+        add_compile_definitions("HAVE_TARGET_WASM=1")
     endif()
 
     if (TARGET LLVMCore)
@@ -349,7 +361,8 @@ endif()
 set(HAVE_LFORTRAN_DEMANGLE yes
     CACHE BOOL "Build with C++ name demangling support (cxxabi.h)")
 
-if (MSVC)
+# to catch clang-cl as well, which uses same library as msvc
+if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
     # MSVC doesn't have cxxabi.h
     set(HAVE_LFORTRAN_DEMANGLE no)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,29 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default configuration",
+            "description": "Using Ninja",
+            "generator": "Ninja",
+            "binaryDir": "build/default"
+        },
+        {
+            "name": "clang",
+            "inherits": "default",
+            "displayName": "Ninja Clang",
+            "toolchainFile": "cmake/toolchains/clang.cmake"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        }
+    ]
+}

--- a/cmake/toolchains/clang.cmake
+++ b/cmake/toolchains/clang.cmake
@@ -1,0 +1,2 @@
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,54 @@
+# create all targets for AST, ASR
+# putting them here as they are common
+find_package(Python)
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/ast.h
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/libasr/asdl_cpp.py ${CMAKE_SOURCE_DIR}/grammar/AST.asdl ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/ast.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/grammar/AST.asdl 
+    VERBATIM
+)
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/libasr/asr.h
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/libasr/asdl_cpp.py ${CMAKE_SOURCE_DIR}/src/libasr/ASR.asdl ${LFORTRAN_GENERATED_FILES_PATH}/libasr/asr.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/libasr/ASR.asdl 
+    VERBATIM
+)
+
+#if (LFORTRAN_BUILD_TO_WASM) Are we always generating wasm code?
+# Generate a wasm_visitor.h from src/libasr/wasm_instructions.txt (C++)
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/libasr/wasm_visitor.h
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/libasr/wasm_instructions_visitor.py
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/libasr/wasm_instructions_visitor.py 
+    WORKING_DIRECTORY ${LFORTRAN_GENERATED_FILES_PATH}/libasr
+    VERBATIM
+)
+#endif()
+
+# Generate the intrinsic_function_registry_util.h (C++)
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/libasr/intrinsic_function_registry_util.h
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/libasr/intrinsic_func_registry_util_gen.py
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/libasr/intrinsic_func_registry_util_gen.py 
+    VERBATIM
+)
+
+add_custom_target(lfortran_generated_files
+    DEPENDS ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/ast.h
+            ${LFORTRAN_GENERATED_FILES_PATH}/libasr/asr.h
+            ${LFORTRAN_GENERATED_FILES_PATH}/libasr/intrinsic_function_registry_util.h
+            ${LFORTRAN_GENERATED_FILES_PATH}/libasr/wasm_visitor.h
+)
+
+add_library(lfortran_base INTERFACE)
+add_dependencies(lfortran_base lfortran_generated_files)
+add_library(lf::base ALIAS lfortran_base)
+target_include_directories(lfortran_base INTERFACE 
+    ${LFORTRAN_GENERATED_FILES_PATH}
+    ${CMAKE_SOURCE_DIR}/src)
+
+# check for single quote (linux only?)
+
 add_subdirectory(libasr)
 add_subdirectory(tests)
 add_subdirectory(lfortran)

--- a/src/lfortran/CMakeLists.txt
+++ b/src/lfortran/CMakeLists.txt
@@ -1,7 +1,33 @@
-set(SRC
-    parser/preprocessor.cpp
-    parser/tokenizer.cpp
-    parser/parser.tab.cc
+# Specific files generated for lfortran
+
+# tokenizer
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/tokenizer.cpp
+    COMMAND re2c -W -b ${CMAKE_SOURCE_DIR}/src/lfortran/parser/tokenizer.re -o ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/tokenizer.cpp
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/lfortran/parser/tokenizer.re
+    VERBATIM
+)
+# preproc
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/preprocessor.cpp
+    COMMAND re2c -W -b ${CMAKE_SOURCE_DIR}/src/lfortran/parser/preprocessor.re -o ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/preprocessor.cpp
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/lfortran/parser/preprocessor.re
+    VERBATIM
+)
+# parser
+add_custom_command(
+    OUTPUT ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/parser/parser.tab.cc
+    BYPRODUCTS ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/parser/parser.output ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/parser/parser.tab.hh
+    COMMAND bison -Wall -d -r all ${CMAKE_SOURCE_DIR}/src/lfortran/parser/parser.yy
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/lfortran/parser/parser.yy
+    WORKING_DIRECTORY ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/parser
+    VERBATIM
+)
+
+add_library(lfortran_lib STATIC
+    ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/preprocessor.cpp
+    ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/tokenizer.cpp
+    ${LFORTRAN_GENERATED_FILES_PATH}/lfortran/parser/parser.tab.cc
     parser/parser.cpp
     parser/fixedform_tokenizer.cpp
 
@@ -24,23 +50,18 @@ set(SRC
 )
 
 if (WITH_WHEREAMI)
-    set(SRC ${SRC} ../bin/tpl/whereami/whereami.cpp)
+    target_sources(lfortran_lib PUBLIC ../bin/tpl/whereami/whereami.cpp)
 endif()
 
 if (WITH_XEUS)
-    set(SRC ${SRC}
-        fortran_kernel.cpp
-    )
+    target_sources(lfortran_lib PUBLIC fortran_kernel.cpp)
 endif()
 if (WITH_JSON)
-    set(SRC ${SRC}
-        ast_to_json.cpp
-    )
+    target_sources(lfortran_lib PUBLIC ast_to_json.cpp)
 endif()
-add_library(lfortran_lib STATIC ${SRC})
 target_include_directories(lfortran_lib PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-configure_file(config.h.cmakein config.h @ONLY)
+configure_file(config.h.cmakein ${LFORTRAN_GENERATED_FILES_PATH}/config.h @ONLY)
 target_link_libraries(lfortran_lib asr lfortran_runtime_static)
 
 

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.23)
 
 project(libasr)
 
@@ -12,7 +12,7 @@ if (NOT LFORTRAN_VERSION)
         CACHE STRING "LFortran version" FORCE)
 endif ()
 
-configure_file(config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
+configure_file(config.h.in ${LFORTRAN_GENERATED_FILES_PATH}/libasr/config.h)
 
 set(SRC
     codegen/asr_to_cpp.cpp
@@ -23,11 +23,6 @@ set(SRC
     codegen/asr_to_py.cpp
     codegen/x86_assembler.cpp
     codegen/asr_to_x86.cpp
-    codegen/asr_to_wasm.cpp
-    codegen/wasm_to_wat.cpp
-    codegen/wasm_to_x86.cpp
-    codegen/wasm_to_x64.cpp
-    codegen/wasm_utils.cpp
 
     pass/nested_vars.cpp
     pass/simplifier.cpp
@@ -84,6 +79,17 @@ set(SRC
     stacktrace.cpp
     utils2.cpp
 )
+
+#if (LFORTRAN_BUILD_TO_WASM) wasm sources not dependent on var ?
+    set(SRC ${SRC}
+        codegen/asr_to_wasm.cpp
+        codegen/wasm_to_wat.cpp
+        codegen/wasm_to_x86.cpp
+        codegen/wasm_to_x64.cpp
+        codegen/wasm_utils.cpp
+    )
+#endif()
+
 if (WITH_LLVM)
     set(SRC ${SRC}
         codegen/evaluator.cpp
@@ -111,6 +117,10 @@ endif()
 add_library(asr STATIC ${SRC})
 target_include_directories(asr BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(asr BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
+
+# to get the include directories for generated files
+target_link_libraries(asr PUBLIC lf::base)
+
 if (WITH_LIBUNWIND)
     target_link_libraries(asr p::libunwind)
 endif()

--- a/src/runtime/legacy/CMakeLists.txt
+++ b/src/runtime/legacy/CMakeLists.txt
@@ -12,7 +12,7 @@ mark_as_advanced( MATH_LIBRARIES )
 add_library(lfortran_runtime SHARED ${SRC})
 target_include_directories(lfortran_runtime BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(lfortran_runtime BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
-target_link_libraries(lfortran_runtime PRIVATE ${MATH_LIBRARIES})
+target_link_libraries(lfortran_runtime PUBLIC lf::base PRIVATE ${MATH_LIBRARIES})
 set_target_properties(lfortran_runtime PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR})
@@ -22,7 +22,7 @@ set_target_properties(lfortran_runtime PROPERTIES
 add_library(lfortran_runtime_static STATIC ${SRC})
 target_include_directories(lfortran_runtime_static BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(lfortran_runtime_static BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
-target_link_libraries(lfortran_runtime PRIVATE ${MATH_LIBRARIES})
+target_link_libraries(lfortran_runtime_static PUBLIC lf::base PRIVATE ${MATH_LIBRARIES})
 set_target_properties(lfortran_runtime_static PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ..)
 


### PR DESCRIPTION
Adding custom commands for file generation, getting the version from git, removing the need not to forget to start build0.sh/bat when touching a non-source file.

Adding basis for CMake presets, allowing to define profiles and variables in a shareable way instead of command line or custom scripts (having to maintain them in win/linux for instance).

Draft: as I am trying to get it to work with clang on windows, I still have some compilation issue left to fix atm