### PR TITLE
enh: Connect Unit 0, 5 and 6 with FLUSH

### DIFF
--- a/integration_tests/flush_03.f90
+++ b/integration_tests/flush_03.f90
@@ -1,0 +1,7 @@
+program flush_03
+    use iso_fortran_env
+    implicit none
+    FLUSH(INPUT_UNIT)
+    FLUSH(OUTPUT_UNIT)
+    FLUSH(ERROR_UNIT)
+end program flush_03

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3033,6 +3033,19 @@ LFORTRAN_API void _lfortran_flush(int32_t unit_num)
         bool unit_file_bin;
         FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin);
         if( filep == NULL ) {
+            if ( unit_num == 6 ) {
+                // special case: flush OUTPUT_UNIT
+                fflush(stdout);
+                return;
+            } else if ( unit_num == 5 ) {
+                // special case: flush INPUT_UNIT
+                fflush(stdin);
+                return;
+            } else if ( unit_num == 0 ) {
+                // special case: flush ERROR_UNIT
+                fflush(stderr);
+                return;
+            }
             printf("Specified UNIT %d in FLUSH is not connected.\n", unit_num);
             exit(1);
         }


### PR DESCRIPTION
Fixes: #3815 

- Handle special case for `stdin (unit 5)`, `stdout (unit = 6)` and `stderr (unit 0)` and connect with FLUSH correctly