### PR TITLE
Adds LFortranAccessor::previewSymbol

### DIFF
--- a/src/bin/lfortran_accessor.cpp
+++ b/src/bin/lfortran_accessor.cpp
@@ -2,6 +2,7 @@
 
 #include <libasr/asr.h>
 #include <libasr/asr_lookup_name.h>
+#include <libasr/asr_utils.h>
 #include <libasr/diagnostics.h>
 #include <libasr/exception.h>
 #include <libasr/location.h>
@@ -119,6 +120,71 @@ namespace LCompilers::LLanguageServer {
                         loc.filename
                     );
                     loc.symbol_type = s->type;
+                }
+            }
+        }
+
+        return symbol_lists;
+    }
+
+    auto LFortranAccessor::previewSymbol(
+        const std::string &filename,
+        const std::string &text,
+        const CompilerOptions &compiler_options
+    ) -> std::vector<std::pair<LCompilers::document_symbols, std::string>> {
+        std::unique_lock<std::mutex> lock(mutex);
+        LCompilers::FortranEvaluator fe(compiler_options);
+        std::vector<std::pair<LCompilers::document_symbols, std::string>> symbol_lists;
+
+        LCompilers::LocationManager lm;
+        {
+            LCompilers::LocationManager::FileLocations fl;
+            fl.in_filename = filename;
+            lm.files.push_back(fl);
+            lm.file_ends.push_back(text.size());
+        }
+        {
+            LCompilers::diag::Diagnostics diagnostics;
+            LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
+                x = fe.get_asr2(text, lm, diagnostics);
+            if (x.ok) {
+                // populate_symbol_lists(x.result, lm, symbol_lists);
+                uint16_t l = std::stoi(compiler_options.line);
+                uint16_t c = std::stoi(compiler_options.column);
+                uint64_t input_pos = lm.linecol_to_pos(l, c);
+                if (c > 0 && input_pos > 0 && !is_id_chr(text[input_pos]) &&
+                    is_id_chr(text[input_pos - 1])) {
+                    // input_pos is to the right of the word boundary
+                    --input_pos;
+                }
+                uint64_t output_pos = lm.input_to_output_pos(input_pos, false);
+                LCompilers::ASR::asr_t* asr =
+                    fe.handle_lookup_name(x.result, output_pos);
+                if (ASR::is_a<ASR::symbol_t>(*asr)) {
+                    std::pair<LCompilers::document_symbols, std::string> &pair =
+                        symbol_lists.emplace_back();
+
+                    ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(asr);
+                    std::string symbol_name = ASRUtils::symbol_name( s );
+                    LCompilers::document_symbols &loc = pair.first;
+                    loc.symbol_name = symbol_name;
+                    lm.pos_to_linecol(
+                        lm.output_to_input_pos(asr->loc.first, false),
+                        loc.first_line,
+                        loc.first_column,
+                        loc.filename
+                    );
+                    lm.pos_to_linecol(
+                        lm.output_to_input_pos(asr->loc.last, true),
+                        loc.last_line,
+                        loc.last_column,
+                        loc.filename
+                    );
+                    loc.symbol_type = s->type;
+
+                    // TODO: Replace the following with a full preview of the symbol:
+                    ASR::ttype_t *t = ASRUtils::symbol_type(s);
+                    pair.second = ASRUtils::type_to_str_fortran(t);
                 }
             }
         }

--- a/src/bin/lfortran_accessor.h
+++ b/src/bin/lfortran_accessor.h
@@ -2,6 +2,7 @@
 
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <libasr/exception.h>
@@ -27,6 +28,12 @@ namespace LCompilers::LLanguageServer {
             const std::string &text,
             const CompilerOptions &compiler_options
         ) -> std::vector<LCompilers::document_symbols>;
+
+        auto previewSymbol(
+            const std::string &filename,
+            const std::string &text,
+            const CompilerOptions &compiler_options
+        ) -> std::vector<std::pair<LCompilers::document_symbols, std::string>>;
 
         auto getAllOccurrences(
             const std::string &filename,


### PR DESCRIPTION
Adds LFortranAccessor::previewSymbol to more efficiently extract the symbol preview for a hover event.

Fixes #6875.