### PR TITLE
enh: don't set `m_body` of `Interactive` function as `nullptr`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2244,6 +2244,7 @@ RUN(NAME separate_compilation_06 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_07 LABELS gfortran llvm EXTRAFILES separate_compilation_07a.f90 separate_compilation_07b.f90 separate_compilation_07c.c)
 RUN(NAME separate_compilation_08 LABELS gfortran llvm EXTRAFILES separate_compilation_08a.f90 separate_compilation_08b.f90)
 RUN(NAME separate_compilation_09 LABELS gfortran llvm EXTRAFILES separate_compilation_09a.f90 separate_compilation_09b.f90 separate_compilation_09c.c)
+RUN(NAME separate_compilation_10 LABELS gfortran llvm EXTRAFILES separate_compilation_10a.f90)
 
 
 

--- a/integration_tests/separate_compilation_10.f90
+++ b/integration_tests/separate_compilation_10.f90
@@ -1,0 +1,7 @@
+program separate_compilation_10
+use history_mod_separate_compilation_10a
+real :: xhist(5,5)
+call rangehist(xhist)
+print *, xhist
+if (any(abs(xhist - 99.124) > 1e-8)) error stop
+end program

--- a/integration_tests/separate_compilation_10a.f90
+++ b/integration_tests/separate_compilation_10a.f90
@@ -1,0 +1,8 @@
+module history_mod_separate_compilation_10a
+contains
+subroutine rangehist(xhist)
+        real, intent(inout) :: xhist(:, :)
+        xhist = reshape([xhist(:, 5), xhist(:, 5)], shape(xhist))
+        xhist = 99.124
+end subroutine
+end module

--- a/src/libasr/asr_scopes.cpp
+++ b/src/libasr/asr_scopes.cpp
@@ -51,10 +51,6 @@ void SymbolTable::mark_all_variables_external(Allocator &al) {
                 ASR::Function_t *v = ASR::down_cast<ASR::Function_t>(a.second);
                 ASR::FunctionType_t* v_func_type = ASR::down_cast<ASR::FunctionType_t>(v->m_function_signature);
                 if (v_func_type->m_abi != ASR::abiType::Interactive && v_func_type->m_abi != ASR::abiType::BindC) {
-                    v->m_body = nullptr;
-                    v->n_body = 0;
-                    PassUtils::UpdateDependenciesVisitor ud(al);
-                    ud.visit_Function(*v);
                     v_func_type->m_abi = ASR::abiType::Interactive;
                 }
 

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -435,10 +435,6 @@ public:
     }
 
     void visit_Function(const Function_t &x) {
-        if (ASRUtils::get_FunctionType(&x)->m_abi == abiType::Interactive) {
-            require(x.n_body == 0,
-            "The Function::n_body should be 0 if abi set to Interactive");
-        }
         std::vector<std::string> function_dependencies_copy = function_dependencies;
         function_dependencies.clear();
         function_dependencies.reserve(x.n_dependencies);

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -118,7 +118,6 @@ class InsertDeallocate: public ASR::CallReplacerOnExpressionsVisitor<InsertDeall
 
         void visit_Function(const ASR::Function_t& x) {
             if (ASRUtils::get_FunctionType(&x)->m_abi == ASR::abiType::Interactive) {
-                ASR::CallReplacerOnExpressionsVisitor<InsertDeallocate>::visit_Function(x);
                 return;
             }
             ASR::Function_t &xx = const_cast<ASR::Function_t&>(x);

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -173,7 +173,7 @@ class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
                 mangle_c(sym , std::string(x.m_name));
             }
         }
-        if (intrinsic_symbols_mangling && startswith(x.m_name, "_lcompilers_")) {
+        if (intrinsic_symbols_mangling && (startswith(x.m_name, "_lcompilers_") || startswith(x.m_name, "__lcompilers"))) {
             ASR::symbol_t *sym = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)&x);
             sym_to_renamed[sym] = update_name(x.m_name);
         }


### PR DESCRIPTION
Fixes #7347.