### PR TITLE
fix: subroutine runtime polymorphism for derived types declared in a program

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1414,6 +1414,7 @@ RUN(NAME derived_types_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_AR
 RUN(NAME derived_types_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_49.f90
+++ b/integration_tests/derived_types_49.f90
@@ -1,0 +1,38 @@
+module bit_type 
+    implicit none
+
+    type, abstract :: bitset_type
+        integer :: flag
+    contains
+        procedure(from_string_abstract), deferred, pass(self) :: from_string 
+    end type bitset_type
+
+    type, extends(bitset_type) :: bitset_large
+    contains
+        procedure, pass(self)  :: from_string => from_string_large
+    end type bitset_large
+
+    abstract interface
+        subroutine from_string_abstract(self)
+            import :: bitset_type
+            class(bitset_type), intent(out) :: self
+        end subroutine from_string_abstract
+    end interface 
+
+   contains
+
+    subroutine from_string_large(self)
+        class(bitset_large), intent(out) :: self
+
+        if (self%flag /= 1) error stop
+    end subroutine from_string_large
+end module
+
+program derived_types_49
+    use bit_type
+    implicit none
+
+    type(bitset_large) :: b
+    b%flag = 1
+    call b%from_string()
+end program derived_types_49

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3768,8 +3768,8 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
         class2vtab[struct_type_][symtab].push_back(vtab_obj);
     }
 
-    void collect_class_type_names_and_struct_types(
-        std::set<std::string>& class_type_names,
+    void collect_variable_names_and_struct_types(
+        std::set<std::string>& variable_names,
         std::vector<ASR::symbol_t*>& struct_types,
         SymbolTable* x_symtab) {
         if (x_symtab == nullptr) {
@@ -3782,14 +3782,17 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 ASR::ttype_t* v_type = ASRUtils::type_get_past_pointer(v->m_type);
                 if( ASR::is_a<ASR::ClassType_t>(*v_type) ) {
                     ASR::ClassType_t* v_class_t = ASR::down_cast<ASR::ClassType_t>(v_type);
-                    class_type_names.insert(ASRUtils::symbol_name(v_class_t->m_class_type));
+                    variable_names.insert(ASRUtils::symbol_name(v_class_t->m_class_type));
+                } else if (ASR::is_a<ASR::StructType_t>(*v_type)) {
+                    ASR::StructType_t* v_struct_t = ASR::down_cast<ASR::StructType_t>(v_type);
+                    variable_names.insert(ASRUtils::symbol_name(v_struct_t->m_derived_type));
                 }
             } else if (ASR::is_a<ASR::Struct_t>(
                         *ASRUtils::symbol_get_past_external(var_sym))) {
                 struct_types.push_back(var_sym);
             }
         }
-        collect_class_type_names_and_struct_types(class_type_names, struct_types, x_symtab->parent);
+        collect_variable_names_and_struct_types(variable_names, struct_types, x_symtab->parent);
     }
     void set_VariableInital_value(ASR::Variable_t* v, llvm::Value* target_var){
         if (v->m_value != nullptr) {
@@ -4117,13 +4120,14 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
         uint32_t debug_arg_count = 0;
         std::vector<std::string> var_order = ASRUtils::determine_variable_declaration_order(x.m_symtab);
         if( create_vtabs ) {
-            std::set<std::string> class_type_names;
+            std::set<std::string> variable_names;
             std::vector<ASR::symbol_t*> struct_types;
-            collect_class_type_names_and_struct_types(class_type_names, struct_types, x.m_symtab);
+            // Collects all Struct symbols and ClassType and StructType variables in x.m_symtab and its parent symtabs
+            collect_variable_names_and_struct_types(variable_names, struct_types, x.m_symtab);
             for( size_t i = 0; i < struct_types.size(); i++ ) {
                 ASR::symbol_t* struct_type = struct_types[i];
                 bool create_vtab = false;
-                for( const std::string& class_name: class_type_names ) {
+                for( const std::string& class_name: variable_names ) {
                     ASR::symbol_t* class_sym = x.m_symtab->resolve_symbol(class_name);
                     bool is_vtab_needed = false;
                     while( !is_vtab_needed && struct_type ) {
@@ -9776,10 +9780,6 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             proc_sym_name = class_proc->m_name;
             is_nopass = class_proc->m_is_nopass;
         }
-        if( is_deferred ) {
-            visit_RuntimePolymorphicSubroutineCall(x, proc_sym_name);
-            return ;
-        }
         ASR::Function_t *s;
         char* self_argument = nullptr;
         llvm::Value* pass_arg = nullptr;
@@ -9882,7 +9882,14 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 throw CodeGenError("SubroutineCall: StructType symbol type not supported");
             }
         }
-
+        if (is_deferred) {
+            if (is_nopass || args.empty()) {
+                visit_RuntimePolymorphicSubroutineCall(x, proc_sym_name, nullptr);
+            } else {
+                visit_RuntimePolymorphicSubroutineCall(x, proc_sym_name, args[0]);
+            }
+            return;
+        }
         std::string sub_name = s->m_name;
         uint32_t h;
         ASR::FunctionType_t* s_func_type = ASR::down_cast<ASR::FunctionType_t>(s->m_function_signature);
@@ -10077,7 +10084,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
         return CreateCallUtil(fn->getFunctionType(), fn, args, asr_return_type);
     }
 
-    void visit_RuntimePolymorphicSubroutineCall(const ASR::SubroutineCall_t& x, std::string proc_sym_name) {
+    void visit_RuntimePolymorphicSubroutineCall(const ASR::SubroutineCall_t& x, std::string proc_sym_name, llvm::Value *llvm_polymorphic) {
         std::vector<std::pair<llvm::Value*, ASR::symbol_t*>> vtabs;
         ASR::Struct_t* dt_sym_type = nullptr;
         ASR::ttype_t* dt_ttype_t = ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(
@@ -10106,11 +10113,16 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             }
         }
 
-        uint64_t ptr_loads_copy = ptr_loads;
-        ptr_loads = 0;
-        this->visit_expr_wrapper(x.m_dt);
-        ptr_loads = ptr_loads_copy;
-        llvm::Value* llvm_dt = tmp;
+        llvm::Value *llvm_dt = nullptr;
+        if (llvm_polymorphic == nullptr) {
+            uint64_t ptr_loads_copy = ptr_loads;
+            ptr_loads = 0;
+            this->visit_expr_wrapper(x.m_dt);
+            ptr_loads = ptr_loads_copy;
+            llvm_dt = tmp;
+        } else {
+            llvm_dt = llvm_polymorphic;
+        }
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
         llvm::Type* i64 = llvm::Type::getInt64Ty(context);
         for( size_t i = 0; i < vtabs.size(); i++ ) {

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "d517f426fe942cdafc79f60ad9a5ba3fe6d79efa3350d27e48a30d70",
+    "stdout_hash": "d14715b269fe3e77260ef4ca7125adf8970807850ca411d611050ced",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -66,24 +66,27 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = alloca %__vtab_circle, align 8
+  %3 = getelementptr %__vtab_circle, %__vtab_circle* %2, i32 0, i32 0
+  store i64 0, i64* %3, align 4
   %c = alloca %circle, align 8
-  %2 = getelementptr %circle, %circle* %c, i32 0, i32 0
-  %3 = getelementptr %circle, %circle* %c, i32 0, i32 0
-  store float 1.500000e+00, float* %3, align 4
-  %4 = alloca %circle_polymorphic, align 8
-  %5 = getelementptr %circle_polymorphic, %circle_polymorphic* %4, i32 0, i32 0
-  store i64 0, i64* %5, align 4
-  %6 = getelementptr %circle_polymorphic, %circle_polymorphic* %4, i32 0, i32 1
-  store %circle* %c, %circle** %6, align 8
-  call void @__module_class_circle1_circle_print(%circle_polymorphic* %4)
-  %7 = getelementptr %circle, %circle* %c, i32 0, i32 0
-  store float 2.000000e+00, float* %7, align 4
-  %8 = alloca %circle_polymorphic, align 8
-  %9 = getelementptr %circle_polymorphic, %circle_polymorphic* %8, i32 0, i32 0
-  store i64 0, i64* %9, align 4
-  %10 = getelementptr %circle_polymorphic, %circle_polymorphic* %8, i32 0, i32 1
-  store %circle* %c, %circle** %10, align 8
-  call void @__module_class_circle1_circle_print(%circle_polymorphic* %8)
+  %4 = getelementptr %circle, %circle* %c, i32 0, i32 0
+  %5 = getelementptr %circle, %circle* %c, i32 0, i32 0
+  store float 1.500000e+00, float* %5, align 4
+  %6 = alloca %circle_polymorphic, align 8
+  %7 = getelementptr %circle_polymorphic, %circle_polymorphic* %6, i32 0, i32 0
+  store i64 0, i64* %7, align 4
+  %8 = getelementptr %circle_polymorphic, %circle_polymorphic* %6, i32 0, i32 1
+  store %circle* %c, %circle** %8, align 8
+  call void @__module_class_circle1_circle_print(%circle_polymorphic* %6)
+  %9 = getelementptr %circle, %circle* %c, i32 0, i32 0
+  store float 2.000000e+00, float* %9, align 4
+  %10 = alloca %circle_polymorphic, align 8
+  %11 = getelementptr %circle_polymorphic, %circle_polymorphic* %10, i32 0, i32 0
+  store i64 0, i64* %11, align 4
+  %12 = getelementptr %circle_polymorphic, %circle_polymorphic* %10, i32 0, i32 1
+  store %circle* %c, %circle** %12, align 8
+  call void @__module_class_circle1_circle_print(%circle_polymorphic* %10)
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "697f6bf66043d47f730bc13d8c92476e2746c79c5e097260bdcb234e",
+    "stdout_hash": "b1e92f90d0e859d1fda216ba484a169e3f2189c98c0f8b1eaff4373b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -61,18 +61,21 @@ return:                                           ; preds = %.entry
 
 define void @__module_class_circle2__xx_lcompilers_changed_main_xx() {
 .entry:
+  %0 = alloca %__vtab_circle, align 8
+  %1 = getelementptr %__vtab_circle, %__vtab_circle* %0, i32 0, i32 0
+  store i64 0, i64* %1, align 4
   %c = alloca %circle, align 8
-  %0 = getelementptr %circle, %circle* %c, i32 0, i32 0
-  %1 = getelementptr %circle, %circle* %c, i32 0, i32 0
-  store float 1.000000e+00, float* %1, align 4
   %2 = getelementptr %circle, %circle* %c, i32 0, i32 0
-  store float 1.500000e+00, float* %2, align 4
-  %3 = alloca %circle_polymorphic, align 8
-  %4 = getelementptr %circle_polymorphic, %circle_polymorphic* %3, i32 0, i32 0
-  store i64 0, i64* %4, align 4
-  %5 = getelementptr %circle_polymorphic, %circle_polymorphic* %3, i32 0, i32 1
-  store %circle* %c, %circle** %5, align 8
-  call void @__module_class_circle2_circle_print(%circle_polymorphic* %3)
+  %3 = getelementptr %circle, %circle* %c, i32 0, i32 0
+  store float 1.000000e+00, float* %3, align 4
+  %4 = getelementptr %circle, %circle* %c, i32 0, i32 0
+  store float 1.500000e+00, float* %4, align 4
+  %5 = alloca %circle_polymorphic, align 8
+  %6 = getelementptr %circle_polymorphic, %circle_polymorphic* %5, i32 0, i32 0
+  store i64 0, i64* %6, align 4
+  %7 = getelementptr %circle_polymorphic, %circle_polymorphic* %5, i32 0, i32 1
+  store %circle* %c, %circle** %7, align 8
+  call void @__module_class_circle2_circle_print(%circle_polymorphic* %5)
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "108782c04f3bf906c1550797839aa737ba1a08d73769ace39cc16e03",
+    "stdout_hash": "2f28e671a06373ca615558f83695d59e4e30f339c3170eedee1d73d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%__vtab_foo_c = type { i64 }
 %foo_c = type <{ %foo_b, %bar_c }>
 %foo_b = type <{ %foo_a, %bar_b }>
 %foo_a = type <{ %bar_a }>
@@ -24,61 +25,64 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = alloca %__vtab_foo_c, align 8
+  %3 = getelementptr %__vtab_foo_c, %__vtab_foo_c* %2, i32 0, i32 0
+  store i64 0, i64* %3, align 4
   %foo = alloca %foo_c, align 8
-  %2 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %3 = getelementptr %bar_c, %bar_c* %2, i32 0, i32 1
-  %4 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %5 = getelementptr %foo_b, %foo_b* %4, i32 0, i32 0
-  %6 = getelementptr %foo_a, %foo_a* %5, i32 0, i32 0
-  %7 = getelementptr %bar_a, %bar_a* %6, i32 0, i32 0
-  store i32 -20, i32* %7, align 4
-  %8 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %9 = getelementptr %foo_b, %foo_b* %8, i32 0, i32 1
-  %10 = getelementptr %bar_b, %bar_b* %9, i32 0, i32 1
-  store i32 9, i32* %10, align 4
-  %11 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %12 = getelementptr %bar_c, %bar_c* %11, i32 0, i32 1
-  store i32 11, i32* %12, align 4
-  %13 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %14 = getelementptr %foo_b, %foo_b* %13, i32 0, i32 0
-  %15 = getelementptr %foo_a, %foo_a* %14, i32 0, i32 0
-  %16 = getelementptr %bar_a, %bar_a* %15, i32 0, i32 0
-  %17 = load i32, i32* %16, align 4
-  %18 = alloca i32, align 4
-  store i32 %17, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32* %18)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %20 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %21 = getelementptr %foo_b, %foo_b* %20, i32 0, i32 1
-  %22 = getelementptr %bar_b, %bar_b* %21, i32 0, i32 1
-  %23 = load i32, i32* %22, align 4
-  %24 = alloca i32, align 4
-  store i32 %23, i32* %24, align 4
-  %25 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32* %24)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  %26 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %27 = getelementptr %bar_c, %bar_c* %26, i32 0, i32 1
-  %28 = load i32, i32* %27, align 4
-  %29 = alloca i32, align 4
-  store i32 %28, i32* %29, align 4
-  %30 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32* %29)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %31 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %32 = getelementptr %foo_b, %foo_b* %31, i32 0, i32 0
-  %33 = getelementptr %foo_a, %foo_a* %32, i32 0, i32 0
-  %34 = getelementptr %bar_a, %bar_a* %33, i32 0, i32 0
-  %35 = load i32, i32* %34, align 4
-  %36 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %37 = getelementptr %foo_b, %foo_b* %36, i32 0, i32 1
-  %38 = getelementptr %bar_b, %bar_b* %37, i32 0, i32 1
-  %39 = load i32, i32* %38, align 4
-  %40 = add i32 %35, %39
-  %41 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %42 = getelementptr %bar_c, %bar_c* %41, i32 0, i32 1
-  %43 = load i32, i32* %42, align 4
-  %44 = add i32 %40, %43
-  %45 = icmp ne i32 %44, 0
-  br i1 %45, label %then, label %else
+  %4 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %5 = getelementptr %bar_c, %bar_c* %4, i32 0, i32 1
+  %6 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %7 = getelementptr %foo_b, %foo_b* %6, i32 0, i32 0
+  %8 = getelementptr %foo_a, %foo_a* %7, i32 0, i32 0
+  %9 = getelementptr %bar_a, %bar_a* %8, i32 0, i32 0
+  store i32 -20, i32* %9, align 4
+  %10 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %11 = getelementptr %foo_b, %foo_b* %10, i32 0, i32 1
+  %12 = getelementptr %bar_b, %bar_b* %11, i32 0, i32 1
+  store i32 9, i32* %12, align 4
+  %13 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %14 = getelementptr %bar_c, %bar_c* %13, i32 0, i32 1
+  store i32 11, i32* %14, align 4
+  %15 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %16 = getelementptr %foo_b, %foo_b* %15, i32 0, i32 0
+  %17 = getelementptr %foo_a, %foo_a* %16, i32 0, i32 0
+  %18 = getelementptr %bar_a, %bar_a* %17, i32 0, i32 0
+  %19 = load i32, i32* %18, align 4
+  %20 = alloca i32, align 4
+  store i32 %19, i32* %20, align 4
+  %21 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32* %20)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %22 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %23 = getelementptr %foo_b, %foo_b* %22, i32 0, i32 1
+  %24 = getelementptr %bar_b, %bar_b* %23, i32 0, i32 1
+  %25 = load i32, i32* %24, align 4
+  %26 = alloca i32, align 4
+  store i32 %25, i32* %26, align 4
+  %27 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32* %26)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  %28 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %29 = getelementptr %bar_c, %bar_c* %28, i32 0, i32 1
+  %30 = load i32, i32* %29, align 4
+  %31 = alloca i32, align 4
+  store i32 %30, i32* %31, align 4
+  %32 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32* %31)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  %33 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %34 = getelementptr %foo_b, %foo_b* %33, i32 0, i32 0
+  %35 = getelementptr %foo_a, %foo_a* %34, i32 0, i32 0
+  %36 = getelementptr %bar_a, %bar_a* %35, i32 0, i32 0
+  %37 = load i32, i32* %36, align 4
+  %38 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %39 = getelementptr %foo_b, %foo_b* %38, i32 0, i32 1
+  %40 = getelementptr %bar_b, %bar_b* %39, i32 0, i32 1
+  %41 = load i32, i32* %40, align 4
+  %42 = add i32 %37, %41
+  %43 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %44 = getelementptr %bar_c, %bar_c* %43, i32 0, i32 1
+  %45 = load i32, i32* %44, align 4
+  %46 = add i32 %42, %45
+  %47 = icmp ne i32 %46, 0
+  br i1 %47, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "26f86efb84fc69efba62d5da1c568927c096e62280662608372a3fb3",
+    "stdout_hash": "662412d212b18500e3022e79910a6a21d2ae4243ca33b142b7ef3c7e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -95,12 +95,15 @@ define i32 @main(i32 %0, i8** %1) {
   %ione = alloca i32, align 4
   %izero = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = alloca %__vtab_complextype, align 8
+  %3 = getelementptr %__vtab_complextype, %__vtab_complextype* %2, i32 0, i32 0
+  store i64 0, i64* %3, align 4
   %a = alloca %complextype, align 8
-  %2 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
-  %3 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
+  %4 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
+  %5 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %c = alloca %complextype, align 8
-  %4 = getelementptr %complextype, %complextype* %c, i32 0, i32 1
-  %5 = getelementptr %complextype, %complextype* %c, i32 0, i32 0
+  %6 = getelementptr %complextype, %complextype* %c, i32 0, i32 1
+  %7 = getelementptr %complextype, %complextype* %c, i32 0, i32 0
   %fpone = alloca float, align 4
   %fptwo = alloca float, align 4
   %fpzero = alloca float, align 4
@@ -113,32 +116,32 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %ione1, align 4
   store i32 0, i32* %izero2, align 4
   store float -1.000000e+00, float* %negfpone, align 4
-  %6 = getelementptr %complextype, %complextype* %c, i32 0, i32 0
-  %7 = load float, float* %fpone, align 4
-  store float %7, float* %6, align 4
-  %8 = getelementptr %complextype, %complextype* %c, i32 0, i32 1
-  %9 = load float, float* %fptwo, align 4
+  %8 = getelementptr %complextype, %complextype* %c, i32 0, i32 0
+  %9 = load float, float* %fpone, align 4
   store float %9, float* %8, align 4
-  %10 = alloca %complextype_polymorphic, align 8
-  %11 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %10, i32 0, i32 0
-  store i64 0, i64* %11, align 4
-  %12 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %10, i32 0, i32 1
-  store %complextype* %c, %complextype** %12, align 8
-  call void @__module_complex_module_integer_add_subrout(%complextype_polymorphic* %10, i32* %ione1, i32* %izero2, %complextype* %a)
-  %13 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
-  %14 = load float, float* %13, align 4
-  %15 = alloca float, align 4
-  store float %14, float* %15, align 4
-  %16 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
-  %17 = load float, float* %16, align 4
-  %18 = alloca float, align 4
-  store float %17, float* %18, align 4
-  %19 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i32 0, float* %15, float* %18)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  %20 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
-  %21 = load float, float* %20, align 4
-  %22 = fcmp une float %21, 2.000000e+00
-  br i1 %22, label %then, label %else
+  %10 = getelementptr %complextype, %complextype* %c, i32 0, i32 1
+  %11 = load float, float* %fptwo, align 4
+  store float %11, float* %10, align 4
+  %12 = alloca %complextype_polymorphic, align 8
+  %13 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %12, i32 0, i32 0
+  store i64 0, i64* %13, align 4
+  %14 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %12, i32 0, i32 1
+  store %complextype* %c, %complextype** %14, align 8
+  call void @__module_complex_module_integer_add_subrout(%complextype_polymorphic* %12, i32* %ione1, i32* %izero2, %complextype* %a)
+  %15 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
+  %16 = load float, float* %15, align 4
+  %17 = alloca float, align 4
+  store float %16, float* %17, align 4
+  %18 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
+  %19 = load float, float* %18, align 4
+  %20 = alloca float, align 4
+  store float %19, float* %20, align 4
+  %21 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i32 0, float* %17, float* %20)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  %22 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
+  %23 = load float, float* %22, align 4
+  %24 = fcmp une float %23, 2.000000e+00
+  br i1 %24, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0))
@@ -149,10 +152,10 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %23 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
-  %24 = load float, float* %23, align 4
-  %25 = fcmp une float %24, 2.000000e+00
-  br i1 %25, label %then3, label %else4
+  %25 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
+  %26 = load float, float* %25, align 4
+  %27 = fcmp une float %26, 2.000000e+00
+  br i1 %27, label %then3, label %else4
 
 then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
@@ -163,26 +166,26 @@ else4:                                            ; preds = %ifcont
   br label %ifcont5
 
 ifcont5:                                          ; preds = %else4, %then3
-  %26 = alloca %complextype_polymorphic, align 8
-  %27 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %26, i32 0, i32 0
-  store i64 0, i64* %27, align 4
-  %28 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %26, i32 0, i32 1
-  store %complextype* %c, %complextype** %28, align 8
-  call void @__module_complex_module_real_add_subrout(%complextype_polymorphic* %26, float* %fpzero, float* %negfpone, %complextype* %a)
-  %29 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
-  %30 = load float, float* %29, align 4
-  %31 = alloca float, align 4
-  store float %30, float* %31, align 4
-  %32 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
-  %33 = load float, float* %32, align 4
-  %34 = alloca float, align 4
-  store float %33, float* %34, align 4
-  %35 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, float* %31, float* %34)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %35, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  %36 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
-  %37 = load float, float* %36, align 4
-  %38 = fcmp une float %37, 1.000000e+00
-  br i1 %38, label %then6, label %else7
+  %28 = alloca %complextype_polymorphic, align 8
+  %29 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %28, i32 0, i32 0
+  store i64 0, i64* %29, align 4
+  %30 = getelementptr %complextype_polymorphic, %complextype_polymorphic* %28, i32 0, i32 1
+  store %complextype* %c, %complextype** %30, align 8
+  call void @__module_complex_module_real_add_subrout(%complextype_polymorphic* %28, float* %fpzero, float* %negfpone, %complextype* %a)
+  %31 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
+  %32 = load float, float* %31, align 4
+  %33 = alloca float, align 4
+  store float %32, float* %33, align 4
+  %34 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
+  %35 = load float, float* %34, align 4
+  %36 = alloca float, align 4
+  store float %35, float* %36, align 4
+  %37 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, float* %33, float* %36)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  %38 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
+  %39 = load float, float* %38, align 4
+  %40 = fcmp une float %39, 1.000000e+00
+  br i1 %40, label %then6, label %else7
 
 then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @16, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @17, i32 0, i32 0))
@@ -193,10 +196,10 @@ else7:                                            ; preds = %ifcont5
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %then6
-  %39 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
-  %40 = load float, float* %39, align 4
-  %41 = fcmp une float %40, 1.000000e+00
-  br i1 %41, label %then9, label %else10
+  %41 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
+  %42 = load float, float* %41, align 4
+  %43 = fcmp une float %42, 1.000000e+00
+  br i1 %43, label %then9, label %else10
 
 then9:                                            ; preds = %ifcont8
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "951f2b6a68551a935d75e7dc4c6c39df34b5757a2bb5a8856762fc3e",
+    "stdout_hash": "5620f6cadce4f4716f84081cbf0c3d6ef41b7c0da1f9e0f7588f89ab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -194,24 +194,27 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i1, align 1
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = alloca %__vtab_fpm_run_settings, align 8
+  %3 = getelementptr %__vtab_fpm_run_settings, %__vtab_fpm_run_settings* %2, i32 0, i32 0
+  store i64 0, i64* %3, align 4
   %settings = alloca %fpm_run_settings, align 8
-  %2 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 2
-  %3 = call i8* @_lfortran_malloc(i32 5)
-  call void @_lfortran_string_init(i64 5, i8* %3)
-  store i8* %3, i8** %2, align 8
-  %4 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 4
-  %5 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 1
-  %6 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 3
-  %7 = call i8* @_lfortran_malloc(i32 7)
-  call void @_lfortran_string_init(i64 7, i8* %7)
-  store i8* %7, i8** %6, align 8
-  %8 = alloca %fpm_run_settings_polymorphic, align 8
-  %9 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %8, i32 0, i32 0
-  store i64 0, i64* %9, align 4
-  %10 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %8, i32 0, i32 1
-  store %fpm_run_settings* %settings, %fpm_run_settings** %10, align 8
+  %4 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 2
+  %5 = call i8* @_lfortran_malloc(i32 5)
+  call void @_lfortran_string_init(i64 5, i8* %5)
+  store i8* %5, i8** %4, align 8
+  %6 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 4
+  %7 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 1
+  %8 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 3
+  %9 = call i8* @_lfortran_malloc(i32 7)
+  call void @_lfortran_string_init(i64 7, i8* %9)
+  store i8* %9, i8** %8, align 8
+  %10 = alloca %fpm_run_settings_polymorphic, align 8
+  %11 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %10, i32 0, i32 0
+  store i64 0, i64* %11, align 4
+  %12 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %10, i32 0, i32 1
+  store %fpm_run_settings* %settings, %fpm_run_settings** %12, align 8
   store i1 true, i1* %call_arg_value, align 1
-  call void @__module_modules_36_fpm_main_01_cmd_run(%fpm_run_settings_polymorphic* %8, i1* %call_arg_value)
+  call void @__module_modules_36_fpm_main_01_cmd_run(%fpm_run_settings_polymorphic* %10, i1* %call_arg_value)
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-modules_38-8886f9a.json
+++ b/tests/reference/llvm-modules_38-8886f9a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_38-8886f9a.stdout",
-    "stdout_hash": "725402c6298056d8f4732c021daf43d59078352930f22382d966452d",
+    "stdout_hash": "c25252a9b1d3111c28cd06478d0409c12254296a68766d985426d774",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_38-8886f9a.stdout
+++ b/tests/reference/llvm-modules_38-8886f9a.stdout
@@ -53,119 +53,122 @@ define i32 @main(i32 %0, i8** %1) {
   %i = alloca i32, align 4
   %array_size = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__libasr__created__var__0__func_call_res = alloca %string_descriptor, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  store i8* null, i8** %2, align 8
-  %3 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %2 = alloca %__vtab_compiler_t, align 8
+  %3 = getelementptr %__vtab_compiler_t, %__vtab_compiler_t* %2, i32 0, i32 0
   store i64 0, i64* %3, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
-  store i64 0, i64* %4, align 4
+  %__libasr__created__var__0__func_call_res = alloca %string_descriptor, align 8
+  %4 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  store i8* null, i8** %4, align 8
+  %5 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  store i64 0, i64* %5, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  store i64 0, i64* %6, align 4
   %compiler_arg = alloca %compiler_t, align 8
-  %5 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 2
-  %6 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 0
-  store i8* null, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 1
-  store i64 0, i64* %7, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 2
-  store i64 0, i64* %8, align 4
-  %9 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 3
-  %10 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 0
-  store i8* null, i8** %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 1
-  store i64 0, i64* %11, align 4
-  %12 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 2
-  store i64 0, i64* %12, align 4
-  %13 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 4
-  store i1 true, i1* %13, align 1
-  %14 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 0
-  store i8* null, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 1
-  store i64 0, i64* %16, align 4
-  %17 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 2
-  store i64 0, i64* %17, align 4
-  %18 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 0
-  store i32 0, i32* %18, align 4
-  %19 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 5
-  store i1 true, i1* %19, align 1
+  %7 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 2
+  %8 = getelementptr %string_descriptor, %string_descriptor* %7, i32 0, i32 0
+  store i8* null, i8** %8, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %7, i32 0, i32 1
+  store i64 0, i64* %9, align 4
+  %10 = getelementptr %string_descriptor, %string_descriptor* %7, i32 0, i32 2
+  store i64 0, i64* %10, align 4
+  %11 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 3
+  %12 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 0
+  store i8* null, i8** %12, align 8
+  %13 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 1
+  store i64 0, i64* %13, align 4
+  %14 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 2
+  store i64 0, i64* %14, align 4
+  %15 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 4
+  store i1 true, i1* %15, align 1
+  %16 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 1
+  %17 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 0
+  store i8* null, i8** %17, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 1
+  store i64 0, i64* %18, align 4
+  %19 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 2
+  store i64 0, i64* %19, align 4
+  %20 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 0
+  store i32 0, i32* %20, align 4
+  %21 = getelementptr %compiler_t, %compiler_t* %compiler_arg, i32 0, i32 5
+  store i1 true, i1* %21, align 1
   %libs_arg = alloca [4 x %string_t], align 8
   store i32 4, i32* %array_size, align 4
   store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %20 = load i32, i32* %i, align 4
-  %21 = load i32, i32* %array_size, align 4
-  %22 = icmp slt i32 %20, %21
-  br i1 %22, label %loop.body, label %loop.end
+  %22 = load i32, i32* %i, align 4
+  %23 = load i32, i32* %array_size, align 4
+  %24 = icmp slt i32 %22, %23
+  br i1 %24, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %23 = load i32, i32* %i, align 4
-  %24 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 %23
-  %25 = getelementptr %string_t, %string_t* %24, i32 0, i32 0
-  %26 = getelementptr %string_descriptor, %string_descriptor* %25, i32 0, i32 0
-  store i8* null, i8** %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %25, i32 0, i32 1
-  store i64 0, i64* %27, align 4
-  %28 = getelementptr %string_descriptor, %string_descriptor* %25, i32 0, i32 2
-  store i64 0, i64* %28, align 4
-  %29 = load i32, i32* %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
+  %25 = load i32, i32* %i, align 4
+  %26 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 %25
+  %27 = getelementptr %string_t, %string_t* %26, i32 0, i32 0
+  %28 = getelementptr %string_descriptor, %string_descriptor* %27, i32 0, i32 0
+  store i8* null, i8** %28, align 8
+  %29 = getelementptr %string_descriptor, %string_descriptor* %27, i32 0, i32 1
+  store i64 0, i64* %29, align 4
+  %30 = getelementptr %string_descriptor, %string_descriptor* %27, i32 0, i32 2
+  store i64 0, i64* %30, align 4
+  %31 = load i32, i32* %i, align 4
+  %32 = add i32 %31, 1
+  store i32 %32, i32* %i, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   %prefix_arg = alloca i8*, align 8
-  %31 = call i8* @_lfortran_malloc(i32 4)
-  call void @_lfortran_string_init(i64 4, i8* %31)
-  store i8* %31, i8** %prefix_arg, align 8
-  %32 = load i8*, i8** %prefix_arg, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %34 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
-  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
-  %36 = load i8*, i8** %33, align 8
-  call void @_lfortran_free(i8* %36)
-  store i8* null, i8** %33, align 8
-  store i64 0, i64* %34, align 4
-  store i64 0, i64* %35, align 4
-  %37 = alloca %compiler_t_polymorphic, align 8
-  %38 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %37, i32 0, i32 0
-  store i64 0, i64* %38, align 4
-  %39 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %37, i32 0, i32 1
-  store %compiler_t* %compiler_arg, %compiler_t** %39, align 8
-  %40 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
-  %41 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
-  store %string_t* %40, %string_t** %41, align 8
-  %42 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
-  store i32 0, i32* %42, align 4
-  %43 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
-  %44 = alloca %dimension_descriptor, align 8
-  store %dimension_descriptor* %44, %dimension_descriptor** %43, align 8
-  %45 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
-  store i32 1, i32* %45, align 4
-  %46 = load %dimension_descriptor*, %dimension_descriptor** %43, align 8
-  %47 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 0
-  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 0
-  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 1
-  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 2
-  store i32 1, i32* %48, align 4
-  store i32 1, i32* %49, align 4
-  store i32 4, i32* %50, align 4
-  call void @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %37, i8** %prefix_arg, %array* %array_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res)
-  %51 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %52 = load i8*, i8** %51, align 8
-  %53 = alloca i8*, align 8
-  store i8* %52, i8** %53, align 8
-  %54 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info, i32 0, i32 0), i32 0, i8** %53)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %54, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %55 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
-  %56 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
-  %57 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
-  %58 = load i8*, i8** %55, align 8
-  call void @_lfortran_free(i8* %58)
-  store i8* null, i8** %55, align 8
-  store i64 0, i64* %56, align 4
-  store i64 0, i64* %57, align 4
+  %33 = call i8* @_lfortran_malloc(i32 4)
+  call void @_lfortran_string_init(i64 4, i8* %33)
+  store i8* %33, i8** %prefix_arg, align 8
+  %34 = load i8*, i8** %prefix_arg, align 8
+  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %36 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %37 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %38 = load i8*, i8** %35, align 8
+  call void @_lfortran_free(i8* %38)
+  store i8* null, i8** %35, align 8
+  store i64 0, i64* %36, align 4
+  store i64 0, i64* %37, align 4
+  %39 = alloca %compiler_t_polymorphic, align 8
+  %40 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %39, i32 0, i32 0
+  store i64 0, i64* %40, align 4
+  %41 = getelementptr %compiler_t_polymorphic, %compiler_t_polymorphic* %39, i32 0, i32 1
+  store %compiler_t* %compiler_arg, %compiler_t** %41, align 8
+  %42 = getelementptr [4 x %string_t], [4 x %string_t]* %libs_arg, i32 0, i32 0
+  %43 = getelementptr %array, %array* %array_descriptor, i32 0, i32 0
+  store %string_t* %42, %string_t** %43, align 8
+  %44 = getelementptr %array, %array* %array_descriptor, i32 0, i32 1
+  store i32 0, i32* %44, align 4
+  %45 = getelementptr %array, %array* %array_descriptor, i32 0, i32 2
+  %46 = alloca %dimension_descriptor, align 8
+  store %dimension_descriptor* %46, %dimension_descriptor** %45, align 8
+  %47 = getelementptr %array, %array* %array_descriptor, i32 0, i32 4
+  store i32 1, i32* %47, align 4
+  %48 = load %dimension_descriptor*, %dimension_descriptor** %45, align 8
+  %49 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 0
+  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 0
+  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 1
+  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 2
+  store i32 1, i32* %50, align 4
+  store i32 1, i32* %51, align 4
+  store i32 4, i32* %52, align 4
+  call void @__module_fpm_compiler_enumerate_libraries(%compiler_t_polymorphic* %39, i8** %prefix_arg, %array* %array_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res)
+  %53 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %54 = load i8*, i8** %53, align 8
+  %55 = alloca i8*, align 8
+  store i8* %54, i8** %55, align 8
+  %56 = call i8* (i8*, i8*, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info, i32 0, i32 0), i32 0, i8** %55)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %57 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 0
+  %58 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 1
+  %59 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0__func_call_res, i32 0, i32 2
+  %60 = load i8*, i8** %57, align 8
+  call void @_lfortran_free(i8* %60)
+  store i8* null, i8** %57, align 8
+  store i64 0, i64* %58, align 4
+  store i64 0, i64* %59, align 4
   call void @_lpython_free_argv()
   br label %return
 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/6736

We now create a vtab for all `StructType` and `ClassType` variables. Earlier we were creating a vtab only for `ClassType` variables.

We also pass the polymorphic arg to `visit_RuntimePolymorphicSubroutineCall`. Earlier it was assumed that `x.m_dt` is a `ClassType` but it can be a `StructType`.