### PR TITLE
fix: import error for `compiler_version` from `iso_fortran_env`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2147,6 +2147,7 @@ RUN(NAME fortran_02 LABELS gfortran fortran)
 RUN(NAME contig LABELS gfortran llvm)
 
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME compiler_version_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME exit_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME exit_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2148,6 +2148,8 @@ RUN(NAME contig LABELS gfortran llvm)
 
 RUN(NAME compiler_version_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME compiler_version_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME compiler_version_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
 
 RUN(NAME exit_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME exit_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/compiler_version_02.f90
+++ b/integration_tests/compiler_version_02.f90
@@ -1,0 +1,4 @@
+program compiler_version_02
+  use, intrinsic :: iso_fortran_env, only: compiler_version
+  print*, compiler_version()
+end program

--- a/integration_tests/compiler_version_03.f90
+++ b/integration_tests/compiler_version_03.f90
@@ -1,0 +1,31 @@
+module string_mod
+    public
+contains
+    !> Fixed-length string
+    function string()
+       character(len=6) :: string
+       string = "abcdef"
+    end function
+end module
+
+program compiler_version_03
+    use string_mod, only: string
+
+! semantic error: The symbol 'compiler_version' not found in the module 'iso_fortran_env'
+    use, intrinsic :: iso_fortran_env, only: compiler_version
+    
+    character(len=len(compiler_version())) :: a
+    character(len=len(string())) :: b
+    character(len=:), allocatable :: c
+
+    a = compiler_version()
+    print *, len(a), a
+    
+    b = string()
+    print *, len(b), b
+    if ( len(b) /= 6 ) error stop
+    
+    c = compiler_version()
+    print *, len(c), c
+
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1158,7 +1158,7 @@ public:
         {"dim", IntrinsicSignature({"X", "Y"}, 2, 2)},
         {"selected_real_kind", IntrinsicSignature({"p", "r", "radix"}, 0, 3)},
         {"nearest", IntrinsicSignature({"x", "s"}, 2, 2)},
-        {"lfortran_compiler_version", IntrinsicSignature({}, 0, 0)},
+        {"_lfortran_compiler_version", IntrinsicSignature({}, 0, 0)},
         {"compiler_options", IntrinsicSignature({}, 0, 0)},
         {"command_argument_count", IntrinsicSignature({}, 0, 0)},
         {"ishftc", IntrinsicSignature({"i", "shift", "size"}, 2, 3)},

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1158,7 +1158,7 @@ public:
         {"dim", IntrinsicSignature({"X", "Y"}, 2, 2)},
         {"selected_real_kind", IntrinsicSignature({"p", "r", "radix"}, 0, 3)},
         {"nearest", IntrinsicSignature({"x", "s"}, 2, 2)},
-        {"compiler_version", IntrinsicSignature({}, 0, 0)},
+        {"lfortran_compiler_version", IntrinsicSignature({}, 0, 0)},
         {"compiler_options", IntrinsicSignature({}, 0, 0)},
         {"command_argument_count", IntrinsicSignature({}, 0, 0)},
         {"ishftc", IntrinsicSignature({"i", "shift", "size"}, 2, 3)},

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1379,6 +1379,13 @@ public:
     }
 
     void visit_IntrinsicElementalFunction_helper(std::string &out, std::string func_name, const ASR::IntrinsicElementalFunction_t &x) {
+        if ( x.m_intrinsic_id == static_cast<int64_t>(ASRUtils::IntrinsicElementalFunctions::CompilerVersion) ) {
+            src = "";
+            visit_expr(*x.m_value); // we will always have a value
+            out += src;
+            src = out;
+            return;
+        }
         src = "";
         out += func_name;
         if (x.n_args > 0) visit_expr(*x.m_args[0]);

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -490,7 +490,9 @@ public:
         }
         bool is_return_var_declared = false;
         if (x.m_return_var) {
-            if (!ASRUtils::is_array(ASRUtils::expr_type(x.m_return_var))) {
+            if (!ASRUtils::is_array(ASRUtils::expr_type(x.m_return_var)) &&
+                !ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_return_var)) &&
+                !ASRUtils::is_pointer(ASRUtils::expr_type(x.m_return_var))) {
                 is_return_var_declared = true;
                 r += get_type(ASRUtils::expr_type(x.m_return_var));
                 r += " ";

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -974,7 +974,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"trailz", {&Trailz::create_Trailz, &Trailz::eval_Trailz}},
                 {"isnan", {&Isnan::create_Isnan, &Isnan::eval_Isnan}},
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
-                {"lfortran_compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
+                {"_lfortran_compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
                 {"compiler_options", {&CompilerOptions::create_CompilerOptions, &CompilerOptions::eval_CompilerOptions}},
                 {"command_argument_count", {&CommandArgumentCount::create_CommandArgumentCount, nullptr}},
                 {"spacing", {&Spacing::create_Spacing, &Spacing::eval_Spacing}},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -974,7 +974,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"trailz", {&Trailz::create_Trailz, &Trailz::eval_Trailz}},
                 {"isnan", {&Isnan::create_Isnan, &Isnan::eval_Isnan}},
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
-                {"compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
+                {"lfortran_compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
                 {"compiler_options", {&CompilerOptions::create_CompilerOptions, &CompilerOptions::eval_CompilerOptions}},
                 {"command_argument_count", {&CommandArgumentCount::create_CommandArgumentCount, nullptr}},
                 {"spacing", {&Spacing::create_Spacing, &Spacing::eval_Spacing}},

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -23,7 +23,7 @@ integer, parameter :: iostat_end = -1
 contains
 function compiler_version() result(version)
     character(len=:), allocatable :: version
-    version = lfortran_compiler_version() ! note: LFortran takes this and creates an IntrinsicElementalFunction
+    version = _lfortran_compiler_version() ! note: LFortran takes this and creates an IntrinsicElementalFunction
 end function compiler_version
 
 

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -22,7 +22,7 @@ integer, parameter :: iostat_end = -1
 
 contains
 function compiler_version() result(version)
-    character(len=100) :: version
+    character(len=:), allocatable :: version
     version = lfortran_compiler_version() ! note: LFortran takes this and creates an IntrinsicElementalFunction
 end function compiler_version
 

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -20,4 +20,11 @@ integer, parameter :: logical_kinds(1) = [4]
 
 integer, parameter :: iostat_end = -1
 
+contains
+function compiler_version() result(version)
+    character(len=100) :: version
+    version = lfortran_compiler_version() ! note: LFortran takes this and creates an IntrinsicElementalFunction
+end function compiler_version
+
+
 end module

--- a/tests/reference/asr-submodule_02-9152b7b.json
+++ b/tests/reference/asr-submodule_02-9152b7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_02-9152b7b.stdout",
-    "stdout_hash": "9c6a73e3ffa9f9180531dc4b76564770cadd243ae335c090c5aaa231",
+    "stdout_hash": "f4a7f9fa160b27bf0c30f048b421c1f2c67b8867e98da716f47da25b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_02-9152b7b.stdout
+++ b/tests/reference/asr-submodule_02-9152b7b.stdout
@@ -7,16 +7,16 @@
             points:
                 (Module
                     (SymbolTable
-                        5
+                        6
                         {
                             point:
                                 (Struct
                                     (SymbolTable
-                                        6
+                                        7
                                         {
                                             x:
                                                 (Variable
-                                                    6
+                                                    7
                                                     x
                                                     []
                                                     Local
@@ -34,7 +34,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    6
+                                                    7
                                                     y
                                                     []
                                                     Local
@@ -67,11 +67,11 @@
                             point_dist_func:
                                 (Function
                                     (SymbolTable
-                                        7
+                                        8
                                         {
                                             a:
                                                 (Variable
-                                                    7
+                                                    8
                                                     a
                                                     []
                                                     In
@@ -82,7 +82,7 @@
                                                         []
                                                         []
                                                         .true.
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -94,7 +94,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    7
+                                                    8
                                                     b
                                                     []
                                                     In
@@ -105,7 +105,7 @@
                                                         []
                                                         []
                                                         .true.
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -117,7 +117,7 @@
                                                 ),
                                             distance:
                                                 (Variable
-                                                    7
+                                                    8
                                                     distance
                                                     []
                                                     ReturnVar
@@ -140,13 +140,13 @@
                                             []
                                             []
                                             .true.
-                                            5 point
+                                            6 point
                                         )
                                         (StructType
                                             []
                                             []
                                             .true.
-                                            5 point
+                                            6 point
                                         )]
                                         (Real 4)
                                         Source
@@ -161,10 +161,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 7 a)
-                                    (Var 7 b)]
+                                    [(Var 8 a)
+                                    (Var 8 b)]
                                     []
-                                    (Var 7 distance)
+                                    (Var 8 distance)
                                     Public
                                     .false.
                                     .false.
@@ -173,11 +173,11 @@
                             point_dist_subrout:
                                 (Function
                                     (SymbolTable
-                                        8
+                                        9
                                         {
                                             a:
                                                 (Variable
-                                                    8
+                                                    9
                                                     a
                                                     []
                                                     In
@@ -188,7 +188,7 @@
                                                         []
                                                         []
                                                         .true.
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -200,7 +200,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    8
+                                                    9
                                                     b
                                                     []
                                                     In
@@ -211,7 +211,7 @@
                                                         []
                                                         []
                                                         .true.
-                                                        5 point
+                                                        6 point
                                                     )
                                                     ()
                                                     Source
@@ -223,7 +223,7 @@
                                                 ),
                                             distance:
                                                 (Variable
-                                                    8
+                                                    9
                                                     distance
                                                     []
                                                     Out
@@ -246,13 +246,13 @@
                                             []
                                             []
                                             .true.
-                                            5 point
+                                            6 point
                                         )
                                         (StructType
                                             []
                                             []
                                             .true.
-                                            5 point
+                                            6 point
                                         )
                                         (Real 4)]
                                         ()
@@ -268,9 +268,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 8 a)
-                                    (Var 8 b)
-                                    (Var 8 distance)]
+                                    [(Var 9 a)
+                                    (Var 9 b)
+                                    (Var 9 distance)]
                                     []
                                     ()
                                     Public
@@ -280,7 +280,7 @@
                                 ),
                             rkind:
                                 (ExternalSymbol
-                                    5
+                                    6
                                     rkind
                                     4 real32
                                     lfortran_intrinsic_iso_fortran_env
@@ -297,13 +297,13 @@
             points_a:
                 (Module
                     (SymbolTable
-                        9
+                        10
                         {
                             point:
                                 (ExternalSymbol
-                                    9
+                                    10
                                     point
-                                    5 point
+                                    6 point
                                     points
                                     []
                                     point
@@ -312,13 +312,13 @@
                             point_dist_func:
                                 (Function
                                     (SymbolTable
-                                        10
+                                        11
                                         {
                                             1_point_x:
                                                 (ExternalSymbol
-                                                    10
+                                                    11
                                                     1_point_x
-                                                    6 x
+                                                    7 x
                                                     point
                                                     []
                                                     x
@@ -326,9 +326,9 @@
                                                 ),
                                             1_point_y:
                                                 (ExternalSymbol
-                                                    10
+                                                    11
                                                     1_point_y
-                                                    6 y
+                                                    7 y
                                                     point
                                                     []
                                                     y
@@ -336,7 +336,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    10
+                                                    11
                                                     a
                                                     []
                                                     In
@@ -347,7 +347,7 @@
                                                         []
                                                         []
                                                         .true.
-                                                        9 point
+                                                        10 point
                                                     )
                                                     ()
                                                     Source
@@ -359,7 +359,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    10
+                                                    11
                                                     b
                                                     []
                                                     In
@@ -370,7 +370,7 @@
                                                         []
                                                         []
                                                         .true.
-                                                        9 point
+                                                        10 point
                                                     )
                                                     ()
                                                     Source
@@ -382,7 +382,7 @@
                                                 ),
                                             distance:
                                                 (Variable
-                                                    10
+                                                    11
                                                     distance
                                                     []
                                                     ReturnVar
@@ -405,13 +405,13 @@
                                             []
                                             []
                                             .true.
-                                            9 point
+                                            10 point
                                         )
                                         (StructType
                                             []
                                             []
                                             .true.
-                                            9 point
+                                            10 point
                                         )]
                                         (Real 4)
                                         Source
@@ -426,196 +426,8 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 10 a)
-                                    (Var 10 b)]
-                                    [(Assignment
-                                        (Var 10 distance)
-                                        (IntrinsicElementalFunction
-                                            Sqrt
-                                            [(RealBinOp
-                                                (RealBinOp
-                                                    (RealBinOp
-                                                        (StructInstanceMember
-                                                            (Var 10 a)
-                                                            10 1_point_x
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (StructInstanceMember
-                                                            (Var 10 b)
-                                                            10 1_point_x
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        (Real 4)
-                                                        ()
-                                                    )
-                                                    Pow
-                                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                                    (Real 4)
-                                                    ()
-                                                )
-                                                Add
-                                                (RealBinOp
-                                                    (RealBinOp
-                                                        (StructInstanceMember
-                                                            (Var 10 a)
-                                                            10 1_point_y
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (StructInstanceMember
-                                                            (Var 10 b)
-                                                            10 1_point_y
-                                                            (Real 4)
-                                                            ()
-                                                        )
-                                                        (Real 4)
-                                                        ()
-                                                    )
-                                                    Pow
-                                                    (IntegerConstant 2 (Integer 4) Decimal)
-                                                    (Real 4)
-                                                    ()
-                                                )
-                                                (Real 4)
-                                                ()
-                                            )]
-                                            0
-                                            (Real 4)
-                                            ()
-                                        )
-                                        ()
-                                    )]
-                                    (Var 10 distance)
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            point_dist_subrout:
-                                (Function
-                                    (SymbolTable
-                                        11
-                                        {
-                                            1_point_x:
-                                                (ExternalSymbol
-                                                    11
-                                                    1_point_x
-                                                    6 x
-                                                    point
-                                                    []
-                                                    x
-                                                    Public
-                                                ),
-                                            1_point_y:
-                                                (ExternalSymbol
-                                                    11
-                                                    1_point_y
-                                                    6 y
-                                                    point
-                                                    []
-                                                    y
-                                                    Public
-                                                ),
-                                            a:
-                                                (Variable
-                                                    11
-                                                    a
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (StructType
-                                                        []
-                                                        []
-                                                        .true.
-                                                        9 point
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                ),
-                                            b:
-                                                (Variable
-                                                    11
-                                                    b
-                                                    []
-                                                    In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (StructType
-                                                        []
-                                                        []
-                                                        .true.
-                                                        9 point
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                ),
-                                            distance:
-                                                (Variable
-                                                    11
-                                                    distance
-                                                    []
-                                                    Out
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                )
-                                        })
-                                    point_dist_subrout
-                                    (FunctionType
-                                        [(StructType
-                                            []
-                                            []
-                                            .true.
-                                            9 point
-                                        )
-                                        (StructType
-                                            []
-                                            []
-                                            .true.
-                                            9 point
-                                        )
-                                        (Real 4)]
-                                        ()
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .true.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    []
                                     [(Var 11 a)
-                                    (Var 11 b)
-                                    (Var 11 distance)]
+                                    (Var 11 b)]
                                     [(Assignment
                                         (Var 11 distance)
                                         (IntrinsicElementalFunction
@@ -677,6 +489,194 @@
                                         )
                                         ()
                                     )]
+                                    (Var 11 distance)
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            point_dist_subrout:
+                                (Function
+                                    (SymbolTable
+                                        12
+                                        {
+                                            1_point_x:
+                                                (ExternalSymbol
+                                                    12
+                                                    1_point_x
+                                                    7 x
+                                                    point
+                                                    []
+                                                    x
+                                                    Public
+                                                ),
+                                            1_point_y:
+                                                (ExternalSymbol
+                                                    12
+                                                    1_point_y
+                                                    7 y
+                                                    point
+                                                    []
+                                                    y
+                                                    Public
+                                                ),
+                                            a:
+                                                (Variable
+                                                    12
+                                                    a
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .true.
+                                                        10 point
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            b:
+                                                (Variable
+                                                    12
+                                                    b
+                                                    []
+                                                    In
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .true.
+                                                        10 point
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                ),
+                                            distance:
+                                                (Variable
+                                                    12
+                                                    distance
+                                                    []
+                                                    Out
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Real 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                )
+                                        })
+                                    point_dist_subrout
+                                    (FunctionType
+                                        [(StructType
+                                            []
+                                            []
+                                            .true.
+                                            10 point
+                                        )
+                                        (StructType
+                                            []
+                                            []
+                                            .true.
+                                            10 point
+                                        )
+                                        (Real 4)]
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .true.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    []
+                                    [(Var 12 a)
+                                    (Var 12 b)
+                                    (Var 12 distance)]
+                                    [(Assignment
+                                        (Var 12 distance)
+                                        (IntrinsicElementalFunction
+                                            Sqrt
+                                            [(RealBinOp
+                                                (RealBinOp
+                                                    (RealBinOp
+                                                        (StructInstanceMember
+                                                            (Var 12 a)
+                                                            12 1_point_x
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (StructInstanceMember
+                                                            (Var 12 b)
+                                                            12 1_point_x
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        (Real 4)
+                                                        ()
+                                                    )
+                                                    Pow
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (Real 4)
+                                                    ()
+                                                )
+                                                Add
+                                                (RealBinOp
+                                                    (RealBinOp
+                                                        (StructInstanceMember
+                                                            (Var 12 a)
+                                                            12 1_point_y
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (StructInstanceMember
+                                                            (Var 12 b)
+                                                            12 1_point_y
+                                                            (Real 4)
+                                                            ()
+                                                        )
+                                                        (Real 4)
+                                                        ()
+                                                    )
+                                                    Pow
+                                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                                    (Real 4)
+                                                    ()
+                                                )
+                                                (Real 4)
+                                                ()
+                                            )]
+                                            0
+                                            (Real 4)
+                                            ()
+                                        )
+                                        ()
+                                    )]
                                     ()
                                     Public
                                     .false.
@@ -685,7 +685,7 @@
                                 ),
                             rkind:
                                 (ExternalSymbol
-                                    9
+                                    10
                                     rkind
                                     4 real32
                                     lfortran_intrinsic_iso_fortran_env
@@ -733,7 +733,7 @@
             submodules_02:
                 (Program
                     (SymbolTable
-                        12
+                        13
                         {
                             
                         })

--- a/tests/reference/asr-use_02-fe85e54.json
+++ b/tests/reference/asr-use_02-fe85e54.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-use_02-fe85e54.stdout",
-    "stdout_hash": "de9c505b22fc8fa8c114b4019fc4b8360138c481ca03c1316b6556b0",
+    "stdout_hash": "ca6ae59c35de5948977adbebcb9b744940593f85ad777e30aca3a336",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-use_02-fe85e54.stdout
+++ b/tests/reference/asr-use_02-fe85e54.stdout
@@ -7,11 +7,11 @@
             use_02:
                 (Program
                     (SymbolTable
-                        5
+                        6
                         {
                             dp:
                                 (ExternalSymbol
-                                    5
+                                    6
                                     dp
                                     4 real64
                                     lfortran_intrinsic_iso_fortran_env
@@ -21,7 +21,7 @@
                                 ),
                             i:
                                 (Variable
-                                    5
+                                    6
                                     i
                                     []
                                     Local
@@ -41,13 +41,13 @@
                     use_02
                     [use_02_module]
                     [(Assignment
-                        (Var 5 i)
+                        (Var 6 i)
                         (IntegerConstant 1234567890123456789 (Integer 8) Decimal)
                         ()
                     )
                     (If
                         (IntegerCompare
-                            (Var 5 i)
+                            (Var 6 i)
                             NotEq
                             (IntegerConstant 1234567890123456789 (Integer 8) Decimal)
                             (Logical 4)


### PR DESCRIPTION
Fixes #6981. Fixes #6731. Fixes #6553. Fixes #4928. Closes #4248.