### PR TITLE
fix: don't replace Var by StructConstant

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1447,6 +1447,7 @@ RUN(NAME derived_types_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_58.f90
+++ b/integration_tests/derived_types_58.f90
@@ -1,0 +1,13 @@
+module derived_types_58_m
+   type :: enum_stat
+      integer :: success = 0
+   end type enum_stat
+
+   type(enum_stat), parameter :: toml_stat = enum_stat()
+end module
+
+program derived_types_58
+    use derived_types_58_m, only: toml_stat
+
+    if (toml_stat%success /= 0) error stop
+end program

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -2193,7 +2193,8 @@ class ReplaceModuleVarWithValue:
             ASRUtils::symbol_get_past_external(x->m_v));
         if( !((check_if_ASR_owner_is_module(y->m_parent_symtab->asr_owner)) &&
               y->m_storage == ASR::storage_typeType::Parameter) ||
-            y->m_symbolic_value == nullptr ) {
+            y->m_symbolic_value == nullptr ||
+            ASR::is_a<ASR::StructConstant_t>(*y->m_value)) {
             return ;
         }
 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7306