### PR TITLE
CI: test PRIMA with --std=f23 flag

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -276,6 +276,44 @@ time_section "🧪 Testing PRIMA" '
     cd ..
   fi
 
+  print_subsection "Building PRIMA with f23 standard"
+  FC="$FC --cpp --std=f23" cmake -S . -B build \
+    -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+    -DCMAKE_Fortran_FLAGS="" \
+    -DCMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS="" \
+    -DCMAKE_MACOSX_RPATH=OFF \
+    -DCMAKE_SKIP_INSTALL_RPATH=ON \
+    -DCMAKE_SKIP_RPATH=ON
+
+  cmake --build build --target install
+
+  run_test ./build/fortran/example_bobyqa_fortran_1_exe
+  run_test ./build/fortran/example_bobyqa_fortran_2_exe
+  run_test ./build/fortran/example_cobyla_fortran_1_exe
+  run_test ./build/fortran/example_cobyla_fortran_2_exe
+  run_test ./build/fortran/example_lincoa_fortran_1_exe
+  run_test ./build/fortran/example_lincoa_fortran_2_exe
+  run_test ./build/fortran/example_newuoa_fortran_1_exe
+  run_test ./build/fortran/example_newuoa_fortran_2_exe
+  run_test ./build/fortran/example_uobyqa_fortran_1_exe
+  run_test ./build/fortran/example_uobyqa_fortran_2_exe
+
+  if [[ "$RUNNER_OS" == "macos-latest" ]]; then
+    cd fortran
+    test_name=test_bobyqa.f90 FC="$FC --std=f23" ./script.sh
+    test_name=test_newuoa.f90 FC="$FC --std=f23" ./script.sh
+    test_name=test_uobyqa.f90 FC="$FC --std=f23" ./script.sh
+    test_name=test_cobyla.f90 FC="$FC --std=f23" ./script.sh
+    test_name=test_lincoa.f90 FC="$FC --std=f23" ./script.sh
+    cd ..
+  fi
+
+  if [[ "$RUNNER_OS" == "ubuntu-latest" ]]; then
+    cd fortran
+    test_name=test_uobyqa.f90 FC="$FC --std=f23" ./script.sh
+    cd ..
+  fi
+
   print_subsection "Rebuilding PRIMA with optimization"
   git clean -dfx
 


### PR DESCRIPTION
## Description

Towards: https://github.com/lfortran/lfortran/issues/6020

One reason to not test `--fast` + `--std=f23` is that, PRIMA is one of the most time taking repository to build + run at LFortran's CI, so to not increase the time too much we can maybe skip testing the combination `--fast` + `--std=f23` at LFortran's CI.

An example of time duration can be seen here: https://gist.github.com/gxyd/666361ad6e1161c42e8257d7a0656516 (taken from [sample CI run](https://productionresultssa19.blob.core.windows.net/actions-results/43bd26c8-d24d-4a3a-9475-4b0d96fca3fa/workflow-job-run-3acc5174-d881-5774-8d41-f98651d1a5e1/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-05-22T07%3A44%3A30Z&sig=4xp9InrsRTnPAneywkYBfkPYvb95O5Ry17bkNAsBuwI%3D&ske=2025-05-22T18%3A00%3A15Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-05-22T06%3A00%3A15Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-05-22T07%3A34%3A25Z&sv=2025-05-05))