### PR TITLE
fix: check if struct symbols match when finding overloaded function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1315,6 +1315,7 @@ RUN(NAME operator_overloading_04 LABELS gfortran llvm)
 RUN(NAME operator_overloading_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME operator_overloading_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_09.f90
+++ b/integration_tests/operator_overloading_09.f90
@@ -1,0 +1,54 @@
+module stdlib_bitsets_operator_overloading_9_m
+    implicit none
+    public :: bitset_type, bitset_large, bitset_64
+    public :: operator(==)
+
+    type, abstract :: bitset_type
+        private
+        integer(4) :: num_bits
+    contains
+    end type bitset_type
+
+    type, extends(bitset_type) :: bitset_large
+    end type bitset_large
+
+    type, extends(bitset_type) :: bitset_64
+    end type bitset_64
+
+    interface operator(==)
+        elemental module function eqv_large(set1, set2) result(eqv)
+            logical                        :: eqv
+            type(bitset_large), intent(in) :: set1, set2
+        end function eqv_large
+
+        elemental module function eqv_64(set1, set2) result(eqv)
+            logical                     :: eqv
+            type(bitset_64), intent(in) :: set1, set2
+        end function eqv_64
+    end interface operator(==)
+
+    contains
+
+    elemental module function eqv_large(set1, set2) result(eqv)
+        logical                        :: eqv
+        type(bitset_large), intent(in) :: set1, set2
+        eqv = .false. ! dummy implementation
+    end function eqv_large
+
+    elemental module function eqv_64(set1, set2) result(eqv)
+        logical                     :: eqv
+        type(bitset_64), intent(in) :: set1, set2
+        eqv = .true. ! dummy implementation
+    end function eqv_64
+end module stdlib_bitsets_operator_overloading_9_m
+
+program operator_overloading_09
+  use stdlib_bitsets_operator_overloading_9_m
+  implicit none
+
+  type(bitset_large) :: set0, set1
+  type(bitset_64) :: set2, set3
+
+  if ((set1 == set0) .neqv. .false.) error stop
+  if ((set2 == set3) .neqv. .true.) error stop
+end program operator_overloading_09

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1692,7 +1692,9 @@ public:
                 parent_scope->erase_symbol(sym_name);
             } else if (ASR::is_a<ASR::Function_t>(*f1)) {
                 ASR::Function_t* f2 = ASR::down_cast<ASR::Function_t>(f1);
-                if (ASRUtils::get_FunctionType(f2)->m_abi == ASR::abiType::Interactive) {
+                if (ASRUtils::get_FunctionType(f2)->m_abi == ASR::abiType::Interactive ||
+                    // TODO: Throw error when interface definition and implementation signatures are different
+                    ASRUtils::get_FunctionType(f2)->m_deftype == ASR::deftypeType::Interface) {
                     // Previous declaration will be shadowed
                     parent_scope->erase_symbol(sym_name);
                 } else {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1200,6 +1200,27 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                             ASR::is_a<ASR::StructType_t>(*left_type))
                         || (ASR::is_a<ASR::ClassType_t>(*right_arg_type) &&
                             ASR::is_a<ASR::StructType_t>(*right_type))) {
+                            // If all are StructTypes then the Struct symbols should match
+                            if (ASR::is_a<ASR::StructType_t>(*left_type) &&
+                                ASR::is_a<ASR::StructType_t>(*right_type) &&
+                                ASR::is_a<ASR::StructType_t>(*left_arg_type) &&
+                                ASR::is_a<ASR::StructType_t>(*right_arg_type)) {
+                                ASR::Struct_t *left_sym = ASR::down_cast<ASR::Struct_t>(
+                                        ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructType_t>(
+                                        left_type)->m_derived_type));
+                                ASR::Struct_t *right_sym = ASR::down_cast<ASR::Struct_t>(
+                                    ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructType_t>(
+                                    right_type)->m_derived_type));
+                                ASR::Struct_t *left_arg_sym = ASR::down_cast<ASR::Struct_t>(
+                                        ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructType_t>(
+                                        left_arg_type)->m_derived_type));
+                                ASR::Struct_t *right_arg_sym = ASR::down_cast<ASR::Struct_t>(
+                                    ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructType_t>(
+                                    right_arg_type)->m_derived_type));
+                                if (left_sym != left_arg_sym || right_sym != right_arg_sym) {
+                                    break;
+                                }
+                            }
                             found = true;
                             Vec<ASR::call_arg_t> a_args;
                             a_args.reserve(al, 2);


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7030

Towards https://github.com/lfortran/lfortran/issues/7029

I've added a TODO for throwing an error if the interface signature and implementation signatures don't match. If they match only then we should shadow.