### PR TITLE
enh: handling of intrinsic modules in separate compilation

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -118,7 +118,7 @@ time_section "🧪 Testing Numerical Methods Fortran" '
   git clean -dfx
   print_subsection "Building Numerical Methods Fortran with separate compilation"
 
-  FC="$FC --generate-object-code" make
+  FC="$FC --generate-object-code --skip-pass=pass_array_by_data" make
   run_test test_fix_point.exe
   run_test test_integrate_one.exe
   run_test test_linear.exe

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -114,7 +114,31 @@ time_section "🧪 Testing Numerical Methods Fortran" '
   run_test plot_pendulum.exe
   run_test plot_transes_iso.exe
 
+
+  git clean -dfx
+  print_subsection "Building Numerical Methods Fortran with separate compilation"
+
+  FC="$FC --generate-object-code" make
+  run_test test_fix_point.exe
+  run_test test_integrate_one.exe
+  run_test test_linear.exe
+  run_test test_newton.exe
+  run_test test_ode.exe
+  run_test test_probability_distribution.exe
+  run_test test_sde.exe
+
+  run_test plot_bogdanov_takens.exe
+  run_test plot_bruinsma.exe
+  run_test plot_fun1.exe
+  run_test plot_lorenz.exe
+  run_test plot_lotka_volterra1.exe
+  run_test plot_lotka_volterra2.exe
+  run_test plot_pendulum.exe
+  run_test plot_transes_iso.exe
+
+
   print_success "Done with Numerical Methods Fortran"
+
   cd ..
 '
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2211,6 +2211,8 @@ RUN(NAME separate_compilation_01 LABELS gfortran llvm llvm_goc EXTRAFILES separa
 RUN(NAME separate_compilation_02 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_02b.f90)
 RUN(NAME separate_compilation_03 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_03a.f90 separate_compilation_03b.f90 EXTRA_ARGS --skip-pass=pass_array_by_data)
 RUN(NAME separate_compilation_04 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_04a.f90 separate_compilation_04b.f90)
+RUN(NAME separate_compilation_05 LABELS gfortran llvm llvm_goc EXTRAFILES separate_compilation_05a.f90 separate_compilation_05b.f90)
+
 
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/separate_compilation_05.f90
+++ b/integration_tests/separate_compilation_05.f90
@@ -1,5 +1,5 @@
-program separate_compilation_04
-use separate_compilation_04b_module
+program separate_compilation_05
+use separate_compilation_05b_module
 use ieee_arithmetic, only: ieee_is_nan
 
 

--- a/integration_tests/separate_compilation_05.f90
+++ b/integration_tests/separate_compilation_05.f90
@@ -1,0 +1,13 @@
+program separate_compilation_04
+use separate_compilation_04b_module
+use ieee_arithmetic, only: ieee_is_nan
+
+
+implicit none
+real, allocatable :: A(:,:)
+allocate(A(3,3))
+A = 02315.1235
+call temp(A)
+print *, ieee_is_nan(A(1,1))
+if ( ieee_is_nan(A(1,1)) ) error stop
+end program

--- a/integration_tests/separate_compilation_05a.f90
+++ b/integration_tests/separate_compilation_05a.f90
@@ -1,0 +1,16 @@
+module separate_compilation_05a_module
+implicit none
+
+contains
+
+subroutine lu()
+end subroutine
+
+
+subroutine resol_lu(L)
+real, allocatable :: L(:,:)
+print *, sum(L)
+if ( abs(sum(L) - 2.08361094e+04 ) > 1e-8 ) error stop
+end subroutine
+
+end module

--- a/integration_tests/separate_compilation_05b.f90
+++ b/integration_tests/separate_compilation_05b.f90
@@ -1,0 +1,13 @@
+module separate_compilation_05b_module
+
+use separate_compilation_05a_module
+implicit none
+
+contains
+
+subroutine temp(A)
+real, allocatable :: A(:, :)
+call resol_lu(A)
+end subroutine
+
+end module

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1117,6 +1117,7 @@ int compile_src_to_object_file(const std::string &infile,
     }
     if (compiler_options.separate_compilation) {
         compiler_options.po.intrinsic_symbols_mangling = true;
+        compiler_options.po.intrinsic_module_name_mangling = true;
     }
     LCompilers::diag::Diagnostics diagnostics;
     t1 = std::chrono::high_resolution_clock::now();
@@ -2331,6 +2332,7 @@ int main_app(int argc, char *argv[]) {
     lcompilers_unique_ID = ( parser.opts.compiler_options.generate_object_code || compiler_options.separate_compilation ) ? get_unique_ID() : "";
     if (parser.opts.compiler_options.generate_object_code) {
         compiler_options.po.intrinsic_symbols_mangling = true;
+        compiler_options.po.intrinsic_module_name_mangling = true;
     }
 
     if (opts.arg_version) {

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -120,6 +120,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--cumulative", compiler_options.po.pass_cumulative, "Apply all the passes cumulatively till the given pass");
         app.add_flag("--realloc-lhs", compiler_options.po.realloc_lhs, "Reallocate left hand side automatically");
         app.add_flag("--module-mangling", compiler_options.po.module_name_mangling, "Mangles the module name");
+        app.add_flag("--intrinsic-module-mangling", compiler_options.po.intrinsic_module_name_mangling, "Mangles only intrinsic module name");
         app.add_flag("--global-mangling", compiler_options.po.global_symbols_mangling, "Mangles all the global symbols");
         app.add_flag("--intrinsic-mangling", compiler_options.po.intrinsic_symbols_mangling, "Mangles all the intrinsic symbols");
         app.add_flag("--all-mangling", compiler_options.po.all_symbols_mangling, "Mangles all possible symbols");

--- a/src/libasr/asr_scopes.cpp
+++ b/src/libasr/asr_scopes.cpp
@@ -52,7 +52,9 @@ void SymbolTable::mark_all_variables_external(Allocator &al) {
             }
             case (ASR::symbolType::Module) : {
                 ASR::Module_t *v = ASR::down_cast<ASR::Module_t>(a.second);
-                v->m_symtab->mark_all_variables_external(al);
+                if ( !startswith(v->m_name, "lfortran_intrinsic") ) {
+                    v->m_symtab->mark_all_variables_external(al);
+                }
             }
             default : {};
         }

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -328,7 +328,7 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
     symtab->add_symbol(module_name, (ASR::symbol_t*)mod2);
     mod2->m_symtab->parent = symtab;
     mod2->m_loaded_from_mod = true;
-    if ( generate_object_code ) {
+    if ( generate_object_code && !startswith(mod2->m_name, "lfortran_intrinsic") ) {
         mod2->m_symtab->mark_all_variables_external(al);
     }
     LCOMPILERS_ASSERT(symtab->resolve_symbol(module_name));
@@ -374,7 +374,7 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
                 symtab->add_symbol(item, (ASR::symbol_t*)mod2);
                 mod2->m_symtab->parent = symtab;
                 mod2->m_loaded_from_mod = true;
-                if ( generate_object_code ) {
+                if ( generate_object_code && !startswith(mod2->m_name, "lfortran_intrinsic") ) {
                     mod2->m_symtab->mark_all_variables_external(al);
                 }
                 rerun = true;

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -46,6 +46,7 @@ struct PassOptions {
     bool realloc_lhs = false;
     std::vector<int64_t> skip_optimization_func_instantiation;
     bool module_name_mangling = false;
+    bool intrinsic_module_name_mangling = false;
     bool global_symbols_mangling = false;
     bool intrinsic_symbols_mangling = false;
     bool all_symbols_mangling = false;


### PR DESCRIPTION
Fixes #7164. With this we set `Numerical Codes Fortran` with separate compilation at CI.