### PR TITLE
CI: fix the name of the LSP workflow

### DIFF
--- a/.github/workflows/LSP.yml
+++ b/.github/workflows/LSP.yml
@@ -1,4 +1,4 @@
-name: CI
+name: LSP (can fail)
 
 on:
   push:


### PR DESCRIPTION
Add "can fail" into the name to make it clear that the workflow can fail.