### PR TITLE
Make LFortran compile with LLVM 20

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -466,7 +466,7 @@ public:
                 }
                 llvm::Value* arr_first = nullptr;
                 if( !compiler_options.stack_arrays ) {
-                    llvm::DataLayout data_layout(module.get());
+                    llvm::DataLayout data_layout(module->getDataLayout());
                     uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
                     prod = builder->CreateMul(prod,
                         llvm::ConstantInt::get(context, llvm::APInt(32, size)));
@@ -1348,7 +1348,7 @@ public:
         if( ASR::is_a<ASR::String_t>(*list_type->m_type) ||
             LLVM::is_llvm_struct(list_type->m_type) ||
             ASR::is_a<ASR::Complex_t>(*list_type->m_type) ) {
-            llvm::DataLayout data_layout(module.get());
+            llvm::DataLayout data_layout(module->getDataLayout());
             type_size = data_layout.getTypeAllocSize(llvm_el_type);
         } else {
             type_size = ASRUtils::extract_kind_from_ttype_t(list_type->m_type);
@@ -1936,7 +1936,7 @@ public:
         if( ASR::is_a<ASR::String_t>(*el_type) ||
             LLVM::is_llvm_struct(el_type) ||
             ASR::is_a<ASR::Complex_t>(*el_type) ) {
-            llvm::DataLayout data_layout(module.get());
+            llvm::DataLayout data_layout(module->getDataLayout());
             type_size = data_layout.getTypeAllocSize(llvm_el_type);
         } else {
             type_size = ASRUtils::extract_kind_from_ttype_t(el_type);
@@ -2200,7 +2200,7 @@ public:
         if( ASR::is_a<ASR::String_t>(*list_type->m_type) ||
             LLVM::is_llvm_struct(list_type->m_type) ||
             ASR::is_a<ASR::Complex_t>(*list_type->m_type) ) {
-            llvm::DataLayout data_layout(module.get());
+            llvm::DataLayout data_layout(module->getDataLayout());
             type_size = data_layout.getTypeAllocSize(llvm_el_type);
         } else {
             type_size = ASRUtils::extract_kind_from_ttype_t(list_type->m_type);
@@ -2528,7 +2528,7 @@ public:
                 int64_t size = ASRUtils::get_fixed_size_of_array(asr_dims, asr_n_dims);
                 llvm::Type* llvm_data_type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::type_get_past_array(
                     ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(x_m_array_type))), module.get());
-                llvm::DataLayout data_layout(module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t data_size = data_layout.getTypeAllocSize(llvm_data_type);
                 llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
                 llvm_size = builder->CreateMul(llvm_size,
@@ -2674,7 +2674,7 @@ public:
     llvm::Value* SizeOfTypeUtil(ASR::ttype_t* m_type, llvm::Type* output_type,
         ASR::ttype_t* output_type_asr) {
         llvm::Type* llvm_type = llvm_utils->get_type_from_ttype_t_util(m_type, module.get());
-        llvm::DataLayout data_layout(module.get());
+        llvm::DataLayout data_layout(module->getDataLayout());
         int64_t type_size = data_layout.getTypeAllocSize(llvm_type);
         return llvm::ConstantInt::get(output_type, llvm::APInt(
             ASRUtils::extract_kind_from_ttype_t(output_type_asr) * 8, type_size));
@@ -3765,7 +3765,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 llvm::APInt(32, ASRUtils::get_fixed_size_of_array(ASR::down_cast<ASR::ArrayConstant_t>(v->m_value)->m_type)));
                 llvm::Type* llvm_data_type = llvm_utils->get_type_from_ttype_t_util(
                     ASRUtils::type_get_past_array(ASRUtils::expr_type(v->m_value)), module.get());
-                llvm::DataLayout data_layout(module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
                 size_t dt_size = data_layout.getTypeAllocSize(llvm_data_type);
                 arg_size = builder->CreateMul(llvm::ConstantInt::get(
                     llvm::Type::getInt32Ty(context), llvm::APInt(32, dt_size)), arg_size);
@@ -3897,7 +3897,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             }
             llvm::Value *ptr = nullptr;
             if( !compiler_options.stack_arrays && array_size ) {
-                llvm::DataLayout data_layout(module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t size = data_layout.getTypeAllocSize(type);
                 array_size = builder->CreateMul(array_size,
                     llvm::ConstantInt::get(context, llvm::APInt(32, size)));
@@ -5332,7 +5332,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                     llvm::Value* size = list_api->len(plist);
                     llvm::Type* el_type = llvm_utils->get_type_from_ttype_t_util(
                         ASRUtils::extract_type(ASRUtils::expr_type(x.m_value)), module.get());
-                    llvm::DataLayout data_layout(module.get());
+                    llvm::DataLayout data_layout(module->getDataLayout());
                     uint64_t size_ = data_layout.getTypeAllocSize(el_type);
                     size = builder->CreateMul(size, llvm::ConstantInt::get(
                         llvm::Type::getInt32Ty(context), llvm::APInt(32, size_)));
@@ -5429,7 +5429,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 ASR::dimension_t* asr_dims = nullptr;
                 size_t asr_n_dims = ASRUtils::extract_dimensions_from_ttype(target_type, asr_dims);
                 int64_t size = ASRUtils::get_fixed_size_of_array(asr_dims, asr_n_dims);
-                llvm::DataLayout data_layout(module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t data_size = data_layout.getTypeAllocSize(target_el_type);
                 llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
                 llvm_size = builder->CreateMul(llvm_size,
@@ -5441,7 +5441,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 ASR::dimension_t* asr_dims = nullptr;
                 size_t asr_n_dims = ASRUtils::extract_dimensions_from_ttype(target_type, asr_dims);
                 int64_t size = ASRUtils::get_fixed_size_of_array(asr_dims, asr_n_dims);
-                llvm::DataLayout data_layout(module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t data_size = data_layout.getTypeAllocSize(target_el_type);
                 llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
                 llvm_size = builder->CreateMul(llvm_size,
@@ -5454,7 +5454,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 llvm::Value* llvm_size = arr_descr->get_array_size(target, nullptr, 4);
                 target = llvm_utils->CreateLoad2(target_el_type->getPointerTo(), arr_descr->get_pointer_to_data(target));
                 value = llvm_utils->create_gep(value, 0);
-                llvm::DataLayout data_layout(module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t data_size = data_layout.getTypeAllocSize(value_el_type);
                 llvm_size = builder->CreateMul(llvm_size,
                     llvm::ConstantInt::get(context, llvm::APInt(32, data_size)));
@@ -5523,7 +5523,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                     ASR::dimension_t* asr_dims = nullptr;
                     size_t asr_n_dims = ASRUtils::extract_dimensions_from_ttype(target_type, asr_dims);
                     int64_t size = ASRUtils::get_fixed_size_of_array(asr_dims, asr_n_dims);
-                    llvm::DataLayout data_layout(module.get());
+                    llvm::DataLayout data_layout(module->getDataLayout());
                     uint64_t data_size = data_layout.getTypeAllocSize(target_el_type);
                     llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
                     llvm_size = builder->CreateMul(llvm_size,

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -301,7 +301,7 @@ namespace LCompilers {
             llvm::Value* arr_first = nullptr;
 
             if( !co.stack_arrays ) {
-                llvm::DataLayout data_layout(module);
+                llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
                 builder->CreateStore(builder->CreateMul(
                     llvm_utils->CreateLoad(llvm_size),
@@ -371,7 +371,7 @@ namespace LCompilers {
             }
             llvm::Value* ptr2firstptr = get_pointer_to_data(arr);
             llvm::AllocaInst *arg_size = llvm_utils->CreateAlloca(*builder, llvm::Type::getInt32Ty(context));
-            llvm::DataLayout data_layout(module);
+            llvm::DataLayout data_layout(module->getDataLayout());
             llvm::Type* ptr_type = llvm_data_type->getPointerTo();
             uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
@@ -766,7 +766,7 @@ namespace LCompilers {
             builder->CreateStore(arr_first, first_ptr);
 
             llvm::Value* ptr2firstptr = this->get_pointer_to_data(array);
-            llvm::DataLayout data_layout(module);
+            llvm::DataLayout data_layout(module->getDataLayout());
             uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);
@@ -838,7 +838,7 @@ namespace LCompilers {
             }
 
             llvm::Value* ptr2firstptr = this->get_pointer_to_data(src);
-            llvm::DataLayout data_layout(module);
+            llvm::DataLayout data_layout(module->getDataLayout());
             uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);
@@ -885,7 +885,7 @@ namespace LCompilers {
 
         void SimpleCMODescriptor::copy_array_data_only(llvm::Value* src, llvm::Value* dest,
             llvm::Module* module, llvm::Type* llvm_data_type, llvm::Value* num_elements) {
-            llvm::DataLayout data_layout(module);
+            llvm::DataLayout data_layout(module->getDataLayout());
             uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
             num_elements = builder->CreateMul(num_elements, llvm_size);

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -281,7 +281,7 @@ namespace LCompilers {
             union_type_llvm = name2dertype[union_type_name];
         } else {
             const std::map<std::string, ASR::symbol_t*>& scope = union_type->m_symtab->get_scope();
-            llvm::DataLayout data_layout(module);
+            llvm::DataLayout data_layout(module->getDataLayout());
             llvm::Type* max_sized_type = nullptr;
             size_t max_type_size = 0;
             for( auto itr = scope.begin(); itr != scope.end(); itr++ ) {
@@ -504,7 +504,7 @@ namespace LCompilers {
         if( LLVM::is_llvm_struct(asr_type) ||
             ASR::is_a<ASR::String_t>(*asr_type) ||
             ASR::is_a<ASR::Complex_t>(*asr_type) ) {
-            llvm::DataLayout data_layout(module);
+            llvm::DataLayout data_layout(module->getDataLayout());
             return data_layout.getTypeAllocSize(llvm_type);
         }
         return a_kind;
@@ -780,7 +780,7 @@ namespace LCompilers {
                 if( LLVM::is_llvm_struct(asr_list->m_type) ||
                     ASR::is_a<ASR::String_t>(*asr_list->m_type) ||
                     ASR::is_a<ASR::Complex_t>(*asr_list->m_type) ) {
-                    llvm::DataLayout data_layout(module);
+                    llvm::DataLayout data_layout(module->getDataLayout());
                     type_size = data_layout.getTypeAllocSize(el_llvm_type);
                 } else {
                     type_size = a_kind;
@@ -1046,7 +1046,7 @@ namespace LCompilers {
                     if( LLVM::is_llvm_struct(asr_list->m_type) ||
                         ASR::is_a<ASR::String_t>(*asr_list->m_type) ||
                         ASR::is_a<ASR::Complex_t>(*asr_list->m_type) ) {
-                        llvm::DataLayout data_layout(module);
+                        llvm::DataLayout data_layout(module->getDataLayout());
                         type_size = data_layout.getTypeAllocSize(el_llvm_type);
                     } else {
                         type_size = a_kind;
@@ -1244,7 +1244,7 @@ namespace LCompilers {
                     if( LLVM::is_llvm_struct(asr_list->m_type) ||
                         ASR::is_a<ASR::String_t>(*asr_list->m_type) ||
                         ASR::is_a<ASR::Complex_t>(*asr_list->m_type) ) {
-                        llvm::DataLayout data_layout(module);
+                        llvm::DataLayout data_layout(module->getDataLayout());
                         type_size = data_layout.getTypeAllocSize(el_llvm_type);
                     } else {
                         type_size = a_kind;
@@ -1467,7 +1467,7 @@ namespace LCompilers {
                 if( LLVM::is_llvm_struct(asr_list->m_type) ||
                     ASR::is_a<ASR::String_t>(*asr_list->m_type) ||
                     ASR::is_a<ASR::Complex_t>(*asr_list->m_type) ) {
-                    llvm::DataLayout data_layout(module);
+                    llvm::DataLayout data_layout(module->getDataLayout());
                     type_size = data_layout.getTypeAllocSize(el_llvm_type);
                 } else {
                     type_size = a_kind;
@@ -2106,7 +2106,7 @@ namespace LCompilers {
                             int64_t size = ASRUtils::get_fixed_size_of_array(asr_dims, asr_n_dims);
                             llvm::Type* llvm_data_type = get_type_from_ttype_t_util(ASRUtils::type_get_past_array(
                                 ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(asr_type))), module);
-                            llvm::DataLayout data_layout(module);
+                            llvm::DataLayout data_layout(module->getDataLayout());
                             uint64_t data_size = data_layout.getTypeAllocSize(llvm_data_type);
                             llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
                             llvm_size = builder->CreateMul(llvm_size,
@@ -2442,7 +2442,7 @@ namespace LCompilers {
                                         initial_capacity, initial_capacity);
         llvm_utils->list_api->list_init(value_type_code, value_list, *module,
                                         initial_capacity, initial_capacity);
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_capacity = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, initial_capacity));
@@ -2472,7 +2472,7 @@ namespace LCompilers {
         llvm::Value* num_buckets_filled_ptr = get_pointer_to_number_of_filled_buckets(dict);
         LLVM::CreateStore(*builder, llvm_zero, num_buckets_filled_ptr);
 
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         llvm::Type* key_value_pair_type = get_key_value_pair_type(key_type_code, value_type_code);
         size_t key_value_type_size = data_layout.getTypeAllocSize(key_value_pair_type);
         llvm::Value* llvm_key_value_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), llvm::APInt(32, key_value_type_size));
@@ -2603,7 +2603,7 @@ namespace LCompilers {
 
         llvm::Value* src_key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(src));
         llvm::Value* dest_key_mask_ptr = get_pointer_to_keymask(dest);
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));
@@ -2766,7 +2766,7 @@ namespace LCompilers {
         LLVM::CreateStore(*builder, src_filled_buckets, get_pointer_to_number_of_filled_buckets(dest));
         LLVM::CreateStore(*builder, src_capacity, get_pointer_to_capacity(dest));
         LLVM::CreateStore(*builder, src_rehash_flag, get_pointer_to_rehash_flag(dest));
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));
@@ -3332,7 +3332,7 @@ namespace LCompilers {
             llvm_utils->create_if_else(builder->CreateICmpNE(
                     llvm_utils->CreateLoad(chain_itr_prev),
                     llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
-                llvm::DataLayout data_layout(module);
+                llvm::DataLayout data_layout(module->getDataLayout());
                 size_t kv_struct_size = data_layout.getTypeAllocSize(kv_struct_type);
                 llvm::Value* malloc_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), kv_struct_size);
                 llvm::Value* new_kv_struct_i8 = LLVM::lfortran_malloc(context, *module, *builder, malloc_size);
@@ -3920,7 +3920,7 @@ namespace LCompilers {
         llvm_utils->list_api->list_init(value_type_code, new_value_list, *module, capacity, capacity);
 
         llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));
@@ -5673,7 +5673,7 @@ namespace LCompilers {
         llvm::Value* el_list = get_el_list(set);
         llvm_utils->list_api->list_init(type_code, el_list, *module,
                                         initial_capacity, initial_capacity);
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_capacity = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, initial_capacity));
@@ -5706,7 +5706,7 @@ namespace LCompilers {
         llvm::Value* num_buckets_filled_ptr = get_pointer_to_number_of_filled_buckets(set);
         LLVM::CreateStore(*builder, llvm_zero, num_buckets_filled_ptr);
 
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         llvm::Type* el_type = typecode2elstruct[el_type_code];
         size_t el_type_size = data_layout.getTypeAllocSize(el_type);
         llvm::Value* llvm_el_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), llvm::APInt(32, el_type_size));
@@ -6150,7 +6150,7 @@ namespace LCompilers {
             llvm_utils->create_if_else(builder->CreateICmpNE(
                     llvm_utils->CreateLoad(chain_itr_prev),
                     llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
-                llvm::DataLayout data_layout(module);
+                llvm::DataLayout data_layout(module->getDataLayout());
                 size_t el_struct_size = data_layout.getTypeAllocSize(el_struct_type);
                 llvm::Value* malloc_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), el_struct_size);
                 llvm::Value* new_el_struct_i8 = LLVM::lfortran_malloc(context, *module, *builder, malloc_size);
@@ -6248,7 +6248,7 @@ namespace LCompilers {
         llvm_utils->list_api->list_init(el_type_code, new_el_list, *module, capacity, capacity);
 
         llvm::Value* el_mask = llvm_utils->CreateLoad(get_pointer_to_mask(set));
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));
@@ -6820,7 +6820,7 @@ namespace LCompilers {
 
         llvm::Value* src_el_mask = llvm_utils->CreateLoad(get_pointer_to_mask(src));
         llvm::Value* dest_el_mask_ptr = get_pointer_to_mask(dest);
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));
@@ -6845,7 +6845,7 @@ namespace LCompilers {
         LLVM::CreateStore(*builder, src_filled_buckets, get_pointer_to_number_of_filled_buckets(dest));
         LLVM::CreateStore(*builder, src_capacity, get_pointer_to_capacity(dest));
         LLVM::CreateStore(*builder, src_rehash_flag, get_pointer_to_rehash_flag(dest));
-        llvm::DataLayout data_layout(module);
+        llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));


### PR DESCRIPTION
There are some failures in some integration tests, but at least everything compiles and links with LLVM 20. Many things work, so we just need to iron out the remaining bugs.

Towards #6570.