### PR TITLE
fix: ignore case for `c_null_ptr` in Frontend

### DIFF
--- a/integration_tests/c_ptr_02.f90
+++ b/integration_tests/c_ptr_02.f90
@@ -3,8 +3,17 @@ program test_c_ptr_02
    implicit none
    complex, target :: c_arr(2)
    real, pointer :: r_ptr(:)
+
+   type :: test_obj
+      type(c_ptr) :: ptr = c_NULL_ptr
+   end type test_obj
+   type(test_obj) :: instance
+   type(c_ptr) :: temp_ptr
+   temp_ptr = instance%ptr
+
    c_arr = (1, 2)
    call c_f_pointer(c_loc(c_arr), r_ptr, shape=[4])
    print *, c_arr
    print *, r_ptr
+   if (c_associated(temp_ptr) .neqv. .false.) error stop
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3617,6 +3617,7 @@ public:
                         }
                     } else if (AST::is_a<AST::Name_t>(*s.m_initializer)) {
                         std::string sym_name = AST::down_cast<AST::Name_t>(s.m_initializer)->m_id;
+                        sym_name = to_lower(sym_name);
                         if (sym_name == "c_null_ptr") {
                             ASR::symbol_t *sym_found = current_scope->resolve_symbol(sym_name);
                             if (sym_found == nullptr) {

--- a/tests/reference/asr-c_ptr_02-fce1b0e.json
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.json
@@ -2,11 +2,11 @@
     "basename": "asr-c_ptr_02-fce1b0e",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/c_ptr_02.f90",
-    "infile_hash": "806976bac654e7004e6f1fb025b769b0f94f3398d6997c1a7ab61ed2",
+    "infile_hash": "b2f28a737ab24c02c4aa0fe0d88023004fbd708e506952f4c61b3211",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-c_ptr_02-fce1b0e.stdout",
-    "stdout_hash": "41f0924a9837ec8de7024fb86b9edc47b42a0b0e606d90232b15ff15",
+    "stdout_hash": "7fef7de3d8b4d000fba78db55315c7bd90e91fa4c84814fc4237050a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-c_ptr_02-fce1b0e.stdout
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.stdout
@@ -9,6 +9,16 @@
                     (SymbolTable
                         2
                         {
+                            1_test_obj_ptr:
+                                (ExternalSymbol
+                                    2
+                                    1_test_obj_ptr
+                                    11 ptr
+                                    test_obj
+                                    []
+                                    ptr
+                                    Public
+                                ),
                             c_arr:
                                 (Variable
                                     2
@@ -282,6 +292,26 @@
                                     c_size_t
                                     Public
                                 ),
+                            instance:
+                                (Variable
+                                    2
+                                    instance
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (StructType
+                                        2 test_obj
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                ),
                             r_ptr:
                                 (Variable
                                     2
@@ -306,11 +336,78 @@
                                     .false.
                                     .false.
                                     .false.
+                                ),
+                            temp_ptr:
+                                (Variable
+                                    2
+                                    temp_ptr
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (CPtr)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                ),
+                            test_obj:
+                                (Struct
+                                    (SymbolTable
+                                        11
+                                        {
+                                            ptr:
+                                                (Variable
+                                                    11
+                                                    ptr
+                                                    []
+                                                    Local
+                                                    (PointerNullConstant
+                                                        (CPtr)
+                                                    )
+                                                    (PointerNullConstant
+                                                        (CPtr)
+                                                    )
+                                                    Default
+                                                    (CPtr)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    test_obj
+                                    []
+                                    [ptr]
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
                                 )
                         })
                     test_c_ptr_02
                     [iso_c_binding]
                     [(Assignment
+                        (Var 2 temp_ptr)
+                        (StructInstanceMember
+                            (Var 2 instance)
+                            2 1_test_obj_ptr
+                            (CPtr)
+                            ()
+                        )
+                        ()
+                    )
+                    (Assignment
                         (Var 2 c_arr)
                         (ArrayBroadcast
                             (ComplexConstructor
@@ -392,6 +489,27 @@
                             (String -1 0 () PointerString)
                             ()
                         )
+                    )
+                    (If
+                        (LogicalBinOp
+                            (PointerAssociated
+                                (Var 2 temp_ptr)
+                                ()
+                                (Logical 4)
+                                ()
+                            )
+                            NEqv
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
                     )]
                 )
         })


### PR DESCRIPTION
Fixes #6650 