### PR TITLE
Proper syntax for lists, sets

### DIFF
--- a/grammar/AST.asdl
+++ b/grammar/AST.asdl
@@ -336,6 +336,8 @@ decl_type
     | TypeProcedure
     | TypeReal
     | TypeType
+    | TypeLF_List
+    | TypeLF_Set
 
 event_attribute
     = AttrStat(identifier variable)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2329,6 +2329,7 @@ RUN(NAME formatted_read_01 LABELS gfortran llvm COPY_TO_BIN formatted_read_input
 
 
 
-# LFortran extensions (lists, dicts, etc.)
-RUN(NAME lp_list_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
-RUN(NAME lp_set_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
+# LFortran extensions (lists, dicts, etc.) 
+RUN(NAME lp_list_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 
+RUN(NAME lp_list_of_lists_test LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 
+RUN(NAME lp_set_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 

--- a/integration_tests/lp_list_of_lists_test.f90
+++ b/integration_tests/lp_list_of_lists_test.f90
@@ -1,0 +1,25 @@
+program lp_list_of_lists_test
+    implicit none
+    type(_lfortran_list(_lfortran_list(integer))) :: x
+    type(_lfortran_list(integer)) :: y 
+    
+    call _lfortran_list_append(x, _lfortran_list_constant(1, 0, 1, 12, 15, 15))
+    y = _lfortran_list_constant(10, 10, 10)
+    call _lfortran_list_append(y, 16)
+    call _lfortran_list_append(x, y)
+
+    if (_lfortran_get_item(_lfortran_get_item(x, 0), 1) /= 0) error stop
+    if (_lfortran_get_item(_lfortran_get_item(x, 1), 0) /= 10) error stop
+
+
+    if (_lfortran_len(_lfortran_get_item(x, 0)) /= 6) error stop
+    if (_lfortran_len(_lfortran_get_item(x, 1)) /= 4) error stop
+
+    ! Making sure its copy
+    call _lfortran_list_append(y, -22)
+    if (_lfortran_len(_lfortran_get_item(x, 1)) /= 4) error stop
+
+    call _lfortran_list_append(_lfortran_get_item(x, 1), 36)
+    if (_lfortran_len(_lfortran_get_item(x, 1)) /= 5) error stop
+end program lp_list_of_lists_test
+

--- a/integration_tests/lp_list_test_01.f90
+++ b/integration_tests/lp_list_test_01.f90
@@ -3,7 +3,7 @@ program lp_list_test_01
     integer :: x
     real :: eps = 1e-6
 
-    type(_lfortran_list_integer) :: test_list 
+    type(_lfortran_list(integer)) :: test_list 
     call _lfortran_list_append(test_list, 1)
     call _lfortran_list_append(test_list, 10)
     x = _lfortran_len(test_list)
@@ -33,7 +33,7 @@ program lp_list_test_01
     if (_lfortran_list_count(test_list, 1) /= 2) error stop
     if (_lfortran_list_count(test_list, -50) /= 1) error stop
      
-    type(_lfortran_list_real) :: test_list_r  = _lfortran_list_constant(1.0, 2.0, 3.0, 4.0)
+    type(_lfortran_list(real(4))) :: test_list_r  = _lfortran_list_constant(1.0, 2.0, 3.0, 4.0)
     if (_lfortran_len(test_list_r) /= 4) error stop
     call _lfortran_list_append(test_list_r, 1.11)
     call _lfortran_list_append(test_list_r, -10.12)
@@ -48,7 +48,7 @@ program lp_list_test_01
     call _lfortran_set_item(test_list_r, 3, 1212.33)
     if (abs(_lfortran_get_item(test_list_r, 3) - 1212.33) > eps) error stop
 
-    type(_lfortran_list_real) :: test_list_r1  
+    type(_lfortran_list(real)) :: test_list_r1  
     if (_lfortran_len(test_list_r1) /= 0) error stop
 
     ! Add other intrinsics later

--- a/integration_tests/lp_set_test_01.f90
+++ b/integration_tests/lp_set_test_01.f90
@@ -1,7 +1,7 @@
 program lp_set_test_01
     integer :: x
 
-    type(_lfortran_set_integer) :: test_set 
+    type(_lfortran_set(integer)) :: test_set 
     test_set = _lfortran_set_constant(1, 2, 3, 4, 4, 5, 4, 10)
     call _lfortran_set_add(test_set, 1)
     call _lfortran_set_add(test_set, 10)

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -361,6 +361,10 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %token <string> KW_WHILE
 %token <string> KW_WRITE
 
+// LFortran specific
+%token <string> KW_LF_LIST
+%token <string> KW_LF_SET
+
 // Nonterminal tokens
 
 %type <ast> designator
@@ -1541,6 +1545,8 @@ intrinsic_type_spec
     | KW_DOUBLE_PRECISION { $$ = ATTR_TYPE(DoublePrecision, @$); }
     | KW_DOUBLE KW_COMPLEX { $$ = ATTR_TYPE(DoubleComplex, @$); }
     | KW_DOUBLE_COMPLEX { $$ = ATTR_TYPE(DoubleComplex, @$); }
+    | KW_LF_LIST "(" intrinsic_type_spec ")" { $$ = ATTR_TYPE_ATTR(LF_List, $3, @$); }
+    | KW_LF_SET "(" intrinsic_type_spec ")" { $$ = ATTR_TYPE_ATTR(LF_Set, $3, @$); }
     ;
 
 declaration_type_spec

--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -527,6 +527,8 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
             'where' { KW(WHERE) }
             'while' { KW(WHILE) }
             'write' { KW(WRITE) }
+            '_lfortran_list' { KW(LF_LIST) }
+            '_lfortran_set' { KW(LF_SET) }
 
             // Tokens
             newline {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4685,16 +4685,7 @@ public:
                 sym_type->m_type = AST::decl_typeType::TypeCharacter;
                 return determine_type(loc, sym, decl_attribute, is_pointer,
                     is_allocatable, dims, type_declaration, abi, is_argument);
-            } else if (startswith(derived_type_name, "_lfortran_")) {
-                // LFortran-specific intrinsics 
-
-                if (derived_type_name == "_lfortran_list_integer") 
-                    return ASRUtils::TYPE(ASR::make_List_t(al, loc, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))); 
-                else if (derived_type_name == "_lfortran_list_real") 
-                    return ASRUtils::TYPE(ASR::make_List_t(al, loc, ASRUtils::TYPE(ASR::make_Real_t(al, loc, 4))));
-                else if (derived_type_name == "_lfortran_set_integer") 
-                    return ASRUtils::TYPE(ASR::make_Set_t(al, loc, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))); 
-            }
+            } 
             ASR::symbol_t* v = current_scope->resolve_symbol(derived_type_name);
             if (v && ASR::is_a<ASR::Variable_t>(*v)
                   && ASR::is_a<ASR::TypeParameter_t>(*
@@ -4739,6 +4730,14 @@ public:
                         type));
                 }
             }
+        } else if (sym_type->m_type == AST::decl_typeType::TypeLF_List) {
+            return ASRUtils::TYPE(ASR::make_List_t(al, loc, determine_type(loc, sym, sym_type->m_attr,
+                    is_pointer, is_allocatable, dims, type_declaration, abi,
+                    is_argument))); 
+        }  else if (sym_type->m_type == AST::decl_typeType::TypeLF_Set) {
+            return ASRUtils::TYPE(ASR::make_Set_t(al, loc, determine_type(loc, sym, sym_type->m_attr,
+                    is_pointer, is_allocatable, dims, type_declaration, abi,
+                    is_argument))); 
         } else if (sym_type->m_type == AST::decl_typeType::TypeClass) {
             std::string derived_type_name;
             if( !sym_type->m_name ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1793,7 +1793,10 @@ public:
             this->visit_expr(*x.m_arg);
             ptr_loads = ptr_loads_copy;
             llvm::Value* plist = tmp;
-            tmp = list_api->len(plist);
+
+            std::string type_code = ASRUtils::get_type_code(x.m_type);
+            llvm::Type* list_type = list_api->get_list_type(nullptr, type_code, 0);
+            tmp = list_api->len2(list_type, plist);
         }
     }
 

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -3,6 +3,7 @@
 #include <libasr/codegen/llvm_array_utils.h>
 #include <libasr/asr_utils.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Type.h>
 #include <llvm/Support/Casting.h>
 
 namespace LCompilers {
@@ -4779,6 +4780,12 @@ namespace LCompilers {
                 llvm::Type::getInt32Ty(context) ,get_pointer_to_current_end_point(list));
     }
 
+    llvm::Value* LLVMList::len2(llvm::Type* list_type, llvm::Value* list) {
+        return llvm_utils->CreateLoad2(
+                llvm::Type::getInt32Ty(context) ,get_pointer_to_current_end_point2(
+                    list_type, list));
+    }
+
     llvm::Value* LLVMDict::len(llvm::Value* dict) {
         return llvm_utils->CreateLoad(get_pointer_to_occupancy(dict));
     }
@@ -4836,8 +4843,48 @@ namespace LCompilers {
         llvm_utils->start_new_block(mergeBB);
     }
 
+    void LLVMList::resize_if_needed2(std::string& type_code, llvm::Value* list, llvm::Value* n,
+                                    llvm::Value* capacity, int32_t type_size,
+                                    llvm::Type* el_type, llvm::Module* module) {
+        llvm::Type* list_type = get_list_type(el_type, type_code, type_size);
+        llvm::Value *cond = builder->CreateICmpEQ(n, capacity);
+        llvm::Function *fn = builder->GetInsertBlock()->getParent();
+        llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
+        llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
+        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
+        builder->CreateCondBr(cond, thenBB, elseBB);
+        builder->SetInsertPoint(thenBB);
+        llvm::Value* new_capacity = builder->CreateMul(llvm::ConstantInt::get(context,
+                                                       llvm::APInt(32, 2)), capacity);
+        new_capacity = builder->CreateAdd(new_capacity, llvm::ConstantInt::get(context,
+                                                        llvm::APInt(32, 1)));
+        llvm::Value* arg_size = builder->CreateMul(llvm::ConstantInt::get(context,
+                                                   llvm::APInt(32, type_size)),
+                                                   new_capacity);
+        llvm::Value* copy_data_ptr = get_pointer_to_list_data2(list_type, list);
+        llvm::Value* copy_data = llvm_utils->CreateLoad2(el_type->getPointerTo() ,copy_data_ptr);
+        copy_data = LLVM::lfortran_realloc(context, *module, *builder,
+                                           copy_data, arg_size);
+        copy_data = builder->CreateBitCast(copy_data, el_type->getPointerTo());
+        builder->CreateStore(copy_data, copy_data_ptr);
+        builder->CreateStore(new_capacity, get_pointer_to_current_capacity2(list_type, list));
+        builder->CreateBr(mergeBB);
+        llvm_utils->start_new_block(elseBB);
+        llvm_utils->start_new_block(mergeBB);
+    }
+
     void LLVMList::shift_end_point_by_one(llvm::Value* list) {
         llvm::Value* end_point_ptr = get_pointer_to_current_end_point(list);
+        llvm::Value* end_point = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
+                                                            end_point_ptr);
+        end_point = builder->CreateAdd(end_point, llvm::ConstantInt::get(context, llvm::APInt(32, 1)));
+        builder->CreateStore(end_point, end_point_ptr);
+    }
+
+
+    void LLVMList::shift_end_point_by_one2(std::string& type_code, llvm::Value* list) {
+        llvm::Type* list_type = get_list_type(nullptr, type_code, 0);
+        llvm::Value* end_point_ptr = get_pointer_to_current_end_point2(list_type, list);
         llvm::Value* end_point = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
                                                             end_point_ptr);
         end_point = builder->CreateAdd(end_point, llvm::ConstantInt::get(context, llvm::APInt(32, 1)));
@@ -4847,17 +4894,20 @@ namespace LCompilers {
     void LLVMList::append(llvm::Value* list, llvm::Value* item,
                           ASR::ttype_t* asr_type, llvm::Module* module,
                           std::map<std::string, std::map<std::string, int>>& name2memidx) {
-        llvm::Value* current_end_point = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
-                                                                 get_pointer_to_current_end_point(list));
-        llvm::Value* current_capacity = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
-                                                                get_pointer_to_current_capacity(list));
         std::string type_code = ASRUtils::get_type_code(asr_type);
         int type_size = std::get<1>(typecode2listtype[type_code]);
         llvm::Type* el_type = std::get<2>(typecode2listtype[type_code]);
-        resize_if_needed(list, current_end_point, current_capacity,
+        llvm::Type* list_type = std::get<0>(typecode2listtype[type_code]);
+
+
+        llvm::Value* current_end_point = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
+                                                                 get_pointer_to_current_end_point2(list_type, list));
+        llvm::Value* current_capacity = llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context),
+                                                                get_pointer_to_current_capacity2(list_type, list));
+        resize_if_needed2(type_code, list, current_end_point, current_capacity,
                          type_size, el_type, module);
         write_item(list, current_end_point, item, asr_type, false, module, name2memidx);
-        shift_end_point_by_one(list);
+        shift_end_point_by_one2(type_code, list);
     }
 
     void LLVMList::insert_item(llvm::Value* list, llvm::Value* pos,

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -3,7 +3,6 @@
 #include <libasr/codegen/llvm_array_utils.h>
 #include <libasr/asr_utils.h>
 #include <llvm/IR/DerivedTypes.h>
-#include <llvm/IR/Type.h>
 #include <llvm/Support/Casting.h>
 
 namespace LCompilers {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -7,6 +7,7 @@
 #include <libasr/asr.h>
 
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <tuple>
 
@@ -450,7 +451,13 @@ namespace LCompilers {
                                   llvm::Value* capacity, int32_t type_size,
                                   llvm::Type* el_type, llvm::Module* module);
 
+            void resize_if_needed2(std::string& type_code, llvm::Value* list, llvm::Value* n,
+                                  llvm::Value* capacity, int32_t type_size,
+                                  llvm::Type* el_type, llvm::Module* module);
+
             void shift_end_point_by_one(llvm::Value* list);
+
+            void shift_end_point_by_one2(std::string& type_code, llvm::Value* list);
 
         public:
 
@@ -498,6 +505,8 @@ namespace LCompilers {
                                    llvm::Module* module, bool get_pointer=false);
 
             llvm::Value* len(llvm::Value* list);
+
+            llvm::Value* len2(llvm::Type* list_type, llvm::Value* list);
 
             void check_index_within_bounds(llvm::Value* list, llvm::Value* pos,
                                            llvm::Module* module);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -7,7 +7,6 @@
 #include <libasr/asr.h>
 
 #include <map>
-#include <string>
 #include <unordered_map>
 #include <tuple>
 


### PR DESCRIPTION
The AST for 
```
type(_lfortran_list(integer))
```

now looks like

```
 (AttrType
                TypeType
                []
                (AttrType
                    TypeLF_List
                    []
                    (AttrType
                        TypeInteger
                        []
                        ()
                        ()
                        None
                    )
                    ()
                    None
                )
                ()
                None
            )
```