### PR TITLE
fix: don't add procedure of ExternalSymbol to class SymbolTable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1983,6 +1983,7 @@ RUN(NAME procedure_16 LABELS gfortran llvm)
 RUN(NAME procedure_17 LABELS gfortran llvm)
 
 
+RUN(NAME procedure_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocated_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocated_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_19.f90
+++ b/integration_tests/procedure_19.f90
@@ -1,0 +1,37 @@
+module mod1_procedure_19
+
+   type :: my_type
+    real :: value = 0.0
+   contains
+      procedure :: plus
+      generic :: g_proc => plus
+   end type my_type
+
+contains
+
+   subroutine plus(self, increment)
+      class(my_type), intent(inout) :: self
+      real, intent(in) :: increment
+      self%value = self%value + increment
+   end subroutine plus
+
+end module mod1_procedure_19
+
+module mod2_procedure_19
+   use mod1_procedure_19
+end module mod2_procedure_19
+
+program procedure_19
+    use mod2_procedure_19
+    type(my_type) :: obj
+
+    real :: test_increment = 5.0
+   
+    call obj%g_proc(test_increment)
+    print *, 'After adding', test_increment, ':', obj%value
+    if (abs(obj%value - 5.0) > 1.0e-6) error stop
+   
+    call obj%g_proc(3.0)
+    print *, 'After adding 3.0:', obj%value
+    if (abs(obj%value - 8.0) > 1.0e-6) error stop
+end program procedure_19

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2388,8 +2388,14 @@ public:
             Location loc;
             loc.first = 1;
             loc.last = 1;
-            ASR::Struct_t *clss = ASR::down_cast<ASR::Struct_t>(
-                                            current_scope->get_symbol(proc.first));
+            ASR::symbol_t* proc_sym = current_scope->get_symbol(proc.first);
+            
+            // if it's an ExternalSymbol, we don't need do anything in the
+            // current translation unit, as it needs to be handled in
+            // from where it's imported from
+            if (ASR::is_a<ASR::ExternalSymbol_t>(*proc_sym)) continue;
+
+            ASR::Struct_t *clss = ASR::down_cast<ASR::Struct_t>(proc_sym);
             for (auto &pname : proc.second) {
                 Vec<ASR::symbol_t*> cand_procs;
                 cand_procs.reserve(al, pname.second.size());


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/5759