### PR TITLE
CI: build in debug mode on macOS

### DIFF
--- a/ci/build_tmp.xsh
+++ b/ci/build_tmp.xsh
@@ -64,7 +64,7 @@ cd test-bld
 # Note: we have to build in Release mode on Windows, because `llvmdev` is
 # compiled in Release mode and we get link failures if we mix and match build
 # modes:
-if $IS_LINUX:
+if $IS_LINUX or $IS_MAC:
     BUILD_TYPE = "Debug"
 else:
     BUILD_TYPE = "Release"


### PR DESCRIPTION
## Description

this will cause a failure at the CI, hence confirming of bug in LFortran, which is currently being fixed with PR https://github.com/lfortran/lfortran/pull/7097

This PR isn't intended to be merged at all, but just a showcase of what we aren't testing in our CI. The same change from this PR is in PR: https://github.com/lfortran/lfortran/pull/7097, which is what should be eventually merged (once reviewed), as that PR addresses the bug exposed from untested *debug mode* on macOS in our CI.