### PR TITLE
enh: frontend to support optional args with `--implicit-interface`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1260,6 +1260,7 @@ RUN(NAME implicit_interface_14 LABELS gfortran) # ! TODO: fix this test
 RUN(NAME implicit_interface_15 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface EXTRAFILES implicit_interface_15b)
 RUN(NAME implicit_interface_16 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface EXTRAFILES implicit_interface_16b)
 RUN(NAME implicit_interface_17 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface EXTRAFILES implicit_interface_17b)
+RUN(NAME implicit_interface_18 LABELS gfortran llvmImplicit EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_18.f90
+++ b/integration_tests/implicit_interface_18.f90
@@ -1,0 +1,32 @@
+program optional_example
+    implicit none
+    real(8) :: result
+    call power_function(3.0_8, result) 
+    if (result /= 9.0_8) error stop 
+    call power_function(3.0_8, result, 3) 
+    if (result /= 27.0_8) error stop 
+    call interface_trouble(5)
+contains
+    subroutine power_function(base, res, exponent)
+        implicit none
+        real(8), intent(in) :: base
+        integer, intent(in), optional :: exponent
+        real(8), intent(out) :: res
+        integer :: exp_value
+        if (present(exponent)) then
+            exp_value = exponent
+        else
+            exp_value = 2
+        end if
+        res = base ** exp_value
+    end subroutine power_function
+
+    recursive subroutine interface_trouble(n,t)
+        implicit none
+        integer, intent(in) :: n
+        real(8), intent(out), optional :: t
+        if(n <= 0) return
+        call interface_trouble(n-1, t)
+    end subroutine interface_trouble
+
+end program optional_example

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -195,7 +195,7 @@ void update_call_args(Allocator &al, SymbolTable *current_scope, bool implicit_i
         }
 
         void handle_Var(ASR::expr_t* arg_expr, ASR::expr_t** expr_to_replace) {
-            if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
+            if (arg_expr && ASR::is_a<ASR::Var_t>(*arg_expr)) {
                 ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(arg_expr);
                 ASR::symbol_t* arg_sym = arg_var->m_v;
                 ASR::symbol_t* arg_sym_underlying = ASRUtils::symbol_get_past_external(arg_sym);


### PR DESCRIPTION
Fixes #6460. 
It is just a minor check. Now it runs with `--implicit-interface`