### PR TITLE
Adds test for textDocument/documentHighlight

### DIFF
--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -99,3 +99,7 @@ class LspClient(ABC):
     @abstractmethod
     def rename(self, uri: str, line: int, column: int, new_name: str) -> None:
         raise NotImplementedError
+
+    @abstractmethod
+    def highlight(self, uri: str, line: int, column: int) -> None:
+        raise NotImplementedError

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -8,8 +8,9 @@ from lsprotocol.types import (
     CompletionClientCapabilitiesCompletionItemTypeResolveSupportType,
     CompletionClientCapabilitiesCompletionItemTypeTagSupportType,
     CompletionItemTag, DefinitionClientCapabilities, DefinitionParams,
-    HoverClientCapabilities, InitializeParams, InsertTextMode, Location,
-    LocationLink, MarkupKind, Position, RenameClientCapabilities, RenameParams,
+    DocumentHighlightClientCapabilities, HoverClientCapabilities,
+    InitializeParams, InsertTextMode, Location, LocationLink, MarkupKind,
+    Position, RenameClientCapabilities, RenameParams,
     TextDocumentDefinitionRequest, TextDocumentDefinitionResponse,
     TextDocumentIdentifier, TextDocumentPublishDiagnosticsNotification,
     TextDocumentRenameRequest, TextDocumentRenameResponse, WorkspaceEdit)
@@ -114,6 +115,7 @@ class LFortranLspTestClient(LspTestClient):
             )
             text_document.definition = DefinitionClientCapabilities()
             text_document.rename = RenameClientCapabilities()
+            text_document.document_highlight = DocumentHighlightClientCapabilities()
         return params
 
     def receive_text_document_publish_diagnostics(


### PR DESCRIPTION
Changes:
* Adds test for `textDocument/documentHighlight`
* Adds decorator for `LspTextDocument` methods that should only be called if their path has been set
* Returns request_id from `LspTestClient.send_request`