### PR TITLE
enh: readability of time report by incorporating changes suggested

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -136,7 +136,7 @@ void print_time_report(std::vector<std::string>& vector_of_time_report) {
         bool is_pass = false;
         if (component_name.find("[PASS]") == 0) {
             component_name = "\t" + component_name.substr(6); // Remove '[PASS]' and indent
-            setw_val = 6;
+            setw_val = 4;
             is_pass = true;
         }
 

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -197,7 +197,7 @@ namespace LCompilers {
                 if (pass_options.time_report) {
                     int time_take_by_current_pass_in_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
                     int time_take_by_current_pass_in_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() % 1000;
-                    std::string message = passes[i] + ": " + std::to_string(time_take_by_current_pass_in_milliseconds) + "." + std::to_string(time_take_by_current_pass_in_microseconds) + " ms";
+                    std::string message = "[PASS]" + passes[i] + ": " + std::to_string(time_take_by_current_pass_in_milliseconds) + "." + std::to_string(time_take_by_current_pass_in_microseconds) + " ms";
                     pass_options.vector_of_time_report.push_back(message);
                 }
                 if (pass_options.verbose) {


### PR DESCRIPTION
Towards #6609


```shell
% lfortran examples/expr2.f90 --time-report         
25
Component name                                     Time (ms)
------------------------------------------------------------
Allocator usage of last chunk (MB)                  0.004280
Allocator chunks                                           1
File reading                                               0
Src -> ASR                                                13
Time taken by pass
	global_stmts                                     0.127
	init_expr                                        2.1
	function_call_in_declaration                     0.343
	openmp                                           0.1
	implied_do_loops                                 0.981
	array_struct_temporary                           2.124
	nested_vars                                      0.918
	transform_optional_argument_functions            1.106
	forall                                           0.348
	class_constructor                                0.653
	pass_list_expr                                   0.615
	where                                            0.480
	subroutine_from_function                         0.861
	array_op                                         0.817
	symbolic                                         0.500
	intrinsic_function                               0.885
	intrinsic_subroutine                             0.269
	array_op                                         0.3
	pass_array_by_data                               1.566
	array_passed_in_function_call                    0.568
	print_struct_type                                0.157
	print_arr                                        1.204
	print_list_tuple                                 0.69
	print_struct_type                                0.1
	array_dim_intrinsics_update                      0.581
	do_loops                                         0.140
	while_else                                       0.474
	select_case                                      0.68
	unused_functions                                 0.592
	unique_symbols                                   0.1
	insert_deallocate                                0.573
ASR -> ASR passes                                     19.250
LLVM IR creation                                       7.799
ASR -> mod                                                 0
LLVM opt                                                   0
LLVM -> BIN                                               29
Linking time                                             167
------------------------------------------------------------
Total time                                           251.497
------------------------------------------------------------
```

![image](https://github.com/user-attachments/assets/534a5142-e04f-4c75-9359-1dfa91e031b3)
