### PR TITLE
Bug Solved : Handling Cases when less arguments are passed in a subroutine than required

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -2,6 +2,11 @@
 ! number of lines below the module to keep the rest of the lines in this file
 ! intact.
 module continue_compilation_1_mod
+    type :: MyClass
+        integer :: value
+    contains
+        procedure :: display
+    end type MyClass
 
 contains
 
@@ -10,18 +15,13 @@ contains
         print *, "hi"
     end subroutine
 
+    subroutine display(self, extra_arg)
+        class(MyClass), intent(in) :: self
+        integer, intent(in) :: extra_arg
+        print *, "Value in object:", self%value
+    end subroutine display
+
 end module
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -290,4 +290,13 @@ program continue_compilation_1
     print *, ieor()
 
     exit
+
+    ! calling function with less arguments
+    call my_func(10)
+    call my_func()
+    ! checking for self argument too 
+    type(MyClass) :: obj
+    obj%value = 42
+    call obj%display()
+
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "1c704f6554659accdaa5949942966b72f64c5834fa2761bdea71e9e2",
+    "infile_hash": "9d3d1851d371e20253b01e58c0f8dbca8cf2e7649ad6786928c6059c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "432298e68dff7ba7cd2504fd7f63599b211181a43123cefc3bc0efe5",
+    "stderr_hash": "7dcc6ecacbc6234f22f4eab3dcfa26f0230ccd92acdf8c5a2f6e4522",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -619,3 +619,24 @@ semantic error: `exit` statements cannot be outside of loops or blocks
     |
 292 |     exit
     |     ^^^^ 
+
+semantic error: Required argument `y` at position 2 is missing in function call
+   --> tests/errors/continue_compilation_1.f90:295:10
+    |
+295 |     call my_func(10)
+    |                  ^^
+
+semantic error: Required argument `x` is missing in function call
+   --> tests/errors/continue_compilation_1.f90:296:5
+    |
+296 |     call my_func()
+    |     ^^^^^^^^^^^^^^
+
+semantic error: Required argument `extra_arg` is missing in function call
+   --> tests/errors/continue_compilation_1.f90:300:5
+    |
+300 |     call my_func()
+    |     ^^^^^^^^^^^^^^
+
+
+


### PR DESCRIPTION
I code is now available to properly throw error for the code given in the issue #6635 