### PR TITLE
fix: throw cerr when file doesn't exist, not ICE

### DIFF
--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -260,6 +260,13 @@ std::unique_ptr<llvm::Module> LLVMEvaluator::parse_module(const std::string &sou
     llvm::SMDiagnostic err;
     std::unique_ptr<llvm::Module> module;
     if (!filename.empty()) {
+        // we throw std::cerr if the file doesn't exist,
+        // not an LCompilersException (i.e. ICE)
+        std::ifstream infile(filename);
+        if (!infile.good()) {
+            std::cerr << "parse_module(): File '" + filename + "' doesn't exist or isn't readable\n";
+            return nullptr;
+        }
         module = llvm::parseAssemblyFile(filename, err, *context);
     } else {
         module = llvm::parseAssemblyString(source, err, *context);


### PR DESCRIPTION
## Description

This PR isn't intended to be merged at all, but instead showcase that we've bug where we don't throw an error, see: https://github.com/lfortran/lfortran/issues/7062