### PR TITLE
enh: trim trailing spaces from the form & status of `open`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1702,6 +1702,7 @@ RUN(NAME file_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME file_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_33.f90
+++ b/integration_tests/file_33.f90
@@ -1,0 +1,20 @@
+program file_33
+    implicit none
+
+    integer :: unit_no, iostat
+    character(len=100) :: filename, form, status, iomsg
+
+    filename = 'file_33_data.txt'
+
+    form = 'formatted   '
+    status = 'replace'
+    open(newunit=unit_no, file=filename, form=form, status=status, iostat=iostat, iomsg=iomsg)
+    if (iostat /= 0) error stop iomsg
+    close(unit_no)
+
+    form = 'formatted'
+    status = 'replace   '
+    open(newunit=unit_no, file=filename, form=form, status=status, iostat=iostat, iomsg=iomsg)
+    if (iostat /= 0) error stop iomsg
+    close(unit_no)
+end program file_33

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -372,6 +372,18 @@ public:
                 if(ASRUtils::is_descriptorString(ASRUtils::expr_type(a_status))){
                     a_status = ASRUtils::cast_string_descriptor_to_pointer(al, a_status);
                 }
+                if (ASR::is_a<ASR::StringConstant_t>(*a_status)) {
+                    std::string str = std::string(ASR::down_cast<ASR::StringConstant_t>(a_status)->m_s);
+                    rtrim(str);
+                    a_status = ASRUtils::EXPR(ASR::make_StringConstant_t(
+                                al, x.base.base.loc, s2c(al, str),
+                                ASRUtils::TYPE(ASR::make_String_t(
+                                    al, a_status->base.loc, 1,
+                                    ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, a_status->base.loc, str.length(),
+                                        ASRUtils::TYPE(ASR::make_Integer_t(al, a_status->base.loc, 4)))),
+                                    ASR::string_length_kindType::ExpressionLength,
+                                    ASR::string_physical_typeType::PointerString))));
+                }
             } else if( m_arg_str == std::string("form") ) {
                 if ( a_form != nullptr ) {
                     diag.add(Diagnostic(
@@ -396,7 +408,18 @@ public:
                 if(ASRUtils::is_descriptorString(ASRUtils::expr_type(a_form))){
                     a_form = ASRUtils::cast_string_descriptor_to_pointer(al, a_form);
                 }
-
+                if (ASR::is_a<ASR::StringConstant_t>(*a_form)) {
+                    std::string str = std::string(ASR::down_cast<ASR::StringConstant_t>(a_form)->m_s);
+                    rtrim(str);
+                    a_form = ASRUtils::EXPR(ASR::make_StringConstant_t(
+                                al, x.base.base.loc, s2c(al, str),
+                                ASRUtils::TYPE(ASR::make_String_t(
+                                    al, a_form->base.loc, 1,
+                                    ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, a_form->base.loc, str.length(),
+                                        ASRUtils::TYPE(ASR::make_Integer_t(al, a_form->base.loc, 4)))),
+                                    ASR::string_length_kindType::ExpressionLength,
+                                    ASR::string_physical_typeType::PointerString))));
+                }
             } else if( m_arg_str == std::string("access") ) {  //TODO: Handle 'direct' as access argument
                 if ( a_access != nullptr ) {
                     diag.add(Diagnostic(

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3579,6 +3579,26 @@ LFORTRAN_API int64_t _lfortran_open(int32_t unit_num, char *f_name, char *status
         *(end + 1) = '\0';
     }
 
+    len = strlen(status);
+    if (*(status + len - 1) == ' ') {
+        // trim trailing spaces
+        char* end = status + len - 1;
+        while (end > status && isspace((unsigned char) *end)) {
+            end--;
+        }
+        *(end + 1) = '\0';
+    }
+
+    len = strlen(form);
+    if (*(form + len - 1) == ' ') {
+        // trim trailing spaces
+        char* end = form + len - 1;
+        while (end > form && isspace((unsigned char) *end)) {
+            end--;
+        }
+        *(end + 1) = '\0';
+    }
+
     _lfortran_inquire(f_name, file_exists, -1, NULL, NULL, NULL);
     char *access_mode = NULL;
     /*


### PR DESCRIPTION
Fixes: #7750 

- Remove the trailing spaces from the `form` and `status` both argument of `open` statement