### PR TITLE
fix : Convert Variable to Function for implicit-interface only when m_type is not FunctionType

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1243,6 +1243,7 @@ RUN(NAME interface_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME interface_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_STD_F23)
 RUN(NAME interface_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_STD_F23)
 RUN(NAME interface_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_STD_F23)
+RUN(NAME interface_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME implicit_interface_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/interface_18.f90
+++ b/integration_tests/interface_18.f90
@@ -1,0 +1,72 @@
+module module_interface_18
+    implicit none
+
+    abstract interface
+        subroutine OBJ(x, f)
+            implicit none
+            real(4), intent(in) :: x(:)
+            real(4), intent(out) :: f
+        end subroutine OBJ
+    end interface
+
+    interface evaluate
+        module procedure evaluatef
+    end interface evaluate
+
+    contains
+
+    function moderatex(x) result(y)
+        implicit none
+        real, intent(in) :: x(:)
+        real :: y(size(x))
+        y = 2
+    end function moderatex
+
+    subroutine evaluatef(calfun, x, f)
+        implicit none
+
+        procedure(OBJ) :: calfun  
+        real, intent(in) :: x(:)
+        real, intent(out) :: f
+        call calfun(moderatex(x), f)
+    end subroutine evaluatef
+
+    subroutine initxf(calfun, xpt)
+        implicit none
+
+        procedure(OBJ) :: calfun
+        real, intent(out) :: xpt(:, :)
+
+        real :: f
+        real :: x(size(xpt, 1))
+
+        x = 1
+        f = 2
+        call evaluate(calfun, x, f)
+    end subroutine initxf
+
+end module module_interface_18
+
+program interface_18
+    use module_interface_18
+    implicit none
+
+    real :: xpt(1, 5)
+    
+    call initxf(calfun, xpt)
+
+contains
+
+    subroutine calfun(x, f)
+        implicit none
+        real, intent(in) :: x(:)
+        real, intent(out) :: f
+
+        print * , "x = " , x
+        print * , "f = " , f
+        
+        if (x(1) /= 2.0) error stop
+        if (f /= 2.0) error stop
+    end subroutine
+
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3771,7 +3771,7 @@ public:
                 break;
             }
             case (ASR::symbolType::Variable) : {
-                if (compiler_options.implicit_interface) {
+                if (compiler_options.implicit_interface && !ASR::is_a<ASR::FunctionType_t>(*ASR::down_cast<ASR::Variable_t>(original_sym)->m_type)) {
                     // In case of implicit_interface, we redefine the symbol
                     // from a Variable to Function. Example:
                     //


### PR DESCRIPTION
fix #6728 

