### PR TITLE
fix : use implicit_dictionary to declare implicit variable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1264,7 +1264,7 @@ RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_03 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_04 LABELS gfortran llvmImplicit EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_typing_05 LABELS gfortran llvm  EXTRA_ARGS --implicit-typing)
-RUN(NAME implicit_typing_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME implicit_typing_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --implicit-typing)
 
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1264,7 +1264,7 @@ RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_03 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_04 LABELS gfortran llvmImplicit EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_typing_05 LABELS gfortran llvm  EXTRA_ARGS --implicit-typing)
-
+RUN(NAME implicit_typing_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_typing_06.f90
+++ b/integration_tests/implicit_typing_06.f90
@@ -1,0 +1,12 @@
+module mod_implicit_typing_06
+   implicit none
+   private
+   public a
+   integer, parameter :: a = 1
+end module mod_implicit_typing_06
+
+program implicit_typing_06 
+    use mod_implicit_typing_06
+    print *, a
+    if (a /= 1) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3055,12 +3055,9 @@ public:
                                 ASR::symbol_t* sym_ = current_scope->resolve_symbol(sym);
                                 if (!sym_ && compiler_options.implicit_typing && sa->m_attr != AST::simple_attributeType
                                                         ::AttrExternal) {
-                                    ASR::expr_t* value = nullptr;
-                                    if (sa->m_attr == AST::simple_attributeType::AttrParameter) {
-                                        this->visit_expr(*s.m_initializer);
-                                        value = ASRUtils::EXPR(tmp);
+                                    if ( implicit_dictionary[std::string(1, sym[0])] != nullptr ) {
+                                        sym_ = declare_implicit_variable2(x.m_syms[i].loc, sym, ASR::intentType::Local, implicit_dictionary[std::string(1, sym[0])]);
                                     }
-                                    sym_ = declare_implicit_variable(x.m_syms[i].loc, sym, ASR::intentType::Local, value);
                                 }
                             }
                         }


### PR DESCRIPTION
fix #6017 

MRE :- 
```.f90
module mod_implicit_typing_06
   implicit none
   private
   public a
   integer, parameter :: a = 1
end module mod_implicit_typing_06

program implicit_typing_06 
    use mod_implicit_typing_06
    print *, a
end program
```

LFortran Output :- 
```console
(lf) lordansh@LordAnsh:~/dev/lfort4/lfortran$ lfortran try.f90 --std=f23
 1
```

Generated ASR for a :- 
```.f90
a:
  (Variable
      2
      a
      []
      Local
      (IntegerConstant 1 (Integer 4) Decimal)
      (IntegerConstant 1 (Integer 4) Decimal)
      Parameter
      (Integer 4)
      ()
      Source
      Public
      Required
      .false.
      .false.
      .false.
  )

```