### PR TITLE
fix: ensure array dimensions are compile-time constants

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1728,31 +1728,37 @@ public:
             left, end_bin_op->m_op, right, end_bin_op->m_type, end_bin_op->m_value));
     }
 
-    bool dimension_attribute_error_check(ASR::expr_t* dim_expr) {
-        if (ASR::is_a<ASR::Var_t>(*dim_expr)) {
-            ASR::Var_t* dim_expr_var = ASR::down_cast<ASR::Var_t>(dim_expr);
-            ASR::symbol_t* dim_expr_sym = dim_expr_var->m_v;
-            SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(dim_expr_sym);
-            if (ASR::is_a<ASR::Variable_t>(*dim_expr_sym)) {
-                ASR::Variable_t* dim_expr_variable = ASR::down_cast<ASR::Variable_t>(dim_expr_sym);
+	bool var_dimension_error_check(ASR::Var_t* dim_expr_var) {
+        ASR::symbol_t* dim_expr_sym = dim_expr_var->m_v;
+        SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(dim_expr_sym);
 
-                if (dim_expr_variable->m_type->type != ASR::ttypeType::Integer) {
+        if (ASR::is_a<ASR::Variable_t>(*dim_expr_sym)) {
+            ASR::Variable_t* dim_expr_variable = ASR::down_cast<ASR::Variable_t>(dim_expr_sym);
+
+            if (dim_expr_variable->m_type->type != ASR::ttypeType::Integer) {
+                return true;
+            } else {
+                if ((dim_expr_variable->m_storage != ASR::storage_typeType::Parameter) && !(in_Subroutine) && (symbol_scope->counter == current_scope->counter)) {
                     return true;
-                } else {
-
-                    if ((dim_expr_variable->m_storage != ASR::storage_typeType::Parameter) && !(in_Subroutine) && (symbol_scope->counter == current_scope->counter)) {
-                        return true;
-                    }
                 }
             }
-        } else {
+		}
 
-            ASR::ttype_t* dim_expr_type = ASRUtils::expr_type(dim_expr);
+		return false;
+	}
 
-            if (dim_expr_type->type != ASR::ttypeType::Integer) {
-                return true;
-            }
+    bool dimension_attribute_error_check(ASR::expr_t* dim_expr) {
+        ASR::ttype_t* dim_expr_type = ASRUtils::expr_type(dim_expr);
+
+		// If any expression doesn't evaluate to integer, return true
+        if (dim_expr_type->type != ASR::ttypeType::Integer) {
+            return true;
         }
+
+		if (ASR::is_a<ASR::Var_t>(*dim_expr)) {
+			ASR::Var_t* dim_expr_var = ASR::down_cast<ASR::Var_t>(dim_expr);
+			return var_dimension_error_check(dim_expr_var);
+		}
 
         return false;
     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1766,13 +1766,33 @@ public:
 		return false;
 	}
 
+	bool array_physical_dimension_error_check(ASR::expr_t* dim_expr) {
+		ASR::ArrayPhysicalCast_t* dim_expr_arr = ASR::down_cast<ASR::ArrayPhysicalCast_t>(dim_expr);
+
+		return eval_expr(dim_expr_arr->m_arg);
+	}
+	
+	bool array_constructor_dimension_error_check(ASR::expr_t* dim_expr) {
+		ASR::ArrayConstructor_t* dim_expr_arr = ASR::down_cast<ASR::ArrayConstructor_t>(dim_expr);
+
+		for (size_t i = 0; i < dim_expr_arr->n_args; i++) {
+			if (eval_expr(dim_expr_arr->m_args[i]))
+				return true;
+		}
+
+		return false;
+	}
+
 	bool eval_expr(ASR::expr_t* dim_expr) {
 		switch (dim_expr->type) {
 			case ASR::exprType::Var: return var_dimension_error_check(dim_expr);
 			case ASR::exprType::IntrinsicArrayFunction: return intrinsic_arr_dimension_error_check(dim_expr);
 			case ASR::exprType::IntrinsicElementalFunction: return intrinsic_ele_dimension_error_check(dim_expr);
+			case ASR::exprType::ArrayConstructor: return array_constructor_dimension_error_check(dim_expr);
+			case ASR::exprType::ArrayPhysicalCast: return array_physical_dimension_error_check(dim_expr);
+			case ASR::exprType::ArrayConstant: return false;
 			case ASR::exprType::IntegerConstant: return false;
-			default: return false;
+			default: return true;
 		}
 	}
 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1744,9 +1744,34 @@ public:
 		return false;
 	}
 
+	bool intrinsic_arr_dimension_error_check(ASR::expr_t* dim_expr) {
+		ASR::IntrinsicArrayFunction_t* dim_expr_intrinsic = ASR::down_cast<ASR::IntrinsicArrayFunction_t>(dim_expr);
+		
+		for (size_t i = 0; i < dim_expr_intrinsic->n_args; i++) {
+			if (eval_expr(dim_expr_intrinsic->m_args[i]))
+				return true;
+		}
+
+		return false;
+	}
+	
+	bool intrinsic_ele_dimension_error_check(ASR::expr_t* dim_expr) {
+		ASR::IntrinsicElementalFunction_t* dim_expr_intrinsic = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(dim_expr);
+		
+		for (size_t i = 0; i < dim_expr_intrinsic->n_args; i++) {
+			if (eval_expr(dim_expr_intrinsic->m_args[i]))
+				return true;
+		}
+
+		return false;
+	}
+
 	bool eval_expr(ASR::expr_t* dim_expr) {
 		switch (dim_expr->type) {
 			case ASR::exprType::Var: return var_dimension_error_check(dim_expr);
+			case ASR::exprType::IntrinsicArrayFunction: return intrinsic_arr_dimension_error_check(dim_expr);
+			case ASR::exprType::IntrinsicElementalFunction: return intrinsic_ele_dimension_error_check(dim_expr);
+			case ASR::exprType::IntegerConstant: return false;
 			default: return false;
 		}
 	}

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1783,6 +1783,12 @@ public:
 		return false;
 	}
 
+	bool int_unary_minus_dimension_error_check(ASR::expr_t* dim_expr) {
+		ASR::IntegerUnaryMinus_t* dim_expr_int = ASR::down_cast<ASR::IntegerUnaryMinus_t>(dim_expr);
+
+		return eval_expr(dim_expr_int->m_arg);
+	}
+
 	bool eval_expr(ASR::expr_t* dim_expr) {
 		switch (dim_expr->type) {
 			case ASR::exprType::Var: return var_dimension_error_check(dim_expr);
@@ -1790,6 +1796,7 @@ public:
 			case ASR::exprType::IntrinsicElementalFunction: return intrinsic_ele_dimension_error_check(dim_expr);
 			case ASR::exprType::ArrayConstructor: return array_constructor_dimension_error_check(dim_expr);
 			case ASR::exprType::ArrayPhysicalCast: return array_physical_dimension_error_check(dim_expr);
+			case ASR::exprType::IntegerUnaryMinus: return int_unary_minus_dimension_error_check(dim_expr);
 			case ASR::exprType::ArrayConstant: return false;
 			case ASR::exprType::IntegerConstant: return false;
 			default: return true;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1753,6 +1753,10 @@ public:
 		return false;
 	}
 
+	bool binary_operation_dimension_error_check(ASR::IntegerBinOp_t* dim_expr_node) {
+		return eval_expr(dim_expr_node->m_left) || eval_expr(dim_expr_node->m_right);
+	}
+
 	bool eval_expr(ASR::expr_t* dim_expr) {
 		switch (dim_expr->type) {
 			case ASR::exprType::Var:
@@ -1767,6 +1771,8 @@ public:
 				return eval_expr(ASR::down_cast<ASR::ArrayPhysicalCast_t>(dim_expr)->m_arg);
 			case ASR::exprType::IntegerUnaryMinus:
 				return eval_expr(ASR::down_cast<ASR::IntegerUnaryMinus_t>(dim_expr)->m_arg);
+			case ASR::exprType::IntegerBinOp:
+				return binary_operation_dimension_error_check(ASR::down_cast<ASR::IntegerBinOp_t>(dim_expr));
 			case ASR::exprType::ArrayConstant:
 			case ASR::exprType::IntegerConstant:
 				return false;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1728,23 +1728,27 @@ public:
             left, end_bin_op->m_op, right, end_bin_op->m_type, end_bin_op->m_value));
     }
 
-	bool var_dimension_error_check(ASR::Var_t* dim_expr_var) {
+	bool var_dimension_error_check(ASR::expr_t* dim_expr) {
+		ASR::Var_t* dim_expr_var = ASR::down_cast<ASR::Var_t>(dim_expr);
         ASR::symbol_t* dim_expr_sym = dim_expr_var->m_v;
         SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(dim_expr_sym);
 
         if (ASR::is_a<ASR::Variable_t>(*dim_expr_sym)) {
             ASR::Variable_t* dim_expr_variable = ASR::down_cast<ASR::Variable_t>(dim_expr_sym);
 
-            if (dim_expr_variable->m_type->type != ASR::ttypeType::Integer) {
+            if ((dim_expr_variable->m_storage != ASR::storage_typeType::Parameter) && !(in_Subroutine) && (symbol_scope->counter == current_scope->counter)) {
                 return true;
-            } else {
-                if ((dim_expr_variable->m_storage != ASR::storage_typeType::Parameter) && !(in_Subroutine) && (symbol_scope->counter == current_scope->counter)) {
-                    return true;
-                }
             }
 		}
 
 		return false;
+	}
+
+	bool eval_expr(ASR::expr_t* dim_expr) {
+		switch (dim_expr->type) {
+			case ASR::exprType::Var: return var_dimension_error_check(dim_expr);
+			default: return false;
+		}
 	}
 
     bool dimension_attribute_error_check(ASR::expr_t* dim_expr) {
@@ -1755,12 +1759,7 @@ public:
             return true;
         }
 
-		if (ASR::is_a<ASR::Var_t>(*dim_expr)) {
-			ASR::Var_t* dim_expr_var = ASR::down_cast<ASR::Var_t>(dim_expr);
-			return var_dimension_error_check(dim_expr_var);
-		}
-
-        return false;
+		return eval_expr(dim_expr);
     }
 
 


### PR DESCRIPTION
This is a fix for the issue #6179, but there is only one issue, which is that I am not handling when functions are used as an array dimensions, e.g:
```fortran
module my_math
  implicit none
contains

  integer function my_abs(x) result(res)
    implicit none
    integer, intent(in) :: x
    if (x < 0) then
      res = -x
    else
      res = x
    end if
  end function my_abs

end module my_math

program main
  use my_math
  implicit none

  integer :: arr(my_abs(-5))  ! Using my_abs to determine array size

  print *, "Array size: ", size(arr)

end program main
```
The above code would run normally, while it should give an error, and the reason is that when I don't allow functions to be used, the following `ctest` doesn't pass:
```
(lf)  ✘ akramhany@akramhany  ~/Akram/Projects/Fortran/lfortran   ArraysShapeNotConst ±  ctest --rerun-failed --output-on-failure        
Test project /home/akramhany/Akram/Projects/Fortran/lfortran
    Start 3: test_lfortran
1/1 Test #3: test_lfortran ....................***Failed    0.34 sec
<string>:5:9: error: expected instruction opcode
    %1 =x alloca i64
        ^
<string>:5:9: error: expected instruction opcode
    %1 =x alloca i64
        ^
<string>:5:25: error: use of undefined value '@count'
    %1 = load i64, i64* @count
                        ^
[doctest] doctest version is "2.4.8"
[doctest] run with "--help" for options
0    0    0    0    0    0    0    0    0    0
5    5    5
src/lfortran/tests/ir.ll: error: Could not open input file: No such file or directory
src/lfortran/tests/ir.ll: error: Could not open input file: No such file or directory
===============================================================================
/home/akramhany/Akram/Projects/Fortran/lfortran/src/lfortran/tests/test_llvm.cpp:1229:
TEST CASE:  FortranEvaluator asr verify 2

/home/akramhany/Akram/Projects/Fortran/lfortran/src/lfortran/tests/test_llvm.cpp:1256: ERROR: CHECK( r.ok ) is NOT correct!
  values: CHECK( false )

/home/akramhany/Akram/Projects/Fortran/lfortran/src/lfortran/tests/test_llvm.cpp:1265: ERROR: CHECK( r.ok ) is NOT correct!
  values: CHECK( false )

/home/akramhany/Akram/Projects/Fortran/lfortran/src/lfortran/tests/test_llvm.cpp:1270: ERROR: CHECK( r.result.i32 == 1 ) is NOT correct!
  values: CHECK( 0 == 1 )

/home/akramhany/Akram/Projects/Fortran/lfortran/src/lfortran/tests/test_llvm.cpp:1274: ERROR: CHECK( r.result.i32 == 1 ) is NOT correct!
  values: CHECK( 0 == 1 )

/home/akramhany/Akram/Projects/Fortran/lfortran/src/lfortran/tests/test_llvm.cpp:1278: ERROR: CHECK( r.result.i32 == 1 ) is NOT correct!
  values: CHECK( 0 == 1 )

===============================================================================
[doctest] test cases:  95 |  94 passed | 1 failed | 0 skipped
[doctest] assertions: 673 | 668 passed | 5 failed |
[doctest] Status: FAILURE!


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.34 sec

The following tests FAILED:
	  3 - test_lfortran (Failed)
Errors while running CTest
```

The above error is coming from the following test, which is expected to pass (I don't understand why):
```cpp
TEST_CASE("FortranEvaluator asr verify 2") {
    CompilerOptions cu;
    cu.interactive = true;
    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
    FortranEvaluator e(cu);
    LCompilers::Result<FortranEvaluator::EvalResult>
    r = e.evaluate2(R"(
pure function id(x) result(r)
    integer, intent(in) :: x
    integer :: r
    r = x
end function id
)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
    r = e.evaluate2(R"(
subroutine sa(l, a)
    integer, intent(in) :: l
    integer, intent(inout) :: a(id(l))
    
    integer :: i
    
    do i = 1, size(a)
        a(i) = a(i) + 1
    end do
end subroutine sa
)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
    r = e.evaluate2("integer :: arr(3)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
    r = e.evaluate2("arr = 0");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
    r = e.evaluate2("call sa(3, arr)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::statement);
    r = e.evaluate2("arr(1)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
    CHECK(r.result.i32 == 1);
    r = e.evaluate2("arr(2)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
    CHECK(r.result.i32 == 1);
    r = e.evaluate2("arr(3)");
    CHECK(r.ok);
    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
    CHECK(r.result.i32 == 1);
}
```