### PR TITLE
fix: update dependencies of DerviedType appropriately

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1965,7 +1965,7 @@ public:
             }
             char* aggregate_type_name = nullptr;
             if (item.first != "~abstract_type") {
-                ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(item.second));
+                ASR::ttype_t* var_type = ASRUtils::extract_type(ASRUtils::symbol_type(item.second));
                 if( ASR::is_a<ASR::StructType_t>(*var_type) ) {
                     ASR::symbol_t* sym = ASR::down_cast<ASR::StructType_t>(var_type)->m_derived_type;
                     aggregate_type_name = ASRUtils::symbol_name(sym);
@@ -1974,7 +1974,7 @@ public:
                     aggregate_type_name = ASRUtils::symbol_name(sym);
                 }
             }
-            if( aggregate_type_name ) {
+            if( aggregate_type_name && std::strcmp(aggregate_type_name, "~abstract_type") != 0) {
                 struct_dependencies.push_back(al, aggregate_type_name);
             }
         }

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -535,9 +535,8 @@ public:
                 ASR::is_a<ASR::CustomOperator_t>(*a.second) ) {
                 continue ;
             }
-            // TODO: Uncomment the following line
-            // ASR::ttype_t* var_type = ASRUtils::extract_type(ASRUtils::symbol_type(a.second));
-            ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(a.second));
+
+            ASR::ttype_t* var_type = ASRUtils::extract_type(ASRUtils::symbol_type(a.second));
             char* aggregate_type_name = nullptr;
             ASR::symbol_t* sym = nullptr;
             if( ASR::is_a<ASR::StructType_t>(*var_type) ) {

--- a/tests/reference/asr-associate_08-570ac7d.json
+++ b/tests/reference/asr-associate_08-570ac7d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-associate_08-570ac7d.stdout",
-    "stdout_hash": "6aa8647b584a5699730d756ea764cb8f92d7861bcb4f549720cb06c9",
+    "stdout_hash": "475e465ec7491317e029303acad41c172f485918c9c765eeb4fc22f8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-associate_08-570ac7d.stdout
+++ b/tests/reference/asr-associate_08-570ac7d.stdout
@@ -602,7 +602,7 @@
                                                 )
                                         })
                                     t_2
-                                    []
+                                    [t_1]
                                     [type_2]
                                     Source
                                     Public

--- a/tests/reference/asr-dependency_test_01-280d5b3.json
+++ b/tests/reference/asr-dependency_test_01-280d5b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-dependency_test_01-280d5b3.stdout",
-    "stdout_hash": "636157da243d3c1b391c1794a03d30319aefb00ec945f3212eb23f4b",
+    "stdout_hash": "83a8b6c873fd29b924d5456624cac361a27d80d3c6beeca5421bbe5e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-dependency_test_01-280d5b3.stdout
+++ b/tests/reference/asr-dependency_test_01-280d5b3.stdout
@@ -453,7 +453,7 @@
                                                 )
                                         })
                                     dependency_tree_t
-                                    []
+                                    [dependency_node_t]
                                     [unit
                                     verbosity
                                     dep_dir

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "dcb199a64f7b2b07b912bdfde00c964c62fcd1d03f65c243aa8e19ed",
+    "stdout_hash": "050fc62831dce0a367459b523a00530b5ea1ad7f8273ca4d7c30e0ff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -1216,7 +1216,8 @@
                                                 )
                                         })
                                     toml_datetime
-                                    []
+                                    [toml_date
+                                    toml_time]
                                     [date
                                     time]
                                     Source

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "d58edf1f9f3c0b380804f571dca4ab21fec667339e6ee35853762c42",
+    "stdout_hash": "b67705f0d556268c9bcb9cc4d153c440130ad1449d8a0a9d2d5c6e6d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -1216,7 +1216,8 @@
                                                 )
                                         })
                                     toml_datetime
-                                    []
+                                    [toml_date
+                                    toml_time]
                                     [date
                                     time]
                                     Source

--- a/tests/reference/asr-derived_types_07-c5a29e3.json
+++ b/tests/reference/asr-derived_types_07-c5a29e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-c5a29e3.stdout",
-    "stdout_hash": "6da46d39cd81dcda0048f5e6a45bda1b17fd759deeadaaf17e9de93d",
+    "stdout_hash": "6bcc4fc49b2d443fb0a4e7920e5a109edc3954a364e9327e95e845fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-c5a29e3.stdout
+++ b/tests/reference/asr-derived_types_07-c5a29e3.stdout
@@ -478,7 +478,7 @@
                                                 )
                                         })
                                     toml_node
-                                    []
+                                    [toml_value]
                                     [val]
                                     Source
                                     Public
@@ -550,7 +550,7 @@
                                                 )
                                         })
                                     toml_vector
-                                    []
+                                    [toml_node]
                                     [n
                                     lst]
                                     Source

--- a/tests/reference/asr-modules1-d3dc674.json
+++ b/tests/reference/asr-modules1-d3dc674.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules1-d3dc674.stdout",
-    "stdout_hash": "d365ab036593a049333017447c660801974ce22d8612b67d9f9c60b7",
+    "stdout_hash": "20bca18dbe22381ea058f825e4c42ffe756242dfa74b7e8571206d69",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules1-d3dc674.stdout
+++ b/tests/reference/asr-modules1-d3dc674.stdout
@@ -275,7 +275,7 @@
                                                 )
                                         })
                                     t2
-                                    []
+                                    [t1]
                                     [val]
                                     Source
                                     Public

--- a/tests/reference/asr-modules2-98d8120.json
+++ b/tests/reference/asr-modules2-98d8120.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules2-98d8120.stdout",
-    "stdout_hash": "659f2f5c8a655179006d08e7108eb57bec456206a7d3b535ee6e0a2e",
+    "stdout_hash": "e921b65a5ec12d8ef96a00ebb9c35df15f19555348214f53562deb09",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules2-98d8120.stdout
+++ b/tests/reference/asr-modules2-98d8120.stdout
@@ -418,7 +418,7 @@
                                                 )
                                         })
                                     toml_array
-                                    []
+                                    [toml_ordered]
                                     [list]
                                     Source
                                     Public

--- a/tests/reference/asr-modules3-8936416.json
+++ b/tests/reference/asr-modules3-8936416.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules3-8936416.stdout",
-    "stdout_hash": "6eea2558e752133706b17d048a6e1e289f75b9c9f07d2bb552db758d",
+    "stdout_hash": "d194bd15d41ce8365b6a2d0531d162dde65907f14f3797d53950918d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules3-8936416.stdout
+++ b/tests/reference/asr-modules3-8936416.stdout
@@ -489,7 +489,7 @@
                                                 )
                                         })
                                     toml_array
-                                    []
+                                    [toml_ordered]
                                     [list]
                                     Source
                                     Public

--- a/tests/reference/asr-modules4-22712cd.json
+++ b/tests/reference/asr-modules4-22712cd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules4-22712cd.stdout",
-    "stdout_hash": "e8d58a491d50f91da99f6fe7a4d23cc002aaf41b83595bd5da7e1c2f",
+    "stdout_hash": "0368a22a9ba4a1c7264eb2c8e0c86ead713db181a8bbd14e3d939be6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules4-22712cd.stdout
+++ b/tests/reference/asr-modules4-22712cd.stdout
@@ -479,7 +479,7 @@
                                                 )
                                         })
                                     toml_array
-                                    []
+                                    [toml_ordered]
                                     [list]
                                     Source
                                     Public

--- a/tests/reference/asr-modules_28-9506bba.json
+++ b/tests/reference/asr-modules_28-9506bba.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_28-9506bba.stdout",
-    "stdout_hash": "950192211be91c67ddf9983e9d938ebbcc37a1d13f221ea5af6bac71",
+    "stdout_hash": "44f9fa2b6d7155228c8950fc632e7597713cdc4a63ff2160e4b4fc09",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_28-9506bba.stdout
+++ b/tests/reference/asr-modules_28-9506bba.stdout
@@ -294,7 +294,7 @@
                                                 )
                                         })
                                     dependency_config_t
-                                    []
+                                    [git_target_t]
                                     [name
                                     path
                                     git]

--- a/tests/reference/asr-modules_29-dc71c55.json
+++ b/tests/reference/asr-modules_29-dc71c55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_29-dc71c55.stdout",
-    "stdout_hash": "0c8cbf65a50b1241646f5d0da3670ee4db041bd109a0e7d3ffa78bd4",
+    "stdout_hash": "af54748dfab299050867adf879809fc6e20369f5081e7328f5c3330f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_29-dc71c55.stdout
+++ b/tests/reference/asr-modules_29-dc71c55.stdout
@@ -294,7 +294,7 @@
                                                 )
                                         })
                                     dependency_config_t
-                                    []
+                                    [git_target_t]
                                     [name
                                     path
                                     git]
@@ -808,7 +808,7 @@
                                                 )
                                         })
                                     executable_config_t
-                                    []
+                                    [dependency_config_t]
                                     [name
                                     source_dir
                                     main

--- a/tests/reference/asr-modules_30-9f519b4.json
+++ b/tests/reference/asr-modules_30-9f519b4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_30-9f519b4.stdout",
-    "stdout_hash": "339a19f41d4eb4cabe0cca40dc1ec04e4d20e74ae2ac4be993e75514",
+    "stdout_hash": "1a696c99b49ab522e6c1f2d6927b5a0e7bea161415da8f767abbc74e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_30-9f519b4.stdout
+++ b/tests/reference/asr-modules_30-9f519b4.stdout
@@ -531,7 +531,7 @@
                                                 )
                                         })
                                     package_config_t
-                                    []
+                                    [executable_config]
                                     [name
                                     executable]
                                     Source

--- a/tests/reference/asr-modules_31-cd9bfef.json
+++ b/tests/reference/asr-modules_31-cd9bfef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_31-cd9bfef.stdout",
-    "stdout_hash": "c5bac651a4423bae2fea39e01add4d80585e1ea9c92b5fcfcc032f56",
+    "stdout_hash": "b53b493738f8b2b8716822d2f872806211414499fe2c9cfed6571464",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_31-cd9bfef.stdout
+++ b/tests/reference/asr-modules_31-cd9bfef.stdout
@@ -709,7 +709,7 @@
                                                 )
                                         })
                                     dependency_tree_t
-                                    []
+                                    [dependency_node_t]
                                     [unit
                                     verbosity
                                     dep_dir

--- a/tests/reference/asr-modules_33-b589c22.json
+++ b/tests/reference/asr-modules_33-b589c22.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_33-b589c22.stdout",
-    "stdout_hash": "15ca5420f5183eee03ff69742fd8a4292855fc83d8cca22e7c9bc887",
+    "stdout_hash": "a83b3005d541602130e493ea633e2fa5c6c0814fbfa4babb20c14419",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_33-b589c22.stdout
+++ b/tests/reference/asr-modules_33-b589c22.stdout
@@ -594,7 +594,7 @@
                                                 )
                                         })
                                     dependency_tree_t
-                                    []
+                                    [dependency_node_t]
                                     [unit
                                     verbosity
                                     dep_dir

--- a/tests/reference/asr-modules_45-c69c75f.json
+++ b/tests/reference/asr-modules_45-c69c75f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_45-c69c75f.stdout",
-    "stdout_hash": "81bfbfecf098430d857014c70ad1ff1636e0f2c4ad4b3e6343d2e681",
+    "stdout_hash": "e7ee2694212bedf6216220738271bf1aa7f5832d322cabc3b9c85c86",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_45-c69c75f.stdout
+++ b/tests/reference/asr-modules_45-c69c75f.stdout
@@ -1191,7 +1191,7 @@
                                                 )
                                         })
                                     profile_config_t
-                                    []
+                                    [file_scope_flag]
                                     [profile_name
                                     compiler
                                     os_type

--- a/tests/reference/asr-nullify_03-e2c1d62.json
+++ b/tests/reference/asr-nullify_03-e2c1d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nullify_03-e2c1d62.stdout",
-    "stdout_hash": "b8b20f348aa98edcc9a0e705758909eaa7ad8851dbfa8b0e5dcf5083",
+    "stdout_hash": "3658a1810afbde030b63b181f92076baa8697d54392b7cb105f88072",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nullify_03-e2c1d62.stdout
+++ b/tests/reference/asr-nullify_03-e2c1d62.stdout
@@ -187,7 +187,7 @@
                                                 )
                                         })
                                     sds
-                                    []
+                                    [rp1d]
                                     [ndim
                                     dims
                                     hdf32

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout",
-    "stdout_hash": "b8fb1eed2537af227ad2f6679e7c5e96c10c9689a90619ec3fe99044",
+    "stdout_hash": "664b3ebbc25fe848952c08d50846cc63b9c018a4f1e13f7492514fff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
@@ -1445,7 +1445,7 @@
                                                 )
                                         })
                                     profile_config_t
-                                    []
+                                    [file_scope_flag]
                                     [profile_name
                                     compiler
                                     os_type


### PR DESCRIPTION
## Description

When it's an allocatable / Array / pointer or a combination of one of these types, update the dependencies.

This *might* help us with issue: https://github.com/lfortran/lfortran/issues/5655