### PR TITLE
enh: implement class allocatable variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1675,7 +1675,7 @@ RUN(NAME class_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME class_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
-# RUN(NAME class_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23) #TODO: Issue #7318
+RUN(NAME class_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME class_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1687,6 +1687,7 @@ RUN(NAME class_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm NO_STD_F23)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1252,6 +1252,7 @@ RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_04 LABELS gfortran
         EXTRAFILES select_type_03_module.f90 select_type_03.f90)
 RUN(NAME select_type_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
+RUN(NAME select_type_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME program_02 LABELS gfortran llvm)
 RUN(NAME program_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
@@ -1674,7 +1675,7 @@ RUN(NAME class_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME class_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
-RUN(NAME class_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
+# RUN(NAME class_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23) #TODO: Issue #7318
 RUN(NAME class_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -1684,6 +1685,8 @@ RUN(NAME class_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm NO_STD_F23)
 

--- a/integration_tests/class_20.f90
+++ b/integration_tests/class_20.f90
@@ -1,0 +1,21 @@
+module class_20_m
+    implicit none
+
+    type base 
+        integer :: m = 44
+    end type
+
+    type, extends(base) :: derived
+        integer :: n = 45
+    end type
+end module
+
+program class_20
+    use class_20_m
+    implicit none
+
+    class(base), allocatable :: b
+    allocate(derived :: b)
+
+    if (b%m /= 44) error stop
+end program

--- a/integration_tests/class_21.f90
+++ b/integration_tests/class_21.f90
@@ -1,0 +1,11 @@
+program class_21
+    type :: val_type
+        integer :: origin = 3
+    end type
+    integer :: stat
+    class(val_type), allocatable :: val
+    allocate(val)
+    stat = merge(val%origin, stat, .true.)
+
+    if (stat /= 3) error stop
+end program

--- a/integration_tests/class_22.f90
+++ b/integration_tests/class_22.f90
@@ -1,0 +1,28 @@
+module class_22_m
+  implicit none
+  private
+  public :: inner_class, cast_integer
+
+  ! Define the inner class with some integer data
+  type :: inner_class
+     integer :: value
+  end type inner_class
+
+contains
+
+function cast_integer(obj) result(x)
+    class(inner_class), intent(in), allocatable :: obj
+    logical :: x
+
+    x = .true.
+  end function cast_integer
+
+end module class_22_m
+
+program class_22
+  use class_22_m
+  implicit none
+  class(inner_class), allocatable :: inner_obj
+
+  if (cast_integer(inner_obj) .neqv. .true.) error stop
+end program class_22

--- a/integration_tests/select_type_06.f90
+++ b/integration_tests/select_type_06.f90
@@ -1,0 +1,17 @@
+program select_type_06_m
+    implicit none
+
+    type :: string_value
+        character(len=:), allocatable :: raw
+    end type
+
+    class(string_value), allocatable :: val  ! Polymorphic variable
+
+    allocate(val)
+    select type(val)
+    type is(string_value)
+        val%raw = "Hello, Fortran!"
+    end select
+
+    if (val%raw /= "Hello, Fortran!") error stop
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5518,7 +5518,10 @@ public:
         if (x.m_realloc_lhs &&
             ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target)) {
             ASR::StructInstanceMember_t *sim = ASR::down_cast<ASR::StructInstanceMember_t>(x.m_target);
-            if (ASRUtils::is_allocatable(ASRUtils::expr_type(sim->m_v))) {
+            ASR::ttype_t *v_type = ASRUtils::expr_type(sim->m_v);
+            if (ASRUtils::is_allocatable(v_type) &&
+                // TODO: support Classtype here
+                !ASR::is_a<ASR::ClassType_t>(*ASRUtils::extract_type(v_type))) {
                 check_and_allocate(sim->m_v);
             }
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10916,9 +10916,9 @@ public:
                 llvm::Type *dt_type = llvm_utils->getStructType(caller_type,
                     module.get());
                 llvm::Value* dt_1 = llvm_utils->create_gep2(dt_type, dt, dt_idx);
-                dt_1 = llvm_utils->CreateLoad2(a_type, llvm_utils->create_gep2(a_poly_type, llvm_utils->CreateLoad2(a_poly_type->getPointerTo(), dt_1), 1));
+                dt_1 = llvm_utils->CreateLoad2(a_type, llvm_utils->CreateLoad2(a_type->getPointerTo(), llvm_utils->create_gep2(a_poly_type, dt_1, 1)));
                 llvm::Value* class_ptr = llvm_utils->create_gep(dt_polymorphic, 1);
-                builder->CreateStore(dt_1, class_ptr);
+                builder->CreateStore(dt_1, llvm_utils->CreateLoad2(a_type->getPointerTo(), class_ptr));
                 if (self_argument.length() == 0) {
                     args.push_back(dt_polymorphic);
                 } else {

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1318,11 +1318,8 @@ namespace LCompilers {
         ASR::symbol_t *type_declaration, ASR::storage_typeType m_storage,
         bool& is_array_type, bool& is_malloc_array_type, bool& is_list,
         ASR::dimension_t*& m_dims, int& n_dims, int& a_kind, llvm::Module* module,
-        ASR::abiType m_abi, bool is_pointer) {
+        ASR::abiType m_abi) {
         llvm::Type* llvm_type = nullptr;
-
-        // Hide unused parameter warning, it is used in the below macro
-        (void)is_pointer;
 
         #define handle_llvm_pointers1()                                         \
             if (n_dims == 0 && ASR::is_a<ASR::String_t>(*t2)) {              \
@@ -1334,7 +1331,7 @@ namespace LCompilers {
             } else {                                                            \
                 llvm_type = get_type_from_ttype_t(t2, nullptr, m_storage,       \
                     is_array_type, is_malloc_array_type, is_list, m_dims,       \
-                    n_dims, a_kind, module, m_abi, is_pointer_);                \
+                    n_dims, a_kind, module, m_abi);                             \
                 if( !is_pointer_ ) {                                            \
                     llvm_type = llvm_type->getPointerTo();                      \
                 }                                                               \

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1321,6 +1321,9 @@ namespace LCompilers {
         ASR::abiType m_abi, bool is_pointer) {
         llvm::Type* llvm_type = nullptr;
 
+        // Hide unused parameter warning, it is used in the below macro
+        (void)is_pointer;
+
         #define handle_llvm_pointers1()                                         \
             if (n_dims == 0 && ASR::is_a<ASR::String_t>(*t2)) {              \
                 if(ASRUtils::is_descriptorString(t2)) {          \
@@ -1436,7 +1439,7 @@ namespace LCompilers {
                 break;
             }
             case (ASR::ttypeType::ClassType) : {
-                llvm_type = getClassType(asr_type, is_pointer);
+                llvm_type = getClassType(asr_type, true);
                 break;
             }
             case (ASR::ttypeType::UnionType) : {
@@ -1453,8 +1456,9 @@ namespace LCompilers {
             }
             case (ASR::ttypeType::Allocatable) : {
                 ASR::ttype_t *t2 = ASR::down_cast<ASR::Allocatable_t>(asr_type)->m_type;
-                bool is_pointer_ = (ASR::is_a<ASR::String_t>(*t2)
-                    && m_abi != ASR::abiType::BindC);
+                bool is_pointer_ = ((ASR::is_a<ASR::String_t>(*t2) ||
+                                     ASR::is_a<ASR::ClassType_t>(*t2))
+                                    && m_abi != ASR::abiType::BindC);
                 is_malloc_array_type = ASRUtils::is_array(t2);
                 handle_llvm_pointers1()
                 break;

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -388,7 +388,7 @@ namespace LCompilers {
                 ASR::symbol_t *type_declaration, ASR::storage_typeType m_storage,
                 bool& is_array_type, bool& is_malloc_array_type, bool& is_list,
                 ASR::dimension_t*& m_dims, int& n_dims, int& a_kind, llvm::Module* module,
-                ASR::abiType m_abi=ASR::abiType::Source, bool is_pointer=false);
+                ASR::abiType m_abi=ASR::abiType::Source);
 
             llvm::Type* get_type_from_ttype_t_util(ASR::ttype_t* asr_type,
                 llvm::Module* module, ASR::abiType asr_abi=ASR::abiType::Source);

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "f67f6b18168826d8710d9e33f48c725c909c97948cc09609baa4c140",
+    "stdout_hash": "622c4949178890fa2b317470330e2fde995582fdca5cd293042ae74a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -31,58 +31,70 @@ define i32 @main(i32 %0, i8** %1) {
   %foo = alloca %foo_c, align 8
   %4 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
   %5 = getelementptr %bar_c, %bar_c* %4, i32 0, i32 1
-  %6 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %7 = getelementptr %foo_b, %foo_b* %6, i32 0, i32 0
-  %8 = getelementptr %foo_a, %foo_a* %7, i32 0, i32 0
+  %6 = getelementptr %bar_c, %bar_c* %4, i32 0, i32 0
+  %7 = getelementptr %bar_b, %bar_b* %6, i32 0, i32 1
+  %8 = getelementptr %bar_b, %bar_b* %6, i32 0, i32 0
   %9 = getelementptr %bar_a, %bar_a* %8, i32 0, i32 0
-  store i32 -20, i32* %9, align 4
   %10 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
   %11 = getelementptr %foo_b, %foo_b* %10, i32 0, i32 1
   %12 = getelementptr %bar_b, %bar_b* %11, i32 0, i32 1
-  store i32 9, i32* %12, align 4
-  %13 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %14 = getelementptr %bar_c, %bar_c* %13, i32 0, i32 1
-  store i32 11, i32* %14, align 4
-  %15 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %16 = getelementptr %foo_b, %foo_b* %15, i32 0, i32 0
-  %17 = getelementptr %foo_a, %foo_a* %16, i32 0, i32 0
-  %18 = getelementptr %bar_a, %bar_a* %17, i32 0, i32 0
-  %19 = load i32, i32* %18, align 4
-  %20 = alloca i32, align 4
-  store i32 %19, i32* %20, align 4
-  %21 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %20)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %13 = getelementptr %bar_b, %bar_b* %11, i32 0, i32 0
+  %14 = getelementptr %bar_a, %bar_a* %13, i32 0, i32 0
+  %15 = getelementptr %foo_b, %foo_b* %10, i32 0, i32 0
+  %16 = getelementptr %foo_a, %foo_a* %15, i32 0, i32 0
+  %17 = getelementptr %bar_a, %bar_a* %16, i32 0, i32 0
+  %18 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %19 = getelementptr %foo_b, %foo_b* %18, i32 0, i32 0
+  %20 = getelementptr %foo_a, %foo_a* %19, i32 0, i32 0
+  %21 = getelementptr %bar_a, %bar_a* %20, i32 0, i32 0
+  store i32 -20, i32* %21, align 4
   %22 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
   %23 = getelementptr %foo_b, %foo_b* %22, i32 0, i32 1
   %24 = getelementptr %bar_b, %bar_b* %23, i32 0, i32 1
-  %25 = load i32, i32* %24, align 4
-  %26 = alloca i32, align 4
-  store i32 %25, i32* %26, align 4
-  %27 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i32* %26)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  %28 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %29 = getelementptr %bar_c, %bar_c* %28, i32 0, i32 1
-  %30 = load i32, i32* %29, align 4
-  %31 = alloca i32, align 4
-  store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32 0, i32* %31)
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %33 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %34 = getelementptr %foo_b, %foo_b* %33, i32 0, i32 0
-  %35 = getelementptr %foo_a, %foo_a* %34, i32 0, i32 0
-  %36 = getelementptr %bar_a, %bar_a* %35, i32 0, i32 0
+  store i32 9, i32* %24, align 4
+  %25 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %26 = getelementptr %bar_c, %bar_c* %25, i32 0, i32 1
+  store i32 11, i32* %26, align 4
+  %27 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %28 = getelementptr %foo_b, %foo_b* %27, i32 0, i32 0
+  %29 = getelementptr %foo_a, %foo_a* %28, i32 0, i32 0
+  %30 = getelementptr %bar_a, %bar_a* %29, i32 0, i32 0
+  %31 = load i32, i32* %30, align 4
+  %32 = alloca i32, align 4
+  store i32 %31, i32* %32, align 4
+  %33 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %32)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %34 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %35 = getelementptr %foo_b, %foo_b* %34, i32 0, i32 1
+  %36 = getelementptr %bar_b, %bar_b* %35, i32 0, i32 1
   %37 = load i32, i32* %36, align 4
-  %38 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
-  %39 = getelementptr %foo_b, %foo_b* %38, i32 0, i32 1
-  %40 = getelementptr %bar_b, %bar_b* %39, i32 0, i32 1
-  %41 = load i32, i32* %40, align 4
-  %42 = add i32 %37, %41
-  %43 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
-  %44 = getelementptr %bar_c, %bar_c* %43, i32 0, i32 1
-  %45 = load i32, i32* %44, align 4
-  %46 = add i32 %42, %45
-  %47 = icmp ne i32 %46, 0
-  br i1 %47, label %then, label %else
+  %38 = alloca i32, align 4
+  store i32 %37, i32* %38, align 4
+  %39 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i32* %38)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %39, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  %40 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %41 = getelementptr %bar_c, %bar_c* %40, i32 0, i32 1
+  %42 = load i32, i32* %41, align 4
+  %43 = alloca i32, align 4
+  store i32 %42, i32* %43, align 4
+  %44 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32 0, i32* %43)
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  %45 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %46 = getelementptr %foo_b, %foo_b* %45, i32 0, i32 0
+  %47 = getelementptr %foo_a, %foo_a* %46, i32 0, i32 0
+  %48 = getelementptr %bar_a, %bar_a* %47, i32 0, i32 0
+  %49 = load i32, i32* %48, align 4
+  %50 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 0
+  %51 = getelementptr %foo_b, %foo_b* %50, i32 0, i32 1
+  %52 = getelementptr %bar_b, %bar_b* %51, i32 0, i32 1
+  %53 = load i32, i32* %52, align 4
+  %54 = add i32 %49, %53
+  %55 = getelementptr %foo_c, %foo_c* %foo, i32 0, i32 1
+  %56 = getelementptr %bar_c, %bar_c* %55, i32 0, i32 1
+  %57 = load i32, i32* %56, align 4
+  %58 = add i32 %54, %57
+  %59 = icmp ne i32 %58, 0
+  br i1 %59, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_45-ae31b1c.stdout",
-    "stdout_hash": "796e15da1ff564130e2083a94fd7719ae7ae0f781ff16c45e5eb65f0",
+    "stdout_hash": "dfcb2538b292aee5ce6cc157441ef2ac5f6b2938249fb411d710fc7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%__vtab_myint = type { i64 }
 %myint = type <{ i32 }>
 
 @0 = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
@@ -10,31 +11,34 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = alloca %__vtab_myint, align 8
+  %3 = getelementptr %__vtab_myint, %__vtab_myint* %2, i32 0, i32 0
+  store i64 0, i64* %3, align 4
   %ins = alloca %myint*, align 8
   store %myint* null, %myint** %ins, align 8
-  %2 = load %myint*, %myint** %ins, align 8
-  %3 = icmp eq %myint* %2, null
-  br i1 %3, label %then, label %else
+  %4 = load %myint*, %myint** %ins, align 8
+  %5 = icmp eq %myint* %4, null
+  br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %4 = call i8* @_lfortran_malloc(i32 4)
-  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
-  %5 = bitcast i8* %4 to %myint*
-  store %myint* %5, %myint** %ins, align 8
+  %6 = call i8* @_lfortran_malloc(i32 4)
+  call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 4, i1 false)
+  %7 = bitcast i8* %6 to %myint*
+  store %myint* %7, %myint** %ins, align 8
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %6 = load %myint*, %myint** %ins, align 8
-  %7 = getelementptr %myint, %myint* %6, i32 0, i32 0
-  store i32 44, i32* %7, align 4
   %8 = load %myint*, %myint** %ins, align 8
   %9 = getelementptr %myint, %myint* %8, i32 0, i32 0
-  %10 = load i32, i32* %9, align 4
-  %11 = icmp ne i32 %10, 44
-  br i1 %11, label %then1, label %else2
+  store i32 44, i32* %9, align 4
+  %10 = load %myint*, %myint** %ins, align 8
+  %11 = getelementptr %myint, %myint* %10, i32 0, i32 0
+  %12 = load i32, i32* %11, align 4
+  %13 = icmp ne i32 %12, 44
+  br i1 %13, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
@@ -45,17 +49,17 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %12 = load %myint*, %myint** %ins, align 8
-  %13 = ptrtoint %myint* %12 to i64
-  %14 = icmp ne i64 %13, 0
-  br i1 %14, label %then4, label %else5
+  %14 = load %myint*, %myint** %ins, align 8
+  %15 = ptrtoint %myint* %14 to i64
+  %16 = icmp ne i64 %15, 0
+  br i1 %16, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  %15 = alloca i8*, align 8
-  %16 = bitcast %myint* %12 to i8*
-  store i8* %16, i8** %15, align 8
-  %17 = load i8*, i8** %15, align 8
-  call void @_lfortran_free(i8* %17)
+  %17 = alloca i8*, align 8
+  %18 = bitcast %myint* %14 to i8*
+  store i8* %18, i8** %17, align 8
+  %19 = load i8*, i8** %17, align 8
+  call void @_lfortran_free(i8* %19)
   store %myint* null, %myint** %ins, align 8
   br label %ifcont6
 

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "25521fb8f7a2b9724fbd85dc95af1fb4d601288dd293f4fb36a1660d",
+    "stdout_hash": "297ecfbf9f4b6d23ad139763ea5e66e1f6b31819b33a52b28b20818d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -202,13 +202,16 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = call i8* @_lfortran_malloc(i32 7)
   call void @_lfortran_string_init(i64 7, i8* %9)
   store i8* %9, i8** %8, align 8
-  %10 = alloca %fpm_run_settings_polymorphic, align 8
-  %11 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %10, i32 0, i32 0
-  store i64 0, i64* %11, align 4
-  %12 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %10, i32 0, i32 1
-  store %fpm_run_settings* %settings, %fpm_run_settings** %12, align 8
+  %10 = getelementptr %fpm_run_settings, %fpm_run_settings* %settings, i32 0, i32 0
+  %11 = getelementptr %fpm_build_settings, %fpm_build_settings* %10, i32 0, i32 0
+  store i1 false, i1* %11, align 1
+  %12 = alloca %fpm_run_settings_polymorphic, align 8
+  %13 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %12, i32 0, i32 0
+  store i64 0, i64* %13, align 4
+  %14 = getelementptr %fpm_run_settings_polymorphic, %fpm_run_settings_polymorphic* %12, i32 0, i32 1
+  store %fpm_run_settings* %settings, %fpm_run_settings** %14, align 8
   store i1 true, i1* %call_arg_value, align 1
-  call void @__module_modules_36_fpm_main_01_cmd_run(%fpm_run_settings_polymorphic* %10, i1* %call_arg_value)
+  call void @__module_modules_36_fpm_main_01_cmd_run(%fpm_run_settings_polymorphic* %12, i1* %call_arg_value)
   call void @_lpython_free_argv()
   br label %return
 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7355, Fix https://github.com/lfortran/lfortran/issues/7340, Fix https://github.com/lfortran/lfortran/issues/7324, Fix https://github.com/lfortran/lfortran/issues/7383

Implement allocation for class allocatable variables.

- Implement the `allocate` statement for class allocatable variables.
- Support extended types in `allocate_array_members_of_struct()`.
- `integration_tests/class_10.f90` is commented out because we need to support nested `StructInstanceMember` recursively. We need to also improve, or maybe merge, `visit_SubroutineCall()` and `visit_FunctionCall()` in the llvm backend.