### PR TITLE
test: add test with implicit typing and publicily defined variable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -357,6 +357,7 @@ RUN(NAME data_11 LABELS gfortran llvmImplicit)
 RUN(NAME data_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME data_16 LABELS gfortran llvmImplicit)
 
 RUN(NAME datastmt_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/data_16.f90
+++ b/integration_tests/data_16.f90
@@ -1,0 +1,10 @@
+module data_16_module
+    public :: pi
+    data pi /3.14/
+end module
+
+program data_16
+    use data_16_module
+    print *, "pi: ", pi
+    if (abs(pi - 3.14) > 1.0e-6) error stop
+end program data_16


### PR DESCRIPTION
## Description

This just add a test case, and this isn't currently tested with any of the current integration tests or reference tests.

I came across this while working on another PR, which passed all the integration test and reference tests (but the logic was a little incorrect as confirmed to me by GFortran), and hence it's better to have this as an integration test.