### PR TITLE
Fix: Enforce error for character arrays with deferred length but non-deferred shape (Issue #6902)

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3413,6 +3413,27 @@ public:
                 AST::AttrType_t *sym_type =
                     AST::down_cast<AST::AttrType_t>(x.m_vartype);
                 bool is_char_type = sym_type->m_type == AST::decl_typeType::TypeCharacter;
+                  if (is_char_type && sym_type->n_kind == ASR::string_length_kindType::DeferredLength
+                    && s.n_dim > 0) {
+                    bool has_fixed_shape = false;
+
+                    for (size_t d = 0; d < s.n_dim; d++) {
+                       
+                        if (s.m_dim[d].m_end != nullptr && s.m_dim[d].m_end_star == 0) {
+                            has_fixed_shape = true;
+                            break;
+                        }
+                    }
+                    if (has_fixed_shape) {
+                        diag.add(
+                            Diagnostic("Allocatable array '" + std::string(x.m_syms[0].m_name)
+                                           + "' at (1) must have a deferred shape or assumed rank",
+                                       Level::Error,
+                                       Stage::Semantic,
+                                       { Label("", { s.loc }) }));
+                        throw SemanticAbort();
+                    }
+                }
                 if (assgnd_access.count(sym)) {
                     s_access = assgnd_access[sym];
                 }


### PR DESCRIPTION
This PR implements a semantic check for character arrays with deferred length but non-deferred (fixed) shape, as required by Fortran standards and described in issue #6902.