### PR TITLE
fix: wrap with Array ttype when declaration of `cptr` is passed

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1897,6 +1897,7 @@ RUN(NAME character_parameter_padding_trimming LABELS gfortran llvm llvm_wasm llv
 
 RUN(NAME c_ptr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME c_ptr_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME arrayitem_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_indices_array_item LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray NO_STD_F23)

--- a/integration_tests/c_ptr_03.f90
+++ b/integration_tests/c_ptr_03.f90
@@ -1,0 +1,21 @@
+program c_ptr_03
+    use iso_c_binding, only: c_ptr, c_loc, c_int, c_f_pointer
+    implicit none
+    integer(c_int), target :: x, y
+    type(c_ptr), dimension(2) :: c_requests
+    integer(c_int), pointer :: px, py
+
+    x = 10
+    y = 20
+
+    c_requests(1) = c_loc(x)
+    c_requests(2) = c_loc(x)
+    call c_f_pointer(c_requests(1), px)
+    call c_f_pointer(c_requests(2), py)
+
+    print *, "px: ", px
+    if (px /= x) error stop
+
+    print *, "py: ", py
+    if (py /= y) error stop
+end program c_ptr_03

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4476,6 +4476,10 @@ public:
                     al, loc, type, dims.p, dims.size(), abi, is_argument);
             } else if (v && ASRUtils::is_c_ptr(v, derived_type_name)) {
                 type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
+                type = ASRUtils::make_Array_t_util(
+                    al, loc, type, dims.p, dims.size(), abi, is_argument,
+                    ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star
+                );
             } else if (v && ASRUtils::is_c_funptr(v, derived_type_name)) {
                 type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
             } else {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4733,6 +4733,9 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             ptr_loads = 1 - reduce_loads;
             this->visit_expr(*cptr);
             llvm::Value* llvm_cptr = tmp;
+            if (ASR::is_a<ASR::ArrayItem_t>(*cptr)) {
+                llvm_cptr = llvm_utils->CreateLoad(llvm_cptr);
+            }
             ptr_loads = 0;
             this->visit_expr(*fptr);
             llvm::Value* llvm_fptr = tmp;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -476,6 +476,10 @@ namespace LCompilers {
                 el_type = llvm::Type::getInt1Ty(context);
                 break;
             }
+            case ASR::ttypeType::CPtr: {
+                el_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                break;
+            }
             case ASR::ttypeType::StructType: {
                 el_type = getStructType(m_type_, module);
                 break;


### PR DESCRIPTION
## Description


also make sure to load the ArrayItem in visit_CPtrToPointer