### PR TITLE
Fix `--realloc-lhs` if `shape` is dependent on target in `ArrayReshape`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -557,6 +557,7 @@ RUN(NAME arrays_reshape_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
 RUN(NAME arrays_reshape_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME arrays_reshape_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME arrays_elemental_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME arrays_03_func LABELS gfortran cpp llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME arrays_03_func_pass_arr_dims LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)

--- a/integration_tests/arrays_reshape_23.f90
+++ b/integration_tests/arrays_reshape_23.f90
@@ -1,0 +1,38 @@
+module lincoa_mod
+    implicit none
+
+    contains
+
+    subroutine get_lincon(amat)
+        implicit none
+        real, intent(out), allocatable :: amat(:, :)
+        integer :: m, n
+        m = 3
+        n = 2
+        allocate(amat(m, n))
+        amat = reshape([1., 2., 3., 4., 5., 6.], shape(amat))
+    end subroutine get_lincon
+
+    subroutine get_lincon1(amat)
+        implicit none
+        real, intent(out), allocatable :: amat(:, :)
+        integer :: m, n
+        m = 3
+        n = 2
+        amat = reshape([1., 2., 3., 4., 5., 6.], shape(amat))
+    end subroutine get_lincon1
+end module lincoa_mod
+
+program arrays_reshape_23
+    use lincoa_mod
+    implicit none
+    real, allocatable :: a(:, :), b(:, :)
+    call get_lincon(a)
+    print *, a
+    if( any(a(:, 1) /= [1.0, 2.0, 3.0]) ) error stop
+    if( any(a(:, 2) /= [4.0, 5.0, 6.0]) ) error stop
+
+    call get_lincon1(b)
+    if( size(b, 1) /= 0 ) error stop
+    if( size(b, 2) /= 0 ) error stop
+end program arrays_reshape_23


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/6771