### PR TITLE
create copy of format_08s which follows Fortran standard

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -719,7 +719,10 @@ RUN(NAME format_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
-RUN(NAME format_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+# we might eventually need to remove "gfortran" label from format_08, once
+# we start using GFortran version 15
+RUN(NAME format_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME format_08s LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME format_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME format_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME format_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/format_08s.f90
+++ b/integration_tests/format_08s.f90
@@ -1,0 +1,14 @@
+! copy of integration_tests/format_08.f90 but splits edit
+! descriptor by separating it with commas i.e. changes
+! "(aai6)" to "(a,a,i6)", which is exactly how GFortran
+! also expects it as well, see:
+! https://gcc.gnu.org/onlinedocs/gfortran/Commas-in-FORMAT-specifications.html
+program format_08s
+    implicit none
+    character(:), allocatable :: a
+    integer :: b(10)
+    a = "xx"
+    b = 1
+    print "(a,a,i6)", a,"hi",15
+    print "(1000(i6))", b
+end program


### PR DESCRIPTION
## Description

The test case `integration_tests/format_08.f90` isn't a valid fortran and is considered non-conforming, see what GFortran says about it: https://gcc.gnu.org/onlinedocs/gfortran/Commas-in-FORMAT-specifications.html

with that in mind, in this PR we remove `fortran` label from it from integration tests.