### PR TITLE
enh: add time take by each pass and LLVM IR creation with `--time-report`

### DIFF
--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -84,7 +84,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--show-fortran", opts.show_fortran, "Show Fortran translation source for the given file and exit");
         app.add_flag("--show-stacktrace", compiler_options.show_stacktrace, "Show internal stacktrace on compiler errors");
         app.add_flag("--symtab-only", compiler_options.symtab_only, "Only create symbol tables in ASR (skip executable stmt)");
-        app.add_flag("--time-report", opts.time_report, "Show compilation time report");
+        app.add_flag("--time-report", compiler_options.time_report, "Show compilation time report");
         app.add_flag("--static", opts.static_link, "Create a static executable");
         app.add_flag("--shared", opts.shared_link, "Create a shared executable");
         app.add_flag("--logical-casting", compiler_options.logical_casting, "Allow logical casting");

--- a/src/bin/lfortran_command_line_parser.h
+++ b/src/bin/lfortran_command_line_parser.h
@@ -49,7 +49,6 @@ namespace LCompilers::CommandLineInterface {
         bool show_wat = false;
         bool show_julia = false;
         bool show_fortran = false;
-        bool time_report = false;
         bool static_link = false;
         bool shared_link = false;
         std::string skip_pass;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10805,9 +10805,10 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     auto t2 = std::chrono::high_resolution_clock::now();
 
     if (co.time_report) {
-        int millisecond = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-        int microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() % 1000;
-        std::cout << "ASR -> ASR passes: " << std::setw(5) << millisecond << "." << microseconds << " ms" << std::endl;
+        int asr_to_asr_passes_time_in_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+        int asr_to_asr_passes_time_in_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() % 1000;
+        std::string time_report_asr_to_asr_passes = "ASR -> ASR passes: " + std::to_string(asr_to_asr_passes_time_in_milliseconds) + "." + std::to_string(asr_to_asr_passes_time_in_microseconds) + " ms";
+        co.po.vector_of_time_report.push_back(time_report_asr_to_asr_passes);
     }
 
     // Uncomment for debugging the ASR after the transformation
@@ -10844,9 +10845,10 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     t2 = std::chrono::high_resolution_clock::now();
 
     if (co.time_report) {
-        int millisecond = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-        int microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() % 1000;
-        std::cout << "LLVM IR creation: " << std::setw(5) << millisecond << "." << microseconds << " ms" << std::endl;
+        int time_take_for_llvm_ir_creation_in_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+        int time_take_for_llvm_ir_creation_in_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() % 1000;
+        std::string message = "LLVM IR creation: " + std::to_string(time_take_for_llvm_ir_creation_in_milliseconds) + "." + std::to_string(time_take_for_llvm_ir_creation_in_microseconds) + " ms";
+        co.po.vector_of_time_report.push_back(message);
     }
 
     return res;

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -184,7 +184,9 @@ namespace LCompilers {
                 if (pass_options.verbose) {
                     std::cerr << "ASR Pass starts: '" << passes[i] << "'\n";
                 }
+                auto t1 = std::chrono::high_resolution_clock::now();
                 _passes_db[passes[i]](al, *asr, pass_options);
+                auto t2 = std::chrono::high_resolution_clock::now();
 #if defined(WITH_LFORTRAN_ASSERT)
                 if (!asr_verify(*asr, true, diagnostics)) {
                     std::cerr << diagnostics.render2();
@@ -192,6 +194,13 @@ namespace LCompilers {
                         + passes[i]);
                 };
 #endif
+                if (pass_options.time_report) {
+                    int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+                    int microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+                    // get milliseconds.microseconds
+                    microseconds = microseconds % 1000;
+                    std::cout << passes[i] << ": " << milliseconds << "." << microseconds << " ms\n";
+                }
                 if (pass_options.verbose) {
                     std::cerr << "ASR Pass ends: '" << passes[i] << "'\n";
                 }
@@ -293,6 +302,9 @@ namespace LCompilers {
         void apply_passes(Allocator& al, ASR::TranslationUnit_t* asr,
                           PassOptions& pass_options,
                           diag::Diagnostics &diagnostics) {
+            if ( pass_options.time_report ) {
+                std::cout<<"Time taken by ASR passes"<<std::endl;
+            }
             if( !_user_defined_passes.empty() ) {
                 apply_passes(al, asr, _user_defined_passes, pass_options,
                     diagnostics);

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -195,11 +195,10 @@ namespace LCompilers {
                 };
 #endif
                 if (pass_options.time_report) {
-                    int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-                    int microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-                    // get milliseconds.microseconds
-                    microseconds = microseconds % 1000;
-                    std::cout << passes[i] << ": " << milliseconds << "." << microseconds << " ms\n";
+                    int time_take_by_current_pass_in_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+                    int time_take_by_current_pass_in_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() % 1000;
+                    std::string message = passes[i] + ": " + std::to_string(time_take_by_current_pass_in_milliseconds) + "." + std::to_string(time_take_by_current_pass_in_microseconds) + " ms";
+                    pass_options.vector_of_time_report.push_back(message);
                 }
                 if (pass_options.verbose) {
                     std::cerr << "ASR Pass ends: '" << passes[i] << "'\n";
@@ -302,9 +301,6 @@ namespace LCompilers {
         void apply_passes(Allocator& al, ASR::TranslationUnit_t* asr,
                           PassOptions& pass_options,
                           diag::Diagnostics &diagnostics) {
-            if ( pass_options.time_report ) {
-                std::cout<<"Time taken by ASR passes"<<std::endl;
-            }
             if( !_user_defined_passes.empty() ) {
                 apply_passes(al, asr, _user_defined_passes, pass_options,
                     diagnostics);

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -61,6 +61,7 @@ struct PassOptions {
     bool openmp = false;
     bool enable_gpu_offloading = false;
     bool time_report = false;
+    std::vector<std::string> vector_of_time_report;
 };
 
 struct CompilerOptions {

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -60,6 +60,7 @@ struct PassOptions {
     bool c_mangling = false;
     bool openmp = false;
     bool enable_gpu_offloading = false;
+    bool time_report = false;
 };
 
 struct CompilerOptions {
@@ -116,6 +117,7 @@ struct CompilerOptions {
     bool ignore_pragma = false;
     bool stack_arrays = false;
     bool wasm_html = false;
+    bool time_report = false;
     std::string emcc_embed;
     std::vector<std::string> import_paths;
     Platform platform;


### PR DESCRIPTION
Towards #6609.

```console
% lfortran examples/expr2.f90 --time-report
25
Time report:
Allocator usage of last chunk (MB): 0.004280
Allocator chunks: 1
File reading: 0 ms
Src -> ASR:  1 ms
Time taken by pass: 
global_stmts: 0.1 ms
init_expr: 0.22 ms
function_call_in_declaration: 0.8 ms
openmp: 0.1 ms
implied_do_loops: 0.19 ms
array_struct_temporary: 0.63 ms
nested_vars: 0.25 ms
transform_optional_argument_functions: 0.27 ms
forall: 0.5 ms
class_constructor: 0.13 ms
pass_list_expr: 0.10 ms
where: 0.7 ms
subroutine_from_function: 0.20 ms
array_op: 0.17 ms
symbolic: 0.7 ms
intrinsic_function: 0.22 ms
intrinsic_subroutine: 0.7 ms
array_op: 0.2 ms
pass_array_by_data: 0.30 ms
array_passed_in_function_call: 0.10 ms
print_struct_type: 0.5 ms
print_arr: 0.13 ms
print_list_tuple: 0.6 ms
print_struct_type: 0.1 ms
array_dim_intrinsics_update: 0.11 ms
do_loops: 0.9 ms
while_else: 0.12 ms
select_case: 0.5 ms
unused_functions: 0.16 ms
unique_symbols: 0.1 ms
insert_deallocate: 0.9 ms
ASR -> ASR passes: 0.582 ms
LLVM IR creation: 0.121 ms
ASR -> mod:  0 ms
LLVM opt:    0 ms
LLVM -> BIN: 1 ms
Total:       2 ms
Linking time:  41 ms
Total time: 48.205 ms

```