### PR TITLE
Prints LFortran stacktrace, when available, from captured exceptions

### DIFF
--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+#include <libasr/exception.h>
+#include <libasr/stacktrace.h>
+
 #include <server/base_lsp_language_server.h>
 #include <server/lsp_exception.h>
 #include <server/lsp_specification.h>
@@ -146,11 +149,14 @@ namespace LCompilers::LanguageServerProtocol {
         lcli::LFortranCommandLineParser parser(argv);
         try {
             parser.parse();
-        } catch (const lc::LCompilersException &e) {
-            logger.error()
-                << "Failed to initialize compiler options for document with uri=\""
-                << uri << "\": " << e.what() << std::endl;
-            throw LSP_EXCEPTION(ErrorCodes::InvalidParams, e.what());
+        } catch (...) {
+            const std::string message = formatException(
+                ("Failed to initialize compiler options for document with "
+                 "uri=\"" + uri + "\""),
+                std::current_exception()
+            );
+            logger.error() << message << std::endl;
+            throw LSP_EXCEPTION(ErrorCodes::InvalidParams, message);
         }
 
         CompilerOptions &compilerOptions = parser.opts.compiler_options;
@@ -170,6 +176,32 @@ namespace LCompilers::LanguageServerProtocol {
             )
         );
         return record.first->second;
+    }
+
+    auto LFortranLspLanguageServer::formatException(
+        const std::string &heading,
+        const std::exception_ptr &exception_ptr
+    ) const -> std::string {
+        try {
+            if (exception_ptr) {
+                std::rethrow_exception(exception_ptr);
+            } else {
+                return std::string{heading}.append(": ").append("unknown");
+            }
+        } catch (const LCompilers::LCompilersException &e) {
+            std::vector<LCompilers::StacktraceItem> stacktrace =
+                e.stacktrace_addresses();
+            get_local_addresses(stacktrace);
+            get_local_info(stacktrace);
+            return std::string{heading}.append("\n")
+                .append(stacktrace2str(stacktrace, LCompilers::stacktrace_depth, false))
+                .append(e.name()).append(": ").append(e.msg());
+        } catch (...) {
+            return BaseLspLanguageServer::formatException(
+                heading,
+                std::current_exception()
+            );
+        }
     }
 
     auto LFortranLspLanguageServer::validate(
@@ -278,15 +310,20 @@ namespace LCompilers::LanguageServerProtocol {
                         << "Validation canceled before publishing results."
                         << std::endl;
                 }
-            } catch (std::exception &e) {
+            } catch (...) {
                 logger.error()
-                    << "Failed to validate document (uri=\""
-                    << uri << "\"): " << e.what()
+                    << formatException(
+                        ("Failed to validate document (uri=\"" + uri + "\")"),
+                        std::current_exception()
+                    )
                     << std::endl;
             }
-        } catch (std::exception &e) {
+        } catch (...) {
             logger.error()
-                << "Failed to read document attributes: " << e.what()
+                << formatException(
+                    "Failed to read document attributes",
+                    std::current_exception()
+                )
                 << std::endl;
         }
     }

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -62,6 +62,11 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool clientSupportsHover = false;
         std::atomic_bool clientSupportsHighlight = false;
 
+        auto formatException(
+            const std::string &heading,
+            const std::exception_ptr &exception_ptr
+        ) const -> std::string override;
+
         virtual auto validate(
             std::shared_ptr<LspTextDocument> document
         ) -> void = 0;

--- a/src/libasr/colors.h
+++ b/src/libasr/colors.h
@@ -1,6 +1,8 @@
 #ifndef LFORTRAN_COLORS_H
 #define LFORTRAN_COLORS_H
 
+#include <string>
+
 namespace LCompilers {
 
 enum class style {
@@ -64,9 +66,12 @@ enum class bgB {
 
 
 template <typename T>
-std::string color(T const value)
+std::string color(T const value, bool colorize = true)
 {
-    return "\033[" + std::to_string(static_cast<int>(value)) + "m";
+    if (colorize) {
+        return "\033[" + std::to_string(static_cast<int>(value)) + "m";
+    }
+    return "";
 }
 
 

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -436,7 +436,7 @@ std::string read_line_from_file(std::string filename, unsigned int line_number)
    File "/home/ondrej/repos/rcp/src/Teuchos_RCP.hpp", line 428, in Teuchos::RCP<A>::assert_not_null() const
    throw_null_ptr_error(typeName(*this));
 */
-std::string addr2str(const StacktraceItem &i)
+std::string addr2str(const StacktraceItem &i, bool colorize)
 {
   std::ostringstream s;
   // Do the printing --- print as much information as we were able to
@@ -444,27 +444,27 @@ std::string addr2str(const StacktraceItem &i)
   if (i.function_name == "") {
     // If we didn't find the line, at least print the address itself
     if (i.local_pc == 0) {
-        s << color(style::dim);
+        s << color(style::dim, colorize);
         s << "  File unknown, absolute address: " << (void*) i.pc;
-        s << color(style::reset);
+        s << color(style::reset, colorize);
     } else {
         if (i.source_filename == "") {
-            s << color(style::dim);
+            s << color(style::dim, colorize);
             s << "  Binary file \"";
-            s << color(style::reset);
-            s << color(style::bold) << color(fg::magenta);
+            s << color(style::reset, colorize);
+            s << color(style::bold, colorize) << color(fg::magenta, colorize);
             s << i.binary_filename;
-            s << color(fg::reset) << color(style::reset);
-            s << color(style::dim);
+            s << color(fg::reset, colorize) << color(style::reset, colorize);
+            s << color(style::dim, colorize);
             s << "\", local address: " << (void*) i.local_pc;
-            s << color(style::reset);
+            s << color(style::reset, colorize);
         } else {
           // Nicely format the filename + line
-          s << color(style::dim) << "  File \"" << color(style::reset)
-            << color(style::bold) << color(fg::magenta) << i.source_filename
-            << color(fg::reset) << color(style::reset)
-            << color(style::dim) << "\", line " << i.line_number
-            << color(style::reset);
+          s << color(style::dim, colorize) << "  File \"" << color(style::reset, colorize)
+            << color(style::bold, colorize) << color(fg::magenta, colorize) << i.source_filename
+            << color(fg::reset, colorize) << color(style::reset, colorize)
+            << color(style::dim, colorize) << "\", line " << i.line_number
+            << color(style::reset, colorize);
           const std::string line_text = remove_leading_whitespace(
             read_line_from_file(i.source_filename, i.line_number));
           if (line_text != "") {
@@ -475,18 +475,18 @@ std::string addr2str(const StacktraceItem &i)
   } else if (i.source_filename == "") {
       // The file is unknown (and data.line == 0 in this case), so the
       // only meaningful thing to print is the function name:
-      s << color(style::dim) << "  Binary file \"" + color(style::reset)
-        << color(style::bold) << color(fg::magenta) << i.binary_filename
-        << color(fg::reset) << color(style::reset)
-        << color(style::dim) << "\", in " << i.function_name
-        << color(style::reset);
+      s << color(style::dim, colorize) << "  Binary file \"" + color(style::reset, colorize)
+        << color(style::bold, colorize) << color(fg::magenta, colorize) << i.binary_filename
+        << color(fg::reset, colorize) << color(style::reset, colorize)
+        << color(style::dim, colorize) << "\", in " << i.function_name
+        << color(style::reset, colorize);
   } else {
       // Nicely format the filename + function name + line
-      s << color(style::dim) << "  File \"" << color(style::reset)
-        << color(style::bold) << color(fg::magenta) << i.source_filename
-        << color(fg::reset) << color(style::reset)
-        << color(style::dim) << "\", line " << i.line_number
-        << ", in " << i.function_name << color(style::reset);
+      s << color(style::dim, colorize) << "  File \"" << color(style::reset, colorize)
+        << color(style::bold, colorize) << color(fg::magenta, colorize) << i.source_filename
+        << color(fg::reset, colorize) << color(style::reset, colorize)
+        << color(style::dim, colorize) << "\", line " << i.line_number
+        << ", in " << i.function_name << color(style::reset, colorize);
       const std::string line_text = remove_leading_whitespace(
         read_line_from_file(i.source_filename, i.line_number));
       if (line_text != "") {
@@ -559,13 +559,13 @@ void get_llvm_info(std::vector<StacktraceItem> &d)
   Returns a std::string with the stacktrace corresponding to the
   list of addresses (of functions on the stack) in `d`.
 */
-std::string stacktrace2str(const std::vector<StacktraceItem> &d, int skip)
+std::string stacktrace2str(const std::vector<StacktraceItem> &d, int skip, bool colorize)
 {
   std::string full_stacktrace_str("Traceback (most recent call last):\n");
 
   // Loop over the stack
   for (int i=d.size()-1; i >= skip; i--) {
-    full_stacktrace_str += addr2str(d[i]);
+    full_stacktrace_str += addr2str(d[i], colorize);
   }
 
   return full_stacktrace_str;

--- a/src/libasr/stacktrace.h
+++ b/src/libasr/stacktrace.h
@@ -55,7 +55,7 @@ void get_llvm_info(std::vector<StacktraceItem> &d);
 
 // Converts the information stored in `d` into a string
 std::string stacktrace2str(const std::vector<StacktraceItem> &d,
-    int skip);
+    int skip, bool colorize = true);
 
 // Returns line number information from address
 void address_to_line_number(const std::vector<std::string> &filenames,

--- a/src/server/base_lsp_language_server.cpp
+++ b/src/server/base_lsp_language_server.cpp
@@ -355,11 +355,13 @@ namespace LCompilers::LanguageServerProtocol {
             }
             logger.error() << error.message << std::endl;
             response.error = std::move(error);
-        } catch (const std::exception &e) {
+        } catch (...) {
             ResponseError error;
             error.code = static_cast<int>(ErrorCodes::InternalError);
-            error.message = "Caught unhandled exception: ";
-            error.message.append(e.what());
+            error.message = formatException(
+                "Caught unhandled exception",
+                std::current_exception()
+            );
             logger.error() << error.message << std::endl;
             response.error = std::move(error);
         }
@@ -397,9 +399,12 @@ namespace LCompilers::LanguageServerProtocol {
                     std::string issueTitle = reporter.title();
                     std::string issueBody = reporter.body();
                     sendOpenIssue(issueTitle, issueBody);
-                } catch (const std::exception &e) {
+                } catch (...) {
                     logger.error()
-                        << "Failed to open issue: " << e.what()
+                        << formatException(
+                            "Failed to open issue",
+                            std::current_exception()
+                        )
                         << std::endl;
                 }
             }
@@ -1095,9 +1100,12 @@ namespace LCompilers::LanguageServerProtocol {
             (this->workspaceConfig->log.level != workspaceConfig.log.level)) {
             try {
                 logger.setLevel(workspaceConfig.log.level);
-            } catch (std::exception &e) {
+            } catch (...) {
                 logger.error()
-                    << "Caught unhandled exception while updating log level: " << e.what()
+                    << formatException(
+                        "Caught unhandled exception while updating log level",
+                        std::current_exception()
+                    )
                     << std::endl;
             }
         }

--- a/src/server/communication_protocol.cpp
+++ b/src/server/communication_protocol.cpp
@@ -55,7 +55,10 @@ namespace LCompilers::LLanguageServer {
         } catch (std::exception &e) {
             if (e.what() != lst::DEQUEUE_FAILED_MESSAGE) {
                 logger.error()
-                    << "Unhandled exception caught: " << e.what()
+                    << languageServer.formatException(
+                        "Unhandled exception caught",
+                        std::current_exception()
+                    )
                     << std::endl;
             } else {
                 logger.trace()
@@ -64,7 +67,10 @@ namespace LCompilers::LLanguageServer {
             }
         } catch (...) {
             logger.error()
-                << "Unhandled exception caught: unknown"
+                << languageServer.formatException(
+                    "Unhandled exception caught",
+                    std::current_exception()
+                )
                 << std::endl;
         }
         logger.debug() << "Incoming-message listener terminated." << std::endl;
@@ -85,10 +91,12 @@ namespace LCompilers::LLanguageServer {
                         << std::endl;
                 }
             }
-        } catch (std::exception &e) {
+        } catch (...) {
             logger.error()
-                << "Caught unhandled exception while serving requests: "
-                << e.what()
+                << languageServer.formatException(
+                    "Caught unhandled exception while serving requests",
+                    std::current_exception()
+                )
                 << std::endl;
         }
         running = false;

--- a/src/server/concurrent_lsp_language_server.cpp
+++ b/src/server/concurrent_lsp_language_server.cpp
@@ -67,7 +67,10 @@ namespace LCompilers::LanguageServerProtocol {
         } catch (std::exception &e) {
             if (e.what() != lst::DEQUEUE_FAILED_MESSAGE) {
                 logger.error()
-                    << "Unhandled exception caught: " << e.what()
+                    << formatException(
+                        "Unhandled exception caught",
+                        std::current_exception()
+                    )
                     << std::endl;
             } else {
                 logger.trace()
@@ -76,7 +79,10 @@ namespace LCompilers::LanguageServerProtocol {
             }
         } catch (...) {
             logger.error()
-                << "Unhandled exception caught: unknown"
+                << formatException(
+                    "Unhandled exception caught",
+                    std::current_exception()
+                )
                 << std::endl;
         }
     }
@@ -92,12 +98,15 @@ namespace LCompilers::LanguageServerProtocol {
                     sendId,
                     std::make_shared<std::atomic_bool>(true)
                 );
-            } catch (std::exception &e) {
+            } catch (...) {
                 logger.error()
                     << "Failed to handle message: " << message
                     << std::endl;
                 logger.error()
-                    << "Caught unhandled exception: " << e.what()
+                    << formatException(
+                        "Caught unhandled exception",
+                        std::current_exception()
+                    )
                     << std::endl;
             }
             if (pendingSendId <= sendId) {
@@ -184,7 +193,10 @@ namespace LCompilers::LanguageServerProtocol {
             } catch (std::exception &e) {
                 if (e.what() != lst::DEQUEUE_FAILED_MESSAGE) {
                     logger.error()
-                        << "Unhandled exception caught: " << e.what()
+                        << formatException(
+                            "Unhandled exception caught",
+                            std::current_exception()
+                        )
                         << std::endl;
                 } else {
                     logger.trace()

--- a/src/server/language_server.cpp
+++ b/src/server/language_server.cpp
@@ -1,3 +1,4 @@
+#include <exception>
 #include <ostream>
 
 #include <server/language_server.h>
@@ -30,6 +31,23 @@ namespace LCompilers::LLanguageServer {
         if (outgoingMessages.enqueue(buffer) == nullptr) {
             logger.error() << "Failed to enqueue message:" << std::endl
                            << buffer << std::endl;
+        }
+    }
+
+    auto LanguageServer::formatException(
+        const std::string &heading,
+        const std::exception_ptr &exception_ptr
+    ) const -> std::string {
+        try {
+            if (exception_ptr) {
+                std::rethrow_exception(exception_ptr);
+            } else {
+                return std::string{heading}.append(": ").append("unknown");
+            }
+        } catch (const std::exception &exception) {
+            return std::string{heading}.append(": ").append(exception.what());
+        } catch (...) {
+            return std::string{heading}.append(": ").append("unknown");
         }
     }
 

--- a/src/server/language_server.h
+++ b/src/server/language_server.h
@@ -21,6 +21,11 @@ namespace LCompilers::LLanguageServer {
         virtual ~LanguageServer();
         virtual bool isTerminated() const = 0;
         virtual void join();
+
+        virtual auto formatException(
+            const std::string &heading,
+            const std::exception_ptr &exception_ptr
+        ) const -> std::string;
     protected:
         LanguageServer(
             MessageQueue &incomingMessages,

--- a/src/server/parallel_lsp_language_server.cpp
+++ b/src/server/parallel_lsp_language_server.cpp
@@ -141,13 +141,16 @@ namespace LCompilers::LanguageServerProtocol {
                                         << "Canceled before message could be handled."
                                         << std::endl;
                                 }
-                            } catch (std::exception &e) {
+                            } catch (...) {
                                 std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
                                 logger.error()
                                     << "Failed to handle message: " << message
                                     << std::endl;
                                 logger.error()
-                                    << "Caught unhandled exception: " << e.what()
+                                    << formatException(
+                                        "Caught unhandled exception",
+                                        std::current_exception()
+                                    )
                                     << std::endl;
                             }
                             {
@@ -167,13 +170,23 @@ namespace LCompilers::LanguageServerProtocol {
         } catch (std::exception &e) {
             if (e.what() != lst::DEQUEUE_FAILED_MESSAGE) {
                 logger.error()
-                    << "Unhandled exception caught: " << e.what()
+                    << formatException(
+                        "Unhandled exception caught",
+                        std::current_exception()
+                    )
                     << std::endl;
             } else {
                 logger.trace()
                     << "Interrupted while dequeuing messages: " << e.what()
                     << std::endl;
             }
+        } catch (...) {
+            logger.error()
+                << formatException(
+                    "Unhandled exception caught",
+                    std::current_exception()
+                )
+                << std::endl;
         }
     }
 
@@ -236,10 +249,15 @@ namespace LCompilers::LanguageServerProtocol {
                                     if (*taskIsRunning) {
                                         try {
                                             cronJob(std::move(taskIsRunning));
-                                        } catch (const std::exception &e) {
+                                        } catch (...) {
                                             logger.error()
-                                                << "Caught unhandled exception while executing cron job with id="
-                                                << cronId << ": " << e.what() << std::endl;
+                                                << formatException(
+                                                    ("Caught unhandled exception "
+                                                     "while executing cron job "
+                                                     "with id=" + std::to_string(cronId)),
+                                                    std::current_exception()
+                                                )
+                                                << std::endl;
                                         }
                                     } else {
                                         logger.debug()
@@ -266,9 +284,12 @@ namespace LCompilers::LanguageServerProtocol {
                 // NOTE: Wait a short period of time before running the cron jobs again:
                 std::this_thread::sleep_for(40ms);
             }
-        } catch (std::exception &e) {
+        } catch (...) {
             logger.error()
-                << "Unhandled exception caught: " << e.what()
+                << formatException(
+                    "Unhandled exception caught",
+                    std::current_exception()
+                )
                 << std::endl;
         }
     }

--- a/src/server/thread_pool.cpp
+++ b/src/server/thread_pool.cpp
@@ -143,6 +143,10 @@ namespace LCompilers::LLanguageServer::Threading {
                     << "Interrupted while dequeuing messages: " << e.what()
                     << std::endl;
             }
+        } catch (...) {
+            logger.error()
+                << "Unhandled exception caught: unknown"
+                << std::endl;
         }
     }
 


### PR DESCRIPTION
Changes:
1. Prints LFortran stacktrace, when available, from captured exceptions
2. Allows ANSII escape sequences for colors to be disabled in stacktrace