### PR TITLE
Raise `SemanticError` in `allocate` if array has no dimensions specified

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -426,7 +426,7 @@ public:
                             Label("",{x.base.base.loc})
                         }));
                     throw SemanticAbort();
-                } 
+                }
             } else if (m_arg_str == std::string("iomsg")) {
                 if( a_iomsg != nullptr ) {
                     diag.add(Diagnostic(
@@ -457,7 +457,7 @@ public:
                 }
                 if(ASRUtils::is_descriptorString(ASRUtils::expr_type(a_iomsg))) {
                     a_iomsg = ASRUtils::cast_string_descriptor_to_pointer(al, a_iomsg);
-                } 
+                }
             } else {
                 const std::unordered_set<std::string> unsupported_args {"err", "blank", "recl", "fileopt", "action", "position", "pad"};
                 if (unsupported_args.find(m_arg_str) == unsupported_args.end()) {
@@ -3249,7 +3249,7 @@ public:
                         ASR::ArrayReshape_t* array_reshape = ASR::down_cast<ASR::ArrayReshape_t>(value);
                         if (ASR::is_a<ASR::ArrayConstructor_t>(*array_reshape->m_array) && ASR::is_a<ASR::ImpliedDoLoop_t>(**ASR::down_cast<ASR::ArrayConstructor_t>(array_reshape->m_array)->m_args)) {
                             ASR::Array_t* array_reshape_array_type = ASR::down_cast<ASR::Array_t>(array_reshape->m_type);
-                            Vec<ASR::dimension_t> array_reshape_dims; 
+                            Vec<ASR::dimension_t> array_reshape_dims;
                             array_reshape_dims.reserve(al, array_reshape_array_type->n_dims);
                             for (size_t i=0;i<array_reshape_array_type->n_dims;i++) {
                                 array_reshape_dims.push_back(al, array_reshape_array_type->m_dims[i]);

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1576,18 +1576,6 @@ public:
             throw SemanticAbort();
         }
 
-        for( size_t i = 0; i < x.n_args; i++ ) {
-            if( ASRUtils::is_array(ASRUtils::expr_type(alloc_args_vec.p[i].m_a)) &&
-                alloc_args_vec.p[i].n_dims == 0 ) {
-                diag.add(Diagnostic(
-                    "Allocate for arrays should have dimensions specified, "
-                    "found only array variable with no dimensions",
-                    Level::Error, Stage::Semantic, {
-                        Label("Array specification required in allocate statement", {alloc_args_vec.p[i].m_a->base.loc})
-                    }));
-                throw SemanticAbort();
-            }
-        }
         tmp = ASR::make_Allocate_t(al, x.base.base.loc,
                                     alloc_args_vec.p, alloc_args_vec.size(),
                                     stat, errmsg, source);
@@ -1662,6 +1650,19 @@ public:
                 current_body->push_back(al, assign);
             }
             tmp = nullptr;   // Doing it nullptr as we have already pushed allocate
+        } else {
+            for( size_t i = 0; i < x.n_args; i++ ) {
+                if( ASRUtils::is_array(ASRUtils::expr_type(alloc_args_vec.p[i].m_a)) &&
+                    alloc_args_vec.p[i].n_dims == 0 ) {
+                    diag.add(Diagnostic(
+                        "Allocate for arrays should have dimensions specified, "
+                        "found only array variable with no dimensions",
+                        Level::Error, Stage::Semantic, {
+                            Label("Array specification required in allocate statement", {alloc_args_vec.p[i].m_a->base.loc})
+                        }));
+                    throw SemanticAbort();
+                }
+            }
         }
     }
 

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1576,6 +1576,18 @@ public:
             throw SemanticAbort();
         }
 
+        for( size_t i = 0; i < x.n_args; i++ ) {
+            if( ASRUtils::is_array(ASRUtils::expr_type(alloc_args_vec.p[i].m_a)) &&
+                alloc_args_vec.p[i].n_dims == 0 ) {
+                diag.add(Diagnostic(
+                    "Allocate for arrays should have dimensions specified, "
+                    "found only array variable with no dimensions",
+                    Level::Error, Stage::Semantic, {
+                        Label("Array specification required in allocate statement", {alloc_args_vec.p[i].m_a->base.loc})
+                    }));
+                throw SemanticAbort();
+            }
+        }
         tmp = ASR::make_Allocate_t(al, x.base.base.loc,
                                     alloc_args_vec.p, alloc_args_vec.size(),
                                     stat, errmsg, source);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2802,17 +2802,17 @@ public:
 
     bool is_declaration_depending_on_unresolved_genericProcedure_call(const AST::Declaration_t &x){
        if(generic_procedures.empty()) return false;
-        /*  
-            Check for generic procedure call in the dimension attribute 
-            e.g. : `integer, DIMENSION(func_generic(),20) :: arr` 
+        /*
+            Check for generic procedure call in the dimension attribute
+            e.g. : `integer, DIMENSION(func_generic(),20) :: arr`
         */
         for(size_t i = 0; i < x.n_attributes; i++){
             if(AST::is_a<AST::AttrDimension_t>(*x.m_attributes[i])){
                 AST::AttrDimension_t* attr_dim = AST::down_cast<AST::AttrDimension_t>(x.m_attributes[i]);
                 for(size_t j = 0; j< attr_dim->n_dim; j++){
                     for(AST::expr_t* dim_expr : {attr_dim->m_dim[j].m_start, attr_dim->m_dim[j].m_end}){
-                        if( dim_expr && 
-                            dim_expr->type == AST::exprType::FuncCallOrArray && 
+                        if( dim_expr &&
+                            dim_expr->type == AST::exprType::FuncCallOrArray &&
                             generic_procedures.find(
                                 (AST::down_cast<AST::FuncCallOrArray_t>(dim_expr)->m_func))
                             != generic_procedures.end()){
@@ -2831,7 +2831,7 @@ public:
             for(size_t j = 0 ; j < s.n_dim; j++){
                 for(AST::expr_t* dim_expr : {s.m_dim[j].m_start, s.m_dim[j].m_end}){
                     if( dim_expr &&
-                        dim_expr->type == AST::exprType::FuncCallOrArray && 
+                        dim_expr->type == AST::exprType::FuncCallOrArray &&
                         generic_procedures.find(
                             (AST::down_cast<AST::FuncCallOrArray_t>(dim_expr)->m_func))
                         != generic_procedures.end()){

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1281,17 +1281,18 @@ public:
                     "Allocate should only be called with  Allocatable or Pointer type inputs, found " +
                     std::string(ASRUtils::get_type_code(ASRUtils::expr_type(x.m_args[i].m_a))));
             }
-        }
 
-        if( x.m_source == nullptr ) {
-            for( size_t i = 0; i < x.n_args; i++ ) {
-                if( ASRUtils::is_array(ASRUtils::expr_type(x.m_args[i].m_a)) ) {
-                    require(x.m_args[i].n_dims > 0,
-                        "Allocate for arrays should have dimensions specified, "
-                        "found only array variable with no dimensions");
+            if( x.m_source == nullptr ) {
+                for( size_t i = 0; i < x.n_args; i++ ) {
+                    if( ASRUtils::is_array(ASRUtils::expr_type(x.m_args[i].m_a)) ) {
+                        require(x.m_args[i].n_dims > 0,
+                            "Allocate for arrays should have dimensions specified, "
+                            "found only array variable with no dimensions");
+                    }
                 }
             }
         }
+
         BaseWalkVisitor<VerifyVisitor>::visit_Allocate(x);
     }
 

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1282,6 +1282,14 @@ public:
                     std::string(ASRUtils::get_type_code(ASRUtils::expr_type(x.m_args[i].m_a))));
             }
         }
+
+        for( size_t i = 0; i < x.n_args; i++ ) {
+            if( ASRUtils::is_array(ASRUtils::expr_type(x.m_args[i].m_a)) ) {
+                require(x.m_args[i].n_dims > 0,
+                    "Allocate for arrays should have dimensions specified, "
+                    "found only array variable with no dimensions");
+            }
+        }
         BaseWalkVisitor<VerifyVisitor>::visit_Allocate(x);
     }
 

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1283,11 +1283,13 @@ public:
             }
         }
 
-        for( size_t i = 0; i < x.n_args; i++ ) {
-            if( ASRUtils::is_array(ASRUtils::expr_type(x.m_args[i].m_a)) ) {
-                require(x.m_args[i].n_dims > 0,
-                    "Allocate for arrays should have dimensions specified, "
-                    "found only array variable with no dimensions");
+        if( x.m_source == nullptr ) {
+            for( size_t i = 0; i < x.n_args; i++ ) {
+                if( ASRUtils::is_array(ASRUtils::expr_type(x.m_args[i].m_a)) ) {
+                    require(x.m_args[i].n_dims > 0,
+                        "Allocate for arrays should have dimensions specified, "
+                        "found only array variable with no dimensions");
+                }
             }
         }
         BaseWalkVisitor<VerifyVisitor>::visit_Allocate(x);

--- a/tests/errors/incorrect_allocate_for_array.f90
+++ b/tests/errors/incorrect_allocate_for_array.f90
@@ -1,0 +1,5 @@
+program incorrect_allocate_for_array
+    integer, allocatable :: a(:)
+    allocate(a)
+    print *, size(a)
+end program

--- a/tests/reference/asr-incorrect_allocate_for_array-b52ea30.json
+++ b/tests/reference/asr-incorrect_allocate_for_array-b52ea30.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-incorrect_allocate_for_array-b52ea30",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/incorrect_allocate_for_array.f90",
+    "infile_hash": "f60a82bb992ad3cff8f57805c5cae6793003e8814985af976f003a9d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-incorrect_allocate_for_array-b52ea30.stderr",
+    "stderr_hash": "24447f7654ddd6077296652c946cb2297e5e050b1462240f1895a113",
+    "returncode": 2
+}

--- a/tests/reference/asr-incorrect_allocate_for_array-b52ea30.stderr
+++ b/tests/reference/asr-incorrect_allocate_for_array-b52ea30.stderr
@@ -1,0 +1,5 @@
+semantic error: Allocate for arrays should have dimensions specified, found only array variable with no dimensions
+ --> tests/errors/incorrect_allocate_for_array.f90:3:14
+  |
+3 |     allocate(a)
+  |              ^ Array specification required in allocate statement

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4139,6 +4139,10 @@ filename = "errors/array_constructor_with_different_char_lengths.f90"
 asr = true
 
 [[test]]
+filename = "errors/incorrect_allocate_for_array.f90"
+asr = true
+
+[[test]]
 filename = "errors/incompatible_ranks_allocatable_arr1.f90"
 asr = true
 


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/6823