### PR TITLE
ci: test `stdlib` with less workarounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -526,6 +526,8 @@ jobs:
             FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs --no-warnings -I$(pwd)/src -I$(pwd)/subprojects/test-drive/"
             make -j8
             ctest
+            cd ..
+            rm -rf stdlib
 
       - name: Test Numerical Methods Fortran
         shell: bash -e -x -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -511,6 +511,22 @@ jobs:
             ./build0.sh
             ./build1.sh
 
+      - name: Test stdlib ( Less Workarounds )
+        shell: bash -e -x -l {0}
+        run: |
+            git clone https://github.com/czgdp1807/stdlib.git
+            cd stdlib
+            export PATH="$(pwd)/../src/bin:$PATH"
+
+            git checkout n-lf-23
+            git checkout ad6469874d26c7ecd6cf76596f795d0de43d253d
+            micromamba install -c conda-forge fypp
+
+            git clean -fdx
+            FC=lfortran cmake . -DTEST_DRIVE_BUILD_TESTING=OFF -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE -DCMAKE_Fortran_FLAGS="--cpp --realloc-lhs --no-warnings -I$(pwd)/src -I$(pwd)/subprojects/test-drive/"
+            make -j8
+            ctest
+
       - name: Test Numerical Methods Fortran
         shell: bash -e -x -l {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -518,7 +518,7 @@ jobs:
             cd stdlib
             export PATH="$(pwd)/../src/bin:$PATH"
 
-            git checkout n-lf-23
+            git checkout n-lf-3
             git checkout ad6469874d26c7ecd6cf76596f795d0de43d253d
             micromamba install -c conda-forge fypp
 


### PR DESCRIPTION
Towards #3382. To ensure that we do not lose any progress made in this front.