### PR TITLE
fix: use absolute path using PROJECT_SOURCE_DIR

### DIFF
--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 # Add one main test suite for LFortran, composed of many individual cpp files:
 add_executable(test_lfortran ${SRC})
 target_link_libraries(test_lfortran lfortran_lib p::doctest)
+target_compile_definitions(test_lfortran PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 if (HAVE_BUILD_TO_WASM)
     set(WASM_COMPILE_FLAGS "-g0 -fexceptions")
     set(WASM_LINK_FLAGS

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -19,7 +19,6 @@ using LCompilers::TRY;
 using LCompilers::FortranEvaluator;
 using LCompilers::CompilerOptions;
 
-
 TEST_CASE("llvm 1") {
     //std::cout << "LLVM Version:" << std::endl;
     //LFortran::LLVMEvaluator::print_version_message();
@@ -1316,8 +1315,12 @@ end function sub
 
 TEST_CASE("llvm ir 1") {
     LCompilers::LLVMEvaluator e;
-    CHECK_THROWS_AS(e.parse_module2("", "src/lfortran/tests/ir.ll"), LCompilers::LCompilersException);
-    CHECK_THROWS_WITH(e.parse_module2("", "src/lfortran/tests/ir.ll"), "parse_module(): Invalid LLVM IR");
+    std::string file_name = std::string(PROJECT_SOURCE_DIR) + "/src/lfortran/tests/ir.ll";
+    // `file_name` evaluates to something like:
+    // "/Users/gxyd/OpenSource/lfortran/lfortran-${version}/src/lfortran/tests/ir.ll",
+    // where `version` isn't a local variable
+    CHECK_THROWS_AS(e.parse_module2("", file_name), LCompilers::LCompilersException);
+    CHECK_THROWS_WITH(e.parse_module2("", file_name), "parse_module(): Invalid LLVM IR");
 }
 
 // This test does not work on Windows yet


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7062

we now read "src/lfortran/tests/ir.ll" correctly.

At the very least, I'll go through the CI logs to check that now we correctly read `src/lfortran/tests/ir.ll` (i.e. throw error message about incorrect LLVM IR) in the below CI jobs:

LSP Tests (macOS-latest)
LSP Test (ubuntu-latest)
LFortran CI (macOS-latest)
LFortran CI (ubuntu-latest)