### PR TITLE
CI: queue and group management in main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,15 +10,16 @@ on:
     branches:
       - main
 
-# For a PR #7488 against main branch, the `group` will become: CI-{{ 7488 || github.sha }}
-# which eventually evaluates to: CI-7488 and 'sha' isn't used.
+# For a PR #7488 against main branch, the `group` will become: CI-{{ 7488 || 'main' }}
+# which eventually evaluates to: CI-7488 and 'main' isn't used.
 # NOTE: `||` acts as a logical OR and a default operator both,
 # see: https://docs.github.com/en/actions/learn-github-actions/expressions#operators.
 # When it isn't a PR against main but instead a commit pushed (or merged) to main, then `group` will
-# evaluate to `${{ github.sha }}` but "cancel-in-progress" evaluates to false, so the CI on main
-# will run in a new group `${{ github.sha }}`, but no previous CI will be cancelled on main
+# evaluate to CI-main but "cancel-in-progress" evaluates to false, so the CI on main
+# will run in a single group CI-main, in a *queue* (which will slow down the CI on main),
+# and save runner for PR's but no previous CI will be cancelled on main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.number || 'main' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 
@@ -40,7 +41,7 @@ jobs:
 
       - name: Print github concurrent group name
         run: |
-          echo "Concurrency Group: ${{ github.workflow }}-${{ github.event.number || github.sha }}"
+          echo "Concurrency Group: ${{ github.workflow }}-${{ github.event.number || 'main' }}"
           echo "Cancel-in-progress: ${{ github.event_name == 'pull_request' }}"
 
       - name: Check for Added Binary Files


### PR DESCRIPTION
## Description

Try to see if we can have a single queue in *main* with all of the commit's merged in *main* belonging with to a single group `CI-main` but also at the same time making sure that older CI runs are preferred to run over the newer CI runs

Currently we've three workflows running for three PR's which were merged recently to *main* and because of that my PR's are all waiting to be *queued*.

![Screenshot 2025-06-03 at 2 52 48 PM](https://github.com/user-attachments/assets/81f4432d-2d07-491a-9cff-696d8e2ea398)
