### PR TITLE
Restrict iso_c_binding import in omp_lib.f90

### DIFF
--- a/src/runtime/openmp/omp_lib.f90
+++ b/src/runtime/openmp/omp_lib.f90
@@ -1,5 +1,5 @@
 module omp_lib
-use iso_c_binding
+use iso_c_binding, only: c_funptr, c_ptr, c_int
 implicit none
 
 interface


### PR DESCRIPTION
Fixed #7021 