### PR TITLE
Synchronizes start sequence of thread members

### DIFF
--- a/ci/test_lsp.sh
+++ b/ci/test_lsp.sh
@@ -10,5 +10,9 @@ src/bin/lfortran --version
 cmake --version
 if [[ $WIN != "1" ]]; then
     pip install src/server/tests tests/server
-    pytest -vv --showlocals --capture=no --timeout=10 tests/server
+    # NOTE: If you want to print all the messages, even on success, then disable
+    # `--capture` as follows:
+    # --------------------------------------------------------------------------
+    # pytest -vv --showlocals --capture=no --timeout=10 tests/server
+    pytest -vv --showlocals --timeout=10 tests/server
 fi

--- a/src/bin/concurrent_lfortran_lsp_language_server.cpp
+++ b/src/bin/concurrent_lfortran_lsp_language_server.cpp
@@ -22,7 +22,10 @@ namespace LCompilers::LanguageServerProtocol {
         const std::string &extensionId,
         const std::string &compilerVersion,
         int parentProcessId,
-        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
+        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig,
+        std::atomic_bool &start,
+        std::condition_variable &startChanged,
+        std::mutex &startMutex
     ) : BaseLspLanguageServer(
         incomingMessages,
         outgoingMessages,
@@ -35,7 +38,10 @@ namespace LCompilers::LanguageServerProtocol {
             transformer,
             serializer
         ),
-        std::move(workspaceConfig)
+        std::move(workspaceConfig),
+        start,
+        startChanged,
+        startMutex
       )
       , ConcurrentLspLanguageServer(
         incomingMessages,
@@ -49,7 +55,10 @@ namespace LCompilers::LanguageServerProtocol {
             transformer,
             serializer
         ),*/
-        nullptr //-> workspaceConfig
+        nullptr, //-> workspaceConfig
+        start,
+        startChanged,
+        startMutex
       )
       , LFortranLspLanguageServer(
         incomingMessages,
@@ -59,7 +68,10 @@ namespace LCompilers::LanguageServerProtocol {
         extensionId,
         compilerVersion,
         parentProcessId,
-        nullptr //-> workspaceConfig
+        nullptr, //-> workspaceConfig
+        start,
+        startChanged,
+        startMutex
       )
       , logger(logger.having("ConcurrentLFortranLspLanguageServer"))
     {

--- a/src/bin/concurrent_lfortran_lsp_language_server.h
+++ b/src/bin/concurrent_lfortran_lsp_language_server.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 
 #include <libasr/asr.h>
 #include <libasr/diagnostics.h>
@@ -30,7 +33,10 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &extensionId,
             const std::string &compilerVersion,
             int parentProcessId,
-            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
+            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         );
 
     protected:

--- a/src/bin/language_server_interface.h
+++ b/src/bin/language_server_interface.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <regex>
-#include <stdexcept>
 #include <string>
 
 #ifndef CLI11_HAS_FILESYSTEM
@@ -134,7 +136,10 @@ namespace LCompilers::LLanguageServer::Interface {
         auto buildLanguageServer(
             ls::MessageQueue &incomingMessages,
             ls::MessageQueue &outgoingMessages,
-            lsl::Logger &logger
+            lsl::Logger &logger,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         ) -> std::unique_ptr<ls::LanguageServer>;
 
         auto buildCommunicationProtocol(
@@ -142,7 +147,10 @@ namespace LCompilers::LLanguageServer::Interface {
             ls::MessageStream &messageStream,
             ls::MessageQueue &incomingMessages,
             ls::MessageQueue &outgoingMessages,
-            lsl::Logger &logger
+            lsl::Logger &logger,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         ) -> std::unique_ptr<ls::CommunicationProtocol>;
     };
 

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -33,7 +33,10 @@ namespace LCompilers::LanguageServerProtocol {
         const std::string &extensionId,
         const std::string &compilerVersion,
         int parentProcessId,
-        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
+        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig,
+        std::atomic_bool &start,
+        std::condition_variable &startChanged,
+        std::mutex &startMutex
     ) : BaseLspLanguageServer(
         incomingMessages,
         outgoingMessages,
@@ -46,7 +49,10 @@ namespace LCompilers::LanguageServerProtocol {
             transformer,
             serializer
         ),
-        std::move(workspaceConfig)
+        std::move(workspaceConfig),
+        start,
+        startChanged,
+        startMutex
       )
       , logger(logger.having("LFortranLspLanguageServer"))
     {

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -32,7 +35,10 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &extensionId,
             const std::string &compilerVersion,
             int parentProcessId,
-            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
+            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         );
 
         const std::string source = "lfortran";

--- a/src/bin/parallel_lfortran_lsp_language_server.cpp
+++ b/src/bin/parallel_lfortran_lsp_language_server.cpp
@@ -25,7 +25,10 @@ namespace LCompilers::LanguageServerProtocol {
         const std::string &compilerVersion,
         int parentProcessId,
         unsigned int seed,
-        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
+        std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig,
+        std::atomic_bool &start,
+        std::condition_variable &startChanged,
+        std::mutex &startMutex
     ) : BaseLspLanguageServer(
         incomingMessages,
         outgoingMessages,
@@ -38,7 +41,10 @@ namespace LCompilers::LanguageServerProtocol {
             transformer,
             serializer
         ),
-        std::move(workspaceConfig)
+        std::move(workspaceConfig),
+        start,
+        startChanged,
+        startMutex
       )
       , ParallelLspLanguageServer(
         incomingMessages,
@@ -55,7 +61,10 @@ namespace LCompilers::LanguageServerProtocol {
             transformer,
             serializer
         ),*/
-        nullptr //-> workspaceConfig
+        nullptr, //-> workspaceConfig
+        start,
+        startChanged,
+        startMutex
       )
       , LFortranLspLanguageServer(
         incomingMessages,
@@ -65,7 +74,10 @@ namespace LCompilers::LanguageServerProtocol {
         extensionId,
         compilerVersion,
         parentProcessId,
-        nullptr //->workspaceConfig
+        nullptr, //->workspaceConfig
+        start,
+        startChanged,
+        startMutex
       )
       , logger(logger.having("ParallelLFortranLspLanguageServer"))
     {

--- a/src/bin/parallel_lfortran_lsp_language_server.h
+++ b/src/bin/parallel_lfortran_lsp_language_server.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include <libasr/asr.h>
@@ -36,7 +39,10 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &compilerVersion,
             int parentProcessId,
             unsigned int seed,
-            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig
+            std::shared_ptr<lsc::LFortranLspConfig> workspaceConfig,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         );
 
     protected:

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -37,7 +38,10 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &compilerVersion,
             int parentProcessId,
             std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer,
-            std::shared_ptr<lsc::LspConfig> workspaceConfig
+            std::shared_ptr<lsc::LspConfig> workspaceConfig,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         );
 
         lsl::Logger logger;

--- a/src/server/communication_protocol.h
+++ b/src/server/communication_protocol.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 #include <server/language_server.h>
@@ -17,7 +19,11 @@ namespace LCompilers::LLanguageServer {
             MessageStream &messageStream,
             MessageQueue &incomingMessages,
             MessageQueue &outgoingMessages,
-            lsl::Logger &logger);
+            lsl::Logger &logger,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
+        );
         ~CommunicationProtocol();
         auto serve() -> void;
     private:

--- a/src/server/concurrent_lsp_language_server.cpp
+++ b/src/server/concurrent_lsp_language_server.cpp
@@ -35,7 +35,10 @@ namespace LCompilers::LanguageServerProtocol {
         const std::string &compilerVersion,
         int parentProcessId,
         std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer,
-        std::shared_ptr<lsc::LspConfig> workspaceConfig
+        std::shared_ptr<lsc::LspConfig> workspaceConfig,
+        std::atomic_bool &start,
+        std::condition_variable &startChanged,
+        std::mutex &startMutex
     ) : BaseLspLanguageServer(
         incomingMessages,
         outgoingMessages,
@@ -45,7 +48,10 @@ namespace LCompilers::LanguageServerProtocol {
         compilerVersion,
         parentProcessId,
         lspConfigTransformer,
-        workspaceConfig
+        workspaceConfig,
+        start,
+        startChanged,
+        startMutex
       )
       , logger(logger.having("ConcurrentLspLanguageServer"))
     {

--- a/src/server/concurrent_lsp_language_server.h
+++ b/src/server/concurrent_lsp_language_server.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <queue>
 #include <string>
@@ -45,7 +48,10 @@ namespace LCompilers::LanguageServerProtocol {
             const std::string &compilerVersion,
             int parentProcessId,
             std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer,
-            std::shared_ptr<lsc::LspConfig> workspaceConfig
+            std::shared_ptr<lsc::LspConfig> workspaceConfig,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         );
 
         lsl::Logger logger;

--- a/src/server/parallel_lsp_language_server.h
+++ b/src/server/parallel_lsp_language_server.h
@@ -84,7 +84,10 @@ namespace LCompilers::LanguageServerProtocol {
             int parentProcessId,
             unsigned int seed,
             std::shared_ptr<lsc::LspConfigTransformer> lspConfigTransformer,
-            std::shared_ptr<lsc::LspConfig> workspaceConfig
+            std::shared_ptr<lsc::LspConfig> workspaceConfig,
+            std::atomic_bool &start,
+            std::condition_variable &startChanged,
+            std::mutex &startMutex
         );
 
         lsl::Logger logger;

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -71,7 +71,12 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
     # lldb_path = shutil.which('lldb')
     lldb_path = None  #<- FIXME: When LLDB is enabled, remove this line.
 
-    gdb_path = shutil.which('gdb')
+    # NOTE: If you have GDB on your system and would like to run the tests with,
+    # uncomment the following line so it may be found and disable the line that
+    # assigns `None` to it:
+    # --------------------------------------------------------------------------
+    # gdb_path = shutil.which('gdb')
+    gdb_path = None
 
     if lldb_path is not None:
         server_args += [


### PR DESCRIPTION
Changes:
1. Synchronizes start sequence of thread members so they will not start until everything has been initialized
2. Disables (by default) the GDB test runner
3. Re-enables pytest capture of stdout and stderr on successful runs
4. Adds @requires_server_capabilities decorator for methods that require the `server_capabilities` attribute (in case the server was not successfully initialized)

Change (1.) is to address race conditions within thread members during initialization. The latest error caused by such conditions is `libc++abi: Pure virtual function called!`, which occurs when a thread attempts to call a pure virtual method on an object before it has been fully initialized.

Change (4.) addresses a side-effect of the bug that (1.) addresses. If an error occurs that prevents the server from initializing, then the `server_capabilities` attribute will not be set which can cause `AttributeError`s to be thrown that mask the underlying bug.

Changes (2.) and (3.) address issues with the verbosity and performance of the CI test runners.