### PR TITLE
fix: allow comparison of boolean pointer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -321,6 +321,7 @@ RUN(NAME cond_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fo
 RUN(NAME cond_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME cond_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME cond_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME cond_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME expr_01 FAIL LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME expr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran mlir)

--- a/integration_tests/cond_05.f90
+++ b/integration_tests/cond_05.f90
@@ -1,0 +1,29 @@
+program cond_05
+   implicit none
+   logical, pointer :: ptr_bool1, ptr_bool2
+   logical, target :: bool_true, bool_false
+   complex, pointer :: ptr_complex4
+   complex(8), pointer :: ptr_complex8
+   complex, target :: complex4_1, complex4_2
+   complex(8), target :: complex8_1
+   bool_true = .true.
+   bool_false = .false.
+
+   ptr_bool1 => bool_true
+   if (ptr_bool1 .eqv. bool_false) error stop
+   if (ptr_bool1 .neqv. bool_true) error stop
+   if (.not. ptr_bool1 .eqv. ptr_bool1) error stop
+
+   ptr_bool1 => bool_true
+   ptr_bool2 => bool_true
+   if (.not. ptr_bool1 .eqv. ptr_bool2) error stop
+
+   complex4_1 = (1, 2)
+   ptr_complex4 => complex4_1
+   complex4_2 = (2, 3)
+   complex8_1 = complex4_1
+
+   if (ptr_complex4 == complex4_2) error stop
+   if (ptr_complex4 /= complex8_1) error stop
+   if (.not. ptr_complex4 == (complex4_2 - (1,1))) error stop
+end program cond_05

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4323,7 +4323,7 @@ public:
     void visit_If(const AST::If_t &x) {
         visit_expr(*x.m_test);
         ASR::expr_t *test = ASRUtils::EXPR(tmp);
-        ASR::ttype_t *test_type = ASRUtils::expr_type(test);
+        ASR::ttype_t *test_type = ASRUtils::type_get_past_pointer(ASRUtils::expr_type(test));
         if (!ASR::is_a<ASR::Logical_t>(*test_type)) {
             diag.add(diag::Diagnostic("Expected logical expression in if statement, but recieved " +
                 ASRUtils::type_to_str_fortran(test_type) + " instead",


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7311