### PR TITLE
Fix : GenericProcedure calls in variable declaration [postpone the `AST::FuncCallOrArray` node instead of the whole `AST::Declaration `node]

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -473,6 +473,7 @@ RUN(NAME functions_33 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_34 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_35 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME functions_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_37.f90
+++ b/integration_tests/functions_37.f90
@@ -1,0 +1,23 @@
+module functions_37_mod
+    interface generic
+       procedure :: ff
+    end interface
+  
+    contains
+  
+    pure function ff() result(ret)
+      integer :: ret
+      ret  = 190
+    end function
+  
+    function foo() result(arr) 
+      integer :: arr(generic()) ! Depends on `ff` to be fully declared (through interface `generic`)
+    end function
+  
+end module
+  
+program functions_37
+use functions_37_mod
+print *, size(foo())
+if(size(foo()) /= 190) error stop
+end program functions_37

--- a/integration_tests/modules_15b.f90
+++ b/integration_tests/modules_15b.f90
@@ -241,7 +241,7 @@ interface
     ! int f_string(char *s)
     integer(c_int) function f_string0(s) result(r) bind(c, name="f_string")
     import :: c_int, c_char
-    character(len=1, kind=c_char), intent(in) :: s(*)
+    character(len=1, kind=c_char), intent(in) :: s
     end function
 
     integer(c_int) function call_fortran_i32(i) result(r) bind(c)

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1462,14 +1462,23 @@ public:
 
     std::map<std::string, std::vector<std::string>> generic_procedures;
     /*
-        Preserves AST::declaration node + its scope that should be evaluated in.
-        Used to evaluate the `AST::Declaration_t` nodes after resolving `ASR::GenericProcedure_t` node,
-        as these declaration nodes depends on calls to GenericProcedure node.
-        Evalution Flow (of building symbolTables) :
-            Functions -> GenericProcedure(Interface) -> Calls to GenericProcedure.
-    */
-    std::vector<std::pair<SymbolTable*, const AST::Declaration_t*>> delayed_generic_procedure_calls;
-
+     * A struct to store the information of a postponed call to genericProcedure
+     * The information should be consumed by function `evaluate_delayed_generic_procedure_calls`
+     */
+    struct postponed_genericProcedure_call{
+        ASR::expr_t** holder; // Pointer to the expre that should hold the `ASR::FunctionCall`
+        SymbolTable* current_scope; // The scope where the `AST::FuncCallOrArray` should've been evaluated. 
+        AST::expr_t* func_call; // `AST::FuncCallOrArray`
+        char* var_name; // Name of the `ASR::Variable` that the functionCall is part of [integer :: arr(genericCall())]
+        std::function<void(ASR::expr_t*)> check; // Lambda function in case the returning `ASR::expr` should be checked in specific way.
+        // Constructor
+        postponed_genericProcedure_call( ASR::expr_t** holder, SymbolTable* current_scope,
+            AST::expr_t* func_call, char* var_name,
+            std::function<void(ASR::expr_t*)> check
+        ) : holder(holder), current_scope(current_scope), func_call(func_call),
+            var_name(var_name), check(check) {}
+    };
+    std::vector<postponed_genericProcedure_call> postponed_genericProcedure_calls_vec;
     // global save variable
     bool is_global_save_enabled = false;
 
@@ -1800,7 +1809,8 @@ public:
             left, end_bin_op->m_op, right, end_bin_op->m_type, end_bin_op->m_value));
     }
 
-    bool dimension_attribute_error_check(ASR::expr_t* dim_expr) {
+    void dimension_attribute_error_check(ASR::expr_t* dim_expr) {
+        bool error = false;
         if (ASR::is_a<ASR::Var_t>(*dim_expr)) {
             ASR::Var_t* dim_expr_var = ASR::down_cast<ASR::Var_t>(dim_expr);
             ASR::symbol_t* dim_expr_sym = dim_expr_var->m_v;
@@ -1809,11 +1819,11 @@ public:
                 ASR::Variable_t* dim_expr_variable = ASR::down_cast<ASR::Variable_t>(dim_expr_sym);
 
                 if (dim_expr_variable->m_type->type != ASR::ttypeType::Integer) {
-                    return true;
+                    error = true;
                 } else {
 
                     if ((dim_expr_variable->m_storage != ASR::storage_typeType::Parameter) && !(in_Subroutine) && (symbol_scope->counter == current_scope->counter)) {
-                        return true;
+                        error = true;
                     }
                 }
             }
@@ -1822,11 +1832,18 @@ public:
             ASR::ttype_t* dim_expr_type = ASRUtils::expr_type(dim_expr);
 
             if (dim_expr_type->type != ASR::ttypeType::Integer) {
-                return true;
+                error = true;
             }
         }
 
-        return false;
+        if(error){
+            diag.add(Diagnostic(
+                "Expecting a scalar integer or parameter annotated integer variable ",
+                Level::Error, Stage::Semantic, {
+                    Label("",{dim_expr->base.loc})
+                }));
+            throw SemanticAbort();
+        }
     }
 
 
@@ -1878,7 +1895,7 @@ public:
             if ( v->m_type ) {
                 is_char_type = ASR::is_a<ASR::String_t>(*v->m_type);
             }
-	    process_dims(al, dims, s.m_dim, s.n_dim, is_compile_time, is_char_type);
+	    process_dims(al, dims, s.m_dim, s.n_dim, is_compile_time, is_char_type, false, s.m_name);
 
 	    bool is_star_dimension = false;
 
@@ -1934,57 +1951,66 @@ public:
 	}
     }
 
+    bool is_funcCall_to_unresolved_genereicProcedure(AST::expr_t* expr){
+        return AST::is_a<AST::FuncCallOrArray_t>(*expr) &&
+            (generic_procedures.find(
+                AST::down_cast<AST::FuncCallOrArray_t>(expr)->m_func)
+            != generic_procedures.end());
+    }
 
     void process_dims(Allocator &al, Vec<ASR::dimension_t> &dims,
         AST::dimension_t *m_dim, size_t n_dim, bool &is_compile_time,
-        bool is_char_type=false, bool is_argument=false) {
+        bool is_char_type, bool is_argument, char* var_name) {  
         LCOMPILERS_ASSERT(dims.size() == 0);
         is_compile_time = false;
         _processing_dimensions = true;
         dims.reserve(al, n_dim);
         for (size_t i=0; i<n_dim; i++) {
-            ASR::dimension_t dim; dim.m_length = nullptr; dim.m_start = nullptr;
+            ASR::dimension_t dim_dummy; dims.push_back(al, dim_dummy);
+            ASR::dimension_t &dim  = const_cast<ASR::dimension_t&>(dims[dims.size()-1]);
+            dim.m_length = nullptr; dim.m_start = nullptr;
             dim.loc = m_dim[i].loc;
             if (m_dim[i].m_start) {
-                this->visit_expr(*m_dim[i].m_start);
-                dim.m_start = ASRUtils::EXPR(tmp);
-                if (dimension_attribute_error_check(dim.m_start)) {
-                    diag.add(Diagnostic(
-                        "Expecting a scalar integer or parameter annotated integer variable ",
-                        Level::Error, Stage::Semantic, {
-                            Label("",{m_dim[i].m_start->base.loc})
-                        }));
-                    throw SemanticAbort();
+                if(is_funcCall_to_unresolved_genereicProcedure(m_dim[i].m_start)){
+                    postponed_genericProcedure_calls_vec.emplace_back(&dim.m_start,
+                        current_scope, m_dim[i].m_start, var_name, 
+                        [this](ASR::expr_t* start){dimension_attribute_error_check(start);});
+                    dim.m_start = nullptr;
+                } else {
+                    this->visit_expr(*m_dim[i].m_start);
+                    dim.m_start = ASRUtils::EXPR(tmp);
+                    dimension_attribute_error_check(dim.m_start);
                 }
             } else {
                 dim.m_start = nullptr;
             }
             if (m_dim[i].m_end) {
-                this->visit_expr(*m_dim[i].m_end);
-                ASR::expr_t* end = ASRUtils::EXPR(tmp);
-                if (dimension_attribute_error_check(end)) {
-                    diag.add(Diagnostic(
-                        "Expecting a scalar integer or parameter annotated integer variable ",
-                        Level::Error, Stage::Semantic, {
-                            Label("",{m_dim[i].m_end->base.loc})
-                        }));
-                    throw SemanticAbort();
-                }
-                if (ASR::is_a<ASR::Var_t>(*end)) {
-                    ASR::Var_t* end_var = ASR::down_cast<ASR::Var_t>(end);
-                    ASR::symbol_t* end_sym = end_var->m_v;
-                    SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(end_sym);
-                    if ((is_argument || ASRUtils::expr_value(end) == nullptr) &&
-                        (ASR::is_a<ASR::ExternalSymbol_t>(*end_sym) ||
-                        (symbol_scope->counter != current_scope->counter && is_argument &&
-                        ASRUtils::expr_value(end) == nullptr)) ) {
-                            end = get_transformed_function_call(end_sym);
+                ASR::expr_t* end{};
+                if(is_funcCall_to_unresolved_genereicProcedure(m_dim[i].m_end)){ // Delay
+                    postponed_genericProcedure_calls_vec.emplace_back(&dim.m_length,
+                        current_scope, m_dim[i].m_end, var_name, 
+                        [this](ASR::expr_t* start){dimension_attribute_error_check(start);});
+                    dim.m_length = nullptr;
+                } else {
+                    this->visit_expr(*m_dim[i].m_end);
+                    end = ASRUtils::EXPR(tmp);
+                    dimension_attribute_error_check(end);
+                    if (ASR::is_a<ASR::Var_t>(*end)) {
+                        ASR::Var_t* end_var = ASR::down_cast<ASR::Var_t>(end);
+                        ASR::symbol_t* end_sym = end_var->m_v;
+                        SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(end_sym);
+                        if ((is_argument || ASRUtils::expr_value(end) == nullptr) &&
+                            (ASR::is_a<ASR::ExternalSymbol_t>(*end_sym) ||
+                            (symbol_scope->counter != current_scope->counter && is_argument &&
+                            ASRUtils::expr_value(end) == nullptr)) ) {
+                                end = get_transformed_function_call(end_sym);
+                        }
+                    } else if(ASR::is_a<ASR::IntegerBinOp_t>(*end)) {
+                        end = convert_integer_binop_to_function_call(end, is_argument);
                     }
-                } else if(ASR::is_a<ASR::IntegerBinOp_t>(*end)) {
-                    end = convert_integer_binop_to_function_call(end, is_argument);
+                    dim.m_length = ASRUtils::compute_length_from_start_end(al, dim.m_start,
+                                        end);
                 }
-                dim.m_length = ASRUtils::compute_length_from_start_end(al, dim.m_start,
-                                    end);
             } else {
                 dim.m_length = nullptr;
             }
@@ -1994,7 +2020,6 @@ public:
             if (m_dim[i].m_end_star && is_char_type) {
                 continue;
             }
-            dims.push_back(al, dim);
         }
         _processing_dimensions = false;
     }
@@ -2858,54 +2883,7 @@ public:
             al, loc, adjusted_str, value_type));
     }
 
-    bool is_declaration_depending_on_unresolved_genericProcedure_call(const AST::Declaration_t &x){
-       if(generic_procedures.empty()) return false;
-        /*
-            Check for generic procedure call in the dimension attribute
-            e.g. : `integer, DIMENSION(func_generic(),20) :: arr`
-        */
-        for(size_t i = 0; i < x.n_attributes; i++){
-            if(AST::is_a<AST::AttrDimension_t>(*x.m_attributes[i])){
-                AST::AttrDimension_t* attr_dim = AST::down_cast<AST::AttrDimension_t>(x.m_attributes[i]);
-                for(size_t j = 0; j< attr_dim->n_dim; j++){
-                    for(AST::expr_t* dim_expr : {attr_dim->m_dim[j].m_start, attr_dim->m_dim[j].m_end}){
-                        if( dim_expr &&
-                            dim_expr->type == AST::exprType::FuncCallOrArray &&
-                            generic_procedures.find(
-                                (AST::down_cast<AST::FuncCallOrArray_t>(dim_expr)->m_func))
-                            != generic_procedures.end()){
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        /*
-            Check for generic procedure call in the symbol dimension
-            e.g. : `integer :: arr(func_generic(),20)`
-        */
-        for(size_t i = 0; i < x.n_syms; i++){
-            AST::var_sym_t &s = x.m_syms[i];
-            for(size_t j = 0 ; j < s.n_dim; j++){
-                for(AST::expr_t* dim_expr : {s.m_dim[j].m_start, s.m_dim[j].m_end}){
-                    if( dim_expr &&
-                        dim_expr->type == AST::exprType::FuncCallOrArray &&
-                        generic_procedures.find(
-                            (AST::down_cast<AST::FuncCallOrArray_t>(dim_expr)->m_func))
-                        != generic_procedures.end()){
-                        return true;
-                    }
-                }
-            }
-        }
-        return false; // Default if no genericProcedureCall found.
-    }
-
     void visit_DeclarationUtil(const AST::Declaration_t &x) {
-        if(is_declaration_depending_on_unresolved_genericProcedure_call(x)){
-            delayed_generic_procedure_calls.emplace_back(current_scope, &x);
-            return;
-        }
         _declaring_variable = true;
         if (x.m_vartype == nullptr &&
                 x.n_attributes == 1 &&
@@ -3599,7 +3577,7 @@ public:
                             dims_attr_loc = ad->base.base.loc;
                             process_dims(al, dims, ad->m_dim, ad->n_dim, is_compile_time, is_char_type,
                                 (s_intent == ASRUtils::intent_in || s_intent == ASRUtils::intent_out ||
-                                s_intent == ASRUtils::intent_inout) || is_argument);
+                                s_intent == ASRUtils::intent_inout) || is_argument, s.m_name);
                         } else if (AST::is_a<AST::AttrBind_t>(*a)) {
                             AST::AttrBind_t attr_bd = *AST::down_cast<AST::AttrBind_t>(a);
                             extract_bind(attr_bd, s_abi, bindc_name, diag);
@@ -3667,7 +3645,7 @@ public:
                     }
                     process_dims(al, dims, s.m_dim, s.n_dim, is_compile_time, is_char_type,
                         (s_intent == ASRUtils::intent_in || s_intent == ASRUtils::intent_out ||
-                        s_intent == ASRUtils::intent_inout));
+                        s_intent == ASRUtils::intent_inout), s.m_name);
                 }
                 ASR::symbol_t *type_declaration;
                 ASR::ttype_t *type = nullptr;

--- a/tests/reference/asr-array12-cb81afc.json
+++ b/tests/reference/asr-array12-cb81afc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array12-cb81afc.stdout",
-    "stdout_hash": "df9fa4499c6473aa9a7526d2382c9ec802ff93684c213457c7812795",
+    "stdout_hash": "a0ecfbc41f409dcf6bf91172b58ff9fb3c51d2006174880108d71fa9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array12-cb81afc.stdout
+++ b/tests/reference/asr-array12-cb81afc.stdout
@@ -172,7 +172,18 @@
                                         (FunctionCall
                                             2 getcwd
                                             ()
-                                            [((Var 12 cpath))
+                                            [((ArrayPhysicalCast
+                                                (Var 12 cpath)
+                                                DescriptorArray
+                                                StringArraySinglePointer
+                                                (Array
+                                                    (String 1 1 () PointerString)
+                                                    [(()
+                                                    ())]
+                                                    StringArraySinglePointer
+                                                )
+                                                ()
+                                            ))
                                             ((Var 12 buffersize))]
                                             (CPtr)
                                             ()
@@ -223,7 +234,12 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (String 1 1 () PointerString)
+                                                    (Array
+                                                        (String 1 1 () PointerString)
+                                                        [(()
+                                                        ())]
+                                                        StringArraySinglePointer
+                                                    )
                                                     ()
                                                     BindC
                                                     Public
@@ -274,7 +290,12 @@
                                         })
                                     getcwd
                                     (FunctionType
-                                        [(String 1 1 () PointerString)
+                                        [(Array
+                                            (String 1 1 () PointerString)
+                                            [(()
+                                            ())]
+                                            StringArraySinglePointer
+                                        )
                                         (Integer 4)]
                                         (CPtr)
                                         BindC

--- a/tests/reference/asr-modules_15b-09f8335.json
+++ b/tests/reference/asr-modules_15b-09f8335.json
@@ -2,7 +2,7 @@
     "basename": "asr-modules_15b-09f8335",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/modules_15b.f90",
-    "infile_hash": "7bc03c79471232bfa225dd51d7d4886232f7bcb9f86a506f05811403",
+    "infile_hash": "fbbd085f2ba045d9c713c3e0edf41b67cc3f20b94a53364bf3b9f51c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_15b-09f8335.stdout",


### PR DESCRIPTION
Fix #7095 
- It's an enhancement to this PR https://github.com/lfortran/lfortran/pull/7081
### What it it fixes : 
GenericProcedure calls while declaring a variable `integer :: ret(genericProcedure())`

### What is the issue ? : 
We used to postpone the evaluation of the whole `AST::Declaration` node till we Evaluate symbolTable of both the Functions and then -> `AST::Interface`.
That led to some `ASR::Function` node being built with incomplete signature, which invoked semantic errors see #7095.

### The Fix :
Just postpone the `AST::FuncCallOrArray` node instead of the whole `AST::Declaration` node, then evaluate the node at the end (after having complete `ASR::Function` + `ASR::GenericProcedure` nodes).