### PR TITLE
Handle memory leaks for `str_item`, `str_slice` and `printf`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -552,6 +552,7 @@ jobs:
             if [[ "${{matrix.os}}" == "ubuntu-latest" ]]; then
               cd fortran/
               test_name=test_uobyqa.f90 FC="$(pwd)/../../src/bin/lfortran" ./script.sh
+              test_name=test_bobyqa.f90 FC="$(pwd)/../../src/bin/lfortran" ./script.sh
               cd ../
             fi
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2380,8 +2380,12 @@ LFORTRAN_API char* _lfortran_str_slice(char* s, int32_t idx1, int32_t idx2, int3
     }
     if (idx1 == idx2 ||
         (step > 0 && (idx1 > idx2 || idx1 >= s_len)) ||
-        (step < 0 && (idx1 < idx2 || idx2 >= s_len-1)))
-        return "";
+        (step < 0 && (idx1 < idx2 || idx2 >= s_len-1))){
+        char* dest_char = (char*)malloc(1);
+        dest_char[0] = '\0';
+        return dest_char;
+    }
+    
     int dest_len = 0;
     if (step > 0) {
         idx2 = idx2 > s_len ? s_len : idx2;
@@ -2427,13 +2431,14 @@ LFORTRAN_API char* _lfortran_str_slice_assign(char* s, char *r, int32_t idx1, in
             idx2 = -1;
         }
     }
+    char* dest_char = (char*)malloc(s_len + 1);
     if (idx1 == idx2 ||
         (step > 0 && (idx1 > idx2 || idx1 >= s_len)) ||
         (step < 0 && (idx1 < idx2 || idx2 >= s_len-1))) {
-        return s;
+        strcpy(dest_char, s);
+        return dest_char;
     }
 
-    char* dest_char = (char*)malloc(s_len + 1);
     strcpy(dest_char, s);
     int s_i = idx1, d_i = 0;
     while((step > 0 && s_i >= idx1 && s_i < idx2) ||

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "3b613569cf3f2c95b34c727ef0e1868ea96ca557d0eb6007c2978778",
+    "stdout_hash": "95a9f48c729bea4796b3b5551baaf37e61f369aaeb60326fb17ff24f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -265,6 +265,7 @@ ifcont11:                                         ; preds = %else10, %then9
   %154 = sext i32 %153 to i64
   %155 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %154)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %155, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
+  call void @_lfortran_free(i8* %155)
   %156 = load %array*, %array** %c, align 8
   %157 = getelementptr %array, %array* %156, i32 0, i32 0
   %158 = load i32*, i32** %157, align 8
@@ -432,6 +433,7 @@ define i32 @g(%array** %x) {
   %34 = sext i32 %33 to i64
   %35 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %34)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %35, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %35)
   %36 = load %array*, %array** %x, align 8
   %37 = getelementptr %array, %array* %36, i32 0, i32 2
   %38 = load %dimension_descriptor*, %dimension_descriptor** %37, align 8
@@ -539,6 +541,7 @@ ifcont3:                                          ; preds = %else2, %then1
   %116 = sext i32 %115 to i64
   %117 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %116)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %117, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %117)
   %118 = load %array*, %array** %x, align 8
   %119 = getelementptr %array, %array* %118, i32 0, i32 2
   %120 = load %dimension_descriptor*, %dimension_descriptor** %119, align 8
@@ -706,6 +709,7 @@ ifcont3:                                          ; preds = %else2, %then1
   %50 = sext i32 %49 to i64
   %51 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %50)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %51, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @_lfortran_free(i8* %51)
   %52 = load %array*, %array** %c, align 8
   %53 = getelementptr %array, %array* %52, i32 0, i32 2
   %54 = load %dimension_descriptor*, %dimension_descriptor** %53, align 8
@@ -798,11 +802,11 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
 
+declare void @_lfortran_free(i8*)
+
 declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @exit(i32)
-
-declare void @_lfortran_free(i8*)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "8f62d45e1c30066cad28a73dc1df90f1a0236be93461b5cdcc35ed5e",
+    "stdout_hash": "fd9eb032f93939e6eaa980a576657b2c4fb86127c30f4f9f4220ef91",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -125,6 +125,7 @@ ifcont20:                                         ; preds = %else19, %then18, %t
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %3, i32 2, i64 %5, i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   br i1 true, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont20
@@ -205,6 +206,7 @@ ifcont44:                                         ; preds = %else43, %then42, %t
   %14 = sext i32 %13 to i64
   %15 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %10, i32 2, i64 %12, i32 2, i64 %14)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %15)
   br i1 true, label %then46, label %else47
 
 then46:                                           ; preds = %ifcont44
@@ -339,6 +341,7 @@ ifcont84:                                         ; preds = %else83, %then82, %t
   %23 = sext i32 %22 to i64
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 2, i64 %17, i32 2, i64 %19, i32 2, i64 %21, i32 2, i64 %23)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   br i1 true, label %then86, label %else87
 
 then86:                                           ; preds = %ifcont84
@@ -473,6 +476,7 @@ ifcont124:                                        ; preds = %else123, %then122, 
   %32 = sext i32 %31 to i64
   %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 2, i64 %26, i32 2, i64 %28, i32 2, i64 %30, i32 2, i64 %32)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %33)
   br i1 true, label %then126, label %else127
 
 then126:                                          ; preds = %ifcont124
@@ -513,6 +517,7 @@ ifcont136:                                        ; preds = %else135, %then134, 
   %37 = sext i32 %36 to i64
   %38 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %35, i32 2, i64 %37)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %38, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %38)
   br i1 true, label %then138, label %else139
 
 then138:                                          ; preds = %ifcont136
@@ -553,6 +558,7 @@ ifcont148:                                        ; preds = %else147, %then146, 
   %42 = sext i32 %41 to i64
   %43 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %40, i32 2, i64 %42)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @_lfortran_free(i8* %43)
   br i1 true, label %then150, label %else151
 
 then150:                                          ; preds = %ifcont148
@@ -567,6 +573,7 @@ ifcont152:                                        ; preds = %else151, %then150
   %45 = sext i32 %44 to i64
   %46 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %45)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lfortran_free(i8* %46)
   br i1 true, label %then154, label %else155
 
 then154:                                          ; preds = %ifcont152
@@ -581,6 +588,7 @@ ifcont156:                                        ; preds = %else155, %then154
   %48 = sext i32 %47 to i64
   %49 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %48)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lfortran_free(i8* %49)
   call void @_lpython_free_argv()
   br label %return
 
@@ -593,5 +601,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-arrays_03_func-98941b2.json
+++ b/tests/reference/llvm-arrays_03_func-98941b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_03_func-98941b2.stdout",
-    "stdout_hash": "9f7ff73b939a5bcfdaff6bf059adfdf15a1e25381346ee9be8678a30",
+    "stdout_hash": "69d7059db9f61e094223ba8cc69afdcc18ca20716998821e22e3cee2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_03_func-98941b2.stdout
+++ b/tests/reference/llvm-arrays_03_func-98941b2.stdout
@@ -49,6 +49,7 @@ loop.end:                                         ; preds = %loop.head
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   %18 = load i32, i32* %s2, align 4
   %19 = icmp ne i32 %18, 55
   br i1 %19, label %then, label %else
@@ -116,6 +117,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-arrays_08_func-85e526b.json
+++ b/tests/reference/llvm-arrays_08_func-85e526b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_08_func-85e526b.stdout",
-    "stdout_hash": "add211034d40df770ae8e68183401d44857bc63b74ce6b5954c43b86",
+    "stdout_hash": "050511d10a7023b8c437b786e58b46d4cbf5b4b3491e38173b53e698",
     "stderr": "llvm-arrays_08_func-85e526b.stderr",
     "stderr_hash": "d70481e5625f20fa12d3e8bdad4a5dfa6912ac62ade8fc840a5da64b",
     "returncode": 0

--- a/tests/reference/llvm-arrays_08_func-85e526b.stdout
+++ b/tests/reference/llvm-arrays_08_func-85e526b.stdout
@@ -68,6 +68,7 @@ loop.end:                                         ; preds = %loop.head
   %20 = select i1 %19, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0)
   %21 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %20)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %21)
   %22 = load i1, i1* %r, align 1
   %23 = xor i1 %22, true
   br i1 %23, label %then, label %else
@@ -191,6 +192,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "52ef7778e567a9cf955b899386eb0401b0ec69e71c89cca3e1d557a2",
+    "stdout_hash": "04c7e7f8f2f2a651028953244bcd3d9507284d9eb8f97e0902e6273d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -50,10 +50,12 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = ptrtoint i32* %8 to i64
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 19, i64 %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   %11 = load i32, i32* @associate_02.t1, align 4
   %12 = sext i32 %11 to i64
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   %14 = load double*, double** %p2, align 8
   %15 = load double, double* %14, align 8
   %16 = load i32*, i32** %p1, align 8
@@ -66,19 +68,23 @@ define i32 @main(i32 %0, i8** %1) {
   %22 = ptrtoint i32* %21 to i64
   %23 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 19, i64 %22)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %23)
   %24 = load i32, i32* @associate_02.t1, align 4
   %25 = sext i32 %24 to i64
   %26 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %25)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %26)
   store i32 8, i32* @associate_02.t1, align 4
   %27 = load i32*, i32** %p1, align 8
   %28 = ptrtoint i32* %27 to i64
   %29 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 19, i64 %28)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %29)
   %30 = load i32, i32* @associate_02.t1, align 4
   %31 = sext i32 %30 to i64
   %32 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %31)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @_lfortran_free(i8* %32)
   %33 = load %complex_4*, %complex_4** %p3, align 8
   %34 = alloca %complex_4, align 8
   %35 = getelementptr %complex_4, %complex_4* %34, i32 0, i32 0
@@ -100,6 +106,7 @@ define i32 @main(i32 %0, i8** %1) {
   %45 = ptrtoint %complex_4* %44 to i64
   %46 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 19, i64 %45)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lfortran_free(i8* %46)
   %47 = load %complex_4, %complex_4* @associate_02.t3, align 4
   %48 = alloca %complex_4, align 8
   store %complex_4 %47, %complex_4* %48, align 4
@@ -113,6 +120,7 @@ define i32 @main(i32 %0, i8** %1) {
   %55 = fpext float %54 to double
   %56 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %51, i32 6, double %55)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lfortran_free(i8* %56)
   call void @_lpython_free_argv()
   br label %return
 
@@ -125,6 +133,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lfortran_complex_mul_32(%complex_4*, %complex_4*, %complex_4*)
 

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "4e329e2657253e10d7a4d975880c030e5f608d84d3a05f1c2d2e610e",
+    "stdout_hash": "00d06a71dcc76d561d28b435b9f619e849b32a57bc62bb7cea20e572",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -24,6 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = sext i32 %4 to i64
   %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %3, i32 2, i64 %5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %6)
   %7 = load i32, i32* @associate_03.t1, align 4
   %8 = load i32, i32* @associate_03.t2, align 4
   %9 = icmp sgt i32 %7, %8
@@ -42,6 +43,7 @@ ifcont:                                           ; preds = %else, %then
   %11 = ptrtoint i32* %10 to i64
   %12 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 19, i64 %11)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %12)
   %13 = load i32*, i32** %p1, align 8
   %14 = load i32, i32* %13, align 4
   store i32 %14, i32* %i1, align 4
@@ -71,6 +73,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "2a2a74b5293ce0894a5267cbe36634085a1a06fe4e2eea2db341e264",
+    "stdout_hash": "67a927844af9f96792e00ffd76b707700597dc4581f8bd431ee703f4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -62,6 +62,7 @@ define i32 @main(i32 %0, i8** %1) {
   %19 = ptrtoint float* %18 to i64
   %20 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 6, double %13, i32 6, double %17, i32 19, i64 %19)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %20)
   %21 = load float*, float** %v, align 8
   %22 = load float*, float** %v, align 8
   %23 = load float, float* %22, align 4
@@ -71,6 +72,7 @@ define i32 @main(i32 %0, i8** %1) {
   %26 = fpext float %25 to double
   %27 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %26)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %27)
   %28 = load float, float* %myreal, align 4
   %29 = fsub float %28, 0x4044EE1480000000
   %30 = fcmp ogt float %29, 0x3EE4F8B580000000
@@ -102,6 +104,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "ee5137cf06625f3c5840345068e85272b39bb846f4acd0ebafda6f22",
+    "stdout_hash": "5bbeba56e6285d6e642934a293a68b3693be80bac519c9b3c1f1e7df",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -84,6 +84,7 @@ define i32 @main(i32 %0, i8** %1) {
   %49 = load double, double* %48, align 8
   %50 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 16, i8* null, i32 6, double %22, i32 6, double %26, i32 5, double %30, i32 5, double %33, i32 6, double %38, i32 6, double %42, i32 5, double %46, i32 5, double %49)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %50, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %50)
   call void @_lpython_free_argv()
   br label %return
 
@@ -96,5 +97,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "9b785734ef2268081b2b4c794f852055161a9e60e75d6db779037dfb",
+    "stdout_hash": "7ef8674abc40cc33c9b475c40ce3463fd1ee4abedd2435fb7c5cac59",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -23,6 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load double, double* %u, align 8
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 6, double %3, i32 5, double %4, i32 6, double %6, i32 5, double %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   call void @_lpython_free_argv()
   br label %return
 
@@ -35,5 +36,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "30e3e865406efd2bd044d8b9f08d80b504b27dba0d4d996de29994ca",
+    "stdout_hash": "a9023228720e7f8d5ab657f95369ba970245b16c7160df7598c341ab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -25,6 +25,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = ptrtoint void* %7 to i64
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 19, i64 %6, i32 19, i64 %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   store i16* %y1, i16** %x, align 8
   %10 = load i16*, i16** %x, align 8
   %11 = bitcast i16* %10 to void*
@@ -33,6 +34,7 @@ define i32 @main(i32 %0, i8** %1) {
   %14 = ptrtoint void* %13 to i64
   %15 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 19, i64 %12, i32 19, i64 %14)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %15)
   call void @_lpython_free_argv()
   br label %return
 
@@ -45,5 +47,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "5c0ded04ac0a6c3774c0fcd7f4397625bb831793bab548869fd215c3",
+    "stdout_hash": "7313660b1e2c39f47f962ccbcfef2d4c2b94d00c18fd67776b38a583",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -25,10 +25,13 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 64, i32* %block_size3, align 4
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 64)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 1, i64 0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 1, i64 -1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   call void @_lpython_free_argv()
   br label %return
 
@@ -41,5 +44,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "64d65fa2fb9a5bcd15ccec22e56f36b6d6285c166e69bf242ff73c9e",
+    "stdout_hash": "7afafeff9b18b81d88c8b523b7e290547fde84f8e7e3a6b872a98260",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -24,6 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 %3, i32 2, i64 %5, i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   call void @_lpython_free_argv()
   br label %return
 
@@ -36,5 +37,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "0c87509549cbc7c9185c3fecdd736798d1365a7c5cac0af58861aa4d",
+    "stdout_hash": "9c329c7412e0403dfcd24cae8db8f65391edc6231cbeadf023fc5f1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -30,6 +30,7 @@ define void @__module_callback_01_foo(float* %c, float* %d) {
   %1 = fpext float %0 to double
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -52,6 +53,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "b9e98f4495321dd2b0a024e9573dd40df8a9236a1ea6acd720fa2c5f",
+    "stdout_hash": "4aa76e2226610ca4e848727af1795b2af78971b83b8cb1caa77fdffb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -16,11 +16,13 @@ define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (fl
   %1 = fpext float %0 to double
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   call void %f(float* %b, float* %res)
   %3 = load float, float* %res, align 4
   %4 = fpext float %3 to double
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   %6 = load float, float* %b, align 4
   %7 = load float, float* %a, align 4
   %8 = fsub float %6, %7
@@ -31,6 +33,7 @@ define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (fl
   %12 = fpext float %11 to double
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -66,6 +69,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "f947ee54e3902e86b2001ccdd73b9bfdc61fbb7cb7c916060a8c57bb",
+    "stdout_hash": "341a03d9a342fc1a62f08a234309584870475b274ccf234210621495",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -32,6 +32,7 @@ define void @__module_callback_03_foo1(float* %c, float* %d) {
   %1 = fpext float %0 to double
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -68,6 +69,7 @@ define void @__module_callback_03_foo2(float* %c, float* %d) {
   %1 = fpext float %0 to double
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -77,6 +79,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "26e735c124158eaa7d0e48e4d137cbe70c2cb36646eff9903c235907",
+    "stdout_hash": "3a7926ba7d6afd57872466403a45d3669c9b11ffc8c1585e101dde7e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -20,6 +20,7 @@ define void @__module_callback_05_printx(i32* %x) {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -51,6 +52,8 @@ declare void @f.1(i32*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "48a65410628baadb8028e3b3c2cea382b8c504adfbadc9f513d09bbe",
+    "stdout_hash": "741b2c73f67f9f90e46d7b573b7237d2d7a306b2b0eaba339fe77c75",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -189,6 +189,7 @@ ifcont17:                                         ; preds = %ifcont16, %then
   %35 = sext i32 %34 to i64
   %36 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @22, i32 0, i32 0), i32 2, i64 %35)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
+  call void @_lfortran_free(i8* %36)
   %37 = load i32, i32* %out2, align 4
   %38 = icmp ne i32 %37, 1
   br i1 %38, label %then18, label %else19
@@ -299,6 +300,7 @@ ifcont38:                                         ; preds = %ifcont37, %then21
   %72 = sext i32 %71 to i64
   %73 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @49, i32 0, i32 0), i32 2, i64 %72)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @50, i32 0, i32 0), i8* %73, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
+  call void @_lfortran_free(i8* %73)
   %74 = load i32, i32* %marks1, align 4
   %75 = icmp sle i32 91, %74
   %76 = load i32, i32* %marks1, align 4
@@ -396,6 +398,7 @@ ifcont56:                                         ; preds = %ifcont55, %then39
   %107 = sext i32 %106 to i64
   %108 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @73, i32 0, i32 0), i32 2, i64 %107)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @74, i32 0, i32 0), i8* %108, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0))
+  call void @_lfortran_free(i8* %108)
   call void @_lpython_free_argv()
   br label %return
 
@@ -408,6 +411,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lfortran_printf(i8*, ...)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "1c1adc037c0322af96e1b6d6df1aba83f959c1be0f369ff17e08c1ee",
+    "stdout_hash": "9a03c808eaa171da0d7ecee5591f1ce966293e92d5e40d1870670e0b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -69,6 +69,7 @@ ifcont6:                                          ; preds = %ifcont, %then
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @10, i32 0, i32 0), i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   store i32 -1, i32* %marks3, align 4
   %9 = load i32, i32* %marks3, align 4
   %10 = icmp sle i32 42, %9
@@ -103,6 +104,7 @@ ifcont12:                                         ; preds = %ifcont11, %then7
   %18 = sext i32 %17 to i64
   %19 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @22, i32 0, i32 0), i32 2, i64 %18)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
+  call void @_lfortran_free(i8* %19)
   call void @_lpython_free_argv()
   br label %return
 
@@ -115,5 +117,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lfortran_printf(i8*, ...)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "15a0e42c1050c471a51c6b4fb9c508ff6255cbbfcd66e02f99810a60",
+    "stdout_hash": "df563d8e44651ba81e918fa37696ebc39d172ab6d0662ecffcfedbb9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -49,6 +49,7 @@ define void @__module_class_circle1_circle_print(%circle_polymorphic* %this) {
   %9 = fpext float %8 to double
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 7, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @1, i32 0, i32 0), i32 6, double %7, i32 7, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), i32 6, double %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -61,6 +62,8 @@ declare float @llvm.powi.f32(float, i32) #0
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "6bb4276e37f34b6e32bf49df10d536ceb92898b076fea6a04f4ed9ce",
+    "stdout_hash": "ccac6ce5ffd075f574a97247d68ad9105abc3a986f512579073dd83c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -49,6 +49,7 @@ define void @__module_class_circle2_circle_print(%circle_polymorphic* %this) {
   %9 = fpext float %8 to double
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 7, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @1, i32 0, i32 0), i32 6, double %7, i32 7, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @2, i32 0, i32 0), i32 6, double %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -81,6 +82,8 @@ declare float @llvm.powi.f32(float, i32) #0
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "ed76f7fda931739ac472ecd15616a339eb087b7189a1b856e06f2967",
+    "stdout_hash": "81a6db6eeb4aebdfd00d9279feeda467d37babeffeed087e37bacce7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -44,6 +44,7 @@ define i32 @main(i32 %0, i8** %1) {
   %18 = sext i32 %17 to i64
   %19 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %18)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %19)
   %20 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
   %21 = getelementptr %foo_b, %foo_b* %20, i32 0, i32 1
   %22 = getelementptr %bar_b, %bar_b* %21, i32 0, i32 1
@@ -51,12 +52,14 @@ define i32 @main(i32 %0, i8** %1) {
   %24 = sext i32 %23 to i64
   %25 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %24)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %25)
   %26 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
   %27 = getelementptr %bar_c, %bar_c* %26, i32 0, i32 1
   %28 = load i32, i32* %27, align 4
   %29 = sext i32 %28 to i64
   %30 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %29)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %30)
   %31 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
   %32 = getelementptr %foo_b, %foo_b* %31, i32 0, i32 0
   %33 = getelementptr %foo_a, %foo_a* %32, i32 0, i32 0
@@ -95,6 +98,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "8aec8183db9d36021c766491a07f7fd00b0ce4fbc048fcc02920a7e3",
+    "stdout_hash": "c57bccbf1dab56b243175a737fef5426d1d9526ea46eef5e97eae7b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -49,6 +49,7 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fpext float %22 to double
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %19, i32 6, double %23)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   %25 = alloca %complex_4, align 8
   %26 = getelementptr %complex_4, %complex_4* %25, i32 0, i32 0
   %27 = getelementptr %complex_4, %complex_4* %25, i32 0, i32 1
@@ -77,6 +78,7 @@ define i32 @main(i32 %0, i8** %1) {
   %42 = fpext float %41 to double
   %43 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %38, i32 6, double %42)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %43)
   %44 = alloca %complex_4, align 8
   %45 = getelementptr %complex_4, %complex_4* %44, i32 0, i32 0
   %46 = getelementptr %complex_4, %complex_4* %44, i32 0, i32 1
@@ -118,6 +120,7 @@ define i32 @main(i32 %0, i8** %1) {
   %69 = fpext float %68 to double
   %70 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %65, i32 6, double %69)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %70, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %70)
   call void @_lpython_free_argv()
   br label %return
 
@@ -132,5 +135,7 @@ declare void @_lfortran_complex_add_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "9a9a67bd0b2ca04363db69d97a0e0b0f0f7b7af752dce9400bfe3c2b",
+    "stdout_hash": "25a958d47a5d1b84ab23197be1f9d71b7f683c58c256623bf316588e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -49,6 +49,7 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fpext float %22 to double
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %19, i32 6, double %23)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   %25 = alloca %complex_4, align 8
   %26 = getelementptr %complex_4, %complex_4* %25, i32 0, i32 0
   %27 = getelementptr %complex_4, %complex_4* %25, i32 0, i32 1
@@ -77,6 +78,7 @@ define i32 @main(i32 %0, i8** %1) {
   %42 = fpext float %41 to double
   %43 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %38, i32 6, double %42)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %43)
   %44 = alloca %complex_4, align 8
   %45 = getelementptr %complex_4, %complex_4* %44, i32 0, i32 0
   %46 = getelementptr %complex_4, %complex_4* %44, i32 0, i32 1
@@ -118,6 +120,7 @@ define i32 @main(i32 %0, i8** %1) {
   %69 = fpext float %68 to double
   %70 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %65, i32 6, double %69)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %70, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %70)
   call void @_lpython_free_argv()
   br label %return
 
@@ -132,6 +135,8 @@ declare void @_lfortran_complex_div_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lfortran_complex_add_32(%complex_4*, %complex_4*, %complex_4*)
 

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "76e81414758c708664e11576e71153183d2674038ff02618874e11f6",
+    "stdout_hash": "1e270bb05d0e482310253a82aa2b29aabaf883eb495bb31028b52740",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -67,6 +67,7 @@ define i32 @main(i32 %0, i8** %1) {
   %38 = fpext float %37 to double
   %39 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 12, i8* null, i32 5, double %17, i32 5, double %20, i32 6, double %25, i32 6, double %29, i32 6, double %34, i32 6, double %38)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %39, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %39)
   call void @_lpython_free_argv()
   br label %return
 
@@ -79,5 +80,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "6007f71cce4729863cb9e18a1947c82ca3cb36d3afc247b2b69dbc74",
+    "stdout_hash": "9f33410bea690aace6d89640a086eac7a7506a3080a2227c8efadab2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -73,6 +73,7 @@ define i32 @main(i32 %0, i8** %1) {
   %36 = load double, double* %35, align 8
   %37 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 12, i8* null, i32 6, double %18, i32 6, double %22, i32 5, double %26, i32 5, double %29, i32 5, double %33, i32 5, double %36)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %37)
   call void @_lpython_free_argv()
   br label %return
 
@@ -85,5 +86,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "8b74de2549e513b80b0b24d3c8e9b53ae62215e58c3b63eae0a02952",
+    "stdout_hash": "8c63b53131826291a88700bf4241fa26a93df9cc02dddd9cd6a82bb5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -49,6 +49,7 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fpext float %22 to double
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %19, i32 6, double %23)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   %25 = alloca %complex_4, align 8
   %26 = getelementptr %complex_4, %complex_4* %25, i32 0, i32 0
   %27 = getelementptr %complex_4, %complex_4* %25, i32 0, i32 1
@@ -77,6 +78,7 @@ define i32 @main(i32 %0, i8** %1) {
   %42 = fpext float %41 to double
   %43 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %38, i32 6, double %42)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %43)
   %44 = load %complex_4, %complex_4* %x, align 4
   %45 = alloca %complex_4, align 8
   %46 = getelementptr %complex_4, %complex_4* %45, i32 0, i32 0
@@ -105,6 +107,7 @@ define i32 @main(i32 %0, i8** %1) {
   %61 = fpext float %60 to double
   %62 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %57, i32 6, double %61)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %62)
   call void @_lpython_free_argv()
   br label %return
 
@@ -119,5 +122,7 @@ declare void @_lfortran_complex_mul_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "69e13467b95d1424712c7494cd672a94ad5f8a0ddca5ede574e70365",
+    "stdout_hash": "844a9d3cc1494f68708d7cd9cd4ab43b7be708ef11713adf11f4fc2c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -49,6 +49,7 @@ define i32 @main(i32 %0, i8** %1) {
   %24 = fpext float %23 to double
   %25 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %20, i32 6, double %24)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %25)
   call void @_lpython_free_argv()
   br label %return
 
@@ -63,5 +64,7 @@ declare void @_lfortran_complex_pow_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "836b222ae3c71e655a15c522ce1dbc25b980cfc24b423dd697d070f6",
+    "stdout_hash": "c1e227d9b02f5dee35b451c1171cdedc127f55414cef13860d291fc9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -64,6 +64,7 @@ define i32 @main(i32 %0, i8** %1) {
   %32 = fpext float %31 to double
   %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %28, i32 6, double %32)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %33)
   %34 = alloca %complex_4, align 8
   %35 = getelementptr %complex_4, %complex_4* %34, i32 0, i32 0
   %36 = getelementptr %complex_4, %complex_4* %34, i32 0, i32 1
@@ -92,6 +93,7 @@ define i32 @main(i32 %0, i8** %1) {
   %51 = fpext float %50 to double
   %52 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %47, i32 6, double %51)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %52)
   %53 = load %complex_4, %complex_4* %x, align 4
   %54 = alloca %complex_4, align 8
   %55 = getelementptr %complex_4, %complex_4* %54, i32 0, i32 0
@@ -120,6 +122,7 @@ define i32 @main(i32 %0, i8** %1) {
   %70 = fpext float %69 to double
   %71 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %66, i32 6, double %70)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %71, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %71)
   call void @_lpython_free_argv()
   br label %return
 
@@ -134,5 +137,7 @@ declare void @_lfortran_complex_sub_32(%complex_4*, %complex_4*, %complex_4*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "724af9934cbeb8643d8b1e1bfde3bea1b0a7c2b7cc5bf650bd0f83ee",
+    "stdout_hash": "babd0867ce98de78f93e3cf36cb153726d67ff6a0980cf275c588e8f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -23,6 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load double, double* %u, align 8
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 6, double %3, i32 5, double %4, i32 6, double %6, i32 5, double %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   call void @_lpython_free_argv()
   br label %return
 
@@ -35,5 +36,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "b315df076fbc154ce58cc558e349967651e82e8cd1e6ed9efeb653aa",
+    "stdout_hash": "ea1cd63d84ae75902bea3f313fb5fe2563bdd7fbe95279de3553f952",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -35,8 +35,11 @@ loop.head:                                        ; preds = %ifcont, %then
   %6 = load i8*, i8** %str, align 8
   %7 = sext i32 %5 to i64
   %8 = call i8* @_lfortran_str_item(i8* %6, i64 %7)
+  %str_item = alloca i8, i32 2, align 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %str_item, i8* %8, i32 2, i1 false)
+  call void @_lfortran_free(i8* %8)
   %9 = alloca i8*, align 8
-  store i8* %8, i8** %9, align 8
+  store i8* %str_item, i8** %9, align 8
   %10 = alloca i8*, align 8
   store i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i8** %10, align 8
   %11 = call i1 @_lpython_str_compare_eq(i8** %9, i8** %10)
@@ -87,12 +90,19 @@ define i8* @_lcompilers_trim_str(i8** %str) {
   %3 = load i8*, i8** %str, align 8
   %4 = call i32 @_lcompilers_len_trim_str(i8** %str)
   %5 = call i8* @_lfortran_str_slice(i8* %3, i32 0, i32 %4, i32 1, i1 true, i1 true)
-  call void @_lfortran_strcpy_pointer_string(i8** %result, i8* %5)
+  %6 = alloca i8*, align 8
+  store i8* %5, i8** %6, align 8
+  %7 = call i32 @_lfortran_str_len(i8** %6)
+  %8 = add i32 1, %7
+  %str_slice = alloca i8, i32 %8, align 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %str_slice, i8* %5, i32 %8, i1 false)
+  call void @_lfortran_free(i8* %5)
+  call void @_lfortran_strcpy_pointer_string(i8** %result, i8* %str_slice)
   br label %return
 
 return:                                           ; preds = %.entry
-  %6 = load i8*, i8** %result, align 8
-  ret i8* %6
+  %9 = load i8*, i8** %result, align 8
+  ret i8* %9
 }
 
 define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val, %string_descriptor* %string) {
@@ -146,6 +156,11 @@ declare i32 @_lfortran_str_len(i8**)
 
 declare i8* @_lfortran_str_item(i8*, i64)
 
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
+
+declare void @_lfortran_free(i8*)
+
 declare i1 @_lpython_str_compare_eq(i8**, i8**)
 
 declare i8* @_lfortran_str_slice(i8*, i32, i32, i32, i1, i1)
@@ -184,6 +199,7 @@ define i32 @main(i32 %0, i8** %1) {
   %13 = load i8*, i8** %12, align 8
   %14 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %13)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %14)
   %15 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 0
   %16 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 1
   %17 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1__func_call_res, i32 0, i32 2
@@ -236,8 +252,6 @@ return:                                           ; preds = %ifcont
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_free(i8*)
-
 declare void @_lfortran_printf(i8*, ...)
 
 declare i1 @_lpython_str_compare_noteq(i8**, i8**)
@@ -247,3 +261,5 @@ declare void @_lcompilers_print_error(i8*, ...)
 declare void @exit(i32)
 
 declare void @_lpython_free_argv()
+
+attributes #0 = { argmemonly nounwind willreturn }

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "b7a9de9bf3d220152dbcafe58c65cb6ce642128abc1955e275440e31",
+    "stdout_hash": "7e6494b95d34f05769a32170c1b6340ad4439674e626e1bb7c5085f2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -102,6 +102,7 @@ ifcont:                                           ; preds = %else, %then
   %13 = sext i32 %12 to i64
   %14 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %13)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %14)
   store i32 0, i32* %j2, align 4
   store i32 11, i32* %i1, align 4
   br label %loop.head3
@@ -140,6 +141,7 @@ ifcont8:                                          ; preds = %else7, %then6
   %26 = sext i32 %25 to i64
   %27 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %26)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %27)
   store i32 0, i32* %j2, align 4
   store i32 -1, i32* %i1, align 4
   br label %loop.head9
@@ -178,6 +180,7 @@ ifcont14:                                         ; preds = %else13, %then12
   %39 = sext i32 %38 to i64
   %40 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %39)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @_lfortran_free(i8* %40)
   store i32 0, i32* %j2, align 4
   store i32 11, i32* %i1, align 4
   br label %loop.head15
@@ -216,6 +219,7 @@ ifcont20:                                         ; preds = %else19, %then18
   %52 = sext i32 %51 to i64
   %53 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %52)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
+  call void @_lfortran_free(i8* %53)
   store i32 0, i32* %j2, align 4
   store i32 -1, i32* %i1, align 4
   br label %loop.head21
@@ -254,6 +258,7 @@ ifcont26:                                         ; preds = %else25, %then24
   %65 = sext i32 %64 to i64
   %66 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %65)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @24, i32 0, i32 0), i8* %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0))
+  call void @_lfortran_free(i8* %66)
   store i32 0, i32* %j2, align 4
   store i32 -2, i32* %i1, align 4
   br label %loop.head27
@@ -292,6 +297,7 @@ ifcont32:                                         ; preds = %else31, %then30
   %78 = sext i32 %77 to i64
   %79 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %78)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  call void @_lfortran_free(i8* %79)
   store i32 0, i32* %j2, align 4
   store i32 13, i32* %i1, align 4
   br label %loop.head33
@@ -330,6 +336,7 @@ ifcont38:                                         ; preds = %else37, %then36
   %91 = sext i32 %90 to i64
   %92 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %91)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @34, i32 0, i32 0), i8* %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0))
+  call void @_lfortran_free(i8* %92)
   store i32 0, i32* %j2, align 4
   store i32 0, i32* %i1, align 4
   br label %loop.head39
@@ -368,6 +375,7 @@ ifcont44:                                         ; preds = %else43, %then42
   %104 = sext i32 %103 to i64
   %105 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %104)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
+  call void @_lfortran_free(i8* %105)
   store i32 0, i32* %j2, align 4
   store i32 2, i32* %i1, align 4
   br label %loop.head45
@@ -406,6 +414,7 @@ ifcont50:                                         ; preds = %else49, %then48
   %117 = sext i32 %116 to i64
   %118 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %117)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @44, i32 0, i32 0), i8* %118, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @43, i32 0, i32 0))
+  call void @_lfortran_free(i8* %118)
   store i32 0, i32* %j2, align 4
   store i32 0, i32* %i1, align 4
   br label %loop.head51
@@ -444,6 +453,7 @@ ifcont56:                                         ; preds = %else55, %then54
   %130 = sext i32 %129 to i64
   %131 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %130)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %131, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
+  call void @_lfortran_free(i8* %131)
   store i32 0, i32* %j2, align 4
   store i32 1, i32* %i1, align 4
   br label %loop.head57
@@ -482,6 +492,7 @@ ifcont62:                                         ; preds = %else61, %then60
   %143 = sext i32 %142 to i64
   %144 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %143)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @54, i32 0, i32 0), i8* %144, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @53, i32 0, i32 0))
+  call void @_lfortran_free(i8* %144)
   call void @_lpython_free_argv()
   br label %return
 
@@ -498,5 +509,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "412d2079f0ff5356a59dbb6c621b51d415f232f65f5cb891531cae37",
+    "stdout_hash": "61689edbf9353a75073123dcca89f0de07cd4b1b342444ff6ab47376",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -71,6 +71,7 @@ ifcont:                                           ; preds = %else, %then
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   store i32 0, i32* %a1, align 4
   store i32 0, i32* %i3, align 4
   br label %loop.head5
@@ -129,6 +130,7 @@ ifcont13:                                         ; preds = %else12, %then11
   %38 = sext i32 %37 to i64
   %39 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %38)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %39, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %39)
   store i32 0, i32* %a1, align 4
   store i32 0, i32* %i3, align 4
   br label %loop.head14
@@ -184,6 +186,7 @@ ifcont22:                                         ; preds = %else21, %then20
   %57 = sext i32 %56 to i64
   %58 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %57)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @_lfortran_free(i8* %58)
   call void @_lpython_free_argv()
   br label %return
 
@@ -200,5 +203,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "57f3071a75e2368941a24e44bac62cb8b4640d9c3d887213de1ebc21",
+    "stdout_hash": "f15ffedf919e6a062648f86f59fc2ee4c4fdc5347c79be4aaf245982",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -87,6 +87,7 @@ ifcont8:                                          ; preds = %else7, %then6
   %17 = sext i32 %16 to i64
   %18 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %17)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %18, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %18)
   store i32 0, i32* %j2, align 4
   store i32 0, i32* %i1, align 4
   br label %loop.head9
@@ -139,6 +140,7 @@ ifcont18:                                         ; preds = %else17, %then16
   %32 = sext i32 %31 to i64
   %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %32)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %33)
   store i32 0, i32* %j2, align 4
   store i32 0, i32* %i1, align 4
   br label %loop.head19
@@ -191,6 +193,7 @@ ifcont27:                                         ; preds = %else26, %then25
   %47 = sext i32 %46 to i64
   %48 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %47)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @13, i32 0, i32 0))
+  call void @_lfortran_free(i8* %48)
   call void @_lpython_free_argv()
   br label %return
 
@@ -207,5 +210,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "e8577242dd5f8437fc5e01e29d755add08be6dc3c109c5766970f65b",
+    "stdout_hash": "b384280d7ec59545cebaca206ca9b6d1930f2a1fb26f8c063b611792",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -87,6 +87,7 @@ ifcont:                                           ; preds = %else, %then
   %31 = sext i32 %30 to i64
   %32 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %31)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %32)
   store i32 0, i32* %j2, align 4
   store i32 -2, i32* %k3, align 4
   %33 = load i32, i32* %k3, align 4
@@ -144,6 +145,7 @@ ifcont9:                                          ; preds = %else8, %then7
   %62 = sext i32 %61 to i64
   %63 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %62)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %63)
   store i32 0, i32* %j2, align 4
   store i32 0, i32* %i1, align 4
   br label %a.head
@@ -339,5 +341,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "d77a9ff9d8371fc7c52920bca1d6ad24ad6f09e40f57a580e2afe33c",
+    "stdout_hash": "ce1a2934fe848346ef49fac9a9b86033e3f1c1a3775463b46a672752",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -15,6 +15,7 @@ define void @a(float (float*)* %f) {
   %2 = fpext float %1 to double
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -37,6 +38,8 @@ declare float @f.1(float*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "b32fa95cbbd9b38d30f7179c9646d4ed277a8dc5c23538154f2ffb8e",
+    "stdout_hash": "368eb8af732fe429a4da999a889db0635c1ccb6b0711e52215ccd014",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -14,6 +14,7 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0), i32 2, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   call void @_lpython_free_argv()
   br label %return
 
@@ -26,5 +27,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "34333c1025b5f04c7f215cceab9dfe28212cba6c63fb3cee6894aec1",
+    "stdout_hash": "96156eac9568c940d5308761a5923dd773f8f05c72e2a2afb833aec7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -131,6 +131,7 @@ define i32 @main(i32 %0, i8** %1) {
   %18 = fpext float %17 to double
   %19 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %15, i32 6, double %18)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %19)
   %20 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %21 = load float, float* %20, align 4
   %22 = fcmp une float %21, 2.000000e+00
@@ -173,6 +174,7 @@ ifcont5:                                          ; preds = %else4, %then3
   %34 = fpext float %33 to double
   %35 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %31, i32 6, double %34)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %35, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lfortran_free(i8* %35)
   %36 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %37 = load float, float* %36, align 4
   %38 = fcmp une float %37, 1.000000e+00
@@ -211,6 +213,8 @@ return:                                           ; preds = %ifcont11
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "197e123e3b9daf77e3fab2dab859bf8c812115c33b648951d884a95d",
+    "stdout_hash": "3c82fbc33d1812fb652860b884373bc7261077bd1ef4db9c7da56fdb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -78,6 +78,7 @@ define void @driver(void (i32*, i32*, i32*)* %fnc, i32* %arr, i32* %m) {
 .entry:
   %0 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double 1.000000e+00)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %0)
   %1 = load i32, i32* %m, align 4
   %2 = mul i32 1, %1
   %3 = getelementptr inbounds i32, i32* %arr, i32 2
@@ -175,6 +176,8 @@ return:                                           ; preds = %ifcont12
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "e50a994bb07d778e2f2b0dc61434a7b4069126b7454bb74c1ea07e3c",
+    "stdout_hash": "cd0a3be0deda6482ec5b9e6cacff4c49a778137a6546359ece6e4b4c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -81,6 +81,7 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fpext float %22 to double
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 20, i8* null, i32 2, i64 1, i32 2, i64 2, i32 6, double 4.000000e+00, i32 6, double %19, i32 6, double %23, i32 2, i64 3, i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 8, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i32 6, double -4.000000e+00, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0))
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   call void @_lpython_free_argv()
   br label %return
 
@@ -99,5 +100,7 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "b1cd0eb1366927c0457fe9f7e864ae7fdc28e2fd5d19d07dce44d014",
+    "stdout_hash": "d08c53e8865f8ec3389844db9da21156ebdf00243f2dddbfd289528a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -14,6 +14,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i64, i64* @int_dp.v, align 4
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %3, i32 1, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 
@@ -26,5 +27,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "14643b4a5d36999a724e0d14b2bdd4ccc7152b4e855c62785045ef02",
+    "stdout_hash": "472427ed53a69ebbce54822b16d0a0bb96bb2f53e1e7e77fae0f42bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -22,6 +22,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i64, i64* @int_dp_param.v, align 4
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %3, i32 1, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 
@@ -34,5 +35,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "c65f7b00e8606c994e77c7cab7cc610b5902bf6706bb7d5a09f3969d",
+    "stdout_hash": "b5979d685113c12b78b7ea1a9b25aa02aef0a286e05eec0934b95131",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -28,6 +28,7 @@ define float @__module_dflt_intent_f(float* %x) {
   %3 = fpext float %2 to double
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -38,6 +39,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "447564f7a95be544175fa61d57c0651d2a65f7a440661872079fa498",
+    "stdout_hash": "784eedbb84dc386fdc5988b92fd8d59987d0f9721a5a9ba9e1d131e7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -118,6 +118,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load double, double* %y, align 8
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 6, double %3, i32 5, double %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   %6 = load float, float* @intrinsics_02.x, align 4
   %7 = fsub float %6, 0x3FEFEB7AA0000000
   store float %7, float* %call_arg_value, align 4
@@ -214,6 +215,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "04fa3affb1332167b1371e4846902e41f5943f7e491644756b4b7724",
+    "stdout_hash": "b17b4440fca43814f66b2e64ae99bc380817332b8591df4b4f994209",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -207,6 +207,7 @@ ifcont14:                                         ; preds = %else13, %then12
   %26 = sext i32 %25 to i64
   %27 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %26)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lfortran_free(i8* %27)
   %28 = call i32 @_lcompilers_abs_i32(i32* @intrinsics_03.i)
   %29 = icmp ne i32 %28, 12
   br i1 %29, label %then15, label %else16
@@ -236,5 +237,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "8cee087e003c5eb0a0006a6ce94be897b8e6b183144f62faebc2bcd3",
+    "stdout_hash": "d9449c9044259441a56cf2f61d93f8bbe83a26a1b24bb0c572f80260",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -17,16 +17,19 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = fpext float %2 to double
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   store float 0x3FF8B07560000000, float* %x, align 4
   %5 = load float, float* %x, align 4
   %6 = fpext float %5 to double
   %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %6)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %7)
   store float 0x3FE85EFAC0000000, float* %x, align 4
   %8 = load float, float* %x, align 4
   %9 = fpext float %8 to double
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   call void @_lpython_free_argv()
   br label %return
 
@@ -39,5 +42,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "621e2710551e38fd09f28ed37e4ebeae4d9fe6fb1bff8ac748bbd4a7",
+    "stdout_hash": "d484117359918f5422b38d33d07fe84348a53cb70108bcf5c124eb81",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -29,36 +29,43 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = fpext float %2 to double
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   store float 1.000000e+00, float* %x, align 4
   %5 = load float, float* %x, align 4
   %6 = fpext float %5 to double
   %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %6)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %7)
   store float 1.000000e+00, float* %x, align 4
   %8 = load float, float* %x, align 4
   %9 = fpext float %8 to double
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   store float 1.000000e+00, float* %x, align 4
   %11 = load float, float* %x, align 4
   %12 = fpext float %11 to double
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   store float 1.000000e+00, float* %x, align 4
   %14 = load float, float* %x, align 4
   %15 = fpext float %14 to double
   %16 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %15)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %16)
   store float 1.000000e+00, float* %x, align 4
   %17 = load float, float* %x, align 4
   %18 = fpext float %17 to double
   %19 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %18)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @_lfortran_free(i8* %19)
   store float 1.000000e+00, float* %x, align 4
   %20 = load float, float* %x, align 4
   %21 = fpext float %20 to double
   %22 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %21)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lfortran_free(i8* %22)
   call void @_lpython_free_argv()
   br label %return
 
@@ -71,5 +78,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "befb276ce716e14fe05b62fd52747411c650ab8f33993c686adb0d7f",
+    "stdout_hash": "3827988805811914ccceb18ebe51eca816cd6728fe3ea2ea3bba5120",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -23,6 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = select i1 %6, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0)
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 8, i8* %4, i32 8, i8* %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   call void @_lpython_free_argv()
   br label %return
 
@@ -35,5 +36,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "4fe159e7369504dc2c34bef29da817332b9be1c67e69490debdb04c1",
+    "stdout_hash": "55d07289abc2e402f55cfac2c92ccbe99933f10d60aa0c6436b6aa65",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -30,6 +30,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = select i1 %9, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0)
   %11 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 8, i8* %4, i32 8, i8* %7, i32 8, i8* %10)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %11)
   call void @_lpython_free_argv()
   br label %return
 
@@ -42,5 +43,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "dbf2fc82588e75e9f79e6b53be9f8b5ac6169969c3c0d8a9b3ddde2a",
+    "stdout_hash": "8a2c332fd42fdf63823d3c66acf04b21975882aa0425b350b7ee8121",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -32,6 +32,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 
@@ -42,5 +43,7 @@ return:                                           ; preds = %.entry
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "25d445b0243f1878d58cca433331ff45d4177812d12105738ccc657a",
+    "stdout_hash": "713e3abbbc426735d9d39837997e818b3acbceda7b2eba0a17505c48",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -16,6 +16,7 @@ define void @__module_modules_11_module11_access_internally() {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -26,6 +27,8 @@ declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
 
+declare void @_lfortran_free(i8*)
+
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -33,6 +36,7 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i32 2, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   call void @__module_modules_11_module11_access_internally()
   call void @_lpython_free_argv()
   br label %return

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "5f234ca431489b881665a21a4ced57a6ed7eedff578daa9198d982dc",
+    "stdout_hash": "d589e6b683f369ae2451f86eb79c77ca802227689ca4020eae7406ec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -38,6 +38,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 
@@ -50,5 +51,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "9257e41c3a38560c9fa6defe529da204d1546254acb31893d5843b32",
+    "stdout_hash": "6b89e055e1901cfa0a6c4c3be1dd15706b871995f012c7560dd34a0b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -155,6 +155,7 @@ loop.end:                                         ; preds = %loop.head
   %52 = load i8*, i8** %51, align 8
   %53 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 7, i8* %52)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %53)
   %54 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
   %55 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
   %56 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "da0f85cc381d9f8cbb6757ab37546a7def2a057a9456fce56cb38fc5",
+    "stdout_hash": "de7b874e40429a53aff6f989dca2bc8f3d0b11fb2d7945b2aa4d5e7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -21,6 +21,7 @@ define void @__module_nested_02_a_c() {
 .entry:
   %0 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %0)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -30,6 +31,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "9620fb547ca9cda7bf55dcbd9275c8de39699a9ea0e29f96cf53939d",
+    "stdout_hash": "44936619db8bc78b5b9862b132fc1b316971b84fc8b7128a78c4bd33",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -30,10 +30,12 @@ define void @__module_nested_03_a_c() {
 .entry:
   %0 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %0)
   %1 = load float, float* @__lcompilers_created__nested_context__b_x, align 4
   %2 = fpext float %1 to double
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -43,6 +45,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "38f2c5f4130d4887b6d7b90953a5ea7a772b8eead15b69c2c3dabe73",
+    "stdout_hash": "bb95eb31bdf5c63607bc677a6c1b001a1843a702d3325b21d5238b3d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -48,14 +48,17 @@ define i32 @__module_nested_04_a_c(i32* %z) {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   %3 = load i32, i32* @__lcompilers_created__nested_context__b_y, align 4
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   %6 = load float, float* @__lcompilers_created__nested_context__b_yy, align 4
   %7 = fpext float %6 to double
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   %9 = load i32, i32* %z, align 4
   store i32 %9, i32* %c, align 4
   br label %return
@@ -68,6 +71,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "45da14814f9775d2a8982b7acf5b59c2361ae17671bdf5976fdc00c4",
+    "stdout_hash": "7cda71bf93c3a769172305d25138c02e0ff6d358ad3b6ff1d2d59119",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -26,10 +26,12 @@ define void @__module_nested_05_a_b() {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   %3 = load float, float* %y, align 4
   %4 = fpext float %3 to double
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   %6 = load i32, i32* %x, align 4
   store i32 %6, i32* @__lcompilers_created__nested_context__b_x, align 4
   %7 = load float, float* %y, align 4
@@ -43,10 +45,12 @@ define void @__module_nested_05_a_b() {
   %11 = sext i32 %10 to i64
   %12 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %11)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %12)
   %13 = load float, float* %y, align 4
   %14 = fpext float %13 to double
   %15 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %14)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @_lfortran_free(i8* %15)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -59,10 +63,12 @@ define void @__module_nested_05_a_c() {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   %3 = load float, float* @__lcompilers_created__nested_context__b_y, align 4
   %4 = fpext float %3 to double
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   store i32 4, i32* @__lcompilers_created__nested_context__b_x, align 4
   store float 3.500000e+00, float* @__lcompilers_created__nested_context__b_y, align 4
   br label %return
@@ -74,6 +80,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "dc6743a37623b4afde0021a776be475cea112aaea8ec8fb1d3ae6338",
+    "stdout_hash": "274d6970cdfec316010a3f63b370acd767ae02baae9bd270425492c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -28,10 +28,12 @@ define void @__module_nested_06_a_c() {
 .entry:
   %0 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %0)
   %1 = load float, float* @__lcompilers_created__nested_context__b_x, align 4
   %2 = fpext float %1 to double
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -41,6 +43,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "0c70f54389e895a362fa931f1b0a3840ee9f87f193d5a44f9d3e5398",
+    "stdout_hash": "c6106cfa26543b40ddba8418aab54d9b13f294934d31b7573675f1b9",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -102,37 +102,45 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = select i1 %3, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 8, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   %6 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %f)
   %7 = icmp eq i1 %6, false
   %8 = select i1 %7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 8, i8* %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   %10 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %t)
   %11 = icmp eq i1 %10, false
   %12 = select i1 %11, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0)
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 8, i8* %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   %14 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %f)
   %15 = icmp eq i1 %14, false
   %16 = select i1 %15, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0)
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i32 8, i8* %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   %18 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %t)
   %19 = sext i32 %18 to i64
   %20 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i32 2, i64 %19)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @22, i32 0, i32 0), i8* %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void @_lfortran_free(i8* %20)
   %21 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %f)
   %22 = sext i32 %21 to i64
   %23 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @24, i32 0, i32 0), i32 2, i64 %22)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0))
+  call void @_lfortran_free(i8* %23)
   %24 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %t)
   %25 = sext i32 %24 to i64
   %26 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i32 2, i64 %25)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @28, i32 0, i32 0), i8* %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
+  call void @_lfortran_free(i8* %26)
   %27 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %f)
   %28 = sext i32 %27 to i64
   %29 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @30, i32 0, i32 0), i32 2, i64 %28)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0))
+  call void @_lfortran_free(i8* %29)
   call void @_lpython_free_argv()
   br label %return
 
@@ -145,5 +153,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "b60c7035611c750402e9b141155f0c8314009cf3e6c80e440f105d84",
+    "stdout_hash": "e07881e537793bcc88ee4e586e745c807a9dd6fa3a5e1bbdb57077db",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -36,6 +36,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = select i1 %3, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0), i32 8, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   store i32 1, i32* %call_arg_value1, align 4
   call void @__module_overload_assignment_m_logical_gets_integer(i1* %tf, i32* %call_arg_value1)
   %6 = load i1, i1* %tf, align 1
@@ -43,6 +44,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = select i1 %7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0), i32 8, i8* %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   call void @_lpython_free_argv()
   br label %return
 
@@ -55,5 +57,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "2bceb0d24bc20a28931cb5c39115c7170dd65ca7efdf8d778eb5a6b7",
+    "stdout_hash": "faa58586e4f23a24f2a4ffc14f17385cf3ec4eea199a3ee6b71912bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -114,41 +114,49 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = select i1 %3, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0)
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 8, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   %6 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %f)
   %7 = icmp eq i1 %6, false
   %8 = select i1 %7, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0)
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i32 8, i8* %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   %10 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %t)
   %11 = icmp eq i1 %10, false
   %12 = select i1 %11, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0)
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i32 8, i8* %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   %14 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %f)
   %15 = icmp eq i1 %14, false
   %16 = select i1 %15, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0)
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i32 8, i8* %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   %18 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %t)
   %19 = icmp eq i1 %18, false
   %20 = select i1 %19, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @22, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0)
   %21 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i32 8, i8* %20)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @24, i32 0, i32 0), i8* %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void @_lfortran_free(i8* %21)
   %22 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %f)
   %23 = icmp eq i1 %22, false
   %24 = select i1 %23, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @28, i32 0, i32 0)
   %25 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i32 8, i8* %24)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0))
+  call void @_lfortran_free(i8* %25)
   %26 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %t)
   %27 = icmp eq i1 %26, false
   %28 = select i1 %27, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0)
   %29 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i32 8, i8* %28)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @34, i32 0, i32 0), i8* %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  call void @_lfortran_free(i8* %29)
   %30 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %f)
   %31 = icmp eq i1 %30, false
   %32 = select i1 %31, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @38, i32 0, i32 0)
   %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @36, i32 0, i32 0), i32 8, i8* %32)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0))
+  call void @_lfortran_free(i8* %33)
   call void @_lpython_free_argv()
   br label %return
 
@@ -161,5 +169,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "d706a512957673cc3800f444d6d7bff6f186300f8c281aa0b2428a6f",
+    "stdout_hash": "dbe34f14b6382e4a3b388ca12dd840796daad400a844deb08fca153c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -21,6 +21,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = sext i32 %7 to i64
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 10, i8* null, i32 2, i64 %3, i32 2, i64 1, i32 2, i64 3, i32 2, i64 %5, i32 2, i64 %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   %10 = load i32, i32* %x1, align 4
   %11 = sext i32 %10 to i64
   %12 = load i32, i32* %x1, align 4
@@ -30,6 +31,7 @@ define i32 @main(i32 %0, i8** %1) {
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 10, i8* null, i32 2, i64 %11, i32 2, i64 1, i32 2, i64 3, i32 2, i64 %13, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   call void @_lpython_free_argv()
   br label %return
 
@@ -42,5 +44,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "73accb75d769a175f2edaec351c18c6d65783224dbb6a0aeeb66a806",
+    "stdout_hash": "5b008307810f406cedd7627c33fefdad96d3ff38762386ecdaa7e43c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -16,11 +16,13 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   %5 = load i32, i32* %i1, align 4
   %6 = add i32 %5, 1
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   call void @_lpython_free_argv()
   br label %return
 
@@ -33,5 +35,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "1ca6b0c449476a8654fa11abbd72d43b3f9d7f86c6da6cc67604625f",
+    "stdout_hash": "2455e7190867e5b39a3d966c0be50a3a32b0a915cff38fcb9cf903ad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -33,6 +33,7 @@ loop.body:                                        ; preds = %loop.head
   %10 = sext i32 %9 to i64
   %11 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %10)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %11)
   %12 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
   store i32 %12, i32* %z1, align 4
   br label %loop.head
@@ -80,5 +81,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "08858183540767253c9aa2ed2a0b5fcf6f305a713b9584a8fa9b3d6d",
+    "stdout_hash": "cb8c07805576fabe8575cc626ffdeda87bd4719a3ae00632a5fa6a57",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -20,6 +20,7 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = fpext float %5 to double
   %7 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 6, double %3, i32 5, double %4, i32 6, double %6)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %7)
   call void @_lpython_free_argv()
   br label %return
 
@@ -32,5 +33,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "6addddae6cc6e9303345d03ec97522920aa93409bce44311f97fecb4",
+    "stdout_hash": "a6b76e36a9c2c220e9b296cd3adc2ac6d07785adc48c5f57789d3801",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -24,6 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = load double, double* @real_dp_param.zero, align 8
   %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 6, double %3, i32 5, double %4, i32 5, double %5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %6)
   call void @_lpython_free_argv()
   br label %return
 
@@ -36,5 +37,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "c508f5de185c08c57f5bab312119ad967be1b8df8289284f9175179a",
+    "stdout_hash": "e6863bb5d95a536640b9390ae3ee9e112ebf0bde8228e549793c7881",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -27,6 +27,7 @@ then:                                             ; preds = %.entry
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   %9 = load i32, i32* %x, align 4
   store i32 %9, i32* @__lcompilers_created__nested_context__sub1_x, align 4
   call void @__module_recursion_01_sub2()
@@ -60,6 +61,7 @@ define void @__module_recursion_01_sub2() {
   %3 = sext i32 %2 to i64
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   call void @__module_recursion_01_sub1(i32* @__lcompilers_created__nested_context__sub1_x)
   br label %return
 
@@ -70,6 +72,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "f8a1f6ddcf075433c292c6138bbd29f9d9a21769e83b2417e69e74d6",
+    "stdout_hash": "606aea9f5e95e71a4728fdef24a810331c3eb6c231ab10ee9cc65981",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -30,6 +30,7 @@ define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
   %2 = sext i32 %1 to i64
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @1, i32 0, i32 0), i32 2, i64 %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   store i32 2, i32* %call_arg_value, align 4
   %4 = load i32, i32* %iter, align 4
   %5 = sub i32 %4, 1
@@ -42,6 +43,7 @@ define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
   %9 = sext i32 %8 to i64
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @4, i32 0, i32 0), i32 2, i64 %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -100,6 +102,7 @@ define i32 @__module_recursion_02_getx() {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @7, i32 0, i32 0), i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   %3 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
   store i32 %3, i32* %getx, align 4
   br label %return
@@ -112,6 +115,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
@@ -128,6 +133,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @13, i32 0, i32 0), i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "90d78a8c1af353dd40143b8be09e7844b8444ead4fb36677d037abcc",
+    "stdout_hash": "3ae5130a424d49465119ea530d8bfb582d5c5332c6048780ce5cd825",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -30,6 +30,7 @@ define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
   %2 = sext i32 %1 to i64
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @1, i32 0, i32 0), i32 2, i64 %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   store i32 2, i32* %call_arg_value, align 4
   %4 = load i32, i32* %iter, align 4
   %5 = sub i32 %4, 1
@@ -42,6 +43,7 @@ define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
   %9 = sext i32 %8 to i64
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @4, i32 0, i32 0), i32 2, i64 %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -114,6 +116,7 @@ define i32 @__module_recursion_03_getx() {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @7, i32 0, i32 0), i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   %3 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
   store i32 %3, i32* %getx, align 4
   br label %return
@@ -126,6 +129,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
@@ -142,6 +147,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @13, i32 0, i32 0), i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @14, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "5e27debbf408dd751229b64b8ff82eea490ae161307653da8a5024dc",
+    "stdout_hash": "c4bf2c6a63af83c2b0beb409f007d8417edd9a2edce2b36d2cb0e955",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -101,6 +101,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = sext i32 %3 to i64
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   store i32 2, i32* %call_arg_value2, align 4
   %6 = call i32 @__module_many_returns_b(i32* %call_arg_value2)
   store i32 %6, i32* %c1, align 4
@@ -108,6 +109,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = sext i32 %7 to i64
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   store i32 3, i32* %call_arg_value3, align 4
   %10 = call i32 @__module_many_returns_b(i32* %call_arg_value3)
   store i32 %10, i32* %c1, align 4
@@ -115,6 +117,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = sext i32 %11 to i64
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   store i32 4, i32* %call_arg_value4, align 4
   %14 = call i32 @__module_many_returns_b(i32* %call_arg_value4)
   store i32 %14, i32* %c1, align 4
@@ -122,6 +125,7 @@ define i32 @main(i32 %0, i8** %1) {
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   call void @_lpython_free_argv()
   br label %return
 
@@ -132,5 +136,7 @@ return:                                           ; preds = %.entry
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "2df99a76c52323cc80f7f35738592cea7349ac8fcc85b40d8621cd9a",
+    "stdout_hash": "c506ff70bd44eb7fa81034585b8fa67c050d6a0129d5ce71f7cacbb5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -12,6 +12,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load double, double* %x, align 8
   %3 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 5, double %2)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %3)
   call void @_lpython_free_argv()
   br label %return
 
@@ -24,5 +25,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "98a0520faba6db392ada7bdcfc24dcb90a30a2b6a6292baa6663dc00",
+    "stdout_hash": "26b2190f6ce4f070079a44b46fab0aabffdf466d12163e89670a8cf1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -18,6 +18,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load i8*, i8** @print_01.my_name, align 8
   %5 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @2, i32 0, i32 0), i32 7, i8* %4)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @_lfortran_free(i8* %5)
   call void @_lpython_free_argv()
   br label %return
 
@@ -36,5 +37,7 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "cb2afbbea6488d72b26a902c2a6d1cd3c4897a25c90efc78b57beaab",
+    "stdout_hash": "eba8594e75214d297eb1003ad8d9fcc612492572138a2feeff86ce55",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -43,6 +43,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = load i8*, i8** %surname, align 8
   %13 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 8, i8* null, i32 7, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @5, i32 0, i32 0), i32 7, i8* %10, i32 7, i8* %11, i32 7, i8* %12)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @_lfortran_free(i8* %13)
   %14 = load i8*, i8** %greetings, align 8
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   call void @_lpython_free_argv()
@@ -63,5 +64,7 @@ declare void @_lfortran_strcpy_pointer_string(i8**, i8*)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "4b48d8f4a71a62c339b67f55e9a1f9bf1a4dde684f8cf1fd7ef55405",
+    "stdout_hash": "f9003e2980cbc71b6c2e4e2ae2836ee9b401c4fa7a60ed2e044a01e2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -85,6 +85,7 @@ define i32 @main(i32 %0, i8** %1) {
   %30 = select i1 %29, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0)
   %31 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %30)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %31)
   call void @_lfortran_strcpy_pointer_string(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
   %32 = load i8*, i8** @string_10.c, align 8
   %33 = alloca i8*, align 8
@@ -122,6 +123,7 @@ define i32 @main(i32 %0, i8** %1) {
   %56 = select i1 %55, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0)
   %57 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %56)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lfortran_free(i8* %57)
   call void @_lfortran_strcpy_pointer_string(i8** @string_10.c, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @18, i32 0, i32 0))
   %58 = load i8*, i8** @string_10.c, align 8
   %59 = alloca i8*, align 8
@@ -159,9 +161,11 @@ define i32 @main(i32 %0, i8** %1) {
   %82 = select i1 %81, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0)
   %83 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 8, i8* %82)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @26, i32 0, i32 0), i8* %83, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @23, i32 0, i32 0))
+  call void @_lfortran_free(i8* %83)
   %84 = load i8*, i8** %num, align 8
   %85 = call i8* @_lfortran_str_slice_assign(i8* %84, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @27, i32 0, i32 0), i32 0, i32 3, i32 1, i1 true, i1 true)
   call void @_lfortran_strcpy_pointer_string(i8** %num, i8* %85)
+  call void @_lfortran_free(i8* %85)
   %86 = load i8*, i8** %num, align 8
   %87 = alloca i8*, align 8
   store i8* %86, i8** %87, align 8
@@ -201,6 +205,8 @@ declare i1 @_lpython_str_compare_lte(i8**, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare i8* @_lfortran_str_slice_assign(i8*, i8*, i32, i32, i32, i1, i1)
 

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "5ca4341a4fbd7f264271a84d09c30a32bd770f701d6b3cb9eb33dcd8",
+    "stdout_hash": "88593ee7933e05b58d1f5afd7c456ec169eb0c6bca9c5f35f7d2565d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -42,7 +42,7 @@ else:                                             ; preds = %.entry
 ifcont:                                           ; preds = %else, %then
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont8, %ifcont
+loop.head:                                        ; preds = %ifcont9, %ifcont
   %7 = load i32, i32* %i, align 4
   %8 = load i8*, i8** %str, align 8
   %9 = alloca i8*, align 8
@@ -55,14 +55,14 @@ loop.head:                                        ; preds = %ifcont8, %ifcont
   %15 = icmp eq i32 %14, 1
   %16 = icmp eq i1 %12, false
   %17 = select i1 %16, i1 %12, i1 %15
-  br i1 %17, label %loop.body, label %loop.end9
+  br i1 %17, label %loop.body, label %loop.end10
 
 loop.body:                                        ; preds = %loop.head
   store i32 0, i32* %k, align 4
   store i32 1, i32* %j, align 4
   br label %loop.head1
 
-loop.head1:                                       ; preds = %ifcont5, %loop.body
+loop.head1:                                       ; preds = %ifcont6, %loop.body
   %18 = load i32, i32* %j, align 4
   %19 = load i8*, i8** %substr, align 8
   %20 = alloca i8*, align 8
@@ -86,63 +86,77 @@ loop.body2:                                       ; preds = %loop.head1
   %33 = sub i32 %32, 1
   %34 = load i32, i32* %pos, align 4
   %35 = call i8* @_lfortran_str_slice(i8* %31, i32 %33, i32 %34, i32 1, i1 true, i1 true)
-  %36 = load i8*, i8** %substr, align 8
-  %37 = load i32, i32* %j, align 4
-  %38 = sub i32 %37, 1
-  %39 = load i32, i32* %j, align 4
-  %40 = call i8* @_lfortran_str_slice(i8* %36, i32 %38, i32 %39, i32 1, i1 true, i1 true)
-  %41 = alloca i8*, align 8
-  store i8* %35, i8** %41, align 8
-  %42 = alloca i8*, align 8
-  store i8* %40, i8** %42, align 8
-  %43 = call i1 @_lpython_str_compare_noteq(i8** %41, i8** %42)
-  br i1 %43, label %then3, label %else4
+  %36 = alloca i8*, align 8
+  store i8* %35, i8** %36, align 8
+  %37 = call i32 @_lfortran_str_len(i8** %36)
+  %38 = add i32 1, %37
+  %str_slice = alloca i8, i32 %38, align 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %str_slice, i8* %35, i32 %38, i1 false)
+  call void @_lfortran_free(i8* %35)
+  %39 = load i8*, i8** %substr, align 8
+  %40 = load i32, i32* %j, align 4
+  %41 = sub i32 %40, 1
+  %42 = load i32, i32* %j, align 4
+  %43 = call i8* @_lfortran_str_slice(i8* %39, i32 %41, i32 %42, i32 1, i1 true, i1 true)
+  %44 = alloca i8*, align 8
+  store i8* %43, i8** %44, align 8
+  %45 = call i32 @_lfortran_str_len(i8** %44)
+  %46 = add i32 1, %45
+  %str_slice3 = alloca i8, i32 %46, align 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %str_slice3, i8* %43, i32 %46, i1 false)
+  call void @_lfortran_free(i8* %43)
+  %47 = alloca i8*, align 8
+  store i8* %str_slice, i8** %47, align 8
+  %48 = alloca i8*, align 8
+  store i8* %str_slice3, i8** %48, align 8
+  %49 = call i1 @_lpython_str_compare_noteq(i8** %47, i8** %48)
+  br i1 %49, label %then4, label %else5
 
-then3:                                            ; preds = %loop.body2
+then4:                                            ; preds = %loop.body2
   store i1 false, i1* %found, align 1
-  br label %ifcont5
+  br label %ifcont6
 
-else4:                                            ; preds = %loop.body2
-  br label %ifcont5
+else5:                                            ; preds = %loop.body2
+  br label %ifcont6
 
-ifcont5:                                          ; preds = %else4, %then3
-  %44 = load i32, i32* %j, align 4
-  %45 = add i32 %44, 1
-  store i32 %45, i32* %j, align 4
-  %46 = load i32, i32* %k, align 4
-  %47 = add i32 %46, 1
-  store i32 %47, i32* %k, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  %50 = load i32, i32* %j, align 4
+  %51 = add i32 %50, 1
+  store i32 %51, i32* %j, align 4
+  %52 = load i32, i32* %k, align 4
+  %53 = add i32 %52, 1
+  store i32 %53, i32* %k, align 4
   br label %loop.head1
 
 loop.end:                                         ; preds = %loop.head1
-  %48 = load i1, i1* %found, align 1
-  %49 = zext i1 %48 to i32
-  %50 = icmp eq i32 %49, 1
-  br i1 %50, label %then6, label %else7
+  %54 = load i1, i1* %found, align 1
+  %55 = zext i1 %54 to i32
+  %56 = icmp eq i32 %55, 1
+  br i1 %56, label %then7, label %else8
 
-then6:                                            ; preds = %loop.end
-  %51 = load i32, i32* %i, align 4
-  store i32 %51, i32* %_lcompilers_index_str, align 4
-  %52 = load i1, i1* %back, align 1
-  store i1 %52, i1* %found, align 1
-  br label %ifcont8
+then7:                                            ; preds = %loop.end
+  %57 = load i32, i32* %i, align 4
+  store i32 %57, i32* %_lcompilers_index_str, align 4
+  %58 = load i1, i1* %back, align 1
+  store i1 %58, i1* %found, align 1
+  br label %ifcont9
 
-else7:                                            ; preds = %loop.end
+else8:                                            ; preds = %loop.end
   store i1 true, i1* %found, align 1
-  br label %ifcont8
+  br label %ifcont9
 
-ifcont8:                                          ; preds = %else7, %then6
-  %53 = load i32, i32* %i, align 4
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %i, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %59 = load i32, i32* %i, align 4
+  %60 = add i32 %59, 1
+  store i32 %60, i32* %i, align 4
   br label %loop.head
 
-loop.end9:                                        ; preds = %loop.head
+loop.end10:                                       ; preds = %loop.head
   br label %return
 
-return:                                           ; preds = %loop.end9
-  %55 = load i32, i32* %_lcompilers_index_str, align 4
-  ret i32 %55
+return:                                           ; preds = %loop.end10
+  %61 = load i32, i32* %_lcompilers_index_str, align 4
+  ret i32 %61
 }
 
 define i32 @_lcompilers_index_str1(i8** %str, i8** %substr, i1* %back, i32* %kind) {
@@ -177,7 +191,7 @@ else:                                             ; preds = %.entry
 ifcont:                                           ; preds = %else, %then
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont8, %ifcont
+loop.head:                                        ; preds = %ifcont9, %ifcont
   %7 = load i32, i32* %i, align 4
   %8 = load i8*, i8** %str, align 8
   %9 = alloca i8*, align 8
@@ -190,14 +204,14 @@ loop.head:                                        ; preds = %ifcont8, %ifcont
   %15 = icmp eq i32 %14, 1
   %16 = icmp eq i1 %12, false
   %17 = select i1 %16, i1 %12, i1 %15
-  br i1 %17, label %loop.body, label %loop.end9
+  br i1 %17, label %loop.body, label %loop.end10
 
 loop.body:                                        ; preds = %loop.head
   store i32 0, i32* %k, align 4
   store i32 1, i32* %j, align 4
   br label %loop.head1
 
-loop.head1:                                       ; preds = %ifcont5, %loop.body
+loop.head1:                                       ; preds = %ifcont6, %loop.body
   %18 = load i32, i32* %j, align 4
   %19 = load i8*, i8** %substr, align 8
   %20 = alloca i8*, align 8
@@ -221,68 +235,87 @@ loop.body2:                                       ; preds = %loop.head1
   %33 = sub i32 %32, 1
   %34 = load i32, i32* %pos, align 4
   %35 = call i8* @_lfortran_str_slice(i8* %31, i32 %33, i32 %34, i32 1, i1 true, i1 true)
-  %36 = load i8*, i8** %substr, align 8
-  %37 = load i32, i32* %j, align 4
-  %38 = sub i32 %37, 1
-  %39 = load i32, i32* %j, align 4
-  %40 = call i8* @_lfortran_str_slice(i8* %36, i32 %38, i32 %39, i32 1, i1 true, i1 true)
-  %41 = alloca i8*, align 8
-  store i8* %35, i8** %41, align 8
-  %42 = alloca i8*, align 8
-  store i8* %40, i8** %42, align 8
-  %43 = call i1 @_lpython_str_compare_noteq(i8** %41, i8** %42)
-  br i1 %43, label %then3, label %else4
+  %36 = alloca i8*, align 8
+  store i8* %35, i8** %36, align 8
+  %37 = call i32 @_lfortran_str_len(i8** %36)
+  %38 = add i32 1, %37
+  %str_slice = alloca i8, i32 %38, align 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %str_slice, i8* %35, i32 %38, i1 false)
+  call void @_lfortran_free(i8* %35)
+  %39 = load i8*, i8** %substr, align 8
+  %40 = load i32, i32* %j, align 4
+  %41 = sub i32 %40, 1
+  %42 = load i32, i32* %j, align 4
+  %43 = call i8* @_lfortran_str_slice(i8* %39, i32 %41, i32 %42, i32 1, i1 true, i1 true)
+  %44 = alloca i8*, align 8
+  store i8* %43, i8** %44, align 8
+  %45 = call i32 @_lfortran_str_len(i8** %44)
+  %46 = add i32 1, %45
+  %str_slice3 = alloca i8, i32 %46, align 1
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %str_slice3, i8* %43, i32 %46, i1 false)
+  call void @_lfortran_free(i8* %43)
+  %47 = alloca i8*, align 8
+  store i8* %str_slice, i8** %47, align 8
+  %48 = alloca i8*, align 8
+  store i8* %str_slice3, i8** %48, align 8
+  %49 = call i1 @_lpython_str_compare_noteq(i8** %47, i8** %48)
+  br i1 %49, label %then4, label %else5
 
-then3:                                            ; preds = %loop.body2
+then4:                                            ; preds = %loop.body2
   store i1 false, i1* %found, align 1
-  br label %ifcont5
+  br label %ifcont6
 
-else4:                                            ; preds = %loop.body2
-  br label %ifcont5
+else5:                                            ; preds = %loop.body2
+  br label %ifcont6
 
-ifcont5:                                          ; preds = %else4, %then3
-  %44 = load i32, i32* %j, align 4
-  %45 = add i32 %44, 1
-  store i32 %45, i32* %j, align 4
-  %46 = load i32, i32* %k, align 4
-  %47 = add i32 %46, 1
-  store i32 %47, i32* %k, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  %50 = load i32, i32* %j, align 4
+  %51 = add i32 %50, 1
+  store i32 %51, i32* %j, align 4
+  %52 = load i32, i32* %k, align 4
+  %53 = add i32 %52, 1
+  store i32 %53, i32* %k, align 4
   br label %loop.head1
 
 loop.end:                                         ; preds = %loop.head1
-  %48 = load i1, i1* %found, align 1
-  %49 = zext i1 %48 to i32
-  %50 = icmp eq i32 %49, 1
-  br i1 %50, label %then6, label %else7
+  %54 = load i1, i1* %found, align 1
+  %55 = zext i1 %54 to i32
+  %56 = icmp eq i32 %55, 1
+  br i1 %56, label %then7, label %else8
 
-then6:                                            ; preds = %loop.end
-  %51 = load i32, i32* %i, align 4
-  store i32 %51, i32* %_lcompilers_index_str1, align 4
-  %52 = load i1, i1* %back, align 1
-  store i1 %52, i1* %found, align 1
-  br label %ifcont8
+then7:                                            ; preds = %loop.end
+  %57 = load i32, i32* %i, align 4
+  store i32 %57, i32* %_lcompilers_index_str1, align 4
+  %58 = load i1, i1* %back, align 1
+  store i1 %58, i1* %found, align 1
+  br label %ifcont9
 
-else7:                                            ; preds = %loop.end
+else8:                                            ; preds = %loop.end
   store i1 true, i1* %found, align 1
-  br label %ifcont8
+  br label %ifcont9
 
-ifcont8:                                          ; preds = %else7, %then6
-  %53 = load i32, i32* %i, align 4
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %i, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %59 = load i32, i32* %i, align 4
+  %60 = add i32 %59, 1
+  store i32 %60, i32* %i, align 4
   br label %loop.head
 
-loop.end9:                                        ; preds = %loop.head
+loop.end10:                                       ; preds = %loop.head
   br label %return
 
-return:                                           ; preds = %loop.end9
-  %55 = load i32, i32* %_lcompilers_index_str1, align 4
-  ret i32 %55
+return:                                           ; preds = %loop.end10
+  %61 = load i32, i32* %_lcompilers_index_str1, align 4
+  ret i32 %61
 }
 
 declare i32 @_lfortran_str_len(i8**)
 
 declare i8* @_lfortran_str_slice(i8*, i32, i32, i32, i1, i1)
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
+
+declare void @_lfortran_free(i8*)
 
 declare i1 @_lpython_str_compare_noteq(i8**, i8**)
 
@@ -322,6 +355,7 @@ else:                                             ; preds = %.entry
   %9 = sext i32 %8 to i64
   %10 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 7, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @6, i32 0, i32 0), i32 2, i64 %9)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void @_lfortran_free(i8* %10)
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -345,3 +379,5 @@ declare void @_lfortran_printf(i8*, ...)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lpython_free_argv()
+
+attributes #0 = { argmemonly nounwind willreturn }

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "60acce42a2406caf65425fdebbd963bb91a776e81813e11f3f87cb2f",
+    "stdout_hash": "0606ecc1da282c005325735bbfeec9e011bb1e4c34b3c5cef30f015d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -63,6 +63,7 @@ else8:                                            ; preds = %ifcont6
 ifcont9:                                          ; preds = %else8, %then7
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 6, i8* null, i32 2, i64 48, i32 2, i64 53, i32 2, i64 57)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   call void @_lpython_free_argv()
   br label %return
 
@@ -79,5 +80,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "3c645699ad43bfe32734a0ba2a70934501a106fc1bd07c7c5cae10c1",
+    "stdout_hash": "52eea11f0cca61fd5ae9611c6687d76d5a32f3f583f0eab69941cb46",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -69,6 +69,7 @@ ifcont:                                           ; preds = %else, %then
   %7 = sext i32 %6 to i64
   %8 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %5, i32 2, i64 %7)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  call void @_lfortran_free(i8* %8)
   %9 = load i32, i32* %i1, align 4
   %10 = icmp ne i32 %9, 1
   br i1 %10, label %then3, label %else4
@@ -115,6 +116,7 @@ ifcont11:                                         ; preds = %else10, %then9
   %16 = sext i32 %15 to i64
   %17 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %16)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void @_lfortran_free(i8* %17)
   %18 = load i32, i32* %j2, align 4
   %19 = icmp ne i32 %18, 4
   br i1 %19, label %then12, label %else13
@@ -148,6 +150,7 @@ ifcont17:                                         ; preds = %else16, %then15
   %23 = sext i32 %22 to i64
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %23)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   %25 = load i32, i32* %j2, align 4
   %26 = icmp ne i32 %25, 4
   br i1 %26, label %then19, label %else20
@@ -183,6 +186,7 @@ ifcont24:                                         ; preds = %else23, %then22
   %32 = sext i32 %31 to i64
   %33 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %32)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  call void @_lfortran_free(i8* %33)
   %34 = load i32, i32* %j2, align 4
   %35 = icmp ne i32 %34, 4
   br i1 %35, label %then26, label %else27
@@ -223,5 +227,7 @@ declare void @exit(i32)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "907e6fbb2021dddc337ad31c7d3a7b3ac2bcb971888d58ba63c53549",
+    "stdout_hash": "561696f3c64b10bdaa06b751a8d91771f74f2db6f65940015dbed7fd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -42,6 +42,7 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = sext i32 %4 to i64
   %6 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %3, i32 2, i64 %5)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %6)
   %7 = load i32, i32* %i1, align 4
   %8 = icmp ne i32 %7, 1
   br i1 %8, label %then, label %else
@@ -75,6 +76,7 @@ ifcont5:                                          ; preds = %else4, %then3
   %14 = sext i32 %13 to i64
   %15 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %12, i32 2, i64 %14)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void @_lfortran_free(i8* %15)
   %16 = load i32, i32* %i1, align 4
   %17 = icmp ne i32 %16, 1
   br i1 %17, label %then6, label %else7
@@ -108,6 +110,7 @@ ifcont11:                                         ; preds = %else10, %then9
   %23 = sext i32 %22 to i64
   %24 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 4, i8* null, i32 2, i64 %21, i32 2, i64 %23)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void @_lfortran_free(i8* %24)
   %25 = load i32, i32* %i1, align 4
   %26 = icmp ne i32 %25, 1
   br i1 %26, label %then12, label %else13
@@ -177,6 +180,8 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "a8f1a476353eb78be069c1b51e7519841d5c54b9317533d5058bac83",
+    "stdout_hash": "75f5f882a4ab222aecedf3d8b8015cae0edc2253fffe307dd45d5866",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -23,6 +23,7 @@ define void @print_int() {
   %1 = sext i32 %0 to i64
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %1)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -32,6 +33,8 @@ return:                                           ; preds = %.entry
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "4d9080d35eb589d59ce4335657d17e012df8bab5d2b7478509da1fe1",
+    "stdout_hash": "1c266d478ed58a06681cb457ebc022b72b8a91d0ff005a2ef1cbcb64",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -17,6 +17,7 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = fpext float %2 to double
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 6, double %3)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @_lfortran_free(i8* %4)
   %5 = load float, float* %r, align 4
   %6 = fptosi float %5 to i32
   store i32 %6, i32* %i1, align 4
@@ -24,6 +25,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = sext i32 %7 to i64
   %9 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %8)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @_lfortran_free(i8* %9)
   call void @_lpython_free_argv()
   br label %return
 
@@ -36,5 +38,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_free_argv()

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run_dbg-runtime_stacktrace_01-dcc746e.stdout",
-    "stdout_hash": "3cbac67824df4a7f5d34a6c972039cfef6d42c038439792177b26622",
+    "stdout_hash": "3d070fb32646475da2d11deddc6005aea43537702444bd60fabf0ce1",
     "stderr": "run_dbg-runtime_stacktrace_01-dcc746e.stderr",
     "stderr_hash": "d7b2063ee2384904c7372e603b621a3e739faa954e5cc144f17d9b08",
     "returncode": 5

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stdout
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stdout
@@ -18,6 +18,7 @@ define i32 @main(i32 %0, i8** %1) !dbg !3 {
   %3 = sext i32 %2 to i64, !dbg !9
   %4 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %3), !dbg !9
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0)), !dbg !9
+  call void @_lfortran_free(i8* %4), !dbg !9
   call void @_lpython_free_argv(), !dbg !9
   br label %return, !dbg !9
 
@@ -67,6 +68,7 @@ define i32 @_xx_lcompilers_changed_main_xx() !dbg !8 {
   %1 = sext i32 %0 to i64, !dbg !24
   %2 = call i8* (i32, i8*, ...) @_lcompilers_string_format_fortran(i32 2, i8* null, i32 2, i64 %1), !dbg !24
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0)), !dbg !24
+  call void @_lfortran_free(i8* %2), !dbg !24
   br label %return, !dbg !24
 
 return:                                           ; preds = %.entry
@@ -86,6 +88,8 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 declare i8* @_lcompilers_string_format_fortran(i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, ...)
+
+declare void @_lfortran_free(i8*)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 


### PR DESCRIPTION
I don't know the best approach to handle those leaks, I was just trying to free them to see if the leak spikes would drop, and it did.