### PR TITLE
enh: enhance cshift for multi-dim arrays

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -55,5 +55,5 @@ if [[ $WIN != "1" ]]; then
     cd ..
 
     pip install src/server/tests tests/server
-    pytest --full-trace --capture=no tests/server
+    pytest -vv --showlocals --full-trace --capture=no --timeout=5 tests/server
 fi

--- a/integration_tests/intrinsics_343.f90
+++ b/integration_tests/intrinsics_343.f90
@@ -1,5 +1,7 @@
 program intrinsics_343
     integer, allocatable :: b(:)
+    integer, dimension(3, 4) :: a
+    a = reshape([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], shape=[3, 4])
     allocate(b(3))
 
     b = reshape([1, 2, 3], shape=[3])
@@ -7,5 +9,10 @@ program intrinsics_343
     b = cshift(b, 2)
     print *, b
 
+    print *, cshift(a, 2)
+    a = cshift(a, 2)
+    print *, a
+
     if( any(b /= [3, 1, 2] ) ) error stop
+    if( any(a /= reshape([3, 1, 2, 6, 4, 5, 9, 7, 8, 12 ,10, 11], shape=[3, 4]) )) error stop
 end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1772,7 +1772,7 @@ namespace Cshift {
                 b.Assignment(i, b.Add(i, b.i32(1))),
             }, nullptr));
         } else {
-            throw LCompilersException("`Nearest` intrinsic is not yet implemented for arrays with rank > 2");
+            throw LCompilersException("`Cshift` intrinsic is not yet implemented for arrays with rank > 2");
         }
         body.push_back(al, b.Return());
         ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,

--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from lsprotocol.types import TextDocumentSaveReason
 
@@ -90,4 +90,8 @@ class LspClient(ABC):
 
     @abstractmethod
     def workspace_did_delete_files(self, files: List[Uri]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def goto_definition(self, uri: str, line: int, column: int) -> None:
         raise NotImplementedError

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -1000,4 +1000,4 @@ class LspTestClient(LspClient):
                 ),
             )
             request_id = self.send_text_document_definition(params)
-            return self.await_response(request_id)
+            self.await_response(request_id)

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -589,7 +589,7 @@ class LspTestClient(LspClient):
         del self.documents_by_id[document_id]
         if self.active_document is not None \
            and self.active_document.document_id == document_id:
-            for prev_document_id in range(document_id - 1, 0):
+            for prev_document_id in range(document_id - 1, -1, -1):
                 prev_document = self.documents_by_id.get(prev_document_id, None)
                 if prev_document is not None:
                     self.active_document = prev_document

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -10,8 +10,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
-from typing import (IO, Any, Callable, Dict, Iterator, List, Optional, Tuple,
-                    Union)
+from typing import (IO, Any, Callable, Dict, Iterator, List, Optional,
+                    Sequence, Tuple, Union)
 
 from cattrs import Converter
 from lsprotocol import converters
@@ -22,17 +22,19 @@ from lsprotocol.types import (
     CompletionClientCapabilitiesCompletionItemTypeInsertTextModeSupportType,
     CompletionClientCapabilitiesCompletionItemTypeResolveSupportType,
     CompletionClientCapabilitiesCompletionItemTypeTagSupportType,
-    CompletionItemTag, CreateFilesParams, DeleteFilesParams,
+    CompletionItemTag, CreateFilesParams, DefinitionClientCapabilities,
+    DefinitionParams, DeleteFilesParams,
     DidChangeConfigurationClientCapabilities, DidChangeConfigurationParams,
     DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, ExitNotification,
     FileCreate, FileDelete, FileOperationClientCapabilities, FileRename,
     HoverClientCapabilities, InitializedNotification, InitializedParams,
     InitializeParams, InitializeRequest, InitializeResponse,
-    InitializeResultServerInfoType, InsertTextMode, MarkupKind, Position,
-    Range, Registration, RenameFilesParams, SaveOptions, ServerCapabilities,
-    ShutdownRequest, TextDocumentClientCapabilities,
+    InitializeResultServerInfoType, InsertTextMode, Location, LocationLink,
+    MarkupKind, Position, Range, Registration, RenameFilesParams, SaveOptions,
+    ServerCapabilities, ShutdownRequest, TextDocumentClientCapabilities,
     TextDocumentContentChangeEvent_Type1, TextDocumentContentChangeEvent_Type2,
+    TextDocumentDefinitionRequest, TextDocumentDefinitionResponse,
     TextDocumentDidChangeNotification, TextDocumentDidCloseNotification,
     TextDocumentDidOpenNotification, TextDocumentDidSaveNotification,
     TextDocumentIdentifier, TextDocumentItem,
@@ -101,6 +103,7 @@ class LspTestClient(LspClient):
     serial_document_id: int
     documents_by_id: Dict[int, LspTextDocument]
     documents_by_uri: Dict[str, LspTextDocument]
+    active_document: Optional[LspTextDocument]
     requests_by_id: Dict[JsonValue, Any]
     responses_by_id: Dict[JsonValue, Any]
     callbacks_by_id: Dict[JsonValue, Tuple[Any, Callback]]
@@ -128,6 +131,7 @@ class LspTestClient(LspClient):
         self.serial_document_id = 0
         self.documents_by_id = dict()
         self.documents_by_uri = dict()
+        self.active_document = None
         self.requests_by_id = dict()
         self.responses_by_id = dict()
         self.callbacks_by_id = dict()
@@ -198,11 +202,17 @@ class LspTestClient(LspClient):
     def open_document(
             self,
             language_id: str,
-            path: Optional[Union[Path, str]]
+            path: Optional[Union[Path, str]],
+            make_active: bool = True
     ) -> LspTextDocument:
         document_id = self.next_document_id()
         document = LspTextDocument(self, document_id, language_id, path)
         self.documents_by_id[document_id] = document
+        if path is not None:
+            self.documents_by_uri[document.uri] = document
+            document.load()
+        if make_active:
+            self.active_document = document
         return document
 
     def await_validation(self, uri: str, version: int) -> Any:
@@ -221,13 +231,29 @@ class LspTestClient(LspClient):
                 return message
         return None
 
-    def await_response(self, request_id: Optional[int] = None) -> Any:
+    def await_response(
+            self,
+            request_id: Optional[int] = None,
+            event_index: Optional[int] = None
+    ) -> Any:
+        if request_id is not None:
+            message = self.responses_by_id.get(request_id, None)
+            if message is not None:
+                return message
+        elif event_index is not None:
+            for index in range(event_index, len(self.events)):
+                event = self.events[index]
+                if isinstance(event, IncomingEvent):
+                    response = event.data
+                    if response.get("id", None) is None:
+                        return response
         while not self.stop.is_set():
             message = self.receive_message()
-            response_id = message.get("id", None)
-            if response_id is not None and response_id in self.responses_by_id:
-                return message
-            if request_id == response_id:
+            if "result" in message:
+                response_id = message.get("id", None)
+                if request_id == response_id:
+                    return message
+            elif request_id is None and message.get("id", None) is None:
                 return message
 
     def initialize_params(self) -> InitializeParams:
@@ -291,6 +317,7 @@ class LspTestClient(LspClient):
                             MarkupKind.Markdown,
                         ],
                     ),
+                    definition=DefinitionClientCapabilities(),
                 ),
             ),
         )
@@ -331,8 +358,9 @@ class LspTestClient(LspClient):
         initialize_id = self.send_initialize(self.initialize_params())
         self.await_response(initialize_id)
 
+        event_index = len(self.events)
         self.send_initialized(self.initialized_params())
-        self.await_response()
+        self.await_response(event_index=event_index)
 
     def terminate(self) -> None:
         shutdown_id = self.send_shutdown()
@@ -499,7 +527,6 @@ class LspTestClient(LspClient):
                     self.send_workspace_did_change_configuration(
                         DidChangeConfigurationParams(self.config)
                     )
-                    self.await_response()
         response = ClientRegisterCapabilityResponse(request.id)
         return response
 
@@ -574,6 +601,12 @@ class LspTestClient(LspClient):
             uri: Optional[str]
     ) -> None:
         del self.documents_by_id[document_id]
+        if self.active_document is not None \
+           and self.active_document.document_id == document_id:
+            for prev_document_id in range(document_id - 1, 0):
+                prev_document = self.documents_by_id.get(prev_document_id, None)
+                if prev_document is not None:
+                    self.active_document = prev_document
         if uri is not None:
             del self.documents_by_uri[uri]
             if self.server_supports_text_document_did_open_or_close():
@@ -934,3 +967,58 @@ class LspTestClient(LspClient):
             notification: TextDocumentPublishDiagnosticsNotification
     ) -> None:
         pass
+
+    def server_supports_text_document_definition(self) -> bool:
+        # NOTE: This returns True if `definition_provider` is True or an instance
+        # of `DefinitionOptions`
+        return bool(self.server_capabilities.definition_provider)
+
+    def send_text_document_definition(self, params: DefinitionParams) -> int:
+        request_id = self.next_request_id()
+        request = TextDocumentDefinitionRequest(request_id, params)
+        self.send_request(request, self.receive_text_document_definition)
+        return request_id
+
+    def receive_text_document_definition(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentDefinitionResponse
+        )
+        loc: Optional[Union[Location, LocationLink]] = None
+        match response.result:
+            case Location():
+                loc = response.result
+            case _ if isinstance(response.result, Sequence) \
+                 and not isinstance(response.result, str) \
+                 and len(response.result) > 0:
+                loc = response.result[0]
+        doc: Optional[LspTextDocument] = None
+        pos: Optional[Position] = None
+        match loc:
+            case Location():
+                doc = self.documents_by_uri.get(loc.uri, None)
+                pos = loc.range.start
+            case LocationLink():
+                doc = self.documents_by_uri.get(loc.target_uri, None)
+                pos = loc.target_range.start
+        if doc is not None and pos is not None:
+            self.active_document = doc
+            doc.cursor = (pos.line, pos.character)
+
+    def goto_definition(self, uri: str, line: int, column: int) -> None:
+        if self.server_supports_text_document_definition():
+            params = DefinitionParams(
+                text_document=TextDocumentIdentifier(
+                    uri=uri,
+                ),
+                position=Position(
+                    line=line,
+                    character=column
+                ),
+            )
+            request_id = self.send_text_document_definition(params)
+            return self.await_response(request_id)

--- a/tests/server/setup.cfg
+++ b/tests/server/setup.cfg
@@ -26,6 +26,7 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     pytest>=8.3.5
+    pytest-timeout>=2.3.1
     llanguage-test-client>=0.0.1
 
 [options.packages.find]

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -28,14 +28,17 @@ def client(request: pytest.FixtureRequest) -> Iterator[LspTestClient]:
 
     log_path = f"{request.node.name}.log"
 
+    timeout_ms = 5000
+
     server_args = [
         "server",
         "--parent-process-id", str(os.getpid()),
         "--log-level", "trace",
         "--log-path", log_path,
+        "--timeout-ms", str(timeout_ms),
     ]
 
-    client = LspTestClient(server_path, server_args, None, 2000, {
+    client = LspTestClient(server_path, server_args, None, timeout_ms, {
         "LFortran": {
             "openIssueReporterOnError": False,
             "maxNumberOfProblems": 100,
@@ -52,7 +55,7 @@ def client(request: pytest.FixtureRequest) -> Iterator[LspTestClient]:
                 "prettyPrint": True,
             },
             "indentSize": 4,
-            "timeoutMs": 100,
+            "timeoutMs": timeout_ms,
             "retry": {
                 "maxAttempts": 3,
                 "minSleepTimeMs": 10,

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from llanguage_test_client.lsp_test_client import LspTestClient
+
+
+def test_goto_definition(client: LspTestClient):
+    path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
+    doc = client.open_document("fortran", path)
+    line, column = 17, 17
+    doc.cursor = line, column
+    doc.goto_definition()
+    assert doc.line == 7
+    assert doc.column == 4


### PR DESCRIPTION
`cshift` can now handle 2-D arrays. For N-Dimensional arrays, we have to modify it by declaring `n_dims` many variables and add `n_dims` many nested loops. Can someone please guide me how to add `n_dims` many nested_loops. 

Fixes #4597.