### PR TITLE
Feat: throw `Semantic Errors` inplace of` LcompilerError` for instantiate functions for intrinsics

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1180,19 +1180,18 @@ int compile_src_to_object_file(const std::string &infile,
         return 1;
 #endif
     }
-    try {
         LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
         res = fe.get_llvm3(*asr, lpm, diagnostics, infile, &time_opt);
-        if (res.ok) {
+    if (diagnostics.has_error()) {
+        std::cerr << diagnostics.render(lm, compiler_options);
+        return 5;
+    }
+    if (res.ok) {
         m = std::move(res.result);
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return 5;
     }
-    } catch (...) {
-        std::cerr << diagnostics.render(lm, compiler_options);
-        return 5;
-    }   
 
     // LLVM -> Machine code (saves to an object file)
     if (assembly) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1180,17 +1180,21 @@ int compile_src_to_object_file(const std::string &infile,
         return 1;
 #endif
     }
+    try {
         LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
         res = fe.get_llvm3(*asr, lpm, diagnostics, infile, &time_opt);
-    if (diagnostics.has_error()) {
         std::cerr << diagnostics.render(lm, compiler_options);
-        return 5;
-    }
-    if (res.ok) {
-        m = std::move(res.result);
-    } else {
-        LCOMPILERS_ASSERT(diagnostics.has_error())
-        return 5;
+        if (res.ok) {
+            m = std::move(res.result);
+        } else {
+            LCOMPILERS_ASSERT(diagnostics.has_error())
+            return 5;
+        }
+    } catch (const LCompilers::RuntimeException &e) {
+        if (diagnostics.has_error()) {
+            std::cerr << diagnostics.render(lm, compiler_options);
+            return 5;
+        }
     }
 
     // LLVM -> Machine code (saves to an object file)

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1180,15 +1180,19 @@ int compile_src_to_object_file(const std::string &infile,
         return 1;
 #endif
     }
-    LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
+    try {
+        LCompilers::Result<std::unique_ptr<LCompilers::LLVMModule>>
         res = fe.get_llvm3(*asr, lpm, diagnostics, infile, &time_opt);
-    std::cerr << diagnostics.render(lm, compiler_options);
-    if (res.ok) {
+        if (res.ok) {
         m = std::move(res.result);
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return 5;
     }
+    } catch (...) {
+        std::cerr << diagnostics.render(lm, compiler_options);
+        return 5;
+    }   
 
     // LLVM -> Machine code (saves to an object file)
     if (assembly) {

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -714,7 +714,7 @@ Result<std::string> asr_to_cpp(Allocator &al, ASR::TranslationUnit_t &asr,
     int64_t default_lower_bound)
 {
     co.po.always_run = true;
-    pass_unused_functions(al, asr, co.po);
+    pass_unused_functions(al, asr, co.po, diagnostics);
     ASRToCPPVisitor v(diagnostics, co, default_lower_bound);
     try {
         v.visit_asr((ASR::asr_t &)asr);

--- a/src/libasr/codegen/asr_to_x86.cpp
+++ b/src/libasr/codegen/asr_to_x86.cpp
@@ -581,14 +581,14 @@ Result<int> asr_to_x86(ASR::TranslationUnit_t &asr, Allocator &al,
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        pass_wrap_global_stmts(al, asr, pass_options);
+        pass_wrap_global_stmts(al, asr, pass_options, diagnostics);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_pass_global = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     }
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        pass_replace_do_loops(al, asr, pass_options);
+        pass_replace_do_loops(al, asr, pass_options, diagnostics);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_pass_do_loops = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     }

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -390,6 +390,9 @@ std::tuple<std::string, std::string, std::string> diag_level_to_str(
                 case (Stage::CodeGen):
                     message_type = "code generation error";
                     break;
+                case (Stage::Runtime):
+                    message_type = "runtime error";
+                    break;
             }
             break;
         case (Level::Warning):

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -70,7 +70,7 @@ enum Level {
  */
 enum Stage {
     CPreprocessor, Prescanner, Tokenizer, Parser, Semantic, ASRPass,
-    ASRVerify, CodeGen
+    ASRVerify, CodeGen, Runtime
 };
 
 /*

--- a/src/libasr/exception.h
+++ b/src/libasr/exception.h
@@ -165,6 +165,10 @@ static inline T TRY(Result<T> result) {
     }
 }
 
+class RuntimeException
+{
+};
+
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/array_by_data.h
+++ b/src/libasr/pass/array_by_data.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_array_by_data(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1079,7 +1079,7 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
 };
 
 void pass_replace_array_op(Allocator &al, ASR::TranslationUnit_t &unit,
-                           const LCompilers::PassOptions& pass_options) {
+                           const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     ArrayOpVisitor v(al, pass_options.realloc_lhs);
     v.call_replacer_on_value = false;
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/array_passed_in_function_call.cpp
+++ b/src/libasr/pass/array_passed_in_function_call.cpp
@@ -892,7 +892,7 @@ public:
 };
 
 void pass_replace_array_passed_in_function_call(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& /*pass_options*/) {
+                        const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     CallVisitor v(al);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor x(al);

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -2749,7 +2749,7 @@ class InitialiseExprWithTarget: public ASR::BaseWalkVisitor<InitialiseExprWithTa
 };
 
 void pass_array_struct_temporary(Allocator &al, ASR::TranslationUnit_t &unit,
-                     const PassOptions &pass_options) {
+                     const PassOptions &pass_options, diag::Diagnostics& /*diagnostics*/) {
     // TODO: Add a visitor in asdl_cpp.py which will replace
     // current_expr with its own `m_value` (if `m_value` is not nullptr)
     // Call the visitor here.

--- a/src/libasr/pass/array_struct_temporary.h
+++ b/src/libasr/pass/array_struct_temporary.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_array_struct_temporary(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/class_constructor.cpp
+++ b/src/libasr/pass/class_constructor.cpp
@@ -121,7 +121,7 @@ class StructConstructorVisitor : public ASR::CallReplacerOnExpressionsVisitor<St
 
 void pass_replace_class_constructor(Allocator &al,
     ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& pass_options) {
+    const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     StructConstructorVisitor v(al, pass_options.realloc_lhs);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor w(al);

--- a/src/libasr/pass/create_subroutine_from_function.h
+++ b/src/libasr/pass/create_subroutine_from_function.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_create_subroutine_from_function(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/dead_code_removal.cpp
+++ b/src/libasr/pass/dead_code_removal.cpp
@@ -95,7 +95,7 @@ public:
 };
 
 void pass_dead_code_removal(Allocator &al, ASR::TranslationUnit_t &unit,
-                            const LCompilers::PassOptions& pass_options) {
+                            const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     std::string rl_path = pass_options.runtime_library_dir;
     DeadCodeRemovalVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/dead_code_removal.h
+++ b/src/libasr/pass/dead_code_removal.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_dead_code_removal(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/div_to_mul.cpp
+++ b/src/libasr/pass/div_to_mul.cpp
@@ -75,7 +75,7 @@ public:
 };
 
 void pass_replace_div_to_mul(Allocator &al, ASR::TranslationUnit_t &unit,
-                             const LCompilers::PassOptions& pass_options) {
+                             const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     std::string rl_path = pass_options.runtime_library_dir;
     DivToMulVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -66,7 +66,7 @@ public:
 };
 
 void pass_replace_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
-                           const LCompilers::PassOptions& pass_options) {
+                           const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     DoLoopVisitor v(al, pass_options);
     // Each call transforms only one layer of nested loops, so we call it twice
     // to transform doubly nested loops:

--- a/src/libasr/pass/flip_sign.cpp
+++ b/src/libasr/pass/flip_sign.cpp
@@ -206,7 +206,7 @@ public:
 };
 
 void pass_replace_flip_sign(Allocator &al, ASR::TranslationUnit_t &unit,
-                            const LCompilers::PassOptions& pass_options) {
+                            const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     FlipSignVisitor v(al, unit, pass_options);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);

--- a/src/libasr/pass/fma.cpp
+++ b/src/libasr/pass/fma.cpp
@@ -114,7 +114,7 @@ public :
 
 
 void pass_replace_fma(Allocator &al, ASR::TranslationUnit_t &unit,
-                      const LCompilers::PassOptions& pass_options) {
+                      const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     CallReplacerFMA realBinOpFMA_replacer{al, unit, pass_options};
     realBinOpFMA_replacer.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);

--- a/src/libasr/pass/for_all.cpp
+++ b/src/libasr/pass/for_all.cpp
@@ -46,7 +46,7 @@ public:
 };
 
 void pass_replace_for_all(Allocator &al, ASR::TranslationUnit_t &unit,
-                         const LCompilers::PassOptions& /*pass_options*/) {
+                         const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     ForAllVisitor v(al);
     v.visit_TranslationUnit(unit);
 }

--- a/src/libasr/pass/function_call_in_declaration.cpp
+++ b/src/libasr/pass/function_call_in_declaration.cpp
@@ -722,7 +722,7 @@ public:
 };
 
 void pass_replace_function_call_in_declaration(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& /*pass_options*/) {
+                        const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     FunctionTypeVisitor v(al, unit);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor x(al);

--- a/src/libasr/pass/global_stmts.cpp
+++ b/src/libasr/pass/global_stmts.cpp
@@ -19,7 +19,7 @@ using ASRUtils::EXPR;
  *
  */
 void pass_wrap_global_stmts(Allocator &al,
-            ASR::TranslationUnit_t &unit, const LCompilers::PassOptions& pass_options) {
+            ASR::TranslationUnit_t &unit, const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     if (unit.n_items == 0) {
         return ;
     }

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -813,7 +813,7 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
 
 void pass_replace_implied_do_loops(Allocator &al,
     ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& pass_options) {
+    const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     ArrayConstantVisitor v(al, pass_options.realloc_lhs);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);

--- a/src/libasr/pass/init_expr.cpp
+++ b/src/libasr/pass/init_expr.cpp
@@ -215,7 +215,7 @@ class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVis
 
 void pass_replace_init_expr(Allocator &al,
     ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& /*pass_options*/) {
+    const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     InitExprVisitor v(al);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor w(al);

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -473,7 +473,7 @@ class InlineFunctionCallsVisitor: public ASR::CallReplacerOnExpressionsVisitor<I
 };
 
 void pass_inline_function_calls(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const LCompilers::PassOptions& /*pass_options*/) {
+                                const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     InlineFunctionCallsVisitor inline_functions(al);
     inline_functions.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor update_dependencies(al);

--- a/src/libasr/pass/inline_function_calls.h
+++ b/src/libasr/pass/inline_function_calls.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_inline_function_calls(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -174,7 +174,7 @@ class InsertDeallocate: public ASR::CallReplacerOnExpressionsVisitor<InsertDeall
 };
 
 void pass_insert_deallocate(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &/*pass_options*/) {
+                                const PassOptions &/*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     InsertDeallocate v(al);
     v.visit_TranslationUnit(unit);
 }

--- a/src/libasr/pass/insert_deallocate.h
+++ b/src/libasr/pass/insert_deallocate.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_insert_deallocate(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -80,10 +80,10 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
         } catch (const LCompilersException& e) {
             global_diagnostics->add(diag::Diagnostic(
                 std::string(e.what()),
-                diag::Level::Error, diag::Stage::Semantic, {
+                diag::Level::Error, diag::Stage::Runtime, {
                 diag::Label("", {x->base.base.loc})
             }));
-            return;
+            throw RuntimeException();
         }
     }
 

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -363,9 +363,27 @@ void pass_replace_intrinsic_function(Allocator &al, ASR::TranslationUnit_t &unit
         throw LCompilers::LFortran::SemanticAbort();
     }
     ReplaceFunctionCallReturningArrayVisitor u(al, func2intrinsicid);
-    u.visit_TranslationUnit(unit);
+    try {
+        u.visit_TranslationUnit(unit);
+    } catch (const LCompilersException& e) {
+        diagnostics.add(diag::Diagnostic(
+            std::string(e.what()),
+            diag::Level::Error, diag::Stage::Semantic, {
+            diag::Label("", {unit.base.base.loc})
+        }));
+        throw LCompilers::LFortran::SemanticAbort();
+    }
     PassUtils::UpdateDependenciesVisitor w(al);
-    w.visit_TranslationUnit(unit);
+    try {
+        w.visit_TranslationUnit(unit);
+    } catch (const LCompilersException& e) {
+        diagnostics.add(diag::Diagnostic(
+            std::string(e.what()),
+            diag::Level::Error, diag::Stage::Semantic, {
+            diag::Label("", {unit.base.base.loc})
+        }));
+        throw LCompilers::LFortran::SemanticAbort();
+    }
 }
 
 

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -7,12 +7,12 @@
 #include <libasr/pass/intrinsic_function_registry.h>
 #include <libasr/pass/intrinsic_array_function_registry.h>
 #include <libasr/pass/pass_utils.h>
-#include <lfortran/semantics/semantic_exception.h>
 
 #include <vector>
 
 
 namespace LCompilers {
+diag::Diagnostics* global_diagnostics = nullptr;
 
 /*
 
@@ -72,9 +72,19 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
         }
         ASR::ttype_t* type = nullptr;
         type = ASRUtils::extract_type(x->m_type);
-        ASR::expr_t* current_expr_ = instantiate_function(al, x->base.base.loc,
-        global_scope, arg_types, type, new_args, x->m_overload_id);
-        *current_expr = current_expr_;
+        ASR::expr_t* current_expr_ = nullptr;
+         try {
+            current_expr_ = instantiate_function(al, x->base.base.loc,
+            global_scope, arg_types, type, new_args, x->m_overload_id);
+            *current_expr = current_expr_;
+        } catch (const LCompilersException& e) {
+            global_diagnostics->add(diag::Diagnostic(
+                std::string(e.what()),
+                diag::Level::Error, diag::Stage::Semantic, {
+                diag::Label("", {x->base.base.loc})
+            }));
+            return;
+        }
     }
 
     void replace_IntrinsicArrayFunction(ASR::IntrinsicArrayFunction_t* x) {
@@ -351,39 +361,13 @@ class ReplaceFunctionCallReturningArrayVisitor : public ASR::CallReplacerOnExpre
 void pass_replace_intrinsic_function(Allocator &al, ASR::TranslationUnit_t &unit,
                             const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics &diagnostics) {
     std::map<ASR::symbol_t*, ASRUtils::IntrinsicArrayFunctions> func2intrinsicid;
+    global_diagnostics = &diagnostics;
     ReplaceIntrinsicFunctionsVisitor v(al, unit.m_symtab, func2intrinsicid);
-    try {
-        v.visit_TranslationUnit(unit);
-    } catch (const LCompilersException& e) {
-        diagnostics.add(diag::Diagnostic(
-            std::string(e.what()),
-            diag::Level::Error, diag::Stage::Semantic, {
-            diag::Label("", {unit.base.base.loc})
-        }));
-        throw LCompilers::LFortran::SemanticAbort();
-    }
+    v.visit_TranslationUnit(unit);
     ReplaceFunctionCallReturningArrayVisitor u(al, func2intrinsicid);
-    try {
-        u.visit_TranslationUnit(unit);
-    } catch (const LCompilersException& e) {
-        diagnostics.add(diag::Diagnostic(
-            std::string(e.what()),
-            diag::Level::Error, diag::Stage::Semantic, {
-            diag::Label("", {unit.base.base.loc})
-        }));
-        throw LCompilers::LFortran::SemanticAbort();
-    }
+    u.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor w(al);
-    try {
-        w.visit_TranslationUnit(unit);
-    } catch (const LCompilersException& e) {
-        diagnostics.add(diag::Diagnostic(
-            std::string(e.what()),
-            diag::Level::Error, diag::Stage::Semantic, {
-            diag::Label("", {unit.base.base.loc})
-        }));
-        throw LCompilers::LFortran::SemanticAbort();
-    }
+    w.visit_TranslationUnit(unit);
 }
 
 

--- a/src/libasr/pass/intrinsic_subroutine.cpp
+++ b/src/libasr/pass/intrinsic_subroutine.cpp
@@ -175,7 +175,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
 };
 
 void pass_replace_intrinsic_subroutine(Allocator &al, ASR::TranslationUnit_t &unit,
-                             const LCompilers::PassOptions& /*pass_options*/) {
+                             const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     ReplaceIntrinsicSubroutines v(al);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);

--- a/src/libasr/pass/list_expr.h
+++ b/src/libasr/pass/list_expr.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_list_expr(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/loop_unroll.cpp
+++ b/src/libasr/pass/loop_unroll.cpp
@@ -100,7 +100,7 @@ public:
 };
 
 void pass_loop_unroll(Allocator &al, ASR::TranslationUnit_t &unit,
-                      const LCompilers::PassOptions& pass_options) {
+                      const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     LoopUnrollVisitor v(al, pass_options.unroll_factor);
     v.visit_TranslationUnit(unit);
 }

--- a/src/libasr/pass/loop_unroll.h
+++ b/src/libasr/pass/loop_unroll.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_loop_unroll(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/loop_vectorise.cpp
+++ b/src/libasr/pass/loop_vectorise.cpp
@@ -194,7 +194,7 @@ public:
 };
 
 void pass_loop_vectorise(Allocator &al, ASR::TranslationUnit_t &unit,
-                         const LCompilers::PassOptions& pass_options) {
+                         const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     std::string rl_path = pass_options.runtime_library_dir;
     LoopVectoriseVisitor v(al, unit, rl_path);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/loop_vectorise.h
+++ b/src/libasr/pass/loop_vectorise.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_loop_vectorise(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -855,7 +855,7 @@ public:
 };
 
 void pass_nested_vars(Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& /*pass_options*/) {
+    const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     NestedVarVisitor v(al);
     v.visit_TranslationUnit(unit);
     ReplaceNestedVisitor w(al, v.nesting_map);

--- a/src/libasr/pass/nested_vars.h
+++ b/src/libasr/pass/nested_vars.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_nested_vars(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -2370,7 +2370,7 @@ class ParallelRegionVisitor :
 };
 
 void pass_replace_openmp(Allocator &al, ASR::TranslationUnit_t &unit,
-                            const PassOptions &pass_options) {
+                            const PassOptions &pass_options, diag::Diagnostics& /*diagnostics*/) {
     if (pass_options.openmp) {
         ParallelRegionVisitor v(al, pass_options);
         v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -1064,7 +1064,7 @@ class RemoveArrayByDescriptorProceduresVisitor : public PassUtils::PassVisitor<R
 };
 
 void pass_array_by_data(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& pass_options) {
+                        const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     PassArrayByDataProcedureVisitor v(al);
     v.visit_TranslationUnit(unit);
     EditProcedureVisitor e(v);

--- a/src/libasr/pass/pass_list_expr.cpp
+++ b/src/libasr/pass/pass_list_expr.cpp
@@ -556,7 +556,7 @@ public:
 };
 
 void pass_list_expr(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& /*pass_options*/) {
+                        const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     ListExprVisitor v(al, unit);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -71,7 +71,7 @@
 namespace LCompilers {
 
     typedef void (*pass_function)(Allocator&, ASR::TranslationUnit_t&,
-                                  const LCompilers::PassOptions&);
+                                  const LCompilers::PassOptions&, diag::Diagnostics &diagnostics);
 
     class PassManager {
         private:
@@ -186,7 +186,7 @@ namespace LCompilers {
                     std::cerr << "ASR Pass starts: '" << passes[i] << "'\n";
                 }
                 auto t1 = std::chrono::high_resolution_clock::now();
-                _passes_db[passes[i]](al, *asr, pass_options);
+                _passes_db[passes[i]](al, *asr, pass_options, diagnostics);
 #if defined(WITH_LFORTRAN_ASSERT)
                 if (!asr_verify(*asr, true, diagnostics)) {
                     std::cerr << diagnostics.render2();
@@ -360,7 +360,7 @@ namespace LCompilers {
                 if (pass_options.verbose) {
                     std::cerr << "ASR Pass starts: '" << passes[i] << "'\n";
                 }
-                _passes_db[passes[i]](al, *asr, pass_options);
+                _passes_db[passes[i]](al, *asr, pass_options, diagnostics);
                 if (pass_options.dump_all_passes) {
                     std::string str_i = std::to_string(pass_cnt_asr_dump+1);
                     if ( pass_cnt_asr_dump < 9 )  str_i = "0" + str_i;

--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -348,7 +348,7 @@ public:
 };
 
 void pass_replace_print_arr(Allocator &al, ASR::TranslationUnit_t &unit,
-                            const LCompilers::PassOptions& pass_options) {
+                            const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     std::string rl_path = pass_options.runtime_library_dir;
     PrintArrVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/print_list_tuple.cpp
+++ b/src/libasr/pass/print_list_tuple.cpp
@@ -357,7 +357,7 @@ class PrintListTupleVisitor
 
 void pass_replace_print_list_tuple(
     Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions &pass_options) {
+    const LCompilers::PassOptions &pass_options, diag::Diagnostics& /*diagnostics*/) {
     std::string rl_path = pass_options.runtime_library_dir;
     PrintListTupleVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/print_struct_type.cpp
+++ b/src/libasr/pass/print_struct_type.cpp
@@ -114,7 +114,7 @@ public:
 
 void pass_replace_print_struct_type(
     Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& /*pass_options*/) {
+    const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     PrintStructVisitor v(al);
     v.visit_TranslationUnit(unit);
 }

--- a/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
+++ b/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
@@ -327,7 +327,7 @@ class FixArrayPhysicalCastVisitor: public ASR::CallReplacerOnExpressionsVisitor<
 
 void pass_promote_allocatable_to_nonallocatable(
     Allocator &al, ASR::TranslationUnit_t &unit,
-    const PassOptions &/*pass_options*/) {
+    const PassOptions &/*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     std::map<SymbolTable*, std::vector<ASR::symbol_t*>> scope2var;
     IsAllocatedCalled is_allocated_called(scope2var);
     is_allocated_called.visit_TranslationUnit(unit);

--- a/src/libasr/pass/promote_allocatable_to_nonallocatable.h
+++ b/src/libasr/pass/promote_allocatable_to_nonallocatable.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_promote_allocatable_to_nonallocatable(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_array_op.h
+++ b/src/libasr/pass/replace_array_op.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_array_op(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_array_passed_in_function_call.h
+++ b/src/libasr/pass/replace_array_passed_in_function_call.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_array_passed_in_function_call(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_class_constructor.h
+++ b/src/libasr/pass/replace_class_constructor.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_class_constructor(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_div_to_mul.h
+++ b/src/libasr/pass/replace_div_to_mul.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_div_to_mul(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_do_loops.h
+++ b/src/libasr/pass/replace_do_loops.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_flip_sign.h
+++ b/src/libasr/pass/replace_flip_sign.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_flip_sign(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_fma.h
+++ b/src/libasr/pass/replace_fma.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_fma(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_for_all.h
+++ b/src/libasr/pass/replace_for_all.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_for_all(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_function_call_in_declaration.h
+++ b/src/libasr/pass/replace_function_call_in_declaration.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_function_call_in_declaration(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_implied_do_loops.h
+++ b/src/libasr/pass/replace_implied_do_loops.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_implied_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_init_expr.h
+++ b/src/libasr/pass/replace_init_expr.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_init_expr(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_intrinsic_function.h
+++ b/src/libasr/pass/replace_intrinsic_function.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_intrinsic_function(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_intrinsic_subroutine.h
+++ b/src/libasr/pass/replace_intrinsic_subroutine.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_intrinsic_subroutine(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_openmp.h
+++ b/src/libasr/pass/replace_openmp.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_openmp(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_print_arr.h
+++ b/src/libasr/pass/replace_print_arr.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_print_arr(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_print_list_tuple.h
+++ b/src/libasr/pass/replace_print_list_tuple.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_print_list_tuple(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_print_struct_type.h
+++ b/src/libasr/pass/replace_print_struct_type.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_print_struct_type(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_select_case.h
+++ b/src/libasr/pass/replace_select_case.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_select_case(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_sign_from_value.h
+++ b/src/libasr/pass/replace_sign_from_value.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_sign_from_value(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -1052,7 +1052,7 @@ public:
 };
 
 void pass_replace_symbolic(Allocator &al, ASR::TranslationUnit_t &unit,
-                            const LCompilers::PassOptions& /*pass_options*/) {
+                            const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     ReplaceSymbolicVisitor v(al);
     v.visit_TranslationUnit(unit);
 }

--- a/src/libasr/pass/replace_symbolic.h
+++ b/src/libasr/pass/replace_symbolic.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_symbolic(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_where.h
+++ b/src/libasr/pass/replace_where.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_where(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/replace_with_compile_time_values.cpp
+++ b/src/libasr/pass/replace_with_compile_time_values.cpp
@@ -111,7 +111,7 @@ class ExprVisitor: public ASR::CallReplacerOnExpressionsVisitor<ExprVisitor> {
 
 void pass_replace_with_compile_time_values(
     Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& /*pass_options*/) {
+    const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     ExprVisitor v(al);
     // v.call_replacer_on_value = false;
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/replace_with_compile_time_values.h
+++ b/src/libasr/pass/replace_with_compile_time_values.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_replace_with_compile_time_values(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/select_case.cpp
+++ b/src/libasr/pass/select_case.cpp
@@ -237,7 +237,7 @@ public:
 };
 
 void pass_replace_select_case(Allocator &al, ASR::TranslationUnit_t &unit,
-                              const LCompilers::PassOptions& /*pass_options*/) {
+                              const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     SelectCaseVisitor v(al);
     // Each call transforms only one layer of nested loops, so we call it twice
     // to transform doubly nested loops:

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -107,7 +107,7 @@ public:
     }
 };
 void pass_replace_sign_from_value(Allocator &al, ASR::TranslationUnit_t &unit,
-                                  const LCompilers::PassOptions& pass_options) {
+                                  const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     SignFromValueVisitor sign_from_value_visitor(al, unit, pass_options);
     sign_from_value_visitor.visit_TranslationUnit(unit);
     

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -193,7 +193,7 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
 };
 
 void pass_create_subroutine_from_function(Allocator &al, ASR::TranslationUnit_t &unit,
-                                          const LCompilers::PassOptions& /*pass_options*/) {
+                                          const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     CreateFunctionFromSubroutine v(al);
     v.visit_TranslationUnit(unit);
     ReplaceFunctionCallWithSubroutineCallVisitor u(al);

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -596,7 +596,7 @@ class ReplaceSubroutineCallsWithOptionalArgumentsVisitor : public PassUtils::Pas
 
 void pass_transform_optional_argument_functions(
     Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& /*pass_options*/) {
+    const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     std::map<ASR::symbol_t*, std::vector<int32_t>> sym2optionalargidx;
     TransformFunctionsWithOptionalArguments v(al, sym2optionalargidx);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/transform_optional_argument_functions.h
+++ b/src/libasr/pass/transform_optional_argument_functions.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_transform_optional_argument_functions(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -526,7 +526,7 @@ class UniqueSymbolVisitor: public ASR::BaseWalkVisitor<UniqueSymbolVisitor> {
 
 
 void pass_unique_symbols(Allocator &al, ASR::TranslationUnit_t &unit,
-    const LCompilers::PassOptions& pass_options) {
+    const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     /*
      * This pass is applied iff the following options are passed; otherwise, return
      * MANGLING_OPTION="--all-mangling"

--- a/src/libasr/pass/unique_symbols.h
+++ b/src/libasr/pass/unique_symbols.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_unique_symbols(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/unused_functions.cpp
+++ b/src/libasr/pass/unused_functions.cpp
@@ -299,7 +299,7 @@ public:
 };
 
 void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit,
-                           const LCompilers::PassOptions& pass_options) {
+                           const LCompilers::PassOptions& pass_options, diag::Diagnostics& /*diagnostics*/) {
     bool always_run = pass_options.always_run;
     if (is_program_present(unit) || always_run) {
         for (int i=0; i < 4; i++)

--- a/src/libasr/pass/unused_functions.h
+++ b/src/libasr/pass/unused_functions.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
@@ -154,7 +154,7 @@ class ArrayDimIntrinsicCallsVisitor : public ASR::CallReplacerOnExpressionsVisit
 };
 
 void pass_update_array_dim_intrinsic_calls(Allocator &al, ASR::TranslationUnit_t &unit,
-                                           const LCompilers::PassOptions& /*pass_options*/) {
+                                           const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     ArrayDimIntrinsicCallsVisitor v(al);
     v.visit_TranslationUnit(unit);
     PassUtils::UpdateDependenciesVisitor u(al);

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.h
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_update_array_dim_intrinsic_calls(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/src/libasr/pass/where.cpp
+++ b/src/libasr/pass/where.cpp
@@ -114,7 +114,7 @@ class TransformWhereVisitor: public ASR::CallReplacerOnExpressionsVisitor<Transf
 };
 
 void pass_replace_where(Allocator &al, ASR::TranslationUnit_t &unit,
-                        const LCompilers::PassOptions& /*pass_options*/) {
+                        const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     TransformWhereVisitor v(al);
     v.visit_TranslationUnit(unit);
 }

--- a/src/libasr/pass/while_else.cpp
+++ b/src/libasr/pass/while_else.cpp
@@ -114,7 +114,7 @@ public:
 };
 
 void pass_while_else(Allocator &al, ASR::TranslationUnit_t &unit,
-                           const LCompilers::PassOptions& /*pass_options*/) {
+                           const LCompilers::PassOptions& /*pass_options*/, diag::Diagnostics& /*diagnostics*/) {
     WhileLoopVisitor v(al);
     ExitVisitor e(al);
     v.visit_TranslationUnit(unit);

--- a/src/libasr/pass/while_else.h
+++ b/src/libasr/pass/while_else.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
 void pass_while_else(Allocator &al, ASR::TranslationUnit_t &unit,
-                     const PassOptions &pass_options);
+                     const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 } // namespace LCompilers
 
 #endif // LIBASR_PASS_WHILE_ELSE_H

--- a/src/libasr/pass/wrap_global_stmts.h
+++ b/src/libasr/pass/wrap_global_stmts.h
@@ -7,7 +7,7 @@
 namespace LCompilers {
 
     void pass_wrap_global_stmts(Allocator &al, ASR::TranslationUnit_t &unit,
-                                const PassOptions &pass_options);
+                                const PassOptions &pass_options, diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers
 

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "run_dbg-runtime_stacktrace_01-dcc746e.stdout",
     "stdout_hash": "22a33b413c2a67997ddcab21f9da9c861e4c5786572ad4dcd3de3ed2",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "run_dbg-runtime_stacktrace_01-dcc746e.stderr",
+    "stderr_hash": "d7b2063ee2384904c7372e603b621a3e739faa954e5cc144f17d9b08",
     "returncode": 5
 }

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "run_dbg-runtime_stacktrace_01-dcc746e.stdout",
     "stdout_hash": "22a33b413c2a67997ddcab21f9da9c861e4c5786572ad4dcd3de3ed2",
-    "stderr": "run_dbg-runtime_stacktrace_01-dcc746e.stderr",
-    "stderr_hash": "d7b2063ee2384904c7372e603b621a3e739faa954e5cc144f17d9b08",
+    "stderr": null,
+    "stderr_hash": null,
     "returncode": 5
 }

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stderr
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stderr
@@ -1,9 +1,0 @@
-code generation error: asr_to_llvm: module failed verification. Error:
-!dbg attachment points at wrong subprogram for function
-!3 = distinct !DISubprogram(name: "expr2", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-i32 (i32, i8**)* @main
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1), !dbg !7
-!7 = !DILocation(line: 1, column: 1, scope: !8)
-!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-

--- a/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stderr
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-dcc746e.stderr
@@ -1,0 +1,9 @@
+code generation error: asr_to_llvm: module failed verification. Error:
+!dbg attachment points at wrong subprogram for function
+!3 = distinct !DISubprogram(name: "expr2", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+i32 (i32, i8**)* @main
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1), !dbg !7
+!7 = !DILocation(line: 1, column: 1, scope: !8)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+


### PR DESCRIPTION
This PR tries to throw semantic errors inplace of throwing lcompiler error. This even eliminates the printing of the stack trace.
For example
Consider the following example:
```
program idint_example
    implicit none
    real(4) :: x
    integer :: i

    x = 42.98
    i = idint(x)
end program idint_example
```

Currently we throw lcompiler exception and print the stack trace
```
 lfortran a.f90                                                                
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  File "/Users/parth1211/repos/lfortran/src/bin/lfortran.cpp", line 2726
    LCompilers::print_stack_on_segfault();
  File "/Users/parth1211/repos/lfortran/src/bin/lfortran.cpp", line 2653
    err = compile_src_to_object_file(arg_file, tmp_o, compiler_options.time_report, false,
  File "/Users/parth1211/repos/lfortran/src/bin/lfortran.cpp", line 1184
    res = fe.get_llvm3(*asr, lpm, diagnostics, infile, &time_opt);
  File "/Users/parth1211/repos/lfortran/src/lfortran/fortran_evaluator.cpp", line 391
    = asr_to_llvm(asr, diagnostics,
  File "/Users/parth1211/repos/lfortran/src/libasr/codegen/asr_to_llvm.cpp", line 11739
    pass_manager.apply_passes(al, &asr, co.po, diagnostics);
  File "/Users/parth1211/repos/lfortran/src/libasr/pass/pass_manager.h", line 318
    apply_passes(al, asr, _passes, pass_options, diagnostics, cummulative_time_taken_by_passes_in_microseconds);
  File "/Users/parth1211/repos/lfortran/src/libasr/pass/pass_manager.h", line 189
    _passes_db[passes[i]](al, *asr, pass_options);
  File "/Users/parth1211/repos/lfortran/src/libasr/pass/intrinsic_function.cpp", line 354
    v.visit_TranslationUnit(unit);
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_expr_call_replacer_visitor.h", line 39
    for (auto &a : x.m_symtab->get_scope()) {
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_base_visitor.h", line 345
    void visit_symbol(const symbol_t &b) { visit_symbol_t(b, self()); }
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_base_visitor.h", line 30
    case symbolType::Program: { v.visit_Program((const Program_t &)x); return; }
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_expr_call_replacer_visitor.h", line 51
    self().transform_stmts(xx.m_body, xx.n_body);
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_expr_call_replacer_visitor.h", line 33
    self().visit_stmt(*m_body[i]);
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_base_visitor.h", line 361
    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_base_visitor.h", line 54
    case stmtType::Assign: { v.visit_Assign((const Assign_t &)x); return; }
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_expr_call_replacer_visitor.h", line 267
    current_expr = const_cast<ASR::expr_t**>(&(x.m_value));
  File "/Users/parth1211/repos/lfortran/src/libasr/pass/intrinsic_function.cpp", line 144
    replacer.replace_expr(*current_expr);
  File "/Users/parth1211/repos/lfortran/src/libasr/asr_expr_base_replacer_visitor.h", line 2078
    self().replace_IntrinsicElementalFunction(down_cast<ASR::IntrinsicElementalFunction_t>(x));
  File "/Users/parth1211/repos/lfortran/src/libasr/pass/intrinsic_function.cpp", line 75
    global_scope, arg_types, type, new_args, x->m_overload_id);
  File "/Users/parth1211/repos/lfortran/src/libasr/pass/intrinsic_functions.h", line 3158
    throw LCompilersException("first argument of `idint` must have kind equals to 8");
LCompilersException: first argument of `idint` must have kind equals to 8
```



This PR tries to provide a better error message by elimination of returning stack trace and throwing of lcompiler exception. It is replaced with semantic error. For example:

```
lfortran a.f90                
semantic error: first argument of `idint` must have kind equals to 8
 --> a.f90:1:1 - 8:25
  |
1 |    program idint_example
  |    ^^^^^^^^^^^^^^^^^^^^^...
...
  |
8 |    end program idint_example
  | ...^^^^^^^^^^^^^^^^^^^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

This PR is an initial draft of the implementation and it might require significant refactoring, improvements and addition of error tests.
