### PR TITLE
Makes calls against LFortranAccessor mutually exclusive

### DIFF
--- a/src/bin/lfortran_accessor.cpp
+++ b/src/bin/lfortran_accessor.cpp
@@ -17,7 +17,8 @@ namespace LCompilers::LLanguageServer {
         const std::string &filename,
         const std::string &text,
         const CompilerOptions &compiler_options
-    ) const -> std::vector<LCompilers::error_highlight> {
+    ) -> std::vector<LCompilers::error_highlight> {
+        std::unique_lock<std::mutex> lock(mutex);
         LCompilers::FortranEvaluator fe(compiler_options);
 
         LCompilers::LocationManager lm;
@@ -71,7 +72,8 @@ namespace LCompilers::LLanguageServer {
         const std::string &filename,
         const std::string &text,
         const CompilerOptions &compiler_options
-    ) const -> std::vector<LCompilers::document_symbols> {
+    ) -> std::vector<LCompilers::document_symbols> {
+        std::unique_lock<std::mutex> lock(mutex);
         LCompilers::FortranEvaluator fe(compiler_options);
         std::vector<LCompilers::document_symbols> symbol_lists;
 
@@ -128,7 +130,8 @@ namespace LCompilers::LLanguageServer {
         const std::string &filename,
         const std::string &text,
         const CompilerOptions &compiler_options
-    ) const -> std::vector<LCompilers::document_symbols> {
+    ) -> std::vector<LCompilers::document_symbols> {
+        std::unique_lock<std::mutex> lock(mutex);
         LCompilers::FortranEvaluator fe(compiler_options);
         std::vector<LCompilers::document_symbols> symbol_lists;
 
@@ -170,7 +173,8 @@ namespace LCompilers::LLanguageServer {
         bool color,
         int indent,
         bool indent_unit
-    ) const -> LCompilers::Result<std::string> {
+    ) -> LCompilers::Result<std::string> {
+        std::unique_lock<std::mutex> lock(mutex);
         LCompilers::FortranEvaluator fe(compiler_options);
         LCompilers::LocationManager lm;
         LCompilers::diag::Diagnostics diagnostics;
@@ -200,7 +204,8 @@ namespace LCompilers::LLanguageServer {
         const std::string &filename,
         const std::string &text,
         const CompilerOptions &compiler_options
-    ) const -> std::vector<LCompilers::document_symbols> {
+    ) -> std::vector<LCompilers::document_symbols> {
+        std::unique_lock<std::mutex> lock(mutex);
         LCompilers::FortranEvaluator fe(compiler_options);
         std::vector<LCompilers::document_symbols> symbol_lists;
 

--- a/src/bin/lfortran_accessor.h
+++ b/src/bin/lfortran_accessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -15,30 +16,29 @@ namespace LCompilers::LLanguageServer {
 
     class LFortranAccessor {
     public:
-
         auto showErrors(
             const std::string &filename,
             const std::string &text,
             const CompilerOptions &compiler_options
-        ) const -> std::vector<LCompilers::error_highlight>;
+        ) -> std::vector<LCompilers::error_highlight>;
 
         auto lookupName(
             const std::string &filename,
             const std::string &text,
             const CompilerOptions &compiler_options
-        ) const -> std::vector<LCompilers::document_symbols>;
+        ) -> std::vector<LCompilers::document_symbols>;
 
         auto getAllOccurrences(
             const std::string &filename,
             const std::string &text,
             const CompilerOptions &compiler_options
-        ) const -> std::vector<LCompilers::document_symbols>;
+        ) -> std::vector<LCompilers::document_symbols>;
 
         auto getSymbols(
             const std::string &filename,
             const std::string &text,
             const CompilerOptions &compiler_options
-        ) const -> std::vector<LCompilers::document_symbols>;
+        ) -> std::vector<LCompilers::document_symbols>;
 
         template <typename T>
         auto populateSymbolLists(
@@ -46,7 +46,7 @@ namespace LCompilers::LLanguageServer {
             LCompilers::LocationManager &lm,
             std::vector<LCompilers::document_symbols> &symbol_lists,
             int parent_index
-        ) const -> void {
+        ) -> void {
             for (auto &a : x->m_symtab->get_scope()) {
                 std::size_t index = symbol_lists.size();
                 LCompilers::document_symbols &loc = symbol_lists.emplace_back();
@@ -85,7 +85,9 @@ namespace LCompilers::LLanguageServer {
             bool color,
             int indent,
             bool indent_unit
-        ) const -> LCompilers::Result<std::string>;
+        ) -> LCompilers::Result<std::string>;
+    private:
+        std::mutex mutex;
     };
 
 } // namespace LCompilers::LLanguageServer


### PR DESCRIPTION
Adds a mutex to LFortranAccessor so it may only be accessed by one thread at a time (to work around dependencies that might not be thread-safe)