### PR TITLE
fix: simplify `structConstructor` args in `array_struct_temporary` pass

### DIFF
--- a/integration_tests/class_21.f90
+++ b/integration_tests/class_21.f90
@@ -4,8 +4,10 @@ program class_21
     end type
     integer :: stat
     class(val_type), allocatable :: val
+    type(val_type) :: tmp
     allocate(val)
     stat = merge(val%origin, stat, .true.)
-
+    tmp = val_type(merge(val%origin - 1, stat, any([stat, val%origin] /= 0)))
     if (stat /= 3) error stop
+    if (tmp%origin /= 2) error stop
 end program

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -1544,6 +1544,7 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
     }
 
     void visit_StructConstructor(const ASR::StructConstructor_t& x) {
+        ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>::visit_StructConstructor(x);
         Vec<ASR::call_arg_t> x_m_args; x_m_args.reserve(al, x.n_args);
         traverse_call_args(x_m_args, x.m_args, x.n_args,
             std::string("_struct_type_constructor_") + ASRUtils::symbol_name(x.m_dt_sym));


### PR DESCRIPTION
Fixes #7451 