### PR TITLE
Adds additional layers of timeouts to prevent LSP bugs from blocking the pipeline

### DIFF
--- a/.github/workflows/LSP.yml
+++ b/.github/workflows/LSP.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Test (Linux / macOS)
         shell: bash -e -l {0}
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        timeout-minutes: 5
         run: |
             case "$OSTYPE" in darwin*) export MACOS=1;; *) export MACOS=0;; esac
             export LFORTRAN_TEST_ENV_VAR='STATUS OK!'

--- a/ci/test_lsp.sh
+++ b/ci/test_lsp.sh
@@ -14,6 +14,6 @@ if [[ $WIN != "1" ]]; then
     # `--capture` as follows:
     # --------------------------------------------------------------------------
     # pytest -vv --showlocals --capture=no --timeout=10 tests/server
-    pytest -vv --showlocals --timeout=10 --execution-strategy="concurrent" tests/server
-    pytest -vv --showlocals --timeout=10 --execution-strategy="parallel" tests/server
+    timeout -k 10 60s pytest -vv --showlocals --timeout=10 --execution-strategy="concurrent" tests/server
+    timeout -k 10 60s pytest -vv --showlocals --timeout=10 --execution-strategy="parallel" tests/server
 fi


### PR DESCRIPTION
Adds the following levels of timeouts:
1. `pytest` is run with `timeout` which will send it a `SIGTERM` after 60 seconds and a `SIGKILL` 10 seconds later (if it hasn't terminated).
2. The whole step is run with a timeout of 5 minutes. Github will kill the process after 5 minutes if it has not terminated.