### PR TITLE
fix: StructConstructor overload with import using "only" clause

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1383,6 +1383,7 @@ RUN(NAME derived_types_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
+RUN(NAME derived_types_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_46.f90
+++ b/integration_tests/derived_types_46.f90
@@ -1,0 +1,26 @@
+module derived_types_46_m
+   type :: derived
+       integer :: n
+   end type derived
+
+   interface derived
+      procedure :: init
+   end interface derived
+contains
+
+   function init() result(self)
+      type(derived) :: self
+      self%n = 10
+   end function init
+
+end module derived_types_46_m
+
+program derived_types_46
+   use derived_types_46_m, only: derived
+
+   type(derived) :: obj
+   obj = derived()
+
+   if (obj%n /= 10) error stop
+
+end program derived_types_46

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2950,6 +2950,11 @@ public:
                 );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(v));
         } else if( ASR::is_a<ASR::Struct_t>(*t) ) {
+            // Check for any interface overriding a constructor for the struct
+            ASR::symbol_t *interface_override_s = m->m_symtab->resolve_symbol("~" + remote_sym);
+            if (interface_override_s) {
+                to_be_imported_later.push(std::make_pair("~" + remote_sym, "~" + local_sym));
+            }
             ASR::symbol_t* imported_struct_type = current_scope->get_symbol(local_sym);
             ASR::Struct_t *mv = ASR::down_cast<ASR::Struct_t>(t);
             if (imported_struct_type != nullptr) {

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "6eef6354523eb3de0074b0fb1ce5ff909f1519076a87f12780591da4",
+    "stdout_hash": "06b890c9620503c957f0407a2606a1b75797e2a324af93fa95c1cad2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -1424,6 +1424,16 @@
                                     convert_raw
                                     Public
                                 ),
+                            new_toml_time@~toml_time:
+                                (ExternalSymbol
+                                    2
+                                    new_toml_time@~toml_time
+                                    7 new_toml_time
+                                    tomlf_datetime
+                                    []
+                                    new_toml_time
+                                    Public
+                                ),
                             toml_date:
                                 (ExternalSymbol
                                     2
@@ -1463,6 +1473,16 @@
                                     []
                                     toml_time
                                     Public
+                                ),
+                            ~toml_time:
+                                (ExternalSymbol
+                                    2
+                                    ~toml_time
+                                    7 ~toml_time
+                                    tomlf_datetime
+                                    []
+                                    ~toml_time
+                                    Public
                                 )
                         })
                     tomlf_utils
@@ -1480,6 +1500,16 @@
                                     4
                                     convert_raw
                                     [4 toml_raw_to_timestamp]
+                                    Public
+                                ),
+                            new_toml_time@~toml_time:
+                                (ExternalSymbol
+                                    4
+                                    new_toml_time@~toml_time
+                                    7 new_toml_time
+                                    tomlf_datetime
+                                    []
+                                    new_toml_time
                                     Public
                                 ),
                             toml_date:
@@ -1714,6 +1744,16 @@
                                     tomlf_datetime
                                     []
                                     toml_time
+                                    Public
+                                ),
+                            ~toml_time:
+                                (ExternalSymbol
+                                    4
+                                    ~toml_time
+                                    7 ~toml_time
+                                    tomlf_datetime
+                                    []
+                                    ~toml_time
                                     Public
                                 )
                         })


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/6859