### PR TITLE
Adds support for remaining config options

### DIFF
--- a/src/bin/language_server_interface.cpp
+++ b/src/bin/language_server_interface.cpp
@@ -313,6 +313,12 @@ namespace LCompilers::LLanguageServer::Interface {
             "Number of spaces to indent the pretty-printed JSON."
         )->capture_default_str();
 
+        opts.extensionId = "lcompilers.lfortran-lsp";
+        server->add_option(
+            "--extension-id", opts.extensionId,
+            "Identifies the language client extension that interacts with this server."
+        )->capture_default_str();
+
         return server;
     }
 
@@ -347,6 +353,7 @@ namespace LCompilers::LLanguageServer::Interface {
                         opts.numWorkerThreads,
                         logger,
                         opts.configSection,
+                        opts.extensionId,
                         workspaceConfig
                     );
                 } else {

--- a/src/bin/language_server_interface.h
+++ b/src/bin/language_server_interface.h
@@ -102,6 +102,7 @@ namespace LCompilers::LLanguageServer::Interface {
         std::size_t numRequestThreads;
         std::size_t numWorkerThreads;
         std::string configSection;
+        std::string extensionId;
     };
 
     class LanguageServerInterface {

--- a/src/bin/lfortran_accessor.cpp
+++ b/src/bin/lfortran_accessor.cpp
@@ -33,6 +33,7 @@ namespace LCompilers::LLanguageServer {
         }
 
         std::vector<LCompilers::error_highlight> diag_lists;
+        diag_lists.reserve(diagnostics.diagnostics.size());
         LCompilers::error_highlight h;
         for (auto &d : diagnostics.diagnostics) {
             if (compiler_options.no_warnings && d.level != LCompilers::diag::Level::Error) {

--- a/src/bin/lfortran_lsp_config.h
+++ b/src/bin/lfortran_lsp_config.h
@@ -20,7 +20,6 @@ namespace LCompilers::LanguageServerProtocol::Config {
     };
 
     struct LFortranLspConfig : public LspConfig {
-        bool openIssueReporterOnError;
         unsigned int maxNumberOfProblems;
         LFortranLspConfig_compiler compiler;
     };
@@ -28,6 +27,7 @@ namespace LCompilers::LanguageServerProtocol::Config {
     class LFortranLspConfigTransformer : public LspConfigTransformer {
     public:
         LFortranLspConfigTransformer(
+            lsp::LspTransformer &transformer,
             lsp::LspJsonSerializer &serializer
         );
 
@@ -35,9 +35,17 @@ namespace LCompilers::LanguageServerProtocol::Config {
             const lsp::LSPAny &any
         ) const -> LFortranLspConfig_compiler;
 
+        auto lfortranLspConfig_compilerToAny(
+            const LFortranLspConfig_compiler &compiler
+        ) const -> LSPAny;
+
         auto anyToLspConfig(
             const lsp::LSPAny &any
         ) const -> std::shared_ptr<LspConfig> override;
+
+        auto lspConfigToAny(
+            const LspConfig &config
+        ) const -> LSPAny override;
     private:
         lsp::LspJsonSerializer &serializer;
 

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -217,7 +217,7 @@ namespace LCompilers::LanguageServerProtocol {
                             std::to_string(duration.count()) + "ms";
                         if (trace >= TraceValues::Verbose) {
                             LSPAny any = transformer.publishDiagnosticsParamsToAny(params);
-                            logTraceParams.verbose = "Result: " + serializer.pprint(any);
+                            logTraceParams.verbose = "Result: " + toJsonString(any);
                         }
                         sendLogTrace(logTraceParams);
                     }

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -28,6 +28,7 @@ namespace LCompilers::LanguageServerProtocol {
         std::size_t numWorkerThreads,
         lsl::Logger &logger,
         const std::string &configSection,
+        const std::string &extensionId,
         std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
     ) : BaseLspLanguageServer(
         incomingMessages,
@@ -36,7 +37,9 @@ namespace LCompilers::LanguageServerProtocol {
         numWorkerThreads,
         logger,
         configSection,
+        extensionId,
         std::make_shared<lsc::LFortranLspConfigTransformer>(
+            transformer,
             serializer
         ),
         std::move(workspaceConfig)

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -176,8 +176,18 @@ namespace LCompilers::LanguageServerProtocol {
                     std::vector<LCompilers::error_highlight> highlights =
                         lfortran.showErrors(path, text, *compilerOptions);
 
+                    const std::shared_ptr<lsc::LFortranLspConfig> config =
+                        getLFortranConfig(uri);
+                    unsigned int numProblems = config->maxNumberOfProblems;
+                    if (highlights.size() < numProblems) {
+                        numProblems = highlights.size();
+                    }
+
                     std::vector<Diagnostic> diagnostics;
-                    for (const LCompilers::error_highlight &highlight : highlights) {
+                    diagnostics.reserve(numProblems);
+                    for (unsigned int i = 0; i < numProblems; ++i) {
+                        const LCompilers::error_highlight &highlight = highlights[i];
+
                         Position start;
                         start.line = highlight.first_line - 1;
                         start.character = highlight.first_column - 1;

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -28,7 +28,7 @@ namespace LCompilers::LanguageServerProtocol {
         std::size_t numWorkerThreads,
         lsl::Logger &logger,
         const std::string &configSection,
-        std::shared_ptr<lsc::LspConfig> workspaceConfig
+        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
     ) : BaseLspLanguageServer(
         incomingMessages,
         outgoingMessages,
@@ -91,8 +91,8 @@ namespace LCompilers::LanguageServerProtocol {
         }
     }
 
-    auto LFortranLspLanguageServer::invalidateConfigCache() -> void {
-        BaseLspLanguageServer::invalidateConfigCache();
+    auto LFortranLspLanguageServer::invalidateConfigCaches() -> void {
+        BaseLspLanguageServer::invalidateConfigCaches();
         {
             std::unique_lock<std::shared_mutex> writeLock(optionMutex);
             optionsByUri.clear();

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -30,11 +30,11 @@ namespace LCompilers::LanguageServerProtocol {
             std::size_t numWorkerThreads,
             lsl::Logger &logger,
             const std::string &configSection,
-            std::shared_ptr<lsc::LspConfig> workspaceConfig
+            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
         );
     protected:
 
-        auto invalidateConfigCache() -> void override;
+        auto invalidateConfigCaches() -> void override;
 
         // ================= //
         // Incoming Requests //

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -30,6 +30,7 @@ namespace LCompilers::LanguageServerProtocol {
             std::size_t numWorkerThreads,
             lsl::Logger &logger,
             const std::string &configSection,
+            const std::string &extensionId,
             std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
         );
     protected:

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LLANGUAGE_SERVER_SRC
   lsp_transformer.cpp
   language_server.cpp
   lsp_language_server.cpp
+  lsp_issue_reporter.cpp
   base_lsp_language_server.cpp
   message_stream.cpp
   lsp_message_stream.cpp

--- a/src/server/base_lsp_language_server.cpp
+++ b/src/server/base_lsp_language_server.cpp
@@ -460,6 +460,27 @@ namespace LCompilers::LanguageServerProtocol {
         }
     }
 
+    auto BaseLspLanguageServer::toJsonString(const LSPAny &any) -> std::string {
+        if (workspaceConfig->log.prettyPrint) {
+            return serializer.pprint(any);
+        }
+        return serializer.serialize(any);
+    }
+
+    auto BaseLspLanguageServer::toJsonString(const LSPArray &array) -> std::string {
+        if (workspaceConfig->log.prettyPrint) {
+            return serializer.pprint(array);
+        }
+        return serializer.serialize(array);
+    }
+
+    auto BaseLspLanguageServer::toJsonString(const LSPObject &object) -> std::string {
+        if (workspaceConfig->log.prettyPrint) {
+            return serializer.pprint(object);
+        }
+        return serializer.serialize(object);
+    }
+
     auto BaseLspLanguageServer::logReceiveTrace(
         const std::string &messageType,
         const std::string &traceId,
@@ -474,12 +495,12 @@ namespace LCompilers::LanguageServerProtocol {
                 switch (messageParams.type()) {
                 case MessageParamsType::Object: {
                     const LSPObject &object = messageParams.object();
-                    params.verbose = "Params: " + serializer.pprint(object);
+                    params.verbose = "Params: " + toJsonString(object);
                     break;
                 }
                 case MessageParamsType::Array: {
                     const LSPArray &array = messageParams.array();
-                    params.verbose = "Params: " + serializer.pprint(array);
+                    params.verbose = "Params: " + toJsonString(array);
                     break;
                 }
                 case MessageParamsType::Uninitialized: {
@@ -512,11 +533,11 @@ namespace LCompilers::LanguageServerProtocol {
                     auto iter_0 = object_0.find("result");
                     if (iter_0 != object_0.end()) {
                         const LSPAny &result = *iter_0->second;
-                        params.verbose = "Result: " + serializer.pprint(result);
+                        params.verbose = "Result: " + toJsonString(result);
                     } else if ((iter_0 = object_0.find("error")) != object_0.end()) {
                         const auto &error_0 = *iter_0->second;
                         params.verbose =
-                            "Error: " + serializer.pprint(error_0);
+                            "Error: " + toJsonString(error_0);
                     } else {
                         params.verbose = "No result returned.";
                     }
@@ -552,11 +573,11 @@ namespace LCompilers::LanguageServerProtocol {
                     if (iter_0 != object_0.end()) {
                         const auto &result_0 = *iter_0->second;
                         params.verbose =
-                            "Result: " + serializer.pprint(result_0);
+                            "Result: " + toJsonString(result_0);
                     } else if ((iter_0 = object_0.find("error")) != object_0.end()) {
                         const auto &error_0 = *iter_0->second;
                         params.verbose =
-                            "Error: " + serializer.pprint(error_0);
+                            "Error: " + toJsonString(error_0);
                     } else {
                         params.verbose = "No result returned.";
                     }

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -88,6 +88,10 @@ namespace LCompilers::LanguageServerProtocol {
         auto notifySent() -> void;
         auto to_string(const RequestId &requestId) -> std::string;
 
+        auto toJsonString(const LSPAny &any) -> std::string;
+        auto toJsonString(const LSPArray &array) -> std::string;
+        auto toJsonString(const LSPObject &object) -> std::string;
+
         auto initializeParams() const -> const InitializeParams &;
         auto assertInitialized() -> void;
         auto assertRunning() -> void;

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -51,7 +51,6 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool _initialized = false;
         std::atomic_bool _shutdown = false;
         std::atomic_bool _exit = false;
-        std::atomic_int serialRequestId = 0;
         std::unordered_map<int, std::string> callbacksById;
         std::mutex callbackMutex;
         std::atomic<TraceValues> trace{TraceValues::Off};
@@ -79,7 +78,6 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool clientSupportsWorkspaceConfigChangeNotifications = false;
 
         auto nextSendId() -> std::size_t;
-        auto nextRequestId(const std::string &method) -> int override;
         auto isInitialized() const -> bool;
         auto isShutdown() const -> bool;
         auto isRunning() const -> bool;
@@ -101,6 +99,7 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &response
         ) const -> void override;
 
+        auto send(const RequestMessage &request) -> void override;
         auto send(const std::string &request, std::size_t sendId) -> void;
 
         auto handle(const std::string &incoming, std::size_t sendId) -> void;

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -35,11 +35,13 @@ namespace LCompilers::LanguageServerProtocol {
             std::size_t numWorkerThreads,
             lsl::Logger &logger,
             const std::string &configSection,
+            const std::string &extensionId,
             std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer,
             std::shared_ptr<lsc::LspConfig> workspaceConfig
         );
 
         const std::string configSection;
+        const std::string extensionId;
         std::thread listener;
         lst::ThreadPool requestPool;
         lst::ThreadPool workerPool;
@@ -154,6 +156,11 @@ namespace LCompilers::LanguageServerProtocol {
         auto updateWorkspaceConfig(std::shared_ptr<lsc::LspConfig> workspaceConfig) -> void;
         auto updateLogLevel(lsc::LspConfig &workspaceConfig) -> void;
         auto updatePrettyPrintIndentSize(lsc::LspConfig &workspaceConfig) -> void;
+
+        auto sendOpenIssue(
+            const std::string &issueTitle,
+            const std::string &issueBody
+        ) -> void;
 
         auto receiveInitialize(
             InitializeParams &params

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -30,7 +30,7 @@ namespace LCompilers::LanguageServerProtocol {
             std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer,
             std::shared_ptr<lsc::LspConfig> workspaceConfig
         );
-    protected:
+
         std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer;
         std::unordered_map<DocumentUri, std::shared_ptr<LspTextDocument>> documentsByUri;
         std::shared_mutex documentMutex;
@@ -67,8 +67,10 @@ namespace LCompilers::LanguageServerProtocol {
             const DocumentUri &uri
         ) -> const std::shared_ptr<lsc::LspConfig>;
 
-        virtual auto invalidateConfigCache() -> void;
-        auto updateLogLevel() -> void;
+        virtual auto invalidateConfigCaches() -> void;
+        auto updateWorkspaceConfig(std::shared_ptr<lsc::LspConfig> workspaceConfig) -> void;
+        auto updateLogLevel(lsc::LspConfig &workspaceConfig) -> void;
+        auto updatePrettyPrintIndentSize(lsc::LspConfig &workspaceConfig) -> void;
 
         auto receiveInitialize(
             InitializeParams &params

--- a/src/server/generator/llanguage_server/cxx/lsp_file_generator.py
+++ b/src/server/generator/llanguage_server/cxx/lsp_file_generator.py
@@ -517,6 +517,7 @@ class CPlusPlusLspFileGenerator(FileGenerator, NestedContext):
             specs: Optional[Union[str, List[str]]] = None,
             docs: Optional[str] = None,
             virtual: bool = False,
+            pure: bool = False,
             override: bool = False
     ) -> None:
         self.generate_docstring(docs)
@@ -531,7 +532,10 @@ class CPlusPlusLspFileGenerator(FileGenerator, NestedContext):
             if isinstance(specs, list):
                 specs = " ".join(specs)
             line += f' {specs}'
-        line += f' -> {ret_type}{suffix};'
+        line += f' -> {ret_type}{suffix}'
+        if pure:
+            line += ' = 0'
+        line += ';'
         if len(line) < self.column_width:
             self.inline(line, end='\n')
         else:
@@ -552,7 +556,10 @@ class CPlusPlusLspFileGenerator(FileGenerator, NestedContext):
                 self.inline(') ', indent=True)
                 if specs is not None:
                     self.inline(f'{specs} ')
-            self.inline(f'-> {ret_type}{suffix};', end='\n')
+            self.inline(f'-> {ret_type}{suffix}')
+            if pure:
+                self.inline(' = 0')
+            self.inline(';', end='\n')
 
     @contextmanager
     def gen_fn(

--- a/src/server/generator/llanguage_server/cxx/lsp_language_server_header_generator.py
+++ b/src/server/generator/llanguage_server/cxx/lsp_language_server_header_generator.py
@@ -255,9 +255,9 @@ class CPlusPlusLspLanguageServerHeaderGenerator(BaseCPlusPlusLspVisitor):
             self.newline()
             with self.gen_class('LspLanguageServer', sups=['ls::LanguageServer']):
                 with self.gen_public():
-                    self.generate_constructor()
                     self.write('auto isTerminated() const -> bool override;')
                 with self.gen_protected():
+                    self.generate_constructor()
                     self.write('const std::string configSection;')
                     self.write('std::thread listener;')
                     self.write('lst::ThreadPool requestPool;')

--- a/src/server/generator/llanguage_server/cxx/lsp_language_server_source_generator.py
+++ b/src/server/generator/llanguage_server/cxx/lsp_language_server_source_generator.py
@@ -27,514 +27,17 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 params=[
                     'ls::MessageQueue &incomingMessages',
                     'ls::MessageQueue &outgoingMessages',
-                    'std::size_t numRequestThreads',
-                    'std::size_t numWorkerThreads',
                     'lsl::Logger &logger',
-                    'const std::string &configSection'
                 ],
                 sups=[
                     ('ls::LanguageServer', [
                         'incomingMessages',
                         'outgoingMessages',
-                        'logger'
+                        'logger',
                     ]),
                 ],
-                inits=[
-                    ('configSection', ['configSection']),
-                    ('listener', ['[this]{ listen(); }']),
-                    ('requestPool', [
-                        '"request"',
-                        'numRequestThreads',
-                        'logger'
-                    ]),
-                    ('workerPool', [
-                        '"worker"',
-                        'numWorkerThreads',
-                        'logger'
-                    ])
-                ]
         ):
-            self.write('callbacksById.reserve(256);')
-        self.newline()
-
-    def generate_next_send_id(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::nextSendId',
-                'std::size_t'
-        ):
-            self.gen_return('serialSendId++')
-        self.newline()
-
-    def generate_next_request_id(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::nextRequestId',
-                'int'
-        ):
-            self.gen_return('serialRequestId++')
-        self.newline()
-
-    def generate_is_initialized(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::isInitialized',
-                'bool',
-                specs='const'
-        ):
-            self.gen_return('_initialized')
-        self.newline()
-
-    def generate_is_shutdown(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::isShutdown',
-                'bool',
-                specs='const'
-        ):
-            self.gen_return('_shutdown')
-        self.newline()
-
-    def generate_is_running(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::isRunning',
-                'bool',
-                specs='const'
-        ):
-            self.gen_return('!_shutdown')
-        self.newline()
-
-    def generate_join(self) -> None:
-        with self.gen_fn('LspLanguageServer::join'):
-            with self.gen_if('listener.joinable()'):
-                self.write('listener.join();')
-                self.write('logger.debug()')
-                with self.indent():
-                    self.write('<< "[LspLanguageServer] Incoming-message listener terminated."')
-                    self.write('<< std::endl;')
-            self.write('requestPool.join();')
-            self.write('logger.debug()')
-            with self.indent():
-                self.write('<< "[LspLanguageServer] Request thread-pool terminated."')
-                self.write('<< std::endl;')
-            self.write('workerPool.join();')
-            self.write('logger.debug()')
-            with self.indent():
-                self.write('<< "[LspLanguageServer] Worker thread-pool terminated."')
-                self.write('<< std::endl;')
-        self.newline()
-
-    def generate_listen(self) -> None:
-        with self.gen_fn('LspLanguageServer::listen'):
-            with self.gen_try():
-                with self.gen_while('!_exit'):
-                    self.gen_assign(
-                        'const std::string message',
-                        'incomingMessages.dequeue()'
-                    )
-                    with self.gen_if('!_exit'):
-                        self.write('std::size_t sendId = nextSendId();')
-                        self.write('requestPool.execute([this, message, sendId](')
-                        with self.indent():
-                            self.write('const std::string &threadName,')
-                            self.write('const std::size_t threadId')
-                        self.write(') {')
-                        with self.indent():
-                            with self.gen_try():
-                                self.write('handle(message, sendId);')
-                            with self.gen_catch('std::exception &e'):
-                                self.write('std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());')
-                                self.write('logger.error()')
-                                with self.indent():
-                                    self.write('<< "[" << threadName << "_" << threadId << "] "')
-                                    self.write('"Failed to handle message: " << message')
-                                    self.write('<< std::endl;')
-                                self.write('logger.error()')
-                                with self.indent():
-                                    self.write('<< "[" << threadName << "_" << threadId << "] "')
-                                    self.write('"Caught unhandled exception: " << e.what()')
-                                    self.write('<< std::endl;')
-                        self.write('});')
-            with self.gen_catch('std::exception &e'):
-                with self.gen_if('e.what() != lst::DEQUEUE_FAILED_MESSAGE', end=''):
-                    self.write('logger.error()')
-                    with self.indent():
-                        self.write('<< "[LspLanguageServer] "')
-                        self.write('"Unhandled exception caught: " << e.what()')
-                        self.write('<< std::endl;')
-                with self.gen_else():
-                    self.write('logger.trace()')
-                    with self.indent():
-                        self.write('<< "[LspLanguageServer] "')
-                        self.write('"Interrupted while dequeuing messages: " << e.what()')
-                        self.write('<< std::endl;')
-        self.newline()
-
-    def generate_notify_sent(self) -> None:
-        with self.gen_fn('LspLanguageServer::notifySent'):
-            self.write('++pendingSendId;')
-            with self.block():
-                self.write('std::unique_lock<std::mutex> sentLock(sentMutex);')
-                self.write('sent.notify_all();')
-        self.newline()
-
-    def generate_synchronized_send(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::send',
-                params=[
-                    'const std::string &message',
-                    'std::size_t sendId'
-                ]
-        ):
-            self.write('// -------------------------------------------------------------------------')
-            self.write('// NOTE: The LSP spec requires responses to be returned in roughly the same')
-            self.write('// order of receipt of their corresponding requests. Some types of responses')
-            self.write('// may be returned out-of-order, but in order to support those we will need')
-            self.write('// to implement a sort of dependency graph. Without knowledge of their')
-            self.write('// dependencies, we must respond to all requests in order of receipt.')
-            self.write('// -------------------------------------------------------------------------')
-            with self.block():
-                self.write('std::unique_lock<std::mutex> sentLock(sentMutex);')
-                self.write('sent.wait(sentLock, [this, sendId]{')
-                with self.indent():
-                    self.write('return (pendingSendId == sendId) || _exit;')
-                self.write('});')
-            with self.gen_if('(pendingSendId == sendId) && !_exit'):
-                self.write('ls::LanguageServer::send(message);')
-                self.write('notifySent();')
-        self.newline()
-
-    def generate_log_receive_trace(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::logReceiveTrace',
-                'void',
-                params=[
-                    'const std::string &messageType',
-                    'const std::string &traceId',
-                    'const std::optional<MessageParams> &optionalParams'
-                ]
-        ):
-            with self.gen_if('(trace >= TraceValues::Messages) && (traceId.length() > 0)'):
-                self.write('LogTraceParams params;')
-                self.gen_assign(
-                    'params.message',
-                    '"Received " + messageType + " \'" + traceId + "\'."'
-                )
-                with self.gen_if('(trace >= TraceValues::Verbose) && optionalParams.has_value()'):
-                    self.gen_assign(
-                        'const MessageParams &messageParams',
-                        'optionalParams.value()'
-                    )
-                    with self.gen_switch('messageParams.type()'):
-                        object_field = rename_field('object')
-                        with self.gen_case('MessageParamsType', 'object'):
-                            self.gen_assign(
-                                'const LSPObject &object',
-                                f'messageParams.{object_field}()'
-                            )
-                            self.gen_assign(
-                                'params.verbose',
-                                '"Params: " + serializer.pprint(object)'
-                            )
-                            self.write('break;')
-                        array_field = rename_field('array')
-                        with self.gen_case('MessageParamsType', 'array'):
-                            self.gen_assign(
-                                'const LSPArray &array',
-                                f'messageParams.{array_field}()'
-                            )
-                            self.gen_assign(
-                                'params.verbose',
-                                '"Params: " + serializer.pprint(array)'
-                            )
-                            self.write('break;')
-                        with self.gen_case('MessageParamsType', 'Uninitialized'):
-                            self.gen_throw(
-                                'LSP_EXCEPTION',
-                                'ErrorCodes::InternalError',
-                                '"MessageParams has not been initialized"'
-                            )
-                self.write('sendLogTrace(params);')
-        self.newline()
-
-    @gensym_context
-    def generate_log_receive_response_trace(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::logReceiveResponseTrace',
-                params=[
-                    'const std::string &traceId',
-                    'const LSPAny &document'
-                ]
-        ):
-            with self.gen_if('trace >= TraceValues::Messages'):
-                self.write('LogTraceParams params;')
-                with self.gen_if('traceId.length() > 0', end=''):
-                    self.write(f'params.message = "Received response \'" + traceId + "\'.";')
-                with self.gen_else():
-                    self.write(f'params.message = "Received response.";')
-                with self.gen_if('trace >= TraceValues::Verbose'):
-                    object_enum = rename_enum('object')
-                    with self.gen_if(f'document.type() == LSPAnyType::{object_enum}', end=''):
-                        object_field = rename_field('object')
-                        object_name = self.gensym_ref('object', f'document.{object_field}()')
-                        iter_name = self.gensym_init('iter', f'{object_name}.find("result")')
-                        with self.gen_if(f'{iter_name} != {object_name}.end()', end=''):
-                            self.write(f'const LSPAny &result = *{iter_name}->second;')
-                            self.write(f'params.verbose = "Result: " + serializer.pprint(result);')
-                        with self.gen_elif(f'({iter_name} = {object_name}.find("error")) != {object_name}.end()', end=''):
-                            error_name = self.gensym_ref('error', f'*{iter_name}->second')
-                            self.gen_assign(
-                                'params.verbose',
-                                f'"Error: " + serializer.pprint({error_name})'
-                            )
-                        with self.gen_else():
-                            self.write(f'params.verbose = "No result returned.";')
-                    with self.gen_else():
-                        self.write('logger.error()')
-                        with self.indent():
-                            self.write('<< "Cannot log verbose message for response of type LSPAnyType::"')
-                            self.write('<< LSPAnyTypeNames.at(document.type())')
-                            self.write('<< std::endl;')
-                self.write('sendLogTrace(params);')
-        self.newline()
-
-    @gensym_context
-    def generate_log_send_response_trace(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::logSendResponseTrace',
-                params=[
-                    'const std::string &traceId',
-                    'const std::chrono::time_point<std::chrono::high_resolution_clock> &start',
-                    'const LSPAny &response'
-                ]
-        ):
-            with self.gen_if('(trace >= TraceValues::Messages) && (traceId.length() > 0)'):
-                end_name = self.gensym_init('end', 'std::chrono::high_resolution_clock::now()')
-                duration_name = self.gensym_init(
-                    'duration',
-                    f'std::chrono::duration_cast<std::chrono::milliseconds>({end_name} - start)'
-                )
-                self.write('LogTraceParams params;')
-                self.write(f'params.message =')
-                with self.indent():
-                    self.write('"Sending response \'" + traceId + "\'. Processing request took " +')
-                    self.write(f'std::to_string({duration_name}.count()) + "ms";')
-                with self.gen_if('trace >= TraceValues::Verbose'):
-                    object_enum = rename_enum('object')
-                    object_field = rename_field('object')
-                    with self.gen_if(f'response.type() == LSPAnyType::{object_enum}', end=''):
-                        object_name = self.gensym_ref(f'object', f'response.{object_field}()')
-                        iter_name = self.gensym_init('iter', f'{object_name}.find("result")')
-                        with self.gen_if(f'{iter_name} != {object_name}.end()', end=''):
-                            result_name = self.gensym_ref('result', f'*{iter_name}->second')
-                            self.gen_assign(
-                                f'params.verbose',
-                                f'"Result: " + serializer.pprint({result_name})'
-                            )
-                        with self.gen_elif(f'({iter_name} = {object_name}.find("error")) != {object_name}.end()', end=''):
-                            error_name = self.gensym_ref('error', f'*{iter_name}->second')
-                            self.gen_assign(
-                                f'params.verbose',
-                                f'"Error: " + serializer.pprint({error_name})'
-                            )
-                        with self.gen_else():
-                            self.write(f'params.verbose = "No result returned.";')
-                    with self.gen_else():
-                        self.write('logger.error()')
-                        with self.indent():
-                            self.write('<< "Cannot log verbose message for response of type LSPAnyType::"')
-                            self.write('<< LSPAnyTypeNames.at(response.type())')
-                            self.write('<< std::endl;')
-                self.write('sendLogTrace(params);')
-        self.newline()
-
-    def generate_handle(self) -> None:
-        with self.gen_fn('LspLanguageServer::handle', params=[
-            'const std::string &incoming',
-            'std::size_t sendId'
-        ]):
-            object_enum = rename_enum('object')
-            array_enum = rename_enum('array')
-            object_field = rename_field('object')
-            self.gen_assign('const auto start', 'std::chrono::high_resolution_clock::now()')
-            self.write('ResponseMessage response;')
-            self.write('std::string traceId;')
-            with self.gen_try():
-                self.write('// The language server protocol always uses “2.0” as the jsonrpc version.')
-                self.write(f'response.jsonrpc = JSON_RPC_VERSION;')
-                self.write(f'response.id = nullptr;')
-                self.newline()
-                self.write('LspJsonParser parser(incoming);')
-                self.write('std::unique_ptr<LSPAny> document = parser.parse();')
-                self.newline()
-                with self.gen_if(f'document->type() != LSPAnyType::{object_enum}'):
-                    self.write('// TODO: Add support for batched messages, i.e. multiple messages within')
-                    self.write('// an array.')
-                    with self.gen_if(f'document->type() == LSPAnyType::{array_enum}'):
-                        self.gen_throw_invalid_params(
-                            '"Batched requests are not supported (currently)."'
-                        )
-                    self.gen_throw_invalid_params(
-                        '"Invalid request message: " + incoming'
-                    )
-                self.newline()
-                self.write(f'const LSPObject &object = document->{object_field}();')
-                self.write('LSPObject::const_iterator iter;')
-                self.newline()
-                with self.gen_if(f'(iter = object.find("id")) != object.end()'):
-                    self.write(f'response.id = transformer.anyToResponseId(*iter->second);')
-                self.newline()
-                with self.gen_if(f'(iter = object.find("method")) != object.end()', end=''):
-                    self.write('const std::string &method =')
-                    with self.indent():
-                        self.write('transformer.anyToString(*iter->second);')
-                    with self.gen_if('isIncomingRequest(method)', end=''):
-                        with self.gen_if('response.id.type() == ResponseIdType::Null'):
-                            self.gen_throw(
-                                'LSP_EXCEPTION',
-                                'ErrorCodes::InvalidParams',
-                                '"Missing request method=\\"" + method + "\\" attribute: id"'
-                            )
-                        self.write('RequestMessage request =')
-                        with self.indent():
-                            self.write('transformer.anyToRequestMessage(*document);')
-                        with self.gen_if('trace >= TraceValues::Messages'):
-                            self.write(f'traceId = request.method + " - (" + to_string(request.id) + ")";')
-                            self.write(f'logReceiveTrace("request", traceId, request.params);')
-                        self.write(f'response.jsonrpc = request.jsonrpc;')
-                        self.write(f'dispatch(response, request);')
-                    with self.gen_elif('isIncomingNotification(method)', end=''):
-                        with self.gen_if('response.id.type() != ResponseIdType::Null'):
-                            self.gen_throw_invalid_params(
-                                '"Notification method=\\"" + method + "\\" must not contain the attribute: id"'
-                            )
-                        self.write('NotificationMessage notification =')
-                        with self.indent():
-                            self.write('transformer.anyToNotificationMessage(*document);')
-                        with self.gen_if('trace >= TraceValues::Messages'):
-                            self.write(f'traceId = notification.method;')
-                            self.write(f'logReceiveTrace("notification", traceId, notification.params);')
-                        self.write(f'response.jsonrpc = notification.jsonrpc;')
-                        self.write(f'dispatch(response, notification);')
-                    with self.gen_else():
-                        self.gen_throw(
-                            'LSP_EXCEPTION',
-                            'ErrorCodes::InvalidRequest',
-                            '"Unsupported method: \\"" + method + "\\""'
-                        )
-                with self.gen_elif(f'(iter = object.find("result")) != object.end()', end=''):
-                    self.write('notifySent();')
-                    self.write(f'response.result = transformer.copy(*iter->second);')
-                    self.write(f'dispatch(response, traceId, *document);')
-                    self.write('return;')
-                with self.gen_elif(f'(iter = object.find("error")) != object.end()', end=''):
-                    self.write('notifySent();')
-                    self.write(f'response.error = transformer.anyToResponseError(*iter->second);')
-                    self.write(f'dispatch(response, traceId, *document);')
-                    self.write('return;')
-                with self.gen_else():
-                    self.gen_throw(
-                        'LSP_EXCEPTION',
-                        'ErrorCodes::InvalidRequest',
-                        '"Missing required attribute: method"'
-                    )
-            with self.gen_catch('const LspException &e', end=''):
-                self.write('logger.error()')
-                with self.indent():
-                    self.write('<< "[" << e.file() << ":" << e.line() << "] "')
-                    self.write('<< e.what()')
-                    self.write('<< std::endl;')
-                self.write('ResponseError error;')
-                with self.gen_switch('e.code().type'):
-                    with self.gen_case('ErrorCodeType', 'errorCodes'):
-                        error_codes_field = rename_field('ErrorCodes')
-                        self.write(f'ErrorCodes errorCode = e.code().{error_codes_field};')
-                        self.write('error.code = static_cast<int>(errorCode);')
-                        self.write('break;')
-                    with self.gen_case('ErrorCodeType', 'lspErrorCodes'):
-                        lsp_error_codes_field = rename_field('LSPErrorCodes')
-                        self.write(f'LSPErrorCodes errorCode = e.code().{lsp_error_codes_field};')
-                        self.write('error.code = static_cast<int>(errorCode);')
-                        self.write('break;')
-                self.write('error.message = e.what();')
-                self.write(f'response.error = std::move(error);')
-            with self.gen_catch('const std::exception &e'):
-                self.write('logger.error()')
-                with self.indent():
-                    self.write('<< "Caught unhandled exception: "')
-                    self.write('<< e.what() << std::endl;')
-                self.write('ResponseError error;')
-                self.write('error.code = static_cast<int>(ErrorCodes::InternalError);')
-                self.write('error.message =')
-                with self.indent():
-                    self.write('("An unexpected exception occurred. If it continues, "')
-                    self.write(' "please file a ticket.");')
-                self.write(f'response.error = std::move(error);')
-            self.gen_assign(
-                'LSPAny any',
-                'transformer.responseMessageToAny(response)'
-            )
-            self.write(f'logSendResponseTrace(traceId, start, any);')
-            self.write('const std::string outgoing = serializer.serialize(any);')
-            self.write('send(outgoing, sendId);')
-        self.newline()
-
-    def generate_is_terminated(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::isTerminated',
-                'bool',
-                specs='const'
-        ):
-            self.write('return _exit;')
-        self.newline()
-
-    def generate_initialize_params(self) -> None:
-        with self.gen_fn(
-                'LspLanguageServer::initializeParams',
-                'const InitializeParams &',
-                specs='const'
-        ):
-            with self.gen_if('_initializeParams'):
-                self.write('return *_initializeParams;')
-            self.write('throw std::logic_error("Server has not been initialized.");')
-        self.newline()
-
-    def generate_assert_initialized(self) -> None:
-        with self.gen_fn('LspLanguageServer::assertInitialized'):
-            with self.gen_if('!_initialized'):
-                self.write('throw LSP_EXCEPTION(')
-                with self.indent():
-                    self.write('ErrorCodes::ServerNotInitialized,')
-                    self.write('"Method \\"initialize\\" must be called first."')
-                self.write(');')
-        self.newline()
-
-    def generate_assert_running(self) -> None:
-        with self.gen_fn('LspLanguageServer::assertRunning'):
-            with self.gen_if('_shutdown'):
-                self.write('throw LSP_EXCEPTION(')
-                with self.indent():
-                    self.write('LSPErrorCodes::RequestFailed,')
-                    self.write('"Server has shutdown and cannot accept new requests."')
-                self.write(');')
-        self.newline()
-
-    def generate_request_id_to_string(self) -> None:
-        integer_field = rename_field('integer')
-        string_field = rename_field('string')
-        with self.gen_fn(
-                'LspLanguageServer::to_string',
-                'std::string',
-                params=[
-                    'const RequestId &requestId',
-                ]
-        ):
-            with self.gen_switch('requestId.type()'):
-                with self.gen_case('RequestIdType', 'integer'):
-                    self.write(f'return std::to_string(requestId.{integer_field}());')
-                with self.gen_case('RequestIdType', 'string'):
-                    self.write(f'return requestId.{string_field}();')
-                with self.gen_default():
-                    self.gen_throw_invalid_params(
-                        '("Cannot log request trace with Id of type RequestIdType::" +',
-                        ' RequestIdTypeNames.at(requestId.type()))'
-                    )
+            self.write('// empty')
         self.newline()
 
     def generate_dispatch_request(self) -> None:
@@ -542,25 +45,10 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 'LspLanguageServer::dispatch',
                 params=[
                     'ResponseMessage &response',
-                    'RequestMessage &request'
+                    'RequestMessage &request',
+                    'IncomingRequest method'
                 ]
         ):
-            self.write('IncomingRequest method;')
-            with self.gen_try():
-                self.write('method = incomingRequestByValue(request.method);')
-            with self.gen_catch('std::invalid_argument &/*e*/'):
-                self.write('goto invalidMethod;')
-            self.write('assertRunning();')
-            with self.gen_if('method != IncomingRequest::Initialize', end=''):
-                self.write('assertInitialized();')
-            with self.gen_else():
-                self.write('bool expected = false;    // a reference is required')
-                with self.gen_if('!_initialized.compare_exchange_strong(expected, true)'):
-                    self.gen_throw(
-                        'LSP_EXCEPTION',
-                        'ErrorCodes::InvalidRequest',
-                        '"Server may be initialized only once."'
-                    )
             with self.gen_switch('method'):
                 for request_spec in self.schema["requests"]:
                     if request_spec["messageDirection"] == "clientToServer":
@@ -571,38 +59,15 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                         with self.gen_case('IncomingRequest', method_enum):
                             params_spec = request_spec.get("params", None)
                             if params_spec is not None:
-                                is_initialize = request_method == "initialize"
-                                num_levels = int(is_initialize)
-                                if is_initialize:
-                                    self.write('try {')
-                                with self.indent(num_levels):
-                                    self.write('MessageParams &messageParams = requireMessageParams(request);')
-                                    self.write(f'{params_spec["name"]} requestParams =')
-                                    with self.indent(): self.write(f'transformer.as{request_name}Params(messageParams);')
-                                    self.write(f'{result_name} result =')
-                                    with self.indent(): self.write(f'{receive_fn(request_method)}(requestParams);')
-                                    self.write(f'response.result =')
-                                    with self.indent():
-                                        self.write(f'transformer.{lower_first(result_name)}ToAny(result);')
-                                    if is_initialize:
-                                        self.gen_assign(
-                                            '_initializeParams',
-                                            'std::make_unique<InitializeParams>(std::move(requestParams))'
-                                        )
-                                if is_initialize:
-                                    self.write('} catch (LspException &e) {')
-                                    with self.indent():
-                                        self.write('bool expected = true;')
-                                        self.write('if (!_initialized.compare_exchange_strong(expected, false)) {')
-                                        with self.indent():
-                                            self.write('throw LSP_EXCEPTION(')
-                                            with self.indent():
-                                                self.write('ErrorCodes::InvalidRequest,')
-                                                self.write('"Server initialization out of sync."')
-                                            self.write(');')
-                                        self.write('}')
-                                        self.write('throw e;')
-                                    self.write('}')
+                                self.write('MessageParams &messageParams = requireMessageParams(request);')
+                                self.write(f'{params_spec["name"]} requestParams =')
+                                with self.indent():
+                                    self.write(f'transformer.as{request_name}Params(messageParams);')
+                                self.write(f'{result_name} result =')
+                                with self.indent(): self.write(f'{receive_fn(request_method)}(requestParams);')
+                                self.write(f'response.result =')
+                                with self.indent():
+                                    self.write(f'transformer.{lower_first(result_name)}ToAny(result);')
                             else:
                                 self.write(f'{result_name} result = {receive_fn(request_method)}();')
                                 self.write(f'response.result =')
@@ -610,7 +75,6 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                                     self.write(f'transformer.{lower_first(result_name)}ToAny(result);')
                             self.gen_break()
                 with self.gen_default():
-                    self.write('invalidMethod:')
                     self.gen_throw(
                         'LSP_EXCEPTION',
                         'ErrorCodes::MethodNotFound',
@@ -623,20 +87,10 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 'LspLanguageServer::dispatch',
                 params=[
                     'ResponseMessage &/*response*/',
-                    'NotificationMessage &notification'
+                    'NotificationMessage &notification',
+                    'IncomingNotification method'
                 ]
         ):
-            self.write('IncomingNotification method;')
-            with self.gen_try():
-                self.write('method = incomingNotificationByValue(notification.method);')
-            with self.gen_catch('std::invalid_argument &/*e*/'):
-                self.write('goto invalidMethod;')
-            with self.gen_if('method != IncomingNotification::Exit'):
-                with self.gen_if('!_initialized'):
-                    self.write('// Notifications should be dropped, except for the exit notification.')
-                    self.write('// This will allow the exit of a server without an initialize request.')
-                    self.write('return;')
-                self.write('assertRunning();')
             with self.gen_switch('method'):
                 for notification_spec in self.schema["notifications"]:
                     if notification_spec["messageDirection"] == "clientToServer":
@@ -651,13 +105,13 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                                     'requireMessageParams(notification)'
                                 )
                                 self.write(f'{params_spec["name"]} notificationParams =')
-                                with self.indent(): self.write(f'transformer.as{notification_name}Params(messageParams);')
+                                with self.indent():
+                                    self.write(f'transformer.as{notification_name}Params(messageParams);')
                                 self.write(f'{receive_fn(notification_method)}(notificationParams);')
                             else:
                                 self.write(f'{receive_fn(notification_method)}();')
                             self.gen_break()
                 with self.gen_default():
-                    self.write('invalidMethod:')
                     with self.gen_if('notification.method.compare(0, 2, "$/") == 0', end=''):
                         self.write('// NOTE: If a server or client receives notifications starting with "$/"')
                         self.write('// it is free to ignore the notification:')
@@ -678,79 +132,50 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 'LspLanguageServer::dispatch',
                 params=[
                     'ResponseMessage &response',
-                    'std::string &traceId',
-                    'const LSPAny &document'
+                    'const std::string &method'
                 ]
         ):
-            with self.gen_switch('response.id.type()'):
-                with self.gen_case('ResponseIdType', 'integer'):
-                    integer_field = rename_field("integer")
-                    self.write(f'int responseId = response.id.{integer_field}();')
-                    self.write('std::unique_lock<std::mutex> callbackLock(callbackMutex);')
-                    self.write('auto iter = callbacksById.find(responseId);')
-                    self.write('if (iter == callbacksById.end()) {')
-                    with self.indent():
-                        self.write('logger.error() << "Cannot locate request with id: " << responseId << std::endl;')
-                        self.write('return;')
-                    self.write('}')
-                    self.write('const std::string method = iter->second;  // copy before delete')
-                    self.write('callbacksById.erase(iter);')
-                    self.write('callbackLock.unlock();')
-                    self.write('traceId = method + " - (" + std::to_string(responseId) + ")";')
-                    self.write('logReceiveResponseTrace(traceId, document);')
-                    self.newline()
-                    self.write('OutgoingRequest request;')
-                    with self.gen_try():
-                        self.write('request = outgoingRequestByValue(method);')
-                    with self.gen_catch('std::invalid_argument &/*e*/'):
-                        self.write('goto invalidMethod;')
-                    self.newline()
-                    with self.gen_switch('request'):
-                        for request_spec in self.schema["requests"]:
-                            if request_spec["messageDirection"] == "serverToClient":
-                                request_method = request_spec["method"]
-                                request_name = method_to_camel_case(request_method)
-                                result_name = f'{request_name}Result'
-                                request_enum = method_to_camel_case(request_method)
-                                with self.gen_case('OutgoingRequest', request_enum):
-                                    result_spec = request_spec.get("result", None)
-                                    if result_spec is not None:
-                                        with self.gen_if('!response.result.has_value()'):
-                                            self.write(f'logger.error()')
-                                            with self.indent():
-                                                self.write(f'<< ("Missing required attribute for method "')
-                                                self.write(f'    "\\"{request_method}\\": result")')
-                                                self.write('<< std::endl;')
-                                            self.write('return;')
-                                        self.gen_assign(
-                                            'LSPAny &result',
-                                            f'response.result.value()'
-                                        )
-                                        self.gen_assign(
-                                            f'{result_name} params',
-                                            f'transformer.anyTo{upper_first(result_name)}(result)'
-                                        )
-                                        self.write(f'{receive_fn(request_method)}(params);')
-                                    else:
-                                        self.write(f'{receive_fn(request_method)}()')
-                                    self.gen_break()
-                        with self.gen_default():
-                            self.write('invalidMethod:')
-                            self.write(f'logger.error()')
-                            with self.indent():
-                                self.write('<< "Unsupported request method: \\""')
-                                self.write('<< method << "\\"";')
-                    self.gen_break()
-                with self.gen_case('ResponseIdType', 'null'):
-                    self.write('logReceiveResponseTrace(traceId, document);')
-                    self.write('break;')
+            self.write('OutgoingRequest request;')
+            with self.gen_try():
+                self.write('request = outgoingRequestByValue(method);')
+            with self.gen_catch('std::invalid_argument &/*e*/'):
+                self.write('goto invalidMethod;')
+            self.newline()
+            with self.gen_switch('request'):
+                for request_spec in self.schema["requests"]:
+                    if request_spec["messageDirection"] == "serverToClient":
+                        request_method = request_spec["method"]
+                        request_name = method_to_camel_case(request_method)
+                        result_name = f'{request_name}Result'
+                        request_enum = method_to_camel_case(request_method)
+                        with self.gen_case('OutgoingRequest', request_enum):
+                            result_spec = request_spec.get("result", None)
+                            if result_spec is not None:
+                                with self.gen_if('!response.result.has_value()'):
+                                    self.write(f'logger.error()')
+                                    with self.indent():
+                                        self.write(f'<< ("Missing required attribute for method "')
+                                        self.write(f'    "\\"{request_method}\\": result")')
+                                        self.write('<< std::endl;')
+                                    self.write('return;')
+                                self.gen_assign(
+                                    'LSPAny &result',
+                                    f'response.result.value()'
+                                )
+                                self.gen_assign(
+                                    f'{result_name} params',
+                                    f'transformer.anyTo{upper_first(result_name)}(result)'
+                                )
+                                self.write(f'{receive_fn(request_method)}(params);')
+                            else:
+                                self.write(f'{receive_fn(request_method)}()')
+                            self.gen_break()
                 with self.gen_default():
-                    self.write('logger.error()')
+                    self.write('invalidMethod:')
+                    self.write(f'logger.error()')
                     with self.indent():
-                        self.write('<< "Cannot dispatch response with id of type ResponseIdType::"')
-                        self.write('<< ResponseIdTypeNames.at(response.id.type())')
-                        self.write('<< std::endl;')
-                    self.write('return;')
+                        self.write('<< "Unsupported request method: \\""')
+                        self.write('<< method << "\\"";')
         self.newline()
 
     def generate_require_request_params(self) -> None:
@@ -786,10 +211,6 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
             )
         self.newline()
 
-    def generate_require_message_params(self) -> None:
-        self.generate_require_request_params()
-        self.generate_require_notification_params()
-
     def generate_receive_request(self, request_spec: LspSpec) -> None:
         request_method = request_spec["method"]
         request_name = method_to_camel_case(request_method)
@@ -797,10 +218,7 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
         params = []
         params_spec = request_spec.get("params", None)
         if params_spec is not None:
-            if request_method == "initialize":
-                params.append(f'{params_spec["name"]} &params')
-            else:
-                params.append(f'{params_spec["name"]} &/*params*/')
+            params.append(f'{params_spec["name"]} &/*params*/')
         receive_request = receive_fn(request_method)
         self.write(f'// request: "{request_method}"')
         with self.gen_fn(
@@ -808,25 +226,11 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 result_name,
                 params=params
         ):
-            match request_method:
-                case "initialize":
-                    with self.gen_if('params.trace.has_value()'):
-                        self.gen_assign('trace', 'params.trace.value()')
-                    self.newline()
-                    self.write('InitializeResult result;')
-                    self.newline()
-                    self.gen_return('result')
-                case "shutdown":
-                    self.write('bool expected = false;')
-                    with self.gen_if('_shutdown.compare_exchange_strong(expected, true)'):
-                        self.write('logger.info() << "Shutting down server." << std::endl;')
-                    self.gen_return('nullptr')
-                case _:
-                    self.gen_throw(
-                        'LSP_EXCEPTION',
-                        'ErrorCodes::MethodNotFound',
-                        f'"No handler exists for method: \\"{request_method}\\""'
-                    )
+            self.gen_throw(
+                'LSP_EXCEPTION',
+                'ErrorCodes::MethodNotFound',
+                f'"No handler exists for method: \\"{request_method}\\""'
+            )
         self.newline()
 
     def generate_receive_notification(self, notification_spec: LspSpec) -> None:
@@ -835,49 +239,22 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
         params = []
         params_spec = notification_spec.get("params", None)
         if params_spec is not None:
-            match notification_method:
-                case "$/setTrace":
-                    params.append(f'{params_spec["name"]} &params')
-                case _:
-                    params.append(f'{params_spec["name"]} &/*params*/')
+            params.append(f'{params_spec["name"]} &/*params*/')
         self.write(f'// notification: "{notification_method}"')
         with self.gen_fn(f'LspLanguageServer::{receive_notification}', params=params):
-            match notification_method:
-                case "exit":
-                    self.write('bool expected = false;')
-                    with self.gen_if('_exit.compare_exchange_strong(expected, true)'):
-                        self.write('logger.info() << "Exiting server." << std::endl;')
-                        self.write('expected = false;')
-                        with self.gen_if('_shutdown.compare_exchange_strong(expected, true)'):
-                            self.write('logger.error()')
-                            with self.indent():
-                                self.write('<< "Server exited before being notified to shutdown!"')
-                                self.write('<< std::endl;')
-                        self.write('incomingMessages.stopNow();')
-                        self.write('requestPool.stopNow();')
-                        self.write('workerPool.stopNow();')
-                        self.write('// NOTE: Notify the message stream that the server is terminating.')
-                        self.write('// NOTE: This works because the null character is not included in')
-                        self.write('// the JSON spec.')
-                        self.write('std::cin.putback(\'\\0\');')
-                case "initialized":
-                    self.write('// empty')
-                case "$/setTrace":
-                    self.write('trace = params.value;')
-                case _:
-                    if notification_method.startswith("$/"):
-                        self.write('// NOTE: If a server or client receives notifications starting with "$/" it')
-                        self.write('// is free to ignore the notification:')
-                        self.write('logger.debug()')
-                        with self.indent():
-                            self.write(f'<< "No handler exists for method: \\"{notification_method}\\""')
-                            self.write('<< std::endl;')
-                    else:
-                        self.gen_throw(
-                            'LSP_EXCEPTION',
-                            'ErrorCodes::MethodNotFound',
-                            f'"No handler exists for method: \\"{notification_method}\\""'
-                        )
+            if notification_method.startswith("$/"):
+                self.write('// NOTE: If a server or client receives notifications starting with "$/" it')
+                self.write('// is free to ignore the notification:')
+                self.write('logger.debug()')
+                with self.indent():
+                    self.write(f'<< "No handler exists for method: \\"{notification_method}\\""')
+                    self.write('<< std::endl;')
+            else:
+                self.gen_throw(
+                    'LSP_EXCEPTION',
+                    'ErrorCodes::MethodNotFound',
+                    f'"No handler exists for method: \\"{notification_method}\\""'
+                )
         self.newline()
 
     def generate_send_request(self, request_spec: LspSpec) -> None:
@@ -894,13 +271,10 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 params=params
         ):
             self.write('RequestMessage request;')
-            self.write('request.jsonrpc = JSON_RPC_VERSION;')
-            self.write('int requestId = nextRequestId();')
-            self.write('request.id = requestId;')
-            with self.block():
-                self.write('std::unique_lock<std::mutex> callbackLock(callbackMutex);')
-                self.write(f'callbacksById.emplace(requestId, "{request_method}");')
-            self.write(f'request.method = "{request_method}";')
+            self.gen_assign('request.jsonrpc', 'JSON_RPC_VERSION')
+            self.gen_assign('request.method', f'"{request_method}"')
+            self.gen_assign('int requestId', 'nextRequestId(request.method)')
+            self.gen_assign('request.id', 'requestId')
             if params_spec is not None:
                 self.write('request.params = transformer.asMessageParams(params);')
             self.gen_assign(
@@ -911,7 +285,7 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
                 'const std::string message',
                 'serializer.serialize(any)'
             )
-            self.write('ls::LanguageServer::send(message);')
+            self.gen_call('ls::LanguageServer::send', 'message')
             self.write('return requestId;')
         self.newline()
 
@@ -1021,7 +395,6 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
         print(f'Generating: {self.file_path}')
         self.generate_disclaimer()
         self.gen_include('cctype')
-        self.gen_include('chrono')
         self.gen_include('cstdio')
         self.gen_include('iostream')
         self.gen_include('stdexcept')
@@ -1034,27 +407,9 @@ class CPlusPlusLspLanguageServerSourceGenerator(BaseCPlusPlusLspVisitor):
         with self.gen_namespace(self.namespace):
             self.newline()
             self.generate_constructor()
-            self.generate_next_send_id()
-            self.generate_next_request_id()
-            self.generate_is_initialized();
-            self.generate_is_shutdown();
-            self.generate_is_running()
-            self.generate_join()
-            self.generate_listen()
-            self.generate_notify_sent()
-            self.generate_synchronized_send()
-            self.generate_request_id_to_string()
-            self.generate_log_receive_trace()
-            self.generate_log_receive_response_trace()
-            self.generate_log_send_response_trace()
-            self.generate_handle()
-            self.generate_is_terminated()
-            self.generate_initialize_params()
-            self.generate_assert_initialized()
-            self.generate_assert_running();
-            self.generate_prepare()
             self.generate_dispatch_request()
             self.generate_dispatch_notification()
             self.generate_dispatch_response()
-            self.generate_require_message_params()
+            self.generate_require_request_params()
+            self.generate_require_notification_params()
             super().generate_code()

--- a/src/server/language_server.h
+++ b/src/server/language_server.h
@@ -18,15 +18,15 @@ namespace LCompilers::LLanguageServer {
 
     class LanguageServer {
     public:
+        virtual ~LanguageServer();
+        virtual bool isTerminated() const = 0;
+        virtual void join() = 0;
+    protected:
         LanguageServer(
             MessageQueue &incomingMessages,
             MessageQueue &outgoingMessages,
             lsl::Logger &logger
         );
-        virtual ~LanguageServer();
-        virtual bool isTerminated() const = 0;
-        virtual void join() = 0;
-    protected:
         MessageQueue &incomingMessages;
         MessageQueue &outgoingMessages;
         lsl::Logger &logger;

--- a/src/server/lsp_config.h
+++ b/src/server/lsp_config.h
@@ -5,6 +5,7 @@
 
 #include <server/logger.h>
 #include <server/lsp_specification.h>
+#include <server/lsp_transformer.h>
 
 namespace LCompilers::LanguageServerProtocol::Config {
     namespace fs = std::filesystem;
@@ -25,28 +26,43 @@ namespace LCompilers::LanguageServerProtocol::Config {
 
     struct LspConfig {
         virtual ~LspConfig() = default;
+        bool openIssueReporterOnError;
         LspConfig_trace trace;
         LspConfig_log log;
     };
 
     class LspConfigTransformer {
     public:
-        LspConfigTransformer() = default;
+        LspConfigTransformer(lsp::LspTransformer &transformer);
         virtual ~LspConfigTransformer() = default;
 
         auto anyToLspConfig_trace(
             const lsp::LSPAny &any
         ) const -> LspConfig_trace;
 
+        auto lspConfig_traceToAny(
+            const LspConfig_trace &trace
+        ) const -> LSPAny;
+
         auto anyToLspConfig_log(
             const lsp::LSPAny &any
         ) const -> LspConfig_log;
+
+        auto lspConfig_logToAny(
+            const LspConfig_log &log
+        ) const -> LSPAny;
 
         virtual auto anyToLspConfig(
             const lsp::LSPAny &any
         ) const -> std::shared_ptr<LspConfig>;
 
+        virtual auto lspConfigToAny(
+            const LspConfig &config
+        ) const -> LSPAny;
+
     protected:
+        lsp::LspTransformer &transformer;
+
         virtual auto makeConfig() const -> std::shared_ptr<LspConfig>;
     };
 

--- a/src/server/lsp_issue_reporter.cpp
+++ b/src/server/lsp_issue_reporter.cpp
@@ -1,0 +1,152 @@
+#include <server/lsp_issue_reporter.h>
+
+namespace LCompilers::LanguageServerProtocol::Reporter {
+
+    const std::map<IssueType, std::string> IssueTypeNames = {
+        {IssueType::Bug, "Bug"},
+        {IssueType::PerformanceIssue, "PerformanceIssue"},
+        {IssueType::FeatureRequest, "FeatureRequest"},
+    };
+
+    const std::map<IssueSource, std::string> IssueSourceNames = {
+        {IssueSource::VSCode, "VSCode"},
+        {IssueSource::Extension, "Extension"},
+        {IssueSource::Marketplace, "Marketplace"},
+    };
+
+    const std::map<IssueSource, std::string> IssueSourceValues = {
+        {IssueSource::VSCode, "vscode"},
+        {IssueSource::Extension, "extension"},
+        {IssueSource::Marketplace, "marketplace"},
+    };
+
+    LspIssueReporter::LspIssueReporter(
+        LspJsonSerializer &serializer,
+        LspTransformer &transformer
+        ) : serializer(serializer)
+          , transformer(transformer)
+    {
+        // empty
+    }
+
+    auto LspIssueReporter::escape(
+        std::string &buffer,
+        const std::string &text
+    ) const -> void {
+        for (const unsigned char c : text) {
+            switch (c) {
+            case '\\': {
+                buffer.append("\\\\");
+                break;
+            }
+            case '\n': {
+                buffer.append("\\n");
+                break;
+            }
+            case '\t': {
+                buffer.append("\\t");
+                break;
+            }
+            case '\b': {
+                buffer.append("\\b");
+                break;
+            }
+            case '\r': {
+                buffer.append("\\r");
+                break;
+            }
+            case '\f': {
+                buffer.append("\\f");
+                break;
+            }
+            default: {
+                buffer.push_back(c);
+            }
+            }
+        }
+    }
+
+    InternalErrorReporter::InternalErrorReporter(
+        LspJsonSerializer &serializer,
+        LspTransformer &transformer,
+        const std::string &extensionId,
+        const InitializeParams &initializeParams,
+        const lsc::LspConfig &config,
+        lsc::LspConfigTransformer &configTransformer,
+        const std::string &message,
+        const std::string &traceId,
+        const ResponseError &error
+    ) : LspIssueReporter(serializer, transformer)
+      , extensionId(extensionId)
+      , initializeParams(initializeParams)
+      , config(config)
+      , configTransformer(configTransformer)
+      , message(message)
+      , traceId(traceId)
+      , error(error)
+    {
+        // empty
+    }
+
+    auto InternalErrorReporter::title() const -> std::string {
+        if (traceId.length() > 0) {
+            return "[Generated] Internal error while handling " + traceId + ": " + error.message;
+        }
+        return "[Generated] Internal error: " + error.message;
+    }
+
+    auto InternalErrorReporter::body() const -> std::string {
+        std::string body{""};
+        if (traceId.length() > 0) {
+            body.append("Caught internal error while handing: ");
+            body.append(traceId);
+            body.append("\n");
+            body.append("Error Message: ");
+            body.append(error.message);
+        } else {
+            body.append("Caught internal error: ");
+            body.append(error.message);
+        }
+        body.append("\n\n");
+        body.append("### LSP/JSON-RPC Message:");
+        body.append("\n\n");
+        escape(body, message);
+        body.append("\n\n");
+        body.append("### Additional Information:");
+        body.append("\n\n");
+        body.append("Please describe what you were doing when the error occurred.");
+        if (initializeParams.clientInfo.has_value()) {
+            const _InitializeParams_clientInfo &clientInfo =
+                initializeParams.clientInfo.value();
+            body.append("\n\n");
+            body.append("### Client Details:");
+            body.append("\n\n");
+            body.append("Name: ");
+            body.append(clientInfo.name);
+            if (clientInfo.version.has_value()) {
+                body.append("\n");
+                body.append("Version: ");
+                body.append(clientInfo.version.value());
+            }
+        }
+        body.append("\n\n");
+        body.append("### Initialize Parameters:");
+        body.append("\n\n");
+        body.append(
+            serializer.serialize(
+                transformer.initializeParamsToAny(initializeParams)
+            )
+        );
+        body.append("\n\n");
+        body.append("### Workspace Config:");
+        body.append("\n\n");
+        body.append(
+            serializer.serialize(
+                configTransformer.lspConfigToAny(config)
+            )
+        );
+        body.append("\n");
+        return body;
+    }
+
+} // namespace LCompilers::LanguageServerProtocol::Reporter

--- a/src/server/lsp_issue_reporter.h
+++ b/src/server/lsp_issue_reporter.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include <server/lsp_config.h>
+#include <server/lsp_json_serializer.h>
+#include <server/lsp_specification.h>
+#include <server/lsp_transformer.h>
+
+namespace LCompilers::LanguageServerProtocol::Reporter {
+    namespace lsc = LCompilers::LanguageServerProtocol::Config;
+
+    // NOTE: IssueType is an enum from the VSCode sources for the issue dialog.
+    enum class IssueType {
+        Bug = 0,
+        PerformanceIssue = 1,
+        FeatureRequest = 2,
+    };
+
+    extern const std::map<IssueType, std::string> IssueTypeNames;
+
+    // NOTE: IssueSource is an enum from the VSCode sources for the issue
+    // dialog.
+    enum class IssueSource {
+        VSCode,
+        Extension,
+        Marketplace,
+    };
+
+    extern const std::map<IssueSource, std::string> IssueSourceNames;
+    extern const std::map<IssueSource, std::string> IssueSourceValues;
+
+    class LspIssueReporter {
+    public:
+        LspIssueReporter(
+            LspJsonSerializer &serializer,
+            LspTransformer &transformer
+        );
+        virtual ~LspIssueReporter() = default;
+        virtual auto title() const -> std::string = 0;
+        virtual auto body() const -> std::string = 0;
+    protected:
+        LspJsonSerializer &serializer;
+        LspTransformer &transformer;
+
+        auto escape(std::string &buffer, const std::string &text) const -> void;
+    };
+
+    class InternalErrorReporter : public LspIssueReporter {
+    public:
+        InternalErrorReporter(
+            LspJsonSerializer &serializer,
+            LspTransformer &transformer,
+            const std::string &extensionId,
+            const InitializeParams &initializeParams,
+            const lsc::LspConfig &config,
+            lsc::LspConfigTransformer &configTransformer,
+            const std::string &message,
+            const std::string &traceId,
+            const ResponseError &error
+        );
+
+        auto title() const -> std::string override;
+        auto body() const -> std::string override;
+    private:
+        const std::string &extensionId;
+        const InitializeParams &initializeParams;
+        const lsc::LspConfig &config;
+        lsc::LspConfigTransformer &configTransformer;
+        const std::string &message;
+        const std::string &traceId;
+        const ResponseError &error;
+    };
+
+} // namespace LCompilers::LanguageServerProtocol::Reporter

--- a/src/server/lsp_json_serializer.cpp
+++ b/src/server/lsp_json_serializer.cpp
@@ -25,6 +25,20 @@ namespace LCompilers::LanguageServerProtocol {
         return buffer;
     }
 
+    auto LspJsonSerializer::serialize(const LSPObject &object) const -> std::string {
+        std::string buffer;
+        buffer.reserve(1024);
+        serializeObject(buffer, object);
+        return buffer;
+    }
+
+    auto LspJsonSerializer::serialize(const LSPArray &array) const -> std::string {
+        std::string buffer;
+        buffer.reserve(1024);
+        serializeArray(buffer, array);
+        return buffer;
+    }
+
     auto LspJsonSerializer::pprint(
         const LSPAny &any
     ) const -> std::string {
@@ -35,20 +49,20 @@ namespace LCompilers::LanguageServerProtocol {
     }
 
     auto LspJsonSerializer::pprint(
-        const LSPArray &array
-    ) const -> std::string {
-        std::string buffer;
-        buffer.reserve(2048);
-        pprintArray(buffer, array, 0);
-        return buffer;
-    }
-
-    auto LspJsonSerializer::pprint(
         const LSPObject &object
     ) const -> std::string {
         std::string buffer;
         buffer.reserve(2048);
         pprintObject(buffer, object, 0);
+        return buffer;
+    }
+
+    auto LspJsonSerializer::pprint(
+        const LSPArray &array
+    ) const -> std::string {
+        std::string buffer;
+        buffer.reserve(2048);
+        pprintArray(buffer, array, 0);
         return buffer;
     }
 

--- a/src/server/lsp_json_serializer.h
+++ b/src/server/lsp_json_serializer.h
@@ -14,18 +14,12 @@ namespace LCompilers::LanguageServerProtocol {
         LspJsonSerializer(const std::string &indent);
 
         auto serialize(const LSPAny &any) const -> std::string;
+        auto serialize(const LSPObject &object) const -> std::string;
+        auto serialize(const LSPArray &array) const -> std::string;
 
-        auto pprint(
-            const LSPArray &array
-        ) const -> std::string;
-
-        auto pprint(
-            const LSPObject &object
-        ) const -> std::string;
-
-        auto pprint(
-            const LSPAny &any
-        ) const -> std::string;
+        auto pprint(const LSPAny &any) const -> std::string;
+        auto pprint(const LSPObject &object) const -> std::string;
+        auto pprint(const LSPArray &array) const -> std::string;
 
         inline auto indent() const -> const std::string & {
             return _indent;


### PR DESCRIPTION
Changes:
* Alters pretty-printing behavior of trace logs according to the workspace config (whether to pretty-print and what how many spaces to include per level of indentation)
* Moves almost all the boilerplate logic out of the generated LspLanguageServer into BaseLspLanguageServer for easier maintenance and so some logic could be guarded according to the workspace config
* Limits the number of errors and warnings returned, per file, according to the workspace config
* If enabled in the workspace config, opens a Github issue when an internal error occurs.
* Adds support for sending custom requests and notifications (method names should be prefixed with `$/`, e.g. `$/openIssue`)