### PR TITLE
Runs the tests in both concurrent and parallel modes in the CI

### DIFF
--- a/ci/test_lsp.sh
+++ b/ci/test_lsp.sh
@@ -14,5 +14,6 @@ if [[ $WIN != "1" ]]; then
     # `--capture` as follows:
     # --------------------------------------------------------------------------
     # pytest -vv --showlocals --capture=no --timeout=10 tests/server
-    pytest -vv --showlocals --timeout=10 tests/server
+    pytest -vv --showlocals --timeout=10 --execution-strategy="concurrent" tests/server
+    pytest -vv --showlocals --timeout=10 --execution-strategy="parallel" tests/server
 fi


### PR DESCRIPTION
Changes:
1. Adds command-line option to pytest to select the execution strategy
2. Runs the tests in both concurrent and parallel modes in the CI