### PR TITLE
feat: add lcompiler assert for `mergebits` intrinsic

### DIFF
--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4183,12 +4183,8 @@ namespace Mergebits {
         auto mask = declare("m", arg_types[0], Local);
         auto numberofbits = declare("n", arg_types[0], Local);
 
-        if(ASRUtils::extract_kind_from_ttype_t(arg_types[0]) != ASRUtils::extract_kind_from_ttype_t(arg_types[1])){
-            throw LCompilersException("The second argument of 'merge_bits' intrinsic must be the same type and kind as first argument");
-        }
-        if(ASRUtils::extract_kind_from_ttype_t(arg_types[0]) != ASRUtils::extract_kind_from_ttype_t(arg_types[2])){
-            throw LCompilersException("The third argument of 'merge_bits' intrinsic must be the same type and kind as first argument");
-        }
+        LCOMPILERS_ASSERT(ASRUtils::extract_kind_from_ttype_t(arg_types[0]) == ASRUtils::extract_kind_from_ttype_t(arg_types[1]));
+        LCOMPILERS_ASSERT(ASRUtils::extract_kind_from_ttype_t(arg_types[0]) == ASRUtils::extract_kind_from_ttype_t(arg_types[2]));
 
         body.push_back(al, b.Assignment(result, b.i_t(0, arg_types[0])));
         body.push_back(al, b.Assignment(itr, b.i_t(0, arg_types[0])));

--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -62,8 +62,8 @@ program continue_compilation_3
         integer :: xx
     end type
     type(t) :: y
-
-
+    integer :: merge_i = 4, merge_j = 5
+    integer(8) :: merge_k = 8
 
 
 
@@ -172,6 +172,9 @@ program continue_compilation_3
     do i_incorrect_pragma = 1, 10
         print *, i_incorrect_pragma
     end do
+    !merge_bits
+    print *, merge_bits(1, 2, 3_8)
+    print *, merge_bits(merge_i,merge_j,merge_k)
 
     contains 
     subroutine bpe()

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "3372ed97d71f10242ad9a94fac0433da8d3a4beef6aa9aaaa659bcc3",
+    "infile_hash": "157f37eb046b08fd8f22ee033a002341745153fc37dc5adcc2534abe",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "c2ab491bfe0eb25580d4d9dac4d949d6baa4d21314929413ef7ca5a8",
+    "stderr_hash": "ab5be0cd1ff8893c8249352f49b67f9632620dfd529f801860545014",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -259,20 +259,32 @@ semantic error: Array reference is not allowed on scalar variable
 168 |     c(1) = 1
     |     ^^^^ 
 
-semantic error: Argument of `size` must be an array
-   --> tests/errors/continue_compilation_3.f90:178:18
+semantic error: Kind of all the arguments of Mergebits must be the same
+   --> tests/errors/continue_compilation_3.f90:176:14
     |
-178 |         print *, size(bpe)
+176 |     print *, merge_bits(1, 2, 3_8)
+    |              ^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Kind of all the arguments of Mergebits must be the same
+   --> tests/errors/continue_compilation_3.f90:177:14
+    |
+177 |     print *, merge_bits(merge_i,merge_j,merge_k)
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Argument of `size` must be an array
+   --> tests/errors/continue_compilation_3.f90:181:18
+    |
+181 |         print *, size(bpe)
     |                  ^^^^^^^^^ 
 
 semantic error: Variable 'd' is not declared
-   --> tests/errors/continue_compilation_3.f90:179:15
+   --> tests/errors/continue_compilation_3.f90:182:15
     |
-179 |         bpe = d
+182 |         bpe = d
     |               ^ 'd' is undeclared
 
 semantic error: Assignment to subroutine is not allowed
-   --> tests/errors/continue_compilation_3.f90:179:9
+   --> tests/errors/continue_compilation_3.f90:182:9
     |
-179 |         bpe = d
+182 |         bpe = d
     |         ^^^ 


### PR DESCRIPTION
This pull request refines the `merge_bits` intrinsic function and updates associated tests to improve error handling and ensure consistent behavior. The most notable changes include replacing runtime exceptions with compile-time assertions for type consistency, adding new test cases for `merge_bits`, and updating reference files to reflect these changes.

### Enhancements to `merge_bits` intrinsic:

* [`src/libasr/pass/intrinsic_functions.h`](diffhunk://#diff-d639d777644a941a4832c0e3c1a9c1ce5517747c030d82e896100741de2eefa6L4186-R4187): Replaced runtime exceptions with `LCOMPILERS_ASSERT`

### Test additions and update test references:

* [`tests/errors/continue_compilation_3.f90`](diffhunk://#diff-bd7e38718b72b902eb03246cdcde91d9b7b40b7c6b8808b0c36437c4168ab95bL65-R66): Added new error test cases to validate the behavior of the `merge_bits` intrinsic for compile time as well as runtime values.