### PR TITLE
Fix nested ``Allocatable`` type in ASR

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -505,6 +505,7 @@ RUN(NAME matrix_02_matmul LABELS gfortran fortran)
 RUN(NAME array_01_pack LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME array_01_transfer LABELS gfortran)
 RUN(NAME array_02_pack LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME array_03_pack LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME array_02_transfer LABELS gfortran)
 RUN(NAME array_03_transfer LABELS gfortran)
 RUN(NAME array_04_transfer LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -2322,6 +2323,6 @@ RUN(NAME formatted_read_01 LABELS gfortran llvm COPY_TO_BIN formatted_read_input
 
 
 
-# LFortran extensions (lists, dicts, etc.) 
-RUN(NAME lp_list_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 
-RUN(NAME lp_set_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 
+# LFortran extensions (lists, dicts, etc.)
+RUN(NAME lp_list_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
+RUN(NAME lp_set_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran

--- a/integration_tests/array_03_pack.f90
+++ b/integration_tests/array_03_pack.f90
@@ -1,0 +1,15 @@
+program array_03_pack
+
+    implicit none
+    character(len=1), dimension(:,:), allocatable :: array
+    integer :: packoutput(10)
+
+    allocate(array(3, 5))
+    array(1, :) = "a"
+    array(2, :) = "."
+    array(3, :) = "c"
+    print *, ichar(pack(array, mask=(array /= '.')))
+    packoutput = ichar(pack(array, mask=(array /= '.')))
+    if( any(packoutput /= [97, 99, 97, 99, 97, 99, 97, 99, 97, 99]) ) error stop
+
+end program

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1256,7 +1256,8 @@ public:
     }
 
     void visit_Allocatable(const Allocatable_t &x) {
-        require(!ASR::is_a<ASR::Pointer_t>(*x.m_type),
+        require(!ASR::is_a<ASR::Pointer_t>(*x.m_type) &&
+                !ASR::is_a<ASR::Allocatable_t>(*x.m_type),
             "Allocatable type conflicts with Pointer type");
         ASR::dimension_t* m_dims = nullptr;
         size_t n_dims = ASRUtils::extract_dimensions_from_ttype(x.m_type, m_dims);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5634,7 +5634,7 @@ public:
             value_class_hash = llvm_utils->CreateLoad2(i64, value_class_hash);
 
             llvm::Value* target_class_hash_ptr = llvm_utils->create_gep2(target_llvm_type, target_struct, 0);
-            
+
             builder->CreateStore(value_class_hash, target_class_hash_ptr);
 
             // deepcopy the class ptr
@@ -5648,7 +5648,7 @@ public:
                             ASR::down_cast<ASR::StructType_t>(ASRUtils::extract_type(asr_target_type))->m_derived_type));
             llvm::Type* wrapper_target_llvm_type = llvm_utils->get_type_from_ttype_t_util(wrapped_target_struct_type, module.get());
 
-            
+
             llvm::Value* value_class_ptr = llvm_utils->create_gep2(value_llvm_type, value_struct, 1);
             value_class_ptr = llvm_utils->CreateLoad2(wrapper_value_llvm_type->getPointerTo(), value_class_ptr);
             // bitcast to the correct type
@@ -5657,7 +5657,7 @@ public:
 
             llvm::Value* target_class_ptr = llvm_utils->create_gep2(target_llvm_type, target_struct, 1);
             target_class_ptr = llvm_utils->CreateLoad2(wrapper_target_llvm_type->getPointerTo(), target_class_ptr);
-            
+
             builder->CreateStore(value_class_ptr, target_class_ptr);
 
             return;
@@ -9998,7 +9998,7 @@ public:
                                                                 ASRUtils::type_get_past_allocatable(arg->m_type),
                                                                 module.get()),
                                                             tmp, 1);
-                                    
+
                                     if (ASRUtils::is_class_type(
                                             ASRUtils::type_get_past_allocatable(arg->m_type))
                                         && !ASR::is_a<ASR::Allocatable_t>(*orig_arg->m_type)) {

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -4950,7 +4950,8 @@ namespace Pack {
             is_type_allocatable = true;
         }
         if (is_type_allocatable) {
-            ret_type = TYPE(ASRUtils::make_Allocatable_t_util(al, loc, ret_type));
+            ret_type = TYPE(ASRUtils::make_Allocatable_t_util(al, loc,
+                ASRUtils::type_get_past_allocatable_pointer(ret_type)));
         }
         Vec<ASR::expr_t*> arg_values; arg_values.reserve(al, 3);
         arg_values.push_back(al, expr_value(array)); arg_values.push_back(al, expr_value(mask));

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -753,7 +753,7 @@ static inline ASR::asr_t* create_ArrIntrinsic(
         return_type = ASRUtils::duplicate_type(al, array_type, &dims, ASR::array_physical_typeType::DescriptorArray, true);
         if ( (int64_t) n_dims == 1 ) {
             // For the arrays of rank 1, we return a scalar value
-            // instead of an array. Currently `return_type` in case of 
+            // instead of an array. Currently `return_type` in case of
             // allocatable will be `Allocatable( integer 4 )` and hence
             // we need to remove the allocatable part.
             return_type = ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_array(return_type));
@@ -3708,7 +3708,7 @@ namespace FindLoc {
                             b.If(b.And(found_value, b.Not(back)), {
                                 b.Exit()
                             }, {})
-                        }), 
+                        }),
                     })
                 }, {
                     b.DoLoop(i, b.i_t(1, type), UBound(array, 1), {
@@ -3722,7 +3722,7 @@ namespace FindLoc {
                                 b.Exit()
                             }, {})
                         }),
-    
+
                     })
                 })
             }));

--- a/tests/reference/asr-modules_43-d01691f.json
+++ b/tests/reference/asr-modules_43-d01691f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_43-d01691f.stdout",
-    "stdout_hash": "3702e830e29a097fe7d0b8e89576f59c83a9c187de37c2be932e32c2",
+    "stdout_hash": "51675df73caa93e04930fadc4844e1eb97b88694c69e8434864e5d92",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_43-d01691f.stdout
+++ b/tests/reference/asr-modules_43-d01691f.stdout
@@ -254,18 +254,16 @@
                                                 )]
                                                 2
                                                 (Allocatable
-                                                    (Allocatable
-                                                        (Array
-                                                            (StructType
-                                                                []
-                                                                []
-                                                                .true.
-                                                                2 srcfile_t
-                                                            )
-                                                            [(()
-                                                            ())]
-                                                            DescriptorArray
+                                                    (Array
+                                                        (StructType
+                                                            []
+                                                            []
+                                                            .true.
+                                                            2 srcfile_t
                                                         )
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
                                                     )
                                                 )
                                                 ()
@@ -303,18 +301,16 @@
                                                     )]
                                                     2
                                                     (Allocatable
-                                                        (Allocatable
-                                                            (Array
-                                                                (StructType
-                                                                    []
-                                                                    []
-                                                                    .true.
-                                                                    2 srcfile_t
-                                                                )
-                                                                [(()
-                                                                ())]
-                                                                DescriptorArray
+                                                        (Array
+                                                            (StructType
+                                                                []
+                                                                []
+                                                                .true.
+                                                                2 srcfile_t
                                                             )
+                                                            [(()
+                                                            ())]
+                                                            DescriptorArray
                                                         )
                                                     )
                                                     ()

--- a/tests/reference/pass_array_op-modules_43-6930881.json
+++ b/tests/reference/pass_array_op-modules_43-6930881.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_array_op-modules_43-6930881.stdout",
-    "stdout_hash": "a65e2cb8c4bd3be035d0938d89b080d8056df927f6ed1358ddf661b3",
+    "stdout_hash": "96ff2785999b807ae69ca2bbd7bd55039b1158ebe13c8bc4ecad6b78",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_array_op-modules_43-6930881.stdout
+++ b/tests/reference/pass_array_op-modules_43-6930881.stdout
@@ -292,18 +292,16 @@
                                                 )]
                                                 2
                                                 (Allocatable
-                                                    (Allocatable
-                                                        (Array
-                                                            (StructType
-                                                                []
-                                                                []
-                                                                .true.
-                                                                2 srcfile_t
-                                                            )
-                                                            [(()
-                                                            ())]
-                                                            DescriptorArray
+                                                    (Array
+                                                        (StructType
+                                                            []
+                                                            []
+                                                            .true.
+                                                            2 srcfile_t
                                                         )
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
                                                     )
                                                 )
                                                 ()
@@ -422,18 +420,16 @@
                                                                 )]
                                                                 2
                                                                 (Allocatable
-                                                                    (Allocatable
-                                                                        (Array
-                                                                            (StructType
-                                                                                []
-                                                                                []
-                                                                                .true.
-                                                                                2 srcfile_t
-                                                                            )
-                                                                            [(()
-                                                                            ())]
-                                                                            DescriptorArray
+                                                                    (Array
+                                                                        (StructType
+                                                                            []
+                                                                            []
+                                                                            .true.
+                                                                            2 srcfile_t
                                                                         )
+                                                                        [(()
+                                                                        ())]
+                                                                        DescriptorArray
                                                                     )
                                                                 )
                                                                 ()
@@ -495,18 +491,16 @@
                                                 )]
                                                 2
                                                 (Allocatable
-                                                    (Allocatable
-                                                        (Array
-                                                            (StructType
-                                                                []
-                                                                []
-                                                                .true.
-                                                                2 srcfile_t
-                                                            )
-                                                            [(()
-                                                            ())]
-                                                            DescriptorArray
+                                                    (Array
+                                                        (StructType
+                                                            []
+                                                            []
+                                                            .true.
+                                                            2 srcfile_t
                                                         )
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
                                                     )
                                                 )
                                                 ()
@@ -546,18 +540,16 @@
                                                         )]
                                                         2
                                                         (Allocatable
-                                                            (Allocatable
-                                                                (Array
-                                                                    (StructType
-                                                                        []
-                                                                        []
-                                                                        .true.
-                                                                        2 srcfile_t
-                                                                    )
-                                                                    [(()
-                                                                    ())]
-                                                                    DescriptorArray
+                                                            (Array
+                                                                (StructType
+                                                                    []
+                                                                    []
+                                                                    .true.
+                                                                    2 srcfile_t
                                                                 )
+                                                                [(()
+                                                                ())]
+                                                                DescriptorArray
                                                             )
                                                         )
                                                         ()


### PR DESCRIPTION
Closes https://github.com/lfortran/lfortran/issues/6727

The underlying problem is due to creation of nested ``Allocatable`` type i.e., `Allocatable(Allocatable(Array(...)))` which is not correct. I fixed and also added an ASR verify check for it.

Let's see how the CI responds.