### PR TITLE
CI: use branch for POT3D with much simplier git history

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -566,18 +566,21 @@ jobs:
             cd ..
             ./validate.sh
 
-            # this checkout has deallocate workaround
-            git checkout b7aa6cd25297d39c9481292d51035a431beac205
-            cd src
-            ${CC} -I$CONDA_PREFIX/include -c mpi_wrapper.c
-            ${FC} -c --fast mpi_c_bindings.f90
-            ${FC} -c --fast mpi.f90
-            ${FC} -c --fast psi_io.f90 --no-style-warnings --no-warnings
-            ${FC} -c --fast --skip-pass="dead_code_removal" --cpp --implicit-interface pot3d.F90 --no-style-warnings --no-warnings
-            ${FC} --fast mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
-            cp pot3d ../bin/
-            cd ..
-            ./validate.sh
+            if [[ "${{matrix.os}}" == "macos-latest" ]]; then
+              # this checkout has deallocate workaround
+              git checkout b7aa6cd25297d39c9481292d51035a431beac205
+              cd src
+              ${CC} -I$CONDA_PREFIX/include -c mpi_wrapper.c
+              ${FC} -c --fast mpi_c_bindings.f90
+              ${FC} -c --fast mpi.f90
+              ${FC} -c --fast psi_io.f90 --no-style-warnings --no-warnings
+              ${FC} -c --fast --skip-pass="dead_code_removal" --cpp --implicit-interface pot3d.F90 --no-style-warnings --no-warnings
+              ${FC} --fast mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
+              cp pot3d ../bin/
+              cd ..
+              ./validate.sh
+            fi
+
 
       - name: Test PRIMA
         shell: bash -e -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,8 +547,8 @@ jobs:
             # 2. namelist reading support replaced with use of file read (see: https://github.com/lfortran/lfortran/issues/1999)
             # 3. MPI support replaced with custom MPI wrappers (we've C MPI wrappers from https://github.com/gxyd/c_mpi)
             # 4. moved global procedures to module procedures (see: https://github.com/lfortran/lfortran/issues/6059)
-            git checkout -t origin/build_pot3d_custom_mpi_wrappers_and_without_hdf5
-            git checkout 57f34b62990d647108d837b41112b92c270ad204
+            git checkout -t origin/hdf5_mpi_namelist_global_workaround
+            git checkout bd1c773cf5f822ba0a7983797637ca70e521ffb8
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,8 +547,9 @@ jobs:
             # 2. namelist reading support replaced with use of file read (see: https://github.com/lfortran/lfortran/issues/1999)
             # 3. MPI support replaced with custom MPI wrappers (we've C MPI wrappers from https://github.com/gxyd/c_mpi)
             # 4. moved global procedures to module procedures (see: https://github.com/lfortran/lfortran/issues/6059)
-            git checkout -t origin/hdf5_mpi_namelist_global_workaround
-            git checkout bd1c773cf5f822ba0a7983797637ca70e521ffb8
+            git checkout -t origin/hdf5_mpi_namelist_global_deallocate_workaround
+            # this checkout doesn't have deallocate workaround
+            git checkout 68414dcf82e895af9a293b9c1338f679e416adfd
             cd src
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then
               CC=clang
@@ -561,6 +562,19 @@ jobs:
             ${FC} -c psi_io.f90 --no-style-warnings --no-warnings
             ${FC} -c --cpp --implicit-interface pot3d.F90 --no-style-warnings --no-warnings
             ${FC} mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
+            cp pot3d ../bin/
+            cd ..
+            ./validate.sh
+
+            # this checkout has deallocate workaround
+            git checkout b7aa6cd25297d39c9481292d51035a431beac205
+            cd src
+            ${CC} -I$CONDA_PREFIX/include -c mpi_wrapper.c
+            ${FC} -c --fast mpi_c_bindings.f90
+            ${FC} -c --fast mpi.f90
+            ${FC} -c --fast psi_io.f90 --no-style-warnings --no-warnings
+            ${FC} -c --fast --skip-pass="dead_code_removal" --cpp --implicit-interface pot3d.F90 --no-style-warnings --no-warnings
+            ${FC} --fast mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
             cp pot3d ../bin/
             cd ..
             ./validate.sh


### PR DESCRIPTION
## Description

this branch has only five extra commits on top of the *main* branch (link to the branch: https://github.com/gxyd/POT3D/tree/hdf5_mpi_namelist_global_workaround)

1. 0739fea85f58ce390dff94688b5cff766f1b826e: HDF5 read
2. 2850c7e609f9f47d53707909245d529980099f46: MPI wrappers
3. 05f66a70bf568cba26e46835e05d4d98ba3b60e9: Namelist workaround
4. a0f0d0e6c4fe4b2375b9a08dcdfe0bd905e422c9: global procedure
5. bd1c773cf5f822ba0a7983797637ca70e521ffb8: adds scripts for building with LFortran & GFortran