### PR TITLE
Corrects synchronization among stacked request handlers in concurrent mode

### DIFF
--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -66,7 +66,7 @@ namespace LCompilers::LanguageServerProtocol {
         ) -> void;
 
         auto getCompilerOptions(
-            const LspTextDocument &document
+            LspTextDocument &document
         ) -> const std::shared_ptr<CompilerOptions>;
 
         auto diagnosticLevelToLspSeverity(

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -20,6 +20,8 @@ def test_goto_definition(client: LFortranLspTestClient) -> None:
 def test_diagnostics(client: LFortranLspTestClient) -> None:
     path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
     doc = client.open_document("fortran", path)
+    # assert client.await_validation(doc.uri, doc.version) is not None
+
     line, column = 21, 1
     doc.cursor = line, column
     doc.write("error")

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -20,8 +20,7 @@ def test_goto_definition(client: LFortranLspTestClient) -> None:
 def test_diagnostics(client: LFortranLspTestClient) -> None:
     path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
     doc = client.open_document("fortran", path)
-    # assert client.await_validation(doc.uri, doc.version) is not None
-
+    assert client.await_validation(doc.uri, doc.version) is not None
     line, column = 21, 1
     doc.cursor = line, column
     doc.write("error")
@@ -63,6 +62,7 @@ def test_configuration_caching(client: LFortranLspTestClient) -> None:
             delete=True
     ) as tmp_file:
         doc = client.open_document("fortran", tmp_file.name)
+        assert client.await_validation(doc.uri, doc.version) is not None
         doc.write("foo")
         doc.save()
         assert client.await_validation(doc.uri, doc.version) is not None
@@ -97,6 +97,7 @@ def test_configuration_caching(client: LFortranLspTestClient) -> None:
 def test_rename(client: LFortranLspTestClient) -> None:
     path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
     doc = client.open_document("fortran", path)
+    assert client.await_validation(doc.uri, doc.version) is not None
     line, column = 4, 20
     doc.cursor = line, column
     doc.rename("foo")

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import pytest
-
 from lsprotocol.types import DidChangeConfigurationParams
 
 from llanguage_test_client.lsp_test_client import IncomingEvent
@@ -19,7 +17,6 @@ def test_goto_definition(client: LFortranLspTestClient) -> None:
     assert doc.line == 8
     assert doc.column == 5
 
-@pytest.mark.skip("Timeout")
 def test_diagnostics(client: LFortranLspTestClient) -> None:
     path = Path(__file__).absolute().parent.parent.parent / "function_call1.f90"
     doc = client.open_document("fortran", path)
@@ -57,7 +54,6 @@ def test_diagnostics(client: LFortranLspTestClient) -> None:
     diagnostics = validation["params"]["diagnostics"]
     assert len(diagnostics) == 0
 
-@pytest.mark.skip("Timeout")
 def test_configuration_caching(client: LFortranLspTestClient) -> None:
     with NamedTemporaryFile(
             prefix="test_configuration_caching-",


### PR DESCRIPTION
Changes:
1. Releases document read locks before request their configs.
2. Re-acquires document read locks after receiving their configs.
3. Re-enables affected unit tests.
4. Synchronizes feature tests on document validation after opening them.