### PR TITLE
DON'T MERGE: CI: check to see if the workaround can be removed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -565,8 +565,8 @@ jobs:
             FC="$(pwd)/src/bin/lfortran"
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
-            git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout de3890cc12cb6a3c1b15710bb82f4c3e816cd59f
+            git checkout -t origin/check_workaround_removal
+            git checkout 3adb758855198924704a4972a07da5191c0aa783
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang


### PR DESCRIPTION
## Description

This PR isn't intended to be merged at all, only intends to check whether the workaround https://github.com/gxyd/POT3D/commit/432ee83a1a33f0e066063c3c4082eee2b80b6e48 can be removed or not.

At the CI, even if the tests pass once on this PR, I'll re-run it to make sure that no random segfault occurs, and if the segfault does occur even once, it will be a sign that we need to create an MRE and then fix the issue as well.