### PR TITLE
tests: update reference tests in accordance with #7117

### DIFF
--- a/tests/reference/asr-continue_compilation_ff_1-c2d5950.json
+++ b/tests/reference/asr-continue_compilation_ff_1-c2d5950.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-continue_compilation_ff_1-c2d5950.stdout",
-    "stdout_hash": "999b82bc454e0a1a08f6cd4c1bf88e65bac37cd59c3006c839cf8c7d",
+    "stdout_hash": "e535af79c8b20aea010465a49071cb071e781a2bbadc2c47e5e3b44f",
     "stderr": "asr-continue_compilation_ff_1-c2d5950.stderr",
     "stderr_hash": "5058e79f75dbfe91f0ae19335276116f9240813af8445d32b0017abe",
     "returncode": 1

--- a/tests/reference/asr-continue_compilation_ff_1-c2d5950.stdout
+++ b/tests/reference/asr-continue_compilation_ff_1-c2d5950.stdout
@@ -29,6 +29,7 @@
                                                     .false.
                                                     .false.
                                                     .false.
+                                                    ()
                                                 ),
                                             x:
                                                 (Variable
@@ -47,6 +48,7 @@
                                                     .false.
                                                     .false.
                                                     .false.
+                                                    ()
                                                 )
                                         })
                                     f
@@ -112,6 +114,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             a_2:
                                 (Variable
@@ -135,6 +138,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             a_3:
                                 (Variable
@@ -158,6 +162,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             a_4:
                                 (Variable
@@ -176,6 +181,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             a_5:
                                 (Variable
@@ -194,6 +200,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             circlearea:
                                 (Variable
@@ -212,6 +219,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             i:
                                 (Variable
@@ -230,6 +238,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             i_1:
                                 (Variable
@@ -248,6 +257,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             i_2:
                                 (Variable
@@ -266,6 +276,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             i_3:
                                 (Variable
@@ -284,6 +295,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             ij:
                                 (Variable
@@ -302,6 +314,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             image:
                                 (Variable
@@ -327,6 +340,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             init_x:
                                 (Variable
@@ -345,6 +359,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             j:
                                 (Variable
@@ -363,6 +378,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             j_1:
                                 (Variable
@@ -381,6 +397,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             kindvar:
                                 (Variable
@@ -399,6 +416,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             nx:
                                 (Variable
@@ -417,6 +435,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             ny:
                                 (Variable
@@ -435,6 +454,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             shape:
                                 (Variable
@@ -460,6 +480,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             size_a:
                                 (Variable
@@ -478,6 +499,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             size_a_2:
                                 (Variable
@@ -496,6 +518,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             str:
                                 (Variable
@@ -520,6 +543,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             val:
                                 (Variable
@@ -538,6 +562,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             x:
                                 (Variable
@@ -556,6 +581,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             x_2:
                                 (Variable
@@ -574,6 +600,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             x_3:
                                 (Variable
@@ -599,6 +626,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             y_1:
                                 (Variable
@@ -619,6 +647,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             y_2:
                                 (Variable
@@ -644,6 +673,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             y_3:
                                 (Variable
@@ -662,6 +692,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 ),
                             y_4:
                                 (Variable
@@ -680,6 +711,7 @@
                                     .false.
                                     .false.
                                     .false.
+                                    ()
                                 )
                         })
                     continue_compilation_ff


### PR DESCRIPTION
## Description

This fixes failing CI in our *main* as of https://github.com/lfortran/lfortran/commit/e1d85b2eefea8990f14f897bfee3e0776f07f5ca

e.g.; CI run failure: https://github.com/lfortran/lfortran/actions/runs/14769610223/job/41467364462

we made changes in ASR in PR #7117, but the PR #7106 was merged right after that and hence it didn't take into account the updation of reference tests in `Variable` ASR node