### PR TITLE
fix: wrap StructInstanceMember with ArrayItem when in allocate

### DIFF
--- a/integration_tests/struct_allocate.f90
+++ b/integration_tests/struct_allocate.f90
@@ -1,0 +1,19 @@
+module mod_struct_allocate
+    implicit none
+    integer, parameter, private :: mxdim = 3
+    type :: rp1d
+        real(8), dimension(:), pointer :: f
+    end type
+
+    type :: sds
+        type(rp1d), dimension(mxdim) :: scales
+    end type
+end module
+
+program struct_allocate
+    use mod_struct_allocate
+    implicit none
+    type(sds) :: s
+    allocate(s%scales(1)%f(4))
+    allocate(s%scales(2)%f(3))
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9751,7 +9751,7 @@ public:
                 SymbolTable* scope = current_scope;
                 tmp = (ASR::asr_t*) replace_with_common_block_variables(
                     ASRUtils::EXPR(this->resolve_variable2(loc, to_lower(x_m_id),
-                    to_lower(x_m_member[0].m_name), scope)));
+                    to_lower(x_m_member[0].m_name), scope, nullptr, 0, x_m_member[1].m_args, x_m_member[1].n_args)));
             } else {
                 // TODO: incorporate m_args
                 SymbolTable* scope = current_scope;

--- a/tests/reference/asr-struct_allocate-606e066.json
+++ b/tests/reference/asr-struct_allocate-606e066.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-struct_allocate-606e066",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/struct_allocate.f90",
+    "infile_hash": "8f826ffcc557e1f998f9fb99e619bed6aa68bc3f5e45768ad8fa12a9",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-struct_allocate-606e066.stdout",
+    "stdout_hash": "1bf9839f423741072f5f10307ddd2b45f7072a5446dc97dbc44e4686",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-struct_allocate-606e066.stdout
+++ b/tests/reference/asr-struct_allocate-606e066.stdout
@@ -1,0 +1,277 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            mod_struct_allocate:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            mxdim:
+                                (Variable
+                                    2
+                                    mxdim
+                                    []
+                                    Local
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    Parameter
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Private
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                ),
+                            rp1d:
+                                (Struct
+                                    (SymbolTable
+                                        3
+                                        {
+                                            f:
+                                                (Variable
+                                                    3
+                                                    f
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Pointer
+                                                        (Array
+                                                            (Real 8)
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
+                                                        )
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    rp1d
+                                    []
+                                    [f]
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
+                                ),
+                            sds:
+                                (Struct
+                                    (SymbolTable
+                                        4
+                                        {
+                                            scales:
+                                                (Variable
+                                                    4
+                                                    scales
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (StructType
+                                                            2 rp1d
+                                                        )
+                                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    sds
+                                    []
+                                    [scales]
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
+                                )
+                        })
+                    mod_struct_allocate
+                    []
+                    .false.
+                    .false.
+                ),
+            struct_allocate:
+                (Program
+                    (SymbolTable
+                        5
+                        {
+                            1_rp1d_f:
+                                (ExternalSymbol
+                                    5
+                                    1_rp1d_f
+                                    3 f
+                                    rp1d
+                                    []
+                                    f
+                                    Public
+                                ),
+                            1_sds_scales:
+                                (ExternalSymbol
+                                    5
+                                    1_sds_scales
+                                    4 scales
+                                    sds
+                                    []
+                                    scales
+                                    Public
+                                ),
+                            rp1d:
+                                (ExternalSymbol
+                                    5
+                                    rp1d
+                                    2 rp1d
+                                    mod_struct_allocate
+                                    []
+                                    rp1d
+                                    Public
+                                ),
+                            s:
+                                (Variable
+                                    5
+                                    s
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (StructType
+                                        5 sds
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                ),
+                            sds:
+                                (ExternalSymbol
+                                    5
+                                    sds
+                                    2 sds
+                                    mod_struct_allocate
+                                    []
+                                    sds
+                                    Public
+                                )
+                        })
+                    struct_allocate
+                    [mod_struct_allocate]
+                    [(Allocate
+                        [((StructInstanceMember
+                            (ArrayItem
+                                (StructInstanceMember
+                                    (Var 5 s)
+                                    5 1_sds_scales
+                                    (Array
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (StructType
+                                    5 rp1d
+                                )
+                                ColMajor
+                                ()
+                            )
+                            5 1_rp1d_f
+                            (Pointer
+                                (Array
+                                    (Real 8)
+                                    [(()
+                                    ())]
+                                    DescriptorArray
+                                )
+                            )
+                            ()
+                        )
+                        [((IntegerConstant 1 (Integer 4) Decimal)
+                        (IntegerConstant 4 (Integer 4) Decimal))]
+                        ()
+                        ())]
+                        ()
+                        ()
+                        ()
+                    )
+                    (Allocate
+                        [((StructInstanceMember
+                            (ArrayItem
+                                (StructInstanceMember
+                                    (Var 5 s)
+                                    5 1_sds_scales
+                                    (Array
+                                        (StructType
+                                            5 rp1d
+                                        )
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                )
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())]
+                                (StructType
+                                    5 rp1d
+                                )
+                                ColMajor
+                                ()
+                            )
+                            5 1_rp1d_f
+                            (Pointer
+                                (Array
+                                    (Real 8)
+                                    [(()
+                                    ())]
+                                    DescriptorArray
+                                )
+                            )
+                            ()
+                        )
+                        [((IntegerConstant 1 (Integer 4) Decimal)
+                        (IntegerConstant 3 (Integer 4) Decimal))]
+                        ()
+                        ())]
+                        ()
+                        ()
+                        ()
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -787,6 +787,10 @@ asr = true
 pass = "array_struct_temporary,array_op"
 
 [[test]]
+filename = "../integration_tests/struct_allocate.f90"
+asr = true
+
+[[test]]
 filename = "../integration_tests/doloop_01.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
## Description

Addresses the comments for discussion here: https://github.com/lfortran/lfortran/pull/6434#issuecomment-2703743937