### PR TITLE
fix: don't throw error if source shape is assumend

### DIFF
--- a/integration_tests/allocate_17.f90
+++ b/integration_tests/allocate_17.f90
@@ -1,8 +1,8 @@
 program allocate_17
     implicit none
-    integer, allocatable :: arr1(:), arr2(:), arr3(:), arr4(:)
+    integer, allocatable :: arr1(:), arr2(:), arr3(:), arr4(:), arr5(:,:)
     logical, allocatable :: l_arr1(:), l_arr2(:), l_arr3(:)
-    integer, parameter :: src(5) = [2,1,3,4,1]
+    integer, parameter :: src(5) = [2,1,3,4,1], src2(2,3) = reshape([1,2,3,2,1,3], [2,3])
     logical, parameter :: l_src(3) = [.true.,.false.,.true.]
     integer :: isrc
     isrc = 10
@@ -17,6 +17,11 @@ program allocate_17
     allocate(arr3(5), arr4(5), source=src)
     if (any(arr3 /= [2,1,3,4,1])) error stop
     if (any(arr4 /= [2,1,3,4,1])) error stop
+
+    allocate(arr5(2,3), source=src2(:,1:3))
+    if (any(arr5(:,1) /= [1,2])) error stop
+    if (any(arr5(:,2) /= [3,2])) error stop
+    if (any(arr5(:,3) /= [1,3])) error stop
 
     allocate(l_arr1(3), source = .true.)
     if (any(l_arr1 .neqv. .true.)) error stop

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1627,7 +1627,7 @@ public:
                             int source_dim_shape = ASRUtils::extract_dim_value_int(source_m_dims[j].m_length);
                             int var_dim_shape = ASRUtils::extract_dim_value_int(var_m_dims[j].m_length);
 
-                            if (source_dim_shape != var_dim_shape) {
+                            if (source_dim_shape != -1 && var_dim_shape != -1 && source_dim_shape != var_dim_shape) {
                                 diag.add(Diagnostic(
                                             "Shape mismatch in `allocate` statement.",
                                             Level::Error, Stage::Semantic, {


### PR DESCRIPTION
Fixes #7001 