### PR TITLE
BUGFIX: fixes a segfault in the parser

### DIFF
--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -1703,7 +1703,7 @@ return make_Program_t(al, a_loc,
         /*contains*/ CONTAINS(contains), \
         /*n_contains*/ contains.size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc))
+        /*end_name*/ (name_opt) ? &((name_opt)->loc) : nullptr)
 #define RESULT(x) p.result.push_back(p.m_a, x)
 
 #define STMT_NAME(id_first, id_last, stmt) \


### PR DESCRIPTION
Fixes parser expression that resulted in segfaults when the line end information for a program was unavailable.

The `end_program` production can be a nullptr:

	end_program
	    : KW_END_PROGRAM id_opt { $$ = $2; }
	    | KW_ENDPROGRAM id_opt { $$ = $2; }
	    | KW_END { $$ = nullptr; }
	    ;

So we cannot derefernce it without checking for nullptr first.