### PR TITLE
[OPENMP] FEAT: Implement Single/Master Construct

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2274,6 +2274,8 @@ RUN(NAME openmp_43 LABELS llvm_omp llvm)
 RUN(NAME openmp_44 LABELS llvm_omp  gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_45 LABELS llvm_omp  gfortran GFORTRAN_ARGS -fopenmp)
 RUN(NAME openmp_47 LABELS llvm_omp  gfortran GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_48 LABELS llvm_omp  gfortran GFORTRAN_ARGS -fopenmp)
+RUN(NAME openmp_49 LABELS llvm_omp  gfortran GFORTRAN_ARGS -fopenmp)
 
 RUN(NAME nullify_01 LABELS gfortran fortran llvm)
 RUN(NAME nullify_02 LABELS gfortran fortran llvm)

--- a/integration_tests/openmp_48.f90
+++ b/integration_tests/openmp_48.f90
@@ -1,0 +1,14 @@
+program openmp_48
+    use omp_lib
+    implicit none
+    integer :: i=0
+    call omp_set_num_threads(8)
+
+    !$omp parallel reduction(+:i)
+        !$omp single
+            i=i+1 !This will be done by one thread only hence 1 will be added to i
+        !$omp end single
+        i=i+1 !This will be done by all threads hence eventually 8 will be added to i
+    !$omp end parallel 
+    if(i/=9) error stop
+end program openmp_48

--- a/integration_tests/openmp_49.f90
+++ b/integration_tests/openmp_49.f90
@@ -1,0 +1,12 @@
+program openmp_49
+    use omp_lib
+    implicit none
+    call omp_set_num_threads(8)
+
+    !$omp parallel
+        !$omp master
+            print *, "Welcome to Master Thread!"
+            if(omp_get_thread_num() /= 0) error stop
+        !$omp end master
+    !$omp end parallel 
+end program openmp_49

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -5232,6 +5232,9 @@ public:
                 } else if (LCompilers::startswith(x.m_construct_name, "single")) {
                     // Collect the body of the previous section
                     collect_omp_body(ASR::omp_region_typeType::Single);
+                } else if (LCompilers::startswith(x.m_construct_name, "master")) {
+                    // Collect the body of the previous section
+                    collect_omp_body(ASR::omp_region_typeType::Master);
                 } else if (LCompilers::startswith(x.m_construct_name, "task")) {
                     collect_omp_body(ASR::omp_region_typeType::Task);
                     tmp=(ASR::asr_t*)(ASR::down_cast<ASR::OMPRegion_t>(omp_region_body.back())); 
@@ -5327,6 +5330,15 @@ public:
                 body.reserve(al, 0);
                 omp_region_body.push_back(ASRUtils::STMT(
                     ASR::make_OMPRegion_t(al, loc, ASR::omp_region_typeType::Single, clauses.p, clauses.n, body.p, body.n)));
+            
+            } else if(to_lower(x.m_construct_name) == "master") {
+                pragma_nesting_level_2++;
+                Vec<ASR::omp_clause_t*> clauses;
+                clauses = get_clauses(x);
+                Vec<ASR::stmt_t*> body;
+                body.reserve(al, 0);
+                omp_region_body.push_back(ASRUtils::STMT(
+                    ASR::make_OMPRegion_t(al, loc, ASR::omp_region_typeType::Master, clauses.p, clauses.n, body.p, body.n)));
             } else if (to_lower(x.m_construct_name) == "task") {
                 pragma_nesting_level_2++;
                 Vec<ASR::omp_clause_t*> clauses;

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -246,7 +246,7 @@ arraybound = LBound | UBound
 arraystorage = RowMajor | ColMajor
 string_format_kind = FormatFortran | FormatC | FormatPythonPercent | FormatPythonFString | FormatPythonFormat
 
-omp_region_type = Parallel | Do | ParallelDo | Sections | Section | ParallelSections | Single | Task | Simd | Teams | Target | TargetData
+omp_region_type = Parallel | Do | ParallelDo | Sections | Section | ParallelSections | Single | Master | Task | Simd | Teams | Target | TargetData
 omp_clause
   = OMPPrivate(expr* vars)
   | OMPShared(expr* vars)


### PR DESCRIPTION
Towards #7332 and #7365

This will form base for implementing the `TASK` Construct in subsequent PR, I just thought to keep it separate so as to keep reviewing simpler hence make separate PR
