### PR TITLE
Minor fix for codegen type errors

### DIFF
--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -386,7 +386,7 @@ public:
             } else if(ASR::is_a<ASR::CPtr_t>(*t2)) {
                 sub = format_type_c("", "void**", v.m_name, false, false);
             } else {
-                diag.codegen_error_label("Type number '"
+                diag.codegen_error_label("Type '"
                     + ASRUtils::type_to_str_python(t2)
                     + "' not supported", {v.base.base.loc}, "");
                 throw Abort();
@@ -550,7 +550,7 @@ public:
                 // Ignore type variables
                 return "";
             } else {
-                diag.codegen_error_label("Type number '"
+                diag.codegen_error_label("Type '"
                     + ASRUtils::type_to_str_python(v_m_type)
                     + "' not supported", {v.base.base.loc}, "");
                 throw Abort();

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -258,7 +258,7 @@ public:
                 std::string encoded_type_name = "i" + std::to_string(t->m_kind * 8);
                 handle_array(t2, type_name, true)
             } else {
-                diag.codegen_error_label("Type number '"
+                diag.codegen_error_label("Type '"
                     + ASRUtils::type_to_str_python(v.m_type)
                     + "' not supported", {v.base.base.loc}, "");
                 throw Abort();
@@ -305,7 +305,7 @@ public:
                 sub = format_type_c("", list_type_c, v.m_name,
                                     false, false);
             } else {
-                diag.codegen_error_label("Type number '"
+                diag.codegen_error_label("Type '"
                     + ASRUtils::type_to_str_python(v.m_type)
                     + "' not supported", {v.base.base.loc}, "");
                 throw Abort();


### PR DESCRIPTION
LP still printed type names b4 the latest sync https://github.com/lcompilers/lpython/issues/2816 but we can't merge there since the sync is completed yet. I checked LF to see if this was already fixed. It was but there were still some 'Type number's left so i went ahead and removed those

Code in asr->c fixed to print type names but still has type number 
https://github.com/lfortran/lfortran/blob/4ffef1008bf6594e55457a2fb3c6f4af45008c97/src/libasr/codegen/asr_to_c.cpp#L389-L391

Similar code in asr->julia doesn't print type number
https://github.com/lfortran/lfortran/blob/4ffef1008bf6594e55457a2fb3c6f4af45008c97/src/libasr/codegen/asr_to_julia.cpp#L310-L313