### PR TITLE
ci: test `1e-16` precision for prima examples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -516,7 +516,7 @@ jobs:
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
             git checkout -t origin/lf-prima-10
-            git checkout f5de3ee791dd3619a710a01cf2585fc09af27ee4
+            git checkout 4dc779741c077caaa82095f3244f59e1ac4ac78c
             git clean -dfx
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,8 +515,8 @@ jobs:
         run: |
             git clone https://github.com/Pranavchiku/prima.git
             cd prima
-            git checkout -t origin/lf-prima-9
-            git checkout acbf29109602adad6b1f0dd04a99787dd0f8aec0
+            git checkout -t origin/lf-prima-10
+            git checkout f5de3ee791dd3619a710a01cf2585fc09af27ee4
             git clean -dfx
             FC="$(pwd)/../src/bin/lfortran --cpp" cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_Fortran_FLAGS=""  -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS=""  -DCMAKE_MACOSX_RPATH=OFF -DCMAKE_SKIP_INSTALL_RPATH=ON  -DCMAKE_SKIP_RPATH=ON && cmake --build build --target install
             ./build/fortran/example_bobyqa_fortran_1_exe


### PR DESCRIPTION
Okay, for the examples that did not match bit-to-bit with GFortran on Mac, there might be two cases

- We checking wrong values ( will be proved if CI passes now )
- GFortran gives different output on Mac and Linux ( will be proved if Linux fails )

