### PR TITLE
CI: remove another workaround from use in POT3D repository

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -548,7 +548,7 @@ jobs:
             # 3. MPI support replaced with custom MPI wrappers (we've C MPI wrappers from https://github.com/gxyd/c_mpi)
             # 4. moved global procedures to module procedures (see: https://github.com/lfortran/lfortran/issues/6059)
             git checkout -t origin/hdf5_mpi_namelist_global_deallocate_workaround_3
-            git checkout 219453c81aae490510c2297f0575acb9c50d8868
+            git checkout 40a5b0f2b6ae57cca9436a4a1da59d2fb9d85c56
             FC="$(pwd)/../src/bin/lfortran" ./build_and_run.sh
 
             if [[ "${{matrix.os}}" == "macos-latest" ]]; then


### PR DESCRIPTION
## Description

After the PR: https://github.com/lfortran/lfortran/pull/6618 is done, we are now removing the last workaround that we can remove from it

Once it passes, I'll create a new branch from `hdf5_mpi_namelist_global_deallocate_workaround_3` and have just 5 workarounds i.e.:

* one commit for MPI
* one commit for HDF5
* one commit for global procedures
* one commit for adding a build script
* one commit for namelist workaround