### PR TITLE
fix: correct `Struct` name order in `visit_arrayitem` and CreateLoad for nested SIM

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1707,6 +1707,7 @@ RUN(NAME class_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_30.f90
+++ b/integration_tests/class_30.f90
@@ -1,0 +1,28 @@
+ module class_30_mod
+    type :: abstract_lexer
+    end type
+
+   type :: stack_item
+      integer :: scope
+   end type stack_item
+
+   type, extends(abstract_lexer) :: toml_lexer
+      integer :: top = 1
+      type(stack_item), allocatable :: stack(:)
+   end type toml_lexer
+end module
+
+program class_30
+    use class_30_mod
+    type(toml_lexer) :: lexer
+    allocate(lexer%stack(10))
+    lexer%stack(lexer%top)%scope = 1
+    call check_scope(lexer)
+
+contains
+
+    subroutine check_scope(lex)
+        class(toml_lexer), intent(in) :: lex
+        if (lex%stack(lex%top)%scope /= 1) error stop
+    end subroutine check_scope
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2443,13 +2443,6 @@ public:
             array = tmp;
         }
 
-        if( ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(x.m_type)) && !ASRUtils::is_class_type(x.m_type) ) {
-            ASR::StructType_t* der_type = ASR::down_cast<ASR::StructType_t>(
-                ASRUtils::extract_type(x.m_type));
-            current_der_type_name = ASRUtils::symbol_name(
-                ASRUtils::symbol_get_past_external(der_type->m_derived_type));
-        }
-
         ASR::dimension_t* m_dims;
         int n_dims = ASRUtils::extract_dimensions_from_ttype(x_mv_type, m_dims);
         if (ASRUtils::is_character(*x.m_type) && n_dims == 0) {
@@ -2562,6 +2555,12 @@ public:
                                                     array_t->m_physical_type == ASR::array_physical_typeType::PointerToDataArray,
                                                     is_fixed_size, llvm_diminfo.p, is_polymorphic, current_select_type_block_type);
             }
+        }
+        if( ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(x.m_type)) && !ASRUtils::is_class_type(x.m_type) ) {
+            ASR::StructType_t* der_type = ASR::down_cast<ASR::StructType_t>(
+                ASRUtils::extract_type(x.m_type));
+            current_der_type_name = ASRUtils::symbol_name(
+                ASRUtils::symbol_get_past_external(der_type->m_derived_type));
         }
     }
 
@@ -2846,6 +2845,11 @@ public:
         int member_idx = name2memidx[current_der_type_name][member_name];
 
         llvm::Type *xtype = name2dertype[current_der_type_name];
+        if (ASR::is_a<ASR::StructType_t>(*x_m_v_type) && 
+            !ASRUtils::is_class_type(ASRUtils::extract_type(x_m_v_type)) && 
+            ASRUtils::is_allocatable(x_m_v_type)) {
+            tmp = llvm_utils->CreateLoad2(xtype->getPointerTo(), tmp);
+        }
         tmp = llvm_utils->create_gep2(xtype, tmp, member_idx);
         ASR::ttype_t* member_type = ASRUtils::type_get_past_pointer(
             ASRUtils::type_get_past_allocatable(member->m_type));


### PR DESCRIPTION
Fixes #7433 
Fixes #7434 