### PR TITLE
FIX: Handle Allocate for User-Defined StructInstanceMember

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2065,7 +2065,7 @@ RUN(NAME openmp_41 LABELS llvm_omp llvm)
 RUN(NAME openmp_42 LABELS llvm_omp llvm)
 RUN(NAME openmp_43 LABELS llvm_omp llvm)
 
-RUN(NAME struct_allocate LABELS gfortran llvm)
+RUN(NAME struct_allocate LABELS gfortran llvm NOFAST_TILL_LLVM16)
 
 RUN(NAME nullify_01 LABELS gfortran fortran llvm)
 RUN(NAME nullify_02 LABELS gfortran fortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2065,6 +2065,8 @@ RUN(NAME openmp_41 LABELS llvm_omp llvm)
 RUN(NAME openmp_42 LABELS llvm_omp llvm)
 RUN(NAME openmp_43 LABELS llvm_omp llvm)
 
+RUN(NAME struct_allocate LABELS gfortran llvm)
+
 RUN(NAME nullify_01 LABELS gfortran fortran llvm)
 RUN(NAME nullify_02 LABELS gfortran fortran llvm)
 RUN(NAME nullify_03 LABELS gfortran llvm)

--- a/integration_tests/struct_allocate.f90
+++ b/integration_tests/struct_allocate.f90
@@ -1,0 +1,26 @@
+module p
+    implicit none
+    integer, parameter, private :: mxdim = 3
+    type :: rp1d
+        real(8), dimension(:), pointer :: f
+    end type
+
+    type :: sds
+        integer, dimension(:), pointer :: dims
+        type(rp1d), dimension(mxdim) :: scales
+        integer :: f
+    end type
+end module
+
+program struct_allocate
+    use p
+    implicit none
+    type(sds) :: s
+    ! allocate(s%dims(2))
+    ! allocate(s%scales(2)%f(2))
+    ! s%scales(2)%f=[3,4]
+    ! print *, 'Scale 0:', s%scales(2)%f(1)
+    allocate(s%scales(1)%f(2))
+    ! s%scales(1)%f=[1,2]
+    ! print *, 'Scale 0:', s%scales(1)%f(1)
+end program

--- a/integration_tests/struct_allocate.f90
+++ b/integration_tests/struct_allocate.f90
@@ -7,6 +7,7 @@ module mod_struct_allocate
 
     type :: sds
         type(rp1d), dimension(mxdim) :: scales
+        integer, dimension(:), pointer ::dims
     end type
 end module
 
@@ -14,6 +15,16 @@ program struct_allocate
     use mod_struct_allocate
     implicit none
     type(sds) :: s
-    allocate(s%scales(1)%f(4))
+
+    allocate(s%dims(2))
+    s%dims=[10,11]
+    print *, s%dims(1)
+
     allocate(s%scales(2)%f(3))
+    s%scales(2)%f=[6,7,8]
+    print *, s%scales(2)%f(3)
+    
+    allocate(s%scales(1)%f(2))
+    s%scales(1)%f=[1,2]
+    print *, s%scales(1)%f(1)
 end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2694,14 +2694,15 @@ public:
         current_der_type_name = "";
         ASR::ttype_t* x_m_v_type = ASRUtils::expr_type(x.m_v);
         int64_t ptr_loads_copy = ptr_loads;
-        if( ASR::is_a<ASR::UnionInstanceMember_t>(*x.m_v) ||
-            ASR::is_a<ASR::ClassType_t>(*ASRUtils::type_get_past_pointer(x_m_v_type)) ) {
-            ptr_loads = 0;
-        } else {
-            ptr_loads = 2 - LLVM::is_llvm_pointer(*x_m_v_type);
-        }
+        ptr_loads = (ASR::is_a<ASR::UnionInstanceMember_t>(*x.m_v) ||
+                 ASR::is_a<ASR::ClassType_t>(*ASRUtils::type_get_past_pointer(x_m_v_type)))
+                ? 0 : 2 - LLVM::is_llvm_pointer(*x_m_v_type);
+
+
         this->visit_expr(*x.m_v);
         ptr_loads = ptr_loads_copy;
+        llvm::Value* base_tmp = tmp; // Save the result of x.m_v
+        llvm::Type* base_type = llvm_utils->get_type_from_ttype_t_util(x_m_v_type, module.get());
         if( ASR::is_a<ASR::ClassType_t>(*ASRUtils::type_get_past_pointer(
                 ASRUtils::type_get_past_allocatable(x_m_v_type))) ) {
             if (ASRUtils::is_allocatable(x_m_v_type)) {
@@ -2716,6 +2717,20 @@ public:
             } else {
                 // TODO: Select type by comparing with vtab
             }
+        } else if (ASR::is_a<ASR::Array_t>(*x_m_v_type)) {
+            ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(x_m_v_type);
+            ASR::ttype_t* element_type = array_type->m_type;
+    
+            llvm::Value* index = llvm::ConstantInt::get(context, llvm::APInt(32, 0)); // 0-based indexing
+            std::vector<llvm::Value*> idx_vec = {
+                llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+                index
+            };
+            llvm::Type* element_llvm_type = llvm_utils->get_type_from_ttype_t_util(element_type, module.get());
+            tmp = builder->CreateGEP(base_type, base_tmp, idx_vec);
+            base_type = element_llvm_type;
+            current_der_type_name = ASRUtils::symbol_name(
+                ASR::down_cast<ASR::StructType_t>(element_type)->m_derived_type);
         }
         ASR::Variable_t* member = down_cast<ASR::Variable_t>(symbol_get_past_external(x.m_m));
         std::string member_name = std::string(member->m_name);
@@ -2729,7 +2744,6 @@ public:
             current_der_type_name = dertype2parent[current_der_type_name];
         }
         int member_idx = name2memidx[current_der_type_name][member_name];
-
         llvm::Type *xtype = name2dertype[current_der_type_name];
         tmp = llvm_utils->create_gep2(xtype, tmp, member_idx);
         ASR::ttype_t* member_type = ASRUtils::type_get_past_pointer(

--- a/tests/reference/asr-struct_allocate-606e066.json
+++ b/tests/reference/asr-struct_allocate-606e066.json
@@ -2,11 +2,11 @@
     "basename": "asr-struct_allocate-606e066",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/struct_allocate.f90",
-    "infile_hash": "8f826ffcc557e1f998f9fb99e619bed6aa68bc3f5e45768ad8fa12a9",
+    "infile_hash": "63dc4bc223f7ee610f0480c65f164a2c0f8927913788db84cfd1f4d2",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-struct_allocate-606e066.stdout",
-    "stdout_hash": "1bf9839f423741072f5f10307ddd2b45f7072a5446dc97dbc44e4686",
+    "stdout_hash": "f05bf5584fea66070c6e5ee1844c0b02704d36339590c9169bcc87b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-struct_allocate-606e066.stdout
+++ b/tests/reference/asr-struct_allocate-606e066.stdout
@@ -72,6 +72,31 @@
                                     (SymbolTable
                                         4
                                         {
+                                            dims:
+                                                (Variable
+                                                    4
+                                                    dims
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Pointer
+                                                        (Array
+                                                            (Integer 4)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                ),
                                             scales:
                                                 (Variable
                                                     4
@@ -100,7 +125,8 @@
                                         })
                                     sds
                                     []
-                                    [scales]
+                                    [scales
+                                    dims]
                                     Source
                                     Public
                                     .false.
@@ -128,6 +154,16 @@
                                     rp1d
                                     []
                                     f
+                                    Public
+                                ),
+                            1_sds_dims:
+                                (ExternalSymbol
+                                    5
+                                    1_sds_dims
+                                    4 dims
+                                    sds
+                                    []
+                                    dims
                                     Public
                                 ),
                             1_sds_scales:
@@ -185,33 +221,11 @@
                     [mod_struct_allocate]
                     [(Allocate
                         [((StructInstanceMember
-                            (ArrayItem
-                                (StructInstanceMember
-                                    (Var 5 s)
-                                    5 1_sds_scales
-                                    (Array
-                                        (StructType
-                                            5 rp1d
-                                        )
-                                        [((IntegerConstant 1 (Integer 4) Decimal)
-                                        (IntegerConstant 3 (Integer 4) Decimal))]
-                                        FixedSizeArray
-                                    )
-                                    ()
-                                )
-                                [(()
-                                (IntegerConstant 1 (Integer 4) Decimal)
-                                ())]
-                                (StructType
-                                    5 rp1d
-                                )
-                                ColMajor
-                                ()
-                            )
-                            5 1_rp1d_f
+                            (Var 5 s)
+                            5 1_sds_dims
                             (Pointer
                                 (Array
-                                    (Real 8)
+                                    (Integer 4)
                                     [(()
                                     ())]
                                     DescriptorArray
@@ -220,12 +234,68 @@
                             ()
                         )
                         [((IntegerConstant 1 (Integer 4) Decimal)
-                        (IntegerConstant 4 (Integer 4) Decimal))]
+                        (IntegerConstant 2 (Integer 4) Decimal))]
                         ()
                         ())]
                         ()
                         ()
                         ()
+                    )
+                    (Assignment
+                        (StructInstanceMember
+                            (Var 5 s)
+                            5 1_sds_dims
+                            (Pointer
+                                (Array
+                                    (Integer 4)
+                                    [(()
+                                    ())]
+                                    DescriptorArray
+                                )
+                            )
+                            ()
+                        )
+                        (ArrayConstant
+                            8
+                            [10, 11]
+                            (Array
+                                (Integer 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(ArrayItem
+                                (StructInstanceMember
+                                    (Var 5 s)
+                                    5 1_sds_dims
+                                    (Pointer
+                                        (Array
+                                            (Integer 4)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (Integer 4)
+                                ColMajor
+                                ()
+                            )]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
                     )
                     (Allocate
                         [((StructInstanceMember
@@ -270,6 +340,250 @@
                         ()
                         ()
                         ()
+                    )
+                    (Assignment
+                        (StructInstanceMember
+                            (ArrayItem
+                                (StructInstanceMember
+                                    (Var 5 s)
+                                    5 1_sds_scales
+                                    (Array
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())]
+                                (StructType
+                                    5 rp1d
+                                )
+                                ColMajor
+                                ()
+                            )
+                            5 1_rp1d_f
+                            (Pointer
+                                (Array
+                                    (Real 8)
+                                    [(()
+                                    ())]
+                                    DescriptorArray
+                                )
+                            )
+                            ()
+                        )
+                        (ArrayConstant
+                            24
+                            [6.0000000000000000e+00, 7.0000000000000000e+00, 8.0000000000000000e+00]
+                            (Array
+                                (Real 8)
+                                [(()
+                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                DescriptorArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(ArrayItem
+                                (StructInstanceMember
+                                    (ArrayItem
+                                        (StructInstanceMember
+                                            (Var 5 s)
+                                            5 1_sds_scales
+                                            (Array
+                                                (StructType
+                                                    5 rp1d
+                                                )
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                        )
+                                        [(()
+                                        (IntegerConstant 2 (Integer 4) Decimal)
+                                        ())]
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        ColMajor
+                                        ()
+                                    )
+                                    5 1_rp1d_f
+                                    (Pointer
+                                        (Array
+                                            (Real 8)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 3 (Integer 4) Decimal)
+                                ())]
+                                (Real 8)
+                                ColMajor
+                                ()
+                            )]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
+                    )
+                    (Allocate
+                        [((StructInstanceMember
+                            (ArrayItem
+                                (StructInstanceMember
+                                    (Var 5 s)
+                                    5 1_sds_scales
+                                    (Array
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (StructType
+                                    5 rp1d
+                                )
+                                ColMajor
+                                ()
+                            )
+                            5 1_rp1d_f
+                            (Pointer
+                                (Array
+                                    (Real 8)
+                                    [(()
+                                    ())]
+                                    DescriptorArray
+                                )
+                            )
+                            ()
+                        )
+                        [((IntegerConstant 1 (Integer 4) Decimal)
+                        (IntegerConstant 2 (Integer 4) Decimal))]
+                        ()
+                        ())]
+                        ()
+                        ()
+                        ()
+                    )
+                    (Assignment
+                        (StructInstanceMember
+                            (ArrayItem
+                                (StructInstanceMember
+                                    (Var 5 s)
+                                    5 1_sds_scales
+                                    (Array
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (StructType
+                                    5 rp1d
+                                )
+                                ColMajor
+                                ()
+                            )
+                            5 1_rp1d_f
+                            (Pointer
+                                (Array
+                                    (Real 8)
+                                    [(()
+                                    ())]
+                                    DescriptorArray
+                                )
+                            )
+                            ()
+                        )
+                        (ArrayConstant
+                            16
+                            [1.0000000000000000e+00, 2.0000000000000000e+00]
+                            (Array
+                                (Real 8)
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                DescriptorArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(ArrayItem
+                                (StructInstanceMember
+                                    (ArrayItem
+                                        (StructInstanceMember
+                                            (Var 5 s)
+                                            5 1_sds_scales
+                                            (Array
+                                                (StructType
+                                                    5 rp1d
+                                                )
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                        )
+                                        [(()
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        ())]
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        ColMajor
+                                        ()
+                                    )
+                                    5 1_rp1d_f
+                                    (Pointer
+                                        (Array
+                                            (Real 8)
+                                            [(()
+                                            ())]
+                                            DescriptorArray
+                                        )
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (Real 8)
+                                ColMajor
+                                ()
+                            )]
+                            FormatFortran
+                            (String -1 0 () PointerString)
+                            ()
+                        )
                     )]
                 )
         })


### PR DESCRIPTION
Towards 
https://github.com/lfortran/lfortran/issues/5655

## MRE 
----
```fortran
module p
    implicit none
    integer, parameter, private :: mxdim = 3
    type :: rp1d
        real(8), dimension(:), pointer :: f
    end type

    type :: sds
        integer, dimension(:), pointer :: dims
        type(rp1d), dimension(mxdim) :: scales
        integer :: f
    end type
end module

program struct_allocate
    use p
    implicit none
    type(sds) :: s
    !allocate(s%dims(2))
    ! allocate(s%scales(2)%f(2))
    ! s%scales(2)%f=[3,4]
    ! print *, 'Scale 0:', s%scales(2)%f(1)
    allocate(s%scales(1)%f(2))
    ! s%scales(1)%f=[1,2]
    ! print *, 'Scale 0:', s%scales(1)%f(1)
end program
```