### PR TITLE
fix: handle scalar mask in minloc/maxloc for runtime values

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1112,6 +1112,7 @@ RUN(NAME intrinsics_374 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # get_env
 RUN(NAME intrinsics_375 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # move_alloc for string
 RUN(NAME intrinsics_376 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # present
 RUN(NAME intrinsics_377 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # minval, maxval
+RUN(NAME intrinsics_378 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # minloc, maxloc
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_378.f90
+++ b/integration_tests/intrinsics_378.f90
@@ -1,0 +1,13 @@
+program main
+  implicit none
+  real :: input(2)
+  input = [1, 2]
+  call solve(input)
+contains
+
+  subroutine solve(input)
+    real :: input(2)
+    print*, minloc(input, 1, .true.)  
+    print*, maxloc(input, 1, .true.)
+  end subroutine
+end program


### PR DESCRIPTION
Fixes #6666 