### PR TITLE
fix : Create copy for implicit dictionary before nesting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1256,6 +1256,7 @@ RUN(NAME implicit_interface_18 LABELS gfortran llvmImplicit EXTRA_ARGS --implici
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_03 LABELS gfortran llvmImplicit)
+RUN(NAME implicit_typing_04 LABELS gfortran llvmImplicit EXTRA_ARGS --implicit-interface)
 
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_typing_04.f90
+++ b/integration_tests/implicit_typing_04.f90
@@ -1,0 +1,18 @@
+subroutine outer(x)
+
+   implicit real(kind=8) (a-h,o-z), integer(kind=4) (i-n)
+
+contains
+   
+   function inner()
+      implicit real(kind=8) (a-h,o-z), integer(kind=4) (i-n)
+      inner = 1
+   end function inner
+
+end subroutine outer
+
+program implicit_typing_04 
+   implicit none
+   real(8) :: x
+   call outer(x)
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1102,13 +1102,9 @@ public:
         for (size_t i=0; i<x.n_contains; i++) {
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
-            if ( compiler_options.implicit_typing ) {
-                std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
-                visit_program_unit(*x.m_contains[i]);
-                implicit_dictionary = implicit_dictionary_copy;
-            } else {
-                visit_program_unit(*x.m_contains[i]);
-            }
+            std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
+            visit_program_unit(*x.m_contains[i]);
+            implicit_dictionary = implicit_dictionary_copy;
             default_storage_save = current_storage_save;
         }
         Vec<ASR::expr_t*> args;

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1102,7 +1102,13 @@ public:
         for (size_t i=0; i<x.n_contains; i++) {
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
-            visit_program_unit(*x.m_contains[i]);
+            if ( compiler_options.implicit_typing ) {
+                std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
+                visit_program_unit(*x.m_contains[i]);
+                implicit_dictionary = implicit_dictionary_copy;
+            } else {
+                visit_program_unit(*x.m_contains[i]);
+            }
             default_storage_save = current_storage_save;
         }
         Vec<ASR::expr_t*> args;


### PR DESCRIPTION
fix : #6479

MRE :-  
```.f90
subroutine outer(x)

   implicit real(kind=8) (a-h,o-z), integer(kind=4) (i-n)

contains
   
   function inner()
      implicit real(kind=8) (a-h,o-z), integer(kind=4) (i-n)
      inner = 1
   end function inner

end subroutine outer
```

Corrected ASR for x :- 
```.f90
x:
    (Variable
        2
        x
        []
        Unspecified
        ()
        ()
        Default
        (Real 8)
        ()
        Source
        Public
        Required
        .false.
        .false.
        .false.
    )

```