### PR TITLE
use appropriate format specifier for 'unsigned long long int' in C

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -4388,7 +4388,7 @@ LFORTRAN_API void print_stacktrace_addresses(char *filename, bool use_colors) {
 #ifdef HAVE_LFORTRAN_MACHO
                 DIM ", line %lld\n" S_RESET
 #else
-                DIM ", line %ld\n" S_RESET
+                DIM ", line %llu\n" S_RESET
 #endif
                 "    %s\n", source_filename, d.line_numbers[index],
                 remove_whitespace(read_line_from_file(source_filename,
@@ -4398,7 +4398,7 @@ LFORTRAN_API void print_stacktrace_addresses(char *filename, bool use_colors) {
 #ifdef HAVE_LFORTRAN_MACHO
                 "line %lld\n    %s\n",
 #else
-                "line %ld\n    %s\n",
+                "line %llu\n    %s\n",
 #endif
                 source_filename, d.line_numbers[index],
                 remove_whitespace(read_line_from_file(source_filename,


### PR DESCRIPTION
## Description

Towards: https://github.com/lfortran/lfortran/issues/6769

this fixes the error we get when building without MACHO and with RUNTIME_STACKTRACE enabled on macOS

I verified that this fixes the errors on my macOS when initially being able to reproduce the error locally, the configuration for building LFortran I used:
```console
Configuration results
---------------------
LFORTRAN_VERSION: 0.50.0-69-g489ec9bc1-dirty
CPACK_PACKAGE_FILE_NAME: lfortran-0.50.0-69-g489ec9bc1-dirty-Darwin
C compiler      : /Library/Developer/CommandLineTools/usr/bin/clang
C++ compiler    : /Library/Developer/CommandLineTools/usr/bin/clang++
Build type: Debug
C compiler flags      : -g
C++ compiler flags    : -Wall -Wextra -g -ggdb
Installation prefix: /Users/gxyd/OpenSource/lfortran/inst
WITH_LFORTRAN_ASSERT: yes
LFORTRAN_STATIC_BIN: no
LFORTRAN_BUILD_TO_WASM: no
WITH_STACKTRACE: no
WITH_RUNTIME_STACKTRACE: yes
WITH_UNWIND: yes
WITH_LIBUNWIND: no
WITH_BFD: no
WITH_LLVM_STACKTRACE: no
WITH_DWARFDUMP: no
WITH_LINKH: no
WITH_MACHO: no
HAVE_LFORTRAN_DEMANGLE: yes
WITH_LLVM: yes
WITH_MLIR: no
WITH_XEUS: no
WITH_JSON: no
WITH_LSP: no
WITH_FMT: no
WITH_BENCHMARKS: no
WITH_LFORTRAN_BINARY_MODFILES: YES
WITH_RUNTIME_LIBRARY: YES
WITH_WHEREAMI: yes
WITH_ZLIB: yes
WITH_TARGET_AARCH64: yes
WITH_TARGET_X86: no
WITH_TARGET_WASM: no
WITH_KOKKOS: no
WITH_CCACHE: no
CXXFLAGS: -Werror
CFLAGS: -Werror
```