### PR TITLE
enh: add `character_storage_size` to `iso_fortran_env`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1721,6 +1721,7 @@ RUN(NAME test_iso_fortran_env LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm
 RUN(NAME test_ieee_arithmetic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_ieee_arithmetic_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME iso_fortran_env_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME iso_fortran_env_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 
 RUN(NAME abs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran mlir)

--- a/integration_tests/iso_fortran_env_02.f90
+++ b/integration_tests/iso_fortran_env_02.f90
@@ -1,0 +1,5 @@
+program iso_fortran_env_02
+    use iso_fortran_env, only: character_storage_size
+    print *, "character_storage_size: ", character_storage_size
+    if (character_storage_size /= 8) error stop
+end program

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -21,6 +21,7 @@ integer, parameter :: logical_kinds(1) = [4]
 integer, parameter :: iostat_end = -1
 
 integer, parameter :: numeric_storage_size = 32
+integer, parameter :: character_storage_size = 8
 
 contains
 function compiler_version() result(version)

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.json
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nested_struct_proc_01-3b9017b.stdout",
-    "stdout_hash": "8c8ca42c016c814b7fc24f0cbc6a284c0bd08c8605bf1732025b4ec1",
+    "stdout_hash": "d2086ccb9b494ce0f5f3bb6a87540f5b00f06ac3838caac066c5a3ec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
@@ -17,6 +17,16 @@
                                     character_kinds
                                     Public
                                 ),
+                            character_storage_size:
+                                (ExternalSymbol
+                                    2
+                                    character_storage_size
+                                    4 character_storage_size
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    character_storage_size
+                                    Public
+                                ),
                             compiler_version:
                                 (ExternalSymbol
                                     2
@@ -884,6 +894,16 @@
                                     lfortran_intrinsic_iso_fortran_env
                                     []
                                     character_kinds
+                                    Public
+                                ),
+                            character_storage_size:
+                                (ExternalSymbol
+                                    11
+                                    character_storage_size
+                                    4 character_storage_size
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    character_storage_size
                                     Public
                                 ),
                             compiler_version:


### PR DESCRIPTION
Fixes #7111 