### PR TITLE
fix: bitcast complex_type_4 to an array of size 2 float

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9396,8 +9396,11 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                                                     tmp = llvm_utils->CreateLoad2(type_fx2, tmp);
                                                 } else if (compiler_options.platform == Platform::macOS_ARM) {
                                                     // tmp is {float, float}*
-                                                    llvm::Type* type_fx2 = complex_type_4;
-                                                    tmp = llvm_utils->CreateLoad2(type_fx2, tmp);
+                                                    // type_fx2 is [2 x float]
+                                                    llvm::Type* type_fx2 = llvm::ArrayType::get(llvm::Type::getFloatTy(context), 2);
+                                                    // we bitcast complex_type_4 to [2 x float]*
+                                                    llvm::Value *complex_as_array_ptr = builder->CreateBitCast(tmp, type_fx2->getPointerTo());
+                                                    tmp = llvm_utils->CreateLoad2(type_fx2, complex_as_array_ptr);
                                                 } else {
                                                     // tmp is {float, float}*
                                                     // type_fx2 is <2 x float>

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -707,7 +707,9 @@ namespace LCompilers {
                                 llvm::Type* type_fx2 = llvm::Type::getInt64Ty(context);
                                 type = type_fx2;
                             } else if (compiler_options.platform == Platform::macOS_ARM) {
-                                type = getComplexType(a_kind, false);
+                                // type_fx2 is [2 x float]
+                                llvm::Type* type_fx2 = llvm::ArrayType::get(llvm::Type::getFloatTy(context), 2);
+                                type = type_fx2;
                             } else {
                                 // type_fx2 is <2 x float>
                                 llvm::Type* type_fx2 = FIXED_VECTOR_TYPE::get(llvm::Type::getFloatTy(context), 2);


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7082

I'll move the PR first to draft mode to understand, whether the `--fast` test continue to pass or not with these changes on our CI.


With these changes, all the failing integration tests with `--fast` mentioned to be failing here: https://github.com/lfortran/lfortran/issues/7082#issue-3022886116, now pass on my machine locally.