### PR TITLE
Implicitly allocate with StructConstructor 2

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1375,6 +1375,7 @@ RUN(NAME derived_types_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_45.f90
+++ b/integration_tests/derived_types_45.f90
@@ -1,0 +1,16 @@
+module derived_types_45_mod
+    implicit none
+    type myint
+        integer :: m
+    end type
+ end module derived_types_45_mod
+
+program derived_types_45
+    use derived_types_45_mod
+
+    implicit none
+    type(myint), allocatable :: ins
+    ins = myint(44)
+
+    if (ins%m /= 44) error stop
+end program derived_types_45

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3024,6 +3024,23 @@ public:
                 }));
             throw SemanticAbort();
         }
+        else if (compiler_options.po.realloc_lhs &&
+                 ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(target)) &&
+                 ASR::is_a<ASR::StructConstructor_t>(*value)) {
+            // Implicitly allocate the Struct by pushing an Allocate_t to the body
+            Vec<ASR::alloc_arg_t> alloc_args; alloc_args.reserve(al, 1);
+            ASR::alloc_arg_t alloc_arg;
+            alloc_arg.loc = x.base.base.loc;
+            alloc_arg.m_a = target;
+            alloc_arg.m_dims = nullptr;
+            alloc_arg.n_dims = 0;
+            alloc_arg.m_type = nullptr;
+            alloc_arg.m_len_expr = nullptr;
+            alloc_args.push_back(al, alloc_arg);
+            current_body->push_back( al,
+                ASRUtils::STMT(
+                    ASR::make_Allocate_t(al, x.base.base.loc, alloc_args.p, 1, nullptr, nullptr, nullptr)));
+        }
 
         check_ArrayAssignmentCompatibility(target, value, x);
 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3436,9 +3436,6 @@ public:
                                 // Do nothing for now
                             } else if (sa->m_attr == AST::AttrContiguous){
                                 contig_attr = true;
-                            }else if (sa->m_attr == AST::simple_attributeType
-                                    ::AttrAllocatable) {
-                                // TODO
                             } else if (sa->m_attr == AST::simple_attributeType
                                     ::AttrValue) {
                                 value_attr = true;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5633,6 +5633,9 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             llvm_utils->dict_api->write_item(pdict, key, value, module.get(),
                                 dict_type->m_key_type,
                                 dict_type->m_value_type, name2memidx);
+        } else if (ASR::is_a<ASR::Allocatable_t>(*target_type) && ASR::is_a<ASR::StructType_t>(*value_type)) {
+            target = llvm_utils->CreateLoad(target);
+            builder->CreateStore(value, target);
         } else {
             builder->CreateStore(value, target);
         }
@@ -9632,7 +9635,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 ASR::ttype_t* s_m_args0_type = ASRUtils::type_get_past_pointer(
                                                 ASRUtils::expr_type(s->m_args[0]));
                 // derived type declared type
-                ASR::ttype_t* dt_type = ASRUtils::type_get_past_pointer(caller->m_type);
+                ASR::ttype_t* dt_type = ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(caller->m_type));
                 dt = convert_to_polymorphic_arg(dt, s_m_args0_type, dt_type);
                 args.push_back(dt);
             } else if (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_dt)) {

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -31,7 +31,8 @@ class InsertDeallocate: public ASR::CallReplacerOnExpressionsVisitor<InsertDeall
             if( ASR::is_a<ASR::Variable_t>(*s) && 
                 ASR::is_a<ASR::Allocatable_t>(*ASRUtils::symbol_type(s)) && 
                 (ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_allocatable(ASRUtils::symbol_type(s))) ||
-                ASRUtils::is_array(ASRUtils::symbol_type(s))) &&
+                ASRUtils::is_array(ASRUtils::symbol_type(s)) ||
+                ASRUtils::is_struct(*ASRUtils::symbol_type(s))) &&
                 ASRUtils::symbol_intent(s) == ASRUtils::intent_local){
                 return true;
             }


### PR DESCRIPTION
Previous reverted PR: #6683 

Fix #1726 

Added a commit to keep track of allocated symbols in body visitor. So we only allocate if not already allocated.