### PR TITLE
enh: add support for compiletime array source in `transfer`

### DIFF
--- a/integration_tests/array_04_transfer.f90
+++ b/integration_tests/array_04_transfer.f90
@@ -1,8 +1,22 @@
+module array_04_transfer_mod
+    use, intrinsic :: iso_fortran_env, only: int32, int64, real32
+    implicit none
+    integer(int32), parameter :: sc_constsub = int(z'deadbeef', int32)
+    integer(int32), parameter :: int32_arr(2) = [sc_constsub, sc_constsub]
+    real(real32),  parameter :: real32_arr(2) = [real(1.23, real32), real(4.56, real32)]
+    integer(int64), parameter :: int32_int64 = transfer(int32_arr, 0_int64)
+    integer(int64), parameter :: real32_int64 = transfer(real32_arr, 0_int64)
+    integer(int64), parameter :: real32_int32 = transfer(real32_arr, 0_int32)
+end module
 program array_04_transfer
+    use array_04_transfer_mod
     implicit none
     real :: value(5) = [1.1, 1.2, 1.3, 1.4, 1.5]
     integer :: val(5)
     val = transfer(value, val, 1 * size(value))
     print * , val
     if (all(val /= [1066192077, 1067030938, 1067869798, 1068708659, 1069547520])) error stop
+    if (real32_int32 /= 1067282596) error stop
+    if (real32_int64 /= 4652758847580893348_8) error stop
+    if (int32_int64 /= -2401053088876216593_8) error stop
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7145,6 +7145,45 @@ public:
                     source_bits.assign(reinterpret_cast<uint8_t*>(&val),
                                     reinterpret_cast<uint8_t*>(&val) + sizeof(val));
                 }
+            } else if (ASRUtils::is_array(ASRUtils::expr_type(source)) && ASRUtils::is_value_constant(source_value)) {
+                ASR::ArrayConstant_t* const_source = ASR::down_cast<ASR::ArrayConstant_t>(ASRUtils::expr_value(source_value));
+                ASR::ttype_t* source_type = ASRUtils::expr_type(source_value);
+                int kind = ASRUtils::extract_kind_from_ttype_t(source_type);
+                size_t n_elements = ASRUtils::get_fixed_size_of_array(source_type);
+
+                if (ASRUtils::is_integer(*source_type)) {
+                    if (kind == 4) {
+                        for (size_t i=0; i < n_elements; i++) {
+                            int32_t val = ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::fetch_ArrayConstant_value(al, const_source, i))->m_n;
+                            source_bits.insert(source_bits.end(),
+                                reinterpret_cast<uint8_t*>(&val),
+                                reinterpret_cast<uint8_t*>(&val) + sizeof(val));
+                        }
+                    } else {
+                        for (size_t i=0; i < n_elements; i++) {
+                            int64_t val = ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::fetch_ArrayConstant_value(al, const_source, i))->m_n;
+                            source_bits.insert(source_bits.end(),
+                                reinterpret_cast<uint8_t*>(&val),
+                                reinterpret_cast<uint8_t*>(&val) + sizeof(val));
+                        }
+                    }
+                } else if (ASRUtils::is_real(*source_type)) {
+                    if (kind == 4) {
+                        for (size_t i=0; i < n_elements; i++) {
+                            float val = ASR::down_cast<ASR::RealConstant_t>(ASRUtils::fetch_ArrayConstant_value(al, const_source, i))->m_r;
+                            source_bits.insert(source_bits.end(),
+                                reinterpret_cast<uint8_t*>(&val),
+                                reinterpret_cast<uint8_t*>(&val) + sizeof(val));
+                        }
+                    } else {
+                        for (size_t i=0; i < n_elements; i++) {
+                            double val = ASR::down_cast<ASR::RealConstant_t>(ASRUtils::fetch_ArrayConstant_value(al, const_source, i))->m_r;
+                            source_bits.insert(source_bits.end(),
+                                reinterpret_cast<uint8_t*>(&val),
+                                reinterpret_cast<uint8_t*>(&val) + sizeof(val));
+                        }
+                    }
+                }
             } else {
                 return ASR::make_BitCast_t(al, x.base.base.loc, source, mold, size, type, nullptr);
             }


### PR DESCRIPTION
Fixes #7182 