### PR TITLE
Fix: tokenizer error doesn't return correct location information

### DIFF
--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -11,6 +11,7 @@ using LCompilers::diag::Label;
 using LCompilers::diag::Diagnostic;
 
 namespace LCompilers::LFortran {
+unsigned char *string_start_pointer = nullptr;
 
 void Tokenizer::set_string(const std::string &str)
 {
@@ -151,6 +152,9 @@ void Tokenizer::add_rel_warning(diag::Diagnostics &diagnostics, bool fixed_form,
 
 int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnostics &diagnostics, bool continue_compilation)
 {
+    if (string_start_pointer == nullptr) {
+        string_start_pointer = cur;
+    }
     if (enddo_state == 1) {
         enddo_state = 2;
         KW(END_DO)
@@ -810,6 +814,8 @@ void lex_format(unsigned char *&cur, Location &loc,
             * {
                 token_loc(loc);
                 std::string t = token(tok, cur);
+                loc.first = cur-string_start_pointer;
+                loc.last = cur-string_start_pointer;
                 diagnostics.add(diag::Diagnostic(
                     "Token '" + t + "' is not recognized in `format` statement",
                     diag::Level::Error, diag::Stage::Tokenizer, {

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "2d870d63914154948fb8517f48c02cc92141926d610a01d79b914208",
+    "stderr_hash": "e204cfda3408b1e6b60ce686ab48f185a6703c270abf0bac2423ecb1",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -57,10 +57,10 @@ tokenizer error: Token '?' is not recognized
     |                 ^ token not recognized
 
 tokenizer error: Token '@' is not recognized in `format` statement
- --> tests/errors/continue_compilation_2.f90:1:2
-  |
-1 | module Geometry
-  |  ^ 
+   --> tests/errors/continue_compilation_2.f90:436:22
+    |
+436 |     100 FORMAT(A10, @)
+    |                      ^ 
 
 semantic error: Global name is already being used
   --> tests/errors/continue_compilation_2.f90:24:1 - 25:21


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/6278

Consider this fortran file:
```
cat a.f90
program main
    100 FORMAT(A10, @)
end program main%         
```


Before this implementation the current main branch code returns incorrect location information
```
lfortran a.f90
tokenizer error: Token '@' is not recognized in `format` statement
 --> a.f90:1:2
  |
1 | program main
  |  ^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

Now with the fix it returns the following location information
```
lfortran a.f90                                                                  
tokenizer error: Token '@' is not recognized in `format` statement
 --> a.f90:2:22
  |
2 |     100 FORMAT(A10, @)
  |                      ^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```
