### PR TITLE
Enh : Inform PassManager about the backend we're targeting

### DIFF
--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -512,7 +512,7 @@ Result<std::string> FortranEvaluator::get_c3(ASR::TranslationUnit_t &asr,
     compiler_options.po.always_run = false;
     compiler_options.po.run_fun = "f";
     pass_manager.skip_c_passes();
-    pass_manager.apply_passes(al, &asr, compiler_options.po, diagnostics);
+    pass_manager.apply_passes(al, &asr, compiler_options.po, diagnostics, PassManager::backend::c);
     // ASR pass -> C
     return asr_to_c(al, asr, diagnostics, compiler_options, default_lower_bound);
 }
@@ -548,7 +548,7 @@ Result<std::unique_ptr<MLIRModule>> FortranEvaluator::get_mlir(
     if (ASR::is_a<ASR::unit_t>(asr)) {
         pass_manager.use_default_passes();
         pass_manager.apply_passes(al, (ASR::TranslationUnit_t *)&asr,
-            compiler_options.po, diagnostics);
+            compiler_options.po, diagnostics, PassManager::backend::mlir);
     }
     Result<std::unique_ptr<MLIRModule>> res = asr_to_mlir(al,
         (ASR::asr_t &)asr, diagnostics);
@@ -578,7 +578,7 @@ Result<std::string> FortranEvaluator::get_fortran(const std::string &code,
     if (asr.ok) {
         LCompilers::PassManager pass_manager;
         pass_manager.use_fortran_passes();
-        pass_manager.apply_passes(al, asr.result, compiler_options.po, diagnostics);
+        pass_manager.apply_passes(al, asr.result, compiler_options.po, diagnostics, PassManager::backend::fortran);
         return asr_to_fortran(*asr.result, diagnostics, false, 4);
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10790,7 +10790,7 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     co.po.always_run = false;
     co.po.skip_optimization_func_instantiation = skip_optimization_func_instantiation;
     pass_manager.rtlib = co.rtlib;
-    pass_manager.apply_passes(al, &asr, co.po, diagnostics);
+    pass_manager.apply_passes(al, &asr, co.po, diagnostics, LCompilers::PassManager::backend::llvm);
 
     // Uncomment for debugging the ASR after the transformation
     // std::cout << LCompilers::pickle(asr, true, false, false) << std::endl;

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -3409,7 +3409,7 @@ Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr,
                 "implied_do_loops", "print_arr", "do_loops", "select_case",
                 "nested_vars", "unused_functions", "intrinsic_function"};
     LCompilers::PassManager pass_manager;
-    pass_manager.apply_passes(al, &asr, passes, co.po, diagnostics);
+    pass_manager.apply_passes(al, &asr, passes, co.po, diagnostics, PassManager::backend::wasm);
 
 
 #ifdef SHOW_ASR


### PR DESCRIPTION
- Use `backend` enum defined in `pass_manager.h`.
- enh how we do number pass dumps so we can skip passes and not ruin numbering. 