### PR TITLE
fix: get type pointer for classes in `associated`  and `allocated` intrinsics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1713,6 +1713,7 @@ RUN(NAME class_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --rea
 RUN(NAME class_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)

--- a/integration_tests/class_29.f90
+++ b/integration_tests/class_29.f90
@@ -8,6 +8,7 @@ program class_29
     type(toml_table), target :: temp_table
     temp_table%x = 42
     temp => temp_table
+    nullify(temp2)
     if (associated(temp2) .or. .not. associated(temp)) error stop
     
     if (allocated(temp3)) error stop

--- a/integration_tests/class_29.f90
+++ b/integration_tests/class_29.f90
@@ -1,0 +1,13 @@
+program class_29
+    type :: toml_table
+        integer :: x
+    end type
+    class(toml_table), pointer :: temp
+    class(toml_table), pointer :: temp2
+    type(toml_table), target :: temp_table
+    temp_table%x = 42
+    temp => temp_table
+    print *, associated(temp)
+    print *, associated(temp2)
+    if (associated(temp2) .or. .not. associated(temp)) error stop
+end program

--- a/integration_tests/class_29.f90
+++ b/integration_tests/class_29.f90
@@ -4,10 +4,13 @@ program class_29
     end type
     class(toml_table), pointer :: temp
     class(toml_table), pointer :: temp2
+    class(toml_table), allocatable :: temp3
     type(toml_table), target :: temp_table
     temp_table%x = 42
     temp => temp_table
-    print *, associated(temp)
-    print *, associated(temp2)
     if (associated(temp2) .or. .not. associated(temp)) error stop
+    
+    if (allocated(temp3)) error stop
+    allocate(temp3)
+    if (.not. allocated(temp3)) error stop
 end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5006,7 +5006,12 @@ public:
             ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(p_type)), module.get());
 #endif
-        ptr = llvm_utils->CreateLoad2(p_type, ptr);
+        if (ASRUtils::is_class_type(ASRUtils::extract_type(p_type))) {
+            // If the pointer is class, get its type pointer
+            ptr = llvm_utils->CreateLoad(llvm_utils->create_gep(ptr, 1));
+        } else {
+            ptr = llvm_utils->CreateLoad2(p_type, ptr);
+        }
         if( ASRUtils::is_array(p_type) &&
             ASRUtils::extract_physical_type(p_type) ==
             ASR::array_physical_typeType::DescriptorArray) {


### PR DESCRIPTION
Fixes #7352
Fixes #7353