### PR TITLE
Make do_concurrent_12 run fast

### DIFF
--- a/integration_tests/do_concurrent_12.f90
+++ b/integration_tests/do_concurrent_12.f90
@@ -2,10 +2,11 @@
 
 subroutine matrix_multiplication(l, m, n)
 use omp_lib
+integer, parameter :: dp = kind(0.d0)
 integer :: l, m, n, i, j, k
 integer :: seed
-double precision :: a(l, n), b(l, m), c(m, n)
-double precision :: start_time, end_time
+real(dp) :: a(l, n), b(l, m), c(m, n)
+real(dp) :: start_time, end_time
 
 seed = 123456789
 
@@ -14,7 +15,7 @@ c = 29124.012D0
 
 do concurrent (j = 1:n) shared(a, b, c, l, m, n) local(i, k)
     do concurrent (i = 1:l)
-        a(i,j) = 0.0D+00
+        a(i,j) = 0
         do concurrent (k = 1:m)
             a(i,j) = a(i,j) + b(i,k) * c(k,j)
         end do
@@ -22,9 +23,9 @@ do concurrent (j = 1:n) shared(a, b, c, l, m, n) local(i, k)
 end do
 
 print *, "sum(a): ", sum(a)
-if (abs(sum(a) - (440952103687207.56D0)) > 1D-12) error stop
+if (abs(sum(a) - (4.40952103686020386e+11_dp)) > 1e-12_dp) error stop
 end subroutine
 
 program do_concurrent_12
-call matrix_multiplication(500, 500, 500)
+call matrix_multiplication(50, 50, 50)
 end program


### PR DESCRIPTION
Fixes #6821.

Also speeds up do_concurrent_13.

Now the total running time of all compiled tests is
```
Total Test time (real) =   0.40 sec
```
While in main it is:
```
Total Test time (real) =   0.63 sec
```

And each individual test now seems to take 0.00 s. So less than 10ms, which is good. These two tests fixed in this PR were the only two tests that were not 0.00s:
```
1455/1456 Test #1393: do_concurrent_13 ...................................   Passed    0.07 sec
1456/1456 Test #1392: do_concurrent_12 ...................................   Passed    0.23 sec
```
But now they are as well.