### PR TITLE
fix: don't create temporary for args of compile time intrinsic function

### DIFF
--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -177,8 +177,10 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al,
     bool is_size_only_dependent_on_arguments = ASRUtils::is_dimension_dependent_only_on_arguments(
         value_m_dims, value_n_dims);
     bool is_allocatable = ASRUtils::is_allocatable(value_type);
+    bool is_compile_time = ASRUtils::is_value_constant(ASRUtils::expr_value(value));
     ASR::ttype_t* var_type = nullptr;
-    if( (is_fixed_sized_array || is_size_only_dependent_on_arguments || is_allocatable) &&
+    if( (is_fixed_sized_array || is_size_only_dependent_on_arguments || 
+            is_allocatable || is_compile_time) &&
         !is_pointer_required ) {
         var_type = value_type;
     } else {
@@ -196,10 +198,10 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al,
     }
 
     std::string var_name = scope->get_unique_name("__libasr_created_" + name_hint);
-    if (ASR::is_a<ASR::ArrayConstant_t>(*value)) {
+    if (is_compile_time) {
         ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
             al, value->base.loc, scope, s2c(al, var_name), nullptr, 0, ASR::intentType::Local,
-            value, value, ASR::storage_typeType::Parameter, var_type, nullptr, ASR::abiType::Source,
+            ASRUtils::expr_value(value), ASRUtils::expr_value(value), ASR::storage_typeType::Parameter, var_type, nullptr, ASR::abiType::Source,
             ASR::accessType::Public, ASR::presenceType::Required, false));
         scope->add_symbol(var_name, temporary_variable);
         return ASRUtils::EXPR(ASR::make_Var_t(al, temporary_variable->base.loc, temporary_variable));
@@ -838,7 +840,7 @@ ASR::expr_t* create_and_allocate_temporary_variable_for_array(
     }
     ASR::expr_t* array_var_temporary = create_temporary_variable_for_array(
         al, allocate_size_reference, current_scope, name_hint, is_pointer_required);
-    if (ASR::is_a<ASR::ArrayConstant_t>(*allocate_size_reference)) {
+    if (ASRUtils::is_value_constant(ASRUtils::expr_value(allocate_size_reference))) {
         return array_var_temporary;
     }
     if( ASRUtils::is_pointer(ASRUtils::expr_type(array_var_temporary)) ) {
@@ -1440,14 +1442,18 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
     }
 
     void visit_IntrinsicElementalFunction(const ASR::IntrinsicElementalFunction_t& x) {
-        visit_IntrinsicCall(x, "_intrinsic_elemental_function_" +
-            ASRUtils::get_intrinsic_name(x.m_intrinsic_id));
-        ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>::visit_IntrinsicElementalFunction(x);
+        if (!ASRUtils::is_value_constant(x.m_value)) {   // Only simplify runtime function's args
+            visit_IntrinsicCall(x, "_intrinsic_elemental_function_" +
+                ASRUtils::get_intrinsic_name(x.m_intrinsic_id));
+            ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>::visit_IntrinsicElementalFunction(x);
+        }
     }
 
     void visit_IntrinsicArrayFunction(const ASR::IntrinsicArrayFunction_t& x) {
-        visit_IntrinsicCall(x, "_intrinsic_array_function_" +
-            ASRUtils::get_array_intrinsic_name(x.m_arr_intrinsic_id));
+        if (!ASRUtils::is_value_constant(x.m_value)) {   // Only simplify runtime function's args
+            visit_IntrinsicCall(x, "_intrinsic_array_function_" +
+                ASRUtils::get_array_intrinsic_name(x.m_arr_intrinsic_id));
+        }
         ASR::IntrinsicArrayFunction_t& xx = const_cast<ASR::IntrinsicArrayFunction_t&>(x);
         if( ASRUtils::IntrinsicArrayFunctionRegistry::get_dim_index(
                 static_cast<ASRUtils::IntrinsicArrayFunctions>(x.m_arr_intrinsic_id)) == 1 &&
@@ -2431,11 +2437,15 @@ class VerifySimplifierASROutput:
     }
 
     void visit_IntrinsicElementalFunction(const ASR::IntrinsicElementalFunction_t& x) {
-        visit_IntrinsicCall(x);
+        if (!ASRUtils::is_value_constant(x.m_value)) {   // Only verify args for runtime functions
+            visit_IntrinsicCall(x);
+        }
     }
 
     void visit_IntrinsicArrayFunction(const ASR::IntrinsicArrayFunction_t& x) {
-        visit_IntrinsicCall(x);
+        if (!ASRUtils::is_value_constant(x.m_value)) {   // Only verify args for runtime functions
+            visit_IntrinsicCall(x);
+        }
         check_if_linked_to_target(x.base, x.m_type);
     }
 

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -179,8 +179,7 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al,
     bool is_allocatable = ASRUtils::is_allocatable(value_type);
     bool is_compile_time = ASRUtils::is_value_constant(ASRUtils::expr_value(value));
     ASR::ttype_t* var_type = nullptr;
-    if( (is_fixed_sized_array || is_size_only_dependent_on_arguments || 
-            is_allocatable || is_compile_time) &&
+    if( (is_fixed_sized_array || is_size_only_dependent_on_arguments || is_allocatable) &&
         !is_pointer_required ) {
         var_type = value_type;
     } else {
@@ -201,7 +200,8 @@ ASR::expr_t* create_temporary_variable_for_array(Allocator& al,
     if (is_compile_time) {
         ASR::symbol_t* temporary_variable = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
             al, value->base.loc, scope, s2c(al, var_name), nullptr, 0, ASR::intentType::Local,
-            ASRUtils::expr_value(value), ASRUtils::expr_value(value), ASR::storage_typeType::Parameter, var_type, nullptr, ASR::abiType::Source,
+            ASRUtils::expr_value(value), ASRUtils::expr_value(value), ASR::storage_typeType::Parameter, 
+            ASRUtils::expr_type(ASRUtils::expr_value(value)), nullptr, ASR::abiType::Source,
             ASR::accessType::Public, ASR::presenceType::Required, false));
         scope->add_symbol(var_name, temporary_variable);
         return ASRUtils::EXPR(ASR::make_Var_t(al, temporary_variable->base.loc, temporary_variable));

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -4885,6 +4885,7 @@ namespace Pack {
         ASR::expr_t *value = nullptr;
         if (all_args_evaluated(m_args)) {
             value = eval_Pack(al, loc, ret_type, arg_values, diag);
+            ret_type = ASRUtils::expr_type(value);
         }
         return make_IntrinsicArrayFunction_t_util(al, loc,
             static_cast<int64_t>(IntrinsicArrayFunctions::Pack),


### PR DESCRIPTION
Towards #2524. It gives a huge boost for `fortran-primes` compilation as there are large arrays.

For Program: 
```fortran
 module prime_constants
    integer, parameter :: min_factor(4) = 1
end module

program test
    use prime_constants
    print *, pack(min_factor,min_factor>=1)
end program
```

**ASR Afer all passes:**

Without this PR:
```fortran
! Fortran code after applying the pass: insert_deallocate
module prime_constants
implicit none
integer(4), dimension(4), parameter :: min_factor = [1, 1, 1, 1]
end module prime_constants

program test
use prime_constants, only: min_factor
implicit none
integer(4) :: __libasr_created__intrinsic_array_function_Count
integer(4), dimension(4), parameter :: __libasr_created__intrinsic_array_function_Pack = [1, 1, 1, 1]
logical(4), dimension(4) :: __libasr_created__intrinsic_array_function_Pack1
integer(4), dimension(4), parameter :: __libasr_created_integer_compare_left_ = [1, 1, 1, 1]
integer(4), dimension(:), allocatable :: __libasr_created_string_format
integer(4) :: __libasr_index_0_
integer(4) :: __libasr_index_0_1
__libasr_index_0_1 = lbound(__libasr_created_integer_compare_left_, 1)
__libasr_index_0_ = lbound(__libasr_created__intrinsic_array_function_Pack1, 1) - 1
do while (__libasr_index_0_ + 1 <= ubound(__libasr_created__intrinsic_array_function_Pack1, 1))
    __libasr_index_0_ = __libasr_index_0_ + 1
    __libasr_created__intrinsic_array_function_Pack1(__libasr_index_0_) = __libasr_created_integer_compare_left_(__libas&
        r_index_0_1) >= 1
    __libasr_index_0_1 = __libasr_index_0_1 + 1
end do
deallocate(__libasr_created_string_format)
__libasr_created__intrinsic_array_function_Count = _lcompilers_count_logical____0(__libasr_created__intrinsic_array_func&
        tion_Pack1, 1, 4)
allocate(__libasr_created_string_format(__libasr_created__intrinsic_array_function_Count))
__libasr_created_string_format(1) = 1
__libasr_created_string_format(2) = 1
__libasr_created_string_format(3) = 1
__libasr_created_string_format(4) = 1
print *, __libasr_created_string_format
deallocate(__libasr_created_string_format) ! Implicit deallocate

contains

integer(4) function _lcompilers_count_logical____0(mask, __1mask, __2mask) result(result)
    integer(4), intent(in) :: __1mask
    integer(4), intent(in) :: __2mask
    integer(4) :: i_0
    logical(4), dimension(__1mask:(__1mask)+(__2mask)-1), intent(in) :: mask
    result = 0
    i_0 = int(__1mask, kind=4) - 1
    do while (i_0 + 1 <= __2mask + __1mask - 1)
        i_0 = i_0 + 1
        if (mask(i_0)) then
            result = result + 1
        end if
    end do
    return
end function _lcompilers_count_logical____0

end program test
```

With this PR:
```fortran
! Fortran code after applying the pass: insert_deallocate
module prime_constants
implicit none
integer(4), dimension(4), parameter :: min_factor = [1, 1, 1, 1]
end module prime_constants

program test
use prime_constants, only: min_factor
implicit none
integer(4), dimension(4), parameter :: __libasr_created_string_format = [1, 1, 1, 1]
print *, __libasr_created_string_format
end program test
```

