### PR TITLE
fix: handle keyword arguments correctly for class procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1566,6 +1566,7 @@ RUN(NAME class_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME class_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm NO_STD_F23)
 

--- a/integration_tests/class_14.f90
+++ b/integration_tests/class_14.f90
@@ -1,0 +1,42 @@
+module malloc_failure
+   
+    implicit none
+    
+    type, public, abstract :: AbsType
+    contains
+       procedure(callee), deferred, nopass :: callee
+    end type AbsType
+    
+    abstract interface
+       subroutine callee(mode)
+          integer, intent(in)  :: mode
+       end subroutine callee
+    end interface
+       
+    type :: SomeClass
+       private
+       class(AbsType), allocatable :: object
+    contains
+       procedure :: caller
+    end type SomeClass
+    
+    interface SomeClass
+       procedure :: constructor
+    end interface SomeClass
+    
+ contains
+ 
+    function constructor(object) result(self)
+       type(SomeClass)            :: self
+       class(AbsType), intent(in) :: object
+       self%object = object
+    end function constructor
+    
+    subroutine caller(self)
+       class(SomeClass), intent(in)  :: self
+       call self%object%callee(mode=0)
+    end subroutine caller
+ 
+end module malloc_failure
+program main
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9544,7 +9544,7 @@ public:
                 diag::Diagnostics& diag, size_t type_bound=0) {
         size_t n_args = args.size();
         std::string fn_name = fn->m_name;
-
+        if (type_bound >= fn_n_args) type_bound = 0;
         if (n_args + n > fn_n_args) {
             diag.semantic_error_label(
                 "Procedure '" + fn_name + "' accepts " + std::to_string(fn_n_args)


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/1693#issuecomment-2703157527