### PR TITLE
fix: don't try to convert a procedure variable to a Function declaration

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1246,6 +1246,7 @@ RUN(NAME interface_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_S
 RUN(NAME interface_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_STD_F23)
 RUN(NAME interface_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_STD_F23)
 RUN(NAME interface_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME interface_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME implicit_interface_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/interface_19.f90
+++ b/integration_tests/interface_19.f90
@@ -1,0 +1,58 @@
+module interface_19_mod
+    implicit none
+
+    abstract interface
+        function FUNC_WITH_ARGS(x, args) result(f)
+        implicit none
+        real, intent(in) :: x
+        real, intent(in) :: args(:)
+        real :: f
+        end function FUNC_WITH_ARGS
+    end interface
+
+    contains
+
+    ! an implementation of the abstract interface 'FUNC_WITH_ARGS'
+    function g0(x, args) result(f)
+        implicit none
+        real, intent(in) :: x
+        real, intent(in) :: args(:)
+        real :: f
+        f = x + sum(args)
+    end function g0
+
+    function interval_max(fun, args, grid_size) result(x)
+        implicit none
+        !> 'fun' is a procedure variable
+        procedure(FUNC_WITH_ARGS) :: fun
+        real, intent(in) :: args(:)
+        integer, intent(in) :: grid_size
+
+        real :: x
+
+        real :: k
+        integer :: i
+        real :: fgrid(grid_size)
+
+        !> function call with procedure variable
+        fgrid = [(fun(k, args), i=1, grid_size)]
+        ! we return a random value
+        x = sum(fgrid)
+
+    end function interval_max
+end module interface_19_mod
+
+program interface_19
+    use interface_19_mod
+    implicit none
+    real, allocatable :: args_i(:)
+    integer, parameter :: grid_size_i = 5
+    real :: x
+
+    allocate(args_i(8))
+    args_i = [1., 5., 3., 7., 8., 9., 10., 1.]
+
+    x = interval_max(g0, args_i, grid_size_i)
+    print *, x
+    if (x /= 220.0_4) error stop
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3862,7 +3862,9 @@ public:
                 break;
             }
             case (ASR::symbolType::Variable) : {
-                if (compiler_options.implicit_interface && !ASR::is_a<ASR::FunctionType_t>(*ASR::down_cast<ASR::Variable_t>(original_sym)->m_type)) {
+                if (compiler_options.implicit_interface &&
+                    !ASRUtils::is_symbol_procedure_variable(original_sym)
+                ) {
                     // In case of implicit_interface, we redefine the symbol
                     // from a Variable to Function. Example:
                     //

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8373,8 +8373,7 @@ public:
                         );
                     throw SemanticAbort();
                 }
-            } else if (compiler_options.implicit_interface) {
-
+            } else if (compiler_options.implicit_interface && !ASRUtils::is_symbol_procedure_variable(v)) {
                 bool is_function = true;
                 // NOTE: ideally this shouldn't be needed, this is only to handle
                 // 'dble', 'shifta', 'float', 'dfloat', which aren't currently

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -143,6 +143,17 @@ static inline ASR::symbol_t* symbol_get_past_ClassProcedure(ASR::symbol_t* f){
     return f;
 }
 
+/*
+Returns true, when the symbol 'f' is a procedure variable
+*/
+static inline bool is_symbol_procedure_variable(ASR::symbol_t* f) {
+    if (ASR::is_a<ASR::Variable_t>(*f)) {
+        ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(f);
+        return ASR::is_a<ASR::FunctionType_t>(*v->m_type);
+    }
+    return false;
+}
+
 template <typename T>
 Location get_vec_loc(const Vec<T>& args) {
     LCOMPILERS_ASSERT(args.size() > 0);


### PR DESCRIPTION
## Description

The fix is pretty much what was done in https://github.com/lfortran/lfortran/pull/6742.

The added test case fails with current *main* when `--std=f23` (specifically `--implicit-interface`) flag is used.