### PR TITLE
CI: update hash commit of *Test POT3D*

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -573,7 +573,7 @@ jobs:
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
             git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 3c84e76c33cc2522c7ae8db910153dcf1a273a45
+            git checkout 0c8a7c652ebee393ed29ca973aa7a750e6038a9e
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang


### PR DESCRIPTION
## Description

we've removed two workarounds, and link to commit reversals
* https://github.com/gxyd/POT3D/commit/0c8a7c652ebee393ed29ca973aa7a750e6038a9e use of 'contiguous' attribute in POT3D repo
* https://github.com/gxyd/POT3D/commit/02d74dcf8384f9c44b6dbcc809bd62800b87b75e bug in passing array section to a function call