### PR TITLE
enh: set env variable in python script and remove from other places

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,7 +94,6 @@ jobs:
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
             case "$OSTYPE" in darwin*) export MACOS=1;; *) export MACOS=0;; esac
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             shell ci/test.sh
 
       - name: Test LFortran's Command Line Interface (Linux / macOS)
@@ -108,7 +107,6 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
             cd ./integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b llvm --std=f23
             ./run_tests.py -b llvm -f --std=f23
 
@@ -438,7 +436,6 @@ jobs:
             ./run_tests.py
             ./run_tests.py -vh
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -m
             ./run_tests.py -b llvm
             ./run_tests.py -b llvm -f
@@ -1038,7 +1035,6 @@ jobs:
             export PATH=$HOME/wasmtime-v19.0.2-x86_64-linux:$PATH
             export WASMTIME_NEW_CLI=0
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b llvm_wasm llvm_wasm_emcc
 
       - name: Build Linux
@@ -1065,7 +1061,6 @@ jobs:
         run: |
             ctest --output-on-failure
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b llvm llvmImplicit
             ./run_tests.py -b llvm llvmImplicit -f
 
@@ -1282,7 +1277,6 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b gfortran
 
       - name: Build Linux
@@ -1312,7 +1306,6 @@ jobs:
             ./run_tests.py
             ./run_tests.py -vh
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -m
             ./run_tests.py -b llvm
             ./run_tests.py -b llvm -f
@@ -1321,14 +1314,12 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b llvm_omp
 
       - name: Test Fortran Backend
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b fortran -j1
             ./run_tests.py -b fortran -f -j1
 
@@ -1349,7 +1340,6 @@ jobs:
             cd ../../..
 
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b cpp c c_nopragma
             ./run_tests.py -b cpp c c_nopragma -f
 
@@ -1369,7 +1359,6 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b wasm
             ./run_tests.py -b wasm -f
 
@@ -1473,7 +1462,6 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!';
             ./run_tests.py -b mlir mlir_omp mlir_llvm_omp -j1
 
   upload_docs:

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -108,6 +108,8 @@ def main():
     # Setup
     global NO_OF_THREADS, fast_tests, std_f23_tests
     os.environ["PATH"] += os.pathsep + LFORTRAN_PATH
+    # Set environment variable for testing
+    os.environ["LFORTRAN_TEST_ENV_VAR"] = "STATUS OK!"
     # delete previously created directories (if any)
     for backend in SUPPORTED_BACKENDS:
         run_cmd(f"rm -rf {BASE_DIR}/test-{backend}")


### PR DESCRIPTION
With this we don't need to worry about setting `LFORTRAN_TEST_ENV_VAR`