### PR TITLE
CI: build and run dftatom third party repository with --std=f23

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -498,6 +498,22 @@ time_section "🧪 Testing dftatom" '
   git clean -dfx
   make -f Makefile.manual F90=$FC F90FLAGS="-I../../src --generate-object-code --fast"
   make -f Makefile.manual quicktest
+
+  git clean -dfx
+  make -f Makefile.manual F90=$FC F90FLAGS="-I../../src --std=f23"
+  make -f Makefile.manual quicktest
+
+  git clean -dfx
+  make -f Makefile.manual F90=$FC F90FLAGS="-I../../src --fast --std=f23"
+  make -f Makefile.manual quicktest
+
+  git clean -dfx
+  make -f Makefile.manual F90=$FC F90FLAGS="-I../../src --generate-object-code --std=f23"
+  make -f Makefile.manual quicktest
+
+  git clean -dfx
+  make -f Makefile.manual F90=$FC F90FLAGS="-I../../src --generate-object-code --fast --std=f23"
+  make -f Makefile.manual quicktest
 '
 
 


### PR DESCRIPTION
## Description

Towards: https://github.com/lfortran/lfortran/issues/6020

Once the CI checks pass on this PR, we should wait to see how much time it takes at LFortran's CI now, compared to what it used to take earlier.

In one of the earlier CI runs, we noticed that dftatom on current *main* takes ~75 seconds (see: https://gist.github.com/gxyd/666361ad6e1161c42e8257d7a0656516)