### PR TITLE
fix: only resolve procedure recursively when scope is different from current

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1717,6 +1717,7 @@ RUN(NAME pass_array_by_data_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llv
 RUN(NAME pass_array_by_data_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME pass_array_by_data_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME pass_array_by_data_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray NO_STD_F23)
+RUN(NAME pass_array_by_data_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 
 RUN(NAME implicit_deallocate_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/pass_array_by_data_11.f90
+++ b/integration_tests/pass_array_by_data_11.f90
@@ -2,22 +2,27 @@ program pass_array_by_data_11
 
     implicit none
     real :: y0(5)
-    if (AB5(func, y0(:)) /= 1.0) error stop 
+    y0 = AB5(func, y0(:))
+    if (any(y0 /= [1.0,1.0,1.0,1.0,0.0])) error stop 
 
 contains
 
-    real function AB5(f, y0)
+    function AB5(f, y0)
         interface
             real function f(y)
                 real, intent(in) :: y(:)
             end function
         end interface
         real, intent(in) :: y0(:)
-        AB5 = 1.0
+        real, allocatable :: AB5(:)
+        allocate(AB5(size(y0)))
+        AB5(1:size(y0)-1) = func(y0(1:3))
+        AB5(size(y0)) = 0.0 
     end function
 
     real function func(y)
         real, intent(in) :: y(:)
+        func = 1.0
     end function
 
 end program

--- a/integration_tests/pass_array_by_data_11.f90
+++ b/integration_tests/pass_array_by_data_11.f90
@@ -1,0 +1,23 @@
+program pass_array_by_data_11
+
+    implicit none
+    real :: y0(5)
+    if (AB5(func, y0(:)) /= 1.0) error stop 
+
+contains
+
+    real function AB5(f, y0)
+        interface
+            real function f(y)
+                real, intent(in) :: y(:)
+            end function
+        end interface
+        real, intent(in) :: y0(:)
+        AB5 = 1.0
+    end function
+
+    real function func(y)
+        real, intent(in) :: y(:)
+    end function
+
+end program

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -521,7 +521,8 @@ class EditProcedureCallsVisitor : public ASR::ASRPassBaseWalkVisitor<EditProcedu
             if( v.proc2newproc.find(ext_sym) != v.proc2newproc.end() ) {
                 ASR::symbol_t* new_sym = v.proc2newproc[ext_sym].first;
                 ASR::asr_t* new_sym_parent = ASRUtils::symbol_parent_symtab(new_sym)->asr_owner;
-                if ( ASR::is_a<ASR::symbol_t>(*new_sym_parent) ) {
+                if ( ASR::is_a<ASR::symbol_t>(*new_sym_parent) && 
+                        current_scope->get_counter() != ASRUtils::symbol_parent_symtab(new_sym)->get_counter() ) {
                     ASR::symbol_t* resolved_parent_sym = resolve_new_proc(ASR::down_cast<ASR::symbol_t>(new_sym_parent));
                     if ( resolved_parent_sym != nullptr ) {
                         ASR::symbol_t* sym_to_return = ASRUtils::symbol_symtab(resolved_parent_sym)->get_symbol(ASRUtils::symbol_name(new_sym));

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -362,7 +362,8 @@ class EditProcedureReplacer: public ASR::BaseExprReplacer<EditProcedureReplacer>
         if( v.proc2newproc.find(ext_sym) != v.proc2newproc.end() ) {
             ASR::symbol_t* new_sym = v.proc2newproc[ext_sym].first;
             ASR::asr_t* new_sym_parent = ASRUtils::symbol_parent_symtab(new_sym)->asr_owner;
-            if ( ASR::is_a<ASR::symbol_t>(*new_sym_parent) ) {
+            if ( ASR::is_a<ASR::symbol_t>(*new_sym_parent) && 
+                 current_scope->get_counter() != ASRUtils::symbol_parent_symtab(new_sym)->get_counter() ) {
                 ASR::symbol_t* resolved_parent_sym = resolve_new_proc(ASR::down_cast<ASR::symbol_t>(new_sym_parent));
                 if ( resolved_parent_sym != nullptr ) {
                     ASR::symbol_t* sym_to_return = ASRUtils::symbol_symtab(resolved_parent_sym)->get_symbol(ASRUtils::symbol_name(new_sym));


### PR DESCRIPTION
Fixes #6384 