### PR TITLE
Adds initial implementation of "textDocument/completion"

### DIFF
--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -1,3 +1,5 @@
+#include "bin/lfortran_accessor.h"
+#include <cctype>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -5,6 +7,7 @@
 #include <memory>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -107,6 +110,35 @@ namespace LCompilers::LanguageServerProtocol {
             return SymbolKind::TypeParameter;
         default:
             return SymbolKind::Function;
+        }
+    }
+
+    auto LFortranLspLanguageServer::asrSymbolTypeToCompletionItemKind(
+        ASR::symbolType symbolType
+    ) const -> CompletionItemKind {
+        switch (symbolType) {
+        case ASR::symbolType::Module:
+            return CompletionItemKind::Module;
+        case ASR::symbolType::Function:
+            return CompletionItemKind::Function;
+        case ASR::symbolType::GenericProcedure:
+            return CompletionItemKind::Function;
+        case ASR::symbolType::CustomOperator:
+            return CompletionItemKind::Operator;
+        case ASR::symbolType::Struct:
+            return CompletionItemKind::Struct;
+        case ASR::symbolType::Enum:
+            return CompletionItemKind::Enum;
+        case ASR::symbolType::Variable:
+            return CompletionItemKind::Variable;
+        case ASR::symbolType::Class:
+            return CompletionItemKind::Class;
+        case ASR::symbolType::ClassProcedure:
+            return CompletionItemKind::Method;
+        case ASR::symbolType::Template:
+            return CompletionItemKind::TypeParameter;
+        default:
+            return CompletionItemKind::Function;
         }
     }
 
@@ -361,6 +393,14 @@ namespace LCompilers::LanguageServerProtocol {
                 clientSupportsHover = textDocument.hover.has_value();
                 clientSupportsHighlight = textDocument.documentHighlight.has_value();
                 clientSupportsSemanticHighlight = textDocument.semanticTokens.has_value();
+                if (textDocument.completion.has_value()) {
+                    clientSupportsCodeCompletion = true;
+                    const CompletionClientCapabilities &completion =
+                        textDocument.completion.value();
+                    clientSupportsCodeCompletionContext =
+                        completion.contextSupport.has_value()
+                        && completion.contextSupport.value();
+                }
             }
             logger.debug()
                 << "clientSupportsGotoDefinition = "
@@ -389,6 +429,14 @@ namespace LCompilers::LanguageServerProtocol {
             logger.debug()
                 << "clientSupportsSemanticHighlight = "
                 << clientSupportsSemanticHighlight
+                << std::endl;
+            logger.debug()
+                << "clientSupportsCodeCompletion = "
+                << clientSupportsCodeCompletion
+                << std::endl;
+            logger.debug()
+                << "clientSupportsCodeCompletionContext = "
+                << clientSupportsCodeCompletionContext
                 << std::endl;
         }
 
@@ -473,6 +521,13 @@ namespace LCompilers::LanguageServerProtocol {
             ServerCapabilities_semanticTokensProvider &semanticTokensProvider =
                 capabilities.semanticTokensProvider.emplace();
             semanticTokensProvider = std::move(semanticTokensOptions);
+        }
+
+        if (clientSupportsCodeCompletion) {
+            CompletionOptions &completionProvider =
+                capabilities.completionProvider.emplace();
+            completionProvider.triggerCharacters = {"%"};
+            completionProvider.resolveProvider = true;
         }
 
         return result;
@@ -985,6 +1040,73 @@ namespace LCompilers::LanguageServerProtocol {
         } else {
             result = nullptr;
         }
+        return result;
+    }
+
+    inline auto startsWith(
+        const std::string &term,
+        const std::string_view &prefix
+    ) -> bool {
+        return (term.length() >= prefix.length())
+            && (term.compare(0, prefix.size(), prefix) == 0);
+    }
+
+    // request: "textDocument/completion"
+    auto LFortranLspLanguageServer::receiveTextDocument_completion(
+        const RequestMessage &/*request*/,
+        CompletionParams &params
+    ) -> TextDocument_CompletionResult {
+        TextDocument_CompletionResult result;
+        if (clientSupportsCodeCompletion) {
+            const std::string &uri = params.textDocument.uri;
+            std::shared_ptr<LspTextDocument> document = getDocument(uri);
+            const std::shared_ptr<CompilerOptions> compilerOptions = getCompilerOptions(*document);
+            std::shared_lock<std::shared_mutex> readLock(document->mutex());
+            const std::string &path = document->path().string();
+            const std::string &text = document->text();
+            logger.trace()
+                << "Looking up all symbols in document with URI=" << uri
+                << std::endl;
+            std::vector<lc::document_symbols> symbols =
+                lfortran.getSymbols(path, text, *compilerOptions);
+            logger.trace()
+                << "Found " << symbols.size() << " symbol(s) matching the query."
+                << std::endl;
+            std::string_view query = document->symbolAt(
+                params.position.line,
+                params.position.character
+            );
+            auto completionItems = std::make_unique<std::vector<CompletionItem>>();
+            completionItems->reserve(symbols.size());
+            std::unordered_set<std::string> visited;
+            visited.reserve(symbols.size());
+            for (const lc::document_symbols &symbol : symbols) {
+                if (startsWith(symbol.symbol_name, query)
+                    && (visited.find(symbol.symbol_name) == visited.end())) {
+                    CompletionItem &item = completionItems->emplace_back();
+                    item.label = symbol.symbol_name;
+                    item.kind = asrSymbolTypeToCompletionItemKind(symbol.symbol_type);
+                    visited.insert(symbol.symbol_name);
+                }
+            }
+            result = std::move(completionItems);
+        } else {
+            result = nullptr;
+        }
+        return result;
+    }
+
+    // request: "completionItem/resolve"
+    auto LFortranLspLanguageServer::receiveCompletionItem_resolve(
+        const RequestMessage &/*request*/,
+        CompletionItem &params
+    ) -> CompletionItem_ResolveResult {
+        // NOTE: Use this handler to lazily populate code-completion attributes
+        // --------------------------------------------------------------------
+        // NOTE: `CompletionItem_ResolveResult` is an alias of `CompletionItem`,
+        // so returning the params, directly, is acceptable (making this a sort
+        // of identity function).
+        CompletionItem_ResolveResult &result = params;
         return result;
     }
 

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -1,4 +1,3 @@
-#include "bin/lfortran_accessor.h"
 #include <cctype>
 #include <chrono>
 #include <cstdlib>
@@ -24,6 +23,7 @@
 #endif // CLI11_HAS_FILESYSTEM
 #include <bin/CLI11.hpp>
 
+#include <bin/lfortran_accessor.h>
 #include <bin/lfortran_command_line_parser.h>
 #include <bin/lfortran_lsp_config.h>
 #include <bin/lfortran_lsp_language_server.h>

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -71,6 +71,8 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool clientSupportsHover = false;
         std::atomic_bool clientSupportsHighlight = false;
         std::atomic_bool clientSupportsSemanticHighlight = false;
+        std::atomic_bool clientSupportsCodeCompletion = false;
+        std::atomic_bool clientSupportsCodeCompletionContext = false;
 
         auto formatException(
             const std::string &heading,
@@ -97,6 +99,10 @@ namespace LCompilers::LanguageServerProtocol {
         auto asrSymbolTypeToLspSymbolKind(
             ASR::symbolType symbol_type
         ) const -> SymbolKind;
+
+        auto asrSymbolTypeToCompletionItemKind(
+            ASR::symbolType symbol_type
+        ) const -> CompletionItemKind;
 
         auto encodeHighlights(
             std::vector<unsigned int> &encodings,
@@ -175,6 +181,16 @@ namespace LCompilers::LanguageServerProtocol {
             const RequestMessage &request,
             SemanticTokensParams &params
         ) -> TextDocument_SemanticTokens_FullResult override;
+
+        auto receiveTextDocument_completion(
+            const RequestMessage &request,
+            CompletionParams &params
+        ) -> TextDocument_CompletionResult override;
+
+        auto receiveCompletionItem_resolve(
+            const RequestMessage &request,
+            CompletionItem &params
+        ) -> CompletionItem_ResolveResult override;
 
         // ====================== //
         // Incoming Notifications //

--- a/src/server/lsp_text_document.cpp
+++ b/src/server/lsp_text_document.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
@@ -256,6 +257,26 @@ namespace LCompilers::LanguageServerProtocol {
             scol = position - posByLine[line];
         }
         column = static_cast<std::size_t>(scol);
+    }
+
+    inline bool isIdentifier(unsigned char c) {
+        return std::isalnum(c) || (c == '_');
+    }
+
+    auto LspTextDocument::symbolAt(
+        std::size_t line,
+        std::size_t column
+    ) const -> std::string_view {
+        std::size_t lower = toPosition(line, column);
+        std::size_t upper = lower;
+        while ((lower > 0) && isIdentifier(_text[lower - 1])) {
+            --lower;
+        }
+        while ((upper < _text.length()) && isIdentifier(upper + 1)) {
+            ++upper;
+        }
+        std::size_t length = upper - lower;
+        return std::string_view(_text.data() + lower, length);
     }
 
     auto LspTextDocument::from(

--- a/src/server/lsp_text_document.h
+++ b/src/server/lsp_text_document.h
@@ -5,6 +5,7 @@
 #include <shared_mutex>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <server/logger.h>
@@ -70,6 +71,8 @@ namespace LCompilers::LanguageServerProtocol {
             std::size_t &column,
             std::size_t position
         ) const -> void;
+
+        auto symbolAt(std::size_t line, std::size_t column) const -> std::string_view;
     private:
         // NOTE: The document's URI might change but its id will remain
         // the same.

--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -111,3 +111,7 @@ class LspClient(ABC):
     @abstractmethod
     def semantic_highlight(self, uri: str) -> None:
         raise NotImplementedError
+
+    @abstractmethod
+    def complete(self, uri: str, line: int, column: int) -> None:
+        raise NotImplementedError

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -70,7 +70,9 @@ from lsprotocol.types import (ClientCapabilities,
                               WorkspaceDidRenameFilesNotification,
                               WorkspaceWillCreateFilesRequest,
                               WorkspaceWillDeleteFilesRequest,
-                              WorkspaceWillRenameFilesRequest)
+                              WorkspaceWillRenameFilesRequest,
+                              CompletionParams,
+                              TextDocumentCompletionRequest)
 
 from llanguage_test_client.json_rpc import JsonObject, JsonValue
 from llanguage_test_client.lsp_client import FileRenameMapping, LspClient, Uri
@@ -1275,4 +1277,44 @@ class LspTestClient(LspClient):
                 ),
             )
             request_id = self.send_text_document_semantic_tokens_full(params)
+            self.await_response(request_id)
+
+    @requires_server_capabilities
+    def server_supports_code_completion(self) -> bool:
+        return self.server_capabilities.completion_provider is not None
+
+    def send_text_document_completion(
+            self,
+            params: CompletionParams
+    ) -> int:
+        request_id = self.next_request_id()
+        request = TextDocumentCompletionRequest(request_id, params)
+        return self.send_request(
+            request_id,
+            request,
+            self.receive_text_document_completion
+        )
+
+    def receive_text_document_completion(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        # NOTE: Implement this in the concrete subclass because it may require
+        # language-specific information (such as the language identifier for the
+        # associated text document).
+        raise NotImplementedError
+
+    def complete(self, uri: str, line: int, column: int) -> None:
+        if self.server_supports_document_highlight():
+            params = CompletionParams(
+                text_document=TextDocumentIdentifier(
+                    uri=uri,
+                ),
+                position=Position(
+                    line=line,
+                    character=column,
+                ),
+            )
+            request_id = self.send_text_document_completion(params)
             self.await_response(request_id)

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -25,7 +25,8 @@ from lsprotocol import converters
 from lsprotocol.types import (ClientCapabilities,
                               ClientRegisterCapabilityRequest,
                               ClientRegisterCapabilityResponse,
-                              CreateFilesParams, DeleteFilesParams,
+                              CompletionParams, CreateFilesParams,
+                              DeleteFilesParams,
                               DidChangeConfigurationClientCapabilities,
                               DidChangeConfigurationParams,
                               DidChangeTextDocumentParams,
@@ -43,6 +44,7 @@ from lsprotocol.types import (ClientCapabilities,
                               SemanticTokensParams, ServerCapabilities,
                               ShutdownRequest, TelemetryEventNotification,
                               TextDocumentClientCapabilities,
+                              TextDocumentCompletionRequest,
                               TextDocumentContentChangeEvent_Type1,
                               TextDocumentContentChangeEvent_Type2,
                               TextDocumentDidChangeNotification,
@@ -70,9 +72,7 @@ from lsprotocol.types import (ClientCapabilities,
                               WorkspaceDidRenameFilesNotification,
                               WorkspaceWillCreateFilesRequest,
                               WorkspaceWillDeleteFilesRequest,
-                              WorkspaceWillRenameFilesRequest,
-                              CompletionParams,
-                              TextDocumentCompletionRequest)
+                              WorkspaceWillRenameFilesRequest)
 
 from llanguage_test_client.json_rpc import JsonObject, JsonValue
 from llanguage_test_client.lsp_client import FileRenameMapping, LspClient, Uri

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -14,14 +14,15 @@ from lsprotocol.types import (
     Position, RenameClientCapabilities, RenameParams,
     SemanticTokensClientCapabilities,
     SemanticTokensClientCapabilitiesRequestsType,
-    TextDocumentContentChangeEvent, TextDocumentContentChangeEvent_Type1,
-    TextDocumentContentChangeEvent_Type2, TextDocumentDefinitionRequest,
-    TextDocumentDefinitionResponse, TextDocumentDocumentHighlightResponse,
-    TextDocumentDocumentSymbolResponse, TextDocumentHoverResponse,
-    TextDocumentIdentifier, TextDocumentPublishDiagnosticsNotification,
-    TextDocumentRenameRequest, TextDocumentRenameResponse,
-    TextDocumentSemanticTokensFullResponse, TextDocumentSyncKind, TokenFormat,
-    VersionedTextDocumentIdentifier, WorkspaceEdit, TextDocumentCompletionResponse)
+    TextDocumentCompletionResponse, TextDocumentContentChangeEvent,
+    TextDocumentContentChangeEvent_Type1, TextDocumentContentChangeEvent_Type2,
+    TextDocumentDefinitionRequest, TextDocumentDefinitionResponse,
+    TextDocumentDocumentHighlightResponse, TextDocumentDocumentSymbolResponse,
+    TextDocumentHoverResponse, TextDocumentIdentifier,
+    TextDocumentPublishDiagnosticsNotification, TextDocumentRenameRequest,
+    TextDocumentRenameResponse, TextDocumentSemanticTokensFullResponse,
+    TextDocumentSyncKind, TokenFormat, VersionedTextDocumentIdentifier,
+    WorkspaceEdit)
 
 from llanguage_test_client.json_rpc import JsonArray, JsonObject
 from llanguage_test_client.lsp_test_client import LspTestClient

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -21,7 +21,7 @@ from lsprotocol.types import (
     TextDocumentIdentifier, TextDocumentPublishDiagnosticsNotification,
     TextDocumentRenameRequest, TextDocumentRenameResponse,
     TextDocumentSemanticTokensFullResponse, TextDocumentSyncKind, TokenFormat,
-    VersionedTextDocumentIdentifier, WorkspaceEdit)
+    VersionedTextDocumentIdentifier, WorkspaceEdit, TextDocumentCompletionResponse)
 
 from llanguage_test_client.json_rpc import JsonArray, JsonObject
 from llanguage_test_client.lsp_test_client import LspTestClient
@@ -390,3 +390,16 @@ class LFortranLspTestClient(LspTestClient):
         uri = request.params.text_document.uri
         doc = self.get_document("fortran", uri)
         doc.semantic_highlights = response.result
+
+    def receive_text_document_completion(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentCompletionResponse
+        )
+        uri = request.params.text_document.uri
+        doc = self.get_document("fortran", uri)
+        doc.completions = response.result

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List
 
-from lsprotocol.types import (CompletionItem, CompletionItemKind, DidChangeConfigurationParams, DocumentHighlight,
+from lsprotocol.types import (CompletionItem, CompletionItemKind,
+                              DidChangeConfigurationParams, DocumentHighlight,
                               DocumentSymbol, Hover, MarkupContent, MarkupKind,
                               Position, Range, SymbolKind)
 


### PR DESCRIPTION
Changes:
1. Adds initial implementation of `"textDocument/completion"`
2. Allows negative indices in `LspTextDocument.cursor` (testing framework)
3. Adds `LspTextDocument::symbolAt` to extract the symbol text at some location within the document