### PR TITLE
CI: update hash of POT3D

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -556,7 +556,7 @@ jobs:
             # 3. MPI support replaced with custom MPI wrappers (we've C MPI wrappers from https://github.com/gxyd/c_mpi)
             # 4. moved global procedures to module procedures (see: https://github.com/lfortran/lfortran/issues/6059)
             git checkout -t origin/lf_hdf5_mpi_namelist_global_workarounds
-            git checkout eb05c69d30b7c88454d97d66ab6be46db10e7552
+            git checkout 83e1e90db7e7517fcbe8c7bce5ba309addfb23f6
             FC="$(pwd)/../src/bin/lfortran" ./build_and_run.sh
             FC="$(pwd)/../src/bin/lfortran --fast --skip-pass=dead_code_removal" ./build_and_run.sh
 


### PR DESCRIPTION
## Description

we've merged in the changes from *main* branch of predscri/pot3d which contain some fixes to conform POT3D to --std=f18, which now makes it work with GFortran along --std=f18 flag

This contains the fix in *POT3D* repository itself of issue: https://github.com/lfortran/lfortran/issues/6699