### PR TITLE
enh: make compiler_options work with iso_fortran_env

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1107,7 +1107,6 @@ public:
         {"selected_real_kind", IntrinsicSignature({"p", "r", "radix"}, 0, 3)},
         {"nearest", IntrinsicSignature({"x", "s"}, 2, 2)},
         {"compiler_version", IntrinsicSignature({}, 0, 0)},
-        {"compiler_options", IntrinsicSignature({}, 0, 0)},
         {"command_argument_count", IntrinsicSignature({}, 0, 0)},
         {"ishftc", IntrinsicSignature({"i", "shift", "size"}, 2, 3)},
         {"ichar", IntrinsicSignature({"C", "kind"}, 1, 2)},
@@ -1273,7 +1272,7 @@ public:
     IntrinsicProcedures intrinsic_procedures;
     IntrinsicProceduresAsASRNodes intrinsic_procedures_as_asr_nodes;
     std::set<std::string> intrinsic_module_procedures_as_asr_nodes = {
-        "c_loc", "c_f_pointer", "c_associated", "c_funloc"
+        "c_loc", "c_f_pointer", "c_associated", "c_funloc", "compiler_options"
     };
 
     ASR::accessType dflt_access = ASR::Public;
@@ -6925,6 +6924,17 @@ public:
         return ASR::make_Iachar_t(al, x.base.base.loc, arg, type, iachar_value);
     }
 
+    ASR::asr_t* create_CompilerOptions(const AST::FuncCallOrArray_t& x) {
+        Vec<ASR::expr_t*> args;
+        std::vector<std::string> kwarg_names = {};
+        handle_intrinsic_node_args(x, args, kwarg_names, 0, 0, "compiler_options");
+        ASRUtils::ASRBuilder b(al, x.base.base.loc);
+        ASR::ttype_t *type = ASR::down_cast<ASR::ttype_t>(ASR::make_String_t(
+                al, x.base.base.loc, 1, -1, nullptr, ASR::string_physical_typeType::PointerString));
+        ASR::expr_t *m_value =  b.StringConstant(lcompilers_commandline_options, type);
+        return ASR::make_CompilerOptions_t(al, x.base.base.loc, type, m_value);
+    }
+
     ASR::asr_t* create_Complex(const AST::FuncCallOrArray_t& x) {
         const Location &loc = x.base.base.loc;
         Vec<ASR::expr_t*> args;
@@ -8202,6 +8212,8 @@ public:
                         tmp = create_Associated(x);
                     } else if (var_name == "c_funloc") {
                         tmp = create_PointerToCptr(x);
+                    } else if (var_name == "compiler_options") {
+                        tmp = create_CompilerOptions(x);
                     } else {
                         LCOMPILERS_ASSERT(false)
                     }

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -179,6 +179,7 @@ expr
     | IntegerBitLen(expr a, ttype type, expr? value)
     | Ichar(expr arg, ttype type, expr? value)
     | Iachar(expr arg, ttype type, expr? value)
+    | CompilerOptions(ttype type, expr? value)
     | SizeOfType(ttype arg, ttype type, expr? value)
     | PointerNullConstant(ttype type)
     | PointerAssociated(expr ptr, expr? tgt, ttype type, expr? value)

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1407,7 +1407,6 @@ public:
         else if(intrinsic_func_name == "StringLenTrim") intrinsic_func_name = "len_trim";
         else if(intrinsic_func_name == "StringTrim") intrinsic_func_name = "trim";
         else if(intrinsic_func_name == "MoveAlloc") intrinsic_func_name = "move_alloc";
-        else if(intrinsic_func_name == "CompilerOptions") intrinsic_func_name = "compiler_options";
         else if(intrinsic_func_name == "CompilerVersion") intrinsic_func_name = "compiler_version";
         else if(intrinsic_func_name == "CommandArgumentCount") intrinsic_func_name = "command_argument_count";
         else if(intrinsic_func_name == "ErfcScaled") intrinsic_func_name = "erfc_scaled";

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1520,6 +1520,23 @@ public:
         }
     }
 
+    void visit_CompilerOptions(const ASR::CompilerOptions_t &x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+        std::string runtime_func_name = "_lfortran_compiler_options";
+        llvm::Function *fn = module->getFunction(runtime_func_name);
+        if (!fn) {
+            llvm::FunctionType *function_type = llvm::FunctionType::get(
+                llvm::Type::getInt8Ty(context)->getPointerTo(), // Return type: char*
+                {}, false);
+            fn = llvm::Function::Create(function_type,
+                    llvm::Function::ExternalLinkage, runtime_func_name, *module);
+        }
+        tmp = builder->CreateCall(fn, {});
+    }
+
     void visit_RealSqrt(const ASR::RealSqrt_t &x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -64,7 +64,6 @@ inline std::string get_intrinsic_name(int64_t x) {
         INTRINSIC_NAME_CASE(Isnan)
         INTRINSIC_NAME_CASE(Nearest)
         INTRINSIC_NAME_CASE(CompilerVersion)
-        INTRINSIC_NAME_CASE(CompilerOptions)
         INTRINSIC_NAME_CASE(CommandArgumentCount)
         INTRINSIC_NAME_CASE(Spacing)
         INTRINSIC_NAME_CASE(Modulo)
@@ -299,8 +298,6 @@ namespace IntrinsicElementalFunctionRegistry {
             {&Nearest::instantiate_Nearest, &Nearest::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerVersion),
             {nullptr, &CompilerVersion::verify_args}},
-        {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerOptions),
-            {nullptr, &CompilerOptions::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::CommandArgumentCount),
             {&CommandArgumentCount::instantiate_CommandArgumentCount, &CommandArgumentCount::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Spacing),
@@ -642,8 +639,6 @@ namespace IntrinsicElementalFunctionRegistry {
             "nearest"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerVersion),
             "compiler_version"},
-        {static_cast<int64_t>(IntrinsicElementalFunctions::CompilerOptions),
-            "compiler_options"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::CommandArgumentCount),
             "command_argument_count"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Spacing),
@@ -975,7 +970,6 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"isnan", {&Isnan::create_Isnan, &Isnan::eval_Isnan}},
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
                 {"compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
-                {"compiler_options", {&CompilerOptions::create_CompilerOptions, &CompilerOptions::eval_CompilerOptions}},
                 {"command_argument_count", {&CommandArgumentCount::create_CommandArgumentCount, nullptr}},
                 {"spacing", {&Spacing::create_Spacing, &Spacing::eval_Spacing}},
                 {"modulo", {&Modulo::create_Modulo, &Modulo::eval_Modulo}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -142,7 +142,6 @@ enum class IntrinsicElementalFunctions : int64_t {
     Range,
     Sign,
     CompilerVersion,
-    CompilerOptions,
     CommandArgumentCount,
     SignFromValue,
     Logical,
@@ -1195,33 +1194,6 @@ namespace CompilerVersion {
                 nullptr, 0, 0, return_type, m_value);
     }
 } // namespace CompilerVersion
-
-namespace CompilerOptions {
-
-    static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
-        ASRUtils::require_impl(x.n_args == 0,
-            "compiler_options() takes no argument",
-            x.base.base.loc, diagnostics);
-    }
-
-    static ASR::expr_t *eval_CompilerOptions(Allocator &al, const Location &loc,
-            ASR::ttype_t */*t1*/, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
-        ASRUtils::ASRBuilder b(al, loc);
-        return b.StringConstant(lcompilers_commandline_options, character(-1));
-    }
-
-    static inline ASR::asr_t* create_CompilerOptions(Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
-        ASR::ttype_t *return_type = character(-1);
-        ASR::expr_t *m_value = nullptr;
-        return_type = ASRUtils::extract_type(return_type);
-        m_value = eval_CompilerOptions(al, loc, return_type, args, diag);
-        if (diag.has_error()) {
-            return nullptr;
-        }
-        return ASR::make_IntrinsicElementalFunction_t(al, loc, static_cast<int64_t>(IntrinsicElementalFunctions::CompilerOptions),
-                nullptr, 0, 0, return_type, m_value);
-    }
-} // namespace CompilerOptions
 
 namespace CommandArgumentCount {
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -59,6 +59,7 @@ extern int dl_iterate_phdr (int (*__callback) (struct dl_phdr_info *,
 #define LCOMPILERS_MAX_STACKTRACE_LENGTH 200
 char *source_filename;
 char *binary_executable_path = "/proc/self/exe";
+char *lcompilers_commandline_options;
 
 struct Stacktrace {
     uintptr_t pc[LCOMPILERS_MAX_STACKTRACE_LENGTH];
@@ -3785,6 +3786,9 @@ LFORTRAN_API int32_t _lfortran_iachar(char *c) {
     return (int32_t) (uint8_t)(c[0]);
 }
 
+LFORTRAN_API char *_lfortran_compiler_options() {
+    return lcompilers_commandline_options;
+}
 // Command line arguments
 int32_t _argc;
 char **_argv;

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -267,6 +267,7 @@ LFORTRAN_API void _lpython_close(int64_t fd);
 LFORTRAN_API void _lfortran_close(int32_t unit_num, char* status);
 LFORTRAN_API int32_t _lfortran_ichar(char *c);
 LFORTRAN_API int32_t _lfortran_iachar(char *c);
+LFORTRAN_API char *_lfortran_compiler_options();
 LFORTRAN_API void _lpython_set_argv(int32_t argc_1, char *argv_1[]);
 LFORTRAN_API void _lpython_free_argv();
 LFORTRAN_API int32_t _lpython_get_argc();

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -20,4 +20,10 @@ integer, parameter :: logical_kinds(1) = [4]
 
 integer, parameter :: iostat_end = -1
 
+interface
+    function compiler_options() result(s)
+        character(len=1024) :: s
+    end function
+end interface
+
 end module

--- a/tests/reference/asr-submodule_02-9152b7b.json
+++ b/tests/reference/asr-submodule_02-9152b7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_02-9152b7b.stdout",
-    "stdout_hash": "07aedec02d49265e9d759dfd609ea9731e446b6ce9818898cc8a0ba0",
+    "stdout_hash": "ed883ea58fd7f4600f2ff572c31fb750dfb4a8ae66133aacbe076e1c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_02-9152b7b.stdout
+++ b/tests/reference/asr-submodule_02-9152b7b.stdout
@@ -7,16 +7,16 @@
             points:
                 (Module
                     (SymbolTable
-                        5
+                        6
                         {
                             point:
                                 (Struct
                                     (SymbolTable
-                                        6
+                                        7
                                         {
                                             x:
                                                 (Variable
-                                                    6
+                                                    7
                                                     x
                                                     []
                                                     Local
@@ -34,7 +34,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    6
+                                                    7
                                                     y
                                                     []
                                                     Local
@@ -66,11 +66,11 @@
                             point_dist_func:
                                 (Function
                                     (SymbolTable
-                                        7
+                                        8
                                         {
                                             a:
                                                 (Variable
-                                                    7
+                                                    8
                                                     a
                                                     []
                                                     In
@@ -78,7 +78,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -90,7 +90,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    7
+                                                    8
                                                     b
                                                     []
                                                     In
@@ -98,7 +98,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -110,7 +110,7 @@
                                                 ),
                                             distance:
                                                 (Variable
-                                                    7
+                                                    8
                                                     distance
                                                     []
                                                     ReturnVar
@@ -130,10 +130,10 @@
                                     point_dist_func
                                     (FunctionType
                                         [(StructType
-                                            5 point
+                                            6 point
                                         )
                                         (StructType
-                                            5 point
+                                            6 point
                                         )]
                                         (Real 4)
                                         Source
@@ -148,10 +148,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 7 a)
-                                    (Var 7 b)]
+                                    [(Var 8 a)
+                                    (Var 8 b)]
                                     []
-                                    (Var 7 distance)
+                                    (Var 8 distance)
                                     Public
                                     .false.
                                     .false.
@@ -160,11 +160,11 @@
                             point_dist_subrout:
                                 (Function
                                     (SymbolTable
-                                        8
+                                        9
                                         {
                                             a:
                                                 (Variable
-                                                    8
+                                                    9
                                                     a
                                                     []
                                                     In
@@ -172,7 +172,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -184,7 +184,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    8
+                                                    9
                                                     b
                                                     []
                                                     In
@@ -192,7 +192,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -204,7 +204,7 @@
                                                 ),
                                             distance:
                                                 (Variable
-                                                    8
+                                                    9
                                                     distance
                                                     []
                                                     Out
@@ -224,10 +224,10 @@
                                     point_dist_subrout
                                     (FunctionType
                                         [(StructType
-                                            5 point
+                                            6 point
                                         )
                                         (StructType
-                                            5 point
+                                            6 point
                                         )
                                         (Real 4)]
                                         ()
@@ -243,9 +243,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 8 a)
-                                    (Var 8 b)
-                                    (Var 8 distance)]
+                                    [(Var 9 a)
+                                    (Var 9 b)
+                                    (Var 9 distance)]
                                     []
                                     ()
                                     Public
@@ -255,7 +255,7 @@
                                 ),
                             rkind:
                                 (ExternalSymbol
-                                    5
+                                    6
                                     rkind
                                     4 real32
                                     lfortran_intrinsic_iso_fortran_env
@@ -272,13 +272,13 @@
             points_a:
                 (Module
                     (SymbolTable
-                        9
+                        10
                         {
                             point:
                                 (ExternalSymbol
-                                    9
+                                    10
                                     point
-                                    5 point
+                                    6 point
                                     points
                                     []
                                     point
@@ -287,13 +287,13 @@
                             point_dist_func:
                                 (Function
                                     (SymbolTable
-                                        10
+                                        11
                                         {
                                             1_point_x:
                                                 (ExternalSymbol
-                                                    10
+                                                    11
                                                     1_point_x
-                                                    6 x
+                                                    7 x
                                                     point
                                                     []
                                                     x
@@ -301,9 +301,9 @@
                                                 ),
                                             1_point_y:
                                                 (ExternalSymbol
-                                                    10
+                                                    11
                                                     1_point_y
-                                                    6 y
+                                                    7 y
                                                     point
                                                     []
                                                     y
@@ -311,7 +311,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    10
+                                                    11
                                                     a
                                                     []
                                                     In
@@ -319,7 +319,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        9 point
+                                                        10 point
                                                     )
                                                     ()
                                                     Source
@@ -331,7 +331,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    10
+                                                    11
                                                     b
                                                     []
                                                     In
@@ -339,7 +339,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        9 point
+                                                        10 point
                                                     )
                                                     ()
                                                     Source
@@ -351,7 +351,7 @@
                                                 ),
                                             distance:
                                                 (Variable
-                                                    10
+                                                    11
                                                     distance
                                                     []
                                                     ReturnVar
@@ -371,10 +371,10 @@
                                     point_dist_func
                                     (FunctionType
                                         [(StructType
-                                            9 point
+                                            10 point
                                         )
                                         (StructType
-                                            9 point
+                                            10 point
                                         )]
                                         (Real 4)
                                         Source
@@ -389,184 +389,8 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 10 a)
-                                    (Var 10 b)]
-                                    [(Assignment
-                                        (Var 10 distance)
-                                        (IntrinsicElementalFunction
-                                            Sqrt
-                                            [(RealBinOp
-                                                (RealBinOp
-                                                    (RealBinOp
-                                                        (StructInstanceMember
-                                                            (Var 10 a)
-                                                            10 1_point_x
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (StructInstanceMember
-                                                            (Var 10 b)
-                                                            10 1_point_x
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        (Real 4)
-                                                        ()
-                                                    )
-                                                    Pow
-                                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                                    (Real 4)
-                                                    ()
-                                                )
-                                                Add
-                                                (RealBinOp
-                                                    (RealBinOp
-                                                        (StructInstanceMember
-                                                            (Var 10 a)
-                                                            10 1_point_y
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (StructInstanceMember
-                                                            (Var 10 b)
-                                                            10 1_point_y
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        (Real 4)
-                                                        ()
-                                                    )
-                                                    Pow
-                                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                                    (Real 4)
-                                                    ()
-                                                )
-                                                (Real 4)
-                                                ()
-                                            )]
-                                            0
-                                            (Real 4)
-                                            ()
-                                        )
-                                        ()
-                                    )]
-                                    (Var 10 distance)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            point_dist_subrout:
-                                (Function
-                                    (SymbolTable
-                                        11
-                                        {
-                                            1_point_x:
-                                                (ExternalSymbol
-                                                    11
-                                                    1_point_x
-                                                    6 x
-                                                    point
-                                                    []
-                                                    x
-                                                    Public
-                                                ),
-                                            1_point_y:
-                                                (ExternalSymbol
-                                                    11
-                                                    1_point_y
-                                                    6 y
-                                                    point
-                                                    []
-                                                    y
-                                                    Public
-                                                ),
-                                            a:
-                                                (Variable
-                                                    11
-                                                    a
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (StructType
-                                                        9 point
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                ),
-                                            b:
-                                                (Variable
-                                                    11
-                                                    b
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (StructType
-                                                        9 point
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                ),
-                                            distance:
-                                                (Variable
-                                                    11
-                                                    distance
-                                                    []
-                                                    Out
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                )
-                                        })
-                                    point_dist_subrout
-                                    (FunctionType
-                                        [(StructType
-                                            9 point
-                                        )
-                                        (StructType
-                                            9 point
-                                        )
-                                        (Real 4)]
-                                        ()
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .true.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    []
                                     [(Var 11 a)
-                                    (Var 11 b)
-                                    (Var 11 distance)]
+                                    (Var 11 b)]
                                     [(Assignment
                                         (Var 11 distance)
                                         (IntrinsicElementalFunction
@@ -628,6 +452,182 @@
                                         )
                                         ()
                                     )]
+                                    (Var 11 distance)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            point_dist_subrout:
+                                (Function
+                                    (SymbolTable
+                                        12
+                                        {
+                                            1_point_x:
+                                                (ExternalSymbol
+                                                    12
+                                                    1_point_x
+                                                    7 x
+                                                    point
+                                                    []
+                                                    x
+                                                    Public
+                                                ),
+                                            1_point_y:
+                                                (ExternalSymbol
+                                                    12
+                                                    1_point_y
+                                                    7 y
+                                                    point
+                                                    []
+                                                    y
+                                                    Public
+                                                ),
+                                            a:
+                                                (Variable
+                                                    12
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (StructType
+                                                        10 point
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    12
+                                                    b
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (StructType
+                                                        10 point
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            distance:
+                                                (Variable
+                                                    12
+                                                    distance
+                                                    []
+                                                    Out
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    point_dist_subrout
+                                    (FunctionType
+                                        [(StructType
+                                            10 point
+                                        )
+                                        (StructType
+                                            10 point
+                                        )
+                                        (Real 4)]
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .true.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 12 a)
+                                    (Var 12 b)
+                                    (Var 12 distance)]
+                                    [(Assignment
+                                        (Var 12 distance)
+                                        (IntrinsicElementalFunction
+                                            Sqrt
+                                            [(RealBinOp
+                                                (RealBinOp
+                                                    (RealBinOp
+                                                        (StructInstanceMember
+                                                            (Var 12 a)
+                                                            12 1_point_x
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (StructInstanceMember
+                                                            (Var 12 b)
+                                                            12 1_point_x
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        (Real 4)
+                                                        ()
+                                                    )
+                                                    Pow
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (Real 4)
+                                                    ()
+                                                )
+                                                Add
+                                                (RealBinOp
+                                                    (RealBinOp
+                                                        (StructInstanceMember
+                                                            (Var 12 a)
+                                                            12 1_point_y
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (StructInstanceMember
+                                                            (Var 12 b)
+                                                            12 1_point_y
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        (Real 4)
+                                                        ()
+                                                    )
+                                                    Pow
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (Real 4)
+                                                    ()
+                                                )
+                                                (Real 4)
+                                                ()
+                                            )]
+                                            0
+                                            (Real 4)
+                                            ()
+                                        )
+                                        ()
+                                    )]
                                     ()
                                     Public
                                     .false.
@@ -636,7 +636,7 @@
                                 ),
                             rkind:
                                 (ExternalSymbol
-                                    9
+                                    10
                                     rkind
                                     4 real32
                                     lfortran_intrinsic_iso_fortran_env
@@ -684,7 +684,7 @@
             submodules_02:
                 (Program
                     (SymbolTable
-                        12
+                        13
                         {
                             
                         })

--- a/tests/reference/asr-use_02-fe85e54.json
+++ b/tests/reference/asr-use_02-fe85e54.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-use_02-fe85e54.stdout",
-    "stdout_hash": "de9c505b22fc8fa8c114b4019fc4b8360138c481ca03c1316b6556b0",
+    "stdout_hash": "ca6ae59c35de5948977adbebcb9b744940593f85ad777e30aca3a336",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-use_02-fe85e54.stdout
+++ b/tests/reference/asr-use_02-fe85e54.stdout
@@ -7,11 +7,11 @@
             use_02:
                 (Program
                     (SymbolTable
-                        5
+                        6
                         {
                             dp:
                                 (ExternalSymbol
-                                    5
+                                    6
                                     dp
                                     4 real64
                                     lfortran_intrinsic_iso_fortran_env
@@ -21,7 +21,7 @@
                                 ),
                             i:
                                 (Variable
-                                    5
+                                    6
                                     i
                                     []
                                     Local
@@ -41,13 +41,13 @@
                     use_02
                     [use_02_module]
                     [(Assignment
-                        (Var 5 i)
+                        (Var 6 i)
                         (IntegerConstant 1234567890123456789 (Integer 8) Decimal)
                         ()
                     )
                     (If
                         (IntegerCompare
-                            (Var 5 i)
+                            (Var 6 i)
                             NotEq
                             (IntegerConstant 1234567890123456789 (Integer 8) Decimal)
                             (Logical 4)


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/6553