### PR TITLE
fix: allow appropriate indexing of external symbol as well

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2045,6 +2045,7 @@ RUN(NAME character_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME character_09 LABELS gfortran llvm fortran)
 RUN(NAME char_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_indexing LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME char_array_indexing_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME character_parameter_padding_trimming LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME character_array_parameter_padding_trimming LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/char_array_indexing_02.f90
+++ b/integration_tests/char_array_indexing_02.f90
@@ -1,0 +1,13 @@
+module mod_char_array_indexing_02
+    implicit none
+    character, parameter :: chars(0:9) = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+end module mod_char_array_indexing_02
+
+program char_array_indexing_02
+    use mod_char_array_indexing_02, only : chars
+    implicit none
+    character(len=1) :: x
+    x = chars(3)
+    print *, "x: ", x
+    if (x /= "d") error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4865,8 +4865,8 @@ public:
     }
 
     int get_based_indexing(ASR::symbol_t* v) {
-        if (v != nullptr && ASR::is_a<ASR::Variable_t>(*v)) {
-            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(v);
+        if (v != nullptr && ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(v))) {
+            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(v));
             if (ASRUtils::is_array(var->m_type) && var->m_value && var->m_storage == ASR::storage_typeType::Parameter) {
                 ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(var->m_type);
                 for (size_t i = 0; i < arr->n_dims; i++) {


### PR DESCRIPTION
## Description

Towards https://github.com/lfortran/lfortran/issues/7188, apparently the fix in this PR doesn't completely fix the linked issue though.