### PR TITLE
Fix: Handle Associate when Value is FunctionCall with return type as pointer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2133,7 +2133,7 @@ RUN(NAME polymorphic_arguments_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME polymorphic_class_compare LABELS gfortran)
 
-RUN(NAME nested_struct_proc_01 LABELS gfortran)
+RUN(NAME nested_struct_proc_01 LABELS gfortran llvm)
 
 RUN(NAME binop_of_struct_instance_in_function_call gfortran llvm fortran)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -642,6 +642,7 @@ RUN(NAME global_array_pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc N
 RUN(NAME global_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME pointer_03 LABELS gfortran llvm)
 RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/nested_struct_proc_01.f90
+++ b/integration_tests/nested_struct_proc_01.f90
@@ -47,7 +47,7 @@ contains
 
       this%map%stored_value = value  ! Store the value
       tmp => this%map%at(key, rc=status)
-      print *, "Real:", real(tmp), "Imag:", aimag(tmp), "Status:", status
+      ! print *, "Real:", real(tmp), "Imag:", aimag(tmp), "Status:", status
       if (abs(real(tmp) - real(value)) > tol .or. abs(aimag(tmp) - aimag(value)) > tol) then
          print *, "Test failed: tmp does not match value"
          error stop

--- a/integration_tests/pointer_03.f90
+++ b/integration_tests/pointer_03.f90
@@ -1,0 +1,20 @@
+module test
+    implicit none
+    integer, target :: i
+    contains
+    function mergei32() result(r)
+        integer, pointer :: r
+        i=5
+        r=>i
+    end function
+end module
+program main
+    use test
+    implicit none
+    integer, pointer :: r
+    r=>mergei32()
+    if (r /= 5) then
+        print *, "Test failed: r does not point to the expected value"
+        error stop
+    end if
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5151,6 +5151,10 @@ ptr_type[ptr_member] = llvm_utils->get_type_from_ttype_t_util(
                 llvm::Value* value_class = llvm_utils->CreateLoad2(value_llvm_type, llvm_utils->create_gep(llvm_value, 1));
                 builder->CreateStore(value_vtabid, llvm_utils->create_gep(llvm_target, 0));
                 builder->CreateStore(value_class, llvm_utils->create_gep(llvm_target, 1));
+            } else if (ASR::is_a<ASR::Pointer_t>(*value_type) &&
+                       ASR::is_a<ASR::Pointer_t>(*target_type) &&
+                       ASR::is_a<ASR::FunctionCall_t>(*x.m_value)) {
+                builder->CreateStore(llvm_value, llvm_target);
             } else {
                 bool is_value_data_only_array = (ASRUtils::is_array(value_type) && (
                       ASRUtils::extract_physical_type(value_type) == ASR::array_physical_typeType::PointerToDataArray ||


### PR DESCRIPTION
Towards https://github.com/lfortran/lfortran/pull/7309#issuecomment-2885633480
