### PR TITLE
Fix : promoting String-allocatable arrays into nonallocatable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -772,7 +772,7 @@ RUN(NAME intrinsics_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # 
 RUN(NAME intrinsics_open_close_read_write LABELS gfortran llvm)
 RUN(NAME intrinsics_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #min
 RUN(NAME intrinsics_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # merge
-# RUN(NAME intrinsics_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # merge
+RUN(NAME intrinsics_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # merge
 RUN(NAME intrinsics_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sign
 RUN(NAME intrinsics_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sign
 RUN(NAME intrinsics_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN intrinsics_60_data.txt) # iachar for extended ascii


### PR DESCRIPTION
This is built on top of this PR #7048 

example 
```.f90
program pp
  character(len=:),allocatable :: shorts(:)
  allocate(character(len=6) :: shorts(10))
  print *, shorts
  
end program 
```

that allocatable array used to end up like this after applying `promote_allocatable_to_nonallocatable`
```clj
(Array
  (String 1 -2 () PointerString)
  [((IntegerConstant 1 (Integer 4) Decimal)
  (IntegerConstant 10 (Integer 4) Decimal))]
  FixedSizeArray
)
```
After string node refactor (here https://github.com/lfortran/lfortran/pull/7048)
```clj
(Array
    (String 1 () .false. .true. PointerString)
    [((IntegerConstant 1 (Integer 4) Decimal)
    (IntegerConstant 10 (Integer 4) Decimal))]
    FixedSizeArray
)
```
After Fix in this PR
```clj
  (Array
      (String 1 (IntegerConstant 6 (Integer 4) Decimal) .false. .false. PointerString)
      [((IntegerConstant 1 (Integer 4) Decimal)
      (IntegerConstant 10 (Integer 4) Decimal))]
      FixedSizeArray
  )
```