### PR TITLE
fix: time report for passes

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10898,7 +10898,13 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
 
     if (co.time_report) {
         int time_take_to_run_asr_passes = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-        std::string message = "ASR -> ASR passes: " + std::to_string(time_take_to_run_asr_passes / 1000) + "." + std::to_string(time_take_to_run_asr_passes % 1000) + " ms";
+        double time_in_milliseconds = (double) time_take_to_run_asr_passes / 1000.0;
+        std::string message = "";
+        if ( time_in_milliseconds >= 1.0 ) {
+            message = "ASR -> ASR passes: " + std::to_string(time_take_to_run_asr_passes / 1000) + "." + std::to_string(time_take_to_run_asr_passes % 1000) + " ms";
+        } else {
+            message = "ASR -> ASR passes: " + std::to_string(time_in_milliseconds) + " ms";
+        }
         co.po.vector_of_time_report.push_back(message);
     }
 

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -3409,7 +3409,8 @@ Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr,
                 "implied_do_loops", "print_arr", "do_loops", "select_case",
                 "nested_vars", "unused_functions", "intrinsic_function"};
     LCompilers::PassManager pass_manager;
-    pass_manager.apply_passes(al, &asr, passes, co.po, diagnostics);
+    double cummulative_time_take_by_passes = 0.0;
+    pass_manager.apply_passes(al, &asr, passes, co.po, diagnostics, cummulative_time_take_by_passes);
 
 
 #ifdef SHOW_ASR


### PR DESCRIPTION
Towards #6678. This PR tallies the sum of time take across each pass + other processing time = time for ASR -> ASR passes.

```console
% time lfortran examples/expr2.f90 --time-report
25
Allocator usage of last chunk (MB)                     0.004
Allocator chunks                                       1.000
------------------------------------------------------------
Component name                                     Time (ms)
------------------------------------------------------------
File reading                                           0.420
Src -> ASR                                             1.233
Time taken by pass
    global_stmts                                       0.032
    init_expr                                          0.048
    function_call_in_declaration                       0.016
    openmp                                             0.006
    implied_do_loops                                   0.029
    array_struct_temporary                             0.091
    nested_vars                                        0.038
    transform_optional_argument_functions              0.037
    forall                                             0.012
    class_constructor                                  0.019
    pass_list_expr                                     0.019
    where                                              0.012
    subroutine_from_function                           0.029
    array_op                                           0.024
    symbolic                                           0.013
    intrinsic_function                                 0.033
    intrinsic_subroutine                               0.014
    array_op                                           0.007
    pass_array_by_data                                 0.041
    array_passed_in_function_call                      0.015
    print_list_tuple                                   0.022
    array_dim_intrinsics_update                        0.018
    do_loops                                           0.018
    while_else                                         0.021
    select_case                                        0.011
    unused_functions                                   0.024
    unique_symbols                                     0.005
    insert_deallocate                                  0.017
    other processing time                              0.047
ASR -> ASR passes                                      0.719
LLVM IR creation                                       0.157
ASR -> mod                                             0.500
LLVM opt                                               0.000
LLVM -> BIN                                            1.772
Linking time                                          37.931
------------------------------------------------------------
Total time                                            45.182
------------------------------------------------------------
lfortran examples/expr2.f90 --time-report  0.12s user 0.02s system 109% cpu 0.126 total
```