### PR TITLE
fix: support scalar `mask` in minloc and maxloc

### DIFF
--- a/integration_tests/intrinsics_339.f90
+++ b/integration_tests/intrinsics_339.f90
@@ -6,4 +6,6 @@ program intrinsics_339
     if (any(minloc(score, mask=(score > 0)) /= 2)) error stop
     print *, minloc(score, 1, [.false., .true., .true., .true.])
     if (minloc(score, 1, [.false., .true., .true., .true.]) /= 2) error stop
+    print*, minloc([1, 2, 3], 1, .true.)
+    if (minloc([1, 2, 3], 1, .true.) /= 1) error stop
 end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1235,8 +1235,8 @@ static inline ASR::asr_t* create_MaxMinLoc(Allocator& al, const Location& loc,
     }
     if (args[2]) {
         mask_expr = args[2];
-        if (!is_array(expr_type(args[2])) || !is_logical(*expr_type(args[2]))) {
-            append_error(diag, "`mask` argument of `"+ intrinsic_name +"` must be a logical array", loc);
+        if (!is_logical(*expr_type(args[2]))) {
+            append_error(diag, "`mask` argument of `"+ intrinsic_name +"` must be logical", loc);
             return nullptr;
         }
         m_args.push_back(al, args[2]);


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/6409