### PR TITLE
pop optimization

### DIFF
--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -5543,7 +5543,6 @@ namespace LCompilers {
         llvm::AllocaInst *pos_ptr = llvm_utils->CreateAlloca(
                                     llvm::Type::getInt32Ty(context));
         LLVM::CreateStore(*builder, pos, pos_ptr);
-        llvm::Value* tmp = nullptr;
 
         // Get element to return
         llvm::Value* item = read_item_using_typecode(list_element_type_code, list, llvm_utils->CreateLoad(pos_ptr),
@@ -5557,33 +5556,25 @@ namespace LCompilers {
             item = target;
         }
 
-        llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
-        llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
-        llvm::BasicBlock *loopend = llvm::BasicBlock::Create(context, "loop.end");
+        llvm::Value* num_elements = builder->CreateSub(end_point, pos);
+        llvm::Value* num_elements_shift = builder->CreateSub(num_elements, 
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 1));
 
-        // head
-        llvm_utils->start_new_block(loophead);
-        {
-            llvm::Value *cond = builder->CreateICmpSGT(end_point, builder->CreateAdd(
-                                    llvm_utils->CreateLoad(pos_ptr),
-                                    llvm::ConstantInt::get(context, llvm::APInt(32, 1))));
-            builder->CreateCondBr(cond, loopbody, loopend);
-        }
+        llvm::Value* cond = builder->CreateICmpEQ(num_elements, llvm::ConstantInt::get(
+                                                   context, llvm::APInt(32, 1)));
 
-        // body
-        llvm_utils->start_new_block(loopbody);
-        {
-            tmp = builder->CreateAdd(
-                        llvm_utils->CreateLoad(pos_ptr),
-                        llvm::ConstantInt::get(context, llvm::APInt(32, 1)));
-            write_item_using_typecode(list_element_type_code, list, llvm_utils->CreateLoad(pos_ptr),
-                read_item_using_typecode(list_element_type_code, list, tmp, false, module, false), false, module);
-            LLVM::CreateStore(*builder, tmp, pos_ptr);
-        }
-        builder->CreateBr(loophead);
+        llvm_utils->create_if_else(cond, [&](){}, [&](){
+            llvm::Value *dest_ptr = read_item_using_typecode(list_element_type_code,
+                                                             list, pos, true, module, true);
+            llvm::Value *src_ptr = read_item_using_typecode(list_element_type_code, list, 
+                builder->CreateAdd(pos, llvm::ConstantInt::get(context, llvm::APInt(32, 1))),
+                true, module, true);
+            int32_t type_size = std::get<1>(typecode2listtype[list_element_type_code]);
+            llvm::Value* llvm_type_size = llvm::ConstantInt::get(context, llvm::APInt(32, type_size));
 
-        // end
-        llvm_utils->start_new_block(loopend);
+        llvm::Value* bytes_to_move = builder->CreateMul(llvm_type_size, num_elements_shift);
+            builder->CreateMemMove(dest_ptr, llvm::MaybeAlign(), src_ptr, llvm::MaybeAlign(), bytes_to_move);
+        });
 
         // Decrement end point by one
         end_point = builder->CreateSub(end_point, llvm::ConstantInt::get(


### PR DESCRIPTION
Fixes: https://github.com/lcompilers/lpython/issues/2741
Based on: https://github.com/lcompilers/lpython/pull/2805

Tested locally with

```f90
program name
   implicit none
   _lfortran_list(integer):: x
   integer:: i, g
   do i = 1, 100000
      call _lfortran_list_append(x, i)
   end do

   do i = 1, 100000
      g = _lfortran_pop(x, 0)
   end do
end program name
```

Unoptimized
```bash
(lf_20) $ time lfortran test.f90
lfortran test.f90  17.23s user 0.12s system 98% cpu 17.573 total
(lf_20) $ time lfortran test.f90 --fast
lfortran test.f90 --fast  0.91s user 0.12s system 69% cpu 1.488 total
```

Optimized
```bash
(lf_20) $ time lfortran test.f90
lfortran test.f90  0.92s user 0.26s system 36% cpu 3.261 total
(lf_20) $ time lfortran test.f90 --fast
lfortran test.f90 --fast  0.92s user 0.05s system 74% cpu 1.300 total
```

Gives same performance as `--fast` after optimization
17s->0.92s