### PR TITLE
fix: handle return_var correctly for `findloc` intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1066,7 +1066,7 @@ RUN(NAME intrinsics_366 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_367 LABELS gfortran llvm) # get_environment_variable
 RUN(NAME intrinsics_368 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # kind
 RUN(NAME intrinsics_369 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-RUN(NAME intrinsics_370 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME intrinsics_370 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # findloc
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1066,6 +1066,7 @@ RUN(NAME intrinsics_366 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_367 LABELS gfortran llvm) # get_environment_variable
 RUN(NAME intrinsics_368 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # kind
 RUN(NAME intrinsics_369 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME intrinsics_370 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_370.f90
+++ b/integration_tests/intrinsics_370.f90
@@ -1,0 +1,14 @@
+program intrinsics
+    implicit none
+
+    integer, dimension(5) :: value  
+    integer :: val, iloc
+
+    value = [0, 2, 1, 3, 1]  
+    val = 1                  
+
+    iloc = findloc(value, val, dim=1)  
+
+    print * , iloc
+    if (iloc /= 3) error stop 
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3580,9 +3580,13 @@ namespace FindLoc {
     fill_func_arg("kind", arg_types[4]);
     fill_func_arg("back", arg_types[5]);
     ASR::expr_t* result = nullptr;
-    result = declare("result", ASRUtils::duplicate_type_with_empty_dims(
+    if( !ASRUtils::is_array(return_type) ) {
+        result = declare("result", return_type, ReturnVar);
+    } else {
+        result = declare("result", ASRUtils::duplicate_type_with_empty_dims(
             al, return_type, ASR::array_physical_typeType::DescriptorArray, true), Out);
-    args.push_back(al, result);
+        args.push_back(al, result);
+    }
     ASR::ttype_t *type = ASRUtils::extract_type(return_type);
     ASR::expr_t *i = declare("i", type, Local);
     ASR::expr_t *j = declare("j", type, Local);
@@ -3611,9 +3615,8 @@ namespace FindLoc {
         }));
     } else {
         int array_rank = ASRUtils::extract_n_dims_from_ttype(array_type);
-        ASR::ttype_t* ret_type = ASRUtils::type_get_past_array(return_type);
         if (array_rank == 1) {
-            body.push_back(al, b.Assignment(result, b.i_t(0, ret_type)));
+            body.push_back(al, b.Assignment(result, b.i_t(0, type)));
             body.push_back(al, b.DoLoop(i, b.i_t(1, type), UBound(array, 1), {
                 b.If(b.Eq(ArrayItem_02(array, i), value), {
                     b.Assignment(result, i),
@@ -3627,11 +3630,11 @@ namespace FindLoc {
             Vec<ASR::expr_t*> idx_vars_ji; idx_vars_ji.reserve(al, 2);
             idx_vars_ij.push_back(al, i); idx_vars_ij.push_back(al, j);
             idx_vars_ji.push_back(al, j); idx_vars_ji.push_back(al, i);
-            body.push_back(al, b.Assignment(result, b.i_t(0, ret_type)));
-            body.push_back(al, b.If(b.Eq(dim, b.i_t(1, ret_type)), {
-                b.DoLoop(i, b.i_t(1, ret_type), UBound(array, 2), {
+            body.push_back(al, b.Assignment(result, b.i_t(0, type)));
+            body.push_back(al, b.If(b.Eq(dim, b.i_t(1, type)), {
+                b.DoLoop(i, b.i_t(1, type), UBound(array, 2), {
                     b.Assignment(found_value, b.bool_t(0, logical)),
-                    b.DoLoop(j, b.i_t(1, ret_type), UBound(array, 1), {
+                    b.DoLoop(j, b.i_t(1, type), UBound(array, 1), {
                         b.If(b.Eq(ArrayItem_02(array, idx_vars_ji), value), {
                             b.Assignment(b.ArrayItem_01(result, {i}), j),
                             b.Assignment(found_value, b.bool_t(1, logical)),
@@ -3642,9 +3645,9 @@ namespace FindLoc {
                     })
                 })
             }, {
-                b.DoLoop(i, b.i_t(1, ret_type), UBound(array, 1), {
+                b.DoLoop(i, b.i_t(1, type), UBound(array, 1), {
                     b.Assignment(found_value, b.bool_t(0, logical)),
-                    b.DoLoop(j, b.i_t(1, ret_type), UBound(array, 2), {
+                    b.DoLoop(j, b.i_t(1, type), UBound(array, 2), {
                         b.If(b.Eq(ArrayItem_02(array, idx_vars_ij), value), {
                             b.Assignment(b.ArrayItem_01(result, {i}), j),
                             b.Assignment(found_value, b.bool_t(1, logical)),
@@ -3659,9 +3662,14 @@ namespace FindLoc {
     }
 
     body.push_back(al, b.Return());
-    ASR::expr_t* return_var = nullptr;
-    ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
-            body, return_var, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+    ASR::symbol_t *fn_sym = nullptr;
+    if( ASRUtils::expr_intent(result) == ASR::intentType::ReturnVar ) {
+        fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
+            body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+    } else {
+        fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
+            body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+    }
     scope->add_symbol(fn_name, fn_sym);
     return b.Call(fn_sym, m_args, return_type, nullptr);
 }


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/6735