### PR TITLE
enh: handling of call arguments in case of specified intent

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -133,6 +133,10 @@ time_section "🧪 Testing Fortran-Primes" '
   print_subsection "Building and running Fortran-Primes"
   FC=$FC ./build_and_run.sh
 
+  print_subsection "Building Fortran-Primes with separate compilation"
+  git clean -dfx
+  FC="$FC --generate-object-code" ./build_and_run.sh
+
   print_success "Done with Fortran-Primes"
   cd ..
   rm -rf fortran-primes

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1605,6 +1605,8 @@ RUN(NAME nbody LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME intent_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intent_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME intent_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
 
 RUN(NAME callback_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME callback_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intent_03.f90
+++ b/integration_tests/intent_03.f90
@@ -1,0 +1,26 @@
+module prime_numbers_intent_03_module
+   integer, parameter :: p40001_to_50000(10) = &
+        [ 40009, 40011, 40013, 40027, 40029, 40039, 40051, 40057, 40063, 40069 ]
+
+    contains
+
+    ! Return the n-th prime number
+    function prime() result(prime_number)
+        integer :: prime_number
+        prime_number = next_prime(p40001_to_50000(4))
+    end function prime
+
+    elemental integer function next_prime(n)
+       integer, intent(in) :: n
+       next_prime = n + 9
+    end function next_prime
+
+end module prime_numbers_intent_03_module
+
+program intent_03
+
+  use prime_numbers_intent_03_module
+  print *, prime()
+  if ( prime() /= 40036 ) error stop
+end program
+


### PR DESCRIPTION
Fixes #7380. Towards #7328, with this we get `fortran-primes` working with separate compilation.