### PR TITLE
Adds unit tests for `textDocument/hover` and `textDocument/documentSymbol`

### DIFF
--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -103,3 +103,7 @@ class LspClient(ABC):
     @abstractmethod
     def highlight(self, uri: str, line: int, column: int) -> None:
         raise NotImplementedError
+
+    @abstractmethod
+    def hover(self, uri: str, line: int, column: int) -> None:
+        raise NotImplementedError

--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from lsprotocol.types import TextDocumentSaveReason
 

--- a/src/server/tests/src/llanguage_test_client/lsp_text_document.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_text_document.py
@@ -3,7 +3,8 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from lsprotocol.types import (DocumentHighlight, Hover, Position, Range,
+from lsprotocol.types import (DocumentHighlight, DocumentSymbol, Hover,
+                              Position, Range, SymbolInformation,
                               TextDocumentSaveReason, TextEdit)
 
 from llanguage_test_client.lsp_client import LspClient
@@ -50,6 +51,9 @@ def requires_path(fn: Callable) -> Callable:
     return wrapper
 
 
+ChangeListener = Callable[[int, Optional[str]], None]
+
+
 class LspTextDocument:
     client: LspClient
     document_id: int
@@ -62,9 +66,12 @@ class LspTextDocument:
     pos_by_line: List[int]
     len_by_line: List[int]
 
+    change_listeners: List[ChangeListener]
+
     selection: Optional[Range]
     highlights: Optional[List[DocumentHighlight]]
     preview: Optional[Hover]
+    symbols: Union[List[SymbolInformation], List[DocumentSymbol], None]
 
     def __init__(
             self,
@@ -88,6 +95,16 @@ class LspTextDocument:
         self.selection = None
         self.highlights = None
         self.preview = None
+        self.symbols = None
+        self.change_listeners = []
+
+    def on_change(self, listener: ChangeListener) -> None:
+        self.change_listeners.append(listener)
+
+    def signal_change(self) -> None:
+        uri = self.uri if self._path is not None else None
+        for change_fn in self.change_listeners:
+            change_fn(self.document_id, uri)
 
     @property
     def path(self) -> Path:
@@ -187,6 +204,7 @@ class LspTextDocument:
                 self.bump_version(),
                 self.text
             )
+            self.signal_change()
         else:
             raise RuntimeError('`path` must be set before calling `load()`')
 
@@ -327,6 +345,7 @@ class LspTextDocument:
                 self.text, ""
             )
         self.recompute_indices()
+        self.signal_change()
 
     def backspace(self, length: int = 1) -> None:
         """
@@ -357,6 +376,7 @@ class LspTextDocument:
                 self.text, text
             )
         self.recompute_indices()
+        self.signal_change()
 
     def newline(self) -> None:
         """
@@ -381,6 +401,7 @@ class LspTextDocument:
                 self.text, text
             )
         self.recompute_indices()
+        self.signal_change()
 
     def apply(self, edits: List[TextEdit]) -> None:
         origin = self.position

--- a/src/server/tests/src/llanguage_test_client/lsp_text_document.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_text_document.py
@@ -3,7 +3,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from lsprotocol.types import (DocumentHighlight, Position, Range,
+from lsprotocol.types import (DocumentHighlight, Hover, Position, Range,
                               TextDocumentSaveReason, TextEdit)
 
 from llanguage_test_client.lsp_client import LspClient
@@ -64,6 +64,7 @@ class LspTextDocument:
 
     selection: Optional[Range]
     highlights: Optional[List[DocumentHighlight]]
+    preview: Optional[Hover]
 
     def __init__(
             self,
@@ -86,6 +87,7 @@ class LspTextDocument:
         self.is_new = (path is None)
         self.selection = None
         self.highlights = None
+        self.preview = None
 
     @property
     def path(self) -> Path:
@@ -413,3 +415,8 @@ class LspTextDocument:
     def highlight(self) -> None:
         line, column = self.pos_to_linecol(self.position)
         self.client.highlight(self.uri, line, column)
+
+    @requires_path
+    def hover(self) -> None:
+        line, column = self.pos_to_linecol(self.position)
+        self.client.hover(self.uri, line, column)

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -12,8 +12,9 @@ from lsprotocol.types import (
     InitializeParams, InsertTextMode, Location, LocationLink, MarkupKind,
     Position, RenameClientCapabilities, RenameParams,
     TextDocumentDefinitionRequest, TextDocumentDefinitionResponse,
-    TextDocumentIdentifier, TextDocumentPublishDiagnosticsNotification,
-    TextDocumentRenameRequest, TextDocumentRenameResponse, WorkspaceEdit)
+    TextDocumentDocumentHighlightResponse, TextDocumentIdentifier,
+    TextDocumentPublishDiagnosticsNotification, TextDocumentRenameRequest,
+    TextDocumentRenameResponse, WorkspaceEdit, TextDocumentHoverResponse)
 
 from llanguage_test_client.json_rpc import JsonArray, JsonObject
 from llanguage_test_client.lsp_test_client import LspTestClient
@@ -107,7 +108,6 @@ class LFortranLspTestClient(LspTestClient):
                 context_support=True,
             )
             text_document.hover = HoverClientCapabilities(
-                dynamic_registration=True,
                 content_format=[
                     MarkupKind.PlainText,
                     MarkupKind.Markdown,
@@ -255,3 +255,31 @@ class LFortranLspTestClient(LspTestClient):
             )
             request_id = self.send_text_document_rename(params)
             self.await_response(request_id)
+
+    def receive_text_document_document_highlight(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentDocumentHighlightResponse
+        )
+        if response.result is not None:
+            uri = request.params.text_document.uri
+            doc = self.get_document("fortran", uri)
+            doc.highlights = response.result
+
+    def receive_text_document_hover(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentHoverResponse
+        )
+        if response.result is not None:
+            uri = request.params.text_document.uri
+            doc = self.get_document("fortran", uri)
+            doc.preview = response.result

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -1,8 +1,6 @@
 import os
 import shutil
-import signal
 import sys
-import time
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -83,10 +81,10 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
     # lldb_path = shutil.which('lldb')
     lldb_path = None  #<- FIXME: When LLDB is enabled, remove this line.
 
-    # NOTE: If you have GDB on your system and would like to run the tests with,
-    # uncomment the following line so it may be found and disable the line that
-    # assigns `None` to it:
-    # --------------------------------------------------------------------------
+    # NOTE: If you have GDB on your system and would like to run the tests with
+    # it, uncomment the following line so GDB may be found and disable the line
+    # that assigns `None` to it:
+    # -------------------------------------------------------------------------
     # gdb_path = shutil.which('gdb')
     gdb_path = None
 

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -3,10 +3,12 @@ from tempfile import NamedTemporaryFile
 from typing import List
 
 from lsprotocol.types import (DidChangeConfigurationParams, DocumentHighlight,
-                              Hover, Position, Range, MarkupContent, MarkupKind)
+                              DocumentSymbol, Hover, MarkupContent, MarkupKind,
+                              Position, Range, SymbolKind)
 
 from lfortran_language_server.lfortran_lsp_test_client import \
     LFortranLspTestClient
+
 from llanguage_test_client.lsp_test_client import IncomingEvent
 
 
@@ -205,3 +207,116 @@ def test_document_hover(client: LFortranLspTestClient) -> None:
             )
         )
     )
+
+
+def test_symbol_tree(client: LFortranLspTestClient) -> None:
+    path = Path(__file__).absolute().parent.parent.parent.parent / "examples" / "expr2.f90"
+    doc = client.open_document("fortran", path)
+    assert client.await_validation(doc.uri, doc.version) is not None
+    assert doc.symbols == [
+        DocumentSymbol(
+            children=[
+                DocumentSymbol(
+                    kind=SymbolKind.Variable,
+                    name="x",
+                    range=Range(
+                        start=Position(
+                            line=3,
+                            character=11,
+                        ),
+                        end=Position(
+                            line=3,
+                            character=12,
+                        ),
+                    ),
+                    selection_range=Range(
+                        start=Position(
+                            line=3,
+                            character=11,
+                        ),
+                        end=Position(
+                            line=3,
+                            character=12,
+                        ),
+                    ),
+                ),
+            ],
+            kind=SymbolKind.Function,
+            name="expr2",
+            range=Range(
+                start=Position(
+                    line=0,
+                    character=0,
+                ),
+                end=Position(
+                    line=8,
+                    character=11,
+                ),
+            ),
+            selection_range=Range(
+                start=Position(
+                    line=0,
+                    character=0,
+                ),
+                end=Position(
+                    line=8,
+                    character=11,
+                ),
+            ),
+        ),
+    ]
+    line, column = 4, 12
+    doc.cursor = line, column
+    doc.rename("y")  # x -> y
+    assert doc.symbols == [
+        DocumentSymbol(
+            children=[
+                DocumentSymbol(
+                    kind=SymbolKind.Variable,
+                    name="y",
+                    range=Range(
+                        start=Position(
+                            line=3,
+                            character=11,
+                        ),
+                        end=Position(
+                            line=3,
+                            character=12,
+                        ),
+                    ),
+                    selection_range=Range(
+                        start=Position(
+                            line=3,
+                            character=11,
+                        ),
+                        end=Position(
+                            line=3,
+                            character=12,
+                        ),
+                    ),
+                ),
+            ],
+            kind=SymbolKind.Function,
+            name="expr2",
+            range=Range(
+                start=Position(
+                    line=0,
+                    character=0,
+                ),
+                end=Position(
+                    line=8,
+                    character=11,
+                ),
+            ),
+            selection_range=Range(
+                start=Position(
+                    line=0,
+                    character=0,
+                ),
+                end=Position(
+                    line=8,
+                    character=11,
+                ),
+            ),
+        ),
+    ]


### PR DESCRIPTION
Adds unit tests for the remaining, currently supported features:
1. `textDocument/hover` (hover previews)
2. `textDocument/documentSymbol` (symbol tree navigation)