### PR TITLE
CI: use `--cpp` flag when building POT3D

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -166,7 +166,7 @@ time_section "🧪 Testing POT3D" '
   FC="$FC --cpp --fast --skip-pass=dead_code_removal -DOPEN_MPI=yes" ./build_and_run.sh
 
   print_subsection "Building POT3D in separate compilation mode"
-  FC="$FC --generate-object-code --skip-pass=pass_array_by_data" ./build_and_run.sh
+  FC="$FC --cpp --generate-object-code --skip-pass=pass_array_by_data -DOPEN_MPI=yes" ./build_and_run.sh
 
   print_success "Done with POT3D"
   cd ..


### PR DESCRIPTION
## Description

This probably fixes an issue with failing CI in *main* , e.g.; of where I've noticed this: https://github.com/lfortran/lfortran/actions/runs/14999695211/job/42143040988?pr=7279


## Reason of failure
The PR's: https://github.com/lfortran/lfortran/pull/7273 and https://github.com/lfortran/lfortran/pull/7266 were merged one after the other and they both touched the *Test POT3D* part of the `test_third_party_codes.sh` file, and hence a probable issue.