### PR TITLE
build: add color diagnostics flags

### DIFF
--- a/build1.sh
+++ b/build1.sh
@@ -13,6 +13,8 @@ cmake \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_LIBDIR=share/lfortran/lib \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=yes \
+    -DCMAKE_C_FLAGS="${CFLAGS} -fdiagnostics-color=always" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fdiagnostics-color=always" \
 -G Ninja \
     .
 cmake --build .


### PR DESCRIPTION
The lack of colours in a ninja build made it a bit difficult to find failures. Now we have some colours in the build.