### PR TITLE
fix: include procedures in new `CustomOperator` symbol for `ExternalSymbol`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1320,6 +1320,7 @@ RUN(NAME operator_overloading_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc N
 RUN(NAME operator_overloading_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_11.f90
+++ b/integration_tests/operator_overloading_11.f90
@@ -1,0 +1,44 @@
+module operator_overloading_11_module_1
+   implicit none
+
+   type :: t
+   end type
+
+   interface operator(/=)
+      module procedure ne
+   end interface
+contains
+   logical function ne(x, y)
+      type(t), intent(in) :: x, y
+      print *, "t::ne"
+      ne = .false.
+   end function
+end module operator_overloading_11_module_1
+
+module operator_overloading_11_module_2
+   use operator_overloading_11_module_1, only: t, operator(/=)
+   type :: u
+      type(t) :: x
+   end type
+   interface operator(/=)
+      module procedure une
+   end interface
+contains
+   logical function une(a, b)
+      type(u), intent(in) :: a, b
+      print *, "u::une"
+      une = .false.
+   end function
+end module operator_overloading_11_module_2
+
+program main
+   use operator_overloading_11_module_2
+
+   implicit none
+
+   type(t) :: x
+   type(u) :: y
+
+   if (x /= x) error stop
+   if (y /= y) error stop
+end program main


### PR DESCRIPTION
fixes #7218 

For a new definition of an operator already
imported in the current scope, we include it's
procedures in the new `CustomOperator` symbol and
overwrite the `ExternalSymbol` with it.