### PR TITLE
ci: setup `numerical-methods-fortran` plotting functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -827,7 +827,7 @@ jobs:
             ./test_ode.exe
             ./test_probability_distribution.exe
             ./test_sde.exe
-            ./plot_bogdanov_takens.exe
+            # ./plot_bogdanov_takens.exe
             ./plot_bruinsma.exe
             ./plot_fun1.exe
             # ./plot_lorenz.exe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -817,8 +817,8 @@ jobs:
             git clone https://github.com/Pranavchiku/numerical-methods-fortran.git
             cd numerical-methods-fortran
             export PATH="$(pwd)/../src/bin:$PATH"
-            git checkout -t origin/lf5
-            git checkout 2af27a1239263cf4dbec2b464ea1d5af94667997
+            git checkout -t origin/lf6
+            git checkout a252989e64b3f8d5d2f930dca18411c104ea85f8
             FC=lfortran make
             ./test_fix_point.exe
             ./test_integrate_one.exe
@@ -827,6 +827,14 @@ jobs:
             ./test_ode.exe
             ./test_probability_distribution.exe
             ./test_sde.exe
+            ./plot_bogdanov_takens.exe
+            ./plot_bruinsma.exe
+            ./plot_fun1.exe
+            # ./plot_lorenz.exe
+            ./plot_lotka_volterra1.exe
+            ./plot_lotka_volterra2.exe
+            # ./plot_pendulum.exe
+            ./plot_transes_iso.exe
 
       # The below projects are tested with a higher CMake version, so replace the current installed version
       - name: Override cmake version to 3.31.2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -511,6 +511,31 @@ jobs:
             ./build0.sh
             ./build1.sh
 
+      - name: Test Numerical Methods Fortran
+        shell: bash -e -x -l {0}
+        run: |
+            git clone https://github.com/Pranavchiku/numerical-methods-fortran.git
+            cd numerical-methods-fortran
+            export PATH="$(pwd)/../src/bin:$PATH"
+            git checkout -t origin/lf6
+            git checkout a252989e64b3f8d5d2f930dca18411c104ea85f8
+            FC=lfortran make
+            ./test_fix_point.exe
+            ./test_integrate_one.exe
+            ./test_linear.exe
+            ./test_newton.exe
+            ./test_ode.exe
+            ./test_probability_distribution.exe
+            ./test_sde.exe
+            # ./plot_bogdanov_takens.exe
+            ./plot_bruinsma.exe
+            ./plot_fun1.exe
+            # ./plot_lorenz.exe
+            ./plot_lotka_volterra1.exe
+            ./plot_lotka_volterra2.exe
+            # ./plot_pendulum.exe
+            ./plot_transes_iso.exe
+
       - name: Test PRIMA
         shell: bash -e -l {0}
         run: |
@@ -810,31 +835,6 @@ jobs:
             make clean
             make -j8 FORTRAN=lfortran FFLAGS="--fast" MPI=no OPENMP=no
             ./gsnap ../qasnap/sample/inp out
-
-      - name: Test Numerical Methods Fortran
-        shell: bash -e -x -l {0}
-        run: |
-            git clone https://github.com/Pranavchiku/numerical-methods-fortran.git
-            cd numerical-methods-fortran
-            export PATH="$(pwd)/../src/bin:$PATH"
-            git checkout -t origin/lf6
-            git checkout a252989e64b3f8d5d2f930dca18411c104ea85f8
-            FC=lfortran make
-            ./test_fix_point.exe
-            ./test_integrate_one.exe
-            ./test_linear.exe
-            ./test_newton.exe
-            ./test_ode.exe
-            ./test_probability_distribution.exe
-            ./test_sde.exe
-            # ./plot_bogdanov_takens.exe
-            ./plot_bruinsma.exe
-            ./plot_fun1.exe
-            # ./plot_lorenz.exe
-            ./plot_lotka_volterra1.exe
-            ./plot_lotka_volterra2.exe
-            # ./plot_pendulum.exe
-            ./plot_transes_iso.exe
 
       # The below projects are tested with a higher CMake version, so replace the current installed version
       - name: Override cmake version to 3.31.2


### PR DESCRIPTION
With this we setup `6/8` plotting functions of `numerical-methods-fortran` on CI. Considering https://github.com/lfortran/lfortran/issues/4703#issuecomment-2700040746, I suspect Linux checks to fail.