### PR TITLE
fix: use StructConstant inside derived type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1385,6 +1385,7 @@ RUN(NAME derived_types_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME derived_types_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_48.f90
+++ b/integration_tests/derived_types_48.f90
@@ -1,0 +1,21 @@
+module derived_types_48_m
+    implicit none
+    type t
+        integer :: x = 1
+        integer :: y = 2
+    end type
+
+    type, extends(t) :: ext_t
+        type(t) :: ins = t()
+    end type
+
+end module derived_types_48_m
+
+program derived_types_48
+    use derived_types_48_m
+    implicit none
+
+    type(ext_t) :: i
+    if (i%ins%x /= 1) error stop
+    if (i%ins%y /= 2) error stop
+end program derived_types_48

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3650,6 +3650,9 @@ public:
                                 is_struct_const = true;
                             }
                         }
+                        if (is_derived_type) {
+                            is_struct_const = true;
+                        }
                         if (sym_found == nullptr) {
                             visit_FuncCallOrArray(*func_call);
                             init_expr = ASRUtils::EXPR(tmp);


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/6833