### PR TITLE
fix: give w+ access to 'scratch' type status

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1576,6 +1576,7 @@ RUN(NAME file_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_
 RUN(NAME file_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_22_data.txt)
 RUN(NAME file_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_23_data.txt)
 RUN(NAME file_24 LABELS gfortran llvm COPY_TO_BIN "file 24 data.txt" file_22_data.txt)
+RUN(NAME file_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_25.f90
+++ b/integration_tests/file_25.f90
@@ -1,0 +1,12 @@
+program file_25
+  implicit none
+  integer :: io
+  integer :: x_write, x_read
+  x_write = 12345
+  open(newunit=io, status="scratch")
+  write(io, *) x_write
+  rewind(io)
+  read(io, *) x_read
+  close(io)
+  if (x_write /= x_read) error stop
+end program 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3255,7 +3255,7 @@ LFORTRAN_API int64_t _lfortran_open(int32_t unit_num, char *f_name, char *status
             exit(1);
         }
         access_mode = "w+";
-    } else if (streql(status, "replace")) {
+    } else if (streql(status, "replace") || streql(status, "scratch")) {
         access_mode = "w+";
     } else if (streql(status, "unknown")) {
         if (!*file_exists) {
@@ -3265,9 +3265,6 @@ LFORTRAN_API int64_t _lfortran_open(int32_t unit_num, char *f_name, char *status
             }
         }
         access_mode = "r+";
-    } else if (streql(status, "scratch")) {
-        printf("Runtime error: Unhandled type status=`scratch`\n");
-        exit(1);
     } else {
         printf("Runtime error: STATUS specifier in OPEN statement has "
             "invalid value '%s'\n", status);


### PR DESCRIPTION
Towards #6872 

Here I have just created temporary file, but in `scratch` mode we should delete it also while closing file.