### PR TITLE
ci: test PRIMA examples with higher prescision

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -516,7 +516,7 @@ jobs:
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
             git checkout -t origin/lf-prima-7
-            git checkout 234a1bf3de58045222bd9b16aad6819ebdc5020f
+            git checkout acec9f6c0187759854fbaf0f52e61ce123c0a0b1
             git clean -dfx
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe


### PR DESCRIPTION
This test LFortran Output with `10e-15` precision on Output given by GFortran.

Closes #6400 