### PR TITLE
CMake: enable standalone parser and C libraries

### DIFF
--- a/src/lfortran/CMakeLists.txt
+++ b/src/lfortran/CMakeLists.txt
@@ -1,19 +1,21 @@
-set(SRC
+set(PARSER_SRC
     parser/preprocessor.cpp
     parser/tokenizer.cpp
     parser/parser.tab.cc
     parser/parser.cpp
     parser/fixedform_tokenizer.cpp
 
+    pickle.cpp
+)
+
+set(SRC
     semantics/ast_symboltable_visitor.cpp
     semantics/ast_body_visitor.cpp
     semantics/ast_to_asr.cpp
 
     fortran_evaluator.cpp
 
-    pickle.cpp
     ast_serialization.cpp
-    cwrapper.cpp
 
     ast_to_src.cpp
     ast_to_openmp.cpp
@@ -22,6 +24,10 @@ set(SRC
 
     utils.cpp
   )
+
+set(CWRAPPER_SRC
+    cwrapper.cpp
+)
 
   if (WITH_WHEREAMI)
     set(SRC ${SRC} ../bin/tpl/whereami/whereami.cpp)
@@ -37,11 +43,26 @@ set(SRC
       ast_to_json.cpp
     )
 endif()
+
+# Parser library for reuse internally
+add_library(lfortran_parser_obj OBJECT ${PARSER_SRC})
+target_link_libraries(lfortran_parser_obj PUBLIC lfortran_utils)
+target_include_directories(lfortran_parser_obj PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+target_include_directories(lfortran_parser_obj BEFORE PUBLIC ${lfortran_SOURCE_DIR}/src)
+target_include_directories(lfortran_parser_obj BEFORE PUBLIC ${lfortran_BINARY_DIR}/src)
+
+# Standalone parser library for external use
+add_library(lfortran_parser $<TARGET_OBJECTS:lfortran_parser_obj> $<TARGET_OBJECTS:lfortran_utils>)
+
+# Standalone C library for external use
+add_library(lfortran_c ${CWRAPPER_SRC})
+target_link_libraries(lfortran_c lfortran_parser_obj lfortran_utils)
+
 add_library(lfortran_lib STATIC ${SRC})
 target_include_directories(lfortran_lib PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 configure_file(config.h.cmakein config.h @ONLY)
-target_link_libraries(lfortran_lib asr lfortran_runtime_static)
+target_link_libraries(lfortran_lib asr lfortran_parser_obj lfortran_runtime_static)
 
 
 if (WITH_ZLIB)

--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(ADDTESTC name)
     add_test(${name} ${PROJECT_BINARY_DIR}/${name})
 endmacro(ADDTESTC)
 
-ADDTESTC(test_cwrapper)
+ADDTESTC(test_cwrapper lfortran_c)
 ADDTEST(test_stacktrace)
 
 set(SRC

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -77,14 +77,10 @@ set(SRC
     asr_verify.cpp
     asr_utils.cpp
     casting_utils.cpp
-    diagnostics.cpp
-    string_utils.cpp
     asr_scopes.cpp
     modfile.cpp
     pickle.cpp
     serialization.cpp
-    stacktrace.cpp
-    utils2.cpp
 )
 if (WITH_LLVM)
     set(SRC ${SRC}
@@ -110,9 +106,29 @@ if (WITH_LLVM)
             COMPILE_FLAGS -Wno-deprecated-declarations)
     endif()
 endif()
+
+set(LFORTRAN_UTILS
+  assert.h
+  colors.h
+  exception.h
+  location.h
+
+  diagnostics.h
+  diagnostics.cpp
+  stacktrace.h
+  stacktrace.cpp
+  string_utils.cpp
+  utils.h
+  utils2.cpp
+)
+add_library(lfortran_utils OBJECT ${LFORTRAN_UTILS})
+target_include_directories(lfortran_utils BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
+target_include_directories(lfortran_utils BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
+
 add_library(asr STATIC ${SRC})
 target_include_directories(asr BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(asr BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
+target_link_libraries(asr lfortran_utils)
 if (WITH_LIBUNWIND)
     target_link_libraries(asr p::libunwind)
 endif()


### PR DESCRIPTION
This tweaks the cmake to be able to build just the parser and/or C wrapper as standalone libraries.