### PR TITLE
fix: mangle ClassProcedure with m_proc_name instead of m_name

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1430,6 +1430,7 @@ RUN(NAME derived_types_50 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_51 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_52 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_54.f90
+++ b/integration_tests/derived_types_54.f90
@@ -1,0 +1,41 @@
+module derived_types_54_m
+    implicit none
+    type :: Base 
+    contains
+        procedure :: get_out => Base_get_out
+    end type
+
+    type, extends(Base) :: Derived
+    contains
+        procedure :: get_out => Derived_get_out
+    end type
+
+    contains
+        subroutine Base_get_out(self, outi)
+            class(Base) :: self
+            integer :: outi
+
+            outi = 1
+        end subroutine
+
+        subroutine Derived_get_out(self, outi)
+            class(Derived) :: self
+            integer :: outi
+
+            outi = 2
+        end subroutine
+end module
+
+program derived_types_54
+    use derived_types_54_m
+    implicit none
+    type(Base) :: b
+    type(Derived) :: d
+
+    integer :: outi
+
+    call d%get_out(outi)
+    if (outi /= 2) error stop
+    call b%get_out(outi)
+    if (outi /= 1) error stop
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1554,7 +1554,13 @@ ASR::symbol_t* import_class_procedure(Allocator &al, const Location& loc,
     if( original_sym && (ASR::is_a<ASR::ClassProcedure_t>(*original_sym) ||
         (ASR::is_a<ASR::Variable_t>(*original_sym) &&
          ASR::is_a<ASR::FunctionType_t>(*ASRUtils::symbol_type(original_sym)))) ) {
-        std::string class_proc_name = ASRUtils::symbol_name(original_sym);
+        std::string class_proc_name;
+        // ClassProcedure name might be same if the procedure is overridden, use proc_name instead
+        if (ASR::is_a<ASR::ClassProcedure_t>(*original_sym)) {
+            class_proc_name = std::string(ASR::down_cast<ASR::ClassProcedure_t>(original_sym)->m_proc_name);
+        } else {
+            class_proc_name = ASRUtils::symbol_name(original_sym);
+        }
         if( original_sym != current_scope->resolve_symbol(class_proc_name) ) {
             std::string imported_proc_name = "1_" + class_proc_name;
             if( current_scope->resolve_symbol(imported_proc_name) == nullptr ) {

--- a/tests/reference/asr-class_01-704dee8.json
+++ b/tests/reference/asr-class_01-704dee8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_01-704dee8.stdout",
-    "stdout_hash": "33bfc6437674132e5ce44bb812102a152da7ba240d9cb564b1d03ccd",
+    "stdout_hash": "cd2222080cd2302d29279b6315f4a7f856bae40662f7272605be4a55",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_01-704dee8.stdout
+++ b/tests/reference/asr-class_01-704dee8.stdout
@@ -7,6 +7,16 @@
                     (SymbolTable
                         6
                         {
+                            1_circle_print:
+                                (ExternalSymbol
+                                    6
+                                    1_circle_print
+                                    3 print
+                                    circle
+                                    []
+                                    print
+                                    Public
+                                ),
                             1_circle_radius:
                                 (ExternalSymbol
                                     6
@@ -15,16 +25,6 @@
                                     circle
                                     []
                                     radius
-                                    Public
-                                ),
-                            1_print:
-                                (ExternalSymbol
-                                    6
-                                    1_print
-                                    3 print
-                                    circle
-                                    []
-                                    print
                                     Public
                                 ),
                             c:
@@ -84,7 +84,7 @@
                         .false.
                     )
                     (SubroutineCall
-                        6 1_print
+                        6 1_circle_print
                         ()
                         []
                         (Var 6 c)
@@ -104,7 +104,7 @@
                         .false.
                     )
                     (SubroutineCall
-                        6 1_print
+                        6 1_circle_print
                         ()
                         []
                         (Var 6 c)
@@ -283,10 +283,10 @@
                                     (SymbolTable
                                         5
                                         {
-                                            1_area:
+                                            1_circle_area:
                                                 (ExternalSymbol
                                                     5
-                                                    1_area
+                                                    1_circle_area
                                                     3 area
                                                     circle
                                                     []
@@ -366,7 +366,7 @@
                                     [(Assignment
                                         (Var 5 area)
                                         (FunctionCall
-                                            5 1_area
+                                            5 1_circle_area
                                             ()
                                             []
                                             (Real 4)

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "702edf2532a3acd5c50ad789c7ccc3da6d600857bf1d42ddb7b2f675",
+    "stdout_hash": "b6707ac40cdebd6c250e6c6828c6613ff3b1d54cd94ca45dc239bae6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -166,12 +166,22 @@
                                     (SymbolTable
                                         8
                                         {
-                                            1_to_string:
+                                            1_date_to_string:
                                                 (ExternalSymbol
                                                     8
-                                                    1_to_string
+                                                    1_date_to_string
                                                     4 to_string
                                                     toml_date
+                                                    []
+                                                    to_string
+                                                    Public
+                                                ),
+                                            1_time_to_string:
+                                                (ExternalSymbol
+                                                    8
+                                                    1_time_to_string
+                                                    3 to_string
+                                                    toml_time
                                                     []
                                                     to_string
                                                     Public
@@ -304,7 +314,7 @@
                                             ()
                                         )
                                         [(SubroutineCall
-                                            8 1_to_string
+                                            8 1_date_to_string
                                             ()
                                             [((Var 8 lhs))]
                                             (StructInstanceMember
@@ -342,7 +352,7 @@
                                                 ()
                                             )
                                             [(SubroutineCall
-                                                8 1_to_string
+                                                8 1_time_to_string
                                                 ()
                                                 [((Var 8 temporary))]
                                                 (StructInstanceMember

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "9277d386a1510b99fa1d06e186142d6a13b6bb356c306f787af0fbf6",
+    "stdout_hash": "f4fcc2175efb3c7af45b4d5d61037190c2f85a8cf20786c4f184273b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -166,12 +166,22 @@
                                     (SymbolTable
                                         12
                                         {
-                                            1_to_string:
+                                            1_date_to_string:
                                                 (ExternalSymbol
                                                     12
-                                                    1_to_string
+                                                    1_date_to_string
                                                     8 to_string
                                                     toml_date
+                                                    []
+                                                    to_string
+                                                    Public
+                                                ),
+                                            1_time_to_string:
+                                                (ExternalSymbol
+                                                    12
+                                                    1_time_to_string
+                                                    10 to_string
+                                                    toml_time
                                                     []
                                                     to_string
                                                     Public
@@ -304,7 +314,7 @@
                                             ()
                                         )
                                         [(SubroutineCall
-                                            12 1_to_string
+                                            12 1_date_to_string
                                             ()
                                             [((Var 12 lhs))]
                                             (StructInstanceMember
@@ -342,7 +352,7 @@
                                                 ()
                                             )
                                             [(SubroutineCall
-                                                12 1_to_string
+                                                12 1_time_to_string
                                                 ()
                                                 [((Var 12 temporary))]
                                                 (StructInstanceMember

--- a/tests/reference/asr-derived_types_08-3680946.json
+++ b/tests/reference/asr-derived_types_08-3680946.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_08-3680946.stdout",
-    "stdout_hash": "98d602c56b473acb0391376c25d5d79df2139b7a56b2900c7499af3a",
+    "stdout_hash": "6420ec2a5aff562e9d629ece7230c2c71a00d72e8d67c35b5bc85e92",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_08-3680946.stdout
+++ b/tests/reference/asr-derived_types_08-3680946.stdout
@@ -7,10 +7,10 @@
                     (SymbolTable
                         6
                         {
-                            1_initialize:
+                            1_initialize_subrout:
                                 (ExternalSymbol
                                     6
-                                    1_initialize
+                                    1_initialize_subrout
                                     3 initialize
                                     shape
                                     []
@@ -159,7 +159,7 @@
                     derived_types_08
                     [shape_mod]
                     [(SubroutineCall
-                        6 1_initialize
+                        6 1_initialize_subrout
                         ()
                         [((IntegerConstant 1 (Integer 4) Decimal))
                         ((LogicalConstant
@@ -171,7 +171,7 @@
                         (Var 6 shp)
                     )
                     (SubroutineCall
-                        6 1_initialize
+                        6 1_initialize_subrout
                         ()
                         [((IntegerConstant 2 (Integer 4) Decimal))
                         ((LogicalConstant

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "90319b1100a9201cb7c148ad9744eb2578e997c3419bcf8bdf3175c9",
+    "stdout_hash": "6cae280eef035c5887c140c0d44f53f0ff11ae7d0a31f763a85b8cb5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -47,6 +47,16 @@
                                     (SymbolTable
                                         7
                                         {
+                                            1___asr_push_back:
+                                                (ExternalSymbol
+                                                    7
+                                                    1___asr_push_back
+                                                    8 push_back
+                                                    intvector
+                                                    []
+                                                    push_back
+                                                    Public
+                                                ),
                                             1_intvector_elements:
                                                 (ExternalSymbol
                                                     7
@@ -55,16 +65,6 @@
                                                     intvector
                                                     []
                                                     elements
-                                                    Public
-                                                ),
-                                            1_push_back:
-                                                (ExternalSymbol
-                                                    7
-                                                    1_push_back
-                                                    8 push_back
-                                                    intvector
-                                                    []
-                                                    push_back
                                                     Public
                                                 ),
                                             __asr_push_back:
@@ -700,7 +700,7 @@
                                     []
                                     []
                                     [(SubroutineCall
-                                        7 1_push_back
+                                        7 1___asr_push_back
                                         ()
                                         [((IntegerConstant 10 (Integer 4) Decimal))]
                                         (Var 7 v)


### PR DESCRIPTION
This is fixing an issue I found.

Before the fix, both subroutine calls in the test returned `outi` as 2.