### PR TITLE
Adds running thread histogram to telemetry event and fixes occasional deadlock

### DIFF
--- a/ci/test_lsp.sh
+++ b/ci/test_lsp.sh
@@ -15,7 +15,5 @@ if [[ $WIN != "1" ]]; then
     # --------------------------------------------------------------------------
     # pytest -vv --showlocals --capture=no --timeout=10 tests/server
     pytest -vv --showlocals --timeout=10 --execution-strategy="concurrent" tests/server
-    if [[ "$MACOS" != "1" ]]; then
-        pytest -vv --showlocals --timeout=10 --execution-strategy="parallel" tests/server
-    fi
+    pytest -vv --showlocals --timeout=10 --execution-strategy="parallel" tests/server
 fi

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -177,123 +177,117 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool &taskIsRunning
     ) -> void {
         const std::string taskType = "validate";
-        startRunning(taskType, std::chrono::system_clock::now());
+        auto tracer = startRunning(taskType);
+        if (!taskIsRunning) {
+            logger.trace()  //<- trace instead of debug because this will happen often
+                << "Validation canceled before execution."
+                << std::endl;
+            return;
+        }
+        const auto start = std::chrono::high_resolution_clock::now();
+        std::shared_lock<std::shared_mutex> readLock(document.mutex());
+        const std::string &path = document.path().string();
+        const std::string &text = document.text();
+        const std::string &uri = document.uri();
         try {
-            if (!taskIsRunning) {
-                logger.trace()  //<- trace instead of debug because this will happen often
-                    << "Validation canceled before execution."
-                    << std::endl;
-                return;
-            }
-            const auto start = std::chrono::high_resolution_clock::now();
-            std::shared_lock<std::shared_mutex> readLock(document.mutex());
-            const std::string &path = document.path().string();
-            const std::string &text = document.text();
-            const std::string &uri = document.uri();
+            // NOTE: These value may have been updated since the validation was
+            // requested, but that's okay because we want to validate the latest
+            // version anyway:
+            int version = document.version();
             try {
-                // NOTE: These value may have been updated since the validation was
-                // requested, but that's okay because we want to validate the latest
-                // version anyway:
-                int version = document.version();
-                try {
-                    readLock.unlock();
-                    std::shared_ptr<CompilerOptions> compilerOptions =
-                        getCompilerOptions(document);
-                    readLock.lock();
-                    logger.trace()
-                        << "Getting diagnostics from LFortran for document with URI="
-                        << uri << std::endl;
-                    // NOTE: Lock the logger to add debug statements to stderr within LFortran.
-                    // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
-                    std::vector<lc::error_highlight> highlights =
-                        lfortran.showErrors(path, text, *compilerOptions);
-                    // loggerLock.unlock();
+                readLock.unlock();
+                std::shared_ptr<CompilerOptions> compilerOptions =
+                    getCompilerOptions(document);
+                readLock.lock();
+                logger.trace()
+                    << "Getting diagnostics from LFortran for document with URI="
+                    << uri << std::endl;
+                // NOTE: Lock the logger to add debug statements to stderr within LFortran.
+                // std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
+                std::vector<lc::error_highlight> highlights =
+                    lfortran.showErrors(path, text, *compilerOptions);
+                // loggerLock.unlock();
 
-                    logger.trace()
-                        << "Collected " << highlights.size()
-                        << " diagnostics for document with URI=" << uri
-                        << std::endl;
+                logger.trace()
+                    << "Collected " << highlights.size()
+                    << " diagnostics for document with URI=" << uri
+                    << std::endl;
 
-                    readLock.unlock();
-                    const std::shared_ptr<lsc::LFortranLspConfig> config =
-                        getLFortranConfig(uri);
-                    readLock.lock();
+                readLock.unlock();
+                const std::shared_ptr<lsc::LFortranLspConfig> config =
+                    getLFortranConfig(uri);
+                readLock.lock();
 
-                    unsigned int numProblems = config->maxNumberOfProblems;
-                    if (highlights.size() < numProblems) {
-                        numProblems = highlights.size();
-                    }
+                unsigned int numProblems = config->maxNumberOfProblems;
+                if (highlights.size() < numProblems) {
+                    numProblems = highlights.size();
+                }
 
-                    std::vector<Diagnostic> diagnostics;
-                    diagnostics.reserve(numProblems);
-                    for (unsigned int i = 0; i < numProblems; ++i) {
-                        const lc::error_highlight &highlight = highlights[i];
+                std::vector<Diagnostic> diagnostics;
+                diagnostics.reserve(numProblems);
+                for (unsigned int i = 0; i < numProblems; ++i) {
+                    const lc::error_highlight &highlight = highlights[i];
 
-                        Position start;
-                        start.line = highlight.first_line - 1;
-                        start.character = highlight.first_column - 1;
+                    Position start;
+                    start.line = highlight.first_line - 1;
+                    start.character = highlight.first_column - 1;
 
-                        Position end;
-                        end.line = highlight.last_line - 1;
-                        end.character = highlight.last_column;
+                    Position end;
+                    end.line = highlight.last_line - 1;
+                    end.character = highlight.last_column;
 
-                        Range range;
-                        range.start = std::move(start);
-                        range.end = std::move(end);
+                    Range range;
+                    range.start = std::move(start);
+                    range.end = std::move(end);
 
-                        Diagnostic diagnostic;
-                        diagnostic.range = std::move(range);
-                        diagnostic.severity =
-                            diagnosticLevelToLspSeverity(highlight.severity);
-                        diagnostic.message = highlight.message;
-                        diagnostic.source = source;
+                    Diagnostic diagnostic;
+                    diagnostic.range = std::move(range);
+                    diagnostic.severity =
+                        diagnosticLevelToLspSeverity(highlight.severity);
+                    diagnostic.message = highlight.message;
+                    diagnostic.source = source;
 
-                        diagnostics.push_back(std::move(diagnostic));
-                    }
+                    diagnostics.push_back(std::move(diagnostic));
+                }
 
-                    if (taskIsRunning) {
-                        PublishDiagnosticsParams params;
-                        params.uri = uri;
-                        params.version = version;
-                        params.diagnostics = std::move(diagnostics);
-                        if (trace >= TraceValues::Messages) {
-                            const auto end = std::chrono::high_resolution_clock::now();
-                            const auto duration =
-                                std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    (end - start)
-                                );
-                            LogTraceParams logTraceParams;
-                            logTraceParams.message =
-                                "Sending response 'textDocument/publishDiagnostics'. "
-                                "Processing request took " +
-                                std::to_string(duration.count()) + "ms";
-                            if (trace >= TraceValues::Verbose) {
-                                LSPAny any = transformer.publishDiagnosticsParamsToAny(params);
-                                logTraceParams.verbose = "Result: " + toJsonString(any);
-                            }
-                            sendLogTrace(logTraceParams);
+                if (taskIsRunning) {
+                    PublishDiagnosticsParams params;
+                    params.uri = uri;
+                    params.version = version;
+                    params.diagnostics = std::move(diagnostics);
+                    if (trace >= TraceValues::Messages) {
+                        const auto end = std::chrono::high_resolution_clock::now();
+                        const auto duration =
+                            std::chrono::duration_cast<std::chrono::milliseconds>(
+                                (end - start)
+                            );
+                        LogTraceParams logTraceParams;
+                        logTraceParams.message =
+                            "Sending response 'textDocument/publishDiagnostics'. "
+                            "Processing request took " +
+                            std::to_string(duration.count()) + "ms";
+                        if (trace >= TraceValues::Verbose) {
+                            LSPAny any = transformer.publishDiagnosticsParamsToAny(params);
+                            logTraceParams.verbose = "Result: " + toJsonString(any);
                         }
-                        sendTextDocument_publishDiagnostics(params);
-                    } else {
-                        logger.trace()  //<- trace instead of debug because this will happen often
-                            << "Validation canceled before publishing results."
-                            << std::endl;
+                        sendLogTrace(logTraceParams);
                     }
-                } catch (std::exception &e) {
-                    logger.error()
-                        << "Failed to validate document (uri=\""
-                        << uri << "\"): " << e.what()
+                    sendTextDocument_publishDiagnostics(params);
+                } else {
+                    logger.trace()  //<- trace instead of debug because this will happen often
+                        << "Validation canceled before publishing results."
                         << std::endl;
                 }
             } catch (std::exception &e) {
                 logger.error()
-                    << "Failed to read document attributes: " << e.what()
+                    << "Failed to validate document (uri=\""
+                    << uri << "\"): " << e.what()
                     << std::endl;
             }
-            stopRunning(taskType);
-        } catch (std::exception &exception) {
-            stopRunning(taskType);
-            throw exception;
+        } catch (std::exception &e) {
+            logger.error()
+                << "Failed to read document attributes: " << e.what()
+                << std::endl;
         }
     }
 

--- a/src/bin/parallel_lfortran_lsp_language_server.cpp
+++ b/src/bin/parallel_lfortran_lsp_language_server.cpp
@@ -102,7 +102,9 @@ namespace LCompilers::LanguageServerProtocol {
             ) {
                 std::shared_lock<std::shared_mutex> readLock(document->mutex());
                 const std::string &uri = document->uri();
+                readLock.unlock();
                 LFortranLspLanguageServer::validate(*document, *taskIsRunning);
+                readLock.lock();
                 std::unique_lock<std::shared_mutex> writeLock(validationMutex);
                 auto iter = validationsByUri.find(uri);
                 if (iter != validationsByUri.end()) {

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -30,6 +30,19 @@ namespace LCompilers::LanguageServerProtocol {
         std::map<std::string, time_point_t>
     > RunningHistogram;
 
+    class BaseLspLanguageServer;
+
+    class RunTracer {
+    public:
+        RunTracer(BaseLspLanguageServer *server, const std::string &taskType);
+        ~RunTracer();
+        auto stop() -> void;
+    private:
+        BaseLspLanguageServer *server;
+        const std::string &taskType;
+        bool stopped{false};
+    }; // class RunTracer
+
     class BaseLspLanguageServer : public LspLanguageServer {
     public:
         auto isTerminated() const -> bool override;
@@ -128,10 +141,7 @@ namespace LCompilers::LanguageServerProtocol {
 
         auto toAny(const time_point_t &timePoint) -> LSPAny;
 
-        auto startRunning(
-            const std::string &taskType,
-            const time_point_t &startTime
-        ) -> void;
+        auto startRunning(const std::string &taskType) -> RunTracer;
 
         auto stopRunning(const std::string &taskType) -> void;
 
@@ -316,6 +326,7 @@ namespace LCompilers::LanguageServerProtocol {
             GetDocumentParams &params
         ) -> GetDocumentResult override;
 
+        friend class RunTracer;
     }; // class BaseLspLanguageServer
 
 } // namespace LCompilers::LanguageServerProtocol

--- a/src/server/logger.cpp
+++ b/src/server/logger.cpp
@@ -57,6 +57,33 @@ namespace LCompilers::LLanguageServer::Logging {
         );
     }
 
+    auto formatTimePoint(const std::chrono::system_clock::time_point& tp) -> std::string {
+        static thread_local std::ostringstream oss;
+        oss.str("");
+        oss.clear();
+
+        // Convert time_point to time_t for seconds
+        auto time_t = std::chrono::system_clock::to_time_t(tp);
+
+        // Convert to UTC time
+        std::tm* tm = std::gmtime(&time_t);
+
+        // Extract milliseconds
+        auto duration = tp.time_since_epoch();
+        auto milliseconds =
+            std::chrono::duration_cast<
+                std::chrono::milliseconds
+            >(duration).count() % 1000;
+
+        // Format the time with seconds
+        oss << std::put_time(tm, "%Y-%m-%dT%H:%M:%S");
+
+        // Append milliseconds (3 digits) and 'Z' for UTC
+        oss << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+
+        return oss.str();
+    }
+
     Formatter::Formatter(Logger &logger, Level level, const std::string &prompt)
         : logger(logger)
         , lock(logger.mutex(), std::defer_lock)
@@ -67,12 +94,7 @@ namespace LCompilers::LLanguageServer::Logging {
                 enabled = true;
 
                 auto now = std::chrono::system_clock::now();
-                std::time_t time_now = std::chrono::system_clock::to_time_t(now);
-                std::tm utc_tm = *std::gmtime(&time_now);
-                auto duration = now.time_since_epoch();
-                auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count() % 1000;
-                logger << '[' << std::put_time(&utc_tm, "%Y-%m-%dT%H:%M:%S")
-                       << "." << std::setfill('0') << std::setw(3) << milliseconds << "Z]";
+                logger << '[' << formatTimePoint(now) << "]";
 
                 logger << '[' << logger.typeName() << ']';
                 for (const std::string &attribute : logger.attributes()) {

--- a/src/server/logger.cpp
+++ b/src/server/logger.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <iomanip>
+#include <sstream>
 #include <stdexcept>
 
 #include <server/logger.h>

--- a/src/server/logger.h
+++ b/src/server/logger.h
@@ -32,6 +32,10 @@ namespace LCompilers::LLanguageServer::Logging {
 
     class Logger;
 
+    auto formatTimePoint(
+        const std::chrono::system_clock::time_point& tp
+    ) -> std::string;
+
     class Formatter {
     public:
         Formatter(Logger &logger, Level level, const std::string &prompt);

--- a/src/server/parallel_lsp_language_server.cpp
+++ b/src/server/parallel_lsp_language_server.cpp
@@ -216,8 +216,6 @@ namespace LCompilers::LanguageServerProtocol {
     auto ParallelLspLanguageServer::chronicle() -> void {
         try {
             while (!_exit) {
-                const std::string taskType = "cron";
-                auto tracer = startRunning(taskType);
                 requestPool.ensureCapacity();
                 workerPool.ensureCapacity();
                 bool changed;
@@ -237,8 +235,6 @@ namespace LCompilers::LanguageServerProtocol {
                                 if (!_exit) {
                                     if (*taskIsRunning) {
                                         try {
-                                            const std::string taskType = "job:" + std::to_string(cronId);
-                                            auto tracer = startRunning(taskType);
                                             cronJob(std::move(taskIsRunning));
                                         } catch (const std::exception &e) {
                                             logger.error()

--- a/src/server/parallel_lsp_language_server.cpp
+++ b/src/server/parallel_lsp_language_server.cpp
@@ -100,6 +100,14 @@ namespace LCompilers::LanguageServerProtocol {
         } else {
             this->logger.warn() << "Request time-outs are disabled." << std::endl;
         }
+        schedule(
+            [this](std::shared_ptr<std::atomic_bool> taskIsRunning) {
+                if (*taskIsRunning) {
+                    sendTelemetry();
+                }
+            },
+            [this]{ return ttl(250ms); }
+        );
     }
 
     auto ParallelLspLanguageServer::join() -> void {
@@ -206,8 +214,10 @@ namespace LCompilers::LanguageServerProtocol {
     }
 
     auto ParallelLspLanguageServer::chronicle() -> void {
+        const std::string taskType = "cron";
         try {
             while (!_exit) {
+                startRunning(taskType, std::chrono::system_clock::now());
                 requestPool.ensureCapacity();
                 workerPool.ensureCapacity();
                 bool changed;
@@ -226,9 +236,13 @@ namespace LCompilers::LanguageServerProtocol {
                             ) {
                                 if (!_exit) {
                                     if (*taskIsRunning) {
+                                        const std::string taskType = "job:" + std::to_string(cronId);
+                                        startRunning(taskType, std::chrono::system_clock::now());
                                         try {
                                             cronJob(std::move(taskIsRunning));
+                                            stopRunning(taskType);
                                         } catch (const std::exception &e) {
+                                            stopRunning(taskType);
                                             logger.error()
                                                 << "Caught unhandled exception while executing cron job with id="
                                                 << cronId << ": " << e.what() << std::endl;
@@ -254,11 +268,13 @@ namespace LCompilers::LanguageServerProtocol {
                         }
                     }
                 } while (!_exit && changed);
+                stopRunning(taskType);
 
                 // NOTE: Wait a short period of time before running the cron jobs again:
                 std::this_thread::sleep_for(40ms);
             }
         } catch (std::exception &e) {
+            stopRunning(taskType);
             logger.error()
                 << "Unhandled exception caught: " << e.what()
                 << std::endl;


### PR DESCRIPTION
Changes:
1. Adds initial telemetry event which is emitted approximately every 250ms
2. Maintains a histogram on running request and worker threads which is useful for detecting things like deadlocks
3. Fixes an occasional deadlock when the document is being validated while it is being changed
4. Re-enables the parallel tests in the CI on macos