### PR TITLE
fix: Create special case for `INT64_MIN` during formatting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -347,7 +347,7 @@ RUN(NAME datastmt_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME max_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
 RUN(NAME max_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
 RUN(NAME min_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
-RUN(NAME min_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran NO_FAST fortran)
+RUN(NAME min_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
 RUN(NAME minmax_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME arithmetic_if_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran) # arithmetic tests use goto
 RUN(NAME arithmetic_if_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)

--- a/integration_tests/intrinsics_238.f90
+++ b/integration_tests/intrinsics_238.f90
@@ -6,4 +6,5 @@ do i = 1, 5
 print*, res(i), maskl(i)
 if (maskl(i) /= res(i) ) error stop
 end do
+print *, maskl(1, 8)
 end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -196,8 +196,15 @@ char* append_to_string(char* str, const char* append) {
 void handle_integer(char* format, int64_t val, char** result) {
     int width = 0, min_width = 0;
     char* dot_pos = strchr(format, '.');
-    int len = (val == 0) ? 1 : (int)log10(llabs(val)) + 1;
+    int len;
     int sign_width = (val < 0) ? 1 : 0;
+    if (val == 0) {
+        len = 1;
+    } else if (val == INT64_MIN) {
+        len = 19;
+    } else {
+        len = (int)log10(llabs(val)) + 1;
+    }
     if (dot_pos != NULL) {
         dot_pos++;
         width = atoi(format + 1);
@@ -238,7 +245,11 @@ void handle_integer(char* format, int64_t val, char** result) {
             }
         }
         char str[20];
-        sprintf(str, "%lld", llabs(val));
+        if (val == INT64_MIN) {
+            sprintf(str, "9223372036854775808");
+        } else {
+            sprintf(str, "%lld", llabs(val));
+        }
         *result = append_to_string(*result, str);
     } else {
         for (int i = 0; i < width; i++) {


### PR DESCRIPTION
Fixes #6529 