### PR TITLE
Fixes for std::thread init order, clean exits, and removal of timeouts

### DIFF
--- a/src/server/base_lsp_language_server.cpp
+++ b/src/server/base_lsp_language_server.cpp
@@ -60,6 +60,10 @@ namespace LCompilers::LanguageServerProtocol {
       , extensionId(extensionId)
       , compilerVersion(compilerVersion)
       , parentProcessId(parentProcessId)
+      , requestPool("request", numRequestThreads, logger)
+      , workerPool("worker", numWorkerThreads, logger)
+      , lspConfigTransformer(std::move(lspConfigTransformer))
+      , randomEngine(seed)
       , listener([this, &logger]{
           logger.threadName("BaseLspLanguageServer_listener");
           listen();
@@ -68,10 +72,6 @@ namespace LCompilers::LanguageServerProtocol {
           logger.threadName("BaseLspLanguageServer_cron");
           chronicle();
       })
-      , requestPool("request", numRequestThreads, logger)
-      , workerPool("worker", numWorkerThreads, logger)
-      , lspConfigTransformer(std::move(lspConfigTransformer))
-      , randomEngine(seed)
     {
         documentsByUri.reserve(256);
         configsByUri.reserve(256);
@@ -1336,10 +1336,6 @@ namespace LCompilers::LanguageServerProtocol {
             incomingMessages.stopNow();
             requestPool.stopNow();
             workerPool.stopNow();
-            // NOTE: Notify the message stream that the server is terminating.
-            // NOTE: This works because the null character is not included in
-            // the JSON spec.
-            std::cin.putback('\0');
         }
     }
 

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -94,8 +94,6 @@ namespace LCompilers::LanguageServerProtocol {
         const std::string extensionId;
         const std::string compilerVersion;
         int parentProcessId;
-        std::thread listener;
-        std::thread cron;
         lst::ThreadPool requestPool;
         lst::ThreadPool workerPool;
         std::atomic_size_t serialSendId = 0;
@@ -186,6 +184,12 @@ namespace LCompilers::LanguageServerProtocol {
 
         std::atomic_bool clientSupportsWorkspaceConfigRequests = false;
         std::atomic_bool clientSupportsWorkspaceConfigChangeNotifications = false;
+
+        // NOTE: By convention and to encourage proper initialization order,
+        // move all std::thread declarations to the bottom of the members!
+        // See: https://github.com/lfortran/lfortran/issues/6756
+        std::thread listener;
+        std::thread cron;
 
         auto nextSendId() -> std::size_t;
         auto isInitialized() const -> bool;

--- a/src/server/communication_protocol.cpp
+++ b/src/server/communication_protocol.cpp
@@ -118,8 +118,9 @@ namespace LCompilers::LLanguageServer {
             << "[CommunicationProtocol] Serving requests."
             << std::endl;
         try {
-            while (!languageServer.isTerminated()) {
-                std::string message = messageStream.next();
+            bool exit = false;
+            while (!languageServer.isTerminated() && !exit) {
+                std::string message = messageStream.next(exit);
                 if (message.length() > 0) {
                     outgoingMessages.enqueue(message);
                 } else {

--- a/src/server/communication_protocol.h
+++ b/src/server/communication_protocol.h
@@ -29,8 +29,12 @@ namespace LCompilers::LLanguageServer {
         MessageQueue &incomingMessages;
         MessageQueue &outgoingMessages;
         lsl::Logger &logger;
-        std::thread listener;
         std::atomic_bool running = true;
+
+        // NOTE: By convention and to encourage proper initialization order,
+        // move all std::thread declarations to the bottom of the members!
+        // See: https://github.com/lfortran/lfortran/issues/6756
+        std::thread listener;
 
         auto listen() -> void;
     };

--- a/src/server/lsp_message_stream.h
+++ b/src/server/lsp_message_stream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <istream>
+#include <regex>
 
 #include <server/logger.h>
 #include <server/message_stream.h>
@@ -12,15 +13,17 @@ namespace LCompilers::LanguageServerProtocol {
     class LspMessageStream : public ls::MessageStream {
     public:
         LspMessageStream(std::istream &istream, lsl::Logger &logger);
-        std::string next() override;
+        std::string next(bool &exit) override;
     private:
+        const std::regex RE_IS_CONTENT_LENGTH;
+        const std::regex RE_IS_EXIT;
+
         std::istream &istream;
         lsl::Logger &logger;
         std::string message;
         std::size_t position;
 
         auto nextChar() -> char;
-        auto nextUpper() -> char;
         auto logEscaped(char c) -> void;
     };
 

--- a/src/server/message_stream.h
+++ b/src/server/message_stream.h
@@ -8,7 +8,7 @@ namespace LCompilers::LLanguageServer {
     public:
         MessageStream();
         virtual ~MessageStream();
-        virtual std::string next() = 0;
+        virtual std::string next(bool &exit) = 0;
     };
 
 } // namespace LCompilers::LLanguageServer

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -108,7 +108,7 @@ class LspTestClient(LspClient):
     responses_by_id: Dict[JsonValue, Any]
     callbacks_by_id: Dict[JsonValue, Tuple[Any, Callback]]
     stop: threading.Event
-    stderr_printer: threading.Thread
+    # stderr_printer: threading.Thread
 
     def __init__(
             self,
@@ -136,10 +136,10 @@ class LspTestClient(LspClient):
         self.responses_by_id = dict()
         self.callbacks_by_id = dict()
         self.stop = threading.Event()
-        self.stderr_printer = threading.Thread(
-            target=self.print_stderr,
-            args=tuple()
-        )
+        # self.stderr_printer = threading.Thread(
+        #     target=self.print_stderr,
+        #     args=tuple()
+        # )
 
     def print_stderr(self) -> None:
         if self.server.stderr is not None:
@@ -322,28 +322,27 @@ class LspTestClient(LspClient):
             [self.server_path] + self.server_params,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            # stderr=subprocess.DEVNULL,
+            # stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             bufsize=0
         )
         if self.server.stdout is None:
             raise RuntimeError("Cannot read from server stdout")
         if self.server.stdin is None:
             raise RuntimeError("Cannot write to server stdin")
-        if self.server.stderr is None:
-            raise RuntimeError("Cannot read from server stderr")
+        # if self.server.stderr is None:
+        #     raise RuntimeError("Cannot read from server stderr")
 
         # Make process stdout non-blocking
         stdout_fd = self.server.stdout.fileno()
         os.set_blocking(stdout_fd, False)
-        stderr_fd = self.server.stderr.fileno()
-        os.set_blocking(stderr_fd, False)
+        # stderr_fd = self.server.stderr.fileno()
+        # os.set_blocking(stderr_fd, False)
 
         self.message_stream = LspJsonStream(self.server.stdout, self.timeout_s)
         self.ostream = self.server.stdin
 
-        self.stderr_printer.start()
-        time.sleep(0.5)
+        # self.stderr_printer.start()
 
         initialize_id = self.send_initialize(self.initialize_params())
         self.await_response(initialize_id)
@@ -357,9 +356,9 @@ class LspTestClient(LspClient):
         self.send_exit()
 
         self.stop.set()
-        self.stderr_printer.join()
+        # self.stderr_printer.join()
 
-        timeout_s = 0.200
+        timeout_s = 0.5
         try:
             self.server.wait(timeout=timeout_s)
         except subprocess.TimeoutExpired as e:

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -64,13 +64,11 @@ def client(request: pytest.FixtureRequest) -> Iterator[LspTestClient]:
         }
     })
 
-    with pytest.raises(RuntimeError) as error:
-        with client.serve():
-            # Steps abstracted by context manager:
-            # 1. Send request: initialize
-            # 2. Send notification: initialized
-            # 3. <yield client>
-            # 4. Send request: shutdown
-            # 5. Send notification: exit
-            yield client
-    assert RE_EXIT_TIMEOUT.fullmatch(str(error.value)), str(error.value)
+    with client.serve():
+        # Steps abstracted by context manager:
+        # 1. Send request: initialize
+        # 2. Send notification: initialized
+        # 3. <yield client>
+        # 4. Send request: shutdown
+        # 5. Send notification: exit
+        yield client


### PR DESCRIPTION
Changes:
* Reorders field-declaration order of std::stread fields to the end of the members (see: #6756 and #6625)
* Adds check to LspMessageStream for when to exit the server; disables logging of subprocess stderr
* Removes extraneous timeouts