### PR TITLE
Adds options for configuring telemetry events

### DIFF
--- a/src/bin/language_server_interface.cpp
+++ b/src/bin/language_server_interface.cpp
@@ -369,6 +369,18 @@ namespace LCompilers::LLanguageServer::Interface {
             "Maximum number of milliseconds to wait between request attempts."
         )->capture_default_str();
 
+        workspaceConfig->telemetry.enabled = false;
+        server->add_option(
+            "--telemetry-enabled", workspaceConfig->telemetry.enabled,
+            "Whether to enable telemetry events (may require a restart)."
+        )->capture_default_str();
+
+        workspaceConfig->telemetry.frequencyMs = 1000;
+        server->add_option(
+            "--telemetry-frequency-ms", workspaceConfig->telemetry.frequencyMs,
+            "Number of milliseconds to wait between telemetry events."
+        )->capture_default_str();
+
         opts.extensionId = "lcompilers.lfortran-lsp";
         server->add_option(
             "--extension-id", opts.extensionId,

--- a/src/server/base_lsp_language_server.h
+++ b/src/server/base_lsp_language_server.h
@@ -355,10 +355,14 @@ namespace LCompilers::LanguageServerProtocol {
             CancelParams &params
         ) -> void override;
 
-        auto receiveGetDocument(
+        auto receiveDocument(
             const RequestMessage &request,
-            GetDocumentParams &params
-        ) -> GetDocumentResult override;
+            DocumentParams &params
+        ) -> DocumentResult override;
+
+        auto receiveTelemetry(
+            const RequestMessage &request
+        ) -> TelemetryResult override;
 
         friend class RunTracer;
     }; // class BaseLspLanguageServer

--- a/src/server/generator/llanguage_server/lsp/auxiliary_schema.py
+++ b/src/server/generator/llanguage_server/lsp/auxiliary_schema.py
@@ -154,7 +154,7 @@ AUXILIARY_SCHEMA: Dict[str, Any] = {
             "documentation": "A Response Message sent as a result of a request. If a request doesn’t\nprovide a result value the receiver of a request still needs to return a\nresponse message to conform to the JSON-RPC specification. The result\nproperty of the ResponseMessage should be set to null in this case to signal\na successful request.",
         },
         {
-            "name": "GetDocumentParams",
+            "name": "DocumentParams",
             "properties": [
                 {
                     "name": "uri",
@@ -166,7 +166,7 @@ AUXILIARY_SCHEMA: Dict[str, Any] = {
             ],
         },
         {
-            "name": "GetDocumentResult",
+            "name": "DocumentResult",
             "properties": [
                 {
                     "name": "uri",
@@ -249,17 +249,25 @@ AUXILIARY_SCHEMA: Dict[str, Any] = {
     ],
     "requests": [
 		{
-			"method": "$/getDocument",
+			"method": "$/document",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
-				"name": "GetDocumentParams",
+				"name": "DocumentParams",
 			},
             "result": {
                 "kind": "reference",
-                "name": "GetDocumentResult",
+                "name": "DocumentResult",
             },
 		},
+        {
+            "method": "$/telemetry",
+            "messageDirection": "clientToServer",
+            "result": {
+                "kind": "reference",
+				"name": "LSPAny"
+            },
+        },
     ],
     "notifications": [
     ],

--- a/src/server/lsp_config.h
+++ b/src/server/lsp_config.h
@@ -29,6 +29,11 @@ namespace LCompilers::LanguageServerProtocol::Config {
         unsigned int maxSleepTimeMs;
     };
 
+    struct LspConfig_telemetry {
+        bool enabled;
+        unsigned int frequencyMs;
+    };
+
     struct LspConfig {
         virtual ~LspConfig() = default;
         bool openIssueReporterOnError;
@@ -37,6 +42,7 @@ namespace LCompilers::LanguageServerProtocol::Config {
         LspConfig_trace trace;
         LspConfig_log log;
         LspConfig_retry retry;
+        LspConfig_telemetry telemetry;
     };
 
     class LspConfigTransformer {
@@ -66,6 +72,14 @@ namespace LCompilers::LanguageServerProtocol::Config {
 
         auto lspConfig_retryToAny(
             const LspConfig_retry &retry
+        ) const -> LSPAny;
+
+        auto anyToLspConfig_telemetry(
+            const lsp::LSPAny &any
+        ) const -> LspConfig_telemetry;
+
+        auto lspConfig_telemetryToAny(
+            const LspConfig_telemetry &telemetry
         ) const -> LSPAny;
 
         virtual auto anyToLspConfig(

--- a/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
+++ b/tests/server/src/lfortran_language_server/lfortran_lsp_test_client.py
@@ -243,22 +243,24 @@ class LFortranLspTestClient(LspTestClient):
             self,
             method: str,
             request_id: int,
-            params: Optional[Union[JsonObject, JsonArray]]
+            params: Optional[Union[JsonObject, JsonArray]] = None
     ) -> JsonObject:
-        return {
+        request = {
             "jsonrpc": "2.0",
             "method": method,
             "id": request_id,
-            "params": params,
         }
+        if params is not None:
+            request["params"] = params
+        return request
 
-    def send_get_document(self, params: JsonObject) -> int:
+    def send_document(self, params: JsonObject) -> int:
         request_id = self.next_request_id()
-        request = self.build_custom_request("$/getDocument", request_id, params)
-        self.send_request(request_id, request, self.receive_get_document)
+        request = self.build_custom_request("$/document", request_id, params)
+        self.send_request(request_id, request, self.receive_document)
         return request_id
 
-    def receive_get_document(
+    def receive_document(
             self,
             request: Any,
             message: JsonObject
@@ -266,7 +268,7 @@ class LFortranLspTestClient(LspTestClient):
         pass
 
     def get_remote_document(self, uri: str) -> JsonObject:
-        request_id = self.send_get_document({
+        request_id = self.send_document({
             "uri": uri,
         })
         response = self.await_response(request_id)
@@ -437,3 +439,21 @@ class LFortranLspTestClient(LspTestClient):
             uri = request.params.text_document.uri
             doc = self.get_document("fortran", uri)
             doc.apply(response.result)
+
+    def send_telemetry(self) -> int:
+        request_id = self.next_request_id()
+        request = self.build_custom_request("$/telemetry", request_id)
+        self.send_request(request_id, request, self.receive_telemetry)
+        return request_id
+
+    def receive_telemetry(
+            self,
+            request: Any,
+            message: JsonObject
+    ) -> None:
+        pass
+
+    def get_telemetry(self) -> Any:
+        request_id = self.send_telemetry()
+        response = self.await_response(request_id)
+        return response["result"]

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -70,6 +70,10 @@ def client(request: pytest.FixtureRequest, capfd: pytest.CaptureFixture) -> Iter
                 "minSleepTimeMs": 10,
                 "maxSleepTimeMs": 300,
             },
+            "telemetry": {
+                "enabled": True,
+                "frequencyMs": 1000,
+            },
         }
     }
 

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List
 
+import pytest
+
 from lsprotocol.types import (CompletionItem, CompletionItemKind,
                               DidChangeConfigurationParams, DocumentHighlight,
                               DocumentSymbol, Hover, MarkupContent, MarkupKind,
@@ -10,6 +12,7 @@ from lsprotocol.types import (CompletionItem, CompletionItemKind,
 from lfortran_language_server.lfortran_lsp_test_client import \
     LFortranLspTestClient
 
+from llanguage_test_client.json_rpc import JsonArray
 from llanguage_test_client.lsp_test_client import IncomingEvent
 
 
@@ -522,3 +525,8 @@ def test_partial_document_formatting(client: LFortranLspTestClient) -> None:
         "end module module_function_call1",
         ""
     ])
+
+def test_telemetry_event(client: LFortranLspTestClient) -> None:
+    telemetry: JsonArray = client.get_telemetry()
+    if not any(filter(lambda event: event["key"] == "processUsage", telemetry)):
+        pytest.skip("ProcessUsage is not supported on this platform")


### PR DESCRIPTION
Changes:
1. Adds options for configuring telemetry events
2. Adds test for telemetry events
3. Adds `$/telemetry` for testing
4. Renames `$/getDocument` to `$/document` to be consistent with `$/telemetry` (minor change; used only for testing)
5. Fixes some potential issues with reading from the workspace config without read-locking it (in case it is updated while being read)