### PR TITLE
CI: Add build test for lapack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -847,6 +847,20 @@ jobs:
             cmake --build . -v
             ./project3
 
+      - name: Test Lapack
+        shell: bash -e -l {0}
+        run: |
+            export PATH="$(pwd)/src/bin:$PATH"
+            git clone https://github.com/Shaikh-Ubaid/lapack.git
+            cd lapack
+            git fetch origin lf_05
+            git checkout lf_05
+            git checkout eb551db50eb1bdce9fb8a8f51c7d1fd19a1697bf
+            cd build
+            micromamba create -f environment_unix.yml
+            micromamba activate lapack
+            ./build_lf.sh
+
 
 # Commented out to save CI runners:
 #  test-pixi:


### PR DESCRIPTION
For now, we only test the single precision BLAS codes. We compile these generating object files.

I am hoping to send another PR with selectively enabling other LAPACK/BLAS codes that we might be able to compile till the ASR level.