### PR TITLE
enh: lhs reallocation for intrinsic types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1417,6 +1417,7 @@ RUN(NAME allocate_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
+RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 
 RUN(NAME block_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME block_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1418,6 +1418,7 @@ RUN(NAME allocate_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
+RUN(NAME automatic_allocation_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 
 RUN(NAME block_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME block_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1415,6 +1415,7 @@ RUN(NAME allocate_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
 RUN(NAME allocate_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME allocate_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)

--- a/integration_tests/allocate_18.f90
+++ b/integration_tests/allocate_18.f90
@@ -1,0 +1,28 @@
+program allocate_18
+    implicit none
+
+    integer, allocatable :: i
+    real, allocatable :: r
+    complex, allocatable :: c
+    logical, allocatable :: l
+
+    allocate(i)
+    allocate(r)
+    allocate(c)
+    allocate(l)
+
+    i = 10
+    r = 4.4
+    c = (1, 2)
+    l = .true.
+
+    if (i /= 10) error stop
+    if (r /= 4.4) error stop
+    if (c /= (1, 2)) error stop
+    if (l .neqv. .true.) error stop
+
+    deallocate(i)
+    deallocate(r)
+    deallocate(c)
+    deallocate(l)
+end program allocate_18

--- a/integration_tests/automatic_allocation_02.f90
+++ b/integration_tests/automatic_allocation_02.f90
@@ -1,0 +1,23 @@
+program automatic_allocation_02
+    implicit none
+
+    integer, allocatable :: i
+    real, allocatable :: r
+    complex, allocatable :: c
+    logical, allocatable :: l
+
+    i = 10
+    r = 4.4
+    c = (1, 2)
+    l = .true.
+
+    if (i /= 10) error stop
+    if (r /= 4.4) error stop
+    if (c /= (1, 2)) error stop
+    if (l .neqv. .true.) error stop
+
+    deallocate(i)
+    deallocate(r)
+    deallocate(c)
+    deallocate(l)
+end program automatic_allocation_02

--- a/integration_tests/automatic_allocation_03.f90
+++ b/integration_tests/automatic_allocation_03.f90
@@ -1,0 +1,9 @@
+program automatic_allocation_03
+    implicit none
+    integer, allocatable :: i
+
+    i = 4
+    i = abs(i - 4);
+
+    if (i /= 0) error stop
+end program automatic_allocation_03

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -37,7 +37,6 @@ public:
     std::vector<ASR::symbol_t*> do_loop_variables;
     std::map<ASR::asr_t*, std::pair<const AST::stmt_t*,int64_t>> print_statements;
     std::vector<ASR::DoConcurrentLoop_t *> omp_constructs;
-    std::set<ASR::symbol_t*> allocated_symbols;
 
     BodyVisitor(Allocator &al, ASR::asr_t *unit, diag::Diagnostics &diagnostics,
         CompilerOptions &compiler_options,
@@ -1482,9 +1481,6 @@ public:
         tmp = ASR::make_Allocate_t(al, x.base.base.loc,
                                     alloc_args_vec.p, alloc_args_vec.size(),
                                     stat, errmsg, source);
-        for (ASR::alloc_arg_t alloc_arg : alloc_args_vec) {
-            allocated_symbols.insert(get_allocate_expr_sym(alloc_arg.m_a));
-        }
 
         if (source) {
             current_body->push_back(al, ASRUtils::STMT(ASR::make_Allocate_t(al, x.base.base.loc,
@@ -3097,25 +3093,7 @@ public:
                     Label("",{x.base.base.loc})
                 }));
             throw SemanticAbort();
-        } else if (compiler_options.po.realloc_lhs &&
-                 ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(target)) &&
-                 ASR::is_a<ASR::StructConstructor_t>(*value) &&
-                 (allocated_symbols.find(get_allocate_expr_sym(target)) == allocated_symbols.end())) {
-            // Implicitly allocate the Struct by pushing an Allocate_t to the body
-            Vec<ASR::alloc_arg_t> alloc_args; alloc_args.reserve(al, 1);
-            ASR::alloc_arg_t alloc_arg;
-            alloc_arg.loc = x.base.base.loc;
-            alloc_arg.m_a = target;
-            alloc_arg.m_dims = nullptr;
-            alloc_arg.n_dims = 0;
-            alloc_arg.m_type = nullptr;
-            alloc_arg.m_len_expr = nullptr;
-            alloc_args.push_back(al, alloc_arg);
-            current_body->push_back( al,
-                ASRUtils::STMT(
-                    ASR::make_Allocate_t(al, x.base.base.loc, alloc_args.p, 1, nullptr, nullptr, nullptr)));
         }
-
         check_ArrayAssignmentCompatibility(target, value, x);
 
         if( overloaded_stmt == nullptr ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5677,6 +5677,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
     // Checks if target_expr is allocated and if not then allocate
     // Used for compiler_options.po.realloc_lhs
     void check_and_allocate(ASR::expr_t *target_expr) {
+        LCOMPILERS_ASSERT(compiler_options.po.realloc_lhs);
         ASR::ttype_t *asr_type = ASRUtils::type_get_past_pointer(
             ASRUtils::type_get_past_allocatable(
             ASRUtils::expr_type(target_expr)));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9384,7 +9384,9 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             } else {
                 ASR::ttype_t* arg_type = expr_type(x.m_args[i].m_value);
                 int64_t ptr_loads_copy = ptr_loads;
-                ptr_loads = !LLVM::is_llvm_struct(arg_type);
+                if (LLVM::is_llvm_struct(arg_type)) {
+                    ptr_loads = 1;
+                }
                 this->visit_expr_wrapper(x.m_args[i].m_value);
 
                 if( x_abi == ASR::abiType::BindC ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9383,10 +9383,6 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 this->visit_expr_wrapper(x.m_args[i].m_value, true);
             } else {
                 ASR::ttype_t* arg_type = expr_type(x.m_args[i].m_value);
-                int64_t ptr_loads_copy = ptr_loads;
-                if (LLVM::is_llvm_struct(arg_type)) {
-                    ptr_loads = 1;
-                }
                 this->visit_expr_wrapper(x.m_args[i].m_value);
 
                 if( x_abi == ASR::abiType::BindC ) {
@@ -9412,7 +9408,6 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                     }
                 }
                 llvm::Value *value = tmp;
-                ptr_loads = ptr_loads_copy;
                 // TODO: we are getting a warning of uninitialized variable,
                 // there might be a bug below.
                 llvm::Type *target_type = nullptr;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1019,7 +1019,10 @@ public:
                     llvm_utils->string_init(alloc_size, ptr_to_init);
                 } else if(ASR::is_a<ASR::StructType_t>(*curr_arg_m_a_type) ||
                           ASR::is_a<ASR::ClassType_t>(*curr_arg_m_a_type) ||
-                          ASR::is_a<ASR::Integer_t>(*curr_arg_m_a_type)) {
+                          ASR::is_a<ASR::Integer_t>(*curr_arg_m_a_type) ||
+                          ASR::is_a<ASR::Real_t>(*curr_arg_m_a_type) ||
+                          ASR::is_a<ASR::Complex_t>(*curr_arg_m_a_type) ||
+                          ASR::is_a<ASR::Logical_t>(*curr_arg_m_a_type)) {
                     llvm::Value* malloc_size = SizeOfTypeUtil(curr_arg_m_a_type, llvm_utils->getIntType(4),
                     ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4)));
                     llvm::Value* malloc_ptr = LLVMArrUtils::lfortran_malloc(
@@ -5316,6 +5319,17 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             builder->CreateStore(tmp, llvm_symtab[target_h]);
             return ;
         }
+
+        // When assigning to a StructInstanceMember, whose instance is allocatable
+        // Check if the underlying struct instance is allocated, if not allocate
+        if (compiler_options.po.realloc_lhs &&
+            ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target)) {
+            ASR::StructInstanceMember_t *sim = ASR::down_cast<ASR::StructInstanceMember_t>(x.m_target);
+            if (ASRUtils::is_allocatable(ASRUtils::expr_type(sim->m_v))) {
+                check_and_allocate(sim->m_v);
+            }
+        }
+
         llvm::Value *target, *value;
         uint32_t h;
         bool lhs_is_string_arrayref = false;
@@ -5341,11 +5355,6 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                             lhs_is_string_arrayref = true;
                         }
                     }
-                }
-            } else if (is_a<ASR::StructInstanceMember_t>(*x.m_target)) {
-                if( ASRUtils::is_allocatable(x.m_target) &&
-                    !ASRUtils::is_character(*ASRUtils::expr_type(x.m_target)) ) {
-                    target = llvm_utils->CreateLoad(target);
                 }
             } else if( ASR::is_a<ASR::StringItem_t>(*x.m_target) ) {
                 ASR::StringItem_t *asr_target0 = ASR::down_cast<ASR::StringItem_t>(x.m_target);
@@ -5645,12 +5654,51 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             llvm_utils->dict_api->write_item(pdict, key, value, module.get(),
                                 dict_type->m_key_type,
                                 dict_type->m_value_type, name2memidx);
-        } else if (ASR::is_a<ASR::Allocatable_t>(*target_type) && ASR::is_a<ASR::StructType_t>(*value_type)) {
+        } else if (ASRUtils::is_allocatable(target_type)) {
+            if (compiler_options.po.realloc_lhs) {
+                ASR::ttype_t* asr_type = ASRUtils::type_get_past_pointer(
+                    ASRUtils::type_get_past_allocatable(
+                    ASRUtils::expr_type(x.m_target)));
+                if (ASR::is_a<ASR::Integer_t>(*asr_type) ||
+                    ASR::is_a<ASR::Real_t>(*asr_type) ||
+                    ASR::is_a<ASR::Complex_t>(*asr_type) ||
+                    ASR::is_a<ASR::Logical_t>(*asr_type)) {
+                    check_and_allocate(x.m_target);
+                }
+            }
+
             target = llvm_utils->CreateLoad(target);
             builder->CreateStore(value, target);
         } else {
             builder->CreateStore(value, target);
         }
+    }
+
+    // Checks if target_expr is allocated and if not then allocate
+    // Used for compiler_options.po.realloc_lhs
+    void check_and_allocate(ASR::expr_t *target_expr) {
+        ASR::ttype_t *asr_type = ASRUtils::type_get_past_pointer(
+            ASRUtils::type_get_past_allocatable(
+            ASRUtils::expr_type(target_expr)));
+        int64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = 0;
+        this->visit_expr_wrapper(target_expr, false);
+        ptr_loads = ptr_loads_copy;
+        llvm::Type* llvm_type = llvm_utils->get_type_from_ttype_t_util(asr_type, module.get());
+        llvm_utils->create_if_else(
+            builder->CreateICmpEQ(
+                    builder->CreateLoad(llvm_type->getPointerTo(), tmp),
+                    llvm::ConstantPointerNull::get(llvm_type->getPointerTo())),
+            [&]() {
+                llvm::Value* malloc_size = SizeOfTypeUtil(asr_type, llvm_utils->getIntType(4),
+                ASRUtils::TYPE(ASR::make_Integer_t(al, target_expr->base.loc, 4)));
+                llvm::Value* malloc_ptr = LLVMArrUtils::lfortran_malloc(
+                    context, *module, *builder, malloc_size);
+                builder->CreateMemSet(malloc_ptr, llvm::ConstantInt::get(context, llvm::APInt(8, 0)), malloc_size, llvm::MaybeAlign());
+                builder->CreateStore(builder->CreateBitCast(
+                    malloc_ptr, llvm_type->getPointerTo()), tmp);
+            },
+            []() {});
     }
 
     void PointerToData_to_Descriptor(ASR::ttype_t* m_type, ASR::ttype_t* m_type_for_dimensions) {

--- a/tests/reference/llvm-automatic_allocation_02-2a7afc4.json
+++ b/tests/reference/llvm-automatic_allocation_02-2a7afc4.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-automatic_allocation_02-2a7afc4",
+    "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/automatic_allocation_02.f90",
+    "infile_hash": "1646e150432feecdb083d01f8f11d5f17ae691764bb12ada80610c85",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-automatic_allocation_02-2a7afc4.stdout",
+    "stdout_hash": "3e9e7ec2e89c44d021e62ee5bd27b1582a283f78dabe8a7676a95dfe",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-automatic_allocation_02-2a7afc4.stdout
+++ b/tests/reference/llvm-automatic_allocation_02-2a7afc4.stdout
@@ -1,0 +1,279 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+%complex_4 = type <{ float, float }>
+
+@0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
+@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@3 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
+@4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@6 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
+@7 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@8 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@9 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
+@10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %c = alloca %complex_4*, align 8
+  store %complex_4* null, %complex_4** %c, align 8
+  %i = alloca i32*, align 8
+  store i32* null, i32** %i, align 8
+  %l = alloca i1*, align 8
+  store i1* null, i1** %l, align 8
+  %r = alloca float*, align 8
+  store float* null, float** %r, align 8
+  %2 = load i32*, i32** %i, align 8
+  %3 = icmp eq i32* %2, null
+  br i1 %3, label %then, label %else
+
+then:                                             ; preds = %.entry
+  %4 = call i8* @_lfortran_malloc(i32 4)
+  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
+  %5 = bitcast i8* %4 to i32*
+  store i32* %5, i32** %i, align 8
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %6 = load i32*, i32** %i, align 8
+  store i32 10, i32* %6, align 4
+  %7 = load float*, float** %r, align 8
+  %8 = icmp eq float* %7, null
+  br i1 %8, label %then1, label %else2
+
+then1:                                            ; preds = %ifcont
+  %9 = call i8* @_lfortran_malloc(i32 4)
+  call void @llvm.memset.p0i8.i32(i8* %9, i8 0, i32 4, i1 false)
+  %10 = bitcast i8* %9 to float*
+  store float* %10, float** %r, align 8
+  br label %ifcont3
+
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
+
+ifcont3:                                          ; preds = %else2, %then1
+  %11 = load float*, float** %r, align 8
+  store float 0x40119999A0000000, float* %11, align 4
+  %12 = alloca %complex_4, align 8
+  %13 = getelementptr %complex_4, %complex_4* %12, i32 0, i32 0
+  %14 = getelementptr %complex_4, %complex_4* %12, i32 0, i32 1
+  store float 1.000000e+00, float* %13, align 4
+  store float 2.000000e+00, float* %14, align 4
+  %15 = load %complex_4, %complex_4* %12, align 1
+  %16 = load %complex_4*, %complex_4** %c, align 8
+  %17 = icmp eq %complex_4* %16, null
+  br i1 %17, label %then4, label %else5
+
+then4:                                            ; preds = %ifcont3
+  %18 = call i8* @_lfortran_malloc(i32 8)
+  call void @llvm.memset.p0i8.i32(i8* %18, i8 0, i32 8, i1 false)
+  %19 = bitcast i8* %18 to %complex_4*
+  store %complex_4* %19, %complex_4** %c, align 8
+  br label %ifcont6
+
+else5:                                            ; preds = %ifcont3
+  br label %ifcont6
+
+ifcont6:                                          ; preds = %else5, %then4
+  %20 = load %complex_4*, %complex_4** %c, align 8
+  store %complex_4 %15, %complex_4* %20, align 1
+  %21 = load i1*, i1** %l, align 8
+  %22 = icmp eq i1* %21, null
+  br i1 %22, label %then7, label %else8
+
+then7:                                            ; preds = %ifcont6
+  %23 = call i8* @_lfortran_malloc(i32 1)
+  call void @llvm.memset.p0i8.i32(i8* %23, i8 0, i32 1, i1 false)
+  %24 = bitcast i8* %23 to i1*
+  store i1* %24, i1** %l, align 8
+  br label %ifcont9
+
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
+
+ifcont9:                                          ; preds = %else8, %then7
+  %25 = load i1*, i1** %l, align 8
+  store i1 true, i1* %25, align 1
+  %26 = load i32*, i32** %i, align 8
+  %27 = load i32, i32* %26, align 4
+  %28 = icmp ne i32 %27, 10
+  br i1 %28, label %then10, label %else11
+
+then10:                                           ; preds = %ifcont9
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont12
+
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
+
+ifcont12:                                         ; preds = %else11, %then10
+  %29 = load float*, float** %r, align 8
+  %30 = load float, float* %29, align 4
+  %31 = fcmp une float %30, 0x40119999A0000000
+  br i1 %31, label %then13, label %else14
+
+then13:                                           ; preds = %ifcont12
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont15
+
+else14:                                           ; preds = %ifcont12
+  br label %ifcont15
+
+ifcont15:                                         ; preds = %else14, %then13
+  %32 = load %complex_4*, %complex_4** %c, align 8
+  %33 = load %complex_4, %complex_4* %32, align 1
+  %34 = alloca %complex_4, align 8
+  %35 = getelementptr %complex_4, %complex_4* %34, i32 0, i32 0
+  %36 = getelementptr %complex_4, %complex_4* %34, i32 0, i32 1
+  store float 1.000000e+00, float* %35, align 4
+  store float 2.000000e+00, float* %36, align 4
+  %37 = load %complex_4, %complex_4* %34, align 1
+  %38 = alloca %complex_4, align 8
+  store %complex_4 %33, %complex_4* %38, align 1
+  %39 = getelementptr %complex_4, %complex_4* %38, i32 0, i32 0
+  %40 = load float, float* %39, align 4
+  %41 = alloca %complex_4, align 8
+  store %complex_4 %37, %complex_4* %41, align 1
+  %42 = getelementptr %complex_4, %complex_4* %41, i32 0, i32 0
+  %43 = load float, float* %42, align 4
+  %44 = alloca %complex_4, align 8
+  store %complex_4 %33, %complex_4* %44, align 1
+  %45 = getelementptr %complex_4, %complex_4* %44, i32 0, i32 1
+  %46 = load float, float* %45, align 4
+  %47 = alloca %complex_4, align 8
+  store %complex_4 %37, %complex_4* %47, align 1
+  %48 = getelementptr %complex_4, %complex_4* %47, i32 0, i32 1
+  %49 = load float, float* %48, align 4
+  %50 = fcmp one float %40, %43
+  %51 = fcmp one float %46, %49
+  %52 = or i1 %50, %51
+  br i1 %52, label %then16, label %else17
+
+then16:                                           ; preds = %ifcont15
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont18
+
+else17:                                           ; preds = %ifcont15
+  br label %ifcont18
+
+ifcont18:                                         ; preds = %else17, %then16
+  %53 = load i1*, i1** %l, align 8
+  %54 = load i1, i1* %53, align 1
+  %55 = icmp eq i1 %54, false
+  %56 = xor i1 %54, true
+  br i1 %56, label %then19, label %else20
+
+then19:                                           ; preds = %ifcont18
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont21
+
+else20:                                           ; preds = %ifcont18
+  br label %ifcont21
+
+ifcont21:                                         ; preds = %else20, %then19
+  %57 = load i32*, i32** %i, align 8
+  %58 = ptrtoint i32* %57 to i64
+  %59 = icmp ne i64 %58, 0
+  br i1 %59, label %then22, label %else23
+
+then22:                                           ; preds = %ifcont21
+  %60 = alloca i8*, align 8
+  %61 = bitcast i32* %57 to i8*
+  store i8* %61, i8** %60, align 8
+  %62 = load i8*, i8** %60, align 8
+  call void @_lfortran_free(i8* %62)
+  store i32* null, i32** %i, align 8
+  br label %ifcont24
+
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
+
+ifcont24:                                         ; preds = %else23, %then22
+  %63 = load float*, float** %r, align 8
+  %64 = ptrtoint float* %63 to i64
+  %65 = icmp ne i64 %64, 0
+  br i1 %65, label %then25, label %else26
+
+then25:                                           ; preds = %ifcont24
+  %66 = alloca i8*, align 8
+  %67 = bitcast float* %63 to i8*
+  store i8* %67, i8** %66, align 8
+  %68 = load i8*, i8** %66, align 8
+  call void @_lfortran_free(i8* %68)
+  store float* null, float** %r, align 8
+  br label %ifcont27
+
+else26:                                           ; preds = %ifcont24
+  br label %ifcont27
+
+ifcont27:                                         ; preds = %else26, %then25
+  %69 = load %complex_4*, %complex_4** %c, align 8
+  %70 = ptrtoint %complex_4* %69 to i64
+  %71 = icmp ne i64 %70, 0
+  br i1 %71, label %then28, label %else29
+
+then28:                                           ; preds = %ifcont27
+  %72 = alloca i8*, align 8
+  %73 = bitcast %complex_4* %69 to i8*
+  store i8* %73, i8** %72, align 8
+  %74 = load i8*, i8** %72, align 8
+  call void @_lfortran_free(i8* %74)
+  store %complex_4* null, %complex_4** %c, align 8
+  br label %ifcont30
+
+else29:                                           ; preds = %ifcont27
+  br label %ifcont30
+
+ifcont30:                                         ; preds = %else29, %then28
+  %75 = load i1*, i1** %l, align 8
+  %76 = ptrtoint i1* %75 to i64
+  %77 = icmp ne i64 %76, 0
+  br i1 %77, label %then31, label %else32
+
+then31:                                           ; preds = %ifcont30
+  %78 = alloca i8*, align 8
+  %79 = bitcast i1* %75 to i8*
+  store i8* %79, i8** %78, align 8
+  %80 = load i8*, i8** %78, align 8
+  call void @_lfortran_free(i8* %80)
+  store i1* null, i1** %l, align 8
+  br label %ifcont33
+
+else32:                                           ; preds = %ifcont30
+  br label %ifcont33
+
+ifcont33:                                         ; preds = %else32, %then31
+  call void @_lpython_free_argv()
+  br label %return
+
+return:                                           ; preds = %ifcont33
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare i8* @_lfortran_malloc(i32)
+
+; Function Attrs: argmemonly nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+
+declare void @_lcompilers_print_error(i8*, ...)
+
+declare void @exit(i32)
+
+declare void @_lfortran_free(i8*)
+
+declare void @_lpython_free_argv()
+
+attributes #0 = { argmemonly nounwind willreturn writeonly }

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-derived_types_45-ae31b1c",
+    "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/derived_types_45.f90",
+    "infile_hash": "e7e4e87444a93ff6319b6d19dac06c02b600da19c934e28fdc831374",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-derived_types_45-ae31b1c.stdout",
+    "stdout_hash": "796e15da1ff564130e2083a94fd7719ae7ae0f781ff16c45e5eb65f0",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -1,0 +1,88 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+%myint = type <{ i32 }>
+
+@0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
+@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %ins = alloca %myint*, align 8
+  store %myint* null, %myint** %ins, align 8
+  %2 = load %myint*, %myint** %ins, align 8
+  %3 = icmp eq %myint* %2, null
+  br i1 %3, label %then, label %else
+
+then:                                             ; preds = %.entry
+  %4 = call i8* @_lfortran_malloc(i32 4)
+  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
+  %5 = bitcast i8* %4 to %myint*
+  store %myint* %5, %myint** %ins, align 8
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %6 = load %myint*, %myint** %ins, align 8
+  %7 = getelementptr %myint, %myint* %6, i32 0, i32 0
+  store i32 44, i32* %7, align 4
+  %8 = load %myint*, %myint** %ins, align 8
+  %9 = getelementptr %myint, %myint* %8, i32 0, i32 0
+  %10 = load i32, i32* %9, align 4
+  %11 = icmp ne i32 %10, 44
+  br i1 %11, label %then1, label %else2
+
+then1:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont3
+
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
+
+ifcont3:                                          ; preds = %else2, %then1
+  %12 = load %myint*, %myint** %ins, align 8
+  %13 = ptrtoint %myint* %12 to i64
+  %14 = icmp ne i64 %13, 0
+  br i1 %14, label %then4, label %else5
+
+then4:                                            ; preds = %ifcont3
+  %15 = alloca i8*, align 8
+  %16 = bitcast %myint* %12 to i8*
+  store i8* %16, i8** %15, align 8
+  %17 = load i8*, i8** %15, align 8
+  call void @_lfortran_free(i8* %17)
+  store %myint* null, %myint** %ins, align 8
+  br label %ifcont6
+
+else5:                                            ; preds = %ifcont3
+  br label %ifcont6
+
+ifcont6:                                          ; preds = %else5, %then4
+  call void @_lpython_free_argv()
+  br label %return
+
+return:                                           ; preds = %ifcont6
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare i8* @_lfortran_malloc(i32)
+
+; Function Attrs: argmemonly nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+
+declare void @_lcompilers_print_error(i8*, ...)
+
+declare void @exit(i32)
+
+declare void @_lfortran_free(i8*)
+
+declare void @_lpython_free_argv()
+
+attributes #0 = { argmemonly nounwind willreturn writeonly }

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3075,6 +3075,16 @@ filename = "../integration_tests/derived_types_41.f90"
 asr = true
 
 [[test]]
+filename = "../integration_tests/derived_types_45.f90"
+llvm = true
+options = "--realloc-lhs"
+
+[[test]]
+filename = "../integration_tests/automatic_allocation_02.f90"
+llvm = true
+options = "--realloc-lhs"
+
+[[test]]
 filename = "../integration_tests/modules_38.f90"
 llvm = true
 


### PR DESCRIPTION
Add automatic allocation for allocatable `integer`, `real`, `complex` and `logical`.