### PR TITLE
fix: use 'check_external' to only apply ASR verify after visiting FixExternalSymbol

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1831,6 +1831,7 @@ RUN(NAME external_08 LABELS gfortran llvmImplicit)
 RUN(NAME external_09 LABELS gfortran llvm EXTRA_ARGS --implicit-interface NO_STD_F23)
 RUN(NAME external_10 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_11 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_12 LABELS gfortran llvm EXTRAFILES external_12_module.f90)
 
 
 RUN(NAME interface_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)

--- a/integration_tests/external_12.f90
+++ b/integration_tests/external_12.f90
@@ -1,0 +1,4 @@
+program external_12
+    use external_12_module2, only: inner
+    call inner()
+end program

--- a/integration_tests/external_12_module.f90
+++ b/integration_tests/external_12_module.f90
@@ -1,0 +1,30 @@
+module external_12_module1
+    LOGICAL(4), ALLOCATABLE, DIMENSION(:) :: inrdone
+end module external_12_module1
+
+MODULE external_12_module2
+
+  use external_12_module1, only: inrdone
+  REAL(4), PARAMETER :: one  = 1.0
+
+  PUBLIC :: inner
+
+  CONTAINS
+
+  SUBROUTINE inner ( )
+
+    REAL(4), ALLOCATABLE, DIMENSION(:) :: dfmxi
+    REAL(4) :: epsi=1.0E-4
+
+    ALLOCATE( dfmxi(5) )
+    ALLOCATE( inrdone(5) )
+
+    dfmxi = -one
+    WHERE( dfmxi <= epsi ) inrdone = .TRUE.
+
+    print *, "inrdone: ", inrdone
+    if (any(inrdone .neqv. .TRUE.)) error stop
+
+  END SUBROUTINE inner
+
+END MODULE external_12_module2

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -383,7 +383,9 @@ public:
                 const_assigned.insert(std::make_pair(current_symtab->counter, variable_name));
             }
         }
-        if ( x.m_realloc_lhs ) {
+        // it's possible that the target is an external symbol, and during
+        // initial deserialization pass, so we don't do the below verification
+        if ( check_external && x.m_realloc_lhs ) {
             ASR::expr_t* a_target = x.m_target;
             bool is_allocatable = ASRUtils::is_allocatable(a_target);
             if ( ASR::is_a<ASR::StructInstanceMember_t>(*a_target) ) {


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7454

Towards: #7445 