### PR TITLE
ci: update hash for splpak

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -53,7 +53,7 @@ time_section "🧪 Testing splpak" '
   micromamba install -c conda-forge fpm
 
   git checkout lf-2
-  git checkout 460bd22f4ac716e5266412e8ed35ce07aa664f08
+  git checkout b31509d68d08c1d1b88b341ddb5cbec3fe4607f0
 
   git clean -dfx
   fpm build --compiler=$FC --profile release --flag "--cpp -DREAL32" --verbose


### PR DESCRIPTION
I was encountering the same error as the CI when the previous PR for setting splpak in the CI was created. However, after updating to the latest main today, the compilation ran successfully on my end. This PR is being opened to check if it now works on the CI as well. If the CI passes, we can go ahead and remove the last commit from the `lf-2` branch.