### PR TITLE
fix: llvm deepcopy when zeroinitializer is passed as src

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1448,6 +1448,7 @@ RUN(NAME derived_types_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_59.f90
+++ b/integration_tests/derived_types_59.f90
@@ -1,0 +1,20 @@
+module derived_types_59_m
+    implicit none
+    type inside
+        integer :: m = 0
+    end type inside
+
+    type wrapper
+        type(inside) :: i = inside()
+    end type
+end module
+
+program derived_types_59
+    use derived_types_59_m
+    implicit none
+
+    type(wrapper) :: w
+    w = wrapper()
+
+    if (w%i%m /= 0) error stop
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2765,13 +2765,7 @@ public:
         int member_idx = name2memidx[current_der_type_name][member_name];
 
         llvm::Type *xtype = name2dertype[current_der_type_name];
-        if (llvm::isa<llvm::ConstantStruct>(tmp)) {
-            llvm::Value *v = builder->CreateExtractValue(tmp, {static_cast<unsigned int>(member_idx)});
-            tmp = llvm_utils->CreateAlloca(v->getType());
-            builder->CreateStore(v, tmp);
-        } else {
-            tmp = llvm_utils->create_gep2(xtype, tmp, member_idx);
-        }
+        tmp = llvm_utils->create_gep2(xtype, tmp, member_idx);
         ASR::ttype_t* member_type = ASRUtils::type_get_past_pointer(
             ASRUtils::type_get_past_allocatable(member->m_type));
 #if LLVM_VERSION_MAJOR > 16

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2241,7 +2241,8 @@ namespace LCompilers {
                         std::string mem_name = item.first;
                         int mem_idx = name2memidx[der_type_name][mem_name];
                         llvm::Value* src_member = nullptr;
-                        if (llvm::isa<llvm::ConstantStruct>(src)) {
+                        if (llvm::isa<llvm::ConstantStruct>(src) ||
+                            llvm::isa<llvm::ConstantAggregateZero>(src)) {
                             src_member = builder->CreateExtractValue(src, {static_cast<unsigned int>(mem_idx)});
                         } else {
                             src_member = create_gep2(name2dertype[der_type_name], src, mem_idx);
@@ -2252,7 +2253,8 @@ namespace LCompilers {
                         if( !LLVM::is_llvm_struct(member_type) &&
                             !ASRUtils::is_array(member_type) &&
                             !ASRUtils::is_descriptorString(member_type) &&
-                            !llvm::isa<llvm::ConstantStruct>(src)) {
+                            !llvm::isa<llvm::ConstantStruct>(src) &&
+                            !llvm::isa<llvm::ConstantAggregateZero>(src)) {
                             src_member = LLVMUtils::CreateLoad2(mem_type, src_member);
                         }
                         llvm::Value* dest_member = create_gep2(name2dertype[der_type_name], dest, mem_idx);


### PR DESCRIPTION
This is fixing a bug I found. The test in the 1st commit threw a segfault before this PR.

In `LLVMUtils::deepcopy` when we pass a `ConstStruct` as src we use `ExtractValue` to get the member instead of getelementptr. When the `ConstStruct` members are all zeros, llvm replaces it with `zeroinitializer`. Added a check for `zeroinitializer` in the condition for using `ExtractValue`