### PR TITLE
Fix: Handle args for Generic ClassProcedures with this as an starting argument

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1318,6 +1318,7 @@ RUN(NAME implicit_typing_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortra
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME generic_procedure_1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/generic_procedure_1.f90
+++ b/integration_tests/generic_procedure_1.f90
@@ -1,0 +1,37 @@
+module custom_deque
+  implicit none
+  type :: Complex32Deque
+    integer :: size_ = 0
+  contains
+    procedure :: Complex32Deque_resize_default
+    generic :: resize => Complex32Deque_resize_default
+  end type Complex32Deque
+
+contains
+
+  subroutine Complex32Deque_resize_default(this, count, value)
+    class(Complex32Deque), intent(inout) :: this
+    integer, intent(in) :: count
+    integer, optional, intent(in) :: value
+
+    ! Simplified implementation to avoid undefined dependencies
+    if (count >= 0) then
+      this%size_ = count
+      if (present(value)) then
+        ! Simulate setting value (not implemented)
+      end if
+    end if
+  end subroutine Complex32Deque_resize_default
+
+end module custom_deque
+
+program generic_procedure_1
+  use custom_deque
+  implicit none
+
+  type(Complex32Deque) :: d
+  integer :: rc=0
+
+  call d%resize(5, value=5)
+  print *, "Size:", d%size_, "RC:", rc
+end program generic_procedure_1

--- a/integration_tests/generic_procedure_1.f90
+++ b/integration_tests/generic_procedure_1.f90
@@ -1,37 +1,48 @@
-module custom_deque
+module derived_types
   implicit none
-  type :: Complex32Deque
-    integer :: size_ = 0
+
+  type :: type_pass
+    integer :: value
   contains
-    procedure :: Complex32Deque_resize_default
-    generic :: resize => Complex32Deque_resize_default
-  end type Complex32Deque
+    procedure :: set_value_pass
+    generic :: set_value => set_value_pass
+  end type
+
+  type :: type_nopass
+    integer :: value
+  contains
+    procedure, nopass :: set_value_nopass
+    generic :: set_value => set_value_nopass
+  end type
 
 contains
 
-  subroutine Complex32Deque_resize_default(this, count, value)
-    class(Complex32Deque), intent(inout) :: this
-    integer, intent(in) :: count
-    integer, optional, intent(in) :: value
+  subroutine set_value_pass(this, value)
+    class(type_pass), intent(inout) :: this
+    integer, intent(in) :: value
+    this%value = 2 * value
+  end subroutine
 
-    ! Simplified implementation to avoid undefined dependencies
-    if (count >= 0) then
-      this%size_ = count
-      if (present(value)) then
-        ! Simulate setting value (not implemented)
-      end if
-    end if
-  end subroutine Complex32Deque_resize_default
+  subroutine set_value_nopass(obj, value)
+    class(type_nopass), intent(inout) :: obj
+    integer, intent(in) :: value
+    obj%value = value
+  end subroutine
 
-end module custom_deque
+end module
 
-program generic_procedure_1
-  use custom_deque
+program main
+  use derived_types
   implicit none
 
-  type(Complex32Deque) :: d
-  integer :: rc=0
+  type(type_pass) :: obj_pass
+  type(type_nopass) :: obj_nopass
 
-  call d%resize(5, value=5)
-  print *, "Size:", d%size_, "RC:", rc
-end program generic_procedure_1
+  obj_pass%value = 42
+  call obj_pass%set_value(value=5)
+  if (obj_pass%value /= 10) error stop "Error in set_value_pass"
+
+  obj_nopass%value = 42
+  call obj_nopass%set_value(obj_nopass, value=5)
+  if (obj_nopass%value /= 5) error stop "Error in set_value_nopass"
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10030,14 +10030,18 @@ public:
     template <typename T>
     void visit_kwargs(Vec<ASR::call_arg_t>& args, AST::keyword_t *kwargs, size_t n,
                 ASR::expr_t **fn_args, size_t fn_n_args, const Location &loc, T* fn,
-                diag::Diagnostics& diag, size_t type_bound=0, bool is_nopass = false) {
+                diag::Diagnostics& diag, size_t type_bound=0, bool is_nopass = false, bool is_ClassProcedure_With_Self_Argument = false) {
         int n_args = args.size();
         std::string fn_name = fn->m_name;
         if (is_nopass) {
             type_bound = 0;
         }
         bool is_method = (type_bound > 0);
-        if (n_args + (int)n > (int)fn_n_args) {
+        int func_args_size = fn_n_args;
+        if (is_ClassProcedure_With_Self_Argument) {
+            func_args_size = fn_n_args + 1;
+        }
+        if (n_args + (int)n > (int)func_args_size) {
             diag.semantic_error_label(
                 "Procedure '" + fn_name + "' accepts " + std::to_string(fn_n_args)
                 + " arguments, but " + std::to_string(n_args + n)

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10030,18 +10030,14 @@ public:
     template <typename T>
     void visit_kwargs(Vec<ASR::call_arg_t>& args, AST::keyword_t *kwargs, size_t n,
                 ASR::expr_t **fn_args, size_t fn_n_args, const Location &loc, T* fn,
-                diag::Diagnostics& diag, size_t type_bound=0, bool is_nopass = false, bool is_ClassProcedure_With_Self_Argument = false) {
+                diag::Diagnostics& diag, size_t type_bound=0, bool is_nopass = false) {
         int n_args = args.size();
         std::string fn_name = fn->m_name;
         if (is_nopass) {
             type_bound = 0;
         }
         bool is_method = (type_bound > 0);
-        int func_args_size = fn_n_args;
-        if (is_ClassProcedure_With_Self_Argument) {
-            func_args_size = fn_n_args + 1;
-        }
-        if (n_args + (int)n > (int)func_args_size) {
+        if (n_args + (int)n > (int)fn_n_args) {
             diag.semantic_error_label(
                 "Procedure '" + fn_name + "' accepts " + std::to_string(fn_n_args)
                 + " arguments, but " + std::to_string(n_args + n)


### PR DESCRIPTION
Towards https://github.com/lfortran/lfortran/issues/7185
