### PR TITLE
enh: implement StructConstant

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1359,6 +1359,7 @@ RUN(NAME derived_types_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_38 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_40 LABELS gfortran llvm)
+RUN(NAME derived_types_41 LABELS gfortran llvm)
 
 RUN(NAME line_continuation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME line_continuation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/derived_types_41.f90
+++ b/integration_tests/derived_types_41.f90
@@ -1,0 +1,19 @@
+module derived_types_41_mod
+    implicit none
+
+    type :: mytype
+        integer :: a(2)
+        integer :: b
+        integer :: c(2)
+    end type mytype
+
+    type(mytype) :: mytype_instance = mytype([1, 2], 3, [4, 5])
+ end module derived_types_41_mod
+
+program derived_types_41
+    use derived_types_41_mod
+
+    if (any(mytype_instance%a /= [1, 2])) error stop
+    if (mytype_instance%b /= 3) error stop
+    if (any(mytype_instance%c /= [4, 5])) error stop
+end program derived_types_41

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -85,6 +85,7 @@ expr
     | IntrinsicImpureFunction(int impure_intrinsic_id, expr* args, int overload_id, ttype? type, expr? value)
     | TypeInquiry(int inquiry_id, ttype arg_type, expr? arg, ttype type, expr value)
     | StructConstructor(symbol dt_sym, call_arg* args, ttype type, expr? value)
+    | StructConstant(symbol dt_sym, call_arg* args, ttype type)
     | EnumConstructor(symbol dt_sym, expr* args, ttype type, expr? value)
     | UnionConstructor(symbol dt_sym, expr* args, ttype type, expr? value)
     | ImpliedDoLoop(expr* values, expr var, expr start, expr end, expr? increment, ttype type, expr? value)

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1121,7 +1121,8 @@ static inline bool is_value_constant(ASR::expr_t *a_value) {
         case ASR::exprType::ImpliedDoLoop:
         case ASR::exprType::PointerNullConstant:
         case ASR::exprType::ArrayConstant:
-        case ASR::exprType::StringConstant: {
+        case ASR::exprType::StringConstant:
+        case ASR::exprType::StructConstant: {
             return true;
         }
         case ASR::exprType::RealBinOp:

--- a/tests/reference/asr-derived_types_41-d6b8ce9.json
+++ b/tests/reference/asr-derived_types_41-d6b8ce9.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-derived_types_41-d6b8ce9",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/derived_types_41.f90",
+    "infile_hash": "7159edfcbabeaa6b15ecf1918e77a04e8513664002ea1c2d083daf22",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-derived_types_41-d6b8ce9.stdout",
+    "stdout_hash": "3da4cd347ea4b5eafaf2cbb91178d7bc2b91b2751fea5a4c5376ae52",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-derived_types_41-d6b8ce9.stdout
+++ b/tests/reference/asr-derived_types_41-d6b8ce9.stdout
@@ -1,0 +1,360 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            derived_types_41:
+                (Program
+                    (SymbolTable
+                        4
+                        {
+                            1_mytype_a:
+                                (ExternalSymbol
+                                    4
+                                    1_mytype_a
+                                    3 a
+                                    mytype
+                                    []
+                                    a
+                                    Public
+                                ),
+                            1_mytype_b:
+                                (ExternalSymbol
+                                    4
+                                    1_mytype_b
+                                    3 b
+                                    mytype
+                                    []
+                                    b
+                                    Public
+                                ),
+                            1_mytype_c:
+                                (ExternalSymbol
+                                    4
+                                    1_mytype_c
+                                    3 c
+                                    mytype
+                                    []
+                                    c
+                                    Public
+                                ),
+                            mytype:
+                                (ExternalSymbol
+                                    4
+                                    mytype
+                                    2 mytype
+                                    derived_types_41_mod
+                                    []
+                                    mytype
+                                    Public
+                                ),
+                            mytype_instance:
+                                (ExternalSymbol
+                                    4
+                                    mytype_instance
+                                    2 mytype_instance
+                                    derived_types_41_mod
+                                    []
+                                    mytype_instance
+                                    Public
+                                )
+                        })
+                    derived_types_41
+                    [derived_types_41_mod]
+                    [(If
+                        (IntrinsicArrayFunction
+                            Any
+                            [(ArrayPhysicalCast
+                                (IntegerCompare
+                                    (StructInstanceMember
+                                        (Var 4 mytype_instance)
+                                        4 1_mytype_a
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ()
+                                    )
+                                    NotEq
+                                    (ArrayConstant
+                                        8
+                                        [1, 2]
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ColMajor
+                                    )
+                                    (Array
+                                        (Logical 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 2 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                FixedSizeArray
+                                DescriptorArray
+                                (Array
+                                    (Logical 4)
+                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 2 (Integer 4) Decimal))]
+                                    DescriptorArray
+                                )
+                                ()
+                            )]
+                            0
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntegerCompare
+                            (StructInstanceMember
+                                (Var 4 mytype_instance)
+                                4 1_mytype_b
+                                (Integer 4)
+                                ()
+                            )
+                            NotEq
+                            (IntegerConstant 3 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        (IntrinsicArrayFunction
+                            Any
+                            [(ArrayPhysicalCast
+                                (IntegerCompare
+                                    (StructInstanceMember
+                                        (Var 4 mytype_instance)
+                                        4 1_mytype_c
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ()
+                                    )
+                                    NotEq
+                                    (ArrayConstant
+                                        8
+                                        [4, 5]
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ColMajor
+                                    )
+                                    (Array
+                                        (Logical 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 2 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                FixedSizeArray
+                                DescriptorArray
+                                (Array
+                                    (Logical 4)
+                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 2 (Integer 4) Decimal))]
+                                    DescriptorArray
+                                )
+                                ()
+                            )]
+                            0
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )]
+                ),
+            derived_types_41_mod:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            mytype:
+                                (Struct
+                                    (SymbolTable
+                                        3
+                                        {
+                                            a:
+                                                (Variable
+                                                    3
+                                                    a
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Integer 4)
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (IntegerConstant 2 (Integer 4) Decimal))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    3
+                                                    b
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            c:
+                                                (Variable
+                                                    3
+                                                    c
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Integer 4)
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (IntegerConstant 2 (Integer 4) Decimal))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    mytype
+                                    []
+                                    [a
+                                    b
+                                    c]
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
+                                ),
+                            mytype_instance:
+                                (Variable
+                                    2
+                                    mytype_instance
+                                    []
+                                    Local
+                                    (StructConstant
+                                        2 mytype
+                                        [((ArrayConstant
+                                            8
+                                            [1, 2]
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        ))
+                                        ((IntegerConstant 3 (Integer 4) Decimal))
+                                        ((ArrayConstant
+                                            8
+                                            [4, 5]
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        ))]
+                                        (StructType
+                                            2 mytype
+                                        )
+                                    )
+                                    (StructConstant
+                                        2 mytype
+                                        [((ArrayConstant
+                                            8
+                                            [1, 2]
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        ))
+                                        ((IntegerConstant 3 (Integer 4) Decimal))
+                                        ((ArrayConstant
+                                            8
+                                            [4, 5]
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        ))]
+                                        (StructType
+                                            2 mytype
+                                        )
+                                    )
+                                    Default
+                                    (StructType
+                                        2 mytype
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                )
+                        })
+                    derived_types_41_mod
+                    []
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3035,6 +3035,10 @@ filename = "../integration_tests/derived_types_32.f90"
 llvm = true
 
 [[test]]
+filename = "../integration_tests/derived_types_41.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/modules_38.f90"
 llvm = true
 


### PR DESCRIPTION
Towards #1101

Use `StructConstant` ASR node only when the declaration of the instance is in a module.

Before this PR any struct initialized in a module would be initialized to `zeroinitializer` despite passing arguments.