### PR TITLE
enh: add `iostat_eor` in `iso_fortran_env`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1787,7 +1787,6 @@ RUN(NAME test_iso_fortran_env LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm
 RUN(NAME test_ieee_arithmetic LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_ieee_arithmetic_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME iso_fortran_env_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
-RUN(NAME iso_fortran_env_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 
 RUN(NAME abs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran mlir)

--- a/integration_tests/iso_fortran_env_01.f90
+++ b/integration_tests/iso_fortran_env_01.f90
@@ -1,5 +1,11 @@
 program iso_fortran_env_01
-    use iso_fortran_env, only: numeric_storage_size
+    use iso_fortran_env, only: numeric_storage_size, character_storage_size, iostat_eor
     print *, "numeric_storage_size: ", numeric_storage_size
     if (numeric_storage_size /= 32) error stop
+
+    print *, "character_storage_size: ", character_storage_size
+    if (character_storage_size /= 8) error stop
+
+    print *, "iostat_eor: ", iostat_eor
+    if (iostat_eor /= -2) error stop
 end program

--- a/integration_tests/iso_fortran_env_02.f90
+++ b/integration_tests/iso_fortran_env_02.f90
@@ -1,5 +1,0 @@
-program iso_fortran_env_02
-    use iso_fortran_env, only: character_storage_size
-    print *, "character_storage_size: ", character_storage_size
-    if (character_storage_size /= 8) error stop
-end program

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -19,6 +19,7 @@ integer, parameter :: character_kinds(1) = [1]
 integer, parameter :: logical_kinds(1) = [4]
 
 integer, parameter :: iostat_end = -1
+integer, parameter :: iostat_eor = -2
 
 integer, parameter :: numeric_storage_size = 32
 integer, parameter :: character_storage_size = 8

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.json
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nested_struct_proc_01-3b9017b.stdout",
-    "stdout_hash": "1906c1c4098481d71ec12fe65a44395b1533249ca61034a5f683a568",
+    "stdout_hash": "3b6a456e5b180c55d041addf56ba0240653a4ba92c770de15ae01e37",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
@@ -198,6 +198,16 @@
                                     iostat_end
                                     Public
                                 ),
+                            iostat_eor:
+                                (ExternalSymbol
+                                    2
+                                    iostat_eor
+                                    4 iostat_eor
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    iostat_eor
+                                    Public
+                                ),
                             logical_kinds:
                                 (ExternalSymbol
                                     2
@@ -1030,6 +1040,16 @@
                                     lfortran_intrinsic_iso_fortran_env
                                     []
                                     iostat_end
+                                    Public
+                                ),
+                            iostat_eor:
+                                (ExternalSymbol
+                                    11
+                                    iostat_eor
+                                    4 iostat_eor
+                                    lfortran_intrinsic_iso_fortran_env
+                                    []
+                                    iostat_eor
                                     Public
                                 ),
                             key:


### PR DESCRIPTION
Fixes #7796 