### PR TITLE
ci: bump `numerical-methods-fortran` to latest branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -796,8 +796,8 @@ jobs:
             git clone https://github.com/Pranavchiku/numerical-methods-fortran.git
             cd numerical-methods-fortran
             export PATH="$(pwd)/../src/bin:$PATH"
-            git checkout -t origin/lf3
-            git checkout a3cd1165832349e5c133681328d2f86fa48d650f
+            git checkout -t origin/lf5
+            git checkout 61b55e40d76c80a500f6e14eabb66078ae3fd014
             FC=lfortran make
             ./test_fix_point.exe
             ./test_integrate_one.exe


### PR DESCRIPTION
We now have to enable compilation of `plots`, without that it works fully with no workarounds.