### PR TITLE
Runs LFortran in interactive mode

### DIFF
--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -157,6 +157,9 @@ namespace LCompilers::LanguageServerProtocol {
         compilerOptions.continue_compilation = true;
         compilerOptions.use_colors = false;  // disable ANSI terminal colors
 
+        // Do not err on partially-constructed blocks when formatting:
+        compilerOptions.interactive = true;
+
         std::unique_lock<std::shared_mutex> writeLock(optionMutex);
         optionIter = optionsByUri.find(uri);
         if (optionIter != optionsByUri.end()) {


### PR DESCRIPTION
Runs LFortran in interactive mode so it does not err on unexpected top-level block types when formatting code

Should address https://github.com/lfortran/lfortran/issues/6875