### PR TITLE
Fix: statement functions initialization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1881,6 +1881,7 @@ RUN(NAME common_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME statement_01 LABELS gfortran llvmImplicit)
 RUN(NAME statement_02 LABELS gfortran llvmImplicit)
 RUN(NAME statement_03 LABELS gfortran llvmImplicit)
+RUN(NAME statement_04 LABELS gfortran llvmImplicit)
 
 RUN(NAME data_implied_do_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/statement_04.f90
+++ b/integration_tests/statement_04.f90
@@ -1,0 +1,13 @@
+program statement
+   integer, parameter :: wp = kind(1.e0)
+   real(wp) :: g2
+   complex(wp) :: g, t
+   real(wp) :: ABSSQ
+   ABSSQ( t ) = real( t )**2 + aimag( t )**2
+
+   g = (3.0, 4.0)
+   g2 = ABSSQ(g)
+
+   print *, g2
+
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2775,7 +2775,7 @@ public:
         current_scope = al.make_new<SymbolTable>(parent_scope);
 
         //create a new function, and add it to the symbol table
-        std::string var_name = AST::down_cast<AST::FuncCallOrArray_t>(x.m_target)->m_func;
+        std::string var_name = to_lower(AST::down_cast<AST::FuncCallOrArray_t>(x.m_target)->m_func);
         auto v = AST::down_cast<AST::FuncCallOrArray_t>(x.m_target);
 
         Vec<ASR::expr_t*> args;


### PR DESCRIPTION
This PR resolves the following semantic error:
```sh
semantic error: Statement function needs to be declared.
 --> ../c.f90:7:4
  |
7 |    ABSSQ( t ) = real( t )**2 + aimag( t )**2
  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
```

The following LAPACK/BLAS/SRC source files now compile successfully:
- `zrotg.f90`
- `crotg.f90`

With this fix, all files in the BLAS/SRC directory now compile without errors.