### PR TITLE
CI: test SNAP with --std=f23 flag at LFortran's CI

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -678,6 +678,7 @@ time_section "🧪 Testing SNAP" '
     git checkout lf11
     git checkout 169a9216f2c922e94065a519efbb0a6c8b55149e
     cd ./src
+
     make -j8 FORTRAN=$FC FFLAGS= MPI=no OPENMP=no
     ./gsnap ../qasnap/sample/inp out
 
@@ -688,6 +689,22 @@ time_section "🧪 Testing SNAP" '
     make clean
     make -j8 FORTRAN=$FC FFLAGS="--fast" MPI=no OPENMP=no
     ./gsnap ../qasnap/sample/inp out
+
+    make clean
+    make -j8 FORTRAN=$FC FFLAGS="--std=f23" MPI=no OPENMP=no
+    ./gsnap ../qasnap/sample/inp out
+
+    make clean
+    make -j8 FORTRAN=$FC FFLAGS="--generate-object-code --std=f23" MPI=no OPENMP=no
+    ./gsnap ../qasnap/sample/inp out
+
+    make clean
+    make -j8 FORTRAN=$FC FFLAGS="--fast --std=f23" MPI=no OPENMP=no
+    ./gsnap ../qasnap/sample/inp out
+
+    print_success "Done with SNAP"
+    cd ../..
+    rm -rf SNAP
 '
 
 


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7445

Towards: https://github.com/lfortran/lfortran/issues/6020#issue-2790936267

Earlier it used to take [~21 seconds to run SNAP at LFortran's CI](https://productionresultssa3.blob.core.windows.net/actions-results/321e4d6b-53a7-49ff-bc02-61bea381c94e/workflow-job-run-68121ad9-9285-535f-a8f8-341dd89c62c8/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-05-28T09%3A16%3A08Z&sig=yVspG6lVsib5dKziugI%2B3%2FyOI36rmuO7v7ND2htLJdQ%3D&ske=2025-05-28T19%3A16%3A06Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-05-28T07%3A16%3A06Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-05-28T09%3A06%3A03Z&sv=2025-05-05):
```
2025-05-28T02:12:56.2323014Z  Success! Done in a SNAP!
2025-05-28T02:12:56.2340180Z [1;33m→ ⏱ Duration: 21 seconds[0m
```

We'll wait for CI to pass on this to see how long it takes now