### PR TITLE
fix: raise ValueError when we haven't reached EOF when parsing 'raw.txt'

### DIFF
--- a/src/libasr/dwarf_convert.py
+++ b/src/libasr/dwarf_convert.py
@@ -60,6 +60,9 @@ class Parser:
         while self.line.startswith("debug_line"):
             d = self.parse_debug_line()
             lines.append(d)
+
+        if (self.line.rstrip() != ""):
+            raise ValueError(f"We haven't reached end of file of {filename}")
         return DebugLines(lines)
 
     def parse_debug_line(self):


### PR DESCRIPTION
## Description

This fix ensures that we raise an error when we haven't reached EOF when parsing `raw.txt` i.e. the file used by llvm's dwarfdump to read symbols's information.