### PR TITLE
fix: early return after temporary variable is created in replace_StructConstructor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1749,6 +1749,7 @@ RUN(NAME class_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
+RUN(NAME class_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1750,6 +1750,7 @@ RUN(NAME class_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --rea
 RUN(NAME class_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_50 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_49.f90
+++ b/integration_tests/class_49.f90
@@ -1,0 +1,32 @@
+module class_49_m_1
+    implicit none
+
+    type base
+        integer :: m = 1
+    end type
+end module
+
+module class_49_m_2
+    use class_49_m_1, only: base
+
+    type, extends(base) :: derived
+        integer :: n = 2
+    end type
+end module
+
+program class_49
+    use class_49_m_1, only: base
+    use class_49_m_2, only: derived
+
+    class(base), allocatable :: b
+    allocate(derived :: b)
+    b = derived(10, 20)
+
+    select type(b)
+        type is (derived)
+            if (b%m /= 10) error stop
+            if (b%n /= 20) error stop
+        class default
+            error stop
+    end select
+end program

--- a/integration_tests/class_50.f90
+++ b/integration_tests/class_50.f90
@@ -1,0 +1,52 @@
+module class_50_m_1
+   private
+
+   type, public, abstract :: Addition
+   contains
+      procedure(addto), deferred :: addto
+   end type Addition
+
+   abstract interface
+      subroutine addto(self,a)
+         import
+         class(Addition), intent(in)    :: self
+         integer,         intent(inout) :: a
+      end subroutine addto
+   end interface
+
+end module class_50_m_1
+
+module class_50_m_2
+   use class_50_m_1, only: Addition
+   private
+
+   type, public, extends(Addition) :: AdderClass
+   contains
+      procedure :: addto
+   end type AdderClass
+
+contains
+
+   subroutine addto(self,a)
+      class(AdderClass), intent(in)    :: self
+      integer,           intent(inout) :: a
+      a = a + 3
+   end subroutine addto
+
+end module class_50_m_2
+
+program class_50
+
+   use class_50_m_1,    only: Addition
+   use class_50_m_2,    only: AdderClass
+
+   integer :: a
+   class(Addition), allocatable :: adder
+
+   a = 1
+   adder = AdderClass()
+
+   call adder%addto(a)
+
+   if (a /= 4) error stop
+end program class_50

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2246,7 +2246,7 @@ namespace LCompilers {
                         dest = create_gep2(name2dertype[struct_sym->m_name], dest, 0);
 
                         ASR::Struct_t* parent_struct_type_t =
-                            ASR::down_cast<ASR::Struct_t>(struct_sym->m_parent);
+                            ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(struct_sym->m_parent));
 
                         der_type_name = parent_struct_type_t->m_name;
                         struct_sym = parent_struct_type_t;

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -658,12 +658,6 @@ namespace LCompilers {
             ASR::cast_kindType cast_kind=ASR::cast_kindType::IntegerToInteger,
             ASR::ttype_t* casted_type=nullptr,
             bool realloc_lhs=false) {
-            if( x->n_args == 0 ) {
-                if( !inside_symtab ) {
-                    remove_original_statement = true;
-                }
-                return ;
-            }
             if( replacer->result_var == nullptr ) {
                 std::string result_var_name = replacer->current_scope->get_unique_name("temp_struct_var__");
                 replacer->result_var = PassUtils::create_auxiliary_variable(x->base.base.loc,
@@ -675,6 +669,9 @@ namespace LCompilers {
                 } else {
                     remove_original_statement = true;
                 }
+            }
+            if( x->n_args == 0 ) {
+                return;
             }
 
             std::deque<ASR::symbol_t*> constructor_arg_syms;


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/2940

First commit is fixing a bug I found.