### PR TITLE
Dumps LSP server stdout and stdin logs on test failure

### DIFF
--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -28,7 +28,9 @@ class LFortranLspTestClient(LspTestClient):
             workspace_path: Optional[Path],
             timeout_ms: float,
             config: Dict[str, Any],
-            client_log_path: str
+            client_log_path: str,
+            stdout_log_path: str,
+            stdin_log_path: str
     ) -> None:
         super().__init__(
             server_path,
@@ -36,7 +38,9 @@ class LFortranLspTestClient(LspTestClient):
             workspace_path,
             timeout_ms,
             config,
-            client_log_path
+            client_log_path,
+            stdout_log_path,
+            stdin_log_path
         )
 
     def await_validation(self, uri: str, version: int) -> Any:

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -25,6 +25,8 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
 
     server_log_path = f"{request.node.name}-server.log"
     client_log_path = f"{request.node.name}-client.log"
+    stdout_log_path = f"{request.node.name}-stdout.log"
+    stdin_log_path = f"{request.node.name}-stdin.log"
 
     config = {
         "LFortran": {
@@ -75,25 +77,33 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
         "--extension-id", "lcompilers.lfortran",
     ]
 
-    client = LFortranLspTestClient(server_path, server_args, None, 1000, config, client_log_path)
+    client = LFortranLspTestClient(
+        server_path=server_path,
+        server_params=server_args,
+        workspace_path=None,
+        timeout_ms=1000,
+        config=config,
+        client_log_path=client_log_path,
+        stdout_log_path=stdout_log_path,
+        stdin_log_path=stdin_log_path
+    )
+
+    def print_log(log_path: str, heading: str) -> None:
+        if os.path.exists(log_path):
+            print(file=sys.stderr)
+            border = "~" * (len(heading) + 6)
+            print(border, file=sys.stderr)
+            print(f"~~ {heading} ~~", file=sys.stderr)
+            print(border, file=sys.stderr)
+            print(file=sys.stderr)
+            with open(log_path) as f:
+                print(f.read(), file=sys.stderr)
 
     def print_logs() -> None:
-        if os.path.exists(client_log_path):
-            print()
-            print("~~~~~~~~~~~~~~~~~", file=sys.stderr)
-            print("~~ Client Logs ~~", file=sys.stderr)
-            print("~~~~~~~~~~~~~~~~~", file=sys.stderr)
-            print()
-            with open(client_log_path) as f:
-                print(f.read(), file=sys.stderr)
-        if os.path.exists(server_log_path):
-            print()
-            print("~~~~~~~~~~~~~~~~~", file=sys.stderr)
-            print("~~ Server Logs ~~", file=sys.stderr)
-            print("~~~~~~~~~~~~~~~~~", file=sys.stderr)
-            print()
-            with open(server_log_path) as f:
-                print(f.read(), file=sys.stderr)
+        print_log(client_log_path, "Client Logs")
+        print_log(stdin_log_path, "Standard Input")
+        print_log(stdout_log_path, "Standard Output")
+        print_log(server_log_path, "Server Logs")
 
     logs_printed = False
     try:


### PR DESCRIPTION
Changes:
* Specifies utf-8 as byte encoding
* Migrates several buffers from StringIO to BytesIO
* Adds SpyIO to pipe the server's stdin and stdout to their respective log files