### PR TITLE
fix: support character type as mold in bitcast

### DIFF
--- a/integration_tests/transfer_01.f90
+++ b/integration_tests/transfer_01.f90
@@ -2,6 +2,7 @@ program transfer_01
     implicit none
     integer :: i, integer_result, y(3, 2)
     real :: r, result, x(5, 4)
+    character(len=*), parameter :: chr = 'A'
     r = 2.987654
     i = 123456
     x = 3.19
@@ -22,4 +23,9 @@ program transfer_01
     result = transfer(y(1,1), x(5,2))
     print *, result
     if (abs(result - 5.60519386E-45) > 1e-6) error stop
+
+    print *, transfer(65, chr)
+    if (transfer(65, chr) /= 'A') error stop
+    print *, transfer(90, 'A')
+    if (transfer(90, 'A') /= 'Z') error stop
 end program transfer_01

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7605,8 +7605,12 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
         llvm::Value* source_ptr = llvm_utils->CreateAlloca(source_type, nullptr, "bitcast_source");
         builder->CreateStore(source, source_ptr);
         llvm::Type* target_base_type = llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get());
-        llvm::Type* target_llvm_type = target_base_type->getPointerTo();
-        tmp = llvm_utils->CreateLoad2(target_base_type, builder->CreateBitCast(source_ptr, target_llvm_type));
+        if (ASR::is_a<ASR::String_t>(*x.m_type)) {
+            tmp = builder->CreateBitCast(source_ptr, target_base_type);
+        } else {
+            llvm::Type* target_llvm_type = target_base_type->getPointerTo();
+            tmp = llvm_utils->CreateLoad2(target_base_type, builder->CreateBitCast(source_ptr, target_llvm_type));
+        }
     }
 
     void visit_Cast(const ASR::Cast_t &x) {


### PR DESCRIPTION
Towards #6596 