### PR TITLE
fix: extended derived types assignment

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1415,6 +1415,7 @@ RUN(NAME derived_types_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_50 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1414,6 +1414,7 @@ RUN(NAME derived_types_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_AR
 RUN(NAME derived_types_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_49.f90
+++ b/integration_tests/derived_types_49.f90
@@ -1,0 +1,32 @@
+module derived_types_49_m
+    implicit none
+    public :: base, derived
+
+    type, abstract :: base
+        integer :: a
+    end type base
+
+    type, extends(base) :: derived
+        integer :: b
+    end type derived
+
+    type, extends(derived) :: derived2
+        integer :: c
+        integer :: d
+    end type derived2
+end module derived_types_49_m
+
+program derived_types_49
+  use derived_types_49_m
+  implicit none
+
+  type(derived2) :: set0, set1
+  set0 = derived2(10, 20, 30, 40)
+
+  set1 = set0
+
+  if (set1%a /= set0%a) error stop
+  if (set1%b /= set0%b) error stop
+  if (set1%c /= set0%c) error stop
+  if (set1%d /= set0%d) error stop
+end program derived_types_49

--- a/integration_tests/derived_types_50.f90
+++ b/integration_tests/derived_types_50.f90
@@ -1,0 +1,74 @@
+module stdlib_bitsets
+    implicit none
+    public ::         &
+        bitset_type,  &
+        bitset_large, &
+        bitset_64,    &
+        bitset_64_concrete
+
+    type, abstract :: bitset_type
+        integer(4) :: num_bits
+    contains
+        procedure(clear_bit_abstract), deferred, pass(self)   :: clear_bit
+        procedure(clear_range_abstract), deferred, pass(self) :: clear_range
+        generic :: clear => clear_bit, clear_range
+    end type bitset_type
+
+    abstract interface
+        elemental subroutine clear_bit_abstract(self, pos)
+            import :: bitset_type
+            class(bitset_type), intent(inout) :: self
+            integer(4), intent(in) :: pos
+        end subroutine clear_bit_abstract
+
+        pure subroutine clear_range_abstract(self, start_pos, stop_pos)
+            import :: bitset_type
+            class(bitset_type), intent(inout) :: self
+            integer(4), intent(in) :: start_pos, stop_pos
+        end subroutine clear_range_abstract
+    end interface
+
+    type, abstract, extends(bitset_type) :: bitset_large
+        private
+        integer(8), private, allocatable :: blocks(:)
+    contains
+    end type bitset_large
+
+    type, abstract, extends(bitset_type) :: bitset_64
+        private
+        integer(8), private :: block = 0
+    contains
+    end type bitset_64
+
+    type, extends(bitset_64) :: bitset_64_concrete
+    contains
+        procedure, pass(self) :: clear_bit   => clear_bit_impl
+        procedure, pass(self) :: clear_range => clear_range_impl
+    end type bitset_64_concrete
+
+contains
+
+    elemental subroutine clear_bit_impl(self, pos)
+        class(bitset_64_concrete), intent(inout) :: self
+        integer(4), intent(in) :: pos
+        ! Dummy implementation
+    end subroutine clear_bit_impl
+
+    pure subroutine clear_range_impl(self, start_pos, stop_pos)
+        class(bitset_64_concrete), intent(inout) :: self
+        integer(4), intent(in) :: start_pos, stop_pos
+        ! Dummy implementation
+    end subroutine clear_range_impl
+
+end module stdlib_bitsets
+
+program derived_types_50
+  use stdlib_bitsets
+  implicit none
+
+  type(bitset_64_concrete) :: set0, set1
+  set0%num_bits = 64
+  set1 = set0
+
+  if (set1%num_bits /= 64) error stop
+end program derived_types_50

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2194,11 +2194,11 @@ namespace LCompilers {
             }
             case ASR::ttypeType::StructType: {
                 ASR::StructType_t* struct_t = ASR::down_cast<ASR::StructType_t>(asr_type);
-                ASR::Struct_t* struct_type_t = ASR::down_cast<ASR::Struct_t>(
+                ASR::Struct_t* struct_sym = ASR::down_cast<ASR::Struct_t>(
                     ASRUtils::symbol_get_past_external(struct_t->m_derived_type));
-                std::string der_type_name = std::string(struct_type_t->m_name);
-                while( struct_type_t != nullptr ) {
-                    for( auto item: struct_type_t->m_symtab->get_scope() ) {
+                std::string der_type_name = std::string(struct_sym->m_name);
+                while( struct_sym != nullptr ) {
+                    for( auto item: struct_sym->m_symtab->get_scope() ) {
                         if( ASR::is_a<ASR::ClassProcedure_t>(*item.second) ||
                             ASR::is_a<ASR::CustomOperator_t>(*item.second) ) {
                             continue ;
@@ -2225,18 +2225,18 @@ namespace LCompilers {
                             ASRUtils::symbol_type(item.second),
                             module, name2memidx);
                     }
-                    if( struct_type_t->m_parent != nullptr ) {
+                    if( struct_sym->m_parent != nullptr ) {
                         // gep the parent struct, which is the 0th member of the child struct
-                        src = create_gep2(name2dertype[struct_type_t->m_name], src, 0);
-                        dest = create_gep2(name2dertype[struct_type_t->m_name], dest, 0);
+                        src = create_gep2(name2dertype[struct_sym->m_name], src, 0);
+                        dest = create_gep2(name2dertype[struct_sym->m_name], dest, 0);
 
                         ASR::Struct_t* parent_struct_type_t =
-                            ASR::down_cast<ASR::Struct_t>(struct_type_t->m_parent);
+                            ASR::down_cast<ASR::Struct_t>(struct_sym->m_parent);
 
                         der_type_name = parent_struct_type_t->m_name;
-                        struct_type_t = parent_struct_type_t;
+                        struct_sym = parent_struct_type_t;
                     } else {
-                        struct_type_t = nullptr;
+                        struct_sym = nullptr;
                     }
                 }
                 break ;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2226,8 +2226,14 @@ namespace LCompilers {
                             module, name2memidx);
                     }
                     if( struct_type_t->m_parent != nullptr ) {
+                        // gep the parent struct, which is the 0th member of the child struct
+                        src = create_gep2(name2dertype[struct_type_t->m_name], src, 0);
+                        dest = create_gep2(name2dertype[struct_type_t->m_name], dest, 0);
+
                         ASR::Struct_t* parent_struct_type_t =
                             ASR::down_cast<ASR::Struct_t>(struct_type_t->m_parent);
+
+                        der_type_name = parent_struct_type_t->m_name;
                         struct_type_t = parent_struct_type_t;
                     } else {
                         struct_type_t = nullptr;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2200,6 +2200,7 @@ namespace LCompilers {
                 while( struct_sym != nullptr ) {
                     for( auto item: struct_sym->m_symtab->get_scope() ) {
                         if( ASR::is_a<ASR::ClassProcedure_t>(*item.second) ||
+                            ASR::is_a<ASR::GenericProcedure_t>(*item.second) ||
                             ASR::is_a<ASR::CustomOperator_t>(*item.second) ) {
                             continue ;
                         }


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7031
Fix https://github.com/lfortran/lfortran/issues/7034

First 2 commits fix the extended derived types assignment.
Third commit skips `GenericProcedure` in deepcopy which fixes #7034