### PR TITLE
fix: correctly assign args size when visiting kwargs

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1660,6 +1660,7 @@ RUN(NAME class_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm NO_STD_F23)
 

--- a/integration_tests/class_18.f90
+++ b/integration_tests/class_18.f90
@@ -1,0 +1,64 @@
+module class_18_mod
+   use iso_fortran_env
+   implicit none
+
+   type KeywordEnforcer
+   end type KeywordEnforcer
+
+   public :: Integer32Complex32Map
+   public :: Integer32Complex32Pair
+
+   type :: Integer32Complex32Pair
+      integer(kind=INT32) :: first
+      complex(kind=REAL32) :: second
+   end type Integer32Complex32Pair
+
+   type, abstract :: map_s_BaseNode
+   end type map_s_BaseNode
+
+   type, extends(map_s_BaseNode) ::  map_s_Node
+      type(map_s_Node), pointer :: parent => null()
+   end type map_s_Node
+
+   type :: map_Set
+      private
+      class(map_s_BaseNode), allocatable :: root
+   contains
+      procedure :: insert_single => map_s_insert_single
+      generic :: insert => insert_single
+   end type map_Set
+
+   type :: Integer32Complex32Map
+      private
+      type(map_Set) :: tree
+   contains
+      procedure :: of => map_of
+   end type Integer32Complex32Map
+   contains
+
+   subroutine map_s_insert_single(this, value, unused, is_new)
+      class(map_Set), target, intent(inout) :: this
+      type(Integer32Complex32Pair), intent(in) :: value
+      type (KeywordEnforcer), optional :: unused
+      logical, optional, intent(out) :: is_new
+      is_new = .true.
+   end subroutine map_s_insert_single
+
+   subroutine map_of(this, key)
+       class(Integer32Complex32Map), target, intent(inout) :: this
+       integer(kind=INT32), intent(in) :: key
+       type(Integer32Complex32Pair) :: p
+       logical :: is_new
+       p%first= key
+       call this%tree%insert(p, is_new=is_new)
+       ! error checking is done here
+       if (is_new .eqv. .false.) error stop
+   end subroutine map_of
+end module class_18_mod
+
+program class_18
+    use class_18_mod
+    implicit none
+    type(Integer32Complex32Map) :: m
+    call m%of(42)
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10139,7 +10139,7 @@ public:
         std::vector<std::string> fn_args2 = convert_fn_args_to_string(fn_args, fn_n_args);
 
         int offset = args.size();
-        for (int i = 0; i < (int)fn_n_args - offset - (int)type_bound; i++) {
+        for (int i = 0; i < (int)fn_n_args - offset - is_method; i++) {
             ASR::call_arg_t call_arg;
             call_arg.loc = loc;
             call_arg.m_value = nullptr;
@@ -10159,7 +10159,7 @@ public:
                 return ;
             }
 
-            int idx = std::distance(fn_args2.begin(), search) - (int)type_bound;
+            int idx = std::distance(fn_args2.begin(), search) - (int)is_method;
             if (idx < n_args) {
                 diag.semantic_error_label(
                     "Keyword argument '" + name + "' is already specified as a positional argument",


### PR DESCRIPTION
## Description
using is_method is correct, as we only need to do offseting on the basis of whether a procedure needs to account for "this/self" or not


Fixes https://github.com/lfortran/lfortran/issues/7275

I'll keep this PR in draft mode, and try to see if I can add more tests for it, once I'm back to work in a hour or not.