### PR TITLE
feat: throw char length mismatch for ichar in AST->ASR

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -6744,8 +6744,17 @@ class RemoveArrayProcessingNodeVisitor: public ASR::CallReplacerOnExpressionsVis
 
         ASR::CallReplacerOnExpressionsVisitor<RemoveArrayProcessingNodeVisitor>::visit_ArrayPhysicalCast(x);
     }
-
 };
+
+static inline int64_t get_fixed_string_len(const ASR::ttype_t* type_t) {
+    if (ASR::is_a<ASR::String_t>(*type_t)) {
+        ASR::expr_t* len_expr = ASR::down_cast<ASR::String_t>(type_t)->m_len;
+        if (len_expr && ASR::is_a<ASR::IntegerConstant_t>(*len_expr)) {
+            return ASR::down_cast<ASR::IntegerConstant_t>(len_expr)->m_n;
+        }
+    }
+    return -1;
+}
 
 } // namespace ASRUtils
 

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4969,13 +4969,8 @@ namespace StringTrim {
 namespace Ichar {
 
     static ASR::expr_t *eval_Ichar(Allocator &al, const Location &loc,
-            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
         char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        int64_t len = std::strlen(str);
-        if (len != 1) {
-            append_error(diag, "Argument to Ichar must have length one", loc);
-            return nullptr;
-        }
         char first_char = str[0];
         int result = (int)first_char;
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);

--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -198,7 +198,7 @@ program continue_compilation_2
     integer  :: ? tokenizer_error
     integer, dimension(3,2) :: m = [ 1, 0, 0, 2, 4, 6 ]
     real :: idint_kind_mismatch = 4.23
-
+    character(5):: ichar_runtime = "Hello"
 
 
 
@@ -439,6 +439,8 @@ program continue_compilation_2
     !idint_kind_mismatch
     print *, idint(4.23)
     print *, idint(idint_kind_mismatch)
+    !ichar_runtime
+    print *, ichar(ichar_runtime)
 
     contains
     logical function f(x)

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "f18ddbb4e7d147216232e27d3a1f2ab34ba2a27a150c5cf84a139159",
+    "infile_hash": "7c3002eac205c51b4bdc7486f97467556f147daf51f31f578aa5cf9b",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "6f547831edb8d167d549459225e53861e5f593822c2a5f306ac53174",
+    "stderr_hash": "822df7e830353810fdd3b7ecc0f009080f2c1d244937ebf9dedc1f70",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -509,7 +509,7 @@ semantic error: Type mismatch in argument at argument (1); passed `real` to `int
 334 |     print *, f(42.9)
     |                ^^^^ 
 
-semantic error: Argument to Ichar must have length one
+semantic error: Argument 1 to Ichar must have length 1
    --> tests/errors/continue_compilation_2.f90:336:13
     |
 336 |     print*, ichar("okay")
@@ -766,3 +766,9 @@ semantic error: first argument of `idint` must have kind equals to 8
     |
 441 |     print *, idint(idint_kind_mismatch)
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Argument 1 to Ichar must have length 1
+   --> tests/errors/continue_compilation_2.f90:443:14
+    |
+443 |     print *, ichar(ichar_runtime)
+    |              ^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-ichar_01-a5284c8.json
+++ b/tests/reference/asr-ichar_01-a5284c8.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-ichar_01-a5284c8.stderr",
-    "stderr_hash": "39fa0fd619eefdd58820aa626fe827781f0b7740476d6ef6a772af15",
+    "stderr_hash": "acd2bd0eb673fed1e139af2f060958c180fba50a2fa022469790cb0e",
     "returncode": 2
 }

--- a/tests/reference/asr-ichar_01-a5284c8.stderr
+++ b/tests/reference/asr-ichar_01-a5284c8.stderr
@@ -1,4 +1,4 @@
-semantic error: Argument to Ichar must have length one
+semantic error: Argument 1 to Ichar must have length 1
  --> tests/errors/ichar_01.f90:3:13
   |
 3 |     print*, ichar("okay")


### PR DESCRIPTION
Resolves: https://github.com/lfortran/lfortran/issues/3734

**Enhancements to ASR utilities:**

- Added the get_fixed_string_len function in src/libasr/asr_utils.h to retrieve the fixed length of a string type, or return -1 otherwise.

**Intrinsic function validation improvements:**

- Introduced a `char_len_validation` field in `src/libasr/intrinsic_func_registry_util_gen.py` to specify constraints on string argument lengths for intrinsic functions.

- Added logic in `add_create_func_arg_type_src` to enforce string length constraints during argument validation, leveraging the `get_fixed_string_len` utility.

The design structure
```
"char_len_validation": [{0: {0: {"min": 1, "max": 1}}}]
```
First Key 0 -> It tells us the index of the argument whose char length needs to be validated.
The key–value pair {0: {"min": 1, "max": 1}} indicates that the 0th argument is expected to have min length 1 and max length 1.