### PR TITLE
CI: use the commit of pot3d branch which exits with non-zero status on validation failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,7 +547,7 @@ jobs:
             # 3. MPI support replaced with custom MPI wrappers (we've C MPI wrappers from https://github.com/gxyd/c_mpi)
             # 4. moved global procedures to module procedures (see: https://github.com/lfortran/lfortran/issues/6059)
             git checkout -t origin/lf_hdf5_mpi_namelist_global_workarounds
-            git checkout e2f2a2b6668e81f5d9f1441c20d64b8c7446aa6b
+            git checkout eb05c69d30b7c88454d97d66ab6be46db10e7552
             FC="$(pwd)/../src/bin/lfortran" ./build_and_run.sh
             FC="$(pwd)/../src/bin/lfortran --fast --skip-pass=dead_code_removal" ./build_and_run.sh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,7 +547,7 @@ jobs:
             # 3. MPI support replaced with custom MPI wrappers (we've C MPI wrappers from https://github.com/gxyd/c_mpi)
             # 4. moved global procedures to module procedures (see: https://github.com/lfortran/lfortran/issues/6059)
             git checkout -t origin/lf_hdf5_mpi_namelist_global_workarounds
-            git checkout 337546b13502ed1c07a0a38cba3afe1a9f35fb27
+            git checkout e2f2a2b6668e81f5d9f1441c20d64b8c7446aa6b
             FC="$(pwd)/../src/bin/lfortran" ./build_and_run.sh
             FC="$(pwd)/../src/bin/lfortran --fast --skip-pass=dead_code_removal" ./build_and_run.sh
 


### PR DESCRIPTION
## Description

I've pushed a commit: https://github.com/gxyd/POT3D/commit/e2f2a2b6668e81f5d9f1441c20d64b8c7446aa6b to branch `lf_hdf5_mpi_namelist_global_workarounds`.

This is an important change, we definitely should've it in our CI. The linked commit ensures that when validation has failed, we exit with non-zero status.

I shouldn't have missed this change. We can possibly squash this commit with the commit prior to this on the same branch, we also would need to update the commit hash in the blog post as well (can't think of anywhere else though).