### PR TITLE
Allow inlining function calls for `IntentOut` and `Out` arguments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -470,6 +470,7 @@ RUN(NAME functions_35 LABELS gfortran llvm NO_STD_F23)
 RUN(NAME functions_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME functions_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME functions_38 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME functions_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_39.f90
+++ b/integration_tests/functions_39.f90
@@ -1,0 +1,19 @@
+program functions_39
+
+integer :: y = 30
+print *, f(y)
+print *, y
+if( y /= 60 ) error stop
+if( f(y) /= 360 ) error stop
+
+contains
+
+integer function f(x) result(r)
+integer, intent(out) :: x
+
+x = 2 * x
+r = 3 * x
+
+end function
+
+end program


### PR DESCRIPTION
This is achieved by simply using pointers for creating local variables for arguments when we inline the function. This works easily and all integration tests pass. Let's see how third party tests behave.