### PR TITLE
CI: use a new github group on PR's merged in main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,16 +10,15 @@ on:
     branches:
       - main
 
-# For a PR #7488 against main branch, the `group` will become: CI-{{ 7488 || 'main' }}
-# which eventually evaluates to: CI-7488 and 'main' isn't used.
+# For a PR #7488 against main branch, the `group` will become: CI-{{ 7488 || github.sha }}
+# which eventually evaluates to: CI-7488 and 'sha' isn't used.
 # NOTE: `||` acts as a logical OR and a default operator both,
 # see: https://docs.github.com/en/actions/learn-github-actions/expressions#operators.
 # When it isn't a PR against main but instead a commit pushed (or merged) to main, then `group` will
 # evaluate to CI-main but "cancel-in-progress" evaluates to false, so the CI on main
-# will run in a single group CI-main, in a *queue* (which will slow down the CI on main),
-# and save runner for PR's but no previous CI will be cancelled on main
+# will run in a new group `${{ github.sha }}`, but no previous CI will be cancelled on main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || 'main' }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 


### PR DESCRIPTION
## Description

Currently, the CI for *main* branch is run in single group named `'main'` in a queue, and that saves resources for PR's, but that approach seems to fail when PR's are merged without much time gap between them, and the older PR's CI get's cancelled on *main* in that case (which is bad), e.g.;

for the below three CI runs merged in *main* (see screenshot below) in chronological order from bottom to top, the three PR's were merged at a time gap of 3 minutes, but the CI run of the bottom two PR's on *main* was cancelled altogether with the error:

```console
Canceling since a higher priority waiting request for CI-main exists
```

![Screenshot 2025-06-02 at 10 09 23 PM](https://github.com/user-attachments/assets/a8a93d85-524a-4832-be54-8d277402cc9c)


Hence, this PR makes sure that this doesn't happen by alloting to each commit merged in *main*, it's own unique group.