### PR TITLE
fix: allow pointer comparison of Real, Ints and Complex

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2217,3 +2217,4 @@ RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emc
     EXTRA_ARGS --implicit-typing)
 
 RUN(NAME logical_testing LABELS gfortran llvm)
+RUN(NAME compare_pointers_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/compare_pointers_01.f90
+++ b/integration_tests/compare_pointers_01.f90
@@ -1,0 +1,45 @@
+program compare_pointers_01
+    implicit none
+
+    integer, target :: int_num1, int_num2
+    integer, pointer :: int_ptr1 => null(), int_ptr2 => null()
+
+    real, target :: real_num1, real_num2
+    real, pointer :: real_ptr1 => null(), real_ptr2 => null()
+
+    int_num1 = 1
+    int_num2 = 2
+
+    real_num1 = 1.0
+    real_num2 = 2.0
+
+    int_ptr1 => int_num1
+    int_ptr2 => int_num2
+
+    real_ptr1 => real_num1
+    real_ptr2 => real_num2
+
+    ! FIXME: this prints incorrectly in LFortran as `False`
+    print *, int_ptr1 < int_ptr2
+    if (int_ptr1 < int_ptr2 ) then
+        print *, "comparison passed"
+    else
+        error stop
+    end if
+
+    ! FIXME: this prints incorrectly in LFortran as `False`
+    print *, int_ptr2 > int_ptr1
+    if (int_ptr2 > int_ptr1) then
+        print *, "comparison passed"
+    else
+        error stop
+    end if
+
+    ! FIXME: this comparison currently fails in LLVM backend
+    ! print *, real_ptr1 < real_ptr2
+    ! if (real_ptr1 < real_ptr2 ) then
+    !     print *, "comparison passed"
+    ! else
+    !     error stop
+    ! end if
+end program compare_pointers_01

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -668,10 +668,10 @@ inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
         }
     }
     // Cast LHS or RHS if necessary
-    ASR::ttype_t *left_type = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(left));
-    ASR::ttype_t *right_type = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(right));
-    ASR::ttype_t *left_type2 = ASRUtils::type_get_past_array(left_type);
-    ASR::ttype_t *right_type2 = ASRUtils::type_get_past_array(right_type);
+    ASR::ttype_t *left_type = ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(left));
+    ASR::ttype_t *right_type = ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(right));
+    ASR::ttype_t *left_type2 = ASRUtils::extract_type(ASRUtils::expr_type(left));
+    ASR::ttype_t *right_type2 = ASRUtils::extract_type(ASRUtils::expr_type(right));
 
     ASR::expr_t *overloaded = nullptr;
     if ( ASRUtils::use_overloaded(left, right, asr_op,


### PR DESCRIPTION
## Description

This is an MRE extracted from pFUnit third party repository (towards: https://github.com/lfortran/lfortran/issues/6930)

```f90
program compare_pointers_01
    implicit none

    integer, target :: int_num1, int_num2
    integer, pointer :: int_ptr1 => null(), int_ptr2 => null()

    int_num1 = 1
    int_num2 = 2

    int_ptr1 => int_num1
    int_ptr2 => int_num2

    print *, int_ptr1 < int_ptr2
end program compare_pointers_01

```

For the above Fortran program, LFortran raises a semantic error currently:
```console
semantic error: Compare: only Integer or Real can be on the LHS and RHS. If operator is .eq. or .neq. then Complex type is also acceptable
  --> test.f90:13:14
   |
13 |     print *, int_ptr1 < int_ptr2
   |              ^^^^^^^^^^^^^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

This PR intends to fix that issue.