### PR TITLE
Remove test with undefined behaviour

### DIFF
--- a/integration_tests/arrays_reshape_23.f90
+++ b/integration_tests/arrays_reshape_23.f90
@@ -12,15 +12,6 @@ module lincoa_mod
         allocate(amat(m, n))
         amat = reshape([1., 2., 3., 4., 5., 6.], shape(amat))
     end subroutine get_lincon
-
-    subroutine get_lincon1(amat)
-        implicit none
-        real, intent(out), allocatable :: amat(:, :)
-        integer :: m, n
-        m = 3
-        n = 2
-        amat = reshape([1., 2., 3., 4., 5., 6.], shape(amat))
-    end subroutine get_lincon1
 end module lincoa_mod
 
 program arrays_reshape_23
@@ -31,7 +22,4 @@ program arrays_reshape_23
     print *, a
     if( any(a(:, 1) /= [1.0, 2.0, 3.0]) ) error stop
     if( any(a(:, 2) /= [4.0, 5.0, 6.0]) ) error stop
-
-    call get_lincon1(b)
-    print *, size(b, 1), size(b, 2)
 end program arrays_reshape_23


### PR DESCRIPTION
Removed `get_lincon1` as it is undefined behaviour in GFortran.

Closes https://github.com/lfortran/lfortran/pull/7147
Closes https://github.com/lfortran/lfortran/pull/7148