### PR TITLE
enh: add missing `numeric_storage_size` to `lfortran_intrinsic_iso_fortran_env`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1697,6 +1697,8 @@ RUN(NAME test_iso_c_binding_constants LABELS gfortran llvm llvm_wasm llvm_wasm_e
 RUN(NAME test_iso_fortran_env LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME test_ieee_arithmetic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_ieee_arithmetic_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME iso_fortran_env_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+
 
 RUN(NAME abs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran mlir)
 RUN(NAME abs_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)

--- a/integration_tests/iso_fortran_env_01.f90
+++ b/integration_tests/iso_fortran_env_01.f90
@@ -1,4 +1,4 @@
-program main
+program iso_fortran_env_01
     use iso_fortran_env, only: numeric_storage_size
     print *, "numeric_storage_size: ", numeric_storage_size
     if (numeric_storage_size /= 32) error stop

--- a/integration_tests/iso_fortran_env_01.f90
+++ b/integration_tests/iso_fortran_env_01.f90
@@ -1,0 +1,5 @@
+program main
+    use iso_fortran_env, only: numeric_storage_size
+    print *, "numeric_storage_size: ", numeric_storage_size
+    if (numeric_storage_size /= 32) error stop
+end program

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -20,6 +20,8 @@ integer, parameter :: logical_kinds(1) = [4]
 
 integer, parameter :: iostat_end = -1
 
+integer, parameter :: numeric_storage_size = 32
+
 contains
 function compiler_version() result(version)
     character(len=:), allocatable :: version


### PR DESCRIPTION
Fixes #7397.