### PR TITLE
CI: run fortran primes with --std=f23 flag

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -147,6 +147,14 @@ time_section "🧪 Testing Fortran-Primes" '
   git clean -dfx
   FC="$FC --generate-object-code" ./build_and_run.sh
 
+  print_subsection "Building and running Fortran-Primes with f23 standard "
+  git clean -dfx
+  FC="$FC --std=f23" ./build_and_run.sh
+
+  print_subsection "Building Fortran-Primes with separate compilation and f23 standard"
+  git clean -dfx
+  FC="$FC --generate-object-code --std=f23" ./build_and_run.sh
+
   print_success "Done with Fortran-Primes"
   cd ..
   rm -rf fortran-primes


### PR DESCRIPTION
## Description

Towards: https://github.com/lfortran/lfortran/issues/6020