### PR TITLE
Adds support for previewing symbol definitions on hover events

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1,6 +1,7 @@
 #include "libasr/utils.h"
 #include <chrono>
 #include <iostream>
+#include <stdexcept>
 #include <stdlib.h>
 #include <filesystem>
 #include <random>
@@ -55,6 +56,7 @@
 #include <cpp-terminal/terminal.h>
 #include <cpp-terminal/prompt0.h>
 
+#include <bin/lfortran_accessor.h>
 #include <bin/lfortran_command_line_parser.h>
 #include <bin/lsp_cli.h>
 
@@ -530,36 +532,22 @@ int format(const std::string &infile, bool inplace, bool color, int indent,
     bool indent_unit, CompilerOptions &compiler_options)
 {
     std::string input = read_file(infile);
+    LCompilers::LLanguageServer::LFortranAccessor lfortran_accessor;
 
-    LCompilers::FortranEvaluator fe(compiler_options);
-    LCompilers::LocationManager lm;
-    LCompilers::diag::Diagnostics diagnostics;
-    {
-        LCompilers::LocationManager::FileLocations fl;
-        fl.in_filename = infile;
-        lm.files.push_back(fl);
-        lm.file_ends.push_back(input.size());
-    }
-    LCompilers::Result<LCompilers::LFortran::AST::TranslationUnit_t*>
-        r = fe.get_ast2(input, lm, diagnostics);
-    std::cerr << diagnostics.render(lm, compiler_options);
-    if (!r.ok) {
-        LCOMPILERS_ASSERT(diagnostics.has_error())
+    try {
+        if (inplace) color = false;
+        std::string source = lfortran_accessor.format(
+            infile, input, compiler_options, color, indent, indent_unit
+        );
+        if (inplace) {
+            std::ofstream out;
+            out.open(infile);
+            out << source;
+        } else {
+            std::cout << source;
+        }
+    } catch (const std::logic_error &e) {
         return 2;
-    }
-    LCompilers::LFortran::AST::TranslationUnit_t* ast = r.result;
-
-    // AST -> Source
-    if (inplace) color = false;
-    std::string source = LCompilers::LFortran::ast_to_src(*ast, color,
-        indent, indent_unit);
-
-    if (inplace) {
-        std::ofstream out;
-        out.open(infile);
-        out << source;
-    } else {
-        std::cout << source;
     }
 
     return 0;

--- a/src/bin/lfortran_accessor.cpp
+++ b/src/bin/lfortran_accessor.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <stdexcept>
 
 #include <libasr/asr.h>
 #include <libasr/asr_lookup_name.h>
@@ -6,6 +7,7 @@
 #include <libasr/exception.h>
 #include <libasr/location.h>
 
+#include <lfortran/ast_to_src.h>
 #include <lfortran/fortran_evaluator.h>
 
 #include <bin/lfortran_accessor.h>
@@ -101,26 +103,23 @@ namespace LCompilers::LLanguageServer {
                 if (ASR::is_a<ASR::symbol_t>(*asr)) {
                     ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(asr);
                     std::string symbol_name = ASRUtils::symbol_name( s );
-                    uint32_t first_line;
-                    uint32_t last_line;
-                    uint32_t first_column;
-                    uint32_t last_column;
-                    std::string filename;
-                    lm.pos_to_linecol(
-                        lm.output_to_input_pos(asr->loc.first, false),
-                        first_line, first_column, filename);
-                    lm.pos_to_linecol(
-                        lm.output_to_input_pos(asr->loc.last, true),
-                        last_line, last_column, filename);
-                    LCompilers::document_symbols loc;
-                    loc.first_column = first_column;
-                    loc.last_column = last_column;
-                    loc.first_line = first_line;
-                    loc.last_line = last_line;
+                    LCompilers::document_symbols &loc = symbol_lists.emplace_back();
                     loc.symbol_name = symbol_name;
-                    loc.filename = filename;
+                    loc.first_pos = lm.output_to_input_pos(asr->loc.first, false);
+                    lm.pos_to_linecol(
+                        loc.first_pos,
+                        loc.first_line,
+                        loc.first_column,
+                        loc.filename
+                    );
+                    loc.last_pos = lm.output_to_input_pos(asr->loc.last, true);
+                    lm.pos_to_linecol(
+                        loc.last_pos,
+                        loc.last_line,
+                        loc.last_column,
+                        loc.filename
+                    );
                     loc.symbol_type = s->type;
-                    symbol_lists.push_back(loc);
                 }
             }
         }
@@ -165,6 +164,39 @@ namespace LCompilers::LLanguageServer {
         }
 
         return symbol_lists;
+    }
+
+    auto LFortranAccessor::format(
+        const std::string &filename,
+        const std::string &text,
+        const CompilerOptions &compiler_options,
+        bool color,
+        int indent,
+        bool indent_unit
+    ) const -> std::string {
+        LCompilers::FortranEvaluator fe(compiler_options);
+        LCompilers::LocationManager lm;
+        LCompilers::diag::Diagnostics diagnostics;
+        {
+            LCompilers::LocationManager::FileLocations fl;
+            fl.in_filename = filename;
+            lm.files.push_back(fl);
+            lm.file_ends.push_back(text.size());
+        }
+        LCompilers::Result<LCompilers::LFortran::AST::TranslationUnit_t*>
+            r = fe.get_ast2(text, lm, diagnostics);
+        std::cerr << diagnostics.render(lm, compiler_options);
+        if (!r.ok) {
+            LCOMPILERS_ASSERT(diagnostics.has_error())
+            throw std::logic_error("fe.get_ast2(text, lm, diagnostics) failed.");
+        }
+        LCompilers::LFortran::AST::TranslationUnit_t* ast = r.result;
+
+        // AST -> Source
+        std::string source = LCompilers::LFortran::ast_to_src(*ast, color,
+            indent, indent_unit);
+
+        return source;
     }
 
     auto LFortranAccessor::getSymbols(

--- a/src/bin/lfortran_accessor.h
+++ b/src/bin/lfortran_accessor.h
@@ -76,6 +76,15 @@ namespace LCompilers::LLanguageServer {
                 }
             }
         }
+
+        auto format(
+            const std::string &filename,
+            const std::string &text,
+            const CompilerOptions &compiler_options,
+            bool color,
+            int indent,
+            bool indent_unit
+        ) const -> std::string;
     };
 
 } // namespace LCompilers::LLanguageServer

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -59,6 +59,10 @@ namespace LCompilers::LanguageServerProtocol {
             DocumentSymbolParams &params
         ) -> TextDocument_DocumentSymbolResult override;
 
+        auto receiveTextDocument_hover(
+            HoverParams &params
+        ) -> TextDocument_HoverResult override;
+
         // ====================== //
         // Incoming Notifications //
         // ====================== //
@@ -96,6 +100,7 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool clientSupportsGotoDefinitionLinks = false;
         std::atomic_bool clientSupportsDocumentSymbols = false;
         std::atomic_bool clientSupportsHierarchicalDocumentSymbols = false;
+        std::atomic_bool clientSupportsHover = false;
 
         auto validate(std::shared_ptr<LspTextDocument> document) -> void;
         auto getCompilerOptions(

--- a/src/libasr/lsp_interface.h
+++ b/src/libasr/lsp_interface.h
@@ -26,6 +26,8 @@ namespace LCompilers {
     std::string filename;
     ASR::symbolType symbol_type;
     int parent_index;  //<- position instead of pointer to avoid std::vector reallocation issues
+    uint32_t first_pos;
+    uint32_t last_pos;
   };
 
 } // namespace LCompilers


### PR DESCRIPTION
Changes:
* Adds support for previewing symbol definitions on hover events
* Formats the definition previews with `lfortran`

TODO: Move the `indentSize` config setting out of `log` and into the root configuration.