### PR TITLE
rem: unnecessary check for `--implicit-interface` while resolving return type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1257,6 +1257,8 @@ RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_03 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_04 LABELS gfortran llvmImplicit EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_typing_05 LABELS gfortran llvm  EXTRA_ARGS --implicit-typing)
+
 
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_typing_05.f90
+++ b/integration_tests/implicit_typing_05.f90
@@ -1,0 +1,14 @@
+subroutine outer()
+   print *, f(2.0_8)
+   if ( abs(f(2.0_8) - 14.928527864588919) > 1e-7 ) error stop
+contains
+   function f(r)
+      implicit real(kind=8) (f, r, n)
+      n = 3.9_8
+      f = r**n
+   end function f
+end subroutine outer
+
+program implicit_typing_05
+call outer()
+end program implicit_typing_05

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1310,7 +1310,7 @@ public:
             size_t n, const Location &loc, std::string &return_var_name, ASR::symbol_t* return_var_sym) {
         AST::AttrType_t* r = nullptr;
         bool found = false;
-        if (n == 0 && compiler_options.implicit_interface && compiler_options.implicit_typing && !return_var_sym) {
+        if (n == 0 && compiler_options.implicit_typing && !return_var_sym) {
             std::string first_letter = to_lower(std::string(1,return_var_name[0]));
             ASR::ttype_t* t = implicit_dictionary[first_letter];
             AST::decl_typeType ttype;

--- a/tests/reference/asr-implicit_typing3-c82e537.json
+++ b/tests/reference/asr-implicit_typing3-c82e537.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-implicit_typing3-c82e537.stderr",
-    "stderr_hash": "da620963fd7a1436b6cf740bbb59ed33720b274f8d5fc22cfb1270fa",
+    "stderr_hash": "515c19327a17d5b2120b4d1677df5f90ccc9eab0b82be69c50a5f1fc",
     "returncode": 2
 }

--- a/tests/reference/asr-implicit_typing3-c82e537.stderr
+++ b/tests/reference/asr-implicit_typing3-c82e537.stderr
@@ -1,4 +1,4 @@
-semantic error: Return type not specified
+semantic error: No implicit return type available for `fun`
  --> tests/errors/implicit_typing3.f90:4:9 - 5:24
   |
 4 |            function fun()


### PR DESCRIPTION
Fixes #6453. The reason it is fine to do so:


> `--implicit-interface` is enabled

- either type is explicitly specified via variable in case no need of `--implicit-typing`
- if it is implicit, and `--implicit-typing` is not enabled, then compiler will already throw error

> `--implicit-interface` is disabled

- we would have never entered so it is fine