### PR TITLE
fix: allow external symbol implementation of class procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1980,6 +1980,7 @@ RUN(NAME procedure_14 LABELS gfortran llvm)
 RUN(NAME procedure_15 LABELS gfortran llvm)
 RUN(NAME procedure_16 LABELS gfortran llvm)
 RUN(NAME procedure_17 LABELS gfortran llvm)
+RUN(NAME procedure_18 LABELS gfortran llvm)
 
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_18.f90
+++ b/integration_tests/procedure_18.f90
@@ -1,0 +1,43 @@
+module mod1_procedure_18
+  implicit none
+  private
+  public :: f_function
+
+  contains
+
+  elemental function f_function(x, y) result(fx)
+    real, intent(in) :: x
+    real, intent(in), optional :: y
+    real :: w_y
+    real :: fx
+    w_y=1.0
+    if (present(y)) w_y=y
+    fx = w_y
+  end function f_function
+end module mod1_procedure_18
+
+module mod2_procedure_18
+  use :: mod1_procedure_18
+  implicit none
+  private
+  public :: function_interface
+
+  interface function_interface
+    module procedure f_function
+  end interface
+end module mod2_procedure_18
+
+program procedure_18
+  use :: mod1_procedure_18
+  use :: mod2_procedure_18
+  implicit none
+  real :: res, eps
+  res = 0.5
+  eps = 1e-8
+  print *, "fx is ", f_function(0.8, y=0.5)
+  if (abs(f_function(0.8, y=0.5) - res) > eps) error stop
+  print *, "fx is ", function_interface(0.8, 0.5)
+  if (abs(function_interface(0.8, 0.5) - res) > eps) error stop
+  print *, "fx is ", function_interface(0.8, y=0.5)
+  if (abs(function_interface(0.8, y=0.5) - res) > eps) error stop
+end program procedure_18

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9304,7 +9304,7 @@ public:
                     bool is_nopass = false;
                     bool is_class_procedure = false;
                     for( int i = 0; i < (int) gp->n_procs; i++ ) {
-                        ASR::symbol_t* f4 = gp->m_procs[i];
+                        ASR::symbol_t* f4 = ASRUtils::symbol_get_past_external(gp->m_procs[i]);
                         if( !ASR::is_a<ASR::Function_t>(*f4) && !ASR::is_a<ASR::ClassProcedure_t>(*f4) ) {
                             diag.add(Diagnostic(std::string(ASRUtils::symbol_name(f4)) +
                             " is not a function.",


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7439