### PR TITLE
ref: handling of optional arguments in `get_environment_variable`

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -116,6 +116,15 @@ time_section "🧪 Testing stdlib (Less Workarounds)" '
   make -j8
   ctest
 
+  git clean -dfx
+  git checkout 9e54a1115c9b5d5558e9db6f295849912b1202d5
+  FC=$FC cmake . \
+      -DTEST_DRIVE_BUILD_TESTING=OFF \
+      -DBUILD_EXAMPLE=ON -DCMAKE_Fortran_COMPILER_WORKS=TRUE \
+      -DCMAKE_Fortran_FLAGS="--cpp --generate-object-code --realloc-lhs --no-warnings --use-loop-variable-after-loop -I$(pwd)/src -I$(pwd)/subprojects/test-drive/"
+  make -j8
+  ctest
+
   print_success "Done with stdlib (Less Workarounds)"
   cd ..
   rm -rf stdlib

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1119,6 +1119,8 @@ RUN(NAME intrinsics_376 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # present
 RUN(NAME intrinsics_377 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # minval, maxval
 RUN(NAME intrinsics_378 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # move_alloc
 RUN(NAME intrinsics_379 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # get_command_argument
+RUN(NAME intrinsics_380 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # get_environment_variable
+RUN(NAME intrinsics_381 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # get_environment_variable
 
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants

--- a/integration_tests/intrinsics_380.f90
+++ b/integration_tests/intrinsics_380.f90
@@ -1,0 +1,36 @@
+module testdrive_intrinsics_380
+  implicit none
+
+contains
+
+  !> Obtain the value of an environment variable
+  subroutine get_variable(var, val)
+
+    !> Name of variable
+    character(len=*), intent(in) :: var
+
+    !> Value of variable
+    character(len=:), allocatable, intent(out) :: val
+
+    integer :: length, stat
+
+    call get_environment_variable(var, length=length, status=stat)
+
+    allocate(character(len=length) :: val, stat=stat)
+
+    if (length > 0) then
+      call get_environment_variable(var, val, status=stat)
+    end if
+
+  end subroutine get_variable
+
+end module testdrive_intrinsics_380
+
+program intrinsics_380
+  use testdrive_intrinsics_380
+  character(len=:), allocatable :: val
+
+  call get_variable("LFORTRAN_TEST_ENV_VAR", val)
+  write(*,*) trim(val)
+  if (trim(val) /= "STATUS OK!") error stop
+end program

--- a/integration_tests/intrinsics_381.f90
+++ b/integration_tests/intrinsics_381.f90
@@ -1,0 +1,9 @@
+PROGRAM intrinsics_381
+CHARACTER(len=255) :: test_env_var
+integer :: len
+CALL get_environment_variable("LFORTRAN_TEST_ENV_VAR", test_env_var, len)
+WRITE (*,*) TRIM(test_env_var)
+if (trim(test_env_var) /= "STATUS OK!") error stop
+print *, len
+if (len /= 9) error stop
+END PROGRAM

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -1171,6 +1171,24 @@ class ASRBuilder {
         return s;
     }
 
+    ASR::symbol_t* create_c_func_subroutines_with_return_type(std::string c_func_name, SymbolTable* fn_symtab, int n_args, std::vector<ASR::ttype_t*> arg_types,
+            ASR::ttype_t* return_type) {
+        SymbolTable *fn_symtab_1 = al.make_new<SymbolTable>(fn_symtab);
+        Vec<ASR::expr_t*> args_1; args_1.reserve(al, 0);
+        for (int i = 0; i < n_args; i++) {
+            args_1.push_back(al, this->Variable(fn_symtab_1, "x_"+std::to_string(i), arg_types[i],
+                ASR::intentType::InOut, ASR::abiType::BindC, true));
+        }
+        ASR::expr_t *return_var_1 = this->Variable(fn_symtab_1, c_func_name,
+           return_type,
+           ASRUtils::intent_return_var, ASR::abiType::BindC, false);
+        SetChar dep_1; dep_1.reserve(al, 1);
+        Vec<ASR::stmt_t*> body_1; body_1.reserve(al, 1);
+        ASR::symbol_t *s = make_ASR_Function_t(c_func_name, fn_symtab_1, dep_1, args_1,
+            body_1, return_var_1, ASR::abiType::BindC, ASR::deftypeType::Interface, s2c(al, c_func_name));
+        return s;
+    }
+
 };
 
 } // namespace LCompilers::ASRUtils

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -731,43 +731,60 @@ namespace GetEnvironmentVariable {
         std::string new_name = "_lcompilers_get_environment_variable_";
         declare_basic_variables(new_name);
         fill_func_arg_sub("name", arg_types[0], InOut);
-        fill_func_arg_sub("value", arg_types[1], InOut);
-        if (arg_types.size() == 3) {
-            fill_func_arg_sub("length", arg_types[2], InOut);
-        }
-        if (arg_types.size() == 4) {
-            fill_func_arg_sub("status", arg_types[3], InOut);
-        }
-        if (arg_types.size() == 5) {
-            fill_func_arg_sub("trim_name", arg_types[4], InOut);
-        }
-        SymbolTable *fn_symtab_1 = al.make_new<SymbolTable>(fn_symtab);
+        if ( arg_types.size() >= 2 && ASRUtils::is_character(*arg_types[1]) ) {
+            // this is the case where args[1] is `value`
+            ASR::ttype_t* CString_type = character(-1);
+            ASR::down_cast<ASR::String_t>(CString_type)->m_physical_type = ASR::string_physical_typeType::CString;
+            fill_func_arg_sub("value", arg_types[1], InOut);
+            ASR::symbol_t *s = b.create_c_func_subroutines_with_return_type(c_func_name, fn_symtab, 1, {CString_type},
+                CString_type);
+            fn_symtab->add_symbol(c_func_name, s);
+            dep.push_back(al, s2c(al, c_func_name));
+            Vec<ASR::expr_t*> call_args; call_args.reserve(al, 1);
+            call_args.push_back(al, args[0]);
+            body.push_back(al, b.Assignment(args[1],
+                    ASRUtils::create_string_physical_cast(al, b.Call(s, call_args, CString_type),
+                    ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(arg_types[1]))->m_physical_type)));
 
-        Vec<ASR::expr_t*> args_1; args_1.reserve(al, 1);
-        ASR::expr_t *arg = b.Variable(fn_symtab_1, "n", arg_types[0],
-            ASR::intentType::InOut, ASR::abiType::BindC, true);
-        args_1.push_back(al, arg);
-        ASR::ttype_t* CString_type = character(-1);
-        ASR::down_cast<ASR::String_t>(CString_type)->m_physical_type = ASR::string_physical_typeType::CString;
-        ASR::expr_t *return_var_1 = b.Variable(fn_symtab_1, c_func_name,
-            ASRUtils::is_character(*arg_types[1]) ?
-            CString_type :
-            ASRUtils::type_get_past_array(ASRUtils::type_get_past_allocatable(arg_types[1])),
-            ASRUtils::intent_return_var, ASR::abiType::BindC, false);
-           
-        SetChar dep_1; dep_1.reserve(al, 1);
-        Vec<ASR::stmt_t*> body_1; body_1.reserve(al, 1);
-        ASR::symbol_t *s = make_ASR_Function_t(c_func_name, fn_symtab_1, dep_1, args_1,
-            body_1, return_var_1, ASR::abiType::BindC, ASR::deftypeType::Interface, s2c(al, c_func_name));
-        fn_symtab->add_symbol(c_func_name, s);
-        dep.push_back(al, s2c(al, c_func_name));
+            if (arg_types.size() >= 3) {
+                std::string c_func_name = "_lfortran_get_length_of_environment_variable";
+                fill_func_arg_sub("length", arg_types[2], InOut);
+                ASR::symbol_t *s = b.create_c_func_subroutines_with_return_type(c_func_name, fn_symtab, 1, {CString_type},
+                    arg_types[2]);
+                fn_symtab->add_symbol(c_func_name, s);
+                dep.push_back(al, s2c(al, c_func_name));
+                Vec<ASR::expr_t*> call_args; call_args.reserve(al, 1);
+                call_args.push_back(al, args[0]);
+                body.push_back(al, b.Assignment(args[2], b.Call(s, call_args, arg_types[2])));
+            }
+            if (arg_types.size() >= 4) {
+                fill_func_arg_sub("status", arg_types[3], InOut);
+            }
+            if (arg_types.size() >= 5) {
+                fill_func_arg_sub("trim_name", arg_types[4], InOut);
+            }
+        } else if ( arg_types.size() >= 2 && ASRUtils::is_integer(*arg_types[1]) ) {
+            // this is the case where args[1] is `length`
+            c_func_name = "_lfortran_get_length_of_environment_variable";
+            fill_func_arg_sub("length", arg_types[1], InOut);
+            ASR::ttype_t* CString_type = character(-1);
+            ASR::down_cast<ASR::String_t>(CString_type)->m_physical_type = ASR::string_physical_typeType::CString;
+            ASR::symbol_t *s = b.create_c_func_subroutines_with_return_type(c_func_name, fn_symtab, 1, {CString_type},
+                arg_types[1]);
+            fn_symtab->add_symbol(c_func_name, s);
+            dep.push_back(al, s2c(al, c_func_name));
+            Vec<ASR::expr_t*> call_args; call_args.reserve(al, 1);
+            call_args.push_back(al, args[0]);
+            body.push_back(al, b.Assignment(args[1], b.Call(s, call_args, arg_types[1])));
 
-        Vec<ASR::expr_t*> call_args; call_args.reserve(al, 1);
-        call_args.push_back(al, args[0]);
-        body.push_back(al, b.Assignment(args[1], ASRUtils::is_character(*arg_types[1])?
-            ASRUtils::create_string_physical_cast(al, b.Call(s, call_args, CString_type),
-                ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(arg_types[1]))->m_physical_type) 
-        : b.Call(s, call_args, arg_types[1])));
+            if (arg_types.size() >= 3) {
+                fill_func_arg_sub("status", arg_types[2], InOut);
+            }
+
+            if (arg_types.size() >= 4) {
+                fill_func_arg_sub("trim_name", arg_types[3], InOut);
+            }
+        }
         ASR::symbol_t *new_symbol = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, new_symbol);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5220,6 +5220,20 @@ LFORTRAN_API char *_lfortran_get_environment_variable(char *name) {
     }
 }
 
+LFORTRAN_API int32_t _lfortran_get_length_of_environment_variable(char *name) {
+    // temporary solution, the below function _lfortran_get_env_variable should be used
+    if (name == NULL) {
+        return 0;
+    } else {
+        char *value = getenv(name);
+        if (value == NULL) {
+            return 0; // If the environment variable is not found, return 0
+        } else {
+            return strlen(value); // Return the length of the environment variable value
+        }
+    }
+}
+
 LFORTRAN_API char *_lfortran_get_env_variable(char *name) {
     return getenv(name);
 }


### PR DESCRIPTION
Fixes #7456. This PR enables `ascii` and `specialfunctions` of stdlib with separate compilation.