### PR TITLE
change `move_alloc` from intrinsic functions to intrinsic subroutine

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3657,74 +3657,6 @@ public:
         }
     }
 
-    void handle_MoveAlloc(const AST::SubroutineCall_t &x, std::string var_name) {
-        if (to_lower(var_name) == "move_alloc") {
-            if (ASRUtils::IntrinsicElementalFunctionRegistry::is_intrinsic_function(var_name)) {
-                IntrinsicSignature signature = get_intrinsic_signature(var_name);
-                Vec<ASR::expr_t*> args;
-                bool signature_matched = false;
-                signature_matched = handle_intrinsic_node_args(
-                    x, args, signature.kwarg_names,
-                    signature.positional_args, signature.max_args,
-                    var_name, true);
-                if( !signature_matched ) {
-                    diag.add(Diagnostic(
-                        "No matching signature found for intrinsic " + var_name,
-                        Level::Error, Stage::Semantic, {
-                            Label("",{x.base.base.loc})
-                        }));
-                    throw SemanticAbort();
-                }
-                if (ASRUtils::expr_value(args[1]) != nullptr) {
-                    diag.add(Diagnostic(
-                        "`to` argument of `move_alloc` must be a variable",
-                        Level::Error, Stage::Semantic, {
-                            Label("",{args[1]->base.loc})
-                        }));
-                    throw SemanticAbort();
-                }
-                if( ASRUtils::IntrinsicElementalFunctionRegistry::is_intrinsic_function(var_name) ) {
-                    fill_optional_kind_arg(var_name, args);
-
-                    ASRUtils::create_intrinsic_function create_func =
-                        ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function(var_name);
-                    ASR::asr_t* func_call = create_func(al, x.base.base.loc, args, diag);
-                    Vec<ASR::expr_t*> explicit_deallocate_args; explicit_deallocate_args.reserve(al, 1);
-                    explicit_deallocate_args.push_back(al, args[0]);
-                    if (ASRUtils::is_array(ASRUtils::expr_type(args[0]))) {
-                        int n_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(args[0]));
-                        Vec<ASR::dimension_t> alloc_dims; alloc_dims.reserve(al, n_dims);
-                        ASR::ttype_t* integer_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
-                        for(int i=0; i<n_dims; i++) {
-                            ASR::dimension_t dim;
-                            dim.loc = x.base.base.loc;
-                            dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                                al, x.base.base.loc, 1, integer_type));
-                            dim.m_length = ASRUtils::EXPR(ASR::make_ArraySize_t(
-                    al, x.base.base.loc, args[0], ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, i+1, integer_type)), integer_type, nullptr));
-                            alloc_dims.push_back(al, dim);
-                        }
-                        Vec<ASR::alloc_arg_t> alloc_args; alloc_args.reserve(al, 1);
-                        ASR::alloc_arg_t alloc_arg;
-                        alloc_arg.loc = x.base.base.loc;
-                        alloc_arg.m_a = args[1];
-                        alloc_arg.m_dims = alloc_dims.p;
-                        alloc_arg.n_dims = alloc_dims.n;
-                        alloc_arg.m_len_expr = nullptr;
-                        alloc_arg.m_type = nullptr;
-                        alloc_args.push_back(al, alloc_arg);
-                        current_body->push_back(al, ASRUtils::STMT(ASR::make_Allocate_t(al, x.base.base.loc, alloc_args.p, alloc_args.n, nullptr, nullptr, nullptr)));
-                    }
-                    ASR::stmt_t* explicit_deallocate = ASRUtils::STMT(ASR::make_ExplicitDeallocate_t(al, x.base.base.loc, explicit_deallocate_args.p, explicit_deallocate_args.n));
-                    tmp = ASRUtils::make_Assignment_t_util(al, x.base.base.loc, args[1], ASRUtils::EXPR(func_call), nullptr, compiler_options.po.realloc_lhs);
-                    current_body->push_back(al, ASRUtils::STMT(tmp));
-                    current_body->push_back(al, explicit_deallocate);
-                    tmp = nullptr;
-                }
-            }
-        }
-    }
-
     /*
         Function to convert 'FLUSH' subroutine call to 'FLUSH' ASR node
     */
@@ -3926,8 +3858,7 @@ public:
             tmp = intrinsic_subroutine;
             return;
         }
-        if (sub_name == "move_alloc" || sub_name == "mvbits") {
-            handle_MoveAlloc(x, sub_name);
+        if (sub_name == "mvbits") {
             handle_Mvbits(x, sub_name);
             return;
         }

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1374,6 +1374,7 @@ public:
             SET_INTRINSIC_SUBROUTINE_NAME(Srand, "srand");
             SET_INTRINSIC_SUBROUTINE_NAME(SystemClock, "system_clock");
             SET_INTRINSIC_SUBROUTINE_NAME(DateAndTime, "date_and_time");
+            SET_INTRINSIC_SUBROUTINE_NAME(MoveAlloc, "move_alloc");
             default : {
                 throw LCompilersException("IntrinsicImpureSubroutine: `"
                     + ASRUtils::get_intrinsic_name(x.m_sub_intrinsic_id)

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -68,12 +68,6 @@ intrinsic_funcs_args = {
             "ret_type_arg_idx": 3
         },
     ],
-    "MoveAlloc": [
-        {
-            "args": [("any", "any")],
-            "ret_type_arg_idx": 0
-        },
-    ],
     "Leadz": [
         {
             "args": [("int",)],

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -77,7 +77,6 @@ inline std::string get_intrinsic_name(int64_t x) {
         INTRINSIC_NAME_CASE(BesselYN)
         INTRINSIC_NAME_CASE(SameTypeAs)
         INTRINSIC_NAME_CASE(Mvbits)
-        INTRINSIC_NAME_CASE(MoveAlloc)
         INTRINSIC_NAME_CASE(Merge)
         INTRINSIC_NAME_CASE(Mergebits)
         INTRINSIC_NAME_CASE(Shiftr)
@@ -317,8 +316,6 @@ namespace IntrinsicElementalFunctionRegistry {
             {&Merge::instantiate_Merge, &Merge::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Mvbits),
             {&Mvbits::instantiate_Mvbits, &Mvbits::verify_args}},
-        {static_cast<int64_t>(IntrinsicElementalFunctions::MoveAlloc),
-            {&MoveAlloc::instantiate_MoveAlloc, &MoveAlloc::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Mergebits),
             {&Mergebits::instantiate_Mergebits, &Mergebits::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Shiftr),
@@ -682,8 +679,6 @@ namespace IntrinsicElementalFunctionRegistry {
             "merge"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Mvbits),
             "mvbits"},
-        {static_cast<int64_t>(IntrinsicElementalFunctions::MoveAlloc),
-            "move_alloc"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Mergebits),
             "mergebits"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Shiftr),
@@ -983,7 +978,6 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"bessel_yn", {&BesselYN::create_BesselYN, &BesselYN::eval_BesselYN}},
                 {"merge", {&Merge::create_Merge, &Merge::eval_Merge}},
                 {"mvbits", {&Mvbits::create_Mvbits, &Mvbits::eval_Mvbits}},
-                {"move_alloc", {&MoveAlloc::create_MoveAlloc, &MoveAlloc::eval_MoveAlloc}},
                 {"merge_bits", {&Mergebits::create_Mergebits, &Mergebits::eval_Mergebits}},
                 {"shiftr", {&Shiftr::create_Shiftr, &Shiftr::eval_Shiftr}},
                 {"rshift", {&Rshift::create_Rshift, &Rshift::eval_Rshift}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -73,7 +73,6 @@ enum class IntrinsicElementalFunctions : int64_t {
     SameTypeAs,
     Merge,
     Mvbits,
-    MoveAlloc,
     Mergebits,
     Shiftr,
     Rshift,
@@ -4195,32 +4194,6 @@ namespace Mvbits {
     }
 
 } // namespace Mvbits
-
-namespace MoveAlloc {
-
-    static ASR::expr_t *eval_MoveAlloc(Allocator &/*al*/, const Location &/*loc*/,
-            ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
-        return nullptr;
-    }
-
-    static inline ASR::expr_t* instantiate_MoveAlloc(Allocator &al, const Location &loc,
-            SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
-            Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
-
-        std::string new_name = "_lcompilers_move_alloc_" + type_to_str_python(arg_types[0]);
-        declare_basic_variables(new_name);
-        fill_func_arg("from", arg_types[0]);
-        fill_func_arg("to", arg_types[1]);
-        auto result = declare(new_name, arg_types[0], ReturnVar);
-        body.push_back(al, b.Assignment(result, args[0]));
-
-        ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
-            body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
-        scope->add_symbol(fn_name, f_sym);
-        return b.Call(f_sym, new_args, return_type, nullptr);
-    }
-
-} // namespace MoveAlloc
 
 namespace Mergebits {
 

--- a/src/libasr/pass/intrinsic_subroutine_registry.h
+++ b/src/libasr/pass/intrinsic_subroutine_registry.h
@@ -30,6 +30,7 @@ inline std::string get_intrinsic_subroutine_name(int x) {
         INTRINSIC_SUBROUTINE_NAME_CASE(Srand)
         INTRINSIC_SUBROUTINE_NAME_CASE(SystemClock)
         INTRINSIC_SUBROUTINE_NAME_CASE(DateAndTime)
+        INTRINSIC_SUBROUTINE_NAME_CASE(MoveAlloc)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -65,6 +66,8 @@ namespace IntrinsicImpureSubroutineRegistry {
             {&ExecuteCommandLine::instantiate_ExecuteCommandLine, &ExecuteCommandLine::verify_args}},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::CpuTime),
             {&CpuTime::instantiate_CpuTime, &CpuTime::verify_args}},
+        {static_cast<int64_t>(IntrinsicImpureSubroutines::MoveAlloc),
+            {&MoveAlloc::instantiate_MoveAlloc, &MoveAlloc::verify_args}},
     };
 
     static const std::map<int64_t, std::string>& intrinsic_subroutine_id_to_name = {
@@ -90,6 +93,8 @@ namespace IntrinsicImpureSubroutineRegistry {
             "execute_command_line"},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::CpuTime),
             "cpu_time"},
+        {static_cast<int64_t>(IntrinsicImpureSubroutines::MoveAlloc),
+            "move_alloc"},
     };
 
 
@@ -106,6 +111,7 @@ namespace IntrinsicImpureSubroutineRegistry {
                 {"execute_command_line", &ExecuteCommandLine::create_ExecuteCommandLine},
                 {"cpu_time", &CpuTime::create_CpuTime},
                 {"date_and_time", &DateAndTime::create_DateAndTime},
+                {"move_alloc", &MoveAlloc::create_MoveAlloc},
     };
 
     static inline bool is_intrinsic_subroutine(const std::string& name) {


### PR DESCRIPTION
Fixes #7473 

As discussed in the last meeting, I have ported the `move_alloc` function from intrinsic functions to intrinsic_subroutine as per https://github.com/lfortran/lfortran/pull/7404#pullrequestreview-2871949502