### PR TITLE
CI: fix debugging info about github group

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ on:
 # NOTE: `||` acts as a logical OR and a default operator both,
 # see: https://docs.github.com/en/actions/learn-github-actions/expressions#operators.
 # When it isn't a PR against main but instead a commit pushed (or merged) to main, then `group` will
-# evaluate to CI-main but "cancel-in-progress" evaluates to false, so the CI on main
+# evaluate to `${{ github.sha }}` but "cancel-in-progress" evaluates to false, so the CI on main
 # will run in a new group `${{ github.sha }}`, but no previous CI will be cancelled on main
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Print github concurrent group name
         run: |
-          echo "Concurrency Group: ${{ github.workflow }}-${{ github.event.number || 'main' }}"
+          echo "Concurrency Group: ${{ github.workflow }}-${{ github.event.number || github.sha }}"
           echo "Cancel-in-progress: ${{ github.event_name == 'pull_request' }}"
 
       - name: Check for Added Binary Files


### PR DESCRIPTION
## Description

The PR: https://github.com/lfortran/lfortran/pull/7561 made changes to how the github group is assigned to PR's merged in main, but I forgot to update the same in debugging info, which is used to understand how things work for github's group.

