### PR TITLE
fix: bitcast class allocatable to required type and do automatic allocation of StructType in backend instead of ASR

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1758,6 +1758,7 @@ RUN(NAME class_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --rea
 RUN(NAME class_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_50 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_51 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_52 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_52.f90
+++ b/integration_tests/class_52.f90
@@ -1,0 +1,29 @@
+module class_52_m
+   type, abstract :: AbsType
+       integer :: n = 10
+   end type AbsType
+
+   type, extends(AbsType) :: MyType
+   end type MyType
+
+   interface MyType
+      procedure :: init
+   end interface MyType
+
+contains
+
+   function init() result(self)
+      type(MyType) :: self
+      self%n = 44
+   end function init
+
+end module class_52_m
+
+program class_52
+   use class_52_m
+
+   class(AbsType), allocatable :: obj
+   obj = MyType()
+
+   if (obj%n /= 44) error stop
+end program class_52

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3394,51 +3394,6 @@ public:
 
         ASRUtils::make_ArrayBroadcast_t_util(al, x.base.base.loc, target, value);
 
-        // insert `Allocate` node for `class` / `type` variables when `value` is `FunctionCall`
-        // returning a `class` / `type` var
-        if (ASRUtils::is_allocatable(target) && !ASRUtils::is_array(target_type)
-            && ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(target_type))
-            && !ASRUtils::is_allocatable(value) && ASR::is_a<ASR::FunctionCall_t>(*value)
-            && !ASRUtils::is_array(target_type)
-            && ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(value_type))
-            && compiler_options.po.realloc_lhs) {
-            Vec<ASR::alloc_arg_t> alloc_args;
-            alloc_args.reserve(al, 1);
-            ASR::alloc_arg_t alloc_arg;
-            alloc_arg.loc = target->base.loc;
-            alloc_arg.m_a = target;
-            alloc_arg.m_dims = nullptr;
-            alloc_arg.n_dims = 0;
-
-            if (ASRUtils::is_class_type(ASRUtils::extract_type(target_type))
-                && !ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(value_type))) {
-                alloc_arg.m_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(
-                    al,
-                    target->base.loc,
-                    ASR::down_cast<ASR::StructType_t>(ASRUtils::extract_type(target_type))
-                        ->m_derived_type));
-            } else {
-                alloc_arg.m_type = ASRUtils::extract_type(value_type);
-            }
-
-            alloc_arg.m_len_expr = nullptr;
-            alloc_args.push_back(al, alloc_arg);
-
-            Vec<ASR::expr_t*> dealloc_args; 
-            dealloc_args.reserve(al, 1);
-            dealloc_args.push_back(al, target);
-
-            current_body->push_back(al,
-                                    ASRUtils::STMT(ASR::make_ExplicitDeallocate_t(
-                                        al, target->base.loc, dealloc_args.p, 1)));
-
-            current_body->push_back(al,
-                                    ASRUtils::STMT(ASR::make_Allocate_t(
-                                        al, target->base.loc, alloc_args.p, 1,
-                                        nullptr, nullptr, nullptr)));
-        }
-
-
         tmp = ASRUtils::make_Assignment_t_util(al, x.base.base.loc, target, value,
                             overloaded_stmt, compiler_options.po.realloc_lhs);
     }


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7707

Also revert a change from https://github.com/lfortran/lfortran/pull/7700, which inserted `Allocate` in ASR. Instead use `check_and_allocate()` in llvm backend.