### PR TITLE
enh: implement `mold` argument in `allocate` for runtime dims

### DIFF
--- a/integration_tests/allocate_01.f90
+++ b/integration_tests/allocate_01.f90
@@ -12,6 +12,10 @@ n = 10
 allocate(e, mold=d)
 if (size(e) /= 5) error stop
 
+allocate(a, mold=e)
+if (size(a) /= 5) error stop
+deallocate(a)
+
 allocate(a(5:n + 5))
 allocate(b(n:2*n, n:3*n), stat=ierr)
 if( size(a) /= n + 1 ) error stop


### PR DESCRIPTION
Fixes #6592 
Refer to https://github.com/lfortran/lfortran/pull/6638#discussion_r2078393105