### PR TITLE
enh: prefix `IntrinsicArrayFunction` with `_lcompilers_`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2206,6 +2206,8 @@ RUN(NAME attr_intrinsic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME separate_compilation_01 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_01b.f90)
 RUN(NAME separate_compilation_02 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_02b.f90)
+RUN(NAME separate_compilation_03 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_03a.f90 separate_compilation_03b.f90 EXTRA_ARGS --skip-pass=pass_array_by_data)
+
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_03.f90
+++ b/integration_tests/separate_compilation_03.f90
@@ -1,0 +1,15 @@
+program separate_compilation_03
+use separate_compilation_03a_module
+use separate_compilation_03b_module
+
+real :: x0(5)
+real :: res1, res2
+x0 = 9124.124
+
+res1 = mixing_anderson(x0)
+print *, mixing_anderson(x0)
+res2 = integrate_trapz_1(x0)
+print *, integrate_trapz_1(x0)
+
+if (abs(res1 - res2) > 1e-8) error stop
+end program

--- a/integration_tests/separate_compilation_03a.f90
+++ b/integration_tests/separate_compilation_03a.f90
@@ -1,0 +1,10 @@
+module separate_compilation_03a_module
+
+contains
+
+real function integrate_trapz_1(Rp) result(s)
+real, intent(in) :: Rp(:)
+s = sum(Rp)
+end function
+
+end module

--- a/integration_tests/separate_compilation_03b.f90
+++ b/integration_tests/separate_compilation_03b.f90
@@ -1,0 +1,11 @@
+module separate_compilation_03b_module
+
+contains
+
+real function mixing_anderson(x0)
+! Finds "x" so that R(x) = 0, uses x0 as the initial estimate
+real, intent(in) :: x0(:)
+mixing_anderson = sum(x0)
+end function
+
+end module

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -895,7 +895,7 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
         int64_t overload_id, ASRUtils::IntrinsicArrayFunctions intrinsic_func_id,
         get_initial_value_func get_initial_value,
         elemental_operation_func elemental_operation) {
-    std::string intrinsic_func_name = ASRUtils::get_array_intrinsic_name(static_cast<int64_t>(intrinsic_func_id));
+    std::string intrinsic_func_name = "_lcompilers_" + ASRUtils::get_array_intrinsic_name(static_cast<int64_t>(intrinsic_func_id));
     ASRBuilder builder(al, loc);
     ASRBuilder& b = builder;
     int64_t id_array = 0, id_array_dim = 1, id_array_mask = 2, id_array_dim_mask = 3;


### PR DESCRIPTION
Fixes #7138. With this we can successfully compile `dftatom` in separate compilation mode. 