### PR TITLE
try to remove implicit function declaration warning from libunwind

### DIFF
--- a/src/runtime/legacy/CMakeLists.txt
+++ b/src/runtime/legacy/CMakeLists.txt
@@ -13,6 +13,11 @@ add_library(lfortran_runtime SHARED ${SRC})
 target_include_directories(lfortran_runtime BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
 target_include_directories(lfortran_runtime BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
 target_link_libraries(lfortran_runtime PRIVATE ${MATH_LIBRARIES})
+
+if (WITH_LIBUNWIND)
+    target_link_libraries(lfortran_runtime PRIVATE p::libunwind)
+endif()
+
 set_target_properties(lfortran_runtime PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
## Description

Towards: https://github.com/lfortran/lfortran/issues/6769

link with libunwind lfortran_runtime