### PR TITLE
fix : Do not use pointer for ArraySection with Descriptor Array having only 1 dimension

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1746,6 +1746,7 @@ RUN(NAME array_section_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStac
 RUN(NAME array_section_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME array_section_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME array_section_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
+RUN(NAME array_section_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME nested_vars_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray NO_STD_F23)
 

--- a/integration_tests/array_section_06.f90
+++ b/integration_tests/array_section_06.f90
@@ -1,0 +1,13 @@
+program array_section_06
+    integer :: arr(2,3)
+    arr(1,1) = 1
+    arr(2,1) = 2
+    arr(1,2) = 3
+    arr(2,2) = 4
+    arr(1,3) = 5
+    arr(2,3) = 6
+    print * , arr(1,:)
+    print * , arr(2,:)
+    if (.not. all(arr(1,:) == [1, 3, 5])) error stop
+    if (.not. all(arr(2,:) == [2, 4, 6])) error stop
+end program

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -968,7 +968,8 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
         ASR::expr_t* array_var_temporary = nullptr;
         bool is_pointer_required = ASR::is_a<ASR::ArraySection_t>(*x_m_args_i) &&
                     !is_common_symbol_present_in_lhs_and_rhs(al, lhs_var, expr) &&
-                    !ASRUtils::is_array_indexed_with_array_indices(ASR::down_cast<ASR::ArraySection_t>(x_m_args_i));
+                    !ASRUtils::is_array_indexed_with_array_indices(ASR::down_cast<ASR::ArraySection_t>(x_m_args_i)) &&
+                    (ASR::down_cast<ASR::Array_t>(ASR::down_cast<ASR::ArraySection_t>(x_m_args_i)->m_type)->n_dims > 1);
         array_var_temporary = create_and_allocate_temporary_variable_for_array(
             x_m_args_i, name_hint, al, current_body, current_scope, exprs_with_target,
             is_pointer_required);


### PR DESCRIPTION
fix #6809 

MRE :- 
```.f90
program test
    integer :: arr(2,3)
    arr(1,1) = 1
    arr(2,1) = 2
    arr(1,2) = 3
    arr(2,2) = 4
    arr(1,3) = 5
    arr(2,3) = 6
    print * , arr(1,:)
    print * , arr(2,:)
end program
```

LFortran Output :- 
```console
(lf) lordansh@LordAnsh:~/dev/lfort2/lfortran$ lfortran try.f90
1    3    5
2    4    6
```

Fortran code after array_struct_temporary pass :- 
```.f90
! Fortran code after applying the pass: array_struct_temporary
program test
implicit none
integer(4), dimension(:), pointer :: __libasr_created__array_section_pointer_
integer(4), dimension(:), pointer :: __libasr_created__array_section_pointer_1
integer(4), dimension(:), allocatable :: __libasr_created_string_format
integer(4), dimension(:), allocatable :: __libasr_created_string_format1
integer(4), dimension(2, 3) :: arr
arr(1, 1) = 1
arr(2, 1) = 2
arr(1, 2) = 3
arr(2, 2) = 4
arr(1, 3) = 5
arr(2, 3) = 6
deallocate(__libasr_created_string_format)
allocate(__libasr_created_string_format((ubound(arr, 2) - lbound(arr, 2))/1 + 1))
__libasr_created__array_section_pointer_ => arr(1, lbound(arr, 2):ubound(arr, 2))
__libasr_created_string_format = __libasr_created__array_section_pointer_
print *, __libasr_created_string_format
deallocate(__libasr_created_string_format1)
allocate(__libasr_created_string_format1((ubound(arr, 2) - lbound(arr, 2))/1 + 1))
__libasr_created__array_section_pointer_1 => arr(2, lbound(arr, 2):ubound(arr, 2))
__libasr_created_string_format1 = __libasr_created__array_section_pointer_1
print *, __libasr_created_string_format1
end program test
```