### PR TITLE
DON'T MERGE CI: test workaround removal from POT3D's branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -597,8 +597,8 @@ jobs:
             FC="$(pwd)/src/bin/lfortran"
             git clone https://github.com/gxyd/pot3d.git
             cd pot3d
-            git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 33c078020dcea467e763b52879a480450a0494fe
+            git checkout -t origin/revert_commit
+            git checkout af057dd54cb7bcf6a86d23632e688922a85cce10
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang


### PR DESCRIPTION
## Description

This PR isn't intended to be merged at all, just want to check which CI tests fail and on which platform(s), when the final and only workaround is removal from POT3D