### PR TITLE
ci: bump to latest commit for stdlib branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -519,7 +519,7 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
 
             git checkout n-lf-3
-            git checkout 02230ca186f22e2b96a1cb25f4255e0f7b042e47
+            git checkout 55eec60bd43d039a03773ec1471fc467acba7ead
             micromamba install -c conda-forge fypp
 
             git clean -fdx

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -519,7 +519,7 @@ jobs:
             export PATH="$(pwd)/../src/bin:$PATH"
 
             git checkout n-lf-3
-            git checkout 55eec60bd43d039a03773ec1471fc467acba7ead
+            git checkout 67b9534ab21daff4dd4922fe0d14f4c5ca37016c
             micromamba install -c conda-forge fypp
 
             git clean -fdx


### PR DESCRIPTION
Towards #3382. With this we have branch `n-lf-3` synced with `lf20` and cleaned as well.