### PR TITLE
Adds many requested LSP tests from #6574

### DIFF
--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -327,6 +327,10 @@ namespace LCompilers::LanguageServerProtocol {
 
         auto receiveCancelRequest(CancelParams &params) -> void override;
 
+        auto receiveGetDocument(
+            GetDocumentParams &params
+        ) -> GetDocumentResult override;
+
     }; // class LspLanguageServer
 
 } // namespace LCompilers::LanguageServerProtocol

--- a/src/server/generator/llanguage_server/lsp/auxiliary_schema.py
+++ b/src/server/generator/llanguage_server/lsp/auxiliary_schema.py
@@ -153,6 +153,44 @@ AUXILIARY_SCHEMA: Dict[str, Any] = {
             ],
             "documentation": "A Response Message sent as a result of a request. If a request doesn’t\nprovide a result value the receiver of a request still needs to return a\nresponse message to conform to the JSON-RPC specification. The result\nproperty of the ResponseMessage should be set to null in this case to signal\na successful request.",
         },
+        {
+            "name": "GetDocumentParams",
+            "properties": [
+                {
+                    "name": "uri",
+                    "type": {
+                        "kind": "base",
+                        "name": "string",
+                    },
+                },
+            ],
+        },
+        {
+            "name": "GetDocumentResult",
+            "properties": [
+                {
+                    "name": "uri",
+                    "type": {
+                        "kind": "base",
+                        "name": "string",
+                    },
+                },
+                {
+                    "name": "version",
+                    "type": {
+                        "kind": "base",
+                        "name": "integer",
+                    },
+                },
+                {
+                    "name": "text",
+                    "type": {
+                        "kind": "base",
+                        "name": "string",
+                    },
+                },
+            ],
+        },
     ],
     "typeAliases": [
         {
@@ -210,6 +248,18 @@ AUXILIARY_SCHEMA: Dict[str, Any] = {
         },
     ],
     "requests": [
+		{
+			"method": "$/getDocument",
+			"messageDirection": "clientToServer",
+			"params": {
+				"kind": "reference",
+				"name": "GetDocumentParams",
+			},
+            "result": {
+                "kind": "reference",
+                "name": "GetDocumentResult",
+            },
+		},
     ],
     "notifications": [
     ],

--- a/src/server/lsp_text_document.cpp
+++ b/src/server/lsp_text_document.cpp
@@ -16,28 +16,26 @@ namespace LCompilers::LanguageServerProtocol {
         int version,
         const std::string &text,
         lsl::Logger &logger
-    ) : _uri(uri)
-      , _languageId(languageId)
+    ) : _languageId(languageId)
       , _version(version)
       , _text(text)
       , logger(logger)
     {
         buffer.reserve(8196);
-        validateUriAndSetPath();
+        setUri(uri);
         indexLines();
     }
 
     LspTextDocument::LspTextDocument(
         const std::string &uri,
         lsl::Logger &logger
-    ) : _uri{uri}
-      , _languageId{""}
+    ) : _languageId{""}
       , _version{-1}
       , _text{""}
       , logger{logger}
     {
         buffer.reserve(8196);
-        validateUriAndSetPath();
+        setUri(uri);
         loadText();
         indexLines();
     }
@@ -55,11 +53,6 @@ namespace LCompilers::LanguageServerProtocol {
         // empty
     }
 
-    auto LspTextDocument::validateUriAndSetPath() -> void {
-        std::string path = std::regex_replace(_uri, RE_FILE_URI, "");
-        _path = fs::absolute(path).lexically_normal();
-    }
-
     auto LspTextDocument::loadText() -> void {
         std::ifstream fs(_path);
         if (fs.is_open()) {
@@ -67,6 +60,12 @@ namespace LCompilers::LanguageServerProtocol {
             ss << fs.rdbuf();
             _text = ss.str();
         }
+    }
+
+    auto LspTextDocument::setUri(const DocumentUri &uri) -> void {
+        _uri = uri;
+        std::string path = std::regex_replace(uri, RE_FILE_URI, "");
+        _path = fs::absolute(path).lexically_normal();
     }
 
     auto LspTextDocument::update(

--- a/src/server/lsp_text_document.h
+++ b/src/server/lsp_text_document.h
@@ -15,8 +15,13 @@ namespace LCompilers::LanguageServerProtocol {
 
     namespace lsl = LCompilers::LLanguageServer::Logging;
 
+    // NOTE: File URIs follow one of the following schemes:
+    // 1. `file:/path` (no hostname)
+    // 2. `file:///path` (empty hostname)
+    // 3. `file://hostname/path`
+    // NOTE: All we are interested in is the `/path` portion
     const std::regex RE_FILE_URI(
-        "^file:(?://)?",
+        "^file:(?://[^/]*)?",
         std::regex_constants::ECMAScript | std::regex_constants::icase
     );
 
@@ -38,6 +43,8 @@ namespace LCompilers::LanguageServerProtocol {
         inline auto uri() const -> const DocumentUri & {
             return _uri;
         }
+
+        auto setUri(const DocumentUri &uri) -> void;
 
         inline auto path() const -> const fs::path & {
             return _path;
@@ -85,7 +92,6 @@ namespace LCompilers::LanguageServerProtocol {
         std::vector<std::size_t> lineIndices;
         std::shared_mutex _mutex;
 
-        auto validateUriAndSetPath() -> void;
         auto indexLines() -> void;
         auto loadText() -> void;
 

--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -95,3 +95,7 @@ class LspClient(ABC):
     @abstractmethod
     def goto_definition(self, uri: str, line: int, column: int) -> None:
         raise NotImplementedError
+
+    @abstractmethod
+    def rename(self, uri: str, line: int, column: int, new_name: str) -> None:
+        raise NotImplementedError

--- a/src/server/tests/src/llanguage_test_client/lsp_text_document.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_text_document.py
@@ -2,7 +2,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
-from lsprotocol.types import TextDocumentSaveReason, TextEdit
+from lsprotocol.types import Position, Range, TextDocumentSaveReason, TextEdit
 
 from llanguage_test_client.lsp_client import LspClient
 
@@ -52,11 +52,8 @@ class LspTextDocument:
     pos_by_line: List[int]
     len_by_line: List[int]
 
-    # Selection/Range coordinates
-    start_line: int
-    start_column: int
-    end_lne: int
-    end_column: int
+    selection: Optional[Range]
+    highlight: Optional[Range]
 
     def __init__(
             self,
@@ -77,6 +74,8 @@ class LspTextDocument:
         self.pos_by_line = [0]
         self.len_by_line = [1]
         self.is_new = (path is None)
+        self.selection = None
+        self.highlight = None
 
     @property
     def path(self) -> Path:
@@ -118,12 +117,13 @@ class LspTextDocument:
 
     @property
     def cursor(self) -> Tuple[int, int]:
-        return self.pos_to_linecol(self.position)
+        line, column = self.pos_to_linecol(self.position)
+        return line + 1, column + 1
 
     @cursor.setter
     def cursor(self, line_and_col: Tuple[int, int]) -> None:
         line, col = line_and_col
-        self.seek(line, col)
+        self.seek(line - 1, col - 1)
 
     @property
     def position(self) -> int:
@@ -206,7 +206,7 @@ class LspTextDocument:
             self.is_new = False
         self.client.text_document_did_save(self.uri, self.text)
 
-    def rename(self, path: Union[Path, str]) -> None:
+    def move(self, path: Union[Path, str]) -> None:
         old_path = self._path
         if old_path is not None:
             old_uri = self.uri
@@ -260,7 +260,7 @@ class LspTextDocument:
         num_lines = len(self.pos_by_line)
         if line < num_lines:
             num_columns = self.len_by_line[line]
-            if column < num_columns:
+            if column <= num_columns:
                 position = self.pos_by_line[line] + column
                 return position
             raise ValueError(
@@ -284,19 +284,14 @@ class LspTextDocument:
             end_line: int,
             end_column: int
     ) -> None:
+        start = Position(start_line, start_column)
+        end = Position(end_line, end_column)
+        self.selection = Range(start, end)
         if (start_line < end_line) \
            or ((start_line == end_line) and (start_column <= end_column)):
-            self.start_line = start_line
-            self.start_column = start_column
-            self.end_line = end_line
-            self.end_column = end_column
-            self.seek(end_line, end_column)
+            self.seek(end_line - 1, end_column - 1)
         else:
-            self.start_line = end_line
-            self.start_column = end_column
-            self.end_line = start_line
-            self.end_column = start_column
-            self.seek(start_line, start_column)
+            self.seek(start_line - 1, start_column - 1)
 
     def delete(self, length: int = 1) -> None:
         """
@@ -315,8 +310,8 @@ class LspTextDocument:
         if self._path is not None:
             self.client.text_document_did_change(
                 self.uri, self.bump_version(),
-                start_line, start_column + 1,
-                end_line, end_column + 1,
+                start_line, start_column,
+                end_line, end_column,
                 self.text, ""
             )
         self.recompute_indices()
@@ -345,8 +340,8 @@ class LspTextDocument:
         if self._path is not None:
             self.client.text_document_did_change(
                 self.uri, self.bump_version(),
-                start_line, start_column + 1,
-                end_line, end_column + 1,
+                start_line, start_column,
+                end_line, end_column,
                 self.text, text
             )
         self.recompute_indices()
@@ -369,8 +364,8 @@ class LspTextDocument:
         if self._path is not None:
             self.client.text_document_did_change(
                 self.uri, self.bump_version(),
-                start_line, start_column + 1,
-                end_line, end_column + 1,
+                start_line, start_column,
+                end_line, end_column,
                 self.text, text
             )
         self.recompute_indices()
@@ -381,10 +376,13 @@ class LspTextDocument:
             range = edit.range
             start = range.start
             end = range.end
-            self.cursor = (end.line, end.character)
+            self.seek(end.line, end.character)
             suffix = self.buf.read()
-            self.cursor = (start.line, start.character)
+            self.seek(start.line, start.character)
             self.buf.write(edit.new_text)
+            # Append the newline if it was replaced
+            if end.character == self.len_by_line[end.line]:
+                self.buf.write('\n')
             self.buf.write(suffix)
             self.buf.truncate()
         origin = min(origin, len(self.text) - 1)
@@ -395,3 +393,8 @@ class LspTextDocument:
         if self._path is not None:
             line, column = self.pos_to_linecol(self.position)
             self.client.goto_definition(self.uri, line, column)
+
+    def rename(self, new_name: str) -> None:
+        if self._path is not None:
+            line, column = self.pos_to_linecol(self.position)
+            self.client.rename(self.uri, line, column, new_name)

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -1,0 +1,249 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from lsprotocol.types import (
+    CompletionClientCapabilities,
+    CompletionClientCapabilitiesCompletionItemType,
+    CompletionClientCapabilitiesCompletionItemTypeInsertTextModeSupportType,
+    CompletionClientCapabilitiesCompletionItemTypeResolveSupportType,
+    CompletionClientCapabilitiesCompletionItemTypeTagSupportType,
+    CompletionItemTag, DefinitionClientCapabilities, DefinitionParams,
+    HoverClientCapabilities, InitializeParams, InsertTextMode, Location,
+    LocationLink, MarkupKind, Position, RenameClientCapabilities, RenameParams,
+    TextDocumentDefinitionRequest, TextDocumentDefinitionResponse,
+    TextDocumentIdentifier, TextDocumentPublishDiagnosticsNotification,
+    TextDocumentRenameRequest, TextDocumentRenameResponse, WorkspaceEdit, TextEdit)
+
+from llanguage_test_client.json_rpc import JsonArray, JsonObject
+from llanguage_test_client.lsp_test_client import LspTestClient
+from llanguage_test_client.lsp_text_document import LspTextDocument
+
+
+class LFortranLspTestClient(LspTestClient):
+
+    def __init__(
+            self,
+            server_path: Path,
+            server_params: List[str],
+            workspace_path: Optional[Path],
+            timeout_ms: float,
+            config: Dict[str, Any]
+    ) -> None:
+        super().__init__(
+            server_path,
+            server_params,
+            workspace_path,
+            timeout_ms,
+            config
+        )
+
+    def await_validation(self, uri: str, version: int) -> Any:
+        def is_validation(message: Any) -> bool:
+            if message.get("method", None) == "textDocument/publishDiagnostics":
+                params = message["params"]
+                return params["uri"] == uri \
+                    and params.get("version", None) == version
+            return False
+        event, _ = self.find_incoming_event(lambda event: is_validation(event.data))
+        if event is not None:
+            return event.data
+        while not self.stop.is_set():
+            message = self.receive_message()
+            if is_validation(message):
+                return message
+        return None
+
+    def dispatch_method(self, message: JsonObject) -> None:
+        match message["method"]:
+            case "textDocument/publishDiagnostics":
+                notification = self.converter.structure(
+                    message,
+                    TextDocumentPublishDiagnosticsNotification
+                )
+                self.receive_text_document_publish_diagnostics(notification)
+                self.respond_to_notification()
+            case _:
+                super().dispatch_method(message)
+
+    def initialize_params(self) -> InitializeParams:
+        params = super().initialize_params()
+        text_document = params.capabilities.text_document
+        if text_document is not None:
+            text_document.completion = CompletionClientCapabilities(
+                dynamic_registration=True,
+                completion_item=CompletionClientCapabilitiesCompletionItemType(
+                    snippet_support=False,
+                    commit_characters_support=False,
+                    documentation_format=[
+                        MarkupKind.PlainText,
+                        MarkupKind.Markdown,
+                    ],
+                    deprecated_support=True,
+                    preselect_support=False,
+                    tag_support=CompletionClientCapabilitiesCompletionItemTypeTagSupportType(
+                        value_set=[
+                            CompletionItemTag.Deprecated,
+                        ],
+                    ),
+                    insert_replace_support=False,
+                    resolve_support=CompletionClientCapabilitiesCompletionItemTypeResolveSupportType(
+                        properties=[],
+                    ),
+                    insert_text_mode_support=CompletionClientCapabilitiesCompletionItemTypeInsertTextModeSupportType(
+                        value_set=[
+                            InsertTextMode.AsIs,
+                            InsertTextMode.AdjustIndentation,
+                        ],
+                    ),
+                    label_details_support=True,
+                ),
+                context_support=True,
+            )
+            text_document.hover = HoverClientCapabilities(
+                dynamic_registration=True,
+                content_format=[
+                    MarkupKind.PlainText,
+                    MarkupKind.Markdown,
+                ],
+            )
+            text_document.definition = DefinitionClientCapabilities()
+            text_document.rename = RenameClientCapabilities()
+        return params
+
+    def receive_text_document_publish_diagnostics(
+            self,
+            notification: TextDocumentPublishDiagnosticsNotification
+    ) -> None:
+        pass
+
+    def server_supports_text_document_definition(self) -> bool:
+        # NOTE: This returns True if `definition_provider` is True or an instance
+        # of `DefinitionOptions`
+        return bool(self.server_capabilities.definition_provider)
+
+    def send_text_document_definition(self, params: DefinitionParams) -> int:
+        request_id = self.next_request_id()
+        request = TextDocumentDefinitionRequest(request_id, params)
+        self.send_request(request_id, request,
+                          self.receive_text_document_definition)
+        return request_id
+
+    def receive_text_document_definition(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentDefinitionResponse
+        )
+        loc: Optional[Union[Location, LocationLink]] = None
+        match response.result:
+            case Location():
+                loc = response.result
+            case _ if isinstance(response.result, Sequence) \
+                 and not isinstance(response.result, str) \
+                 and len(response.result) > 0:
+                loc = response.result[0]
+        doc: Optional[LspTextDocument] = None
+        pos: Optional[Position] = None
+        match loc:
+            case Location():
+                doc = self.documents_by_uri.get(loc.uri, None)
+                pos = loc.range.start
+            case LocationLink():
+                doc = self.documents_by_uri.get(loc.target_uri, None)
+                pos = loc.target_range.start
+        if doc is not None and pos is not None:
+            self.active_document = doc
+            doc.cursor = (pos.line + 1, pos.character + 1)
+
+    def goto_definition(self, uri: str, line: int, column: int) -> None:
+        if self.server_supports_text_document_definition():
+            params = DefinitionParams(
+                text_document=TextDocumentIdentifier(
+                    uri=uri,
+                ),
+                position=Position(
+                    line=line,
+                    character=column
+                ),
+            )
+            request_id = self.send_text_document_definition(params)
+            self.await_response(request_id)
+
+    def build_custom_request(
+            self,
+            method: str,
+            request_id: int,
+            params: Optional[Union[JsonObject, JsonArray]]
+    ) -> JsonObject:
+        return {
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": request_id,
+            "params": params,
+        }
+
+    def send_get_document(self, params: JsonObject) -> int:
+        request_id = self.next_request_id()
+        request = self.build_custom_request("$/getDocument", request_id, params)
+        self.send_request(request_id, request, self.receive_get_document)
+        return request_id
+
+    def receive_get_document(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        pass
+
+    def get_remote_document(self, uri: str) -> JsonObject:
+        request_id = self.send_get_document({
+            "uri": uri,
+        })
+        response = self.await_response(request_id)
+        return response["result"]
+
+    def server_supports_text_document_rename(self) -> bool:
+        return bool(self.server_capabilities.rename_provider)
+
+    def send_text_document_rename(self, params: RenameParams) -> int:
+        request_id = self.next_request_id()
+        request = TextDocumentRenameRequest(request_id, params)
+        self.send_request(request_id, request, self.receive_text_document_rename)
+        return request_id
+
+    def apply(self, workspace_edit: WorkspaceEdit) -> None:
+        changes = workspace_edit.changes
+        if changes is not None:
+            for uri, text_edits in changes.items():
+                document = self.get_document("fortran", uri)
+                document.apply(text_edits)
+
+    def receive_text_document_rename(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentRenameResponse
+        )
+        if response.result is not None:
+            self.apply(response.result)
+
+    def rename(self, uri: str, line: int, column: int, new_name: str) -> None:
+        if self.server_supports_text_document_rename():
+            params = RenameParams(
+                text_document=TextDocumentIdentifier(
+                    uri=uri,
+                ),
+                position=Position(
+                    line=line,
+                    character=column,
+                ),
+                new_name=new_name,
+            )
+            request_id = self.send_text_document_rename(params)
+            self.await_response(request_id)

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -1,20 +1,15 @@
 import os
-import re
 import shutil
 from pathlib import Path
 from typing import Iterator
 
 import pytest
 
-from llanguage_test_client.lsp_test_client import LspTestClient
-
-RE_EXIT_TIMEOUT = re.compile(
-    r'^Timed-out after (?:[0-9]*\.)[0-9]+ seconds while awaiting the server to terminate\.$'
-)
+from lfortran_language_server.lfortran_lsp_test_client import LFortranLspTestClient
 
 
 @pytest.fixture
-def client(request: pytest.FixtureRequest) -> Iterator[LspTestClient]:
+def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
     server_path = None
     if 'LFORTRAN_PATH' in os.environ:
         server_path = os.environ['LFORTRAN_PATH']
@@ -38,7 +33,7 @@ def client(request: pytest.FixtureRequest) -> Iterator[LspTestClient]:
         "--timeout-ms", str(timeout_ms),
     ]
 
-    client = LspTestClient(server_path, server_args, None, timeout_ms, {
+    client = LFortranLspTestClient(server_path, server_args, None, timeout_ms, {
         "LFortran": {
             "openIssueReporterOnError": False,
             "maxNumberOfProblems": 100,

--- a/tests/server/tests/test_document_manipulation.py
+++ b/tests/server/tests/test_document_manipulation.py
@@ -6,10 +6,11 @@ from lsprotocol.types import (TextDocumentContentChangeEvent_Type1,
                               TextDocumentDidOpenNotification,
                               WorkspaceDidRenameFilesNotification)
 
-from llanguage_test_client.lsp_test_client import LspTestClient, OutgoingEvent
+from llanguage_test_client.lsp_test_client import OutgoingEvent
+from lfortran_language_server.lfortran_lsp_test_client import LFortranLspTestClient
 
 
-def test_document_manipulation(client: LspTestClient):
+def test_document_manipulation(client: LFortranLspTestClient):
     with NamedTemporaryFile(
             prefix="test_document_manipulation-",
             suffix=".f90",
@@ -34,15 +35,19 @@ def test_document_manipulation(client: LspTestClient):
                 return False
             assert client.has_outgoing_event(sent_text_document_did_open)
 
+            rdoc = client.get_remote_document(doc.uri)
+            assert doc.uri == rdoc["uri"]
+            assert doc.version == rdoc["version"]
+
             with open(tmp_file_1.name) as f:
-                assert doc.text == f.read() == "\n".join([
+                assert doc.text == rdoc["text"] == f.read() == "\n".join([
                     "module module_function_call1",
                     "end module module_function_call1",
                 ]) + "\n"
 
             assert client.await_validation(doc.uri, doc.version) is not None
 
-            doc.cursor = 0,5
+            doc.cursor = 1,6
             doc.write("foo")
             doc.save()
 
@@ -60,22 +65,26 @@ def test_document_manipulation(client: LspTestClient):
                                 start = range.start
                                 end = range.end
                                 return start.line == 0 \
-                                    and start.character == 6 \
+                                    and start.character == 5 \
                                     and end.line == 0 \
-                                    and end.character == 6 \
+                                    and end.character == 5 \
                                     and content_change.text == "foo"
                 return False
             assert client.has_outgoing_event(sent_text_document_did_write_foo)
 
+            rdoc = client.get_remote_document(doc.uri)
+            assert doc.uri == rdoc["uri"]
+            assert doc.version == rdoc["version"]
+
             with open(tmp_file_1.name) as f:
-                assert doc.text == f.read() == "\n".join([
+                assert doc.text == rdoc["text"] == f.read() == "\n".join([
                     "modulfooe module_function_call1",
                     "end module module_function_call1",
                 ]) + "\n"
 
             assert client.await_validation(doc.uri, doc.version) is not None
 
-            doc.cursor = 0,5
+            doc.cursor = 1,6
             doc.replace("bar")
             doc.save()
 
@@ -94,28 +103,31 @@ def test_document_manipulation(client: LspTestClient):
                                 start = range.start
                                 end = range.end
                                 return start.line == 0 \
-                                    and start.character == 6 \
+                                    and start.character == 5 \
                                     and end.line == 0 \
-                                    and end.character == 9 \
+                                    and end.character == 8 \
                                     and content_change.text == "bar"
                 return False
             assert client.has_outgoing_event(
                 sent_text_document_did_replace_foo_with_bar
             )
 
+            rdoc = client.get_remote_document(doc.uri)
+            assert doc.uri == rdoc["uri"]
+            assert doc.version == rdoc["version"]
+
             with open(tmp_file_1.name) as f:
-                assert doc.text == f.read() == "\n".join([
+                assert doc.text == rdoc["text"] == f.read() == "\n".join([
                     "modulbare module_function_call1",
                     "end module module_function_call1",
                 ]) + "\n"
 
             assert client.await_validation(doc.uri, doc.version) is not None
 
-            doc.cursor = 0,5
-            doc.delete(3)
+            doc.backspace()
             doc.save()
 
-            def sent_text_document_did_delete_bar(event: OutgoingEvent) -> bool:
+            def sent_text_document_did_backspace_r(event: OutgoingEvent) -> bool:
                 if isinstance(event.data, TextDocumentDidChangeNotification):
                     notification = event.data
                     params = notification.params
@@ -129,22 +141,63 @@ def test_document_manipulation(client: LspTestClient):
                                 start = range.start
                                 end = range.end
                                 return start.line == 0 \
-                                    and start.character == 6 \
+                                    and start.character == 7 \
                                     and end.line == 0 \
-                                    and end.character == 9 \
+                                    and end.character == 8 \
                                     and content_change.text == ""
                 return False
-            assert client.has_outgoing_event(sent_text_document_did_delete_bar)
+            assert client.has_outgoing_event(sent_text_document_did_backspace_r)
+
+            rdoc = client.get_remote_document(doc.uri)
+            assert doc.uri == rdoc["uri"]
+            assert doc.version == rdoc["version"]
 
             with open(tmp_file_1.name) as f:
-                assert doc.text == f.read() == "\n".join([
+                assert doc.text == rdoc["text"] == f.read() == "\n".join([
+                    "modulbae module_function_call1",
+                    "end module module_function_call1",
+                ]) + "\n"
+
+            assert client.await_validation(doc.uri, doc.version) is not None
+
+            doc.cursor = 1,6
+            doc.delete(2)
+            doc.save()
+
+            def sent_text_document_did_delete_ba(event: OutgoingEvent) -> bool:
+                if isinstance(event.data, TextDocumentDidChangeNotification):
+                    notification = event.data
+                    params = notification.params
+                    if params.text_document.uri == doc.uri:
+                        content_changes = params.content_changes
+                        if len(content_changes) == 1:
+                            content_change = content_changes[0]
+                            if isinstance(content_change,
+                                          TextDocumentContentChangeEvent_Type1):
+                                range = content_change.range
+                                start = range.start
+                                end = range.end
+                                return start.line == 0 \
+                                    and start.character == 5 \
+                                    and end.line == 0 \
+                                    and end.character == 7 \
+                                    and content_change.text == ""
+                return False
+            assert client.has_outgoing_event(sent_text_document_did_delete_ba)
+
+            rdoc = client.get_remote_document(doc.uri)
+            assert doc.uri == rdoc["uri"]
+            assert doc.version == rdoc["version"]
+
+            with open(tmp_file_1.name) as f:
+                assert doc.text == rdoc["text"] == f.read() == "\n".join([
                     "module module_function_call1",
                     "end module module_function_call1",
                 ]) + "\n"
 
             assert client.await_validation(doc.uri, doc.version) is not None
 
-            doc.rename(tmp_file_2.name)
+            doc.move(tmp_file_2.name)
 
             def sent_workspace_did_rename_file(event: OutgoingEvent) -> bool:
                 if isinstance(event.data, WorkspaceDidRenameFilesNotification):
@@ -160,8 +213,12 @@ def test_document_manipulation(client: LspTestClient):
             open(tmp_file_1.name, "w").close() # ensure it exists during clean-up
             assert os.path.exists(tmp_file_2.name)
 
+            rdoc = client.get_remote_document(doc.uri)
+            assert doc.uri == rdoc["uri"]
+            assert doc.version == rdoc["version"]
+
             with open(tmp_file_2.name) as f:
-                assert doc.text == f.read() == "\n".join([
+                assert doc.text == rdoc["text"] == f.read() == "\n".join([
                     "module module_function_call1",
                     "end module module_function_call1",
                 ]) + "\n"

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -1,13 +1,124 @@
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
-from llanguage_test_client.lsp_test_client import LspTestClient
+from lsprotocol.types import DidChangeConfigurationParams
+
+from llanguage_test_client.lsp_test_client import IncomingEvent
+from lfortran_language_server.lfortran_lsp_test_client import LFortranLspTestClient
 
 
-def test_goto_definition(client: LspTestClient):
+def test_goto_definition(client: LFortranLspTestClient) -> None:
     path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
     doc = client.open_document("fortran", path)
-    line, column = 17, 17
+    line, column = 18, 18
     doc.cursor = line, column
     doc.goto_definition()
-    assert doc.line == 7
-    assert doc.column == 4
+    assert doc.line == 8
+    assert doc.column == 5
+
+def test_diagnostics(client: LFortranLspTestClient) -> None:
+    path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
+    doc = client.open_document("fortran", path)
+    line, column = 21, 1
+    doc.cursor = line, column
+    doc.write("error")
+    validation = client.await_validation(doc.uri, doc.version)
+    assert validation is not None
+    assert validation["params"]["uri"] == doc.uri
+    assert validation["params"]["version"] == doc.version
+    diagnostics = validation["params"]["diagnostics"]
+    assert len(diagnostics) == 2
+
+    assert diagnostics[0]["message"] == "Statement or Declaration expected inside program, found Variable name"
+    assert diagnostics[0]["range"]["start"]["line"] == 20
+    assert diagnostics[0]["range"]["start"]["character"] == 0
+    assert diagnostics[0]["range"]["end"]["line"] == 20
+    assert diagnostics[0]["range"]["end"]["character"] == 5
+    assert diagnostics[0]["severity"] == 1
+    assert diagnostics[0]["source"] == "lfortran"
+
+    assert diagnostics[1]["message"] == "Variable 'error' is not declared"
+    assert diagnostics[1]["range"]["start"]["line"] == 20
+    assert diagnostics[1]["range"]["start"]["character"] == 0
+    assert diagnostics[1]["range"]["end"]["line"] == 20
+    assert diagnostics[1]["range"]["end"]["character"] == 5
+    assert diagnostics[1]["severity"] == 1
+    assert diagnostics[1]["source"] == "lfortran"
+
+    doc.backspace(5)
+    validation = client.await_validation(doc.uri, doc.version)
+    assert validation is not None
+    assert validation["params"]["uri"] == doc.uri
+    assert validation["params"]["version"] == doc.version
+    diagnostics = validation["params"]["diagnostics"]
+    assert len(diagnostics) == 0
+
+def test_configuration_caching(client: LFortranLspTestClient) -> None:
+    with NamedTemporaryFile(
+            prefix="test_configuration_caching-",
+            suffix=".f90",
+            delete=True
+    ) as tmp_file:
+        doc = client.open_document("fortran", tmp_file.name)
+        doc.write("foo")
+        doc.save()
+        assert client.await_validation(doc.uri, doc.version) is not None
+
+        def is_config_request_for_doc(event: IncomingEvent) -> bool:
+            return event.data.get("method", None) == "workspace/configuration" and \
+                len(event.data["params"]["items"]) > 0 and \
+                event.data["params"]["items"][0]["scopeUri"] == doc.uri and \
+                event.data["params"]["items"][0]["section"] == "LFortran"
+
+        event, index = client.find_incoming_event(is_config_request_for_doc)
+        # The config must be requested before it may be cached:
+        assert event is not None
+
+        doc.write("bar")
+        assert client.await_validation(doc.uri, doc.version) is not None
+        event, index = client.find_incoming_event(is_config_request_for_doc, index + 1)
+        # The config has been cached, so there is no need to cache it again:
+        assert event is None
+
+        # Invalidate the document caches:
+        client.send_workspace_did_change_configuration(
+            DidChangeConfigurationParams(client.config)
+        )
+
+        doc.write("baz")
+        assert client.await_validation(doc.uri, doc.version) is not None
+        event, index = client.find_incoming_event(is_config_request_for_doc, index + 1)
+        # The cache was invalidated so the config must be requested again:
+        assert event is not None
+
+def test_rename(client: LFortranLspTestClient) -> None:
+    path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
+    doc = client.open_document("fortran", path)
+    line, column = 4, 20
+    doc.cursor = line, column
+    doc.rename("foo")
+    assert doc.text == "\n".join([
+        "module module_function_call1",
+        "    type :: softmax",
+        "    contains",
+        "      foo",
+        "    end type softmax",
+        "  contains",
+        "  ",
+        "    pure function foo(self, x) result(res)",
+        "      class(softmax), intent(in) :: self",
+        "      real, intent(in) :: x(:)",
+        "      real :: res(size(x))",
+        "    end function foo",
+        "  ",
+        "    pure function eval_1d_prime(self, x) result(res)",
+        "      class(softmax), intent(in) :: self",
+        "      real, intent(in) :: x(:)",
+        "      real :: res(size(x))",
+        # TODO: Once lfortran can rename the function call, swap the following
+        # two lines:
+        # "      res = self%foo(x)",
+        "      res = self%eval_1d(x)",
+        "    end function eval_1d_prime",
+        "end module module_function_call1",
+    ]) + "\n"


### PR DESCRIPTION
Changes:
* Fixes a minor bug where the text document's URI is not updated when its file is renamed
* Adds a custom method `$/getDocument` to validate how documents change with updates
* Fixes minor issue related to the file:// URI regexs
* Renames the method that renames LspTextDocument files from `rename` to `move`
* Adds the method `rename` to LspTextDocument to rename one of its symbols (for the `textDocument/rename` request)
* Refactors LFortran-specific logic from LspTestClient to LFortranLspTestClient
* Makes the convention for interacting with an LspTextDocument's lines and columns 1-indexed (it was 0-indexed)
* Adds tests for receiving diagnostics about documents changes, caching document configurations, and renaming symbols