### PR TITLE
CI: test Legacy Minpack (SciPy) with --std=f23 flag

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -322,12 +322,25 @@ time_section "🧪 Testing Legacy Minpack (SciPy)" '
   run_test examples/example_lmder1
   run_test examples/example_lmdif1
   run_test examples/example_primes
-
   print_subsection "Running CTest"
   ctest
+  cd ../
+
+  print_subsection "Testing with f23 standard"
+  git clean -dfx
+  mkdir lf && cd lf
+  FC="$FC --intrinsic-mangling --std=f23" cmake ..
+  make
+  run_test examples/example_hybrd
+  run_test examples/example_hybrd1
+  run_test examples/example_lmder1
+  run_test examples/example_lmdif1
+  run_test examples/example_primes
+  print_subsection "Running CTest"
+  ctest
+  cd ../
 
   print_subsection "Testing with separate compilation"
-  cd ../
   git clean -dfx
   mkdir lf && cd lf
   FC="$FC --intrinsic-mangling --generate-object-code" cmake ..
@@ -339,6 +352,25 @@ time_section "🧪 Testing Legacy Minpack (SciPy)" '
   run_test examples/example_primes
   print_subsection "Running CTest"
   ctest
+  cd ../
+
+  print_subsection "Testing with separate compilation and f23 standard"
+  git clean -dfx
+  mkdir lf && cd lf
+  FC="$FC --intrinsic-mangling --generate-object-code --std=f23" cmake ..
+  make
+  run_test examples/example_hybrd
+  run_test examples/example_hybrd1
+  run_test examples/example_lmder1
+  run_test examples/example_lmdif1
+  run_test examples/example_primes
+  print_subsection "Running CTest"
+  ctest
+  cd ../
+
+  print_success "Done with Legacy Minpack (SciPy)"
+  cd ../
+  rm -rf minpack
 '
 
 ##########################


### PR DESCRIPTION
## Description

Towards: https://github.com/lfortran/lfortran/issues/6020

I've sent a series of PR's modifying LFortran's CI to move us forward with issue #6020 , for now this is the last PR, since if something does go wrong, it's not too difficult for us to identify the root cause of error.