### PR TITLE
fix : Do not call Deepcopy in LLVM for unlimited polymorphic variable (abstract_type)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1709,6 +1709,7 @@ RUN(NAME class_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)

--- a/integration_tests/class_28.f90
+++ b/integration_tests/class_28.f90
@@ -1,0 +1,41 @@
+module stdlib_hashmap_wrappers_class_28
+
+    implicit none
+    private
+
+    public :: other_type
+
+    type :: other_type
+        class(*), allocatable :: value
+    end type other_type
+
+end module stdlib_hashmap_wrappers_class_28
+
+
+module stdlib_hashmaps_class_28
+
+    use stdlib_hashmap_wrappers_class_28
+
+    implicit none
+
+    type :: open_map_entry_type
+        type(other_type)  :: other
+    end type open_map_entry_type
+
+end module stdlib_hashmaps_class_28
+
+
+program class_28
+
+    use stdlib_hashmaps_class_28
+    use stdlib_hashmap_wrappers_class_28
+
+    implicit none
+
+    type(open_map_entry_type), pointer :: new_ent
+    type(other_type) :: other
+    allocate(new_ent)
+
+    other = new_ent % other
+
+end program

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2189,7 +2189,8 @@ namespace LCompilers {
                     for( auto item: struct_sym->m_symtab->get_scope() ) {
                         if( ASR::is_a<ASR::ClassProcedure_t>(*item.second) ||
                             ASR::is_a<ASR::GenericProcedure_t>(*item.second) ||
-                            ASR::is_a<ASR::CustomOperator_t>(*item.second) ) {
+                            ASR::is_a<ASR::CustomOperator_t>(*item.second) ||
+                            (ASR::is_a<ASR::Struct_t>(*item.second) && std::string(ASR::down_cast<ASR::Struct_t>(item.second)->m_name) == "~abstract_type") ) {
                             continue ;
                         }
                         std::string mem_name = item.first;


### PR DESCRIPTION
Fixes #7438