### PR TITLE
Update and use `CreateLoad2`, `create_ptr_gep2`, `create_gep2`

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1365,7 +1365,7 @@ public:
         }
         llvm::Type* const_list_type = list_api->get_list_type(llvm_el_type, type_code, type_size);
         llvm::Value* const_list = llvm_utils->CreateAlloca(*builder, const_list_type, nullptr, "const_list");
-        list_api->list_init(type_code, const_list, *module, x.n_args, x.n_args);
+        list_api->list_init(type_code, const_list, module.get(), x.n_args, x.n_args);
         int64_t ptr_loads_copy = ptr_loads;
         for( size_t i = 0; i < x.n_args; i++ ) {
             if (is_argument_of_type_CPtr(x.m_args[i])) {
@@ -1611,7 +1611,7 @@ public:
         ptr_loads = ptr_loads_copy;
         llvm::Value *pos = tmp;
 
-        tmp = list_api->read_item(plist, pos, compiler_options.enable_bounds_checking, *module,
+        tmp = list_api->read_item(plist, pos, compiler_options.enable_bounds_checking, module.get(),
                 (LLVM::is_llvm_struct(el_type) || ptr_loads == 0));
     }
 
@@ -1635,11 +1635,11 @@ public:
             ptr_loads = ptr_loads_copy;
             builder->CreateStore(tmp, def_value_ptr);
             llvm_utils->set_dict_api(dict_type);
-            tmp = llvm_utils->dict_api->get_item(pdict, key, *module, dict_type, def_value_ptr,
+            tmp = llvm_utils->dict_api->get_item(pdict, key, module.get(), dict_type, def_value_ptr,
                                   LLVM::is_llvm_struct(dict_type->m_value_type));
         } else {
             llvm_utils->set_dict_api(dict_type);
-            tmp = llvm_utils->dict_api->read_item(pdict, key, *module, dict_type,
+            tmp = llvm_utils->dict_api->read_item(pdict, key, module.get(), dict_type,
                                     compiler_options.enable_bounds_checking,
                                     LLVM::is_llvm_struct(dict_type->m_value_type));
         }
@@ -1659,7 +1659,7 @@ public:
         llvm::Value *key = tmp;
 
         llvm_utils->set_dict_api(dict_type);
-        tmp = llvm_utils->dict_api->pop_item(pdict, key, *module, dict_type,
+        tmp = llvm_utils->dict_api->pop_item(pdict, key, module.get(), dict_type,
                                  LLVM::is_llvm_struct(dict_type->m_value_type));
     }
 
@@ -1688,26 +1688,26 @@ public:
         ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
 
         if(x.m_op == ASR::cmpopType::Eq || x.m_op == ASR::cmpopType::NotEq) {
-            tmp = llvm_utils->is_equal_by_value(left, right, *module,
+            tmp = llvm_utils->is_equal_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left));
             if (x.m_op == ASR::cmpopType::NotEq) {
                 tmp = builder->CreateNot(tmp);
             }
         }
         else if(x.m_op == ASR::cmpopType::Lt) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 0, int32_type);
         }
         else if(x.m_op == ASR::cmpopType::LtE) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 1, int32_type);
         }
         else if(x.m_op == ASR::cmpopType::Gt) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 2, int32_type);
         }
         else if(x.m_op == ASR::cmpopType::GtE) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 3, int32_type);
         }
     }
@@ -1801,7 +1801,7 @@ public:
         this->visit_expr_wrapper(x.m_ele, true);
         ptr_loads = ptr_loads_copy;
         llvm::Value *item = tmp;
-        list_api->remove(plist, item, asr_el_type, *module);
+        list_api->remove(plist, item, asr_el_type, module.get());
     }
 
     void visit_ListCount(const ASR::ListCount_t& x) {
@@ -1815,7 +1815,7 @@ public:
         this->visit_expr_wrapper(x.m_ele, true);
         ptr_loads = ptr_loads_copy;
         llvm::Value *item = tmp;
-        tmp = list_api->count(plist, item, asr_el_type, *module);
+        tmp = list_api->count(plist, item, asr_el_type, module.get());
     }
 
     void generate_ListIndex(ASR::expr_t* m_arg, ASR::expr_t* m_ele,
@@ -1844,7 +1844,7 @@ public:
         }
 
         ptr_loads = ptr_loads_copy;
-        tmp = list_api->index(plist, item, start, end, asr_el_type, *module);
+        tmp = list_api->index(plist, item, start, end, asr_el_type, module.get());
     }
 
     void generate_Exp(ASR::expr_t* m_arg) {
@@ -1876,7 +1876,7 @@ public:
 
         ptr_loads = !LLVM::is_llvm_struct(asr_el_type);
         ptr_loads = ptr_loads_copy;
-        list_api->reverse(plist, *module);
+        list_api->reverse(plist, module.get());
     }
 
     void generate_ListPop_0(ASR::expr_t* m_arg) {
@@ -1888,7 +1888,7 @@ public:
 
         ptr_loads = !LLVM::is_llvm_struct(asr_el_type);
         ptr_loads = ptr_loads_copy;
-        tmp = list_api->pop_last(plist, asr_el_type, *module);
+        tmp = list_api->pop_last(plist, asr_el_type, module.get());
     }
 
     void generate_ListPop_1(ASR::expr_t* m_arg, ASR::expr_t* m_ele) {
@@ -1954,11 +1954,11 @@ public:
         llvm::Type* el_list_type = list_api->get_list_type(llvm_el_type, type_code, type_size);
         llvm::Value* el_list = llvm_utils->CreateAlloca(*builder, el_list_type, nullptr, key_or_value == 0 ?
                                                     "keys_list" : "values_list");
-        list_api->list_init(type_code, el_list, *module, 0, 0);
+        list_api->list_init(type_code, el_list, module.get(), 0, 0);
 
         llvm_utils->set_dict_api(dict_type);
         llvm_utils->dict_api->get_elements_list(pdict, el_list, dict_type->m_key_type,
-                                                dict_type->m_value_type, *module,
+                                                dict_type->m_value_type, module.get(),
                                                 name2memidx, key_or_value);
         tmp = el_list;
     }
@@ -1994,7 +1994,7 @@ public:
         ptr_loads = ptr_loads_copy;
         llvm::Value *el = tmp;
         llvm_utils->set_set_api(set_type);
-        llvm_utils->set_api->remove_item(pset, el, *module, asr_el_type);
+        llvm_utils->set_api->remove_item(pset, el, module.get(), asr_el_type);
     }
 
     void visit_IntrinsicElementalFunction(const ASR::IntrinsicElementalFunction_t& x) {
@@ -2219,8 +2219,7 @@ public:
         llvm::Value* repeat_list = llvm_utils->CreateAlloca(*builder, repeat_list_type, nullptr, "repeat_list");
         llvm::Value* left_len = list_api->len(left);
         llvm::Value* capacity = builder->CreateMul(left_len, right);
-        list_api->list_init(type_code, repeat_list, *module,
-                            capacity, capacity);
+        list_api->list_init(type_code, repeat_list, module.get(), capacity, capacity);
         int64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 1;
         list_api->list_repeat_copy(repeat_list, left, right, left_len, module.get());
@@ -2237,26 +2236,26 @@ public:
         llvm::Value* right = tmp;
         ptr_loads = ptr_loads_copy;
         if(x.m_op == ASR::cmpopType::Eq || x.m_op == ASR::cmpopType::NotEq) {
-            tmp = llvm_utils->is_equal_by_value(left, right, *module,
+            tmp = llvm_utils->is_equal_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left));
             if (x.m_op == ASR::cmpopType::NotEq) {
                 tmp = builder->CreateNot(tmp);
             }
         }
         else if(x.m_op == ASR::cmpopType::Lt) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 0);
         }
         else if(x.m_op == ASR::cmpopType::LtE) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 1);
         }
         else if(x.m_op == ASR::cmpopType::Gt) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 2);
         }
         else if(x.m_op == ASR::cmpopType::GtE) {
-            tmp = llvm_utils->is_ineq_by_value(left, right, *module,
+            tmp = llvm_utils->is_ineq_by_value(left, right, module.get(),
                     ASRUtils::expr_type(x.m_left), 3);
         }
     }
@@ -2324,7 +2323,7 @@ public:
         ASR::Tuple_t* tuple_type = (ASR::Tuple_t*)(ASR::make_Tuple_t(
                                     al, x.base.base.loc, v_type.p, v_type.n));
         tuple_api->concat(left, right, tuple_type_left, tuple_type_right, concat_tuple,
-                          tuple_type, *module, name2memidx);
+                          tuple_type, module.get(), name2memidx);
         tmp = concat_tuple;
     }
 
@@ -4132,7 +4131,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 } else if (is_list) {
                     ASR::List_t* asr_list = ASR::down_cast<ASR::List_t>(v->m_type);
                     std::string type_code = ASRUtils::get_type_code(asr_list->m_type);
-                    list_api->list_init(type_code, ptr, *module);
+                    list_api->list_init(type_code, ptr, module.get());
                 }
             }
         }
@@ -4823,7 +4822,8 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
             ASRUtils::extract_physical_type(p_type) ==
             ASR::array_physical_typeType::DescriptorArray) {
             LCOMPILERS_ASSERT(ASR::is_a<ASR::Pointer_t>(*p_type));
-            ptr = arr_descr->get_pointer_to_data(ptr);
+            ptr = arr_descr->get_pointer_to_data(
+                ASRUtils::type_get_past_allocatable_pointer(p_type), ptr, module.get());
             llvm::Type* array_inner_type = llvm_utils->get_type_from_ttype_t_util(
                 ASRUtils::extract_type(p_type), module.get());
             ptr = llvm_utils->CreateLoad2(array_inner_type->getPointerTo(), ptr);
@@ -5447,7 +5447,7 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 llvm::Value* pos = tmp;
 
                 target = list_api->read_item(list, pos, compiler_options.enable_bounds_checking,
-                                             *module, true);
+                                             module.get(), true);
             }
         } else {
             ASR::Variable_t *asr_target = EXPR2VAR(x.m_target);

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1948,9 +1948,11 @@ namespace LCompilers {
                 // head
                 start_new_block(loophead);
                 {
-                    llvm::Value* i = LLVMUtils::CreateLoad(idx);
-                    llvm::Value* l = LLVMUtils::CreateLoad(create_ptr_gep(left, i));
-                    llvm::Value* r = LLVMUtils::CreateLoad(create_ptr_gep(right, i));
+                    llvm::Value* i = LLVMUtils::CreateLoad2(llvm::Type::getInt32Ty(context), idx);
+                    llvm::Value* l = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context), create_ptr_gep2(
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), left, i));
+                    llvm::Value* r = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context), create_ptr_gep2(
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), right, i));
                     llvm::Value *cond = builder->CreateAnd(
                         builder->CreateICmpNE(l, null_char),
                         builder->CreateICmpNE(r, null_char)
@@ -1962,7 +1964,7 @@ namespace LCompilers {
                 // body
                 start_new_block(loopbody);
                 {
-                    llvm::Value* i = LLVMUtils::CreateLoad(idx);
+                    llvm::Value* i = LLVMUtils::CreateLoad2(llvm::Type::getInt32Ty(context), idx);
                     i = builder->CreateAdd(i, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, 1)));
                     LLVM::CreateStore(*builder, i, idx);
@@ -1972,9 +1974,11 @@ namespace LCompilers {
 
                 // end
                 start_new_block(loopend);
-                llvm::Value* i = LLVMUtils::CreateLoad(idx);
-                llvm::Value* l = LLVMUtils::CreateLoad(create_ptr_gep(left, i));
-                llvm::Value* r = LLVMUtils::CreateLoad(create_ptr_gep(right, i));
+                llvm::Value* i = LLVMUtils::CreateLoad2(llvm::Type::getInt32Ty(context), idx);
+                llvm::Value* l = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context), create_ptr_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo(), left, i));
+                llvm::Value* r = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context), create_ptr_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo(), right, i));
                 return builder->CreateICmpEQ(l, r);
             }
             case ASR::ttypeType::Tuple: {
@@ -2075,9 +2079,11 @@ namespace LCompilers {
                 // head
                 start_new_block(loophead);
                 {
-                    llvm::Value* i = LLVMUtils::CreateLoad(idx);
-                    llvm::Value* l = LLVMUtils::CreateLoad(create_ptr_gep(left, i));
-                    llvm::Value* r = LLVMUtils::CreateLoad(create_ptr_gep(right, i));
+                    llvm::Value* i = LLVMUtils::CreateLoad2(llvm::Type::getInt32Ty(context), idx);
+                    llvm::Value* l = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context),
+                        create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), left, i));
+                    llvm::Value* r = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context),
+                        create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), right, i));
                     llvm::Value *cond = builder->CreateAnd(
                         builder->CreateICmpNE(l, null_char),
                         builder->CreateICmpNE(r, null_char)
@@ -2110,7 +2116,7 @@ namespace LCompilers {
                 // body
                 start_new_block(loopbody);
                 {
-                    llvm::Value* i = LLVMUtils::CreateLoad(idx);
+                    llvm::Value* i = LLVMUtils::CreateLoad2(llvm::Type::getInt32Ty(context), idx);
                     i = builder->CreateAdd(i, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, 1)));
                     LLVM::CreateStore(*builder, i, idx);
@@ -2120,9 +2126,11 @@ namespace LCompilers {
 
                 // end
                 start_new_block(loopend);
-                llvm::Value* i = LLVMUtils::CreateLoad(idx);
-                llvm::Value* l = LLVMUtils::CreateLoad(create_ptr_gep(left, i));
-                llvm::Value* r = LLVMUtils::CreateLoad(create_ptr_gep(right, i));
+                llvm::Value* i = LLVMUtils::CreateLoad2(llvm::Type::getInt32Ty(context), idx);
+                llvm::Value* l = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context),
+                    create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), left, i));
+                llvm::Value* r = LLVMUtils::CreateLoad2(llvm::Type::getInt8Ty(context),
+                    create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), right, i));
                 return builder->CreateICmpULT(l, r);
             }
             case ASR::ttypeType::Tuple: {
@@ -2541,7 +2549,8 @@ namespace LCompilers {
         std::string key_type_code, std::string value_type_code,
         llvm::Value* dict, llvm::Module* module, llvm::Value* llvm_capacity) {
         llvm::Value* rehash_flag_ptr = get_pointer_to_rehash_flag(dict);
-        llvm::Value* rehash_flag = llvm_utils->CreateLoad(rehash_flag_ptr);
+        llvm::Value* rehash_flag = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context), rehash_flag_ptr);
         llvm::Value* llvm_zero = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), llvm::APInt(32, 0));
         llvm::Value* occupancy_ptr = get_pointer_to_occupancy(dict);
         LLVM::CreateStore(*builder, llvm_zero, occupancy_ptr);
@@ -2588,19 +2597,21 @@ namespace LCompilers {
                                  std::map<std::string, std::map<std::string, int>>& name2memidx) {
         LCOMPILERS_ASSERT(src->getType() == dest->getType());
         std::string src_type_code = ASRUtils::get_type_code(element_type);
-        llvm::Value* src_end_point = llvm_utils->CreateLoad(get_pointer_to_current_end_point(src));
-        llvm::Value* src_capacity = llvm_utils->CreateLoad(get_pointer_to_current_capacity(src));
+        llvm::Value* src_end_point = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
+            get_pointer_to_current_end_point(src));
+        llvm::Value* src_capacity = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
+            get_pointer_to_current_capacity(src));
         llvm::Value* dest_end_point_ptr = get_pointer_to_current_end_point(dest);
         llvm::Value* dest_capacity_ptr = get_pointer_to_current_capacity(dest);
         builder->CreateStore(src_end_point, dest_end_point_ptr);
         builder->CreateStore(src_capacity, dest_capacity_ptr);
-        llvm::Value* src_data = llvm_utils->CreateLoad(get_pointer_to_list_data(src));
+        llvm::Type* el_type = std::get<2>(typecode2listtype[src_type_code]);
+        llvm::Value* src_data = llvm_utils->CreateLoad2(el_type->getPointerTo(), get_pointer_to_list_data(src));
         int32_t type_size = std::get<1>(typecode2listtype[src_type_code]);
         llvm::Value* arg_size = builder->CreateMul(llvm::ConstantInt::get(context,
                                                    llvm::APInt(32, type_size)), src_capacity);
         llvm::Value* copy_data = LLVM::lfortran_malloc(context, *module, *builder,
                                                        arg_size);
-        llvm::Type* el_type = std::get<2>(typecode2listtype[src_type_code]);
         copy_data = builder->CreateBitCast(copy_data, el_type->getPointerTo());
 
         // We consider the case when the element type of a list is defined by a struct
@@ -2630,16 +2641,17 @@ namespace LCompilers {
             {
                 llvm::Value *cond = builder->CreateICmpSGT(
                                             src_end_point,
-                                            llvm_utils->CreateLoad(pos_ptr));
+                                            llvm_utils->CreateLoad2(
+                                                llvm::Type::getInt32Ty(context), pos_ptr));
                 builder->CreateCondBr(cond, loopbody, loopend);
             }
 
             // body
             llvm_utils->start_new_block(loopbody);
             {
-                llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
-                llvm::Value* srci = read_item(src, pos, false, *module, true);
-                llvm::Value* desti = read_item(dest, pos, false, *module, true);
+                llvm::Value* pos = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), pos_ptr);
+                llvm::Value* srci = read_item(src, pos, false, module, true);
+                llvm::Value* desti = read_item(dest, pos, false, module, true);
                 llvm_utils->deepcopy(srci, desti, element_type, module, name2memidx);
                 llvm::Value* tmp = builder->CreateAdd(
                             pos,
@@ -2662,7 +2674,8 @@ namespace LCompilers {
                                  ASR::Dict_t* dict_type, llvm::Module* module,
                                  std::map<std::string, std::map<std::string, int>>& name2memidx) {
         LCOMPILERS_ASSERT(src->getType() == dest->getType());
-        llvm::Value* src_occupancy = llvm_utils->CreateLoad(get_pointer_to_occupancy(src));
+        llvm::Value* src_occupancy = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_occupancy(src));
         llvm::Value* dest_occupancy_ptr = get_pointer_to_occupancy(dest);
         LLVM::CreateStore(*builder, src_occupancy, dest_occupancy_ptr);
 
@@ -2677,13 +2690,14 @@ namespace LCompilers {
         llvm_utils->list_api->list_deepcopy(src_value_list, dest_value_list,
                                             dict_type->m_value_type, module, name2memidx);
 
-        llvm::Value* src_key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(src));
+        llvm::Value* src_key_mask = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(),
+            get_pointer_to_keymask(src));
         llvm::Value* dest_key_mask_ptr = get_pointer_to_keymask(dest);
         llvm::DataLayout data_layout(module->getDataLayout());
         size_t mask_size = data_layout.getTypeAllocSize(llvm::Type::getInt8Ty(context));
         llvm::Value* llvm_mask_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                             llvm::APInt(32, mask_size));
-        llvm::Value* src_capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(src));
+        llvm::Value* src_capacity = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), get_pointer_to_capacity(src));
         llvm::Value* dest_key_mask = LLVM::lfortran_calloc(context, *module, *builder, src_capacity,
                                                       llvm_mask_size);
         builder->CreateMemCpy(dest_key_mask, llvm::MaybeAlign(), src_key_mask,
@@ -2711,7 +2725,7 @@ namespace LCompilers {
         llvm_utils->start_new_block(loophead);
         {
             llvm::Value *cond = builder->CreateICmpNE(
-                llvm_utils->CreateLoad(src_itr),
+                llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(), src_itr),
                 llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             builder->CreateCondBr(cond, loopbody, loopend);
@@ -2720,26 +2734,36 @@ namespace LCompilers {
         // body
         llvm_utils->start_new_block(loopbody);
         {
-            llvm::Value* curr_src = builder->CreateBitCast(llvm_utils->CreateLoad(src_itr),
+            llvm::Value* curr_src = builder->CreateBitCast(llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context)->getPointerTo(), src_itr),
                 key_value_pair_type);
-            llvm::Value* curr_dest = builder->CreateBitCast(llvm_utils->CreateLoad(dest_itr),
+            llvm::Value* curr_dest = builder->CreateBitCast(llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context)->getPointerTo(), dest_itr),
                 key_value_pair_type);
-            llvm::Value* src_key_ptr = llvm_utils->create_gep(curr_src, 0);
-            llvm::Value* src_value_ptr = llvm_utils->create_gep(curr_src, 1);
+            std::pair<std::string, std::string> llvm_key = std::make_pair(
+                ASRUtils::get_type_code(dict_type->m_key_type),
+                ASRUtils::get_type_code(dict_type->m_value_type));
+            llvm::Type* key_type = std::get<2>(typecode2dicttype[llvm_key]).first;
+            llvm::Type* value_type = std::get<2>(typecode2dicttype[llvm_key]).second;
+            llvm::Value* src_key_ptr = llvm_utils->create_gep2(key_type->getPointerTo(), curr_src, 0);
+            llvm::Value* src_value_ptr = llvm_utils->create_gep2(value_type->getPointerTo(), curr_src, 1);
             llvm::Value *src_key = src_key_ptr, *src_value = src_value_ptr;
             if( !LLVM::is_llvm_struct(dict_type->m_key_type) ) {
-                src_key = llvm_utils->CreateLoad(src_key_ptr);
+                src_key = llvm_utils->CreateLoad2(key_type, src_key_ptr);
             }
             if( !LLVM::is_llvm_struct(dict_type->m_value_type) ) {
-                src_value = llvm_utils->CreateLoad(src_value_ptr);
+                src_value = llvm_utils->CreateLoad2(value_type, src_value_ptr);
             }
-            llvm::Value* dest_key_ptr = llvm_utils->create_gep(curr_dest, 0);
-            llvm::Value* dest_value_ptr = llvm_utils->create_gep(curr_dest, 1);
+            llvm::Value* dest_key_ptr = llvm_utils->create_gep2(key_type->getPointerTo(), curr_dest, 0);
+            llvm::Value* dest_value_ptr = llvm_utils->create_gep2(value_type->getPointerTo(), curr_dest, 1);
             llvm_utils->deepcopy(src_key, dest_key_ptr, dict_type->m_key_type, module, name2memidx);
             llvm_utils->deepcopy(src_value, dest_value_ptr, dict_type->m_value_type, module, name2memidx);
 
-            llvm::Value* src_next_ptr = llvm_utils->CreateLoad(llvm_utils->create_gep(curr_src, 2));
-            llvm::Value* curr_dest_next_ptr = llvm_utils->create_gep(curr_dest, 2);
+            llvm::Value* src_next_ptr = llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context)->getPointerTo(), llvm_utils->create_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), curr_src, 2));
+            llvm::Value* curr_dest_next_ptr = llvm_utils->create_gep2(
+                llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), curr_dest, 2);
             LLVM::CreateStore(*builder, src_next_ptr, src_itr);
             llvm::Function *fn = builder->GetInsertBlock()->getParent();
             llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
@@ -2750,8 +2774,10 @@ namespace LCompilers {
             builder->CreateCondBr(src_next_exists, thenBB, elseBB);
             builder->SetInsertPoint(thenBB);
             {
-                llvm::Value* next_idx = llvm_utils->CreateLoad(next_ptr);
-                llvm::Value* dest_next_ptr = llvm_utils->create_ptr_gep(dest_key_value_pairs, next_idx);
+                llvm::Value* next_idx = llvm_utils->CreateLoad2(
+                    llvm::Type::getInt32Ty(context), next_ptr);
+                llvm::Value* dest_next_ptr = llvm_utils->create_ptr_gep2(
+                    key_value_pair_type->getPointerTo(), dest_key_value_pairs, next_idx);
                 dest_next_ptr = builder->CreateBitCast(dest_next_ptr, llvm::Type::getInt8Ty(context)->getPointerTo());
                 LLVM::CreateStore(*builder, dest_next_ptr, curr_dest_next_ptr);
                 LLVM::CreateStore(*builder, dest_next_ptr, dest_itr);
@@ -2792,7 +2818,7 @@ namespace LCompilers {
         llvm_utils->start_new_block(loophead);
         {
             llvm::Value *cond = builder->CreateICmpNE(
-                llvm_utils->CreateLoad(src_itr),
+                llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(), src_itr),
                 llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             builder->CreateCondBr(cond, loopbody, loopend);
@@ -2801,25 +2827,36 @@ namespace LCompilers {
         // body
         llvm_utils->start_new_block(loopbody);
         {
-            llvm::Value* curr_src = builder->CreateBitCast(llvm_utils->CreateLoad(src_itr),
+            llvm::Value* curr_src = builder->CreateBitCast(llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context)->getPointerTo(), src_itr),
                 key_value_pair_type);
-            llvm::Value* src_key_ptr = llvm_utils->create_gep(curr_src, 0);
-            llvm::Value* src_value_ptr = llvm_utils->create_gep(curr_src, 1);
+            std::pair<std::string, std::string> llvm_key = std::make_pair(
+                ASRUtils::get_type_code(m_key_type),
+                ASRUtils::get_type_code(m_value_type));
+            llvm::Type* key_type = std::get<2>(typecode2dicttype[llvm_key]).first;
+            llvm::Type* value_type = std::get<2>(typecode2dicttype[llvm_key]).second;
+            llvm::Value* src_key_ptr = llvm_utils->create_gep2(key_type->getPointerTo(), curr_src, 0);
+            llvm::Value* src_value_ptr = llvm_utils->create_gep2(value_type->getPointerTo(), curr_src, 1);
             llvm::Value *src_key = src_key_ptr, *src_value = src_value_ptr;
             if( !LLVM::is_llvm_struct(m_key_type) ) {
-                src_key = llvm_utils->CreateLoad(src_key_ptr);
+                src_key = llvm_utils->CreateLoad2(key_type, src_key_ptr);
             }
             if( !LLVM::is_llvm_struct(m_value_type) ) {
-                src_value = llvm_utils->CreateLoad(src_value_ptr);
+                src_value = llvm_utils->CreateLoad2(value_type, src_value_ptr);
             }
-            llvm::Value* key_hash = get_key_hash(capacity, src_key, m_key_type, *module);
+            llvm::Value* key_hash = get_key_hash(capacity, src_key, m_key_type, module);
             resolve_collision_for_write(
                 dict, key_hash, src_key,
                 src_value, module,
                 m_key_type, m_value_type,
                 name2memidx);
 
-            llvm::Value* src_next_ptr = llvm_utils->CreateLoad(llvm_utils->create_gep(curr_src, 2));
+            llvm::Value* src_next_ptr = llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context)->getPointerTo(),
+                llvm_utils->create_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(),
+                    curr_src, 2)
+            );
             LLVM::CreateStore(*builder, src_next_ptr, src_itr);
         }
 
@@ -2833,11 +2870,16 @@ namespace LCompilers {
         llvm::Value* src, llvm::Value* dest,
         ASR::Dict_t* dict_type, llvm::Module* module,
         std::map<std::string, std::map<std::string, int>>& name2memidx) {
-        llvm::Value* src_occupancy = llvm_utils->CreateLoad(get_pointer_to_occupancy(src));
-        llvm::Value* src_filled_buckets = llvm_utils->CreateLoad(get_pointer_to_number_of_filled_buckets(src));
-        llvm::Value* src_capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(src));
-        llvm::Value* src_key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(src));
-        llvm::Value* src_rehash_flag = llvm_utils->CreateLoad(get_pointer_to_rehash_flag(src));
+        llvm::Value* src_occupancy = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_occupancy(src));
+        llvm::Value* src_filled_buckets = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_number_of_filled_buckets(src));
+        llvm::Value* src_capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(src));
+        llvm::Value* src_key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(src));
+        llvm::Value* src_rehash_flag = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context), get_pointer_to_rehash_flag(src));
         LLVM::CreateStore(*builder, src_occupancy, get_pointer_to_occupancy(dest));
         LLVM::CreateStore(*builder, src_filled_buckets, get_pointer_to_number_of_filled_buckets(dest));
         LLVM::CreateStore(*builder, src_capacity, get_pointer_to_capacity(dest));
@@ -2866,7 +2908,10 @@ namespace LCompilers {
         LLVM::CreateStore(*builder, llvm_zero, copy_itr);
         LLVM::CreateStore(*builder, src_capacity, next_ptr);
 
-        llvm::Value* src_key_value_pairs = llvm_utils->CreateLoad(get_pointer_to_key_value_pairs(src));
+        llvm::Value* src_key_value_pairs = llvm_utils->CreateLoad2(
+            get_key_value_pair_type(dict_type->m_key_type, dict_type->m_value_type)->getPointerTo(),
+            get_pointer_to_key_value_pairs(src)
+        );
         llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
         llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
         llvm::BasicBlock *loopend = llvm::BasicBlock::Create(context, "loop.end");
@@ -2876,16 +2921,20 @@ namespace LCompilers {
         {
             llvm::Value *cond = builder->CreateICmpSGT(
                                         src_capacity,
-                                        llvm_utils->CreateLoad(copy_itr));
+                                        llvm_utils->CreateLoad2(
+                                            llvm::Type::getInt32Ty(context),
+                                            copy_itr));
             builder->CreateCondBr(cond, loopbody, loopend);
         }
 
         // body
         llvm_utils->start_new_block(loopbody);
         {
-            llvm::Value* itr = llvm_utils->CreateLoad(copy_itr);
-            llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-                llvm_utils->create_ptr_gep(src_key_mask, itr));
+            llvm::Value* itr = llvm_utils->CreateLoad2(
+                llvm::Type::getInt32Ty(context), copy_itr);
+            llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context),
+                llvm_utils->create_ptr_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo(), src_key_mask, itr));
             LLVM::CreateStore(*builder, key_mask_value,
                 llvm_utils->create_ptr_gep(dest_key_mask, itr));
             llvm::Value* is_key_set = builder->CreateICmpEQ(key_mask_value,
@@ -2912,9 +2961,9 @@ namespace LCompilers {
     }
 
     void LLVMList::check_index_within_bounds(llvm::Value* list,
-                                    llvm::Value* pos, llvm::Module& module) {
-        llvm::Value* end_point = llvm_utils->CreateLoad(
-                                    get_pointer_to_current_end_point(list));
+                                    llvm::Value* pos, llvm::Module* module) {
+        llvm::Value* end_point = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_current_end_point(list));
         llvm::Value* zero = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                                    llvm::APInt(32, 0));
 
@@ -2991,9 +3040,9 @@ namespace LCompilers {
         // head
         llvm_utils->start_new_block(loophead);
         {
-            llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
-            llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-                llvm_utils->create_ptr_gep(key_mask, pos));
+            llvm::Value* pos = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), pos_ptr);
+            llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context),
+                llvm_utils->create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, pos));
             llvm::Value* is_key_skip = builder->CreateICmpEQ(key_mask_value,
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 3)));
             llvm::Value* is_key_set = builder->CreateICmpNE(key_mask_value,
@@ -3020,12 +3069,17 @@ namespace LCompilers {
             llvm::Value *cond = nullptr;
             if( for_read ) {
                 cond = builder->CreateAnd(is_key_set, builder->CreateNot(
-                            llvm_utils->CreateLoad(is_key_matching_var)));
+                            llvm_utils->CreateLoad2(
+                                llvm::Type::getInt8Ty(context), is_key_matching_var))
+                );
                 cond = builder->CreateOr(is_key_skip, cond);
             } else {
                 cond = builder->CreateAnd(is_key_set, builder->CreateNot(is_key_skip));
                 cond = builder->CreateAnd(cond, builder->CreateNot(
-                            llvm_utils->CreateLoad(is_key_matching_var)));
+                            llvm_utils->CreateLoad2(
+                                llvm::Type::getInt8Ty(context),
+                                is_key_matching_var))
+                );
             }
             builder->CreateCondBr(cond, loopbody, loopend);
         }
@@ -3034,7 +3088,7 @@ namespace LCompilers {
         // body
         llvm_utils->start_new_block(loopbody);
         {
-            llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+            llvm::Value* pos = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), pos_ptr);
             pos = builder->CreateAdd(pos, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                                                  llvm::APInt(32, 1)));
             pos = builder->CreateSRem(pos, capacity);
@@ -3107,9 +3161,11 @@ namespace LCompilers {
         // head
         llvm_utils->start_new_block(loophead);
         {
-            llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
-            llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-                llvm_utils->create_ptr_gep(key_mask, pos));
+            llvm::Value* pos = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), pos_ptr);
+            llvm::Value* key_mask_value = llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context),
+                llvm_utils->create_ptr_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, pos));
             llvm::Value* is_key_skip = builder->CreateICmpEQ(key_mask_value,
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 3)));
             llvm::Value* is_key_set = builder->CreateICmpNE(key_mask_value,
@@ -3135,12 +3191,18 @@ namespace LCompilers {
             llvm::Value *cond = nullptr;
             if( for_read ) {
                 cond = builder->CreateAnd(is_key_set, builder->CreateNot(
-                            llvm_utils->CreateLoad(is_key_matching_var)));
+                            llvm_utils->CreateLoad2(
+                                llvm::Type::getInt8Ty(context),
+                                is_key_matching_var))
+                        );
                 cond = builder->CreateOr(is_key_skip, cond);
             } else {
                 cond = builder->CreateAnd(is_key_set, builder->CreateNot(is_key_skip));
                 cond = builder->CreateAnd(cond, builder->CreateNot(
-                            llvm_utils->CreateLoad(is_key_matching_var)));
+                            llvm_utils->CreateLoad2(
+                                llvm::Type::getInt8Ty(context),
+                                is_key_matching_var))
+                        );
             }
             builder->CreateCondBr(cond, loopbody, loopend);
         }
@@ -3148,7 +3210,8 @@ namespace LCompilers {
         // body
         llvm_utils->start_new_block(loopbody);
         {
-            llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+            llvm::Value* pos = llvm_utils->CreateLoad2(
+                llvm::Type::getInt32Ty(context), pos_ptr);
             pos = builder->CreateAdd(pos, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
                                                                 llvm::APInt(32, 1)));
             pos = builder->CreateSRem(pos, capacity);
@@ -3198,8 +3261,10 @@ namespace LCompilers {
 
         LLVM::CreateStore(*builder,
                 llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()), chain_itr_prev);
-        llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-            llvm_utils->create_ptr_gep(key_mask, key_hash));
+        llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context),
+            llvm_utils->create_ptr_gep2(
+                llvm::Type::getInt8Ty(context)->getPointerTo(),
+                key_mask, key_hash));
         llvm_utils->create_if_else(builder->CreateICmpEQ(key_mask_value,
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1))), [&]() {
             llvm::Value* kv_ll_i8 = builder->CreateBitCast(key_value_pair_linked_list,
@@ -3221,28 +3286,34 @@ namespace LCompilers {
         llvm_utils->start_new_block(loophead);
         {
             llvm::Value *cond = builder->CreateICmpNE(
-                llvm_utils->CreateLoad(chain_itr),
+                llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(), chain_itr),
                 llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())
             );
             cond = builder->CreateAnd(cond, builder->CreateNot(
-                    llvm_utils->CreateLoad(is_key_matching_var)));
+                    llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context), is_key_matching_var)));
             builder->CreateCondBr(cond, loopbody, loopend);
         }
 
         // body
         llvm_utils->start_new_block(loopbody);
         {
-            llvm::Value* kv_struct_i8 = llvm_utils->CreateLoad(chain_itr);
+            llvm::Value* kv_struct_i8 = llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context), chain_itr);
             llvm::Value* kv_struct = builder->CreateBitCast(kv_struct_i8, kv_pair_type->getPointerTo());
-            llvm::Value* kv_struct_key = llvm_utils->create_gep(kv_struct, 0);
+            llvm::Type* llvm_key_type = llvm_utils->get_type_from_ttype_t_util(key_asr_type, module);
+            llvm::Value* kv_struct_key = llvm_utils->create_gep2(llvm_key_type->getPointerTo(), kv_struct, 0);
             if( !LLVM::is_llvm_struct(key_asr_type) ) {
-                kv_struct_key = llvm_utils->CreateLoad(kv_struct_key);
+                kv_struct_key = llvm_utils->CreateLoad2(llvm_key_type, kv_struct_key);
             }
             LLVM::CreateStore(*builder, llvm_utils->is_equal_by_value(key, kv_struct_key,
                                 module, key_asr_type), is_key_matching_var);
-            llvm_utils->create_if_else(builder->CreateNot(llvm_utils->CreateLoad(is_key_matching_var)), [&]() {
+            llvm_utils->create_if_else(builder->CreateNot(llvm_utils->CreateLoad2(
+                llvm::Type::getInt8Ty(context), is_key_matching_var)), [&]() {
                 LLVM::CreateStore(*builder, kv_struct_i8, chain_itr_prev);
-                llvm::Value* next_kv_struct = llvm_utils->CreateLoad(llvm_utils->create_gep(kv_struct, 2));
+                llvm::Value* next_kv_struct = llvm_utils->CreateLoad2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo(),
+                    llvm_utils->create_gep2(
+                        llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), kv_struct, 2));
                 LLVM::CreateStore(*builder, next_kv_struct, chain_itr);
             }, []() {});
         }
@@ -3261,28 +3332,31 @@ namespace LCompilers {
         std::map<std::string, std::map<std::string, int>>& name2memidx) {
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
-        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, *module, key_asr_type);
-        llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
+        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type);
+        llvm::Value* pos = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), pos_ptr);
         llvm_utils->list_api->write_item(key_list, pos, key,
                                          key_asr_type, false, module, name2memidx);
         llvm_utils->list_api->write_item(value_list, pos, value,
                                          value_asr_type, false, module, name2memidx);
-        llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-            llvm_utils->create_ptr_gep(key_mask, pos));
+        llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context),
+            llvm_utils->create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, pos));
         llvm::Value* is_slot_empty = builder->CreateICmpEQ(key_mask_value,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 0)));
         is_slot_empty = builder->CreateOr(is_slot_empty, builder->CreateICmpEQ(key_mask_value,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 3))));
         llvm::Value* occupancy_ptr = get_pointer_to_occupancy(dict);
         is_slot_empty = builder->CreateZExt(is_slot_empty, llvm::Type::getInt32Ty(context));
-        llvm::Value* occupancy = llvm_utils->CreateLoad(occupancy_ptr);
+        llvm::Value* occupancy = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), occupancy_ptr);
         LLVM::CreateStore(*builder, builder->CreateAdd(occupancy, is_slot_empty),
                           occupancy_ptr);
         LLVM::CreateStore(*builder,
                           llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)),
-                          llvm_utils->create_ptr_gep(key_mask, pos));
+                          llvm_utils->create_ptr_gep2(
+                            llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, pos));
     }
 
     void LLVMDictOptimizedLinearProbing::resolve_collision_for_write(
@@ -3313,39 +3387,46 @@ namespace LCompilers {
 
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
-        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, *module, key_asr_type);
-        llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
+        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type);
+        llvm::Value* pos = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), pos_ptr);
         llvm_utils->list_api->write_item(key_list, pos, key,
                                          key_asr_type, false, module, name2memidx);
         llvm_utils->list_api->write_item(value_list, pos, value,
                                          value_asr_type, false, module, name2memidx);
 
-        llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-            llvm_utils->create_ptr_gep(key_mask, pos));
+        llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context),
+            llvm_utils->create_ptr_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, pos));
         llvm::Value* is_slot_empty = builder->CreateICmpEQ(key_mask_value,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 0)));
         is_slot_empty = builder->CreateOr(is_slot_empty, builder->CreateICmpEQ(key_mask_value,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 3))));
         llvm::Value* occupancy_ptr = get_pointer_to_occupancy(dict);
         is_slot_empty = builder->CreateZExt(is_slot_empty, llvm::Type::getInt32Ty(context));
-        llvm::Value* occupancy = llvm_utils->CreateLoad(occupancy_ptr);
+        llvm::Value* occupancy = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), occupancy_ptr);
         LLVM::CreateStore(*builder, builder->CreateAdd(occupancy, is_slot_empty),
                           occupancy_ptr);
 
         llvm::Value* linear_prob_happened = builder->CreateICmpNE(key_hash, pos);
         linear_prob_happened = builder->CreateOr(linear_prob_happened,
             builder->CreateICmpEQ(
-                llvm_utils->CreateLoad(llvm_utils->create_ptr_gep(key_mask, key_hash)),
+                llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context),
+                    llvm_utils->create_ptr_gep2(
+                        llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, key_hash)),
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 2)
             ))
         );
         llvm::Value* set_max_2 = builder->CreateSelect(linear_prob_happened,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 2)),
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)));
-        LLVM::CreateStore(*builder, set_max_2, llvm_utils->create_ptr_gep(key_mask, key_hash));
-        LLVM::CreateStore(*builder, set_max_2, llvm_utils->create_ptr_gep(key_mask, pos));
+        LLVM::CreateStore(*builder, set_max_2, llvm_utils->create_ptr_gep2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, key_hash));
+        LLVM::CreateStore(*builder, set_max_2, llvm_utils->create_ptr_gep2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, pos));
     }
 
     void LLVMDictSeparateChaining::resolve_collision_for_write(
@@ -3388,14 +3469,19 @@ namespace LCompilers {
          *
          */
 
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
-        llvm::Value* key_value_pairs = llvm_utils->CreateLoad(get_pointer_to_key_value_pairs(dict));
-        llvm::Value* key_value_pair_linked_list = llvm_utils->create_ptr_gep(key_value_pairs, key_hash);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
+        llvm::Type* kv_pair_type = get_key_value_pair_type(key_asr_type, value_asr_type);
+        llvm::Value* key_value_pairs = llvm_utils->CreateLoad2(kv_pair_type->getPointerTo(), get_pointer_to_key_value_pairs(dict));
+        llvm::Value* key_value_pair_linked_list = llvm_utils->create_ptr_gep2(
+            kv_pair_type->getPointerTo(), key_value_pairs, key_hash);
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
         llvm::Type* kv_struct_type = get_key_value_pair_type(key_asr_type, value_asr_type);
         this->resolve_collision(capacity, key_hash, key, key_value_pair_linked_list,
-                                kv_struct_type, key_mask, *module, key_asr_type);
-        llvm::Value* kv_struct_i8 = llvm_utils->CreateLoad(chain_itr);
+                                kv_struct_type, key_mask, module, key_asr_type);
+        llvm::Value* kv_struct_i8 = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), chain_itr);
 
         llvm::Function *fn = builder->GetInsertBlock()->getParent();
         llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
@@ -3405,34 +3491,39 @@ namespace LCompilers {
             llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()));
         builder->CreateCondBr(do_insert, thenBB, elseBB);
 
+        llvm::Type* llvm_key_type = llvm_utils->get_type_from_ttype_t_util(key_asr_type, module);
+        llvm::Type* llvm_value_type = llvm_utils->get_type_from_ttype_t_util(value_asr_type, module);
         builder->SetInsertPoint(thenBB);
         {
             llvm_utils->create_if_else(builder->CreateICmpNE(
-                    llvm_utils->CreateLoad(chain_itr_prev),
+                    llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(), chain_itr_prev),
                     llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo())), [&]() {
                 llvm::DataLayout data_layout(module->getDataLayout());
                 size_t kv_struct_size = data_layout.getTypeAllocSize(kv_struct_type);
                 llvm::Value* malloc_size = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), kv_struct_size);
                 llvm::Value* new_kv_struct_i8 = LLVM::lfortran_malloc(context, *module, *builder, malloc_size);
                 llvm::Value* new_kv_struct = builder->CreateBitCast(new_kv_struct_i8, kv_struct_type->getPointerTo());
-                llvm_utils->deepcopy(key, llvm_utils->create_gep(new_kv_struct, 0), key_asr_type, module, name2memidx);
-                llvm_utils->deepcopy(value, llvm_utils->create_gep(new_kv_struct, 1), value_asr_type, module, name2memidx);
+                llvm_utils->deepcopy(key, llvm_utils->create_gep2(llvm_key_type, new_kv_struct, 0), key_asr_type, module, name2memidx);
+                llvm_utils->deepcopy(value, llvm_utils->create_gep2(llvm_value_type, new_kv_struct, 1), value_asr_type, module, name2memidx);
                 LLVM::CreateStore(*builder,
                     llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
-                    llvm_utils->create_gep(new_kv_struct, 2));
-                llvm::Value* kv_struct_prev_i8 = llvm_utils->CreateLoad(chain_itr_prev);
+                    llvm_utils->create_gep2(llvm::Type::getInt8Ty(context)->getPointerTo(), new_kv_struct, 2));
+                llvm::Value* kv_struct_prev_i8 = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(), chain_itr_prev);
                 llvm::Value* kv_struct_prev = builder->CreateBitCast(kv_struct_prev_i8, kv_struct_type->getPointerTo());
-                LLVM::CreateStore(*builder, new_kv_struct_i8, llvm_utils->create_gep(kv_struct_prev, 2));
+                LLVM::CreateStore(*builder, new_kv_struct_i8, llvm_utils->create_gep2(
+                    llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), kv_struct_prev, 2));
             }, [&]() {
-                llvm_utils->deepcopy(key, llvm_utils->create_gep(key_value_pair_linked_list, 0), key_asr_type, module, name2memidx);
-                llvm_utils->deepcopy(value, llvm_utils->create_gep(key_value_pair_linked_list, 1), value_asr_type, module, name2memidx);
+                llvm_utils->deepcopy(key, llvm_utils->create_gep2(llvm_key_type->getPointerTo(), key_value_pair_linked_list, 0), key_asr_type, module, name2memidx);
+                llvm_utils->deepcopy(value, llvm_utils->create_gep2(llvm_value_type->getPointerTo(), key_value_pair_linked_list, 1), value_asr_type, module, name2memidx);
                 LLVM::CreateStore(*builder,
                     llvm::ConstantPointerNull::get(llvm::Type::getInt8Ty(context)->getPointerTo()),
-                    llvm_utils->create_gep(key_value_pair_linked_list, 2));
+                    llvm_utils->create_gep2(
+                        llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), key_value_pair_linked_list, 2));
             });
 
             llvm::Value* occupancy_ptr = get_pointer_to_occupancy(dict);
-            llvm::Value* occupancy = llvm_utils->CreateLoad(occupancy_ptr);
+            llvm::Value* occupancy = llvm_utils->CreateLoad2(
+                llvm::Type::getInt32Ty(context), occupancy_ptr);
             occupancy = builder->CreateAdd(occupancy,
                 llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 1));
             LLVM::CreateStore(*builder, occupancy, occupancy_ptr);
@@ -3441,16 +3532,18 @@ namespace LCompilers {
         llvm_utils->start_new_block(elseBB);
         {
             llvm::Value* kv_struct = builder->CreateBitCast(kv_struct_i8, kv_struct_type->getPointerTo());
-            llvm_utils->deepcopy(key, llvm_utils->create_gep(kv_struct, 0), key_asr_type, module, name2memidx);
-            llvm_utils->deepcopy(value, llvm_utils->create_gep(kv_struct, 1), value_asr_type, module, name2memidx);
+            llvm_utils->deepcopy(key, llvm_utils->create_gep2(llvm_key_type->getPointerTo(), kv_struct, 0), key_asr_type, module, name2memidx);
+            llvm_utils->deepcopy(value, llvm_utils->create_gep2(llvm_value_type->getPointerTo(), kv_struct, 1), value_asr_type, module, name2memidx);
         }
         llvm_utils->start_new_block(mergeBB);
         llvm::Value* buckets_filled_ptr = get_pointer_to_number_of_filled_buckets(dict);
-        llvm::Value* key_mask_value_ptr = llvm_utils->create_ptr_gep(key_mask, key_hash);
-        llvm::Value* key_mask_value = llvm_utils->CreateLoad(key_mask_value_ptr);
+        llvm::Value* key_mask_value_ptr = llvm_utils->create_ptr_gep2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), key_mask, key_hash);
+        llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context), key_mask_value_ptr);
         llvm::Value* buckets_filled_delta = builder->CreateICmpEQ(key_mask_value,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 0)));
-        llvm::Value* buckets_filled = llvm_utils->CreateLoad(buckets_filled_ptr);
+        llvm::Value* buckets_filled = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), buckets_filled_ptr);
         buckets_filled = builder->CreateAdd(
             buckets_filled,
             builder->CreateZExt(buckets_filled_delta, llvm::Type::getInt32Ty(context))
@@ -3463,28 +3556,34 @@ namespace LCompilers {
 
     llvm::Value* LLVMDict::resolve_collision_for_read(
         llvm::Value* dict, llvm::Value* key_hash,
-        llvm::Value* key, llvm::Module& module,
+        llvm::Value* key, llvm::Module* module,
         ASR::ttype_t* key_asr_type, ASR::ttype_t* /*value_asr_type*/) {
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
         this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type, true);
-        llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+        llvm::Value* pos = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), pos_ptr);
         llvm::Value* item = llvm_utils->list_api->read_item(value_list, pos, false, module, true);
         return item;
     }
 
     llvm::Value* LLVMDict::resolve_collision_for_read_with_bound_check(
         llvm::Value* dict, llvm::Value* key_hash,
-        llvm::Value* key, llvm::Module& module,
+        llvm::Value* key, llvm::Module* module,
         ASR::ttype_t* key_asr_type, ASR::ttype_t* /*value_asr_type*/) {
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
         this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type, true);
-        llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+        llvm::Value* pos = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), pos_ptr);
         llvm::Value* is_key_matching = llvm_utils->is_equal_by_value(key,
             llvm_utils->list_api->read_item(key_list, pos, false, module,
                 LLVM::is_llvm_struct(key_asr_type)), module, key_asr_type);
@@ -3516,21 +3615,26 @@ namespace LCompilers {
                                                 false, module, false);
             LLVM::CreateStore(*builder, item, result);
         }, [=]() {
-            LLVM::CreateStore(*builder, llvm_utils->CreateLoad(def_value), result);
+            llvm::Type* llvm_value_type = llvm_utils->get_type_from_ttype_t_util(
+                value_asr_type, module);
+            LLVM::CreateStore(*builder, llvm_utils->CreateLoad2(llvm_value_type, def_value), result);
         });
     }
 
     llvm::Value* LLVMDict::resolve_collision_for_read_with_default(
         llvm::Value* dict, llvm::Value* key_hash,
-        llvm::Value* key, llvm::Module& module,
+        llvm::Value* key, llvm::Module* module,
         ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
         llvm::Value* def_value) {
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
         this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type, true);
-        llvm::Value* pos = llvm_utils->CreateLoad(pos_ptr);
+        llvm::Value* pos = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), pos_ptr);
         std::pair<std::string, std::string> llvm_key = std::make_pair(
             ASRUtils::get_type_code(key_asr_type),
             ASRUtils::get_type_code(value_asr_type)
@@ -3575,15 +3679,18 @@ namespace LCompilers {
 
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
-        llvm::Value* key_mask = llvm_utils->CreateLoad(get_pointer_to_keymask(dict));
-        llvm::Value* capacity = llvm_utils->CreateLoad(get_pointer_to_capacity(dict));
+        llvm::Value* key_mask = llvm_utils->CreateLoad2(
+            llvm::Type::getInt8Ty(context)->getPointerTo(), get_pointer_to_keymask(dict));
+        llvm::Value* capacity = llvm_utils->CreateLoad2(
+            llvm::Type::getInt32Ty(context), get_pointer_to_capacity(dict));
         pos_ptr = llvm_utils->CreateAlloca(llvm::Type::getInt32Ty(context));
         llvm::Function *fn = builder->GetInsertBlock()->getParent();
         llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
         llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
-        llvm::Value* key_mask_value = llvm_utils->CreateLoad(
-                                        llvm_utils->create_ptr_gep(key_mask, key_hash));
+        llvm::Type* llvm_key_type = llvm_utils->get_type_from_ttype_t_util(key_asr_type, module);
+        llvm::Value* key_mask_value = llvm_utils->CreateLoad2(llvm_key_type,
+            llvm_utils->create_ptr_gep2(llvm_key_type->getPointerTo(), key_mask, key_hash));
         llvm::Value* is_prob_not_neeeded = builder->CreateICmpEQ(key_mask_value,
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)));
         builder->CreateCondBr(is_prob_not_neeeded, thenBB, elseBB);

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1552,13 +1552,6 @@ namespace LCompilers {
         return LLVMUtils::CreateGEP(ds, idx_vec);
     }
 
-    llvm::Value* LLVMUtils::create_gep2(llvm::Type *t, llvm::Value* ds, int idx) {
-        std::vector<llvm::Value*> idx_vec = {
-        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
-        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
-        return LLVMUtils::CreateGEP2(t, ds, idx_vec);
-    }
-
     llvm::Value* LLVMUtils::create_gep(llvm::Value* ds, llvm::Value* idx) {
         std::vector<llvm::Value*> idx_vec = {
         llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
@@ -1566,7 +1559,28 @@ namespace LCompilers {
         return LLVMUtils::CreateGEP(ds, idx_vec);
     }
 
+    llvm::Value* LLVMUtils::create_gep2(llvm::Type *t, llvm::Value* ds, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        return LLVMUtils::CreateGEP2(t, ds, idx_vec);
+    }
+
     llvm::Value* LLVMUtils::create_gep2(llvm::Type *t, llvm::Value* ds, llvm::Value* idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        idx};
+        return LLVMUtils::CreateGEP2(t, ds, idx_vec);
+    }
+
+    llvm::Value* LLVMUtils::create_gep2(ASR::ttype_t *t, llvm::Value* ds, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        return LLVMUtils::CreateGEP2(t, ds, idx_vec);
+    }
+
+    llvm::Value* LLVMUtils::create_gep2(ASR::ttype_t *t, llvm::Value* ds, llvm::Value* idx) {
         std::vector<llvm::Value*> idx_vec = {
         llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
         idx};
@@ -1579,18 +1593,29 @@ namespace LCompilers {
         return LLVMUtils::CreateInBoundsGEP(ptr, idx_vec);
     }
 
+    llvm::Value* LLVMUtils::create_ptr_gep(llvm::Value* ptr, llvm::Value* idx) {
+        std::vector<llvm::Value*> idx_vec = {idx};
+        return LLVMUtils::CreateInBoundsGEP(ptr, idx_vec);
+    }
+
     llvm::Value* LLVMUtils::create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, int idx) {
         std::vector<llvm::Value*> idx_vec = {
         llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
         return LLVMUtils::CreateInBoundsGEP2(type, ptr, idx_vec);
     }
 
-    llvm::Value* LLVMUtils::create_ptr_gep(llvm::Value* ptr, llvm::Value* idx) {
-        std::vector<llvm::Value*> idx_vec = {idx};
-        return LLVMUtils::CreateInBoundsGEP(ptr, idx_vec);
+    llvm::Value* LLVMUtils::create_ptr_gep2(ASR::ttype_t* type, llvm::Value* ptr, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        return LLVMUtils::CreateInBoundsGEP2(type, ptr, idx_vec);
     }
 
     llvm::Value* LLVMUtils::create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, llvm::Value* idx) {
+        std::vector<llvm::Value*> idx_vec = {idx};
+        return LLVMUtils::CreateInBoundsGEP2(type, ptr, idx_vec);
+    }
+
+    llvm::Value* LLVMUtils::create_ptr_gep2(ASR::ttype_t* type, llvm::Value* ptr, llvm::Value* idx) {
         std::vector<llvm::Value*> idx_vec = {idx};
         return LLVMUtils::CreateInBoundsGEP2(type, ptr, idx_vec);
     }
@@ -1703,24 +1728,8 @@ namespace LCompilers {
     }
 
     llvm::Value* LLVMUtils::CreateLoad2(ASR::ttype_t *type, llvm::Value *x) {
-#if LLVM_VERSION_MAJOR <= 16
         llvm::Type* el_type = LLVMUtils::get_type_from_ttype_t_util(type, module);
         return builder->CreateLoad(el_type, x);
-#else
-        llvm::Type* el_type = LLVMUtils::get_type_from_ttype_t_util(
-            ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(
-            type)), module);
-        llvm::Type* el_type_copy = el_type;
-        bool is_llvm_ptr = LLVM::is_llvm_pointer(*type);
-        if (is_llvm_ptr && !ASRUtils::is_descriptorString(type)) {
-            el_type_copy = el_type_copy->getPointerTo();
-        }
-        llvm::Value* load = builder->CreateLoad(el_type_copy, x);
-        if (is_llvm_ptr) {
-            ptr_type[load] = el_type;
-        }
-        return load;
-#endif
     }
 
     llvm::Value* LLVMUtils::CreateGEP(llvm::Value *x,
@@ -1746,6 +1755,12 @@ namespace LCompilers {
         return builder->CreateGEP(t, x, idx);
     }
 
+    llvm::Value* LLVMUtils::CreateGEP2(ASR::ttype_t *t, llvm::Value *x,
+        std::vector<llvm::Value *> &idx) {
+        llvm::Type* t_ = get_type_from_ttype_t_util(t, module);
+        return builder->CreateGEP(t_, x, idx);
+    }
+
     llvm::Value* LLVMUtils::CreateGEP2(ASR::ttype_t *type,
             llvm::Value *x, int idx) {
         std::vector<llvm::Value*> idx_vec = {
@@ -1754,6 +1769,14 @@ namespace LCompilers {
         llvm::Type* llvm_type = LLVMUtils::get_type_from_ttype_t_util(type,
             module);
         return LLVMUtils::CreateGEP2(llvm_type, x, idx_vec);
+    }
+
+    llvm::Value* LLVMUtils::CreateGEP2(llvm::Type *type,
+        llvm::Value *x, int idx) {
+        std::vector<llvm::Value*> idx_vec = {
+        llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+        llvm::ConstantInt::get(context, llvm::APInt(32, idx))};
+        return LLVMUtils::CreateGEP2(type, x, idx_vec);
     }
 
     llvm::Value* LLVMUtils::CreateInBoundsGEP(llvm::Value *x,
@@ -1778,6 +1801,12 @@ namespace LCompilers {
             llvm::Value *x, std::vector<llvm::Value *> &idx) {
         return builder->CreateInBoundsGEP(t, x, idx);
     }
+
+    llvm::Value* LLVMUtils::CreateInBoundsGEP2(ASR::ttype_t *t,
+        llvm::Value *x, std::vector<llvm::Value *> &idx) {
+    llvm::Type* t_ = get_type_from_ttype_t_util(t, module);
+    return builder->CreateInBoundsGEP(t_, x, idx);
+}
 
     llvm::Type* LLVMUtils::getIntType(int a_kind, bool get_pointer) {
         llvm::Type* type_ptr = nullptr;

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -268,30 +268,38 @@ namespace LCompilers {
                 std::map<llvm::Value *, llvm::Type *> &ptr_type_);
 
             llvm::Value* create_gep(llvm::Value* ds, int idx);
-
-            llvm::Value* create_gep2(llvm::Type *t, llvm::Value* ds, int idx);
-
             llvm::Value* create_gep(llvm::Value* ds, llvm::Value* idx);
 
             llvm::Value* create_gep2(llvm::Type *t, llvm::Value* ds, llvm::Value* idx);
+            llvm::Value* create_gep2(llvm::Type *t, llvm::Value* ds, int idx);
+            llvm::Value* create_gep2(ASR::ttype_t *t, llvm::Value* ds, int idx);
+            llvm::Value* create_gep2(ASR::ttype_t *t, llvm::Value* ds, llvm::Value* idx);
 
             llvm::Value* create_ptr_gep(llvm::Value* ptr, int idx);
-
-            llvm::Value* create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, int idx);
-
             llvm::Value* create_ptr_gep(llvm::Value* ptr, llvm::Value* idx);
 
+            llvm::Value* create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, int idx);
             llvm::Value* create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, llvm::Value* idx);
+            llvm::Value* create_ptr_gep2(ASR::ttype_t* type, llvm::Value* ptr, int idx);
+            llvm::Value* create_ptr_gep2(ASR::ttype_t* type, llvm::Value* ptr, llvm::Value* idx);
 
             llvm::Value* CreateLoad(llvm::Value *x);
+
             llvm::Value* CreateLoad2(llvm::Type *t, llvm::Value *x);
             llvm::Value* CreateLoad2(ASR::ttype_t *type, llvm::Value *x);
+
             llvm::Value* CreateGEP(llvm::Value *x, std::vector<llvm::Value *> &idx);
             llvm::Value* CreateGEP2(llvm::Type *t, llvm::Value *x,
                 std::vector<llvm::Value *> &idx);
+            llvm::Value* CreateGEP2(llvm::Type *type, llvm::Value *x, int idx);
             llvm::Value* CreateGEP2(ASR::ttype_t *type, llvm::Value *x, int idx);
+            llvm::Value* CreateGEP2(ASR::ttype_t *t, llvm::Value *x,
+                std::vector<llvm::Value *> &idx);
+
             llvm::Value* CreateInBoundsGEP(llvm::Value *x, std::vector<llvm::Value *> &idx);
             llvm::Value* CreateInBoundsGEP2(llvm::Type *t, llvm::Value *x,
+                std::vector<llvm::Value *> &idx);
+            llvm::Value* CreateInBoundsGEP2(ASR::ttype_t *t, llvm::Value *x,
                 std::vector<llvm::Value *> &idx);
 
             llvm::AllocaInst* CreateAlloca(llvm::Type* type,

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -83,7 +83,7 @@ namespace LCompilers {
         if (!fn_printf) {
             llvm::FunctionType *function_type = llvm::FunctionType::get(
                     llvm::Type::getInt8Ty(context)->getPointerTo(),
-                    {llvm::Type::getInt8Ty(context)->getPointerTo(), 
+                    {llvm::Type::getInt8Ty(context)->getPointerTo(),
                     llvm::Type::getInt8Ty(context)->getPointerTo(),
                     llvm::Type::getInt32Ty(context)}, true);
             fn_printf = llvm::Function::Create(function_type,
@@ -94,14 +94,14 @@ namespace LCompilers {
 
     static inline llvm::Value* lfortran_str_copy(llvm::Value* dest, llvm::Value *src, bool is_allocatable,
         llvm::Module &module, llvm::IRBuilder<> &builder, llvm::LLVMContext &context, llvm::Type* string_descriptor ) {
-        if(!is_allocatable){ 
+        if(!is_allocatable){
             std::string runtime_func_name = "_lfortran_strcpy_pointer_string";
             llvm::Function *fn = module.getFunction(runtime_func_name);
             if (!fn) {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
                         llvm::Type::getVoidTy(context),
                         {
-                            llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), 
+                            llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(),
                             llvm::Type::getInt8Ty(context)->getPointerTo()
                         }, false);
                 fn = llvm::Function::Create(function_type,
@@ -127,7 +127,7 @@ namespace LCompilers {
                 llvm::FunctionType *function_type = llvm::FunctionType::get(
                         llvm::Type::getVoidTy(context),
                         {
-                            llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(), 
+                            llvm::Type::getInt8Ty(context)->getPointerTo()->getPointerTo(),
                             llvm::Type::getInt8Ty(context)->getPointerTo(),
                             llvm::Type::getInt64Ty(context)->getPointerTo(),
                             llvm::Type::getInt64Ty(context)->getPointerTo()
@@ -137,7 +137,7 @@ namespace LCompilers {
             }
             return builder.CreateCall(fn, {dest_char_ptr, src_char_ptr, string_size, string_capacity});
         }
-        
+
     }
 
     static inline void print_error(llvm::LLVMContext &context, llvm::Module &module,

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -323,23 +323,23 @@ namespace LCompilers {
 
             /*
              * Allocate heap memory for string.
-             * Fill string with empty characters. 
+             * Fill string with empty characters.
             */
             void initialize_string_heap(llvm::Value* str, llvm::Value* len);
             void initialize_string_heap(llvm::Value* str, int64_t len);
 
             /*
              * Allocate stack memory for string.
-             * Fill string with empty characters. 
+             * Fill string with empty characters.
             */
             void initialize_string_stack(llvm::Value* str, llvm::Value* len){(void)str;(void)len;throw LCompilersException("Not Implemented Yet");};
             void initialize_string_stack(llvm::Value* str, int64_t len){(void)str;(void)len;throw LCompilersException("Not Implemented Yet");};
 
             llvm::Value* is_equal_by_value(llvm::Value* left, llvm::Value* right,
-                                           llvm::Module& module, ASR::ttype_t* asr_type);
+                                           llvm::Module* module, ASR::ttype_t* asr_type);
 
             llvm::Value* is_ineq_by_value(llvm::Value* left, llvm::Value* right,
-                                          llvm::Module& module, ASR::ttype_t* asr_type,
+                                          llvm::Module* module, ASR::ttype_t* asr_type,
                                           int8_t overload_id, ASR::ttype_t* int32_type=nullptr);
 
             void set_module(llvm::Module* module_);
@@ -463,11 +463,11 @@ namespace LCompilers {
                                         int32_t type_size);
 
             void list_init(std::string& type_code, llvm::Value* list,
-                           llvm::Module& module, llvm::Value* initial_capacity,
+                           llvm::Module* module, llvm::Value* initial_capacity,
                            llvm::Value* n);
 
             void list_init(std::string& type_code, llvm::Value* list,
-                            llvm::Module& module, int32_t initial_capacity=1,
+                            llvm::Module* module, int32_t initial_capacity=1,
                             int32_t n=0);
 
             llvm::Value* get_pointer_to_list_data(llvm::Value* list);
@@ -486,12 +486,12 @@ namespace LCompilers {
 
             llvm::Value* read_item(llvm::Value* list, llvm::Value* pos,
                                    bool enable_bounds_checking,
-                                   llvm::Module& module, bool get_pointer=false);
+                                   llvm::Module* module, bool get_pointer=false);
 
             llvm::Value* len(llvm::Value* list);
 
             void check_index_within_bounds(llvm::Value* list, llvm::Value* pos,
-                                           llvm::Module& module);
+                                           llvm::Module* module);
 
             void write_item(llvm::Value* list, llvm::Value* pos,
                 llvm::Value* item, ASR::ttype_t* asr_type,
@@ -500,7 +500,7 @@ namespace LCompilers {
 
             void write_item(llvm::Value* list, llvm::Value* pos,
                             llvm::Value* item, bool enable_bounds_checking,
-                            llvm::Module& module);
+                            llvm::Module* module);
 
             void append(llvm::Value* list, llvm::Value* item,
                         ASR::ttype_t* asr_type, llvm::Module* module,
@@ -515,38 +515,38 @@ namespace LCompilers {
                          ASR::ttype_t* asr_type, llvm::Module* module);
 
             void remove(llvm::Value* list, llvm::Value* item,
-                        ASR::ttype_t* item_type, llvm::Module& module);
+                        ASR::ttype_t* item_type, llvm::Module* module);
 
             llvm::Value* pop_position(llvm::Value* list, llvm::Value* pos,
                                       ASR::ttype_t* list_type, llvm::Module* module,
                                       std::map<std::string, std::map<std::string, int>>& name2memidx);
 
-            llvm::Value* pop_last(llvm::Value* list, ASR::ttype_t* list_type, llvm::Module& module);
+            llvm::Value* pop_last(llvm::Value* list, ASR::ttype_t* list_type, llvm::Module* module);
 
             void list_clear(llvm::Value* list);
 
-            void reverse(llvm::Value* list, llvm::Module& module);
+            void reverse(llvm::Value* list, llvm::Module* module);
 
             llvm::Value* find_item_position(llvm::Value* list,
                 llvm::Value* item, ASR::ttype_t* item_type,
-                llvm::Module& module, llvm::Value* start=nullptr,
+                llvm::Module* module, llvm::Value* start=nullptr,
                 llvm::Value* end=nullptr);
 
             llvm::Value* index(llvm::Value* list, llvm::Value* item,
                                 llvm::Value* start, llvm::Value* end,
-                                ASR::ttype_t* item_type, llvm::Module& module);
+                                ASR::ttype_t* item_type, llvm::Module* module);
 
             llvm::Value* count(llvm::Value* list, llvm::Value* item,
-                                ASR::ttype_t* item_type, llvm::Module& module);
+                                ASR::ttype_t* item_type, llvm::Module* module);
 
-            void free_data(llvm::Value* list, llvm::Module& module);
+            void free_data(llvm::Value* list, llvm::Module* module);
 
             llvm::Value* check_list_equality(llvm::Value* l1, llvm::Value* l2, ASR::ttype_t *item_type,
-                llvm::LLVMContext& context, llvm::IRBuilder<>* builder, llvm::Module& module);
+                llvm::LLVMContext& context, llvm::IRBuilder<>* builder, llvm::Module* module);
 
             llvm::Value* check_list_inequality(llvm::Value* l1, llvm::Value* l2,
                 ASR::ttype_t *item_type, llvm::LLVMContext& context,
-                llvm::IRBuilder<>* builder, llvm::Module& module,
+                llvm::IRBuilder<>* builder, llvm::Module* module,
                 int8_t overload_id, ASR::ttype_t* int32_type=nullptr);
 
             void list_repeat_copy(llvm::Value* repeat_list, llvm::Value* init_list,
@@ -588,15 +588,15 @@ namespace LCompilers {
 
             llvm::Value* check_tuple_equality(llvm::Value* t1, llvm::Value* t2,
                 ASR::Tuple_t* tuple_type, llvm::LLVMContext& context,
-                llvm::IRBuilder<>* builder, llvm::Module& module);
+                llvm::IRBuilder<>* builder, llvm::Module* module);
 
             llvm::Value* check_tuple_inequality(llvm::Value* t1, llvm::Value* t2,
                 ASR::Tuple_t* tuple_type, llvm::LLVMContext& context,
-                llvm::IRBuilder<>* builder, llvm::Module& module, int8_t overload_id);
+                llvm::IRBuilder<>* builder, llvm::Module* module, int8_t overload_id);
 
             void concat(llvm::Value* t1, llvm::Value* t2, ASR::Tuple_t* tuple_type_1,
                         ASR::Tuple_t* tuple_type_2, llvm::Value* concat_tuple,
-                        ASR::Tuple_t* concat_tuple_type, llvm::Module& module,
+                        ASR::Tuple_t* concat_tuple_type, llvm::Module* module,
                         std::map<std::string, std::map<std::string, int>>& name2memidx);
     };
 
@@ -652,7 +652,7 @@ namespace LCompilers {
 
             virtual
             llvm::Value* get_key_hash(llvm::Value* capacity, llvm::Value* key,
-                ASR::ttype_t* key_asr_type, llvm::Module& module);
+                ASR::ttype_t* key_asr_type, llvm::Module* module);
 
             virtual
             void resolve_collision_for_write(llvm::Value* dict, llvm::Value* key_hash,
@@ -663,17 +663,17 @@ namespace LCompilers {
 
             virtual
             llvm::Value* resolve_collision_for_read(llvm::Value* dict, llvm::Value* key_hash,
-                llvm::Value* key, llvm::Module& module,
+                llvm::Value* key, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type) = 0;
 
             virtual
             llvm::Value* resolve_collision_for_read_with_bound_check(llvm::Value* dict, llvm::Value* key_hash,
-                llvm::Value* key, llvm::Module& module,
+                llvm::Value* key, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type) = 0;
 
             virtual
             llvm::Value* resolve_collision_for_read_with_default(llvm::Value* dict, llvm::Value* key_hash,
-                llvm::Value* key, llvm::Module& module,
+                llvm::Value* key, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type, llvm::Value* def_value) = 0;
 
             virtual
@@ -696,17 +696,17 @@ namespace LCompilers {
 
             virtual
             llvm::Value* read_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Module& module, ASR::Dict_t* dict_type, bool enable_bounds_checking,
+                llvm::Module* module, ASR::Dict_t* dict_type, bool enable_bounds_checking,
                 bool get_pointer=false) = 0;
 
             virtual
             llvm::Value* get_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Module& module, ASR::Dict_t* dict_type, llvm::Value* def_value,
+                llvm::Module* module, ASR::Dict_t* dict_type, llvm::Value* def_value,
                 bool get_pointer=false) = 0;
 
             virtual
             llvm::Value* pop_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Module& module, ASR::Dict_t* dict_type,
+                llvm::Module* module, ASR::Dict_t* dict_type,
                 bool get_pointer=false) = 0;
 
 
@@ -727,7 +727,7 @@ namespace LCompilers {
             virtual
             void get_elements_list(llvm::Value* dict,
                 llvm::Value* elements_list, ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type, llvm::Module& module,
+                ASR::ttype_t* value_asr_type, llvm::Module* module,
                 std::map<std::string, std::map<std::string, int>>& name2memidx,
                 bool key_or_value) = 0;
 
@@ -761,7 +761,7 @@ namespace LCompilers {
             virtual
             void resolve_collision(llvm::Value* capacity, llvm::Value* key_hash,
                                 llvm::Value* key, llvm::Value* key_list,
-                                llvm::Value* key_mask, llvm::Module& module,
+                                llvm::Value* key_mask, llvm::Module* module,
                                 ASR::ttype_t* key_asr_type, bool for_read=false);
 
             void resolve_collision_for_write(llvm::Value* dict, llvm::Value* key_hash,
@@ -770,20 +770,20 @@ namespace LCompilers {
                                           ASR::ttype_t* value_asr_type,
                                           std::map<std::string, std::map<std::string, int>>& name2memidx);
 
-            void _check_key_present_or_default(llvm::Module& module, llvm::Value *key, llvm::Value *key_list,
-                ASR::ttype_t* key_asr_type, llvm::Value *value_list, llvm::Value *pos,
+            void _check_key_present_or_default(llvm::Module* module, llvm::Value *key, llvm::Value *key_list,
+                ASR::ttype_t* key_asr_type, llvm::Value *value_list, ASR::ttype_t* value_asr_type, llvm::Value *pos,
                 llvm::Value *def_value, llvm::Value* &result);
 
             llvm::Value* resolve_collision_for_read(llvm::Value* dict, llvm::Value* key_hash,
-                                                 llvm::Value* key, llvm::Module& module,
+                                                 llvm::Value* key, llvm::Module* module,
                                                  ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read_with_bound_check(llvm::Value* dict, llvm::Value* key_hash,
-                                                 llvm::Value* key, llvm::Module& module,
+                                                 llvm::Value* key, llvm::Module* module,
                                                  ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read_with_default(llvm::Value* dict, llvm::Value* key_hash,
-                                                 llvm::Value* key, llvm::Module& module,
+                                                 llvm::Value* key, llvm::Module* module,
                                                  ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
                                                  llvm::Value* def_value);
 
@@ -798,15 +798,15 @@ namespace LCompilers {
                                               std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             llvm::Value* read_item(llvm::Value* dict, llvm::Value* key,
-                                   llvm::Module& module, ASR::Dict_t* key_asr_type, bool enable_bounds_checking,
+                                   llvm::Module* module, ASR::Dict_t* key_asr_type, bool enable_bounds_checking,
                                    bool get_pointer=false);
 
             llvm::Value* get_item(llvm::Value* dict, llvm::Value* key,
-                                   llvm::Module& module, ASR::Dict_t* key_asr_type, llvm::Value* def_value,
+                                   llvm::Module* module, ASR::Dict_t* key_asr_type, llvm::Value* def_value,
                                    bool get_pointer=false);
 
             llvm::Value* pop_item(llvm::Value* dict, llvm::Value* key,
-                                   llvm::Module& module, ASR::Dict_t* dict_type,
+                                   llvm::Module* module, ASR::Dict_t* dict_type,
                                    bool get_pointer=false);
 
             virtual
@@ -820,7 +820,7 @@ namespace LCompilers {
 
             void get_elements_list(llvm::Value* dict,
                 llvm::Value* elements_list, ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type, llvm::Module& module,
+                ASR::ttype_t* value_asr_type, llvm::Module* module,
                 std::map<std::string, std::map<std::string, int>>& name2memidx,
                 bool key_or_value);
 
@@ -837,7 +837,7 @@ namespace LCompilers {
 
             void resolve_collision(llvm::Value* capacity, llvm::Value* key_hash,
                                 llvm::Value* key, llvm::Value* key_list,
-                                llvm::Value* key_mask, llvm::Module& module,
+                                llvm::Value* key_mask, llvm::Module* module,
                                 ASR::ttype_t* key_asr_type, bool for_read=false);
 
             void resolve_collision_for_write(llvm::Value* dict, llvm::Value* key_hash,
@@ -847,15 +847,15 @@ namespace LCompilers {
                                             std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             llvm::Value* resolve_collision_for_read(llvm::Value* dict, llvm::Value* key_hash,
-                                                    llvm::Value* key, llvm::Module& module,
+                                                    llvm::Value* key, llvm::Module* module,
                                                     ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read_with_bound_check(llvm::Value* dict, llvm::Value* key_hash,
-                                                    llvm::Value* key, llvm::Module& module,
+                                                    llvm::Value* key, llvm::Module* module,
                                                     ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read_with_default(llvm::Value* dict, llvm::Value* key_hash,
-                                                    llvm::Value* key, llvm::Module& module,
+                                                    llvm::Value* key, llvm::Module* module,
                                                     ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
                                                     llvm::Value *def_value);
 
@@ -886,7 +886,7 @@ namespace LCompilers {
             void resolve_collision(llvm::Value* capacity, llvm::Value* key_hash,
                 llvm::Value* key, llvm::Value* key_value_pair_linked_list,
                 llvm::Type* kv_pair_type, llvm::Value* key_mask,
-                llvm::Module& module, ASR::ttype_t* key_asr_type);
+                llvm::Module* module, ASR::ttype_t* key_asr_type);
 
             llvm::Type* get_key_value_pair_type(std::string key_type_code, std::string value_type_code);
 
@@ -924,15 +924,15 @@ namespace LCompilers {
                 std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             llvm::Value* resolve_collision_for_read(llvm::Value* dict, llvm::Value* key_hash,
-                llvm::Value* key, llvm::Module& module,
+                llvm::Value* key, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read_with_bound_check(llvm::Value* dict, llvm::Value* key_hash,
-                llvm::Value* key, llvm::Module& module,
+                llvm::Value* key, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read_with_default(llvm::Value* dict, llvm::Value* key_hash,
-                llvm::Value* key, llvm::Module& module,
+                llvm::Value* key, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
                 llvm::Value* def_value);
 
@@ -947,15 +947,15 @@ namespace LCompilers {
                 std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             llvm::Value* read_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Module& module, ASR::Dict_t* dict_type, bool enable_bounds_checking,
+                llvm::Module* module, ASR::Dict_t* dict_type, bool enable_bounds_checking,
                 bool get_pointer=false);
 
             llvm::Value* get_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Module& module, ASR::Dict_t* dict_type, llvm::Value* def_value,
+                llvm::Module* module, ASR::Dict_t* dict_type, llvm::Value* def_value,
                 bool get_pointer=false);
 
             llvm::Value* pop_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Module& module, ASR::Dict_t* dict_type,
+                llvm::Module* module, ASR::Dict_t* dict_type,
                 bool get_pointer=false);
 
             llvm::Value* get_pointer_to_keymask(llvm::Value* dict);
@@ -968,7 +968,7 @@ namespace LCompilers {
 
             void get_elements_list(llvm::Value* dict,
                 llvm::Value* elements_list, ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type, llvm::Module& module,
+                ASR::ttype_t* value_asr_type, llvm::Module* module,
                 std::map<std::string, std::map<std::string, int>>& name2memidx,
                 bool key_or_value);
 
@@ -1020,7 +1020,7 @@ namespace LCompilers {
             llvm::Value* get_pointer_to_capacity(llvm::Value* set) = 0;
 
             llvm::Value* get_el_hash(llvm::Value* capacity, llvm::Value* el,
-                ASR::ttype_t* el_asr_type, llvm::Module& module);
+                ASR::ttype_t* el_asr_type, llvm::Module* module);
 
             virtual
             void resolve_collision_for_write(
@@ -1047,12 +1047,12 @@ namespace LCompilers {
             virtual
             void resolve_collision_for_read_with_bound_check(
                 llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
-                llvm::Module& module, ASR::ttype_t* el_asr_type) = 0;
+                llvm::Module* module, ASR::ttype_t* el_asr_type) = 0;
 
             virtual
             void remove_item(
                 llvm::Value* set, llvm::Value* el,
-                llvm::Module& module, ASR::ttype_t* el_asr_type) = 0;
+                llvm::Module* module, ASR::ttype_t* el_asr_type) = 0;
 
             virtual
             void set_deepcopy(
@@ -1100,7 +1100,7 @@ namespace LCompilers {
             void resolve_collision(
                 llvm::Value* capacity, llvm::Value* el_hash,
                 llvm::Value* el, llvm::Value* el_list,
-                llvm::Value* el_mask, llvm::Module& module,
+                llvm::Value* el_mask, llvm::Module* module,
                 ASR::ttype_t* el_asr_type, bool for_read=false);
 
             void resolve_collision_for_write(
@@ -1118,11 +1118,11 @@ namespace LCompilers {
 
             void resolve_collision_for_read_with_bound_check(
                 llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
-                llvm::Module& module, ASR::ttype_t* el_asr_type);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void remove_item(
                 llvm::Value* set, llvm::Value* el,
-                llvm::Module& module, ASR::ttype_t* el_asr_type);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void set_deepcopy(
                 llvm::Value* src, llvm::Value* dest,
@@ -1150,7 +1150,7 @@ namespace LCompilers {
             void resolve_collision(
                 llvm::Value* el_hash, llvm::Value* el, llvm::Value* el_linked_list,
                 llvm::Type* el_struct_type, llvm::Value* el_mask,
-                llvm::Module& module, ASR::ttype_t* el_asr_type);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void write_el_linked_list(
                 llvm::Value* el_ll, llvm::Value* set, llvm::Value* capacity,
@@ -1199,11 +1199,11 @@ namespace LCompilers {
 
             void resolve_collision_for_read_with_bound_check(
                 llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
-                llvm::Module& module, ASR::ttype_t* el_asr_type);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void remove_item(
                 llvm::Value* set, llvm::Value* el,
-                llvm::Module& module, ASR::ttype_t* el_asr_type);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void set_deepcopy(
                 llvm::Value* src, llvm::Value* dest,


### PR DESCRIPTION
Signatures have been updated for the above functions. However full replacement hasn't happened yet. I plan to do it in parts because, there are 600-700 places to be updated. So for now, `ptr_type` map will be there but will be removed eventually.