### PR TITLE
CI: Enable test for logger & remove all workaround of array

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -205,8 +205,8 @@ time_section "🧪 Testing stdlib (Less Workarounds)" '
   cd stdlib-fortran-lang
   export PATH="$(pwd)/../src/bin:$PATH"
 
-  git checkout n-lf-13
-  git checkout 81d1d1f57035a47798a3b27f813454e7b5ee72b9
+  git checkout n-lf-15
+  git checkout f41b4af9cf23ad604b2297e98cee5dd481f96b04
   micromamba install -c conda-forge fypp
 
   git clean -fdx

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -206,7 +206,7 @@ time_section "🧪 Testing stdlib (Less Workarounds)" '
   export PATH="$(pwd)/../src/bin:$PATH"
 
   git checkout n-lf-15
-  git checkout f41b4af9cf23ad604b2297e98cee5dd481f96b04
+  git checkout be22847d0c0d337d698b3304edd9989e9ee52b07
   micromamba install -c conda-forge fypp
 
   git clean -fdx


### PR DESCRIPTION
This PR:
- Add test for the `stdlib_logger`
- Remove all workaround from `stdlib_array` & enable example for the `stdlib_array`