### PR TITLE
Allow inlining function calls with arrays

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2549,6 +2549,8 @@ public:
 #if LLVM_VERSION_MAJOR > 16
                 ptr_type[array] = llvm_utils->get_type_from_ttype_t_util(
                     ASRUtils::type_get_past_allocatable_pointer(x_m_array_type), module.get());
+                ptr_type[shape] = llvm_utils->get_type_from_ttype_t_util(
+                    ASRUtils::type_get_past_allocatable_pointer(asr_shape_type), module.get());
 #endif
                 tmp = arr_descr->reshape(array, llvm_data_type, shape, asr_shape_type, module.get());
                 break;
@@ -11509,7 +11511,7 @@ Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
     }
 
     // Uncomment for debugging the ASR after the transformation
-    // std::cout << LCompilers::pickle(asr, true, false, false) << std::endl;
+    // std::cout << LCompilers::pickle(asr, false, false, false) << std::endl;
 
     t1 = std::chrono::high_resolution_clock::now();
     try {

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -61,6 +61,24 @@ void transform_stmts_impl(Allocator& al, ASR::stmt_t**& m_body, size_t& n_body,
     current_body = current_body_copy;
 }
 
+class CollectReturnStmt: public ASR::BaseWalkVisitor<CollectReturnStmt> {
+
+    public:
+
+    Allocator& al;
+    Vec<ASR::stmt_t*>& return_stmts;
+    size_t current_stmt_index;
+
+    CollectReturnStmt(Allocator& al_, Vec<ASR::stmt_t*>& return_stmts_):
+        al(al_), return_stmts(return_stmts_), current_stmt_index(0) {
+    }
+
+    void visit_Return(const ASR::Return_t& x) {
+        return_stmts.push_back(al, const_cast<ASR::stmt_t*>(&(x.base)));
+    }
+
+};
+
 class CollectCalls: public ASR::BaseWalkVisitor<CollectCalls> {
 
     public:
@@ -142,7 +160,8 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
         // The type of those Variable symbols shouldn’t be FunctionType.
         for( auto sym: function->m_symtab->get_scope() ) {
             if( !ASR::is_a<ASR::Variable_t>(*sym.second) ||
-                ASRUtils::is_array(ASR::down_cast<ASR::Variable_t>(sym.second)->m_type) ||
+                ASR::is_a<ASR::StructType_t>(
+                    *ASRUtils::extract_type(ASR::down_cast<ASR::Variable_t>(sym.second)->m_type)) ||
                 ASR::is_a<ASR::String_t>(
                     *ASRUtils::extract_type(ASR::down_cast<ASR::Variable_t>(sym.second)->m_type)) ) { // TODO: Remove this check as well, use pointers for arrays
                 return false;
@@ -154,6 +173,12 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
                 return false;
             }
 
+        }
+
+        for( size_t i = 0; i < func_call->n_args; i++ ) {
+            if( ASR::is_a<ASR::ArrayPhysicalCast_t>(*func_call->m_args[i].m_value) ) {
+                return false;
+            }
         }
 
         // Function should only call Functions from global scope
@@ -193,7 +218,44 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
             return false;
         }
 
+        // Check if there is only one return statement
+        // and that too in the end of the function
+        Vec<ASR::stmt_t*> return_stmts; return_stmts.reserve(al, 1);
+        CollectReturnStmt collect_return_stmts(al, return_stmts);
+        collect_return_stmts.visit_Function(*function);
+        // More than one return statements
+        if( return_stmts.size() > 1 ) {
+            return false;
+        }
+
+        // Only one return statement but not in the end.
+        if( function->m_body[function->n_body - 1] != return_stmts[0] ) {
+            return false;
+        }
+
+
         return true;
+    }
+
+    bool is_argument(ASR::symbol_t* variable, ASR::intentType intent,
+                     ASR::expr_t** args, size_t n_args) {
+        if( intent == ASRUtils::intent_in ||
+            intent == ASRUtils::intent_inout ||
+            intent == ASRUtils::intent_out ) {
+            return true;
+        }
+
+        if( intent == ASRUtils::intent_local ||
+            intent == ASRUtils::intent_return_var ) {
+            return false;
+        }
+
+        for( size_t i = 0; i < n_args; i++ ) {
+            if( ASR::down_cast<ASR::Var_t>(args[i])->m_v == variable ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void replace_FunctionCall(ASR::FunctionCall_t* x) {
@@ -220,9 +282,17 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
             ASR::Variable_t* variable = ASR::down_cast<ASR::Variable_t>(sym.second);
             std::string local_sym_unique_name = current_scope->get_unique_name(variable->m_name);
             ASR::ttype_t* local_ttype_copy = type_duplicator.duplicate_ttype(variable->m_type);
-            if( variable->m_intent == ASRUtils::intent_out ||
-                variable->m_intent == ASRUtils::intent_inout ) {
-                local_ttype_copy = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc, local_ttype_copy));
+            if( (variable->m_intent == ASRUtils::intent_out ||
+                variable->m_intent == ASRUtils::intent_inout) ||
+                (ASRUtils::is_array(variable->m_type) &&
+                 is_argument(sym.second, variable->m_intent,
+                             function->m_args, function->n_args)) ) {
+                if( ASRUtils::is_array(variable->m_type) ) {
+                    local_ttype_copy = ASRUtils::duplicate_type_with_empty_dims(
+                        al, local_ttype_copy, ASR::array_physical_typeType::DescriptorArray, true);
+                }
+                local_ttype_copy = ASRUtils::TYPE(ASR::make_Pointer_t(
+                    al, loc, ASRUtils::type_get_past_allocatable_pointer(local_ttype_copy)));
             }
             ASR::symbol_t* local_sym = ASR::down_cast<ASR::symbol_t>(
                 ASRUtils::make_Variable_t_util(al, loc, current_scope, s2c(al, local_sym_unique_name),
@@ -291,6 +361,9 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
         // with their local copies
         ASRUtils::ExprStmtDuplicator stmt_duplicator(al);
         for( size_t i = 0; i < function->n_body; i++ ) {
+            if( ASR::is_a<ASR::Return_t>(*function->m_body[i]) ) {
+                continue ;
+            }
             ASR::stmt_t* stmt_copy = stmt_duplicator.duplicate_stmt(function->m_body[i]);
             fix_symbols.visit_stmt(*stmt_copy);
             current_body->push_back(al, stmt_copy);

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -237,27 +237,6 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
         return true;
     }
 
-    bool is_argument(ASR::symbol_t* variable, ASR::intentType intent,
-                     ASR::expr_t** args, size_t n_args) {
-        if( intent == ASRUtils::intent_in ||
-            intent == ASRUtils::intent_inout ||
-            intent == ASRUtils::intent_out ) {
-            return true;
-        }
-
-        if( intent == ASRUtils::intent_local ||
-            intent == ASRUtils::intent_return_var ) {
-            return false;
-        }
-
-        for( size_t i = 0; i < n_args; i++ ) {
-            if( ASR::down_cast<ASR::Var_t>(args[i])->m_v == variable ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     void replace_FunctionCall(ASR::FunctionCall_t* x) {
         if( !check_inline_possibility(x->m_name, x) ) {
             return ;
@@ -285,8 +264,7 @@ class InlineFunctionCalls: public ASR::BaseExprReplacer<InlineFunctionCalls> {
             if( (variable->m_intent == ASRUtils::intent_out ||
                 variable->m_intent == ASRUtils::intent_inout) ||
                 (ASRUtils::is_array(variable->m_type) &&
-                 is_argument(sym.second, variable->m_intent,
-                             function->m_args, function->n_args)) ) {
+                 ASRUtils::is_arg_dummy(variable->m_intent)) ) {
                 if( ASRUtils::is_array(variable->m_type) ) {
                     local_ttype_copy = ASRUtils::duplicate_type_with_empty_dims(
                         al, local_ttype_copy, ASR::array_physical_typeType::DescriptorArray, true);

--- a/tests/reference/pass_inline_function_calls-functions_05-5502cc1.json
+++ b/tests/reference/pass_inline_function_calls-functions_05-5502cc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_inline_function_calls-functions_05-5502cc1.stdout",
-    "stdout_hash": "09d5e189fa084b6423bb3ed15f6da9a96da0cc9d00c3853cea14f1ac",
+    "stdout_hash": "9f2c46ab247f04f4ae5d88a7753101795ae1dde80408109757fa266f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_inline_function_calls-functions_05-5502cc1.stdout
+++ b/tests/reference/pass_inline_function_calls-functions_05-5502cc1.stdout
@@ -26,25 +26,6 @@
                                     .false.
                                     ()
                                 ),
-                            a1:
-                                (Variable
-                                    2
-                                    a1
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
                             b:
                                 (Variable
                                     2
@@ -55,25 +36,6 @@
                                     ()
                                     Default
                                     (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            b1:
-                                (Variable
-                                    2
-                                    b1
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Integer 4)
                                     ()
                                     Source
                                     Public
@@ -248,63 +210,6 @@
                                                     .false.
                                                     .false.
                                                     ()
-                                                ),
-                                            r:
-                                                (Variable
-                                                    4
-                                                    r
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            x:
-                                                (Variable
-                                                    4
-                                                    x
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            y:
-                                                (Variable
-                                                    4
-                                                    y
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
                                                 )
                                         })
                                     f_real
@@ -322,108 +227,25 @@
                                         []
                                         .false.
                                     )
-                                    []
+                                    [signr32]
                                     [(Var 4 a)]
                                     [(Assignment
-                                        (Var 4 x)
-                                        (RealConstant
-                                            1.000000
-                                            (Real 4)
-                                        )
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
-                                        (Var 4 y)
-                                        (Var 4 a)
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
-                                        (Var 4 r)
-                                        (Var 4 x)
-                                        ()
-                                        .false.
-                                    )
-                                    (If
-                                        (LogicalBinOp
-                                            (LogicalBinOp
-                                                (RealCompare
-                                                    (Var 4 x)
-                                                    GtE
-                                                    (RealConstant
-                                                        0.000000
-                                                        (Real 4)
-                                                    )
-                                                    (Logical 4)
-                                                    ()
-                                                )
-                                                And
-                                                (RealCompare
-                                                    (Var 4 y)
-                                                    GtE
-                                                    (RealConstant
-                                                        0.000000
-                                                        (Real 4)
-                                                    )
-                                                    (Logical 4)
-                                                    ()
-                                                )
-                                                (Logical 4)
-                                                ()
-                                            )
-                                            Or
-                                            (LogicalBinOp
-                                                (RealCompare
-                                                    (Var 4 x)
-                                                    LtE
-                                                    (RealConstant
-                                                        0.000000
-                                                        (Real 4)
-                                                    )
-                                                    (Logical 4)
-                                                    ()
-                                                )
-                                                And
-                                                (RealCompare
-                                                    (Var 4 y)
-                                                    LtE
-                                                    (RealConstant
-                                                        0.000000
-                                                        (Real 4)
-                                                    )
-                                                    (Logical 4)
-                                                    ()
-                                                )
-                                                (Logical 4)
-                                                ()
-                                            )
-                                            (Logical 4)
-                                            ()
-                                        )
-                                        [(Assignment
-                                            (Var 4 r)
-                                            (Var 4 x)
-                                            ()
-                                            .false.
-                                        )]
-                                        [(Assignment
-                                            (Var 4 r)
-                                            (RealUnaryMinus
-                                                (Var 4 x)
-                                                (Real 4)
-                                                ()
-                                            )
-                                            ()
-                                            .false.
-                                        )]
-                                    )
-                                    (Assignment
                                         (Var 4 b)
                                         (RealBinOp
                                             (Var 4 a)
                                             Add
-                                            (Var 4 r)
+                                            (FunctionCall
+                                                2 signr32
+                                                ()
+                                                [((RealConstant
+                                                    1.000000
+                                                    (Real 4)
+                                                ))
+                                                ((Var 4 a))]
+                                                (Real 4)
+                                                ()
+                                                ()
+                                            )
                                             (Real 4)
                                             ()
                                         )
@@ -470,25 +292,6 @@
                                 (Variable
                                     2
                                     q
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            r:
-                                (Variable
-                                    2
-                                    r
                                     []
                                     Local
                                     ()
@@ -690,44 +493,6 @@
                                     .false.
                                     ()
                                 ),
-                            x1:
-                                (Variable
-                                    2
-                                    x1
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Integer 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            x2:
-                                (Variable
-                                    2
-                                    x2
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
                             y:
                                 (Variable
                                     2
@@ -746,56 +511,20 @@
                                     .false.
                                     .false.
                                     ()
-                                ),
-                            y1:
-                                (Variable
-                                    2
-                                    y1
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
                                 )
                         })
                     functions_01
                     []
                     [(Assignment
-                        (Var 2 a1)
-                        (Var 2 x)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 2 x1)
-                        (IntegerConstant 2 (Integer 4) Decimal)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 2 b1)
-                        (IntegerBinOp
-                            (Var 2 a1)
-                            Add
-                            (Var 2 x1)
+                        (Var 2 y)
+                        (FunctionCall
+                            2 f
+                            ()
+                            [((Var 2 x))]
                             (Integer 4)
                             ()
+                            ()
                         )
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 2 y)
-                        (Var 2 b1)
                         ()
                         .false.
                     )
@@ -856,99 +585,16 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 x2)
-                        (Var 2 a)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 2 y1)
-                        (Var 2 b)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 2 r)
-                        (Var 2 x2)
-                        ()
-                        .false.
-                    )
-                    (If
-                        (LogicalBinOp
-                            (LogicalBinOp
-                                (RealCompare
-                                    (Var 2 x2)
-                                    GtE
-                                    (RealConstant
-                                        0.000000
-                                        (Real 4)
-                                    )
-                                    (Logical 4)
-                                    ()
-                                )
-                                And
-                                (RealCompare
-                                    (Var 2 y1)
-                                    GtE
-                                    (RealConstant
-                                        0.000000
-                                        (Real 4)
-                                    )
-                                    (Logical 4)
-                                    ()
-                                )
-                                (Logical 4)
-                                ()
-                            )
-                            Or
-                            (LogicalBinOp
-                                (RealCompare
-                                    (Var 2 x2)
-                                    LtE
-                                    (RealConstant
-                                        0.000000
-                                        (Real 4)
-                                    )
-                                    (Logical 4)
-                                    ()
-                                )
-                                And
-                                (RealCompare
-                                    (Var 2 y1)
-                                    LtE
-                                    (RealConstant
-                                        0.000000
-                                        (Real 4)
-                                    )
-                                    (Logical 4)
-                                    ()
-                                )
-                                (Logical 4)
-                                ()
-                            )
-                            (Logical 4)
+                        (Var 2 c)
+                        (FunctionCall
+                            2 signr32
+                            ()
+                            [((Var 2 a))
+                            ((Var 2 b))]
+                            (Real 4)
+                            ()
                             ()
                         )
-                        [(Assignment
-                            (Var 2 r)
-                            (Var 2 x2)
-                            ()
-                            .false.
-                        )]
-                        [(Assignment
-                            (Var 2 r)
-                            (RealUnaryMinus
-                                (Var 2 x2)
-                                (Real 4)
-                                ()
-                            )
-                            ()
-                            .false.
-                        )]
-                    )
-                    (Assignment
-                        (Var 2 c)
-                        (Var 2 r)
                         ()
                         .false.
                     )

--- a/tests/reference/pass_inline_function_calls-functions_07-bb03cfd.json
+++ b/tests/reference/pass_inline_function_calls-functions_07-bb03cfd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_inline_function_calls-functions_07-bb03cfd.stdout",
-    "stdout_hash": "0baf1ff22697a9636c177829af1cb82a77e39ba014a3fc724801c93a",
+    "stdout_hash": "9b8c693ce4b5f0554086c47d4b35e8e8437bdbaeda5b3f0dc4427db5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_inline_function_calls-functions_07-bb03cfd.stdout
+++ b/tests/reference/pass_inline_function_calls-functions_07-bb03cfd.stdout
@@ -85,190 +85,20 @@
                                     .false.
                                     .false.
                                     ()
-                                ),
-                            u:
-                                (Variable
-                                    8
-                                    u
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            v:
-                                (Variable
-                                    8
-                                    v
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            w:
-                                (Variable
-                                    8
-                                    w
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            x:
-                                (Variable
-                                    8
-                                    x
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            y:
-                                (Variable
-                                    8
-                                    y
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            z:
-                                (Variable
-                                    8
-                                    z
-                                    []
-                                    Local
-                                    ()
-                                    ()
-                                    Default
-                                    (Real 4)
-                                    ()
-                                    Source
-                                    Public
-                                    Required
-                                    .false.
-                                    .false.
-                                    .false.
-                                    ()
                                 )
                         })
                     functions_07
                     [functions_07_c]
                     [(Assignment
-                        (Var 8 w)
-                        (Var 8 p)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 8 x)
-                        (Var 8 w)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 8 u)
-                        (Var 8 x)
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 8 v)
-                        (RealBinOp
-                            (Var 8 u)
-                            Add
-                            (RealConstant
-                                1.000000
-                                (Real 4)
-                            )
-                            (Real 4)
-                            ()
-                        )
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 8 y)
-                        (RealBinOp
-                            (Var 8 v)
-                            Add
-                            (RealConstant
-                                1.000000
-                                (Real 4)
-                            )
-                            (Real 4)
-                            ()
-                        )
-                        ()
-                        .false.
-                    )
-                    (Assignment
-                        (Var 8 z)
-                        (RealBinOp
-                            (Var 8 y)
-                            Add
-                            (RealConstant
-                                1.000000
-                                (Real 4)
-                            )
-                            (Real 4)
-                            ()
-                        )
-                        ()
-                        .false.
-                    )
-                    (Assignment
                         (Var 8 q)
-                        (Var 8 z)
+                        (FunctionCall
+                            8 f_c
+                            ()
+                            [((Var 8 p))]
+                            (Real 4)
+                            ()
+                            ()
+                        )
                         ()
                         .false.
                     )
@@ -395,44 +225,6 @@
                                     (SymbolTable
                                         5
                                         {
-                                            u:
-                                                (Variable
-                                                    5
-                                                    u
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            v:
-                                                (Variable
-                                                    5
-                                                    v
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
                                             x:
                                                 (Variable
                                                     5
@@ -490,30 +282,16 @@
                                     []
                                     [(Var 5 x)]
                                     [(Assignment
-                                        (Var 5 u)
-                                        (Var 5 x)
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
-                                        (Var 5 v)
-                                        (RealBinOp
-                                            (Var 5 u)
-                                            Add
-                                            (RealConstant
-                                                1.000000
-                                                (Real 4)
-                                            )
-                                            (Real 4)
-                                            ()
-                                        )
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
                                         (Var 5 y)
                                         (RealBinOp
-                                            (Var 5 v)
+                                            (FunctionCall
+                                                4 f_a
+                                                ()
+                                                [((Var 5 x))]
+                                                (Real 4)
+                                                ()
+                                                ()
+                                            )
                                             Add
                                             (RealConstant
                                                 1.000000
@@ -567,88 +345,12 @@
                                     (SymbolTable
                                         7
                                         {
-                                            u:
-                                                (Variable
-                                                    7
-                                                    u
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            v:
-                                                (Variable
-                                                    7
-                                                    v
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
                                             w:
                                                 (Variable
                                                     7
                                                     w
                                                     []
                                                     In
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            x:
-                                                (Variable
-                                                    7
-                                                    x
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                ),
-                                            y:
-                                                (Variable
-                                                    7
-                                                    y
-                                                    []
-                                                    Local
                                                     ()
                                                     ()
                                                     Default
@@ -700,51 +402,16 @@
                                     []
                                     [(Var 7 w)]
                                     [(Assignment
-                                        (Var 7 x)
-                                        (Var 7 w)
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
-                                        (Var 7 u)
-                                        (Var 7 x)
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
-                                        (Var 7 v)
-                                        (RealBinOp
-                                            (Var 7 u)
-                                            Add
-                                            (RealConstant
-                                                1.000000
-                                                (Real 4)
-                                            )
-                                            (Real 4)
-                                            ()
-                                        )
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
-                                        (Var 7 y)
-                                        (RealBinOp
-                                            (Var 7 v)
-                                            Add
-                                            (RealConstant
-                                                1.000000
-                                                (Real 4)
-                                            )
-                                            (Real 4)
-                                            ()
-                                        )
-                                        ()
-                                        .false.
-                                    )
-                                    (Assignment
                                         (Var 7 z)
                                         (RealBinOp
-                                            (Var 7 y)
+                                            (FunctionCall
+                                                6 f_b
+                                                ()
+                                                [((Var 7 w))]
+                                                (Real 4)
+                                                ()
+                                                ()
+                                            )
                                             Add
                                             (RealConstant
                                                 1.000000


### PR DESCRIPTION
The said feature is allowed. However there are some restrictions,

1. Any call with `ArrayPhysicalCast` isn't inlined.
2. Any function with multiple return statements or single return statement which is not in the last line of the function body isn't inlined.

We use local pointers for array arguments, so no deep copy happens. This anyways happens when you pass the array to the function call. So all should be safe.