### PR TITLE
Updates for extension rename and a couple bug fixes

### DIFF
--- a/src/bin/language_server_interface.cpp
+++ b/src/bin/language_server_interface.cpp
@@ -243,7 +243,7 @@ namespace LCompilers::LLanguageServer::Interface {
             "Number of threads that will handle sub-tasks of requests."
         )->capture_default_str();
 
-        opts.configSection = "LFortranLanguageServer";
+        opts.configSection = "LFortran";
         server->add_option(
             "--config-section", opts.configSection,
             ("Identifies the server's configuration section within the "
@@ -308,10 +308,10 @@ namespace LCompilers::LLanguageServer::Interface {
             "Whether to pretty-print JSON objects and arrays."
         )->capture_default_str();
 
-        workspaceConfig->log.indentSize = 4;
+        workspaceConfig->indentSize = 4;
         server->add_option(
-            "--log-indent-size", workspaceConfig->log.indentSize,
-            "Number of spaces to indent the pretty-printed JSON."
+            "--indent-size", workspaceConfig->indentSize,
+            "Number of spaces per level of indentation."
         )->capture_default_str();
 
         opts.extensionId = "lcompilers.lfortran-lsp";

--- a/src/bin/lfortran_accessor.cpp
+++ b/src/bin/lfortran_accessor.cpp
@@ -104,16 +104,14 @@ namespace LCompilers::LLanguageServer {
                     std::string symbol_name = ASRUtils::symbol_name( s );
                     LCompilers::document_symbols &loc = symbol_lists.emplace_back();
                     loc.symbol_name = symbol_name;
-                    loc.first_pos = lm.output_to_input_pos(asr->loc.first, false);
                     lm.pos_to_linecol(
-                        loc.first_pos,
+                        lm.output_to_input_pos(asr->loc.first, false),
                         loc.first_line,
                         loc.first_column,
                         loc.filename
                     );
-                    loc.last_pos = lm.output_to_input_pos(asr->loc.last, true);
                     lm.pos_to_linecol(
-                        loc.last_pos,
+                        lm.output_to_input_pos(asr->loc.last, true),
                         loc.last_line,
                         loc.last_column,
                         loc.filename

--- a/src/libasr/lsp_interface.h
+++ b/src/libasr/lsp_interface.h
@@ -26,8 +26,6 @@ namespace LCompilers {
     std::string filename;
     ASR::symbolType symbol_type;
     int parent_index;  //<- position instead of pointer to avoid std::vector reallocation issues
-    uint32_t first_pos;
-    uint32_t last_pos;
   };
 
 } // namespace LCompilers

--- a/src/server/communication_protocol.h
+++ b/src/server/communication_protocol.h
@@ -18,8 +18,11 @@ namespace LCompilers::LLanguageServer {
             MessageQueue &incomingMessages,
             MessageQueue &outgoingMessages,
             lsl::Logger &logger);
+        ~CommunicationProtocol();
         auto serve() -> void;
     private:
+        std::streambuf* cout_sbuf;
+        int stdout_fd;
         LanguageServer &languageServer;
         MessageStream &messageStream;
         MessageQueue &incomingMessages;

--- a/src/server/lsp_config.cpp
+++ b/src/server/lsp_config.cpp
@@ -113,15 +113,6 @@ namespace LCompilers::LanguageServerProtocol::Config {
             );
         }
 
-        if ((iter = object.find("indentSize")) != object.end()) {
-            log.indentSize = iter->second->uinteger();
-        } else {
-            throw LSP_EXCEPTION(
-                ErrorCodes::InvalidParams,
-                "Missing required LspConfig_log attribute: indentSize"
-            );
-        }
-
         return log;
     }
 
@@ -150,12 +141,6 @@ namespace LCompilers::LanguageServerProtocol::Config {
                 transformer.booleanToAny(log.prettyPrint)
             )
         );
-        object.emplace(
-            "indentSize",
-            std::make_unique<LSPAny>(
-                transformer.uintegerToAny(log.indentSize)
-            )
-        );
         any = std::make_unique<LSPObject>(std::move(object));
         return any;
     }
@@ -166,9 +151,7 @@ namespace LCompilers::LanguageServerProtocol::Config {
         if (any.type() != LSPAnyType::Object) {
             throw LSP_EXCEPTION(
                 ErrorCodes::InvalidParams,
-                ("LSPAnyType for a "
-                 "LspConfig"
-                 " must be of type LSPAnyType::Object"
+                ("LSPAnyType for an LspConfig must be of type LSPAnyType::Object"
                  " but received LSPAnyType::" + LSPAnyTypeNames.at(any.type()))
             );
         }
@@ -185,6 +168,15 @@ namespace LCompilers::LanguageServerProtocol::Config {
                 ErrorCodes::InvalidParams,
                 ("Missing required LFortranLspConfig attribute: "
                  "openIssueReporterOnError")
+            );
+        }
+
+        if ((iter = object.find("indentSize")) != object.end()) {
+            config->indentSize = iter->second->uinteger();
+        } else {
+            throw LSP_EXCEPTION(
+                ErrorCodes::InvalidParams,
+                "Missing required LspConfig_log attribute: indentSize"
             );
         }
 

--- a/src/server/lsp_config.h
+++ b/src/server/lsp_config.h
@@ -21,12 +21,12 @@ namespace LCompilers::LanguageServerProtocol::Config {
         fs::path path;
         lsl::Level level;
         bool prettyPrint;
-        unsigned int indentSize;
     };
 
     struct LspConfig {
         virtual ~LspConfig() = default;
         bool openIssueReporterOnError;
+        unsigned int indentSize;
         LspConfig_trace trace;
         LspConfig_log log;
     };

--- a/src/server/lsp_text_document.h
+++ b/src/server/lsp_text_document.h
@@ -29,6 +29,10 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &text,
             lsl::Logger &logger
         );
+        LspTextDocument(
+            const std::string &uri,
+            lsl::Logger &logger
+        );
         LspTextDocument(LspTextDocument &&other) noexcept;    // move constructor
 
         inline auto uri() const -> const DocumentUri & {
@@ -55,10 +59,21 @@ namespace LCompilers::LanguageServerProtocol {
             return _mutex;
         }
 
+        auto update(
+            const std::string &languageId,
+            int version,
+            const std::string &text
+        ) -> void;
+
         auto apply(
             std::vector<TextDocumentContentChangeEvent> &changes,
             int version
         ) -> void;
+
+        auto toPosition(
+            std::size_t line,
+            std::size_t column
+        ) const -> std::size_t;
     private:
         DocumentUri _uri;
         std::string _languageId;
@@ -72,6 +87,7 @@ namespace LCompilers::LanguageServerProtocol {
 
         auto validateUriAndSetPath() -> void;
         auto indexLines() -> void;
+        auto loadText() -> void;
 
         auto from(
             const TextDocumentContentChangeEvent &event


### PR DESCRIPTION
Changes:
* Renames configuration root from "LFortranLanguageServer" to "LFortran"
* Moves the `indentSize` config from `log` to the config root
* BUGFIX: updates hover preview to work across files
* Redirects stdout to stderr to reserve stdout for messages to the language client

Depends on: https://github.com/lfortran/lfortran-vscode-client/pull/71