### PR TITLE
CI: update the checkout commit for POT3D repository

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -566,7 +566,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 26998ea940281760d120c3ccf3cbe523e683a336
+            git checkout eef4fdafb6b94e814576b3a9cfb96b2129ec5616
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -566,7 +566,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout eef4fdafb6b94e814576b3a9cfb96b2129ec5616
+            git checkout de3890cc12cb6a3c1b15710bb82f4c3e816cd59f
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang


### PR DESCRIPTION
## Description

this now removes the workaround: https://github.com/gxyd/POT3D/commit/eef4fdafb6b94e814576b3a9cfb96b2129ec5616