### PR TITLE
fix: handle `move_alloc` for unallocated variables

### DIFF
--- a/integration_tests/intrinsics_378.f90
+++ b/integration_tests/intrinsics_378.f90
@@ -1,6 +1,6 @@
 program intrinsics_378
   implicit none
-  integer, allocatable :: a(:), b(:)
+  integer, allocatable :: a(:), b(:), c(:)
 
   allocate(a(3), b(3))
   a = [1, 2, 3]
@@ -8,5 +8,19 @@ program intrinsics_378
   call move_alloc(a, b)
 
   print *, allocated(a)
+  print *, b
+
+  if (.not. allocated(b)) error stop
+  if (allocated(c)) error stop
+  if (any(b /= [1, 2, 3])) error stop
+    
+  call move_alloc(b, c)
+
+  print *, allocated(b)
+  print *, c
+
+  if (allocated(b)) error stop
+  if (.not. allocated(c)) error stop
+  if (any(c /= [1, 2, 3])) error stop
 
 end program intrinsics_378


### PR DESCRIPTION
Fixes #7400 

I am not sure if this is the best way to do it but we handle the `move_alloc` logic similarly by the function `instantiate_moveAlloc`. 

We can add semantic checks in the function `handle_moveAlloc` itself to prevent any invalid code from executing, and throw errors for wrong arguments like we do in `create_MoveAlloc` function.