### PR TITLE
Retries parallel tests on time-outs

### DIFF
--- a/.github/workflows/LSP.yml
+++ b/.github/workflows/LSP.yml
@@ -14,7 +14,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
 
 jobs:
-  Build:
+  test_lsp:
     name: LSP Tests (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -64,11 +64,49 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: brew install coreutils
 
+      # ~/.bash_logout wanted to run `/usr/bin/clear_console -q` while exiting
+      # login shells which frequently erred on ubuntu-latest since the shell was
+      # not run interactively.
+      - name: Disable ~/.bash_logout (Linux)
+        shell: bash -e {0}
+        if: contains(matrix.os, 'ubuntu')
+        run: mv -v ~/.bash_logout ~/.bash_logout.bak
+
       - name: Test (Linux / macOS)
         shell: bash -e -l {0}
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         timeout-minutes: 5
+        env:
+            EXIT_SUCCESS: 0
+            EXIT_TIMEOUT: 124
+            EXIT_KILL: 137
+            MAX_ATTEMPTS: 3
+            SIGTERM_TIMEOUT: 60s
+            SIGKILL_TIMEOUT: 10s
+            PYTEST_TIMEOUT: 10
         run: |
-            case "$OSTYPE" in darwin*) export MACOS=1;; *) export MACOS=0;; esac
-            export LFORTRAN_TEST_ENV_VAR='STATUS OK!'
-            shell ci/test_lsp.sh
+            set -ex
+            pip install src/server/tests tests/server
+            timeout -k $SIGKILL_TIMEOUT $SIGTERM_TIMEOUT \
+                pytest -vv \
+                    --showlocals \
+                    --timeout=$PYTEST_TIMEOUT \
+                    --execution-strategy="concurrent" \
+                    tests/server
+            set +e
+            for (( ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++ )); do
+                echo "Attempt $ATTEMPT of $MAX_ATTEMPTS"
+                timeout -k $SIGKILL_TIMEOUT $SIGTERM_TIMEOUT \
+                    pytest -vv \
+                        --showlocals \
+                        --timeout=$PYTEST_TIMEOUT \
+                        --execution-strategy="parallel" \
+                        tests/server
+                EXIT_CODE=$?
+                if [ $EXIT_CODE -eq $EXIT_SUCCESS ]; then
+                    break
+                fi
+                echo "Command failed with exit code: $EXIT_CODE" 1>&2
+            done
+            set -e
+            exit $EXIT_CODE


### PR DESCRIPTION
Changes:
- Moves test logic into bash script within the LSP workflow
- Makes testing parameters configurable
- Retries parallel tests up to 3 times