### PR TITLE
fix: pass pointer for constant also in `file_write`

### DIFF
--- a/integration_tests/file_28.f90
+++ b/integration_tests/file_28.f90
@@ -1,7 +1,7 @@
 program file_28
     implicit none
-    integer :: unit_num
-    integer :: stat
+    integer :: unit_num, unit_num2
+    integer :: stat, a, b, c
     integer, dimension(5) :: data_out = [10, 20, 30, 40, 50]
     integer, dimension(5) :: data_in
     ! Choose a unit number
@@ -12,6 +12,11 @@ program file_28
     rewind(unit_num)
     open(unit=unit_num)
     read(unit_num, *) data_in
-    close(unit_num)
-    if(any(data_in /= data_out)) error stop
+    close(unit_num, status='delete')
+    open(newunit=unit_num2, file='file_28.txt', status='replace', access='stream', form='unformatted')
+    write(unit_num2) 1, 2, 3
+    rewind(unit_num2)
+    read(unit_num2) a, b, c
+    close(unit_num2, status='delete')
+    if (a /= 1 .or. b /= 2 .or. c /= 3) error stop
 end program file_28

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8947,6 +8947,14 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                     args.push_back(builder->CreateMul(kind_val, tmp));
                 } else {
                     args.push_back(kind_val);
+                    if (ASRUtils::is_value_constant(m_values[i])) {
+                        this->visit_expr_wrapper(m_values[i], true);
+                        llvm::Type* type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::expr_type(m_values[i]), module.get());
+                        llvm::Value* llvm_arg = llvm_utils->CreateAlloca(*builder, type);
+                        builder->CreateStore(tmp, llvm_arg);
+                        args.push_back(llvm_arg);
+                        continue;
+                    }
                 }
             }
             compute_fmt_specifier_and_arg(fmt, args, m_values[i],


### PR DESCRIPTION
For unformatted write, in `_lfortran_file_write_` we pass data like `(int32_t size, void * data, ......)` 

Now for `write(u) 1,2,3`, we don't have pointer to these constant values, so I have made new pointers for them to maintain similarity.

I am not sure if this is correct solution or not.