### PR TITLE
throw error when input to iachar is not unit length string

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7881,6 +7881,16 @@ public:
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, kind_value));
         ASR::expr_t* iachar_value = nullptr;
         ASR::expr_t* arg_value = ASRUtils::expr_value(arg);
+        ASR::ttype_t * arg_type = ASRUtils::expr_type(arg);
+        if (ASR::is_a<ASR::String_t>(*arg_type) ) {
+            ASR::expr_t* str_len = ASR::down_cast<ASR::String_t>(ASRUtils::expr_type(arg))->m_len;
+            int64_t len = ASR::down_cast<ASR::IntegerConstant_t>(str_len)->m_n;
+            if (len != 1) {
+                diag.add(Diagnostic("Argument of `iachar` intrinsic must be of length one",
+                                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
+        }
         if( arg_value ) {
             std::string arg_str;
             bool is_const_value = ASRUtils::is_value_constant(arg_value, arg_str);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -314,4 +314,6 @@ program continue_compilation_1
     print *, ["aa", string(x+1:x+2), "aaa"]
 
     print *, pack(arr2, mask1)
+    print *, iachar("hello")
+    print *, iachar(string)
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "789a3813606a0798ea07026e64183b74944a030663f339135a495c32",
+    "infile_hash": "6c0535a39449b024cfa62d70fe5156dedcd71ac64b7e0e7e03fa912e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "ea124a9bf70bcbdd53244d14b52bff75c3753e421823fccf28d41dc1",
+    "stderr_hash": "6831fd2d041017ea7e7c573937a4859ae39b3e04f5702616ece2aeee",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -733,3 +733,15 @@ semantic error: The argument `mask` must be of rank 2, an array with rank 1 was 
     |
 316 |     print *, pack(arr2, mask1)
     |                         ^^^^^ 
+
+semantic error: Argument of `iachar` intrinsic must be of length one
+   --> tests/errors/continue_compilation_1.f90:317:14
+    |
+317 |     print *, iachar("hello")
+    |              ^^^^^^^^^^^^^^^ 
+
+semantic error: Argument of `iachar` intrinsic must be of length one
+   --> tests/errors/continue_compilation_1.f90:318:14
+    |
+318 |     print *, iachar(string)
+    |              ^^^^^^^^^^^^^^ 


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/7582