### PR TITLE
fix: allow intrinsic operator overloading for "OR", "AND"

### DIFF
--- a/integration_tests/operator_overloading_12.f90
+++ b/integration_tests/operator_overloading_12.f90
@@ -1,0 +1,84 @@
+module operator_overloading_12_module_1
+  implicit none
+
+  public :: operator(.and.)
+  public :: operator(.or.)
+  ! TODO later
+  !public :: operator(.eor.)
+  public :: operator(.eqv.)
+
+  interface operator(.and.)
+    function and(lhs, rhs) result(diagnosis)
+      implicit none
+      integer, intent(in) :: lhs, rhs
+      integer diagnosis
+    end function
+  end interface
+
+  interface operator(.or.)
+    function or(lhs, rhs) result(diagnosis)
+      implicit none
+      integer, intent(in) :: lhs, rhs
+      integer diagnosis
+    end function
+  end interface
+
+  interface operator(.eqv.)
+    function eqv(lhs, rhs) result(diagnosis)
+      implicit none
+      integer, intent(in) :: lhs, rhs
+      integer diagnosis
+    end function
+  end interface
+
+end module operator_overloading_12_module_1
+
+function and(lhs, rhs) result(diagnosis)
+  implicit none
+  integer, intent(in) :: lhs, rhs
+  integer :: diagnosis
+  ! bitwise AND operation
+  diagnosis = iand(lhs, rhs)
+end function and
+
+function or(lhs, rhs) result(diagnosis)
+  implicit none
+  integer, intent(in) :: lhs, rhs
+  integer :: diagnosis
+  diagnosis = ior(lhs, rhs)
+end function
+
+function eqv(lhs, rhs) result(diagnosis)
+  implicit none
+  integer, intent(in) :: lhs, rhs
+  integer :: diagnosis
+  diagnosis = 0
+  if (lhs == rhs) diagnosis = 1
+end function
+
+program operator_overloading_12
+  use operator_overloading_12_module_1
+  implicit none
+  integer :: a, b, result
+
+  a = 15
+  b = 10
+  result = a .and. b
+  print *, '15 .and. 10 = ', result
+  if (result /= 10) error stop
+
+  result = a .or. b
+  print *, "15 .or. 10 = ", result
+  if (result /= 15) error stop
+
+  ! TODO: the below doesn't give correct output
+  ! result = a .eqv. b
+  ! print *, "15 .eqv. 10 = ", result
+  ! if (result /= 0) error stop
+
+  ! a = 10
+  ! b = 10
+  ! result = a .eqv. b
+  ! print *, "10 .eqv. 10 = ", result
+  ! if (result /= 1) error stop
+end program operator_overloading_12

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1124,6 +1124,9 @@ public:
     };
 
     std::map<AST::intrinsicopType, std::string> intrinsic2str = {
+        {AST::intrinsicopType::AND, "~and"},
+        {AST::intrinsicopType::OR, "~or"},
+        {AST::intrinsicopType::EQV, "~eqv"},
         {AST::intrinsicopType::STAR, "~mul"},
         {AST::intrinsicopType::PLUS, "~add"},
         {AST::intrinsicopType::DIV, "~div"},

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2049,7 +2049,9 @@ public:
                 visit_interface_item(*x.m_items[i]);
             }
         } else if (AST::is_a<AST::InterfaceHeaderOperator_t>(*x.m_header)) {
-            std::string op = intrinsic2str[AST::down_cast<AST::InterfaceHeaderOperator_t>(x.m_header)->m_op];
+            AST::InterfaceHeaderOperator_t* iho = AST::down_cast<AST::InterfaceHeaderOperator_t>(x.m_header);
+            std::string op = intrinsic2str[iho->m_op];
+            LCOMPILERS_ASSERT(op != "")
             std::vector<std::string> proc_names;
             fill_interface_proc_names(x, proc_names);
             // check if the operator is already defined, if yes, then a new defition means it is being overloaded


### PR DESCRIPTION
## Description

Fixes https://github.com/lfortran/lfortran/issues/7815

We should add more tests for other intrinsic operator overloaded functions, like the ones which are added in this PR, and they might reveal more bugs.

I'll take a look at some after this.