### PR TITLE
fix: handle compile time output for transfer (BitCast) intrinsic and IntegerCompare

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1060,6 +1060,7 @@ RUN(NAME intrinsics_364 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_365 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # is_contiguous
 RUN(NAME intrinsics_366 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # shiftl, shiftr, trailz, btest, ibclr
 RUN(NAME intrinsics_367 LABELS gfortran llvm) # get_environment_variable
+RUN(NAME intrinsics_368 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # kind
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_368.f90
+++ b/integration_tests/intrinsics_368.f90
@@ -1,9 +1,9 @@
-module test_mod
+module intrinsics_368_test_mod
     implicit none
     logical, parameter :: param=ichar(transfer(1,'a')) == 0
-end module test_mod
+end module intrinsics_368_test_mod
 program intrinsics_368
-    use test_mod
+    use intrinsics_368_test_mod
     implicit none
     integer(kind=transfer(4_1, 0)) :: x1
     integer(kind=kind(0)) :: x2

--- a/integration_tests/intrinsics_368.f90
+++ b/integration_tests/intrinsics_368.f90
@@ -1,0 +1,20 @@
+module test_mod
+    implicit none
+    logical, parameter :: param=ichar(transfer(1,'a')) == 0
+end module test_mod
+program intrinsics_368
+    use test_mod
+    implicit none
+    integer(kind=transfer(4_1, 0)) :: x1
+    integer(kind=kind(0)) :: x2
+    integer(kind=(4+0)) :: x3
+    integer :: i
+    integer(kind=sum([(i, i=0,3)])-2) :: x4
+    integer(kind=INT(61*BESSEL_JN(4, 2.5))) :: x5
+    integer,parameter::dp=kind(1d0),nextp=selected_real_kind(precision(1d0)+1)
+    integer,parameter::ep = merge(nextp,dp,nextp>0)
+    print *,'pi=acos(-1.0_dp)=', acos(-1.0_dp)
+    if (abs(acos(-1.0_dp) - 3.1415926535897931) > 1e-7) error stop
+    print *,'pi=acos(-1.0_ep)=',acos(-1.0_ep)
+    if (abs(acos(-1.0_ep) - 3.1415926535897931) > 1e-7) error stop
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3102,6 +3102,20 @@ inline int extract_kind(ASR::expr_t* kind_expr, const Location& loc, diag::Diagn
             }
             break;
         }
+        case ASR::exprType::BitCast: {
+            ASR::BitCast_t* kind_bc = ASR::down_cast<ASR::BitCast_t>(kind_expr);
+            if (kind_bc->m_value) {
+                return ASR::down_cast<ASR::IntegerConstant_t>(kind_bc->m_value)->m_n;
+            } else {
+                diag.add(diag::Diagnostic(
+                    "Only Integer literals or expressions which "
+                    "reduce to constant Integer are accepted as kind parameters",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {loc})}));
+                throw SemanticAbort();
+            }
+            break;
+        }
         // allow integer binary operator kinds (e.g. '1 + 7')
         case ASR::exprType::IntegerBinOp:
         // allow integer kinds (e.g. 4, 8 etc.)


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/1484
fixes: https://github.com/lfortran/lfortran/issues/6596