### PR TITLE
(a) format supported in formatted_read

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3997,7 +3997,9 @@ LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, int32_t* iostat, in
             strcpy(*arg, buffer);
             va_end(args);
             free(buffer);
+            return;
         }
+
     }
 
     bool unit_file_bin;


### PR DESCRIPTION
In the following program:
```
program test_stdin
    implicit none
    character(len=10) :: a
    read(*,'(a)') a
    print *, "From stdin:", a
end program
```
an initial runtime error occurred:
`No file found with given unit`
This issue happened because, after handling the stdin case (unit_num == -1), the control flow continued into the file input handling section.
Since no valid file pointer existed for unit_num == -1, the program exited with the above error.

The root cause was the absence of a return statement after successfully reading from stdin.
Without an explicit return, execution proceeded further unnecessarily, resulting in the error.

Adding a return after completing the stdin read ensures that the program exits correctly from the _lfortran_formatted_read function and does not attempt further file operations.