### PR TITLE
test: check to see if warning is treated as error in LFortran CI job

### DIFF
--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -2418,6 +2418,7 @@ class ParallelRegionVisitor :
             std::pair<std::string, ASR::symbol_t*> task_data_module = create_thread_data_module(task_data_symbols, loc, "task_data_struct");
             // Create required modules (iso_c_binding and omp_lib)
             std::vector<ASR::symbol_t*> module_symbols = create_modules_for_lcompilers_function(loc);
+            ASR::expr_t* var = nullptr;
 
             // Create external symbol for the task data module
             ASR::symbol_t* task_data_ext_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(al, loc,


### PR DESCRIPTION
## Description

I noticed that in CI run: https://github.com/lfortran/lfortran/actions/runs/15781257027/job/44487211232, we got an error:
```
FAILED: src/libasr/CMakeFiles/asr.dir/pass/openmp.cpp.o 
sccache /usr/bin/c++ -DHAVE_TARGET_X86=1 -DHAVE_WHEREAMI=1 -DHAVE_ZLIB=1 -DLCOMPILERS_FAST_ALLOC=1 -I/home/runner/work/lfortran/lfortran/src/libasr/.. -isystem /home/runner/micromamba/envs/lf/include -Werror -Wall -Wextra -O3 -funroll-loops -DNDEBUG -std=gnu++17 -fPIC -fno-rtti -MD -MT src/libasr/CMakeFiles/asr.dir/pass/openmp.cpp.o -MF src/libasr/CMakeFiles/asr.dir/pass/openmp.cpp.o.d -o src/libasr/CMakeFiles/asr.dir/pass/openmp.cpp.o -c /home/runner/work/lfortran/lfortran/src/libasr/pass/openmp.cpp
/home/runner/work/lfortran/lfortran/src/libasr/pass/openmp.cpp: In member function ‘LCompilers::ASR::symbol_t* LCompilers::ParallelRegionVisitor::create_lcompilers_function_for_parallel(const LCompilers::Location&, const LCompilers::ASR::OMPRegion_t&, std::map<std::pair<std::__cxx11::basic_string<char>, bool>, LCompilers::ASR::ttype_t*>&, const std::string&, std::vector<LCompilers::ASR::symbol_t*, std::allocator<LCompilers::ASR::symbol_t*> >&)’:
/home/runner/work/lfortran/lfortran/src/libasr/pass/openmp.cpp:2420:30: error: unused variable ‘var’ [-Werror=unused-variable]
 2420 |                 ASR::expr_t* var = b.Variable(current_scope, it.first.first, var_type, ASR::intentType::Local, ASR::abiType::BindC);
      |                              ^~~
```

where in the build process warning was treated as an error, but only the CI job *Check Release build* failed (which is a part of *Exhaustive Checks*), but I was expecting *LFortran CI ubuntu (and macOS and windows)* (i.e. Quick Check) to fail, but it didn't, I would like to see with this PR first whether it fails or not again.

If it doesn't fail, we have a bug in our CI I think.