### PR TITLE
CI: Update to windows-2025

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-2019", "macos-latest", "ubuntu-latest"]
+        os: ["windows-2025", "macos-latest", "ubuntu-latest"]
         python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As windows-2019 will be removed on June 30, 2025.