### PR TITLE
Remove the rest of the PRIMA workarounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,8 +515,8 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
-            git checkout -t origin/lf-prima-4
-            git checkout 3216d838684d3c9bbbd00b8f55afda878b7f2553
+            git checkout -t origin/lf-prima-5
+            git checkout 433b258c9194c93e7093014b92e29f0778cdc25a
             git clean -dfx
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe


### PR DESCRIPTION
I also removed the reference result tests, which we want to keep. But I wanted to make sure that we can compile the upstream code fully.