### PR TITLE
CI: use github model release link associated with certik/fastGPT

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -361,8 +361,10 @@ time_section "🧪 Testing fastGPT" '
         git clean -dfx
         git checkout -t origin/namelist
         git checkout d3eef520c1be8e2db98a3c2189740af1ae7c3e06
+        # NOTE: the release file link below wouldn't necessarily
+        # need to be updated if the commit hash above is updated
         curl -f -L -o model.dat \
-                https://github.com/gxyd/gpt/releases/download/v2.0/model_fastgpt_124M_v1.dat
+            https://github.com/certik/fastGPT/releases/download/v1.0-model-github-release/model_fastgpt_124M_v1.dat
         echo "11f6f018794924986b2fdccfbe8294233bb5e8ba28d40ae971dec3adbdc81ad7  model.dat" | shasum -a 256 --check
 
         mkdir lf


### PR DESCRIPTION
## Description

For the reviewer, atleast the following things need be probably done:
* Check from the release made at: https://github.com/certik/fastGPT/releases/tag/v1.0-model-github-release, whether any improvements are desired? e.g.; the release name, description, etc., so that we can fix it