### PR TITLE
ci: set precision to `1e-16` for `prima` examples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,8 +515,8 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
-            git checkout -t origin/lf-prima-9
-            git checkout acbf29109602adad6b1f0dd04a99787dd0f8aec0
+            git checkout -t origin/lf-prima-9-2
+            git checkout 78d50647204984f68ab1576d2a92c46c67f09589
             git clean -dfx
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,7 +515,7 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
-            git checkout -t origin/lf-prima-9-2
+            git checkout -t origin/lf-prima-9
             git checkout 78d50647204984f68ab1576d2a92c46c67f09589
             git clean -dfx
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install


### PR DESCRIPTION
To test the fact that in https://github.com/lfortran/lfortran/pull/6407, only `--fast` failed even with Mac.