### PR TITLE
fix: improve operator overloading with multiple interfaces

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1327,6 +1327,7 @@ RUN(NAME operator_overloading_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME operator_overloading_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_10.f90
+++ b/integration_tests/operator_overloading_10.f90
@@ -1,0 +1,43 @@
+module operator_overloading_10_module
+   implicit none
+
+   type :: first_type
+      integer :: x
+   end type
+
+   type :: second_type
+      integer :: x
+   end type
+
+   interface operator(/=)
+      module procedure ne
+   end interface
+
+   interface operator(/=)
+      module procedure une
+   end interface
+
+contains
+   logical function ne(x, y)
+      type(first_type), intent(in) :: x, y
+      print *, "first_type::ne"
+      ne = .false.
+   end function
+
+   logical function une(s, z)
+      type(second_type), intent(in) :: s, z
+      print *, "second_type::une"
+      une = .false.
+   end function
+end module operator_overloading_10_module
+
+program main
+   use operator_overloading_10_module
+   implicit none
+
+   type(first_type) :: a1, a2
+   type(second_type) :: b1, b2
+
+   if (a1 /= a2) error stop
+   if (b1 /= b2) error stop
+end program main

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2088,7 +2088,13 @@ public:
             AST::intrinsicopType opType = AST::down_cast<AST::InterfaceHeaderOperator_t>(x.m_header)->m_op;
             std::vector<std::string> proc_names;
             fill_interface_proc_names(x, proc_names);
-            overloaded_op_procs[opType] = proc_names;
+            // check if the operator is already defined, if yes, then a new defition means it is being overloaded
+            if (overloaded_op_procs.find(opType) != overloaded_op_procs.end()) {
+                overloaded_op_procs[opType].insert(overloaded_op_procs[opType].end(),
+                    proc_names.begin(), proc_names.end());
+            } else {
+                overloaded_op_procs[opType] = proc_names;
+            }
         } else if (AST::is_a<AST::InterfaceHeaderDefinedOperator_t>(*x.m_header)) {
             std::string op_name = to_lower(AST::down_cast<AST::InterfaceHeaderDefinedOperator_t>(x.m_header)->m_operator_name);
             std::vector<std::string> proc_names;


### PR DESCRIPTION
Part of #7218

We add the other procedures into the common
interface of the operator and overload it.
Previously, the latest interface declaration
had overwritten prior declarations, leading
to an ICE later.

### Output on `main`
```console
(lf) saurabhkumar@Mac lfortran % lfortran test.f90
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/saurabhkumar/OpenSource/lfortran/src/bin/lfortran.cpp", line 2685
    LCompilers::print_stack_on_segfault();
  File "/Users/saurabhkumar/OpenSource/lfortran/src/bin/lfortran.cpp", line 2616
    err = compile_src_to_object_file(arg_file, tmp_o, compiler_options.time_report, false,
  File "/Users/saurabhkumar/OpenSource/lfortran/src/bin/lfortran.cpp", line 1111
    lcompilers_unique_ID = compiler_options.generate_object_code ? get_unique_ID() : "";
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/fortran_evaluator.cpp", line 276
    Result<ASR::TranslationUnit_t*> res2 = get_asr3(*ast, diagnostics, lm);
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/fortran_evaluator.cpp", line 298
    compiler_options.symtab_only, compiler_options, lm);
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_to_asr.cpp", line 112
    if (res.ok) {
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 5132
    b.is_body_visitor = true;
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 166
    visit_ast(*x.m_items[i]);
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 4969
    void visit_ast(const ast_t &b) { visit_ast_t(b, self()); }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 4924
    case astType::unit: { v.visit_unit((const unit_t &)x); return; }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 4972
    void visit_mod(const mod_t &b) { visit_mod_t(b, self()); }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 4548
    case modType::BlockData: { v.visit_BlockData((const BlockData_t &)x); return; }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 2214
    transform_stmts(body, x.n_body, x.m_body);
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 128
    this->visit_stmt(*m_body[i]);
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 5017
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 4700
    case stmtType::ForAll: { v.visit_ForAll((const ForAll_t &)x); return; }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_body_visitor.cpp", line 4275
    visit_expr(*x.m_test);
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 5069
    void visit_expr(const expr_t &b) { visit_expr_t(b, self()); }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/ast.h", line 4720
    case exprType::DefUnaryOp: { v.visit_DefUnaryOp((const DefUnaryOp_t &)x); return; }
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 9836
    CommonVisitorMethods::visit_Compare(al, x, left, right, tmp,
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/ast_common_visitor.h", line 746
    right_type, conversion_cand,
  File "/Users/saurabhkumar/OpenSource/lfortran/src/lfortran/semantics/asr_implicit_cast_rules.h", line 602
    LCOMPILERS_ASSERT(left_type2->type < num_types);
AssertFailed: left_type2->type < 7
```

### Output on branch

```console
(lf) saurabhkumar@Mac lfortran % gfortran test.f90 && ./a.out
 first_type::ne
 second_type::une
(lf) saurabhkumar@Mac lfortran % lfortran test.f90           
first_type::ne
second_type::une
```