### PR TITLE
fix: correct `m_original_name` for structs in nested pass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1602,6 +1602,7 @@ RUN(NAME nested_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME nested_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)

--- a/integration_tests/nested_12.f90
+++ b/integration_tests/nested_12.f90
@@ -1,0 +1,30 @@
+module struct_var
+type :: toml_value
+    integer :: key = 0
+end type toml_value
+end module
+
+module nested_12_mod
+    use struct_var, only: toml_lexer => toml_value
+contains
+    subroutine char_num()
+        type(toml_lexer) :: lexer
+        lexer%key = 5
+        call temp()
+    contains
+        subroutine temp()
+            call semantics(lexer)
+        end subroutine
+    end subroutine
+
+    subroutine semantics(lexer)
+        class(toml_lexer), intent(inout) :: lexer
+        if(lexer%key /= 5) error stop
+    end subroutine semantics
+end module 
+
+program nested_12
+    use struct_var
+    use nested_12_mod
+   call char_num()
+end program

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -361,7 +361,7 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                                     /* a_name */ fn_name,
                                     original_symbol,
                                     ASRUtils::symbol_name(ASRUtils::get_asr_owner(original_symbol)),
-                                    nullptr, 0, fn_name, ASR::accessType::Public
+                                    nullptr, 0, ASRUtils::symbol_name(original_symbol), ASR::accessType::Public
                                 );
                                 m_derived_type_or_class_type = ASR::down_cast<ASR::symbol_t>(fn);
                                 current_scope->add_symbol(fn_name, m_derived_type_or_class_type);


### PR DESCRIPTION
Previous Error:
```console
ASR verify pass error: ExternalSymbol::m_original_name must match external->m_name
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  Binary file "/home/jinang_shah/Desktop/lfortran/src/bin/lfortran", in _start
  File "./csu/../csu/libc-start.c", line 360, in __libc_start_main
  File "./csu/../sysdeps/nptl/libc_start_call_main.h", line 58, in __libc_start_call_main
  File "/home/jinang_shah/Desktop/lfortran/src/bin/lfortran.cpp", line 2696, in main
    return main_app(argc, argv);
  File "/home/jinang_shah/Desktop/lfortran/src/bin/lfortran.cpp", line 2579, in main_app(int, char**)
    return compile_src_to_object_file(opts.arg_file, outfile, compiler_options.time_report, false,
  File "/home/jinang_shah/Desktop/lfortran/src/bin/lfortran.cpp", line 1168, in (anonymous namespace)::compile_src_to_object_file(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, LCompilers::CompilerOptions&, LCompilers::PassManager&, bool)
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile, &time_opt);
  File "/home/jinang_shah/Desktop/lfortran/src/lfortran/fortran_evaluator.cpp", line 393, in LCompilers::FortranEvaluator::get_llvm3(LCompilers::ASR::TranslationUnit_t&, LCompilers::PassManager&, LCompilers::diag::Diagnostics&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*)
    compiler_options, run_fn, "", infile);
  File "/home/jinang_shah/Desktop/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 11638, in LCompilers::asr_to_llvm(LCompilers::ASR::TranslationUnit_t&, LCompilers::diag::Diagnostics&, llvm::LLVMContext&, Allocator&, LCompilers::PassManager&, LCompilers::CompilerOptions&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    pass_manager.apply_passes(al, &asr, co.po, diagnostics);
  File "/home/jinang_shah/Desktop/lfortran/src/libasr/pass/pass_manager.h", line 318, in LCompilers::PassManager::apply_passes(Allocator&, LCompilers::ASR::TranslationUnit_t*, LCompilers::PassOptions&, LCompilers::diag::Diagnostics&)
    apply_passes(al, asr, _passes, pass_options, diagnostics, cummulative_time_taken_by_passes_in_microseconds);
LCompilersException: Verify failed in the pass: nested_vars
<ERROR> Compilation failed for object " test_compliance_toml2json.f90.o "
<ERROR> stopping due to failed compilation
STOP 1
```