### PR TITLE
chore: add errors for unsupported `mold` argument in allocate statements

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1585,7 +1585,7 @@ public:
         if( !cond ) {
             diag.add(Diagnostic(
                 "`allocate` statement only "
-                "accepts four keyword arguments,"
+                "accepts four keyword arguments: "
                 "`stat`, `errmsg`, `source` and `mold`",
                 Level::Error, Stage::Semantic, {
                     Label("",{x.base.base.loc})

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1543,20 +1543,28 @@ public:
                     ASR::ttype_t* a_type = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(alloc_args_vec[i].m_a));
                     if ( ASRUtils::check_equal_type(mold_type, a_type) ) {
                         if (ASRUtils::is_array(mold_type)) {
-                            ASR::Array_t* mold_array_type = ASR::down_cast<ASR::Array_t>(mold_type);
-                            ASR::alloc_arg_t new_arg;
-                            new_arg.loc = alloc_args_vec[i].loc;
-                            new_arg.m_a = alloc_args_vec[i].m_a;
-                            new_arg.m_len_expr = nullptr;
-                            new_arg.m_type = nullptr;
-                            new_arg.m_dims = mold_array_type->m_dims;
-                            new_arg.n_dims = mold_array_type->n_dims;
-                            new_alloc_args_vec.push_back(al, new_arg);
-                            alloc_args_vec = new_alloc_args_vec;
+                            if (ASR::is_a<ASR::Array_t>(*mold_type)) {
+                                ASR::Array_t* mold_array_type = ASR::down_cast<ASR::Array_t>(mold_type);
+                                ASR::alloc_arg_t new_arg;
+                                new_arg.loc = alloc_args_vec[i].loc;
+                                new_arg.m_a = alloc_args_vec[i].m_a;
+                                new_arg.m_len_expr = nullptr;
+                                new_arg.m_type = nullptr;
+                                new_arg.m_dims = mold_array_type->m_dims;
+                                new_arg.n_dims = mold_array_type->n_dims;
+                                new_alloc_args_vec.push_back(al, new_arg);
+                                alloc_args_vec = new_alloc_args_vec;
+                            } else {
+                                diag.add(Diagnostic("Runtime dimensions are not supported yet for mold.",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("",{mold->base.loc})
+                                    }));
+                                throw SemanticAbort();
+                            }
                         } else {
                             diag.add(Diagnostic("The type of the argument is not supported yet for mold.",
                                 Level::Error, Stage::Semantic, {
-                                    Label("",{x.base.base.loc})
+                                    Label("",{mold->base.loc})
                                 }));
                             throw SemanticAbort();
                         }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -58,7 +58,7 @@ program continue_compilation_1
     character :: c1
     complex :: c = (1.0, 2.0)
     real a_real(0)
-    integer, allocatable ::  shape_(:), arr4(:)
+    integer, allocatable ::  shape_(:), arr4(:), arr5(:)
     integer, dimension(2, 3) :: matrix
     integer, dimension(4) :: source = [1, 2, 3, 4]
     allocate(shape_(2))
@@ -77,7 +77,7 @@ program continue_compilation_1
     character(len=100) :: filename
     type(MyClass), parameter :: myclass_array(2) = [1, MyClass(10)]
     type(MyClass), parameter :: myclass_array2(2) = [MyClass(1), MyClass(q1)]
-    integer, allocatable :: arr5(:)
+    
 
 
 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -77,7 +77,7 @@ program continue_compilation_1
     character(len=100) :: filename
     type(MyClass), parameter :: myclass_array(2) = [1, MyClass(10)]
     type(MyClass), parameter :: myclass_array2(2) = [MyClass(1), MyClass(q1)]
-
+    integer, allocatable :: arr5(:)
 
 
 
@@ -306,4 +306,7 @@ program continue_compilation_1
 
     call logger % add_log_file(filename=filename)
     call logger % add_log_file()
+
+    allocate(arr5, status=q1)
+    allocate(arr5, mold = arr4)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "6ba2b6e82491a9290349000dd81c8f882fa94acb655d1a2086b4c539",
+    "infile_hash": "dccd6e1ce8885a8c5eb7caddd01b8c7bc6e7c07bb8a94b47de4aab77",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "5bc23b9486b1ce590fa95960d7f7ebed4c34cde6dab4d6e2606f4d1d",
+    "stderr_hash": "1638a078b4644a7e699c15bd4a699a5980cf6b0ff549809185244e6b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "dccd6e1ce8885a8c5eb7caddd01b8c7bc6e7c07bb8a94b47de4aab77",
+    "infile_hash": "0ae7783c1abe2f0187a8fcf3aabd80fe406394305ef16ea301293220",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "1638a078b4644a7e699c15bd4a699a5980cf6b0ff549809185244e6b",
+    "stderr_hash": "4b6452525ee3dd4237b6ce2ac60542aae35986608e7302d5a83b7f9c",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -686,7 +686,7 @@ semantic error: Required argument `unit` is missing in function call
 308 |     call logger % add_log_file()
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: `allocate` statement only accepts four keyword arguments,`stat`, `errmsg`, `source` and `mold`
+semantic error: `allocate` statement only accepts four keyword arguments: `stat`, `errmsg`, `source` and `mold`
    --> tests/errors/continue_compilation_1.f90:310:5
     |
 310 |     allocate(arr5, status=q1)

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -685,3 +685,15 @@ semantic error: Required argument `unit` is missing in function call
     |
 308 |     call logger % add_log_file()
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: `allocate` statement only accepts four keyword arguments,`stat`, `errmsg`, `source` and `mold`
+   --> tests/errors/continue_compilation_1.f90:310:5
+    |
+310 |     allocate(arr5, status=q1)
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Runtime dimensions are not supported yet for mold.
+   --> tests/errors/continue_compilation_1.f90:311:27
+    |
+311 |     allocate(arr5, mold = arr4)
+    |                           ^^^^ 


### PR DESCRIPTION
Apply suggestion from https://github.com/lfortran/lfortran/pull/6638#pullrequestreview-2823049951