### PR TITLE
Add an ICE (Internal compiler error) message

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2097,15 +2097,18 @@ public:
         } else {
             Vec<ASR::expr_t*> body;
             body.reserve(al, a->n_value);
-            size_t size_of_array;
+            int size_of_array = 0;
             if (ASR::is_a<ASR::ArraySection_t>(*object)) {
                 size_of_array = ASRUtils::get_fixed_size_of_ArraySection(ASR::down_cast<ASR::ArraySection_t>(object));
                 object = ASR::down_cast<ASR::ArraySection_t>(object)->m_v;
             } else {
                 size_of_array = ASRUtils::get_fixed_size_of_array(array_type->m_dims, array_type->n_dims);
             }
+            if (size_of_array == -1) {
+                throw LCompilersException("ICE: Array size could not be computed");
+            }
             curr_value += size_of_array;
-            for (size_t j=0; j < size_of_array; j++) {
+            for (int j=0; j < size_of_array; j++) {
                 this->visit_expr(*a->m_value[j]);
                 ASR::expr_t* value = ASRUtils::EXPR(tmp);
                 if (!ASRUtils::types_equal(ASRUtils::expr_type(value), array_type->m_type)) {


### PR DESCRIPTION
`get_fixed_size_of_array()` and `get_fixed_size_of_ArraySection()` both return value of `-1` when they are unable to compute the size of the array. We should hence use an integer value to store the returned value (in order to be able to represent the `-1`). Otherwise, if we use `size_t` we end up with an array size of some large positive number. This later leads to accessing of incorrect/non-existent array value (we loop beyond the length of the array).

Note that the changes in this PR don't fix some issue. But rather they help avoid hitting above mentioned issues.  I don't think adding a test case is necessary for this, because
- the changes seem trivial
- figuring out a test case that hits this issue could be tricky. I stepped across this while debugging another issue.