### PR TITLE
CI: try running "Test Fortran backend" in parallel

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -951,8 +951,8 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            ./run_tests.py -b fortran -j1
-            ./run_tests.py -b fortran -f -j1
+            ./run_tests.py -b fortran -j2
+            ./run_tests.py -b fortran -f -j2
 
       - name: Test C/C++ Backend
         shell: bash -e -l {0}


### PR DESCRIPTION
## Description

This is just an attempt to see what happens when I do this at our CI, I expect this to fail currently with an error something like:
```console
f951: Fatal Error: Cannot rename module file 'lfortran_intrinsic_iso_fortran_env.mod0' to 'lfortran_intrinsic_iso_fortran_env.mod': No such file or directory
compilation terminated.
The command 'gfortran -fno-backtrace -o CMakeFiles/intrinsics_228.dir/intrinsics_228.f90.o -c CMakeFiles/intrinsics_228.dir/intrinsics_228.f90.o.tmp.f90' failed.
make[2]: *** [CMakeFiles/intrinsics_228.dir/intrinsics_228.f90.o] Error 11
make[1]: *** [CMakeFiles/intrinsics_228.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

