### PR TITLE
fix: replace symbols in StructConstant to external symbols

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1445,6 +1445,7 @@ RUN(NAME derived_types_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_57.f90
+++ b/integration_tests/derived_types_57.f90
@@ -1,0 +1,17 @@
+module derived_types_57_m
+   type :: ansi_code
+      integer :: m = 44
+   end type
+
+    type :: term
+        type(ansi_code) :: black = ansi_code()
+    end type
+end module
+
+program derived_types_57
+    use derived_types_57_m
+
+    type(term) :: temp = term()
+
+    if (temp%black%m /= 44) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10314,6 +10314,15 @@ public:
                         "Argument '" + constructor_args[i] + "' not specified for " + ASRUtils::symbol_name(fn));
                     throw SemanticAbort();
                 }
+                // Replace symbols in StructConstant to external symbols
+                if (default_init && ASR::is_a<ASR::StructConstant_t>(*default_init)) {
+                    ASR::StructConstant_t *st = ASR::down_cast<ASR::StructConstant_t>(default_init);
+                    ASR::symbol_t *ext_sym = current_scope->resolve_symbol(ASRUtils::symbol_name(st->m_dt_sym));
+                    if (ASR::is_a<ASR::ExternalSymbol_t>(*ext_sym)) {
+                        ASR::ttype_t *type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, ext_sym));
+                        default_init = ASRUtils::EXPR(ASR::make_StructConstant_t(al, loc, ext_sym, st->m_args, st->n_args, type));
+                    }
+                }
                 args.p[i].m_value = default_init;
                 args.p[i].loc = arg_sym->base.loc;
             }


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7301