### PR TITLE
Implement visit_StructConstructor

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1954,6 +1954,27 @@ public:
         llvm::Value *item = tmp;
         tmp = list_api->count(plist, item, asr_el_type, module.get());
     }
+    void visit_StructConstructor(const ASR::StructConstructor_t &x) {
+    ASR::symbol_t *dt_sym = ASRUtils::symbol_get_past_external(x.m_type->m_derived_type);
+    ASR::StructType_t *dt = ASR::down_cast<ASR::StructType_t>(dt_sym);
+
+    llvm::Type *llvm_type = LLVMUtils::get_derived_type_from_ttype_t_util(x.m_type, context, module);
+    llvm::Value *struct_val = builder->CreateAlloca(llvm_type, nullptr);
+
+    for (size_t i = 0; i < x.n_args; i++) {
+        std::string member_name = x.m_args[i].m_name;
+        ASR::expr_t *value_expr = x.m_args[i].m_value;
+
+        this->visit_expr(*value_expr);
+        llvm::Value *val = tmp;
+
+        llvm::Value *field_ptr = LLVMUtils::create_struct_gep(struct_val, i, builder);
+
+        builder->CreateStore(val, field_ptr);
+    }
+
+    tmp = builder->CreateLoad(llvm_type, struct_val);
+    }
 
     void generate_ListIndex(ASR::expr_t* m_arg, ASR::expr_t* m_ele,
             ASR::expr_t* m_start=nullptr, ASR::expr_t* m_end=nullptr) {


### PR DESCRIPTION
fixes #7650 
This merge request implements the `visit_StructConstructor` method in the LLVM backend (`asr_to_llvm.cpp`). This function generates LLVM IR for struct constructor expressions in ASR, enabling support for initializing derived types.

### Changes Made

- Added implementation of `visit_StructConstructor` to:
  - Allocate memory for the struct
  - Evaluate and store values for each member
  - Return the constructed LLVM value

