### PR TITLE
CI: don't test older branch of POT3D with older fortran_mpi

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -199,28 +199,6 @@ time_section "🧪 Testing Numerical Methods Fortran" '
   cd ..
 '
 
-######################
-# Section 4: POT3D    #
-######################
-time_section "🧪 Testing POT3D" '
-  git clone https://github.com/gxyd/pot3d.git
-  cd pot3d
-  git checkout -t origin/lf_hdf5_mpi_namelist_global_workarounds
-  git checkout 83e1e90db7e7517fcbe8c7bce5ba309addfb23f6
-
-  print_subsection "Building with default flags"
-  FC=$FC ./build_and_run.sh
-
-  print_subsection "Building with optimization flags"
-  FC="$FC --fast --skip-pass=dead_code_removal" ./build_and_run.sh
-
-  print_subsection "Building POT3D in separate compilation mode"
-  FC="$FC --generate-object-code --skip-pass=pass_array_by_data" ./build_and_run.sh
-
-  print_success "Done with POT3D"
-  cd ..
-'
-
 #######################
 # Section 5: PRIMA    #
 #######################


### PR DESCRIPTION
## Description

We are removing an outdated test for POT3D that is no longer necessary.

POT3D is already being tested in LFortran’s CI pipeline (https://github.com/lfortran/lfortran/blob/5208cd61d15fde932f1c59de34d4a72a93627a31/ci/test_third_party_codes.sh#L70-L96). This existing test uses the latest version of the lfortran/fortran_mpi wrappers (perhaps missing just a few recent commits).

The test we are removing was originally added when we published our [blog post](https://lfortran.org/blog/2025/03/lfortran-compiles-pot3d/) demonstrating LFortran compiling POT3D. That blog post used an older version of the wrappers.

Since then, we’ve updated the wrappers and already test the same POT3D branch using these updated wrappers in the current CI setup. Therefore, keeping the older test is redundant.

In practice, we were effectively running the same POT3D branch twice — once with the latest fortran_mpi and once with an older version — which doesn’t provide additional value.

Removing this will also save LFortran's CI run time, see for comparison of runtime: https://gist.github.com/gxyd/666361ad6e1161c42e8257d7a0656516 (section: *POT3D (with inbuilt wrappers)*)