### PR TITLE
fix: don't assign back `intent(in)` variables in nested_vars

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1521,7 +1521,7 @@ RUN(NAME nested_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)
-RUN(NAME nested_vars3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)
+RUN(NAME nested_vars3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME nbody LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/nested_vars3.f90
+++ b/integration_tests/nested_vars3.f90
@@ -3,7 +3,9 @@ module nested_vars3
 
     contains
 
-    subroutine h()
+    subroutine h(a, filename)
+        integer, intent(in) :: a
+        character(len=*), intent(in) :: filename
         integer, parameter :: x = 10
         call g()
 
@@ -12,6 +14,9 @@ module nested_vars3
         subroutine g()
             print *, x
             if (x /= 10) error stop
+            print *, a
+            if (a /= 5) error stop
+            if (filename /= "xyz") error stop
         end subroutine
 
     end subroutine
@@ -22,5 +27,5 @@ end module
 program nested_vars3_main
     use nested_vars3, only: h
     implicit none
-    call h()
+    call h(5, "xyz")
 end program

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -699,7 +699,8 @@ public:
                             ASR::stmt_t *assignment = ASRUtils::STMT(ASR::make_Assignment_t(al, t->base.loc,
                                                         target, val, nullptr));
                             body.push_back(al, assignment);
-                            if (ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter) {
+                            if (ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter && 
+                                    ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In) {
                                 assignment = ASRUtils::STMT(ASR::make_Assignment_t(al, t->base.loc,
                                                 val, target, nullptr));
                                 assigns_at_end.push_back(assignment);


### PR DESCRIPTION
Fixes #6762 