### PR TITLE
enh: populate all intrinsic op types in hashmap

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1380,6 +1380,7 @@ RUN(NAME operator_overloading_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_12.f90
+++ b/integration_tests/operator_overloading_12.f90
@@ -1,0 +1,36 @@
+module module_operator_overloading_12
+  implicit none
+
+  public :: operator(.and.)
+
+  interface operator(.and.)
+    elemental module function and(lhs, rhs) result(diagnosis)
+      implicit none
+      integer, intent(in) :: lhs, rhs
+      integer :: diagnosis
+    end function
+  end interface
+contains
+
+  elemental module function and(lhs, rhs) result(diagnosis)
+    implicit none
+    integer, intent(in) :: lhs, rhs
+    integer :: diagnosis
+
+    diagnosis = lhs + rhs
+  end function and
+
+end module module_operator_overloading_12
+
+program operator_overloading_12
+  use module_operator_overloading_12, only: operator(.and.)
+  implicit none
+
+  integer :: a, b, c
+
+  a = 5
+  b = 5
+  c = a .and. b
+  print *, "The result of a .and. b is:", c
+  ! if ( c /= 10 ) error stop ! this fails with LFortran, need to introduce OverLoadedBoolOp
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1125,15 +1125,23 @@ public:
 
     std::map<AST::intrinsicopType, std::string> intrinsic2str = {
         {AST::intrinsicopType::STAR, "~mul"},
+        {AST::intrinsicopType::AND, "~and"},
+        {AST::intrinsicopType::OR, "~or"},
+        {AST::intrinsicopType::XOR, "~xor"},
+        {AST::intrinsicopType::EQV, "~eqv"},
+        {AST::intrinsicopType::NEQV, "~neqv"},
         {AST::intrinsicopType::PLUS, "~add"},
+        {AST::intrinsicopType::MINUS, "~sub"},
+        {AST::intrinsicopType::STAR, "~mul"},
         {AST::intrinsicopType::DIV, "~div"},
+        {AST::intrinsicopType::POW, "~pow"},
+        {AST::intrinsicopType::NOT, "~not"},
         {AST::intrinsicopType::EQ, "~eq"},
         {AST::intrinsicopType::NOTEQ, "~noteq"},
         {AST::intrinsicopType::LT, "~lt"},
         {AST::intrinsicopType::LTE, "~lte"},
         {AST::intrinsicopType::GT, "~gt"},
         {AST::intrinsicopType::GTE, "~gte"},
-        {AST::intrinsicopType::MINUS, "~sub"},
         {AST::intrinsicopType::CONCAT, "~concat"}
     };
 


### PR DESCRIPTION
Fixes #7815.