### PR TITLE
fix: don't create temporary variable when intent is inout or out

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -441,6 +441,7 @@ RUN(NAME subroutines_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME subroutines_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME subroutines_18 LABELS gfortran llvm)
 RUN(NAME subroutines_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME subroutines_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME functions_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm mlir fortran)
 RUN(NAME functions_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)

--- a/integration_tests/class_38.f90
+++ b/integration_tests/class_38.f90
@@ -9,8 +9,8 @@ program class_38
 
     type(regex_pattern) :: my_pattern
     call temp(my_pattern%pattern)
-    ! TODO: issue
-    ! if (my_pattern%pattern(1)%ccl /= 'abc' .or. my_pattern%pattern(2)%ccl /= 'def') error stop
+
+    if (my_pattern%pattern(1)%ccl /= 'abc' .or. my_pattern%pattern(2)%ccl /= 'def') error stop
 contains 
     subroutine temp(pattern)
         type(regex_token), dimension(:), intent(out) :: pattern

--- a/integration_tests/subroutines_20.f90
+++ b/integration_tests/subroutines_20.f90
@@ -1,0 +1,19 @@
+program subroutines_20
+     type :: regex_token
+        character(len=:), allocatable :: ccl
+    end type regex_token
+
+    type :: regex_pattern
+        type(regex_token) :: pattern
+    end type regex_pattern
+
+    type(regex_pattern) :: my_pattern
+    call temp(my_pattern%pattern)
+
+    if (my_pattern%pattern%ccl /= "abc") error stop
+contains
+    subroutine temp(pattern)
+        type(regex_token), intent(out) :: pattern
+        pattern%ccl = 'abc'
+    end subroutine temp
+end program


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7562

Also uncomment a todo in `class_38.f90`.