### PR TITLE
Update ``spread`` implementation to always produce correct results for any dimensions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -214,7 +214,7 @@ macro(RUN)
         RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN RUN_GFORTRAN_ARGS)
     endif()
 
-    if (FAST AND ((NOT NOFAST_LLVM16) OR (NOT RUN_NOFAST_TILL_LLVM16)) 
+    if (FAST AND ((NOT NOFAST_LLVM16) OR (NOT RUN_NOFAST_TILL_LLVM16))
             AND (NOT RUN_NO_FAST))
         set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} --fast)
         set(RUN_NAME "${RUN_NAME}_FAST")
@@ -1069,6 +1069,7 @@ RUN(NAME intrinsics_369 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_370 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # findloc
 RUN(NAME intrinsics_371 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # findloc
 RUN(NAME intrinsics_372 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # cmplx
+RUN(NAME intrinsics_373 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_373.f90
+++ b/integration_tests/intrinsics_373.f90
@@ -1,0 +1,32 @@
+program intrinsics_373
+    integer :: a(2, 3, 4), a1(2), i, j, k, n
+    integer :: b(2, 3, 2, 4)
+
+    a1(1) = 3
+    a1(2) = 4
+    do i = 1, 2
+        do j = 1, 3
+            do k = 1, 4
+                a(i, j, k) = i + j + k
+            end do
+        end do
+    end do
+
+    print *, a
+    print *, a1
+
+    print *, spread(a, 3, 2)
+    print *, spread(a1, 1, 3)
+    b = spread(a, 3, 2)
+    do n = 1, 2
+        do i = 1, 2
+            do j = 1, 3
+                do k = 1, 4
+                    if( b(i, j, n, k) /= i + j + k ) error stop
+                end do
+            end do
+        end do
+    end do
+
+    if( any(spread(a1, 1, 3) /= reshape([3, 3, 3, 4, 4, 4], [3, 2])) ) error stop
+end program

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -295,7 +295,7 @@ class ASRBuilder {
     }
 
     inline ASR::expr_t* ArraySize(ASR::expr_t* x, ASR::expr_t* dim, ASR::ttype_t* t) {
-        return EXPR(make_ArraySize_t_util(al, loc, x, dim, t, nullptr));
+        return EXPR(make_ArraySize_t_util(al, loc, x, dim, t, nullptr, false));
     }
 
     inline ASR::expr_t* Ichar(std::string s, ASR::ttype_t* type, ASR::ttype_t* t) {
@@ -867,6 +867,8 @@ class ASRBuilder {
     }
 
     ASR::expr_t *ArrayItem_01(ASR::expr_t *arr, std::vector<ASR::expr_t*> idx) {
+        // LCOMPILERS_ASSERT(
+        //     ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(arr)) == idx.size());
         Vec<ASR::expr_t*> idx_vars; idx_vars.reserve(al, 1);
         for (auto &x: idx) idx_vars.push_back(al, x);
         return PassUtils::create_array_ref(arr, idx_vars, al);

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3131,9 +3131,9 @@ namespace Sum {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_complex(*array_type)) {
             diag.add(diag::Diagnostic("Input to `Sum` is expected to be numeric, but got " +
-                type_to_str_fortran(array_type), 
-                diag::Level::Error, 
-                diag::Stage::Semantic, 
+                type_to_str_fortran(array_type),
+                diag::Level::Error,
+                diag::Stage::Semantic,
                 {diag::Label("must be integer, real or complex type", { args[0]->base.loc })}));
             return nullptr;
         }
@@ -3172,9 +3172,9 @@ namespace Product {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_complex(*array_type)) {
             diag.add(diag::Diagnostic("Input to `Product` is expected to be numeric, but got " +
-                type_to_str_fortran(array_type), 
-                diag::Level::Error, 
-                diag::Stage::Semantic, 
+                type_to_str_fortran(array_type),
+                diag::Level::Error,
+                diag::Stage::Semantic,
                 {diag::Label("must be integer, real or complex type", { args[0]->base.loc })}));
             return nullptr;
         }
@@ -3213,9 +3213,9 @@ namespace Iparity {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type)) {
             diag.add(diag::Diagnostic("Input to `Iparity` is expected to be an integer, but got " +
-                type_to_str_fortran(array_type), 
-                diag::Level::Error, 
-                diag::Stage::Semantic, 
+                type_to_str_fortran(array_type),
+                diag::Level::Error,
+                diag::Stage::Semantic,
                 {diag::Label("must be of integer type", { args[0]->base.loc })}));
         return nullptr;
     }
@@ -3255,9 +3255,9 @@ namespace MaxVal {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_character(*array_type)) {
             diag.add(diag::Diagnostic("Input to `MaxVal` is expected to be of integer, real or character type, but got " +
-                type_to_str_fortran(array_type), 
-                diag::Level::Error, 
-                diag::Stage::Semantic, 
+                type_to_str_fortran(array_type),
+                diag::Level::Error,
+                diag::Stage::Semantic,
                 {diag::Label("must be integer, real or character type", { args[0]->base.loc })}));
             return nullptr;
         }
@@ -3458,19 +3458,19 @@ namespace FindLoc {
         if (is_real(*array_type) && is_integer(*value_type)){
             if (ASR::is_a<ASR::IntegerConstant_t>(*value)){
                 ASR::IntegerConstant_t *value_int = ASR::down_cast<ASR::IntegerConstant_t>(value);
-                value = EXPR(ASR::make_RealConstant_t(al, loc, value_int->m_n, 
+                value = EXPR(ASR::make_RealConstant_t(al, loc, value_int->m_n,
                 ASRUtils::TYPE(ASR::make_Real_t(al, loc, extract_kind_from_ttype_t(value_type)))));
             } else{
-                value = EXPR(ASR::make_Cast_t(al, loc, value, ASR::cast_kindType::IntegerToReal, 
+                value = EXPR(ASR::make_Cast_t(al, loc, value, ASR::cast_kindType::IntegerToReal,
                 ASRUtils::TYPE(ASR::make_Real_t(al, loc, extract_kind_from_ttype_t(value_type))), nullptr ));
             }
         } else if (is_integer(*array_type) && is_real(*value_type)){
             if (ASR::is_a<ASR::RealConstant_t>(*value)){
                 ASR::RealConstant_t *value_real = ASR::down_cast<ASR::RealConstant_t>(value);
-                value = EXPR(ASR::make_IntegerConstant_t(al, loc, value_real->m_r, 
+                value = EXPR(ASR::make_IntegerConstant_t(al, loc, value_real->m_r,
                 ASRUtils::TYPE(ASR::make_Integer_t(al, loc, extract_kind_from_ttype_t(value_type)))));
             } else{
-                value = EXPR(ASR::make_Cast_t(al, loc, value, ASR::cast_kindType::RealToInteger, 
+                value = EXPR(ASR::make_Cast_t(al, loc, value, ASR::cast_kindType::RealToInteger,
                 ASRUtils::TYPE(ASR::make_Integer_t(al, loc, extract_kind_from_ttype_t(value_type))), nullptr ));
             }
         }
@@ -3732,9 +3732,9 @@ namespace MinVal {
         ASR::ttype_t* array_type = expr_type(args[0]);
         if (!is_integer(*array_type) && !is_real(*array_type) && !is_character(*array_type)) {
             diag.add(diag::Diagnostic("Input to `MinVal` is expected to be of integer, real or character type, but got " +
-                type_to_str_fortran(array_type), 
-                diag::Level::Error, 
-                diag::Stage::Semantic, 
+                type_to_str_fortran(array_type),
+                diag::Level::Error,
+                diag::Stage::Semantic,
                 {diag::Label("must be integer, real or character type", { args[0]->base.loc })}));
             return nullptr;
         }

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -129,7 +129,7 @@ namespace LCompilers {
 
         public:
         // This should be removed after a refactor to `pass_manager.h` (This action should be done using more flexible function)
-        std::vector<std::string> passes_to_skip_with_llvm; 
+        std::vector<std::string> passes_to_skip_with_llvm;
         bool rtlib=false;
         void apply_passes(Allocator& al, ASR::TranslationUnit_t* asr,
                            std::vector<std::string>& passes, PassOptions &pass_options,


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/5418

Implemented https://github.com/lfortran/lfortran/issues/5418#issuecomment-2787424746 (quoted below),

There are two problems with implementation of spread intrinsic in LFortran,

> 1. The shape of resulting array is generated incorrectly (especially if the input is fixed size array) - The correct > way is, size of i-th dimension of resulting array would be defined as `merge(ncopies, merge(original_shape[i], > original_shape[merge(1, i - 1, i == 1)], i < dim), i == dim)`.
>
> 2. The implementation doesn't need a loop, we need to do,
> 
> ```
> do i = lbound(result, selected_dim), ubound(result, selected_dim)
>    result(..., :, :, :, i, :, :, :, ...) = a
> end do
> ```
> Simply copy paste the original array to the output array while iterating over the dim.
>
> Both these are needed to make spread work for general case specified in https://gcc.gnu.org/onlinedocs/gfortran/SPREAD.html. Both are easy to do, I will do it day after tomorrow.