### PR TITLE
Explicitly passes capfd fixture to client fixture to prevent stderr leaks

### DIFF
--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -22,7 +22,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 @pytest.fixture
-def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
+def client(request: pytest.FixtureRequest, capfd: pytest.CaptureFixture) -> Iterator[LFortranLspTestClient]:
     execution_strategy = request.config.getoption("--execution-strategy")
 
     server_path = None
@@ -198,3 +198,6 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
         finally:
             if not logs_printed:
                 print_logs()
+
+    # Consuming stderr should prevent leaks
+    capfd.readouterr()


### PR DESCRIPTION
Passing `capfd` (capture stdout/stderr file descriptors) to the `client` fixture should prevent stderr leaks like those in https://github.com/lfortran/lfortran/issues/6907.