### PR TITLE
fix: set `nopass` value correctly to handle `is_method` flag when dealing with `function` and `subroutine` call

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1738,6 +1738,7 @@ RUN(NAME class_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_45.f90
+++ b/integration_tests/class_45.f90
@@ -1,0 +1,51 @@
+module class_45_mod
+
+   type, public, abstract :: AbsType
+   contains
+      procedure(method), deferred, nopass :: method
+   end type AbsType
+
+   abstract interface
+      function method() result(arr)
+         import
+         integer, allocatable :: arr(:)
+      end function method
+   end interface
+
+   type, extends(AbsType) :: ConcreteType
+   contains
+      procedure, nopass :: method => concrete_method
+   end type ConcreteType
+
+contains
+
+   subroutine client(obj)
+      class(AbsType), intent(in) :: obj
+      integer, allocatable :: local_arr(:)
+      allocate(local_arr(2))
+      
+      local_arr = obj%method()
+      print *, "local_arr: ", local_arr
+
+      if (.not. all(local_arr == [1, 2])) error stop
+   end subroutine client
+
+   function concrete_method() result(arr)
+      integer, allocatable :: arr(:)
+      allocate(arr(2))
+      arr = [1, 2]
+   end function concrete_method
+
+end module class_45_mod
+
+program class_45
+   use class_45_mod
+   implicit none
+
+   class(AbsType), allocatable :: var
+
+   allocate(ConcreteType :: var)
+   
+   call client(var)
+
+end program class_45

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2450,7 +2450,7 @@ public:
 
         } else {
             stmt = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al,loc, master_function_sym,
-                                        master_function_sym, args.p, args.n, nullptr, nullptr, compiler_options.implicit_argument_casting, false));
+                                        master_function_sym, args.p, args.n, nullptr, nullptr, compiler_options.implicit_argument_casting));
         }
         LCOMPILERS_ASSERT(stmt != nullptr);
 
@@ -4347,7 +4347,7 @@ public:
         }
         ASR::stmt_t* cast_stmt = nullptr;
         tmp = ASRUtils::make_SubroutineCall_t_util(al, x.base.base.loc,
-                final_sym, original_sym, args.p, args.size(), v_expr, &cast_stmt, compiler_options.implicit_argument_casting, nopass);
+                final_sym, original_sym, args.p, args.size(), v_expr, &cast_stmt, compiler_options.implicit_argument_casting);
 
         if (cast_stmt != nullptr) {
             current_body->push_back(al, cast_stmt);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1729,7 +1729,7 @@ public:
         current_function_dependencies.push_back(al,s2c(al, func_name));
 
         ASR::expr_t* func_call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, getter_func_sym->base.loc,
-                                getter_func_sym, getter_func_sym, nullptr, 0, ASRUtils::symbol_type(end_sym), nullptr, nullptr, false));
+                                getter_func_sym, getter_func_sym, nullptr, 0, ASRUtils::symbol_type(end_sym), nullptr, nullptr));
         return func_call;
     }
 
@@ -5801,7 +5801,7 @@ public:
         ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
         return ASRUtils::make_FunctionCall_t_util(al, loc,
             final_sym, v, args.p, args.size(), return_type,
-            value, nullptr, false);
+            value, nullptr);
     }
 
     ASR::asr_t* symbol_resolve_external_generic_procedure(
@@ -5875,7 +5875,7 @@ public:
         ASRUtils::set_absent_optional_arguments_to_null(args, func, al, v_expr, v_class_proc->m_is_nopass);
         return ASRUtils::make_FunctionCall_t_util(al, loc,
                 v, nullptr, args.p, args.size(), type, nullptr,
-                v_expr, v_class_proc->m_is_nopass);
+                v_expr);
     }
 
     ASR::asr_t* create_GenericProcedure(const Location &loc,
@@ -5927,7 +5927,7 @@ public:
             ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
             return ASRUtils::make_FunctionCall_t_util(al, loc,
                 final_sym, v, args.p, args.size(), type,
-                nullptr, nullptr, false);
+                nullptr, nullptr);
         }
     }
 
@@ -5987,7 +5987,7 @@ public:
                 ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
                 return ASRUtils::make_FunctionCall_t_util(al, loc,
                     cp_s, v, args.p, args.size(), type,
-                    nullptr, nullptr, false);
+                    nullptr, nullptr);
             } else {
                 if (ASRUtils::symbol_parent_symtab(final_sym)->get_counter() != current_scope->get_counter()) {
                     ADD_ASR_DEPENDENCIES(current_scope, final_sym, current_function_dependencies);
@@ -5997,7 +5997,7 @@ public:
                 ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
                 return ASRUtils::make_FunctionCall_t_util(al, loc,
                     final_sym, v, args.p, args.size(), type,
-                    nullptr, nullptr, false);
+                    nullptr, nullptr);
             }
         }
     }
@@ -6369,7 +6369,7 @@ public:
         validate_create_function_arguments(args, v);
 
         return ASRUtils::make_FunctionCall_t_util(al, loc, v, nullptr,
-            args.p, args.size(), return_type, value, nullptr, false);
+            args.p, args.size(), return_type, value, nullptr);
     }
 
     ASR::asr_t* create_FunctionFromFunctionTypeVariable(const Location &loc,
@@ -6385,10 +6385,10 @@ public:
             ASR::expr_t* dt = ASRUtils::EXPR(ASR::make_StructInstanceMember_t(
                 al, loc, args.p[0].m_value, v, ASRUtils::symbol_type(v), nullptr));
             return ASRUtils::make_FunctionCall_t_util(al, loc, v, nullptr,
-                args.p + 1, args.size() - 1, return_type, nullptr, dt, false);
+                args.p + 1, args.size() - 1, return_type, nullptr, dt);
         } else {
             return ASRUtils::make_FunctionCall_t_util(al, loc, v, nullptr,
-                args.p, args.size(), return_type, nullptr, nullptr, false);
+                args.p, args.size(), return_type, nullptr, nullptr);
         }
     }
 
@@ -10128,7 +10128,7 @@ public:
                         ASRUtils::set_absent_optional_arguments_to_null(a_args, func, al);
                         tmp = ASRUtils::make_FunctionCall_t_util(al, x.base.base.loc,
                             a_name, sym, a_args.p, 2, return_type,
-                            nullptr, nullptr, false);
+                            nullptr, nullptr);
                     } else {
                         diag.add(Diagnostic("Arguements type and Parameters type "
                             "does not match", Level::Error, Stage::Semantic, {Label("", {proc->base.loc})}));
@@ -10272,8 +10272,8 @@ public:
             ADD_ASR_DEPENDENCIES(current_scope, v, current_function_dependencies);
             ASRUtils::insert_module_dependency(v, al, current_module_dependencies);
             tmp = ASRUtils::make_FunctionCall_t_util(al, x.base.base.loc, v,
-                v, args.p, args.size(), return_type, nullptr, nullptr,
-                false);
+                v, args.p, args.size(), return_type, nullptr, nullptr
+                );
             tmp = ASR::make_OverloadedStringConcat_t(al, x.base.base.loc,
                 left, right, return_type, nullptr, ASRUtils::EXPR(tmp));
         }

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -849,8 +849,8 @@ class ASRBuilder {
     ASR::expr_t* Call(ASR::symbol_t* s, Vec<ASR::call_arg_t>& args,
                       ASR::ttype_t* return_type) {
         return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-                s, s, args.p, args.size(), return_type, nullptr, nullptr,
-                false));
+                s, s, args.p, args.size(), return_type, nullptr, nullptr
+                ));
     }
 
     ASR::expr_t* Call(ASR::symbol_t* s, Vec<ASR::expr_t *>& args,
@@ -858,20 +858,19 @@ class ASRBuilder {
         Vec<ASR::call_arg_t> args_; args_.reserve(al, 2);
         visit_expr_list(al, args, args_);
         return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-                s, s, args_.p, args_.size(), return_type, nullptr, nullptr,
-                false));
+                s, s, args_.p, args_.size(), return_type, nullptr, nullptr
+                ));
     }
 
     ASR::expr_t* Call(ASR::symbol_t* s, Vec<ASR::call_arg_t>& args,
                       ASR::ttype_t* return_type, ASR::expr_t* value) {
         return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-                s, s, args.p, args.size(), return_type, value, nullptr,
-                false));
+                s, s, args.p, args.size(), return_type, value, nullptr));
     }
 
     ASR::stmt_t* SubroutineCall(ASR::symbol_t* s, Vec<ASR::call_arg_t>& args) {
         return ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, loc,
-                s, s, args.p, args.size(), nullptr, nullptr, false, false));
+                s, s, args.p, args.size(), nullptr, nullptr, false));
     }
 
     ASR::expr_t *ArrayItem_01(ASR::expr_t *arr, std::vector<ASR::expr_t*> idx) {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -736,8 +736,8 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                             asr = ASRUtils::make_FunctionCall_t_util(al, loc, a_name, sym,
                                                             a_args.p, 2,
                                                             return_type,
-                                                            nullptr, nullptr,
-                                                            false);
+                                                            nullptr, nullptr
+                                                            );
                         }
                     }
                     break;
@@ -829,8 +829,8 @@ void process_overloaded_unary_minus_function(ASR::symbol_t* proc, ASR::expr_t* o
             asr = ASRUtils::make_FunctionCall_t_util(al, loc, a_name, proc,
                                             a_args.p, 1,
                                             return_type,
-                                            nullptr, nullptr,
-                                            false);
+                                            nullptr, nullptr
+                                            );
         }
     }
 }
@@ -1001,7 +1001,7 @@ void process_overloaded_assignment_function(ASR::symbol_t* proc, ASR::expr_t* ta
             ASRUtils::insert_module_dependency(a_name, al, current_module_dependencies);
             ASRUtils::set_absent_optional_arguments_to_null(a_args, subrout, al);
             asr = ASRUtils::make_SubroutineCall_t_util(al, loc, a_name, sym,
-                                            a_args.p, 2, nullptr, nullptr, false, false);
+                                            a_args.p, 2, nullptr, nullptr, false);
         }
     }
 }
@@ -1105,7 +1105,7 @@ void process_overloaded_read_write_function(std::string &read_write, ASR::symbol
         ASRUtils::insert_module_dependency(a_name, al, current_module_dependencies);
         ASRUtils::set_absent_optional_arguments_to_null(a_args, subrout, al);
         asr = ASRUtils::make_SubroutineCall_t_util(al, loc, a_name, sym,
-                                        a_args.p, a_args.n, nullptr, nullptr, false, false);
+                                        a_args.p, a_args.n, nullptr, nullptr, false);
     }
 }
 
@@ -1269,8 +1269,8 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                             asr = ASRUtils::make_FunctionCall_t_util(al, loc, a_name, sym,
                                                             a_args.p, 2,
                                                             return_type,
-                                                            nullptr, nullptr,
-                                                            false);
+                                                            nullptr, nullptr
+                                                            );
                         }
                     }
                     break;
@@ -1451,7 +1451,7 @@ ASR::asr_t* symbol_resolve_external_generic_procedure_without_eval(
         }
         return ASRUtils::make_SubroutineCall_t_util(al, loc, final_sym,
                                         v, args.p, args.size(),
-                                        nullptr, nullptr, false, false);
+                                        nullptr, nullptr, false);
     } else {
         if( func ) {
             ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
@@ -1459,8 +1459,8 @@ ASR::asr_t* symbol_resolve_external_generic_procedure_without_eval(
         return ASRUtils::make_FunctionCall_t_util(al, loc, final_sym,
                                         v, args.p, args.size(),
                                         return_type,
-                                        nullptr, nullptr,
-                                        false);
+                                        nullptr, nullptr
+                                        );
     }
 }
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -6228,9 +6228,10 @@ static inline bool is_elemental(ASR::symbol_t* x) {
 static inline ASR::asr_t* make_FunctionCall_t_util(
     Allocator &al, const Location &a_loc, ASR::symbol_t* a_name,
     ASR::symbol_t* a_original_name, ASR::call_arg_t* a_args, size_t n_args,
-    ASR::ttype_t* a_type, ASR::expr_t* a_value, ASR::expr_t* a_dt, bool nopass=false) {
+    ASR::ttype_t* a_type, ASR::expr_t* a_value, ASR::expr_t* a_dt) {
 
-    Call_t_body(al, a_name, a_args, n_args, a_dt, nullptr, false, nopass);
+    Call_t_body(al, a_name, a_args, n_args, a_dt, nullptr, false, 
+        ASRUtils::get_class_proc_nopass_val(a_name));
 
     if( ASRUtils::is_array(a_type) && ASRUtils::is_elemental(a_name) &&
         !ASRUtils::is_fixed_size_array(a_type) &&
@@ -6277,9 +6278,10 @@ static inline ASR::asr_t* make_FunctionCall_t_util(
 static inline ASR::asr_t* make_SubroutineCall_t_util(
     Allocator &al, const Location &a_loc, ASR::symbol_t* a_name,
     ASR::symbol_t* a_original_name, ASR::call_arg_t* a_args, size_t n_args,
-    ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt, bool implicit_argument_casting, bool nopass) {
+    ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt, bool implicit_argument_casting) {
 
-    Call_t_body(al, a_name, a_args, n_args, a_dt, cast_stmt, implicit_argument_casting, nopass);
+    Call_t_body(al, a_name, a_args, n_args, a_dt, cast_stmt, implicit_argument_casting,
+         ASRUtils::get_class_proc_nopass_val(a_name));
 
     if( a_dt && ASR::is_a<ASR::Variable_t>(
         *ASRUtils::symbol_get_past_external(a_name)) &&

--- a/src/libasr/pass/function_call_in_declaration.cpp
+++ b/src/libasr/pass/function_call_in_declaration.cpp
@@ -296,8 +296,8 @@ public:
                         new_call_args.p, new_call_args.n,
                         integer_type,
                         nullptr,
-                        nullptr,
-                        false));
+                        nullptr
+                        ));
         *current_expr = new_function_call;
 
         ASR::expr_t* function_call_for_return_var = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, x->base.base.loc,
@@ -306,8 +306,8 @@ public:
                         args_for_return_var.p, args_for_return_var.n,
                         integer_type,
                         nullptr,
-                        nullptr,
-                        false));
+                        nullptr
+                        ));
         call_for_return_var = function_call_for_return_var;
         new_function_scope = new_function_scope_copy;
     }
@@ -388,8 +388,8 @@ public:
                         new_call_args.p, new_call_args.n,
                         integer_type,
                         nullptr,
-                        nullptr,
-                        false));
+                        nullptr
+                        ));
         *current_expr = new_function_call;
 
         ASR::expr_t* function_call_for_return_var = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, x->base.base.loc,
@@ -398,8 +398,8 @@ public:
                         args_for_return_var.p, args_for_return_var.n,
                         integer_type,
                         nullptr,
-                        nullptr,
-                        false));
+                        nullptr
+                        ));
         call_for_return_var = function_call_for_return_var;
         new_function_scope = new_function_scope_copy;
     }

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -580,7 +580,7 @@ public:
             ADD_ASR_DEPENDENCIES(current_scope, name, dependencies);
         }
         return ASRUtils::make_FunctionCall_t_util(al, x->base.base.loc, name, x->m_original_name,
-            args.p, args.size(), type, value, dt, false);
+            args.p, args.size(), type, value, dt);
     }
 
     ASR::asr_t* duplicate_SubroutineCall(ASR::SubroutineCall_t *x) {
@@ -624,7 +624,7 @@ public:
             ADD_ASR_DEPENDENCIES(current_scope, name, dependencies);
         }
         return ASRUtils::make_SubroutineCall_t_util(al, x->base.base.loc, name /* change this */,
-            x->m_original_name, args.p, args.size(), dt, nullptr, false, false);
+            x->m_original_name, args.p, args.size(), dt, nullptr, false);
     }
 
     ASR::asr_t* duplicate_StructInstanceMember(ASR::StructInstanceMember_t *x) {
@@ -1617,7 +1617,7 @@ public:
         }
 
         return ASRUtils::make_FunctionCall_t_util(al, x->base.base.loc, name,
-            x->m_original_name, args.p, args.size(), type, value, dt, false);
+            x->m_original_name, args.p, args.size(), type, value, dt);
     }
 
     ASR::asr_t* duplicate_SubroutineCall(ASR::SubroutineCall_t* x) {
@@ -1660,8 +1660,7 @@ public:
         }
 
         return ASRUtils::make_SubroutineCall_t_util(al, x->base.base.loc, name,
-            x->m_original_name, args.p, args.size(), dt, nullptr, false,
-            ASRUtils::get_class_proc_nopass_val(x->m_name));
+            x->m_original_name, args.p, args.size(), dt, nullptr, false);
     }
 
     ASR::asr_t* duplicate_DoLoop(ASR::DoLoop_t *x) {

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -279,7 +279,7 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
         new_args.push_back(al, new_arg);
         ASR::stmt_t* subrout_call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(
             al, x->base.base.loc, x->m_name, x->m_original_name, new_args.p,
-            new_args.size(), x->m_dt, nullptr, false, false));
+            new_args.size(), x->m_dt, nullptr, false));
         pass_result.push_back(al, subrout_call);
     }
 };

--- a/src/libasr/pass/pass_compare.cpp
+++ b/src/libasr/pass/pass_compare.cpp
@@ -126,8 +126,8 @@ public:
 
                 return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
                     fn, nullptr, args.p, args.n,
-                    bool_type, nullptr, nullptr,
-                    false));
+                    bool_type, nullptr, nullptr
+                    ));
             }
             case ASR::ttypeType::List: {
                 ASR::symbol_t *fn = get_list_compare_func(loc, global_scope, type);
@@ -143,8 +143,7 @@ public:
 
                 return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
                     fn, nullptr, args.p, args.n,
-                    bool_type, nullptr, nullptr,
-                    false));
+                    bool_type, nullptr, nullptr));
             }
             default: {
                 LCOMPILERS_ASSERT(false);
@@ -262,7 +261,7 @@ public:
         ASR::symbol_t *fn_sym = get_tuple_compare_func(unit.base.base.loc,
                 unit.m_symtab, ASRUtils::expr_type(x->m_left));
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-            fn_sym, nullptr, args.p, args.n, bool_type, nullptr, nullptr, false));
+            fn_sym, nullptr, args.p, args.n, bool_type, nullptr, nullptr));
         if (x->m_op == ASR::cmpopType::NotEq) {
             *current_expr = ASRUtils::EXPR(ASR::make_LogicalNot_t(al, loc,
                         *current_expr, bool_type, nullptr));
@@ -447,8 +446,8 @@ public:
         ASR::symbol_t *fn_sym = get_list_compare_func(unit.base.base.loc,
                 unit.m_symtab, ASRUtils::expr_type(x->m_left));
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-            fn_sym, nullptr, args.p, args.n, bool_type, nullptr, nullptr,
-            false));
+            fn_sym, nullptr, args.p, args.n, bool_type, nullptr, nullptr
+            ));
         if (x->m_op == ASR::cmpopType::NotEq) {
             *current_expr = ASRUtils::EXPR(ASR::make_LogicalNot_t(al, loc,
                         *current_expr, bool_type, nullptr));

--- a/src/libasr/pass/pass_list_expr.cpp
+++ b/src/libasr/pass/pass_list_expr.cpp
@@ -406,7 +406,7 @@ public:
         }
         ASR::symbol_t *fn_sym = list_section_func_map[list_type_name];
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-            fn_sym, nullptr, args.p, args.n, x->m_type, nullptr, nullptr, false));
+            fn_sym, nullptr, args.p, args.n, x->m_type, nullptr, nullptr));
     }
 
     void create_concat_function(Location& loc,
@@ -530,7 +530,7 @@ public:
         }
         ASR::symbol_t *fn_sym = list_concat_func_map[list_type_name];
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-            fn_sym, nullptr, args.p, 2, x->m_type, nullptr, nullptr, false));
+            fn_sym, nullptr, args.p, 2, x->m_type, nullptr, nullptr));
     }
 
 };

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -1126,7 +1126,7 @@ namespace LCompilers {
             args.push_back(al, arg5_);
             return ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, loc, v,
                                                              nullptr, args.p, args.size(),
-                                                             nullptr, nullptr, false, false));
+                                                             nullptr, nullptr, false));
         }
 
         ASR::expr_t* get_sign_from_value(ASR::expr_t* arg0, ASR::expr_t* arg1,

--- a/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
+++ b/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
@@ -236,8 +236,7 @@ class FixArrayPhysicalCast: public ASR::BaseExprReplacer<FixArrayPhysicalCast> {
             ASR::BaseExprReplacer<FixArrayPhysicalCast>::replace_FunctionCall(x);
             ASR::expr_t* call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(
                 al, x->base.base.loc, x->m_name, x->m_original_name, x->m_args,
-                x->n_args, x->m_type, x->m_value, x->m_dt,
-                ASRUtils::get_class_proc_nopass_val((*x).m_name)));
+                x->n_args, x->m_type, x->m_value, x->m_dt));
             ASR::FunctionCall_t* function_call = ASR::down_cast<ASR::FunctionCall_t>(call);
             x->m_args = function_call->m_args;
             x->n_args = function_call->n_args;
@@ -284,7 +283,7 @@ class FixArrayPhysicalCastVisitor: public ASR::CallReplacerOnExpressionsVisitor<
             ASR::CallReplacerOnExpressionsVisitor<FixArrayPhysicalCastVisitor>::visit_SubroutineCall(x);
             ASR::stmt_t* call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(
                 al, x.base.base.loc, x.m_name, x.m_original_name, x.m_args,
-                x.n_args, x.m_dt, nullptr, false, ASRUtils::get_class_proc_nopass_val(x.m_name)));
+                x.n_args, x.m_dt, nullptr, false));
             ASR::SubroutineCall_t* subrout_call = ASR::down_cast<ASR::SubroutineCall_t>(call);
             ASR::SubroutineCall_t& xx = const_cast<ASR::SubroutineCall_t&>(x);
             xx.m_args = subrout_call->m_args;

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -100,8 +100,8 @@ public:
             call_args.push_back(al, call_arg);
         }
         return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-            sym, sym, call_args.p, call_args.n, return_type, nullptr, nullptr,
-            false));
+            sym, sym, call_args.p, call_args.n, return_type, nullptr, nullptr
+            ));
     }
 
     ASR::symbol_t *create_bindc_function(const Location &loc,

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -72,7 +72,7 @@ public :
             new_call_args.push_back(al, {result_var->base.loc, result_var});
             ASR::stmt_t* subrout_call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, x->base.base.loc,
                                                 x->m_name, nullptr, new_call_args.p, new_call_args.size(), x->m_dt,
-                                                nullptr, false, false));
+                                                nullptr, false));
             // replace functionCall with `result_var` + push subroutineCall into the body.
             *current_expr = result_var;
             pass_result.push_back(al, subrout_call);
@@ -186,7 +186,7 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
             result_arg.m_value = x.m_target;
             s_args.push_back(al, result_arg);
             ASR::stmt_t* subrout_call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al, loc,
-                fc->m_name, fc->m_original_name, s_args.p, s_args.size(), fc->m_dt, nullptr, false, false));
+                fc->m_name, fc->m_original_name, s_args.p, s_args.size(), fc->m_dt, nullptr, false));
             pass_result.push_back(al, subrout_call);
             remove_original_statement = true;
         }

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -541,7 +541,7 @@ class ReplaceFunctionCallsWithOptionalArguments: public ASR::BaseExprReplacer<Re
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al,
                             x->base.base.loc, x->m_name, x->m_original_name,
                             new_args.p, new_args.size(), x->m_type, x->m_value,
-                            x->m_dt, ASRUtils::get_class_proc_nopass_val((*x).m_name)));
+                            x->m_dt));
         new_func_calls.insert(*current_expr);
     }
 
@@ -590,7 +590,7 @@ class ReplaceSubroutineCallsWithOptionalArgumentsVisitor : public PassUtils::Pas
             pass_result.push_back(al, ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al,
                                     x.base.base.loc, x.m_name, x.m_original_name,
                                     new_args.p, new_args.size(), x.m_dt,
-                                    nullptr, false, ASRUtils::get_class_proc_nopass_val(x.m_name))));
+                                    nullptr, false)));
         }
 };
 


### PR DESCRIPTION
fixes #7631