### PR TITLE
Fix a flaky test

### DIFF
--- a/integration_tests/arrays_reshape_23.f90
+++ b/integration_tests/arrays_reshape_23.f90
@@ -19,6 +19,10 @@ module lincoa_mod
         integer :: m, n
         m = 3
         n = 2
+        ! TODO: remove the allocate and change `shape(amat)` to `[m, n]`
+        ! after this issue is fixed:
+        ! https://github.com/lfortran/lfortran/pull/7147
+        allocate(amat(m, n))
         amat = reshape([1., 2., 3., 4., 5., 6.], shape(amat))
     end subroutine get_lincon1
 end module lincoa_mod


### PR DESCRIPTION
Fixes #7147.

This makes the test not test the realloc lhs properly, however there is a bug in LFortran that prevents it to run:
https://github.com/lfortran/lfortran/pull/7147, but that is a separate issue.