### PR TITLE
fix: raise nice error message on missing linker input file

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2448,9 +2448,9 @@ int main_app(int argc, char *argv[]) {
     }
 
     if (CLI::NonexistentPath(opts.arg_file).empty()) {
-        throw LCompilers::LCompilersException(
-            "error: no such file or directory: '" + opts.arg_file + "'"
-        );
+        std::cerr << "error: '" + opts.arg_file + "': linker input file not found: " +
+            "No such file or directory" << std::endl;
+        return 1;
     }
 
     std::string outfile;


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/6645

This now raises:
```console
$ lfortran -c mpi_wrapper.o mpi_c_bindings.o mpi.o psi_io.o pot3d.o -o pot3d -L$CONDA_PREFIX/lib -lmpi -Wl, rpath,$CONDA_PREFIX/lib
error: 'mpi_wrapper.o': linker input file not found: No such file or directory
$ echo $?
1
```