### PR TITLE
Improve derived type default initialization

### DIFF
--- a/integration_tests/template_vector.f90
+++ b/integration_tests/template_vector.f90
@@ -59,10 +59,9 @@ contains
 
     subroutine main()
         instantiate vector_t(integer), only: IntVector => Vector
-        class(IntVector) :: v
-        integer :: i
-        v = IntVector()
-        ! call v%push_back(v, 1)
+        type(IntVector) :: v
+        call v%push_back(10)
+        if (v%elements(1) /= 10) error stop
     end subroutine
 
 end module

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9667,34 +9667,25 @@ public:
                                     constructor_args.end(), name);
             if (search == constructor_args.end()) {
                 diag.semantic_error_label(
-                    "Keyword argument not found " + name,
+                    "Keyword argument not found",
                     {loc},
-                    name + " keyword argument not found.");
+                    "'" + name + "'" + " keyword argument not found");
                 throw SemanticAbort();
             }
 
             size_t idx = std::distance(constructor_args.begin(), search);
             if (args[idx].m_value != nullptr) {
                 diag.semantic_error_label(
-                    "Keyword argument is already specified.",
+                    "Keyword argument is already specified",
                     {loc},
-                    name + "keyword argument is already specified.");
+                    "'" + name + "'" + + " keyword argument is already specified");
                 throw SemanticAbort();
             }
             args.p[idx].loc = expr->base.loc;
             args.p[idx].m_value = expr;
         }
 
-        /*
-
-        The following loop takes the default initial value expression
-        and puts it into the constructor call. The issue with this approach
-        is that one has to replace all the symbols present in the expression
-        with external symbols so that we don't receive out of scope errors
-        in ASR verify pass (with the help of a new visitor ReplaceWithExternalSymbolsInExpression).
-        So for now its commented out and one can deal with the
-        same in the backend itself which appears cleaner to me for now.
-
+        // If value is not specified in args nor in keyword argument, set to default initializer if it exists
         for( size_t i = 0; i < args.size(); i++ ) {
             if( args[i].m_value == nullptr ) {
                 ASR::symbol_t* arg_sym = constructor_arg_syms[i];
@@ -9704,23 +9695,21 @@ public:
                 if( ASR::is_a<ASR::Variable_t>(*arg_sym) ) {
                     ASR::Variable_t* arg_var = ASR::down_cast<ASR::Variable_t>(arg_sym);
                     default_init = arg_var->m_symbolic_value;
-                    if( arg_var->m_storage == ASR::storage_typeType::Allocatable ) {
+                    if( ASRUtils::is_allocatable(arg_var->m_type) ) {
                         is_default_needed = false;
                     }
                 }
                 if( default_init == nullptr && is_default_needed ) {
                     diag.semantic_error_label(
                         "Argument was not specified",
-                        {arg_sym->base.loc},
-                        std::to_string(i) +
-                        "-th argument not specified for " + ASRUtils::symbol_name(fn));
+                        {loc},
+                        "Argument '" + constructor_args[i] + "' not specified for " + ASRUtils::symbol_name(fn));
                     throw SemanticAbort();
                 }
                 args.p[i].m_value = default_init;
                 args.p[i].loc = arg_sym->base.loc;
             }
         }
-        */
 
         for (size_t i = 0; i < constructor_arg_syms.size(); i++) {
             if( args[i].m_value != nullptr ) {

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -1212,7 +1212,7 @@ public:
 
         ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al,
             x->base.base.loc, target_scope, s2c(al, x->m_name), variable_dependencies_vec.p,
-            variable_dependencies_vec.size(), x->m_intent, nullptr, nullptr, x->m_storage,
+            variable_dependencies_vec.size(), x->m_intent, x->m_symbolic_value, x->m_value, x->m_storage,
             new_type, nullptr, x->m_abi, x->m_access, x->m_presence, x->m_value_attr));
         target_scope->add_symbol(x->m_name, s);
 

--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -324,6 +324,12 @@ program continue_compilation_2
     ! member not found
     print *, myCircle%mymember
 
+    ! argument not specified
+    type(Circle) :: myCircle2 = Circle()
+
+    ! invalid keyword argument specified
+    type(Circle) :: myCircle3 = Circle(mykeyword=10)
+
     !tokenizer error
     integer  :: ? tokenizer_error
     100 FORMAT(A10, @)

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "492f44dde4a24af2051ca292e0276fa4dbc1c4173062b291d4ed724c",
+    "infile_hash": "fc81b748b8043c30358fc612927c21c8b5d384d4efefc6bd11d8b8e6",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "f5f3b485e5b309c6c0a621de1d9855b435e1088e3cd228a6cc7dec9f",
+    "stderr_hash": "125efb005b7377badc5d4046280706eed79d87e152c14509c639bbec",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -11,9 +11,9 @@ syntax error: kind 16 is not supported yet.
     |     ^^^^^^^ 
 
 tokenizer error: Token '?' is not recognized
-   --> tests/errors/continue_compilation_2.f90:328:17
+   --> tests/errors/continue_compilation_2.f90:334:17
     |
-328 |     integer  :: ? tokenizer_error
+334 |     integer  :: ? tokenizer_error
     |                 ^ token not recognized
 
 tokenizer error: Token '@' is not recognized in `format` statement
@@ -23,43 +23,43 @@ tokenizer error: Token '@' is not recognized in `format` statement
   |  ^ 
 
 syntax error: End module name does not match module name
-   --> tests/errors/continue_compilation_2.f90:345:1 - 347:28
+   --> tests/errors/continue_compilation_2.f90:351:1 - 353:28
     |
-345 |    module my_module
+351 |    module my_module
     |    ^^^^^^^^^^^^^^^^...
 ...
     |
-347 |    end module wrong_module_name 
+353 |    end module wrong_module_name 
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End subroutine name does not match subroutine name
-   --> tests/errors/continue_compilation_2.f90:349:1 - 351:29
+   --> tests/errors/continue_compilation_2.f90:355:1 - 357:29
     |
-349 |    subroutine my_subroutine1()
+355 |    subroutine my_subroutine1()
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-351 |    end subroutine different_name
+357 |    end subroutine different_name
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End function name does not match function name
-   --> tests/errors/continue_compilation_2.f90:353:1 - 356:28
+   --> tests/errors/continue_compilation_2.f90:359:1 - 362:28
     |
-353 |    function my_function() result(res)
+359 |    function my_function() result(res)
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-356 |    end function not_my_function
+362 |    end function not_my_function
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: End subroutine name does not match subroutine name
-   --> tests/errors/continue_compilation_2.f90:358:1 - 360:29
+   --> tests/errors/continue_compilation_2.f90:364:1 - 366:29
     |
-358 |    subroutine my_subroutine2()
+364 |    subroutine my_subroutine2()
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-360 |    end subroutine different_name 
+366 |    end subroutine different_name 
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Duplicate DIMENSION attribute specified
@@ -182,6 +182,18 @@ semantic error: Kind 16 is not supported for Real
     |
 322 |     real*16 :: unsupported_kind
     |     ^^^^^^^ 
+
+semantic error: Argument was not specified
+   --> tests/errors/continue_compilation_2.f90:328:33
+    |
+328 |     type(Circle) :: myCircle2 = Circle()
+    |                                 ^^^^^^^^ Argument 'radius' not specified for circle
+
+semantic error: Keyword argument not found
+   --> tests/errors/continue_compilation_2.f90:331:33
+    |
+331 |     type(Circle) :: myCircle3 = Circle(mykeyword=10)
+    |                                 ^^^^^^^^^^^^^^^^^^^^ 'mykeyword' keyword argument not found
 
 semantic error: Unexpected args, SetExponent expects (real, int) as arguments
   --> tests/errors/continue_compilation_2.f90:23:14
@@ -679,7 +691,7 @@ semantic error: Variable 'mycircle' doesn't have any member named, 'mymember'.
     |              ^^^^^^^^^^^^^^^^^ 
 
 semantic error: Cannot assign to an intent(in) variable `y`
-   --> tests/errors/continue_compilation_2.f90:342:5
+   --> tests/errors/continue_compilation_2.f90:348:5
     |
-342 |     y = 99  
+348 |     y = 99  
     |     ^ 

--- a/tests/reference/asr-derived_type1-c109ce6.json
+++ b/tests/reference/asr-derived_type1-c109ce6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_type1-c109ce6.stdout",
-    "stdout_hash": "cee631edee5bee32ce658322c035245df0da97f802c20d7753109abe",
+    "stdout_hash": "dd4198de411eb1bcb2db076fe80a4ea0e82a4137c0432041aebca4f0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_type1-c109ce6.stdout
+++ b/tests/reference/asr-derived_type1-c109ce6.stdout
@@ -137,15 +137,38 @@
                                     toml_escape
                                     []
                                     Local
-                                    (StructConstructor
+                                    (StructConstant
                                         2 enum_escape
-                                        [(())]
+                                        [((IntrinsicElementalFunction
+                                            Achar
+                                            [(IntegerConstant 10 (Integer 4) Decimal)]
+                                            0
+                                            (String 1 1 () PointerString)
+                                            (StringConstant
+                                                "\n"
+                                                (String 1 1 () PointerString)
+                                            )
+                                        ))]
                                         (StructType
                                             2 enum_escape
                                         )
-                                        ()
                                     )
-                                    ()
+                                    (StructConstant
+                                        2 enum_escape
+                                        [((IntrinsicElementalFunction
+                                            Achar
+                                            [(IntegerConstant 10 (Integer 4) Decimal)]
+                                            0
+                                            (String 1 1 () PointerString)
+                                            (StringConstant
+                                                "\n"
+                                                (String 1 1 () PointerString)
+                                            )
+                                        ))]
+                                        (StructType
+                                            2 enum_escape
+                                        )
+                                    )
                                     Parameter
                                     (StructType
                                         2 enum_escape

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "d58edf1f9f3c0b380804f571dca4ab21fec667339e6ee35853762c42",
+    "stdout_hash": "993d0220cd829d9b37b79b0ebc498dc5861906c48b22d129b7c99f9d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -1631,9 +1631,9 @@
                                         )
                                         (StructConstructor
                                             4 toml_date
-                                            [(())
-                                            (())
-                                            (())]
+                                            [((IntegerConstant 0 (Integer 4) Decimal))
+                                            ((IntegerConstant 0 (Integer 4) Decimal))
+                                            ((IntegerConstant 0 (Integer 4) Decimal))]
                                             (StructType
                                                 4 toml_date
                                             )

--- a/tests/reference/asr-derived_types_11-c169ea7.json
+++ b/tests/reference/asr-derived_types_11-c169ea7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_11-c169ea7.stdout",
-    "stdout_hash": "8dc6231c5f61c2540f380c7d76934d06bc3c7f96733c73bb728ba929",
+    "stdout_hash": "9ae3d87243cf6caeddf3b045ba942352d8dc4baa6c9550ed923b8d4e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_11-c169ea7.stdout
+++ b/tests/reference/asr-derived_types_11-c169ea7.stdout
@@ -23,15 +23,26 @@
                                     type_y
                                     []
                                     Local
-                                    (StructConstructor
+                                    (StructConstant
                                         2 y
-                                        [(())]
+                                        [((StringConstant
+                                            "\\"
+                                            (String 1 1 () PointerString)
+                                        ))]
                                         (StructType
                                             2 y
                                         )
-                                        ()
                                     )
-                                    ()
+                                    (StructConstant
+                                        2 y
+                                        [((StringConstant
+                                            "\\"
+                                            (String 1 1 () PointerString)
+                                        ))]
+                                        (StructType
+                                            2 y
+                                        )
+                                    )
                                     Parameter
                                     (StructType
                                         2 y

--- a/tests/reference/asr-derived_types_14-75884fe.json
+++ b/tests/reference/asr-derived_types_14-75884fe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_14-75884fe.stdout",
-    "stdout_hash": "2e06c1b060fce4a5e65e6f0665b2011fe3a2993a282cff2eaec03255",
+    "stdout_hash": "921ade1962af260d6f5753870416b29c975cebd4ee8cdade76bea63a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_14-75884fe.stdout
+++ b/tests/reference/asr-derived_types_14-75884fe.stdout
@@ -143,20 +143,30 @@
                                     toml_type
                                     []
                                     Local
-                                    (StructConstructor
+                                    (StructConstant
                                         4 enum_type
-                                        [(())
-                                        (())
-                                        (())
-                                        (())
-                                        (())
-                                        (())]
+                                        [((IntegerConstant 100 (Integer 4) Decimal))
+                                        ((IntegerConstant 101 (Integer 4) Decimal))
+                                        ((IntegerConstant 102 (Integer 4) Decimal))
+                                        ((IntegerConstant 103 (Integer 4) Decimal))
+                                        ((IntegerConstant 104 (Integer 4) Decimal))
+                                        ((IntegerConstant 105 (Integer 4) Decimal))]
                                         (StructType
                                             4 enum_type
                                         )
-                                        ()
                                     )
-                                    ()
+                                    (StructConstant
+                                        4 enum_type
+                                        [((IntegerConstant 100 (Integer 4) Decimal))
+                                        ((IntegerConstant 101 (Integer 4) Decimal))
+                                        ((IntegerConstant 102 (Integer 4) Decimal))
+                                        ((IntegerConstant 103 (Integer 4) Decimal))
+                                        ((IntegerConstant 104 (Integer 4) Decimal))
+                                        ((IntegerConstant 105 (Integer 4) Decimal))]
+                                        (StructType
+                                            4 enum_type
+                                        )
+                                    )
                                     Parameter
                                     (StructType
                                         4 enum_type

--- a/tests/reference/asr-derived_types_20-b526066.json
+++ b/tests/reference/asr-derived_types_20-b526066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_20-b526066.stdout",
-    "stdout_hash": "76faa622c1a9c6e7f31586daf9d2f829a666b8f928e8ee35d46ce1c5",
+    "stdout_hash": "46397e804b876ad41f2f704097f3c90c783b4385df1188419a24a1a3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_20-b526066.stdout
+++ b/tests/reference/asr-derived_types_20-b526066.stdout
@@ -411,8 +411,14 @@
                                                     .false.
                                                     (Logical 4)
                                                 ))
-                                                (())
-                                                (())
+                                                ((LogicalConstant
+                                                    .false.
+                                                    (Logical 4)
+                                                ))
+                                                ((LogicalConstant
+                                                    .false.
+                                                    (Logical 4)
+                                                ))
                                                 ((LogicalConstant
                                                     .false.
                                                     (Logical 4)

--- a/tests/reference/asr-select_type_03-f21585a.json
+++ b/tests/reference/asr-select_type_03-f21585a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_03-f21585a.stdout",
-    "stdout_hash": "b2ea61abcb133b614200e3ea77f1f94a593aa7beb896820ce34fa063",
+    "stdout_hash": "cfe42a6c959fff9e2c50e1270d39e8fb9c72db56d8364c1393a6fbb8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_03-f21585a.stdout
+++ b/tests/reference/asr-select_type_03-f21585a.stdout
@@ -71,16 +71,30 @@
                                     toml_stat
                                     []
                                     Local
-                                    (StructConstructor
+                                    (StructConstant
                                         4 enum_stat
-                                        [(())
-                                        (())]
+                                        [((IntegerConstant 0 (Integer 4) Decimal))
+                                        ((IntegerUnaryMinus
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -1 (Integer 4) Decimal)
+                                        ))]
                                         (StructType
                                             4 enum_stat
                                         )
-                                        ()
                                     )
-                                    ()
+                                    (StructConstant
+                                        4 enum_stat
+                                        [((IntegerConstant 0 (Integer 4) Decimal))
+                                        ((IntegerUnaryMinus
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -1 (Integer 4) Decimal)
+                                        ))]
+                                        (StructType
+                                            4 enum_stat
+                                        )
+                                    )
                                     Parameter
                                     (StructType
                                         4 enum_stat

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "273eb9d48bd56ef2442c5e6ac865e6751e8ce9673ad2a85b3350ead2",
+    "stdout_hash": "d8cadeea35c89bf1ac58844f8f2edbe84ceb1368691ea25466388597",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -71,16 +71,30 @@
                                     toml_stat
                                     []
                                     Local
-                                    (StructConstructor
+                                    (StructConstant
                                         11 enum_stat
-                                        [(())
-                                        (())]
+                                        [((IntegerConstant 0 (Integer 4) Decimal))
+                                        ((IntegerUnaryMinus
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -1 (Integer 4) Decimal)
+                                        ))]
                                         (StructType
                                             11 enum_stat
                                         )
-                                        ()
                                     )
-                                    ()
+                                    (StructConstant
+                                        11 enum_stat
+                                        [((IntegerConstant 0 (Integer 4) Decimal))
+                                        ((IntegerUnaryMinus
+                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                            (Integer 4)
+                                            (IntegerConstant -1 (Integer 4) Decimal)
+                                        ))]
+                                        (StructType
+                                            11 enum_stat
+                                        )
+                                    )
                                     Parameter
                                     (StructType
                                         11 enum_stat

--- a/tests/reference/asr-template_04-f41dd3e.json
+++ b/tests/reference/asr-template_04-f41dd3e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_04-f41dd3e.stdout",
-    "stdout_hash": "89fe209c509e6b45e1b0ce099d52a5932d0c458cc2952280e9083114",
+    "stdout_hash": "acb9a611bb34d3b56a6efc11c51d02b3ebb69ae52e1bd852896919b4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_04-f41dd3e.stdout
+++ b/tests/reference/asr-template_04-f41dd3e.stdout
@@ -84,8 +84,8 @@
                                                     n
                                                     []
                                                     Local
-                                                    ()
-                                                    ()
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                     Parameter
                                                     (Integer 4)
                                                     ()
@@ -129,7 +129,7 @@
                                                         (Integer 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                         (Var 198 n))]
-                                                        PointerToDataArray
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     Source
@@ -289,7 +289,7 @@
                                                                     (Var 198 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 198 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -313,7 +313,7 @@
                                                                     (Var 198 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 198 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -327,7 +327,7 @@
                                                                         (Var 198 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 198 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -346,7 +346,7 @@
                                                                         (Var 198 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 198 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -383,7 +383,7 @@
                                                                                     (Var 198 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 198 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -403,7 +403,7 @@
                                                                                     (Var 198 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 198 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -434,7 +434,7 @@
                                                         (Integer 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                         (Var 198 n))]
-                                                        DescriptorArray
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     ()
@@ -454,7 +454,7 @@
                                                         (Var 198 n))
                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                         (Var 198 n))]
-                                                        PointerToDataArray
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                 )
@@ -468,7 +468,7 @@
                                                             (Var 198 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 198 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -487,7 +487,7 @@
                                                             (Var 198 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 198 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -524,7 +524,7 @@
                                                                 (Var 198 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 198 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -538,7 +538,7 @@
                                                                     (Var 198 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 198 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -557,7 +557,7 @@
                                                                     (Var 198 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 198 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -595,7 +595,7 @@
                                                                                 (Var 198 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 198 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -615,7 +615,7 @@
                                                                                 (Var 198 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 198 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -652,7 +652,7 @@
                                                             (Var 198 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 198 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -682,7 +682,7 @@
                                                                             (Var 198 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 198 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -702,7 +702,7 @@
                                                                             (Var 198 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 198 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -796,8 +796,8 @@
                                                     n
                                                     []
                                                     Local
-                                                    ()
-                                                    ()
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                     Parameter
                                                     (Integer 4)
                                                     ()
@@ -841,7 +841,7 @@
                                                         (Real 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                         (Var 200 n))]
-                                                        PointerToDataArray
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     Source
@@ -1001,7 +1001,7 @@
                                                                     (Var 200 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 200 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -1025,7 +1025,7 @@
                                                                     (Var 200 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 200 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -1039,7 +1039,7 @@
                                                                         (Var 200 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 200 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -1058,7 +1058,7 @@
                                                                         (Var 200 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 200 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -1095,7 +1095,7 @@
                                                                                     (Var 200 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 200 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -1115,7 +1115,7 @@
                                                                                     (Var 200 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 200 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -1146,7 +1146,7 @@
                                                         (Real 4)
                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                         (Var 200 n))]
-                                                        DescriptorArray
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                     ()
@@ -1166,7 +1166,7 @@
                                                         (Var 200 n))
                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                         (Var 200 n))]
-                                                        PointerToDataArray
+                                                        FixedSizeArray
                                                     )
                                                     ()
                                                 )
@@ -1180,7 +1180,7 @@
                                                             (Var 200 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 200 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -1199,7 +1199,7 @@
                                                             (Var 200 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 200 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -1236,7 +1236,7 @@
                                                                 (Var 200 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 200 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -1250,7 +1250,7 @@
                                                                     (Var 200 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 200 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -1269,7 +1269,7 @@
                                                                     (Var 200 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 200 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -1307,7 +1307,7 @@
                                                                                 (Var 200 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 200 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -1327,7 +1327,7 @@
                                                                                 (Var 200 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 200 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -1364,7 +1364,7 @@
                                                             (Var 200 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 200 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -1394,7 +1394,7 @@
                                                                             (Var 200 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 200 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -1414,7 +1414,7 @@
                                                                             (Var 200 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 200 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -1526,8 +1526,8 @@
                                                     n
                                                     []
                                                     Local
-                                                    ()
-                                                    ()
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                     Parameter
                                                     (Integer 4)
                                                     ()
@@ -1658,7 +1658,7 @@
                                                                 (Var 197 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 197 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -1682,7 +1682,7 @@
                                                                 (Var 197 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 197 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -1713,7 +1713,7 @@
                                                             (Var 197 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 197 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -1760,7 +1760,7 @@
                                                                 (Var 197 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 197 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -1787,7 +1787,7 @@
                                                                     (Var 197 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 197 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -1814,7 +1814,7 @@
                                                                         (Var 197 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 197 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -1926,8 +1926,8 @@
                                                     n
                                                     []
                                                     Local
-                                                    ()
-                                                    ()
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                     Parameter
                                                     (Integer 4)
                                                     ()
@@ -2058,7 +2058,7 @@
                                                                 (Var 199 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 199 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -2082,7 +2082,7 @@
                                                                 (Var 199 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 199 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -2113,7 +2113,7 @@
                                                             (Var 199 n))
                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                             (Var 199 n))]
-                                                            PointerToDataArray
+                                                            FixedSizeArray
                                                         )
                                                         ()
                                                     )
@@ -2160,7 +2160,7 @@
                                                                 (Var 199 n))
                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                 (Var 199 n))]
-                                                                PointerToDataArray
+                                                                FixedSizeArray
                                                             )
                                                             ()
                                                         )
@@ -2187,7 +2187,7 @@
                                                                     (Var 199 n))
                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                     (Var 199 n))]
-                                                                    PointerToDataArray
+                                                                    FixedSizeArray
                                                                 )
                                                                 ()
                                                             )
@@ -2214,7 +2214,7 @@
                                                                         (Var 199 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 199 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -2465,8 +2465,8 @@
                                                                     n
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                                     Parameter
                                                                     (Integer 4)
                                                                     ()
@@ -2510,7 +2510,7 @@
                                                                         (Integer 4)
                                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 165 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                     Source
@@ -2670,7 +2670,7 @@
                                                                                     (Var 165 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 165 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -2694,7 +2694,7 @@
                                                                                     (Var 165 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 165 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -2708,7 +2708,7 @@
                                                                                         (Var 165 n))
                                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                         (Var 165 n))]
-                                                                                        PointerToDataArray
+                                                                                        FixedSizeArray
                                                                                     )
                                                                                     ()
                                                                                 )
@@ -2727,7 +2727,7 @@
                                                                                         (Var 165 n))
                                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                         (Var 165 n))]
-                                                                                        PointerToDataArray
+                                                                                        FixedSizeArray
                                                                                     )
                                                                                     ()
                                                                                 )
@@ -2764,7 +2764,7 @@
                                                                                                     (Var 165 n))
                                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                     (Var 165 n))]
-                                                                                                    PointerToDataArray
+                                                                                                    FixedSizeArray
                                                                                                 )
                                                                                                 ()
                                                                                             )
@@ -2784,7 +2784,7 @@
                                                                                                     (Var 165 n))
                                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                     (Var 165 n))]
-                                                                                                    PointerToDataArray
+                                                                                                    FixedSizeArray
                                                                                                 )
                                                                                                 ()
                                                                                             )
@@ -2815,7 +2815,7 @@
                                                                         (Integer 4)
                                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 165 n))]
-                                                                        DescriptorArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                     ()
@@ -2835,7 +2835,7 @@
                                                                         (Var 165 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 165 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -2849,7 +2849,7 @@
                                                                             (Var 165 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 165 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -2868,7 +2868,7 @@
                                                                             (Var 165 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 165 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -2905,7 +2905,7 @@
                                                                                 (Var 165 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 165 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -2919,7 +2919,7 @@
                                                                                     (Var 165 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 165 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -2938,7 +2938,7 @@
                                                                                     (Var 165 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 165 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -2976,7 +2976,7 @@
                                                                                                 (Var 165 n))
                                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                 (Var 165 n))]
-                                                                                                PointerToDataArray
+                                                                                                FixedSizeArray
                                                                                             )
                                                                                             ()
                                                                                         )
@@ -2996,7 +2996,7 @@
                                                                                                 (Var 165 n))
                                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                 (Var 165 n))]
-                                                                                                PointerToDataArray
+                                                                                                FixedSizeArray
                                                                                             )
                                                                                             ()
                                                                                         )
@@ -3033,7 +3033,7 @@
                                                                             (Var 165 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 165 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -3063,7 +3063,7 @@
                                                                                             (Var 165 n))
                                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                             (Var 165 n))]
-                                                                                            PointerToDataArray
+                                                                                            FixedSizeArray
                                                                                         )
                                                                                         ()
                                                                                     )
@@ -3083,7 +3083,7 @@
                                                                                             (Var 165 n))
                                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                             (Var 165 n))]
-                                                                                            PointerToDataArray
+                                                                                            FixedSizeArray
                                                                                         )
                                                                                         ()
                                                                                     )
@@ -3488,8 +3488,8 @@
                                                                     n
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                                     Parameter
                                                                     (Integer 4)
                                                                     ()
@@ -3620,7 +3620,7 @@
                                                                                 (Var 169 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 169 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -3644,7 +3644,7 @@
                                                                                 (Var 169 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 169 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -3675,7 +3675,7 @@
                                                                             (Var 169 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 169 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -3722,7 +3722,7 @@
                                                                                 (Var 169 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 169 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -3749,7 +3749,7 @@
                                                                                     (Var 169 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 169 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -3776,7 +3776,7 @@
                                                                                         (Var 169 n))
                                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                         (Var 169 n))]
-                                                                                        PointerToDataArray
+                                                                                        FixedSizeArray
                                                                                     )
                                                                                     ()
                                                                                 )
@@ -5707,8 +5707,8 @@
                                                     n
                                                     []
                                                     Local
-                                                    ()
-                                                    ()
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                     Parameter
                                                     (Integer 4)
                                                     ()
@@ -5795,7 +5795,7 @@
                                                 (Var 163 n))
                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                 (Var 163 n))]
-                                                PointerToDataArray
+                                                FixedSizeArray
                                             )
                                             ()
                                         )
@@ -5811,7 +5811,7 @@
                                                     (Var 163 n))
                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                     (Var 163 n))]
-                                                    PointerToDataArray
+                                                    FixedSizeArray
                                                 )
                                                 ()
                                             ))
@@ -5824,7 +5824,7 @@
                                                     (Var 163 n))
                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                     (Var 163 n))]
-                                                    PointerToDataArray
+                                                    FixedSizeArray
                                                 )
                                                 ()
                                             ))]
@@ -5834,7 +5834,7 @@
                                                 (Var 163 n))
                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                 (Var 163 n))]
-                                                DescriptorArray
+                                                FixedSizeArray
                                             )
                                             ()
                                             ()
@@ -6791,8 +6791,8 @@
                                                                     n
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                                     Parameter
                                                                     (Integer 4)
                                                                     ()
@@ -6836,7 +6836,7 @@
                                                                         (Real 4)
                                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 190 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                     Source
@@ -6996,7 +6996,7 @@
                                                                                     (Var 190 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 190 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -7020,7 +7020,7 @@
                                                                                     (Var 190 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 190 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -7034,7 +7034,7 @@
                                                                                         (Var 190 n))
                                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                         (Var 190 n))]
-                                                                                        PointerToDataArray
+                                                                                        FixedSizeArray
                                                                                     )
                                                                                     ()
                                                                                 )
@@ -7053,7 +7053,7 @@
                                                                                         (Var 190 n))
                                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                         (Var 190 n))]
-                                                                                        PointerToDataArray
+                                                                                        FixedSizeArray
                                                                                     )
                                                                                     ()
                                                                                 )
@@ -7090,7 +7090,7 @@
                                                                                                     (Var 190 n))
                                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                     (Var 190 n))]
-                                                                                                    PointerToDataArray
+                                                                                                    FixedSizeArray
                                                                                                 )
                                                                                                 ()
                                                                                             )
@@ -7110,7 +7110,7 @@
                                                                                                     (Var 190 n))
                                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                     (Var 190 n))]
-                                                                                                    PointerToDataArray
+                                                                                                    FixedSizeArray
                                                                                                 )
                                                                                                 ()
                                                                                             )
@@ -7141,7 +7141,7 @@
                                                                         (Real 4)
                                                                         [((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 190 n))]
-                                                                        DescriptorArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                     ()
@@ -7161,7 +7161,7 @@
                                                                         (Var 190 n))
                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                         (Var 190 n))]
-                                                                        PointerToDataArray
+                                                                        FixedSizeArray
                                                                     )
                                                                     ()
                                                                 )
@@ -7175,7 +7175,7 @@
                                                                             (Var 190 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 190 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -7194,7 +7194,7 @@
                                                                             (Var 190 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 190 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -7231,7 +7231,7 @@
                                                                                 (Var 190 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 190 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -7245,7 +7245,7 @@
                                                                                     (Var 190 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 190 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -7264,7 +7264,7 @@
                                                                                     (Var 190 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 190 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -7302,7 +7302,7 @@
                                                                                                 (Var 190 n))
                                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                 (Var 190 n))]
-                                                                                                PointerToDataArray
+                                                                                                FixedSizeArray
                                                                                             )
                                                                                             ()
                                                                                         )
@@ -7322,7 +7322,7 @@
                                                                                                 (Var 190 n))
                                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                                 (Var 190 n))]
-                                                                                                PointerToDataArray
+                                                                                                FixedSizeArray
                                                                                             )
                                                                                             ()
                                                                                         )
@@ -7359,7 +7359,7 @@
                                                                             (Var 190 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 190 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -7389,7 +7389,7 @@
                                                                                             (Var 190 n))
                                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                             (Var 190 n))]
-                                                                                            PointerToDataArray
+                                                                                            FixedSizeArray
                                                                                         )
                                                                                         ()
                                                                                     )
@@ -7409,7 +7409,7 @@
                                                                                             (Var 190 n))
                                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                             (Var 190 n))]
-                                                                                            PointerToDataArray
+                                                                                            FixedSizeArray
                                                                                         )
                                                                                         ()
                                                                                     )
@@ -7814,8 +7814,8 @@
                                                                     n
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                                     Parameter
                                                                     (Integer 4)
                                                                     ()
@@ -7946,7 +7946,7 @@
                                                                                 (Var 194 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 194 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -7970,7 +7970,7 @@
                                                                                 (Var 194 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 194 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -8001,7 +8001,7 @@
                                                                             (Var 194 n))
                                                                             ((IntegerConstant 1 (Integer 4) Decimal)
                                                                             (Var 194 n))]
-                                                                            PointerToDataArray
+                                                                            FixedSizeArray
                                                                         )
                                                                         ()
                                                                     )
@@ -8048,7 +8048,7 @@
                                                                                 (Var 194 n))
                                                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                 (Var 194 n))]
-                                                                                PointerToDataArray
+                                                                                FixedSizeArray
                                                                             )
                                                                             ()
                                                                         )
@@ -8075,7 +8075,7 @@
                                                                                     (Var 194 n))
                                                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                     (Var 194 n))]
-                                                                                    PointerToDataArray
+                                                                                    FixedSizeArray
                                                                                 )
                                                                                 ()
                                                                             )
@@ -8102,7 +8102,7 @@
                                                                                         (Var 194 n))
                                                                                         ((IntegerConstant 1 (Integer 4) Decimal)
                                                                                         (Var 194 n))]
-                                                                                        PointerToDataArray
+                                                                                        FixedSizeArray
                                                                                     )
                                                                                     ()
                                                                                 )
@@ -10033,8 +10033,8 @@
                                                     n
                                                     []
                                                     Local
-                                                    ()
-                                                    ()
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
                                                     Parameter
                                                     (Integer 4)
                                                     ()
@@ -10121,7 +10121,7 @@
                                                 (Var 188 n))
                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                 (Var 188 n))]
-                                                PointerToDataArray
+                                                FixedSizeArray
                                             )
                                             ()
                                         )
@@ -10137,7 +10137,7 @@
                                                     (Var 188 n))
                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                     (Var 188 n))]
-                                                    PointerToDataArray
+                                                    FixedSizeArray
                                                 )
                                                 ()
                                             ))
@@ -10150,7 +10150,7 @@
                                                     (Var 188 n))
                                                     ((IntegerConstant 1 (Integer 4) Decimal)
                                                     (Var 188 n))]
-                                                    PointerToDataArray
+                                                    FixedSizeArray
                                                 )
                                                 ()
                                             ))]
@@ -10160,7 +10160,7 @@
                                                 (Var 188 n))
                                                 ((IntegerConstant 1 (Integer 4) Decimal)
                                                 (Var 188 n))]
-                                                DescriptorArray
+                                                FixedSizeArray
                                             )
                                             ()
                                             ()

--- a/tests/reference/asr-template_array_03-b7f9799.json
+++ b/tests/reference/asr-template_array_03-b7f9799.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_array_03-b7f9799.stdout",
-    "stdout_hash": "584482213f8525918854a59ecd92111a1cd75ec5f04d18dd114d4b3f",
+    "stdout_hash": "74e9f6b172309057484f7c08077a42ecf338c919eb03e87913084c85",
     "stderr": "asr-template_array_03-b7f9799.stderr",
     "stderr_hash": "8e5e5eb3564a9c02c74e592aa5fdd1ce96bc1b68565e23b2b4ad7e98",
     "returncode": 0

--- a/tests/reference/asr-template_array_03-b7f9799.stdout
+++ b/tests/reference/asr-template_array_03-b7f9799.stdout
@@ -1379,8 +1379,8 @@
                                                                     x
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
                                                                     Save
                                                                     (Integer 4)
                                                                     ()
@@ -1397,8 +1397,8 @@
                                                                     y
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
                                                                     Save
                                                                     (Integer 4)
                                                                     ()
@@ -1415,8 +1415,8 @@
                                                                     z
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                                                    (IntegerConstant 1 (Integer 4) Decimal)
                                                                     Save
                                                                     (Integer 4)
                                                                     ()

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -2,11 +2,11 @@
     "basename": "asr-template_vector-140858c",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/template_vector.f90",
-    "infile_hash": "23c3387fefdedf9e792fc7b6ddfec9102541f4501a300a3641871023",
+    "infile_hash": "7a93e05536ee4036a4b9a6aab7e3b6a1c1a09a06d852dae81249a0de",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "99fccd04d7ef0ccff981343d6be75e06fa0177479a20f28f15241a2c",
+    "stdout_hash": "6dc07b8c1b72afc6669efe3e2450b545447b70916e0a3d56d7b60f14",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -47,6 +47,26 @@
                                     (SymbolTable
                                         7
                                         {
+                                            1_intvector_elements:
+                                                (ExternalSymbol
+                                                    7
+                                                    1_intvector_elements
+                                                    8 elements
+                                                    intvector
+                                                    []
+                                                    elements
+                                                    Public
+                                                ),
+                                            1_push_back:
+                                                (ExternalSymbol
+                                                    7
+                                                    1_push_back
+                                                    8 push_back
+                                                    intvector
+                                                    []
+                                                    push_back
+                                                    Public
+                                                ),
                                             __asr_push_back:
                                                 (Function
                                                     (SymbolTable
@@ -539,24 +559,6 @@
                                                     .false.
                                                     ()
                                                 ),
-                                            i:
-                                                (Variable
-                                                    7
-                                                    i
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Private
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                ),
                                             intvector:
                                                 (Struct
                                                     (SymbolTable
@@ -615,8 +617,8 @@
                                                                     sz
                                                                     []
                                                                     Local
-                                                                    ()
-                                                                    ()
+                                                                    (IntegerConstant 0 (Integer 4) Decimal)
+                                                                    (IntegerConstant 0 (Integer 4) Decimal)
                                                                     Save
                                                                     (Integer 4)
                                                                     ()
@@ -649,7 +651,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (ClassType
+                                                    (StructType
                                                         7 intvector
                                                     )
                                                     ()
@@ -678,18 +680,44 @@
                                     )
                                     []
                                     []
-                                    [(Assignment
+                                    [(SubroutineCall
+                                        7 1_push_back
+                                        ()
+                                        [((IntegerConstant 10 (Integer 4) Decimal))]
                                         (Var 7 v)
-                                        (StructConstructor
-                                            7 intvector
-                                            [(())
-                                            (())]
-                                            (StructType
-                                                7 intvector
+                                    )
+                                    (If
+                                        (IntegerCompare
+                                            (ArrayItem
+                                                (StructInstanceMember
+                                                    (Var 7 v)
+                                                    7 1_intvector_elements
+                                                    (Allocatable
+                                                        (Array
+                                                            (Integer 4)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                    )
+                                                    ()
+                                                )
+                                                [(()
+                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                ())]
+                                                (Integer 4)
+                                                ColMajor
+                                                ()
                                             )
+                                            NotEq
+                                            (IntegerConstant 10 (Integer 4) Decimal)
+                                            (Logical 4)
                                             ()
                                         )
-                                        ()
+                                        [(ErrorStop
+                                            ()
+                                        )]
+                                        []
                                     )]
                                     ()
                                     Private

--- a/tests/reference/pass_class_constructor-derived_types_20-740d6ce.json
+++ b/tests/reference/pass_class_constructor-derived_types_20-740d6ce.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-derived_types_20-740d6ce.stdout",
-    "stdout_hash": "79bf7b5b130c6e73e2441d6f69410b4fb6a8382abdff8132a06eaa07",
+    "stdout_hash": "6b881280e39542ee01ade68fe570e9d48c5a1181f9eb1364d810df91",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-derived_types_20-740d6ce.stdout
+++ b/tests/reference/pass_class_constructor-derived_types_20-740d6ce.stdout
@@ -316,6 +316,16 @@
                                                     name
                                                     Public
                                                 ),
+                                            1_fpm_new_settings_with_bare:
+                                                (ExternalSymbol
+                                                    7
+                                                    1_fpm_new_settings_with_bare
+                                                    6 with_bare
+                                                    fpm_new_settings
+                                                    []
+                                                    with_bare
+                                                    Public
+                                                ),
                                             1_fpm_new_settings_with_example:
                                                 (ExternalSymbol
                                                     7
@@ -334,6 +344,16 @@
                                                     fpm_new_settings
                                                     []
                                                     with_executable
+                                                    Public
+                                                ),
+                                            1_fpm_new_settings_with_full:
+                                                (ExternalSymbol
+                                                    7
+                                                    1_fpm_new_settings_with_full
+                                                    6 with_full
+                                                    fpm_new_settings
+                                                    []
+                                                    with_full
                                                     Public
                                                 ),
                                             1_fpm_new_settings_with_lib:
@@ -523,6 +543,32 @@
                                             (StructInstanceMember
                                                 (Var 7 cmd_settings)
                                                 7 1_fpm_new_settings_with_example
+                                                (Logical 4)
+                                                ()
+                                            )
+                                            (LogicalConstant
+                                                .false.
+                                                (Logical 4)
+                                            )
+                                            ()
+                                        )
+                                        (Assignment
+                                            (StructInstanceMember
+                                                (Var 7 cmd_settings)
+                                                7 1_fpm_new_settings_with_full
+                                                (Logical 4)
+                                                ()
+                                            )
+                                            (LogicalConstant
+                                                .false.
+                                                (Logical 4)
+                                            )
+                                            ()
+                                        )
+                                        (Assignment
+                                            (StructInstanceMember
+                                                (Var 7 cmd_settings)
+                                                7 1_fpm_new_settings_with_bare
                                                 (Logical 4)
                                                 ()
                                             )

--- a/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.json
+++ b/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-multiple_objects_args-2d1007e.stdout",
-    "stdout_hash": "4b8a71b02d1489a750cfe80bae1ca1dc546492131e34ac0e6f14b784",
+    "stdout_hash": "b21c68b706d72d8f1cc9856bd1b3ebc2f0ea42e86a99633db6d97379",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.stdout
+++ b/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.stdout
@@ -251,6 +251,19 @@
                         )
                         ()
                     )
+                    (Assignment
+                        (StructInstanceMember
+                            (Var 2 temp_struct_var__1)
+                            2 1_circle_radius
+                            (Real 4)
+                            ()
+                        )
+                        (RealConstant
+                            1.000000
+                            (Real 4)
+                        )
+                        ()
+                    )
                     (SubroutineCall
                         2 print_radius
                         ()


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/4189

The first commit fixes `template_vector.f90` test. Without this commit, the second commit will give ASR error for `sz` not being specified. Declaring class improperly should raise an error after (https://github.com/lfortran/lfortran/pull/5922) is merged.

The second commit uncomments a block of code which was commented out because

> The following loop takes the default initial value expression
        and puts it into the constructor call. The issue with this approach
        is that one has to replace all the symbols present in the expression
        with external symbols so that we don't receive out of scope errors
        in ASR verify pass (with the help of a new visitor ReplaceWithExternalSymbolsInExpression).
        So for now its commented out and one can deal with the
        same in the backend itself which appears cleaner to me for now.

I might be wrong but I don't think its a problem anymore. The default initializer values should be compile time constants.

In the test references many `StructConstructor` nodes are replaced with `StructConstant`.