### PR TITLE
Fix: throw error for argument of `ichar` intrinsic having length not equal to 1

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -6712,6 +6712,16 @@ class RemoveArrayProcessingNodeVisitor: public ASR::CallReplacerOnExpressionsVis
 
 };
 
+static inline int64_t get_fixed_string_len(const ASR::ttype_t* type_t) {
+    if (ASR::is_a<ASR::String_t>(*type_t)) {
+        ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(type_t)->m_len;
+        if (len_expr && ASR::is_a<ASR::IntegerConstant_t>(*len_expr)) {
+            return ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
+        }
+    }
+    return -1;
+}
+
 } // namespace ASRUtils
 
 } // namespace LCompilers

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -766,7 +766,10 @@ intrinsic_funcs_args = {
         {
             "args": [("char",)],
             "return": "int32",
-            "kind_arg": True
+            "kind_arg": True,
+            "char_len_validation": [
+                {0: {0: {"min": 1, "max": 1}}}
+            ]
         },
     ],
     "Char": [
@@ -1005,12 +1008,27 @@ def add_create_func_arg_type_src(func_name):
             src += 4 * indent + f'append_error(diag, "Kind of all the arguments of {func_name} must be the same", loc);\n'
             src += 4 * indent + f'return nullptr;\n'
             src += 3 * indent + '}\n'
+        char_len_validation_info = arg_info.get("char_len_validation", [])
+        for validation_item in char_len_validation_info:
+            for arg_name, arg_spec in validation_item.items():
+                arg_pos = list(arg_spec.keys())[0]
+                constraint = list(arg_spec.values())[0]
+                src += 3 * indent + f'if (ASR::is_a<ASR::String_t>(*arg_type{arg_pos})) {{\n'
+                src += 4 * indent + f'int64_t len = ASRUtils::get_fixed_string_len(arg_type{arg_pos});\n'
+                if constraint["min"] == constraint["max"]:
+                    src += 4 * indent + f'if (len != -1 && len != {constraint["min"]}) {{\n'
+                    src += 5 * indent + f'append_error(diag, "Argument {arg_name} to {func_name} must have length {constraint["min"]}", loc);\n'
+                else:
+                    src += 4 * indent + f'if (len != -1 && (len < {constraint["min"]} || len > {constraint["max"]})) {{\n'
+                    src += 5 * indent + f'append_error(diag, "Argument {arg_name} to {func_name} must have length between {constraint["min"]} and {constraint["max"]}", loc);\n'
+                src += 5 * indent + 'return nullptr;\n'
+                src += 4 * indent + '}\n'
+                src += 3 * indent + '}\n'
         src += 2 * indent + "}\n"
     src += 2 * indent + "else {\n"
     src += 3 * indent + f'append_error(diag, "Unexpected number of args, {func_name} takes {no_of_args_msg} arguments, found " + std::to_string(args.size()), loc);\n'
     src += 3 * indent + f'return nullptr;\n'
     src += 2 * indent + "}\n"
-
 
 def add_create_func_return_src(func_name):
     global src, indent

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4998,6 +4998,15 @@ namespace Ichar {
         fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::PointerString)));
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
+
+        ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(ASR::down_cast<ASR::Variable_t>(ASR::down_cast<ASR::Var_t>(args[0])->m_v)->m_type)->m_len;
+        if (ASR::is_a<ASR::IntegerConstant_t>(*len_expr) ) {
+            int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
+            if (len != 1) {
+                throw LCompilersException("Argument to Ichar must have length one");
+            }
+        }
+
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
             ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4999,18 +4999,13 @@ namespace Ichar {
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
 
-        if (ASR::is_a<ASR::Var_t>(*args[0])) {
-            ASR::symbol_t* sym_t = ASR::down_cast<ASR::Var_t>(args[0])->m_v;
-            if (ASR::is_a<ASR::Variable_t>(*sym_t)) {
-                ASR::ttype_t* type_t = ASR::down_cast<ASR::Variable_t>(sym_t)->m_type;
-                if (ASR::is_a<ASR::String_t>(*type_t)) {
-                    ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(type_t)->m_len;
-                    if (len_expr && ASR::is_a<ASR::IntegerConstant_t>(*len_expr) ) {
-                        int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
-                        if (len != 1) {
-                            throw LCompilersException("Argument to Ichar must have length one");
-                        }
-                    }
+        ASR::ttype_t* type_t =ASRUtils::expr_type(args[0]);
+        if (ASR::is_a<ASR::String_t>(*type_t)) {
+            ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(type_t)->m_len;
+            if (len_expr && ASR::is_a<ASR::IntegerConstant_t>(*len_expr) ) {
+                int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
+                if (len != 1) {
+                    throw LCompilersException("Argument to Ichar must have length one");
                 }
             }
         }

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4995,15 +4995,23 @@ namespace Ichar {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
         declare_basic_variables("_lcompilers_ichar_" + type_to_str_python(arg_types[0]));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::PointerString)));
+        fill_func_arg("str",arg_types[0]);
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
 
-        ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(ASR::down_cast<ASR::Variable_t>(ASR::down_cast<ASR::Var_t>(args[0])->m_v)->m_type)->m_len;
-        if (ASR::is_a<ASR::IntegerConstant_t>(*len_expr) ) {
-            int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
-            if (len != 1) {
-                throw LCompilersException("Argument to Ichar must have length one");
+        if (ASR::is_a<ASR::Var_t>(*args[0])) {
+            ASR::symbol_t* sym_t = ASR::down_cast<ASR::Var_t>(args[0])->m_v;
+            if (ASR::is_a<ASR::Variable_t>(*sym_t)) {
+                ASR::ttype_t* type_t = ASR::down_cast<ASR::Variable_t>(sym_t)->m_type;
+                if (ASR::is_a<ASR::String_t>(*type_t)) {
+                    ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(type_t)->m_len;
+                    if (len_expr && ASR::is_a<ASR::IntegerConstant_t>(*len_expr) ) {
+                        int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
+                        if (len != 1) {
+                            throw LCompilersException("Argument to Ichar must have length one");
+                        }
+                    }
+                }
             }
         }
 

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4995,21 +4995,9 @@ namespace Ichar {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
         declare_basic_variables("_lcompilers_ichar_" + type_to_str_python(arg_types[0]));
-        fill_func_arg("str",arg_types[0]);
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::PointerString)));
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
-
-        ASR::ttype_t* type_t =ASRUtils::expr_type(args[0]);
-        if (ASR::is_a<ASR::String_t>(*type_t)) {
-            ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(type_t)->m_len;
-            if (len_expr && ASR::is_a<ASR::IntegerConstant_t>(*len_expr) ) {
-                int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
-                if (len != 1) {
-                    throw LCompilersException("Argument to Ichar must have length one");
-                }
-            }
-        }
-
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
             ASRUtils::EXPR(ASR::make_Ichar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "df024249534fa92187811141a8e888489dea677c363cc8e5a024e641",
+    "stderr_hash": "6ecc5b5e5a83e9a17fc433a48a52a9c49fc2511ae0356ea53e6f8151",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -509,7 +509,7 @@ semantic error: Type mismatch in argument at argument (1); passed `real` to `int
 334 |     print *, f(42.9)
     |                ^^^^ 
 
-semantic error: Argument to Ichar must have length one
+semantic error: Argument 0 to Ichar must have length 1
    --> tests/errors/continue_compilation_2.f90:336:13
     |
 336 |     print*, ichar("okay")

--- a/tests/reference/asr-ichar_01-a5284c8.json
+++ b/tests/reference/asr-ichar_01-a5284c8.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-ichar_01-a5284c8.stderr",
-    "stderr_hash": "39fa0fd619eefdd58820aa626fe827781f0b7740476d6ef6a772af15",
+    "stderr_hash": "42a4f771efe8256b6afa322243212294ce438956e44b6b4a0eae9a19",
     "returncode": 2
 }

--- a/tests/reference/asr-ichar_01-a5284c8.stderr
+++ b/tests/reference/asr-ichar_01-a5284c8.stderr
@@ -1,4 +1,4 @@
-semantic error: Argument to Ichar must have length one
+semantic error: Argument 0 to Ichar must have length 1
  --> tests/errors/ichar_01.f90:3:13
   |
 3 |     print*, ichar("okay")


### PR DESCRIPTION
Resolves: https://github.com/lfortran/lfortran/issues/3734

### Enhancements to ASR utilities:
* Added the `get_fixed_string_len` function in `src/libasr/asr_utils.h` to retrieve the fixed length of a string type, or return `-1` otherwise.

### Intrinsic function validation improvements:
* Introduced a `char_len_validation` field in `src/libasr/intrinsic_func_registry_util_gen.py` to specify constraints on string argument lengths for intrinsic functions.
* Added logic in `add_create_func_arg_type_src` to enforce string length constraints during argument validation, leveraging the `get_fixed_string_len` utility.

The design structure
```
"char_len_validation": [{0: {0: {"min": 1, "max": 1}}}]
```

First Key 0 -> It tells us the index of the argument whose char length needs to be validated. 
The key–value pair `{0: {"min": 1, "max": 1}}` indicates that the 0th argument is expected to have min length 1 and max length 1.
