### PR TITLE
Synchronizes setting `start=true` to avoid a potential race condition

### DIFF
--- a/src/bin/language_server_interface.cpp
+++ b/src/bin/language_server_interface.cpp
@@ -552,7 +552,10 @@ namespace LCompilers::LLanguageServer::Interface {
                     startChanged,
                     startMutex
                 );
-            start = true;
+            {
+                std::unique_lock<std::mutex> startLock(startMutex);
+                start = true;
+            }
             startChanged.notify_all();
             communicationProtocol->serve();
             logger.info()

--- a/src/server/queue.hpp
+++ b/src/server/queue.hpp
@@ -92,6 +92,7 @@ namespace LCompilers::LLanguageServer::Threading {
                 enqueued.notify_one();
                 return elem;
             }
+            lock.unlock();
             logger.warn()
                 << "Failed to add element to queue of size=" << _size
                 << ", capacity=" << N << std::endl;
@@ -116,6 +117,7 @@ namespace LCompilers::LLanguageServer::Threading {
                 dequeued.notify_one();
                 return value;
             }
+            lock.unlock();
             logger.warn()
                 << "Failed to return element from queue of size=" << _size
                 << ", capacity=" << N << std::endl;


### PR DESCRIPTION
Changes:
- Synchronizes setting `start=true` to avoid a potential race condition. It is possible the listener thread missed the notification to start while waiting to acquire the mutex, which would cause it to block indefinitely.
- Unlocks the message queue mutex before logging warnings about adding or removing elements from the queue (minor).

Addresses #7094 