### PR TITLE
Consolidate read_file() implementations

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -84,6 +84,7 @@ namespace {
 
 using LCompilers::endswith;
 using LCompilers::CompilerOptions;
+using LCompilers::read_file_ok;
 
 namespace lcli = LCompilers::CommandLineInterface;
 
@@ -189,22 +190,6 @@ void print_time_report(const std::vector<std::string>& vector_of_time_report) {
     }
 
     std::cout << std::string(60, '-') << '\n';
-}
-
-std::string read_file(const std::string &filename)
-{
-    std::ifstream ifs(filename.c_str(), std::ios::in | std::ios::binary
-            | std::ios::ate);
-
-    std::ifstream::pos_type filesize = ifs.tellg();
-    if (filesize < 0) return std::string();
-
-    ifs.seekg(0, std::ios::beg);
-
-    std::vector<char> bytes(filesize);
-    ifs.read(&bytes[0], filesize);
-
-    return std::string(&bytes[0], filesize);
 }
 
 #ifdef HAVE_LFORTRAN_LLVM
@@ -502,7 +487,7 @@ int prompt(bool verbose, CompilerOptions &cu)
 
 int emit_prescan(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
     LCompilers::LocationManager lm;
     {
         LCompilers::LocationManager::FileLocations fl;
@@ -524,7 +509,7 @@ int emit_prescan(const std::string &infile, CompilerOptions &compiler_options)
 
 int emit_tokens(const std::string &infile, bool line_numbers, const CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
     // Src -> Tokens
     Allocator al(64*1024*1024);
     std::vector<int> toks;
@@ -570,7 +555,7 @@ int emit_tokens(const std::string &infile, bool line_numbers, const CompilerOpti
 
 int emit_ast(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -601,7 +586,7 @@ int emit_ast(const std::string &infile, CompilerOptions &compiler_options)
 
 int emit_ast_f90(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
@@ -627,7 +612,7 @@ int emit_ast_f90(const std::string &infile, CompilerOptions &compiler_options)
 int format(const std::string &infile, bool inplace, bool color, int indent,
     bool indent_unit, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
     LCompilers::LLanguageServer::LFortranAccessor lfortran_accessor;
 
     if (inplace) color = false;
@@ -657,7 +642,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
 
     bool c_order = (0==array_order.compare("c"));
 
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::ASR::TranslationUnit_t* asr;
@@ -715,7 +700,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
 [[maybe_unused]] int run_parser_and_semantics(const std::string &infile,
     CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -741,7 +726,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
     LCompilers::PassManager& pass_manager,
     CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -796,7 +781,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
 
 int emit_cpp(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -821,7 +806,7 @@ int emit_cpp(const std::string &infile, CompilerOptions &compiler_options)
 int emit_c(const std::string &infile,
     LCompilers::PassManager& pass_manager, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -856,7 +841,7 @@ int emit_c(const std::string &infile,
 
 int emit_julia(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -879,7 +864,7 @@ int emit_julia(const std::string &infile, CompilerOptions &compiler_options)
 }
 
 int emit_fortran(const std::string &infile, CompilerOptions &compiler_options) {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -903,7 +888,7 @@ int emit_fortran(const std::string &infile, CompilerOptions &compiler_options) {
 
 int dump_all_passes(const std::string &infile, CompilerOptions &compiler_options,
                         LCompilers::PassManager &pass_manager) {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -980,7 +965,7 @@ int handle_mlir(const std::string &infile,
         const std::string &outfile,
         CompilerOptions &compiler_options,
         bool emit_mlir, bool emit_llvm) {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::ASR::TranslationUnit_t* asr;
@@ -1034,7 +1019,7 @@ int handle_mlir(const std::string &infile,
 int emit_llvm(const std::string &infile, LCompilers::PassManager& pass_manager,
               CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -1059,7 +1044,7 @@ int emit_llvm(const std::string &infile, LCompilers::PassManager& pass_manager,
 
 int emit_asm(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -1098,7 +1083,7 @@ int compile_src_to_object_file(const std::string &infile,
     int time_llvm_to_bin=0;
 
     auto t1 = std::chrono::high_resolution_clock::now();
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
     auto t2 = std::chrono::high_resolution_clock::now();
     time_file_read = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
 
@@ -1253,7 +1238,7 @@ int compile_llvm_to_object_file(const std::string& infile,
                                 const std::string& outfile,
                                 CompilerOptions& compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
     LCompilers::LLVMEvaluator e(compiler_options.target);
 
     std::unique_ptr<LCompilers::LLVMModule> m = e.parse_module2(input, infile);
@@ -1273,7 +1258,7 @@ int compile_to_assembly_file(const std::string &infile,
 
 int emit_wat(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -1313,7 +1298,7 @@ int compile_to_binary_x86(const std::string &infile, const std::string &outfile,
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        input = read_file(infile);
+        input = read_file_ok(infile);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_file_read = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     }
@@ -1414,7 +1399,7 @@ int compile_to_binary_wasm(const std::string &infile, const std::string &outfile
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        input = read_file(infile);
+        input = read_file_ok(infile);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_file_read = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
     }
@@ -1503,7 +1488,7 @@ int compile_to_object_file_cpp(const std::string &infile,
         bool assembly, bool kokkos, const std::string &rtlib_header_dir,
         CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::ASR::TranslationUnit_t* asr;
@@ -1616,7 +1601,7 @@ int compile_to_object_file_c(const std::string &infile,
         LCompilers::PassManager pass_manager,
         CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     // Src -> AST -> ASR
@@ -1716,7 +1701,7 @@ int compile_to_object_file_c(const std::string &infile,
 int compile_to_binary_fortran(const std::string &infile,
         const std::string &outfile,
         CompilerOptions &compiler_options) {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
@@ -2138,7 +2123,7 @@ int link_executable(const std::vector<std::string> &infiles,
 
 int emit_c_preprocessor(const std::string &infile, CompilerOptions &compiler_options)
 {
-    std::string input = read_file(infile);
+    std::string input = read_file_ok(infile);
 
     LCompilers::LFortran::CPreprocessor cpp(compiler_options);
     LCompilers::LocationManager lm;

--- a/src/bin/lsp_cli.cpp
+++ b/src/bin/lsp_cli.cpp
@@ -100,7 +100,7 @@ namespace LCompilers {
 
     int get_symbols(const std::string &infile, CompilerOptions &compiler_options)
     {
-        std::string input = read_file(infile);
+        std::string input = read_file_ok(infile);
         LCompilers::LLanguageServer::LFortranAccessor lfortran_accessor;
         std::vector<LCompilers::document_symbols> symbol_lists =
             lfortran_accessor.getSymbols(infile, input, compiler_options);
@@ -152,7 +152,7 @@ namespace LCompilers {
 
     int get_errors(const std::string &infile, CompilerOptions &compiler_options)
     {
-        std::string input = read_file(infile);
+        std::string input = read_file_ok(infile);
         LCompilers::LLanguageServer::LFortranAccessor lfortran_accessor;
         std::vector<LCompilers::error_highlight> diag_lists =
             lfortran_accessor.showErrors(infile, input, compiler_options);
@@ -205,7 +205,7 @@ namespace LCompilers {
 
     int get_definitions(const std::string &infile, LCompilers::CompilerOptions &compiler_options)
     {
-        std::string input = read_file(infile);
+        std::string input = read_file_ok(infile);
         LCompilers::LLanguageServer::LFortranAccessor lfortran_accessor;
         std::vector<LCompilers::document_symbols> symbol_lists =
             lfortran_accessor.lookupName(infile, input, compiler_options);
@@ -258,7 +258,7 @@ namespace LCompilers {
 
     int get_all_occurences(const std::string &infile, LCompilers::CompilerOptions &compiler_options)
     {
-        std::string input = read_file(infile);
+        std::string input = read_file_ok(infile);
         LCompilers::LLanguageServer::LFortranAccessor lfortran_accessor;
         std::vector<LCompilers::document_symbols> symbol_lists =
             lfortran_accessor.getAllOccurrences(infile, input, compiler_options);
@@ -309,4 +309,3 @@ namespace LCompilers {
     }
 
 } // namespace LCompilers
-

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -350,7 +350,10 @@ public:
         LocationManager::FileLocations fl;
         fl.in_filename = infile;
         lm.files.push_back(fl);
-        std::string input = read_file(infile);
+        std::string input;
+        if (!read_file(infile, input)) {
+            throw CodeGenError("File '" + infile + "' cannot be opened.");
+        }
         lm.init_simple(input);
         lm.file_ends.push_back(input.size());
         lm.pos_to_linecol(lm.output_to_input_pos(loc_first, false),

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -5,6 +5,7 @@
 #include <libasr/assert.h>
 #include <libasr/exception.h>
 #include <libasr/utils.h>
+#include <libasr/string_utils.h>
 
 namespace LCompilers::diag {
 
@@ -138,9 +139,12 @@ void populate_span(diag::Span &s, const LocationManager &lm) {
     lm.pos_to_linecol(lm.output_to_input_pos(s.loc.last, true),
         s.last_line, s.last_column, s.filename);
     std::string input;
-    read_file(s.filename, input);
-    for (uint32_t i = s.first_line; i <= s.last_line; i++) {
-        s.source_code.push_back(get_line(input, i));
+    if (read_file(s.filename, input)) {
+        for (uint32_t i = s.first_line; i <= s.last_line; i++) {
+            s.source_code.push_back(get_line(input, i));
+        }
+    } else {
+        s.source_code.push_back("File not found.\n");
     }
     LCOMPILERS_ASSERT(s.source_code.size() > 0)
 }

--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -127,21 +127,36 @@ std::string replace(const std::string &s,
     return std::regex_replace(s, std::regex(regex), replace);
 }
 
-std::string read_file(const std::string &filename)
+bool read_file(const std::string &filename, std::string &text)
 {
+    if (filename.empty()) return false;
     std::ifstream ifs(filename.c_str(), std::ios::in | std::ios::binary
             | std::ios::ate);
+    if (!ifs.is_open()) return false;
 
     std::ifstream::pos_type filesize = ifs.tellg();
-    if (filesize < 0) return std::string();
+    if (filesize < 0) return false;
 
     ifs.seekg(0, std::ios::beg);
 
     std::vector<char> bytes(filesize);
+    if (filesize == 0) bytes.reserve(1);
     ifs.read(&bytes[0], filesize);
 
-    return std::string(&bytes[0], filesize);
+    text = std::string(&bytes[0], filesize);
+    return true;
 }
+
+std::string read_file_ok(const std::string &filename) {
+    std::string text;
+    if (read_file(filename, text)) {
+        return text;
+    } else {
+        std::cerr << "File '" + filename + "' cannot be opened." << std::endl;
+        abort();
+    }
+}
+
 
 std::string parent_path(const std::string &path) {
     int pos = path.size()-1;

--- a/src/libasr/string_utils.h
+++ b/src/libasr/string_utils.h
@@ -29,7 +29,10 @@ char *s2c(Allocator &al, const std::string &s);
 std::string replace(const std::string &s,
     const std::string &regex, const std::string &replace);
 
-std::string read_file(const std::string &filename);
+// Reads a file, returns success/fail as a result
+bool read_file(const std::string &filename, std::string &text);
+// Reads a file, aborts on failure
+std::string read_file_ok(const std::string &filename);
 
 // Returns the parent path to the given path
 std::string parent_path(const std::string &path);

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -141,7 +141,6 @@ struct CompilerOptions {
     CompilerOptions () : platform{get_platform()} {};
 };
 
-bool read_file(const std::string &filename, std::string &text);
 bool present(Vec<char*> &v, const char* name);
 bool present(char** const v, size_t n, const std::string name);
 int initialize();

--- a/src/libasr/utils2.cpp
+++ b/src/libasr/utils2.cpp
@@ -28,26 +28,6 @@ std::string get_unique_ID() {
     return res;
 }
 
-bool read_file(const std::string &filename, std::string &text)
-{
-    if (filename.empty()) return false;
-    std::ifstream ifs(filename.c_str(), std::ios::in | std::ios::binary
-            | std::ios::ate);
-    if (!ifs.is_open()) return false;
-
-    std::ifstream::pos_type filesize = ifs.tellg();
-    if (filesize < 0) return false;
-
-    ifs.seekg(0, std::ios::beg);
-
-    std::vector<char> bytes(filesize);
-    if (filesize == 0) bytes.reserve(1);
-    ifs.read(&bytes[0], filesize);
-
-    text = std::string(&bytes[0], filesize);
-    return true;
-}
-
 bool present(Vec<char*> &v, const char* name) {
     for (auto &a : v) {
         if (std::string(a) == std::string(name)) {


### PR DESCRIPTION
Previously there were 3 duplicate implementations. The most general implementation returns a success/fail boolean status, and a string. This covers all use cases, so we use that.

For backwards compatibility we also provide read_file_ok() that returns the file content, but aborts on failure to open the file.