### PR TITLE
Fix : [GenericProcedure] Build the symbolTable is this order (Functions -> GenericProcedures -> Variables depending on calls to genericProcedures)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -474,6 +474,7 @@ RUN(NAME functions_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME functions_33 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_34 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_35 LABELS gfortran llvm NO_STD_F23)
+RUN(NAME functions_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_36.f90
+++ b/integration_tests/functions_36.f90
@@ -1,0 +1,46 @@
+
+
+! Test circular dependencies when declaring interface and using it in the function constructing that same interface
+
+
+module functions_36_mod
+    real :: var
+    interface generic  !>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Depends on both `f1` and `f2` to be declared 
+      procedure :: f1
+      procedure :: f2
+    end interface
+    
+    contains
+    
+    pure function f1(vv) result(length)
+    real, intent(in) :: vv
+    integer :: rr(generic(vv, 2)) !>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Depends on `f2` (but through interface) to be fully declared
+    integer :: length
+    length = size(rr)
+    end function 
+    
+    pure function f2(rr, int) result(length)
+    real, intent(in) :: rr
+    integer, intent(in) :: int
+    integer :: length
+    length = int*2
+    end function 
+    
+    subroutine maybe()
+      character(10) :: string(generic(var)) 
+      print *, size(string)
+      if (size(string) /= 4) error stop
+    end subroutine maybe
+    
+end module 
+    
+    
+program functions_36
+    use functions_36_mod
+    var =1.5
+    call maybe()
+end program 
+    
+    
+    
+    

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2824,7 +2824,7 @@ public:
         }
         /*
             Check for generic procedure call in the symbol dimension
-            e.g. : `integer :: arr(func_generic(),20)
+            e.g. : `integer :: arr(func_generic(),20)`
         */
         for(size_t i = 0; i < x.n_syms; i++){
             AST::var_sym_t &s = x.m_syms[i];

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6141,13 +6141,6 @@ public:
             ASRUtils::symbol_parent_symtab(v)->get_counter() != current_scope->get_counter() &&
             !ASR::is_a<ASR::ExternalSymbol_t>(*v)) {
             current_function_dependencies.push_back(al, ASRUtils::symbol_name(v));
-            // // Add call args
-            // LCOMPILERS_ASSERT(ASR::is_a<ASR::Functinocall>(*v))
-            // ASR::FunctionCall_t* func = ASR::down_cast<ASR::FunctionCall_t;
-            // for(int i = 0; i<func->n_args; i++){
-            //     if(ASR::is_a<ASR::Var_t>(ASR::func->m_args[i].m_value)){}
-            //     current_function_dependencies.push_back(al, ASRUtils::EXPR2VAR(func->m_args[i].m_value)->m_name);
-            // }
         }
         ASR::Module_t* v_module = ASRUtils::get_sym_module0(f2);
         if( v_module ) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -495,7 +495,7 @@ public:
         }
         current_module_sym = nullptr;
         add_generic_procedures();
-        Evaluate_delayed_generic_procedure_calls();
+        evaluate_delayed_generic_procedure_calls();
         add_overloaded_procedures();
         add_class_procedures();
         add_generic_class_procedures();
@@ -651,7 +651,7 @@ public:
         handle_save();
         // Build : Functions --> GenericProcedure(Interface) -> variable_decl calling GenericProcedure.
         add_generic_procedures();
-        Evaluate_delayed_generic_procedure_calls();
+        evaluate_delayed_generic_procedure_calls();
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
 
@@ -2403,7 +2403,7 @@ public:
         Evaluate call expressions to genericProcedures that's used in variable declaration.
         e.g : `integer :: arr(generic_proc(),10)`
     */
-    void Evaluate_delayed_generic_procedure_calls(){
+    void evaluate_delayed_generic_procedure_calls(){
         if(!generic_procedures.empty()){
             throw LCompilersException("generic_procedures should be resolved"
                 "before evaluating calls to genericProcedure");

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -85,7 +85,6 @@ public:
         Location loc;
     };
     SymbolTable *global_scope;
-    std::map<std::string, std::vector<std::string>> generic_procedures;
     std::map<std::string, std::map<std::string, std::vector<std::string>>> generic_class_procedures;
     std::map<AST::intrinsicopType, std::vector<std::string>> overloaded_op_procs;
     std::map<std::string, std::vector<std::string>> defined_op_procs;
@@ -496,6 +495,7 @@ public:
         }
         current_module_sym = nullptr;
         add_generic_procedures();
+        Evaluate_delayed_generic_procedure_calls();
         add_overloaded_procedures();
         add_class_procedures();
         add_generic_class_procedures();
@@ -649,7 +649,9 @@ public:
             throw SemanticAbort();
         }
         handle_save();
+        // Build : Functions --> GenericProcedure(Interface) -> variable_decl calling GenericProcedure.
         add_generic_procedures();
+        Evaluate_delayed_generic_procedure_calls();
         parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
 
@@ -2394,6 +2396,62 @@ public:
                 symbols.p, symbols.size(), ASR::Public);
             current_scope->add_or_overwrite_symbol(sym_name_str, ASR::down_cast<ASR::symbol_t>(v));
         }
+        generic_procedures.clear();
+    }
+
+    /* 
+        Evaluate call expressions to genericProcedures that's used in variable declaration.
+        e.g : `integer :: arr(generic_proc(),10)`
+    */
+    void Evaluate_delayed_generic_procedure_calls(){
+        if(!generic_procedures.empty()){
+            throw LCompilersException("generic_procedures should be resolved"
+                "before evaluating calls to genericProcedure");
+        }
+
+        for(auto &[symtable, decl] : delayed_generic_procedure_calls){
+            // Set current scope
+            SymbolTable* current_scope_copy = current_scope;
+            current_scope = symtable;
+            visit_Declaration(*decl);
+
+            // Raise warning for user if variable declaration is calling its function scope recursively.
+            // + Add dependencies of variable to the function (owning the variable)
+            for(size_t i = 0; i< decl->n_syms; i++){ //loop on all symbols per `ASR::Declaration` node .
+                const char* symbol_name = decl->m_syms[i].m_name;
+                LCOMPILERS_ASSERT(ASR::is_a<ASR::Variable_t>(
+                    *symtable->resolve_symbol(symbol_name)))
+                ASR::Variable_t* variable = ASR::down_cast<ASR::Variable_t>(
+                    symtable->resolve_symbol(symbol_name));
+                for(size_t dep_idx = 0 ;dep_idx < variable->n_dependencies; dep_idx++){
+                    if( ASR::is_a<ASR::symbol_t>(*symtable->asr_owner) &&
+                        ASR::is_a<ASR::Function_t>(*(ASR::symbol_t*)symtable->asr_owner)){
+                        ASR::Function_t* func = ASR::down_cast2<ASR::Function_t>(symtable->asr_owner);
+                        // Check for recursive call
+                        if(func->m_name == variable->m_dependencies[dep_idx]){
+                            diag.add(diag::Diagnostic(
+                                "Variable declaration is calling its function scope recursively",
+                                diag::Level::Warning, diag::Stage::Semantic, {
+                                    diag::Label("", {decl->base.base.loc})}));
+                        } 
+                        // Add function call to scoping function dependencies.
+                        if(ASR::is_a<ASR::Function_t>(*symtable->resolve_symbol(variable->m_dependencies[dep_idx]))){
+                            Vec<char*> v_dependencies;v_dependencies.reserve(al, 0);
+                            v_dependencies.from_pointer_n_copy(al, func->m_dependencies, func->n_dependencies);
+                            v_dependencies.push_back(al, variable->m_dependencies[dep_idx]);
+                            func->m_dependencies = v_dependencies.p;
+                            func->n_dependencies = v_dependencies.n;
+                        }
+                    }
+                }
+            }
+
+            // Revert current scope
+            current_scope = current_scope_copy;
+        }
+
+        // Clear the delayed generic procedure calls
+        delayed_generic_procedure_calls.clear();
     }
 
     void add_generic_class_procedures() {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5369,22 +5369,28 @@ static inline void set_enum_value_type(ASR::enumtypeType &enum_value_type,
 }
 
 class CollectIdentifiersFromASRExpression: public ASR::BaseWalkVisitor<CollectIdentifiersFromASRExpression> {
-    private:
+private:
 
         Allocator& al;
         SetChar& identifiers;
         std::string current_name;
 
-    public:
+public:
 
+// Constructors
         CollectIdentifiersFromASRExpression(Allocator& al_, SetChar& identifiers_, std::string current_name_ = "") :
         al(al_), identifiers(identifiers_), current_name(current_name_)
         {}
 
+// Visitors
         void visit_Var(const ASR::Var_t& x) {
             if (ASRUtils::symbol_name(x.m_v) != this->current_name) {
                 identifiers.push_back(al, ASRUtils::symbol_name(x.m_v));
             }
+        }
+        void visit_FunctionCall(const ASR::FunctionCall_t &x){
+            identifiers.push_back(al, ASRUtils::symbol_name(x.m_name));
+            ASR::BaseWalkVisitor<CollectIdentifiersFromASRExpression>::visit_FunctionCall(x);
         }
 };
 

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1126,6 +1126,7 @@ public:
     void visit_FunctionCall(const FunctionCall_t &x) {
         require(x.m_name,
             "FunctionCall::m_name must be present");
+        variable_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
         ASR::symbol_t* asr_owner_sym = nullptr;
         if(current_symtab->asr_owner &&  ASR::is_a<ASR::symbol_t>(*current_symtab->asr_owner) ) {
             asr_owner_sym = ASR::down_cast<ASR::symbol_t>(current_symtab->asr_owner);

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -442,6 +442,13 @@ namespace LCompilers {
                     current_scope = current_scope_copy;
                 }
 
+                void visit_Program(const ASR::Program_t& x){
+                    SymbolTable* current_scope_copy = current_scope;
+                    current_scope = x.m_symtab;
+                    BaseWalkVisitor::visit_Program(x);
+                    current_scope = current_scope_copy;
+                } 
+
                 void visit_Module(const ASR::Module_t& x) {
                     SymbolTable *parent_symtab = current_scope;
                     current_scope = x.m_symtab;
@@ -486,6 +493,9 @@ namespace LCompilers {
                 }
 
                 void visit_FunctionCall(const ASR::FunctionCall_t& x) {
+                    if(fill_variable_dependencies){
+                        variable_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                    }
                     if (fill_function_dependencies) {
                         ASR::symbol_t* asr_owner_sym = nullptr;
                         if (current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner)) {

--- a/tests/reference/asr-string_17-29e01e3.json
+++ b/tests/reference/asr-string_17-29e01e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_17-29e01e3.stdout",
-    "stdout_hash": "6f65c4d7d2b752796898eb38d2a3007565de38c4f992d0b02cf9a898",
+    "stdout_hash": "4fb3b5638965e66f4588b6326e9b7a13b0cec43743ec08a28f884b16",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_17-29e01e3.stdout
+++ b/tests/reference/asr-string_17-29e01e3.stdout
@@ -163,7 +163,8 @@
                                                 (Variable
                                                     5
                                                     maybe_string
-                                                    [string]
+                                                    [len_string
+                                                    string]
                                                     ReturnVar
                                                     ()
                                                     ()

--- a/tests/reference/asr-string_19-d880475.json
+++ b/tests/reference/asr-string_19-d880475.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_19-d880475.stdout",
-    "stdout_hash": "adbe1a0d753821f33d7ff52c0973878b6b14de58b7a8f7d9955466f9",
+    "stdout_hash": "0ccce65c8d319295ad979139b7cba8e287f4aa3fa43fa6e537d1246c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_19-d880475.stdout
+++ b/tests/reference/asr-string_19-d880475.stdout
@@ -163,7 +163,8 @@
                                                 (Variable
                                                     5
                                                     character_string
-                                                    [string]
+                                                    [len_string
+                                                    string]
                                                     ReturnVar
                                                     ()
                                                     ()


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/7066