### PR TITLE
enh: introduce `c_null_funptr` to intrinsic `iso_c_binding`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1812,6 +1812,7 @@ RUN(NAME write_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME do_loop_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME iso_c_binding_01 LABELS gfortran llvm)
+RUN(NAME iso_c_binding_02 LABELS gfortran llvm)
 
 RUN(NAME array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME array_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)

--- a/integration_tests/iso_c_binding_02.f90
+++ b/integration_tests/iso_c_binding_02.f90
@@ -1,0 +1,17 @@
+program iso_c_binding_02
+  use iso_c_binding
+  implicit none
+
+  type(c_funptr) :: fptr
+  type(c_ptr) :: ptr
+  fptr = c_null_funptr
+  ptr = c_null_ptr
+
+  ! check if ptr is null
+  if (c_associated(ptr)) error stop
+
+  ! check if fptr is null
+  if (c_associated(fptr)) error stop
+
+  print *, "Null function pointer assigned successfully."
+end program iso_c_binding_02

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1514,7 +1514,7 @@ public:
             }
         }
 
-        if (var_name == "c_null_ptr") {
+        if (var_name == "c_null_ptr" || var_name == "c_null_funptr") {
             // Check if c_null_ptr is imported from iso_c_binding (intrinsic module)
             if (v && ASR::is_a<ASR::ExternalSymbol_t>(*v)) {
                 std::string m_name = ASR::down_cast<ASR::ExternalSymbol_t>(v)->m_module_name;
@@ -1523,7 +1523,6 @@ public:
                     tmp = ASR::make_PointerNullConstant_t(al, loc, type_);
                     return tmp;
                 }
-
             }
         }
         if (!v) {

--- a/src/runtime/pure/lfortran_intrinsic_iso_c_binding.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_c_binding.f90
@@ -28,6 +28,7 @@ integer, parameter :: c_bool = 1
 integer, parameter :: c_char = 1
 character(len=1), parameter :: c_null_char = char(0)
 type(c_ptr), parameter :: c_null_ptr = c_ptr(0)
+type(c_funptr), parameter :: c_null_funptr = c_funptr(0)
 
 interface
     logical function c_associated(c_ptr_1)

--- a/tests/reference/asr-c_ptr_02-fce1b0e.json
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-c_ptr_02-fce1b0e.stdout",
-    "stdout_hash": "154b2de219853e5132ca59071739c6a245216700d8623f753b8645cc",
+    "stdout_hash": "c81eedc6f4ab4fc19067e045c59ddb1ab4f86206d15e47b8d01cc491",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-c_ptr_02-fce1b0e.stdout
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.stdout
@@ -252,6 +252,16 @@
                                     c_null_char
                                     Public
                                 ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    2
+                                    c_null_funptr
+                                    4 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
+                                    Public
+                                ),
                             c_null_ptr:
                                 (ExternalSymbol
                                     2

--- a/tests/reference/asr_openmp-openmp_37-2c7ae83.json
+++ b/tests/reference/asr_openmp-openmp_37-2c7ae83.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_37-2c7ae83.stdout",
-    "stdout_hash": "88284faad04282b349b90b00d6755653182550125ce6ecfb108b2634",
+    "stdout_hash": "364af4d31e80c3d1a341e6ce0dfe68c222f9e9cd6657d782aef545c6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_37-2c7ae83.stdout
+++ b/tests/reference/asr_openmp-openmp_37-2c7ae83.stdout
@@ -219,6 +219,16 @@
                                     c_null_char
                                     Public
                                 ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    4
+                                    c_null_funptr
+                                    17 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
+                                    Public
+                                ),
                             c_null_ptr:
                                 (ExternalSymbol
                                     4
@@ -981,6 +991,16 @@
                                     lfortran_intrinsic_iso_c_binding
                                     []
                                     c_null_char
+                                    Public
+                                ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    2
+                                    c_null_funptr
+                                    17 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
                                     Public
                                 ),
                             c_null_ptr:

--- a/tests/reference/asr_openmp-openmp_38-2731560.json
+++ b/tests/reference/asr_openmp-openmp_38-2731560.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_38-2731560.stdout",
-    "stdout_hash": "0452b212d4ed8652612445eae7f75032937e361018afd6f79abdcf2c",
+    "stdout_hash": "4529623ccef36a8b93a52fc5367fec6dc49035d7d565dfd98a8b8844",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_38-2731560.stdout
+++ b/tests/reference/asr_openmp-openmp_38-2731560.stdout
@@ -219,6 +219,16 @@
                                     c_null_char
                                     Public
                                 ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    4
+                                    c_null_funptr
+                                    17 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
+                                    Public
+                                ),
                             c_null_ptr:
                                 (ExternalSymbol
                                     4
@@ -981,6 +991,16 @@
                                     lfortran_intrinsic_iso_c_binding
                                     []
                                     c_null_char
+                                    Public
+                                ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    2
+                                    c_null_funptr
+                                    17 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
                                     Public
                                 ),
                             c_null_ptr:

--- a/tests/reference/asr_openmp-openmp_39-aaf2ba8.json
+++ b/tests/reference/asr_openmp-openmp_39-aaf2ba8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_39-aaf2ba8.stdout",
-    "stdout_hash": "3f1bcb7109782d1c38380db63c2ad0b19f8ae52ea4f49345fed06c65",
+    "stdout_hash": "5b71cee856eafb70e146837e76f2a3f471030c80407f47e38681b989",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_39-aaf2ba8.stdout
+++ b/tests/reference/asr_openmp-openmp_39-aaf2ba8.stdout
@@ -219,6 +219,16 @@
                                     c_null_char
                                     Public
                                 ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    4
+                                    c_null_funptr
+                                    17 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
+                                    Public
+                                ),
                             c_null_ptr:
                                 (ExternalSymbol
                                     4
@@ -981,6 +991,16 @@
                                     lfortran_intrinsic_iso_c_binding
                                     []
                                     c_null_char
+                                    Public
+                                ),
+                            c_null_funptr:
+                                (ExternalSymbol
+                                    2
+                                    c_null_funptr
+                                    17 c_null_funptr
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_null_funptr
                                     Public
                                 ),
                             c_null_ptr:


### PR DESCRIPTION
Fixes #6864.