### PR TITLE
Formats whole documents and selections

### DIFF
--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -401,6 +401,8 @@ namespace LCompilers::LanguageServerProtocol {
                         completion.contextSupport.has_value()
                         && completion.contextSupport.value();
                 }
+                clientSupportsFormatting = textDocument.formatting.has_value();
+                clientSupportsRangeFormatting = textDocument.rangeFormatting.has_value();
             }
             logger.debug()
                 << "clientSupportsGotoDefinition = "
@@ -437,6 +439,14 @@ namespace LCompilers::LanguageServerProtocol {
             logger.debug()
                 << "clientSupportsCodeCompletionContext = "
                 << clientSupportsCodeCompletionContext
+                << std::endl;
+            logger.debug()
+                << "clientSupportsFormatting = "
+                << clientSupportsFormatting
+                << std::endl;
+            logger.debug()
+                << "clientSupportsRangeFormatting = "
+                << clientSupportsRangeFormatting
                 << std::endl;
         }
 
@@ -528,6 +538,18 @@ namespace LCompilers::LanguageServerProtocol {
                 capabilities.completionProvider.emplace();
             completionProvider.triggerCharacters = {"%"};
             completionProvider.resolveProvider = true;
+        }
+
+        if (clientSupportsFormatting) {
+            ServerCapabilities_documentFormattingProvider &documentFormattingProvider =
+                capabilities.documentFormattingProvider.emplace();
+            documentFormattingProvider = true;
+        }
+
+        if (clientSupportsRangeFormatting) {
+            ServerCapabilities_documentRangeFormattingProvider &documentRangeFormattingProvider =
+                capabilities.documentRangeFormattingProvider.emplace();
+            documentRangeFormattingProvider = true;
         }
 
         return result;
@@ -1107,6 +1129,123 @@ namespace LCompilers::LanguageServerProtocol {
         // so returning the params, directly, is acceptable (making this a sort
         // of identity function).
         CompletionItem_ResolveResult &result = params;
+        return result;
+    }
+
+    // request: "textDocument/formatting"
+    auto LFortranLspLanguageServer::receiveTextDocument_formatting(
+        const RequestMessage &/*request*/,
+        DocumentFormattingParams &params
+    ) -> TextDocument_FormattingResult {
+        TextDocument_FormattingResult result;
+        if (clientSupportsFormatting) {
+            const std::string &uri = params.textDocument.uri;
+            std::shared_ptr<LspTextDocument> document = getDocument(uri);
+            const std::shared_ptr<CompilerOptions> compilerOptions =
+                getCompilerOptions(*document);
+            std::shared_lock<std::shared_mutex> readLock(document->mutex());
+            const std::string &text = document->text();
+            const std::string &path = document->path();
+            auto formatted = lfortran.format(
+                path,
+                text,
+                *compilerOptions,
+                false,  //-> color
+                params.options.tabSize,
+                true  //-> indent_unit
+            );
+            std::vector<TextEdit> edits;
+            if (formatted.ok) {
+                // TODO: Specify the reformatted document in terms of a diff
+                // between the previous text and the formatted text rather than
+                // replacing the whole text with the formatted version:
+                TextEdit &edit = edits.emplace_back();
+                Range &range = edit.range;
+                Position &start = range.start;
+                Position &end = range.end;
+                start.line = 0;
+                start.character = 0;
+                end.line = document->lastLine();
+                end.character = document->lastColumn(end.line);
+                edit.newText = formatted.result;
+            }
+            result = std::move(edits);
+        } else {
+            result = nullptr;
+        }
+        return result;
+    }
+
+    inline auto isNewline(unsigned char c) -> bool {
+        return (c == '\r') || (c == '\n');
+    }
+
+    auto correctIndentation(
+        std::string &fragment,
+        const std::string_view &indentation
+    ) -> std::string & {
+        for (std::size_t i = 1; i < fragment.length(); ++i) {
+            if ((fragment[i] == '\n')
+                && ((i + 1) < fragment.length())
+                && !isNewline(fragment[i + 1])) {
+                fragment.insert(i + 1, indentation);
+                i += indentation.length();
+                if ((fragment[i + 1] == '\r')
+                    && ((i + 2) < fragment.length())
+                    && (fragment[i + 2] == '\n')) {
+                    ++i;
+                }
+            }
+        }
+        return fragment;
+    }
+
+    // request: "textDocument/rangeFormatting"
+    auto LFortranLspLanguageServer::receiveTextDocument_rangeFormatting(
+        const RequestMessage &/*request*/,
+        DocumentRangeFormattingParams &params
+    ) -> TextDocument_RangeFormattingResult {
+        TextDocument_RangeFormattingResult result;
+        if (clientSupportsRangeFormatting) {
+            const std::string &uri = params.textDocument.uri;
+            std::shared_ptr<LspTextDocument> document = getDocument(uri);
+            CompilerOptions compilerOptions = *getCompilerOptions(*document);
+            compilerOptions.interactive = true;
+            std::shared_lock<std::shared_mutex> readLock(document->mutex());
+            const std::string &path = document->path();
+            const std::string fragment = document->slice(
+                params.range.start.line,
+                params.range.start.character,
+                params.range.end.line,
+                params.range.end.character
+            );
+            auto formatted = lfortran.format(
+                path,
+                fragment,
+                compilerOptions,
+                false,  //-> color
+                params.options.tabSize,
+                true  //-> indent_unit
+            );
+            std::vector<TextEdit> edits;
+            if (formatted.ok) {
+                // TODO: Specify the reformatted document in terms of a diff
+                // between the previous text and the formatted text rather than
+                // replacing the whole text with the formatted version:
+                TextEdit &edit = edits.emplace_back();
+                edit.range.start.line = params.range.start.line;
+                edit.range.start.character = params.range.start.character;
+                edit.range.end.line = params.range.end.line;
+                edit.range.end.character = params.range.end.character;
+                edit.newText = correctIndentation(
+                    formatted.result,
+                    document->leadingIndentation(params.range.start.line)
+                );
+            }
+            result = std::move(edits);
+        } else {
+            result = nullptr;
+        }
         return result;
     }
 

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -1145,7 +1145,7 @@ namespace LCompilers::LanguageServerProtocol {
                 getCompilerOptions(*document);
             std::shared_lock<std::shared_mutex> readLock(document->mutex());
             const std::string &text = document->text();
-            const std::string &path = document->path();
+            const std::string &path = document->path().string();
             auto formatted = lfortran.format(
                 path,
                 text,
@@ -1165,8 +1165,9 @@ namespace LCompilers::LanguageServerProtocol {
                 Position &end = range.end;
                 start.line = 0;
                 start.character = 0;
-                end.line = document->lastLine();
-                end.character = document->lastColumn(end.line);
+                end.line = static_cast<uinteger_t>(document->lastLine());
+                end.character =
+                    static_cast<uinteger_t>(document->lastColumn(end.line));
                 edit.newText = formatted.result;
             }
             result = std::move(edits);
@@ -1212,7 +1213,7 @@ namespace LCompilers::LanguageServerProtocol {
             CompilerOptions compilerOptions = *getCompilerOptions(*document);
             compilerOptions.interactive = true;
             std::shared_lock<std::shared_mutex> readLock(document->mutex());
-            const std::string &path = document->path();
+            const std::string &path = document->path().string();
             const std::string fragment = document->slice(
                 params.range.start.line,
                 params.range.start.character,

--- a/src/bin/lfortran_lsp_language_server.h
+++ b/src/bin/lfortran_lsp_language_server.h
@@ -73,6 +73,8 @@ namespace LCompilers::LanguageServerProtocol {
         std::atomic_bool clientSupportsSemanticHighlight = false;
         std::atomic_bool clientSupportsCodeCompletion = false;
         std::atomic_bool clientSupportsCodeCompletionContext = false;
+        std::atomic_bool clientSupportsFormatting = false;
+        std::atomic_bool clientSupportsRangeFormatting = false;
 
         auto formatException(
             const std::string &heading,
@@ -191,6 +193,16 @@ namespace LCompilers::LanguageServerProtocol {
             const RequestMessage &request,
             CompletionItem &params
         ) -> CompletionItem_ResolveResult override;
+
+        auto receiveTextDocument_formatting(
+            const RequestMessage &request,
+            DocumentFormattingParams &params
+        ) -> TextDocument_FormattingResult override;
+
+        auto receiveTextDocument_rangeFormatting(
+            const RequestMessage &request,
+            DocumentRangeFormattingParams &params
+        ) -> TextDocument_RangeFormattingResult override;
 
         // ====================== //
         // Incoming Notifications //

--- a/src/server/lsp_text_document.h
+++ b/src/server/lsp_text_document.h
@@ -49,6 +49,17 @@ namespace LCompilers::LanguageServerProtocol {
         auto version() const -> int;
         auto text() const -> const std::string &;
         auto mutex() -> std::shared_mutex &;
+        auto numLines() const -> std::size_t;
+        auto lastLine() const -> std::size_t;
+        auto numColumns(std::size_t line) const -> std::size_t;
+        auto lastColumn(std::size_t line) const -> std::size_t;
+        auto leadingIndentation(std::size_t line) -> std::string_view;
+        auto slice(
+            std::size_t startLine,
+            std::size_t startColumn,
+            std::size_t endLine,
+            std::size_t endColumn
+        ) const -> std::string;
 
         auto update(
             const std::string &languageId,

--- a/src/server/tests/src/llanguage_test_client/lsp_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_client.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
-from lsprotocol.types import TextDocumentSaveReason
+from lsprotocol.types import Range, TextDocumentSaveReason
 
 Uri = str
 OldUri = Uri
@@ -114,4 +114,12 @@ class LspClient(ABC):
 
     @abstractmethod
     def complete(self, uri: str, line: int, column: int) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def format(self, uri: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def format_range(self, uri: str, selection: Range) -> None:
         raise NotImplementedError

--- a/src/server/tests/src/llanguage_test_client/lsp_text_document.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_text_document.py
@@ -328,8 +328,8 @@ class LspTextDocument:
             end_line: int,
             end_column: int
     ) -> None:
-        start = Position(start_line, start_column)
-        end = Position(end_line, end_column)
+        start = Position(start_line - 1, start_column - 1)
+        end = Position(end_line - 1, end_column - 1)
         self.selection = Range(start, end)
         if (start_line < end_line) \
            or ((start_line == end_line) and (start_column <= end_column)):
@@ -464,3 +464,12 @@ class LspTextDocument:
     def complete(self) -> None:
         line, column = self.pos_to_linecol(self.position)
         self.client.complete(self.uri, line, column)
+
+    @requires_path
+    def format(self) -> None:
+        self.client.format(self.uri)
+
+    @requires_path
+    def format_range(self) -> None:
+        if self.selection is not None:
+            self.client.format_range(self.uri, self.selection)

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -8,7 +8,9 @@ from lsprotocol.types import (
     CompletionClientCapabilitiesCompletionItemTypeResolveSupportType,
     CompletionClientCapabilitiesCompletionItemTypeTagSupportType,
     CompletionItemTag, DefinitionClientCapabilities, DefinitionParams,
-    DidChangeTextDocumentParams, DocumentHighlightClientCapabilities,
+    DidChangeTextDocumentParams, DocumentFormattingClientCapabilities,
+    DocumentHighlightClientCapabilities,
+    DocumentRangeFormattingClientCapabilities,
     DocumentSymbolClientCapabilities, HoverClientCapabilities,
     InitializeParams, InsertTextMode, Location, LocationLink, MarkupKind,
     Position, RenameClientCapabilities, RenameParams,
@@ -18,8 +20,9 @@ from lsprotocol.types import (
     TextDocumentContentChangeEvent_Type1, TextDocumentContentChangeEvent_Type2,
     TextDocumentDefinitionRequest, TextDocumentDefinitionResponse,
     TextDocumentDocumentHighlightResponse, TextDocumentDocumentSymbolResponse,
-    TextDocumentHoverResponse, TextDocumentIdentifier,
-    TextDocumentPublishDiagnosticsNotification, TextDocumentRenameRequest,
+    TextDocumentFormattingResponse, TextDocumentHoverResponse,
+    TextDocumentIdentifier, TextDocumentPublishDiagnosticsNotification,
+    TextDocumentRangeFormattingResponse, TextDocumentRenameRequest,
     TextDocumentRenameResponse, TextDocumentSemanticTokensFullResponse,
     TextDocumentSyncKind, TokenFormat, VersionedTextDocumentIdentifier,
     WorkspaceEdit)
@@ -170,6 +173,8 @@ class LFortranLspTestClient(LspTestClient):
                 ],
                 formats=[TokenFormat.Relative],
             )
+            text_document.formatting = DocumentFormattingClientCapabilities()
+            text_document.range_formatting = DocumentRangeFormattingClientCapabilities()
         return params
 
     def receive_text_document_publish_diagnostics(
@@ -404,3 +409,31 @@ class LFortranLspTestClient(LspTestClient):
         uri = request.params.text_document.uri
         doc = self.get_document("fortran", uri)
         doc.completions = response.result
+
+    def receive_text_document_formatting(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentFormattingResponse
+        )
+        if response.result is not None:
+            uri = request.params.text_document.uri
+            doc = self.get_document("fortran", uri)
+            doc.apply(response.result)
+
+    def receive_text_document_range_formatting(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        response = self.converter.structure(
+            message,
+            TextDocumentRangeFormattingResponse
+        )
+        if response.result is not None:
+            uri = request.params.text_document.uri
+            doc = self.get_document("fortran", uri)
+            doc.apply(response.result)


### PR DESCRIPTION
Changes:
1. Adds initial implementations of "textDocument/formatting" and "textDocument/rangeFormatting"
2. Adds a few utility methods to LspTextDocument