### PR TITLE
Adds a number of mostly logging-related changes to improve the debuggability of failing tests at the CI

### DIFF
--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -194,8 +194,11 @@ namespace LCompilers::LanguageServerProtocol {
                 logger.trace()
                     << "Getting diagnostics from LFortran for document with URI="
                     << uri << std::endl;
+                // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+                // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
                 std::vector<lc::error_highlight> highlights =
                     lfortran.showErrors(path, text, *compilerOptions);
+                // loggerLock.unlock();
 
                 logger.trace()
                     << "Collected " << highlights.size()
@@ -397,8 +400,11 @@ namespace LCompilers::LanguageServerProtocol {
             << " on line=" << compilerOptions.line
             << ", column=" << compilerOptions.column
             << std::endl;
+        // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+        // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.lookupName(path, text, compilerOptions);
+        // loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -481,8 +487,11 @@ namespace LCompilers::LanguageServerProtocol {
             << " on line=" << compilerOptions.line
             << ", column=" << compilerOptions.column
             << std::endl;
+        // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+        // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.getAllOccurrences(path, text, compilerOptions);
+        // loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -540,8 +549,11 @@ namespace LCompilers::LanguageServerProtocol {
         logger.trace()
             << "Looking up all symbols in document with URI=" << uri
             << std::endl;
+        // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+        // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.getSymbols(path, text, *compilerOptions);
+        // loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -639,8 +651,11 @@ namespace LCompilers::LanguageServerProtocol {
             << " on line=" << compilerOptions.line
             << ", column=" << compilerOptions.column
             << std::endl;
+        // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+        // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.lookupName(path, text, compilerOptions);
+        // loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -675,6 +690,8 @@ namespace LCompilers::LanguageServerProtocol {
             logger.trace()
                 << "Formatting hover preview with LFortran"
                 << std::endl;
+            // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+            // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
             lc::Result<std::string> formatted = lfortran.format(
                 path,
                 preview,
@@ -683,6 +700,7 @@ namespace LCompilers::LanguageServerProtocol {
                 config->indentSize,
                 true  //<- indent units like module bodies
             );
+            // loggerLock.unlock();
             if (formatted.ok) {
                 logger.trace() << "Successfully formatted the preview." << std::endl;
                 content.value.append(formatted.result);
@@ -798,8 +816,11 @@ namespace LCompilers::LanguageServerProtocol {
         logger.trace()
             << "Finding all occurrences of symbol to highlight in document with URI="
             << uri << std::endl;
+        // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+        // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.getAllOccurrences(path, text, compilerOptions);
+        // loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;

--- a/src/server/tests/setup.cfg
+++ b/src/server/tests/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     attrs==24.3.0
     cattrs==24.1.2
     lsprotocol==2023.0.1
+    psutil==7.0.0
 
 [options.packages.find]
 where = src

--- a/src/server/tests/src/llanguage_test_client/lsp_json_stream.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_json_stream.py
@@ -2,7 +2,7 @@ import io
 import json
 import time
 from io import BytesIO
-from typing import IO, Optional, Union
+from typing import Callable, IO, Optional, Union
 
 from llanguage_test_client.json_rpc import JsonArray, JsonObject
 
@@ -15,29 +15,45 @@ class LspJsonStream:
     istream: IO[bytes]
     timeout_s: float
 
-    buf: BytesIO
+    bs: Optional[bytes]
+    bi: int
+    message_buf: BytesIO
     num_bytes: int
     has_content_length: bool
     position: int
     sleep_s: float = 0.100
+    check_server: Callable[[], bool]
 
-    def __init__(self, istream: IO[bytes], timeout_s: float) -> None:
+    def __init__(self, istream: IO[bytes], timeout_s: float, check_server: Callable[[], bool]) -> None:
         self.istream = istream
         self.timeout_s = timeout_s
-        self.buf = BytesIO()
+        self.bs = None
+        self.bi = 0
+        self.message_buf = BytesIO()
+        self.check_server = check_server
 
     def message(self) -> str:
-        return self.buf.getvalue().decode("utf-8")
+        return self.message_buf.getvalue().decode("utf-8")
 
     def next_byte(self) -> bytes:
         start_time = time.perf_counter()
-        while duration(start_time) < self.timeout_s:
+        bi = self.bi
+        bs = self.bs
+        if (bs is not None) and (bi < len(bs)):
+            bj = bi + 1
+            b = bs[bi:bj]
+            self.bi = bj
+            self.message_buf.write(b)
+            self.position += 1
+            return b
+        while self.check_server() \
+              and ((duration(start_time) < self.timeout_s)
+                   or (self.timeout_s == 0.0)):
             try:
-                bs: Optional[bytes] = self.istream.read(1)
-                if bs is not None and len(bs) > 0:
-                    self.buf.write(bs)
-                    self.position += 1
-                    return bs
+                self.bs = self.istream.read(4096)
+                if (self.bs is not None) and (len(self.bs) > 0):
+                    self.bi = 0
+                    return self.next_byte()
             except BlockingIOError:
                 # Try again ...
                 pass
@@ -49,8 +65,8 @@ class LspJsonStream:
     def next(self) -> Union[JsonObject, JsonArray]:
         self.num_bytes = 0
         self.position = 0
-        self.buf.seek(0)
-        self.buf.truncate(0)
+        self.message_buf.seek(0)
+        self.message_buf.truncate(0)
         return self.parse_header_name()
 
     def escape(self, bs: bytes) -> bytes:
@@ -90,9 +106,9 @@ class LspJsonStream:
                     )
                 case b':':
                     length: int = self.position - start - 1
-                    self.buf.seek(start)
-                    header_name: str = self.buf.read(length).upper().decode("utf-8")
-                    self.buf.seek(0, io.SEEK_END)
+                    self.message_buf.seek(start)
+                    header_name: str = self.message_buf.read(length).upper().decode("utf-8")
+                    self.message_buf.seek(0, io.SEEK_END)
                     self.has_content_length = (header_name == "CONTENT-LENGTH")
                     return self.parse_header_value()
                 case _:
@@ -113,9 +129,9 @@ class LspJsonStream:
                             f"Expected \\r to be followed by \\n, not '{self.escape(b)}':\n{self.message()}"
                         )
                     if self.has_content_length:
-                        self.buf.seek(start)
-                        header_value: str = self.buf.read(length).decode("utf-8")
-                        self.buf.seek(0, io.SEEK_END)
+                        self.message_buf.seek(start)
+                        header_value: str = self.message_buf.read(length).decode("utf-8")
+                        self.message_buf.seek(0, io.SEEK_END)
                         self.num_bytes = int(header_value)
                     return self.parse_header_name()
                 case b'\n':
@@ -127,12 +143,23 @@ class LspJsonStream:
 
     def parse_body(self) -> Union[JsonObject, JsonArray]:
         remaining_bytes = self.num_bytes
+        bs = self.bs
+        bi = self.bi
+        if (bs is not None) and (bi < len(bs)):
+            bk = len(bs) - bi
+            bj = bi + min(bk, remaining_bytes)
+            self.message_buf.write(bs[bi:bj])
+            remaining_bytes -= bk
+            self.bi = bj
         start_time = time.perf_counter()
-        while (remaining_bytes > 0) and (duration(start_time) < self.timeout_s):
+        while (remaining_bytes > 0) \
+              and self.check_server() \
+              and ((duration(start_time) < self.timeout_s)
+                   or (self.timeout_s == 0.0)):
             try:
                 bs = self.istream.read(remaining_bytes)
                 if bs is not None and len(bs) > 0:
-                    self.buf.write(bs)
+                    self.message_buf.write(bs)
                     remaining_bytes -= len(bs)
                     continue
             except BlockingIOError:
@@ -142,7 +169,7 @@ class LspJsonStream:
             raise RuntimeError(
                 f'Timed-out after {self.timeout_s} seconds while reading from the stream:\n{self.message()}'
             )
-        self.buf.seek(self.buf.tell() - self.num_bytes)
-        body: str = self.buf.read().decode("utf-8")
-        self.buf.seek(0, io.SEEK_END)
+        self.message_buf.seek(self.message_buf.tell() - self.num_bytes)
+        body: str = self.message_buf.read().decode("utf-8")
+        self.message_buf.seek(0, io.SEEK_END)
         return json.loads(body)

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -6,14 +6,17 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from io import BytesIO, StringIO
+from io import BytesIO
 from pathlib import Path
 from typing import (IO, Any, BinaryIO, Callable, Dict, Iterator, List,
-                    Optional, Set, Tuple, Union)
+                    Optional, Tuple, Union)
+
+import psutil
 
 from cattrs import Converter
 
@@ -184,6 +187,7 @@ class LspTestClient(LspClient):
     timeout_s: float
 
     server: ServerProcess
+    process: psutil.Process
     message_stream: LspJsonStream
     ostream: IO[bytes]
     buf: BytesIO
@@ -202,7 +206,7 @@ class LspTestClient(LspClient):
     responses_by_id: Dict[JsonValue, Any]
     callbacks_by_id: Dict[JsonValue, Tuple[Any, Callback]]
     stop: threading.Event
-    # stderr_printer: threading.Thread
+    stderr_printer: threading.Thread
     client_log_path: str
     stdout_log_path: str
     stdin_log_path: str
@@ -236,37 +240,48 @@ class LspTestClient(LspClient):
         self.responses_by_id = dict()
         self.callbacks_by_id = dict()
         self.stop = threading.Event()
-        # self.stderr_printer = threading.Thread(
-        #     target=self.print_stderr,
-        #     args=tuple()
-        # )
+        self.stderr_printer = threading.Thread(
+            target=self.print_stderr,
+            args=tuple()
+        )
         self.client_log_path = client_log_path
         self.stdout_log_path = stdout_log_path
         self.stdin_log_path = stdin_log_path
 
     def print_stderr(self) -> None:
-        if self.server.stderr is not None:
-            buf = StringIO()
-            while self.check_server() and not self.stop.is_set():
-                try:
-                    bs = self.server.stderr.read(1)
-                    if bs is not None:
-                        buf.seek(0)
-                        buf.truncate(0)
-                        while (bs is not None) and (len(bs) > 0) and not self.stop.is_set():
-                            buf.write(bs.decode("utf-8"))
-                            bs = self.server.stderr.read(1)
-                        print(buf.getvalue(), file=sys.stderr)
-                        continue
-                except BlockingIOError:
-                    pass
-                time.sleep(0.100)
-
-    def has_event(self, pred: EventPredFn) -> bool:
-        for event in self.events:
-            if pred(event):
-                return True
-        return False
+        buf = BytesIO()
+        try:
+            if self.server.stderr is not None:
+                while self.check_server():
+                    try:
+                        bs = self.server.stderr.read(4096)
+                        if bs is not None:
+                            buf.seek(0)
+                            buf.truncate(0)
+                            while (bs is not None) and (len(bs) > 0):
+                                buf.write(bs)
+                                bs = self.server.stderr.read(4096)
+                            print(buf.getvalue().decode('utf-8'), end='', file=sys.stderr)
+                            continue
+                    except BlockingIOError:
+                        pass
+                    time.sleep(0.100)
+        except BaseException as e:
+            print(
+                "Caught unhandled exception while printing stderr logs from the server:", e,
+                file=sys.stderr
+            )
+            traceback.print_exc(file=sys.stderr)
+        finally:
+            # Print whatever is left in the buffer
+            buf.seek(0)
+            buf.truncate(0)
+            if self.server.stderr is not None:
+                bs = self.server.stderr.read(4096)
+                while (bs is not None) and (len(bs) > 0):
+                    buf.write(bs)
+                    bs = self.server.stderr.read(4096)
+            print(buf.getvalue().decode('utf-8'), file=sys.stderr)
 
     def find_incoming_event(self, pred: IncomingEventPredFn, lower_index: int = 0) \
             -> Tuple[Optional[IncomingEvent], int]:
@@ -407,31 +422,33 @@ class LspTestClient(LspClient):
             [self.server_path] + self.server_params,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            # stderr=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             bufsize=0,
-            # bufsize=1,
         )
+
         if self.server.stdout is None:
             raise RuntimeError("Cannot read from server stdout")
         if self.server.stdin is None:
             raise RuntimeError("Cannot write to server stdin")
-        # if self.server.stderr is None:
-        #     raise RuntimeError("Cannot read from server stderr")
+        if self.server.stderr is None:
+            raise RuntimeError("Cannot read from server stderr")
 
         # Make process stdout non-blocking
         stdout_fd = self.server.stdout.fileno()
         os.set_blocking(stdout_fd, False)
-        # stderr_fd = self.server.stderr.fileno()
-        # os.set_blocking(stderr_fd, False)
+        stderr_fd = self.server.stderr.fileno()
+        os.set_blocking(stderr_fd, False)
+
+        self.process = psutil.Process(self.server.pid)
 
         self.message_stream = LspJsonStream(
             SpyIO(self.server.stdout, self.stdout_log),
-            self.timeout_s
+            self.timeout_s,
+            self.check_server
         )
         self.ostream = SpyIO(self.server.stdin, self.stdin_log)
 
-        # self.stderr_printer.start()
+        self.stderr_printer.start()
 
         initialize_id = self.send_initialize(self.initialize_params())
         self.await_response(initialize_id)
@@ -445,22 +462,61 @@ class LspTestClient(LspClient):
         self.send_exit()
 
         self.stop.set()
-        # self.stderr_printer.join()
+        self.stderr_printer.join()
 
         try:
-            self.server.wait(timeout=self.timeout_s)
+            if self.timeout_s > 0.0:
+                self.server.wait(timeout=self.timeout_s)
+            else:
+                self.server.wait()
         except subprocess.TimeoutExpired as e:
-            os.kill(self.server.pid, signal.SIGKILL)
+            self.kill_server()
             raise RuntimeError(
                 f"Timed-out after {self.timeout_s} seconds while awaiting the server to terminate."
             ) from e
 
-    def check_server(self) -> bool:
-        if self.server.poll():
-            raise RuntimeError(
-                f"ServerProcess crashed with status: {self.server.returncode}"
+    def kill_server(self) -> None:
+        self.stop.set()
+        if self.server.poll() is None:
+            print(
+                'Server did not terminate cleanly, terminating it forcefully ...',
+                file=sys.stderr
             )
-        return True
+            try:
+                os.kill(self.server.pid, signal.SIGINT)
+                self.server.wait(timeout=1.0)
+            except ProcessLookupError:
+                pass
+            finally:
+                if self.server.poll() is None:
+                    try:
+                        os.kill(self.server.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+    def check_server(self) -> bool:
+        try:
+            if self.process.is_running():
+                if self.process.status() == psutil.STATUS_ZOMBIE:
+                    self.kill_server()
+                    print(
+                        "ServerProcess has become defunct and will no longer respond",
+                        file=sys.stderr
+                    )
+                else:
+                    # The server is running as expected; there's nothing to do
+                    pass
+            else:
+                self.stop.set()
+                print(
+                    f"ServerProcess crashed with status: {self.server.returncode}",
+                    file=sys.stderr
+                )
+        except BaseException as e:
+            self.stop.set()
+            raise e
+        finally:
+            return not self.stop.is_set()
 
     def send_message(self, message: Any) -> None:
         self.events.append(OutgoingEvent(message))
@@ -474,14 +530,14 @@ class LspTestClient(LspClient):
         self.buf.write(f"Content-Length: {len(body)}\r\n".encode("utf-8"))
         self.buf.write(b"\r\n")
         self.buf.write(body)
-        self.check_server()
         print(
             f"[{timestamp()}] Sending:\n{self.buf.getvalue().decode('utf-8')}",
             file=self.log_file
         )
         self.log_file.flush()
-        self.ostream.write(self.buf.getvalue())
-        self.ostream.flush()
+        if self.check_server():
+            self.ostream.write(self.buf.getvalue())
+            self.ostream.flush()
 
     def send_request(
             self,
@@ -495,21 +551,23 @@ class LspTestClient(LspClient):
         return request_id
 
     def receive_message(self) -> JsonObject:
-        self.check_server()
-        message = self.message_stream.next()
-        print(
-            f"[{timestamp()}] Receiving:\n{self.message_stream.message()}",
-            file=self.log_file
-        )
-        match message:
-            case dict():
-                self.events.append(IncomingEvent(message))
-                self.dispatch_message(message)
-                return message
-            case _:
-                raise RuntimeError(
-                    f"Unsupported message type ({type(message)}): {message}"
-                )
+        if self.check_server():
+            message = self.message_stream.next()
+            print(
+                f"[{timestamp()}] Receiving:\n{self.message_stream.message()}",
+                file=self.log_file
+            )
+            match message:
+                case dict():
+                    self.events.append(IncomingEvent(message))
+                    self.dispatch_message(message)
+                    return message
+                case _:
+                    raise RuntimeError(
+                        f"Unsupported message type ({type(message)}): {message}"
+                    )
+        else:
+            raise RuntimeError("Server has terminated.")
 
     def dispatch_message(self, message: JsonObject) -> None:
         if 'method' in message:


### PR DESCRIPTION
Changes:
1. Prints as much stderr from the subprocess as possible
2. Annotates calls to LFortranAccessor with notes about locking the logger before adding debug statements to stderr within LFortran
3. Launches the unit tests with GDB if it is available
4. Improves the logic for checking the health of the server and terminating it
5. Uses the locally compiled instance of LFortran if it is available
6. Does a better job of buffering the subprocess stdout and stderr to improve performance (especially when running under GDB)