### PR TITLE
fix: lower `remote_sym` name before checking it in symbol table

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1380,6 +1380,7 @@ RUN(NAME operator_overloading_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/operator_overloading_13.f90
+++ b/integration_tests/operator_overloading_13.f90
@@ -1,0 +1,46 @@
+module operator_overloading_13_module
+  implicit none
+  private
+  public :: operator(.separatedBy.)
+
+  interface operator(.separatedBy.)
+    module function strings_with_separator(sep, strings) result(csv)
+      implicit none
+      character(len=*), intent(in) :: sep
+      character(len=*), dimension(:), intent(in) :: strings
+      character(len=:), allocatable :: csv
+    end function
+  end interface
+
+contains
+
+  module function strings_with_separator(sep, strings) result(csv)
+    implicit none
+    character(len=*), intent(in) :: sep
+    character(len=*), dimension(:), intent(in) :: strings
+    character(len=:), allocatable :: csv
+
+    integer :: i
+    character(len=:), allocatable :: temp
+
+    csv = ""
+    do i = 1, size(strings)
+      if (i > 1) csv = csv // sep
+      csv = csv // trim(strings(i))
+    end do
+  end function
+
+end module operator_overloading_13_module
+
+program operator_overloading_13
+  use operator_overloading_13_module, only: operator(.separatedBy.)
+  implicit none
+
+  character(len=:), allocatable :: csv
+  character(len=*), dimension(3), parameter :: strings = ["abc", "def", "ghi"]
+
+  csv = "," .separatedBy. strings
+  print *, "CSV Result: ", trim(csv)
+  if (trim(csv) /= "abc,def,ghi") error stop
+
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2868,6 +2868,7 @@ public:
                              std::string& remote_sym, std::string& local_sym,
                              std::queue<std::pair<std::string, std::string>>& to_be_imported_later,
                              const Location& loc) {
+        remote_sym = to_lower(remote_sym);
         ASR::symbol_t *t = m->m_symtab->resolve_symbol(remote_sym);
         if (!t) {
             diag.add(diag::Diagnostic(


### PR DESCRIPTION
Fixes #7823.