### PR TITLE
CI: fix version of rhash for building LAPACK

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -561,7 +561,11 @@ jobs:
             cd build
             micromamba create -f environment_unix.yml
             micromamba activate lapack
-            ln -s $CONDA_PREFIX/lib/librhash.1.4.6.dylib $CONDA_PREFIX/lib/librhash.1.4.5.dylib
+            if [[ "$(uname)" == "Darwin" ]]; then
+              if [ ! -f "$CONDA_PREFIX/lib/librhash.1.4.5.dylib" ]; then
+                ln -s "$CONDA_PREFIX/lib/librhash.1.4.6.dylib" "$CONDA_PREFIX/lib/librhash.1.4.5.dylib"
+              fi
+            fi
             ./build_lf.sh
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -561,6 +561,7 @@ jobs:
             cd build
             micromamba create -f environment_unix.yml
             micromamba activate lapack
+            ln -s $CONDA_PREFIX/lib/librhash.1.4.6.dylib $CONDA_PREFIX/lib/librhash.1.4.5.dylib
             ./build_lf.sh
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -553,19 +553,14 @@ jobs:
         shell: bash -e -l {0}
         run: |
             export PATH="$(pwd)/src/bin:$PATH"
-            git clone https://github.com/pranavchiku/lapack.git
+            git clone https://github.com/gxyd/lapack.git
             cd lapack
-            git fetch origin lf_06
-            git checkout lf_06
-            git checkout 2e2144d65348b83423d4ebaf4ce26a378f80ab0c
+            git fetch origin lf_07
+            git checkout lf_07
+            git checkout 9d9e48987ca109d46b92d515b59cb591fab9859a
             cd build
             micromamba create -f environment_unix.yml
             micromamba activate lapack
-            if [[ "$(uname)" == "Darwin" ]]; then
-              if [ ! -f "$CONDA_PREFIX/lib/librhash.1.4.5.dylib" ]; then
-                ln -s "$CONDA_PREFIX/lib/librhash.1.4.6.dylib" "$CONDA_PREFIX/lib/librhash.1.4.5.dylib"
-              fi
-            fi
             ./build_lf.sh
 
 


### PR DESCRIPTION
## Description

Intends to fix: https://github.com/lfortran/lfortran/issues/7295

The branch added in this PR, i.e.: https://github.com/gxyd/lapack/tree/lf_07 has only commit on top of the older branch (i.e. https://github.com/Pranavchiku/lapack/tree/lf_06), and the commit is: https://github.com/gxyd/lapack/commit/9d9e48987ca109d46b92d515b59cb591fab9859a

So, the change in this PR fixes the version of rhash in `build/environment_unix.yml` in LAPACK's repository to build with LFortran