### PR TITLE
feat: implement unlimited polymorphic variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1297,6 +1297,7 @@ RUN(NAME select_type_04 LABELS gfortran
 RUN(NAME select_type_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME select_type_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME select_type_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME program_02 LABELS gfortran llvm)
 RUN(NAME program_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -1791,11 +1792,12 @@ RUN(NAME class_51 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_52 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 
 RUN(NAME class_allocate_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
-# RUN(NAME class_allocate_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) TODO: Uncomment when class(*) is implemented
+RUN(NAME class_allocate_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME kwargs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME kwargs_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/class_55.f90
+++ b/integration_tests/class_55.f90
@@ -1,0 +1,41 @@
+program class_55
+    type coor
+        integer :: x
+        integer :: y
+    end type
+
+    class(*), allocatable :: c
+
+    type(coor), allocatable :: i
+    i = coor(11, 22)
+
+    allocate(c, source = i)
+
+    select type (c)
+        type is (integer)
+            error stop
+        type is (real)
+            error stop
+        type is (coor)
+            if (c%x /= 11) error stop
+            print *, c
+        class default
+            error stop
+    end select
+
+    deallocate(c)
+
+    allocate(c, source = 4)
+    select type (c)
+        type is (integer)
+            if (c /= 4) error stop
+            print *, c
+        type is (real)
+            error stop
+        type is (coor)
+            error stop
+        class default
+            error stop
+    end select
+
+end program

--- a/integration_tests/select_type_08.f90
+++ b/integration_tests/select_type_08.f90
@@ -1,0 +1,41 @@
+program select_type_08
+    implicit none
+
+    type base
+        integer :: x
+    end type
+
+    integer :: case_int
+
+    class(*), allocatable :: x
+
+    allocate(x, source = 10)
+    call f(x, case_int)
+    if (case_int /= 0) error stop
+
+    deallocate(x)
+
+    allocate(x, source = base(10))
+    call f(x, case_int)
+    if (case_int /= 1) error stop
+
+contains
+
+    subroutine f(generic, selected_case)
+        class(*) :: generic
+        integer, intent(out) :: selected_case
+
+        select type(generic)
+            type is (integer)
+                print *, generic
+                if (generic /= 10) error stop
+                selected_case = 0
+            type is (base)
+                print *, generic%x
+                if (generic%x /= 10) error stop
+                selected_case = 1
+            class default
+                error stop
+        end select
+    end subroutine f
+end program select_type_08

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8364,7 +8364,12 @@ public:
                        int& arg_kind, int& dest_kind)
     {
         dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
-        ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+        ASR::ttype_t* curr_type = nullptr;
+        if (ASRUtils::is_abstract_class_type(ASRUtils::expr_type(x.m_arg))) {
+            curr_type = current_select_type_block_type_asr;
+        } else {
+            curr_type = extract_ttype_t_from_expr(x.m_arg);
+        }
         LCOMPILERS_ASSERT(curr_type != nullptr)
         arg_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -178,6 +178,7 @@ public:
     // Stores the map of pointer and associated type, map<ptr, i32>, Used by Load or GEP
     std::map<llvm::Value *, llvm::Type *> ptr_type;
     llvm::Type* current_select_type_block_type;
+    ASR::ttype_t* current_select_type_block_type_asr;
     std::string current_select_type_block_der_type;
     std::string current_selector_var_name;
 
@@ -219,6 +220,7 @@ public:
     global_array_count(0),
     compiler_options(compiler_options_),
     current_select_type_block_type(nullptr),
+    current_select_type_block_type_asr(nullptr),
     current_scope(nullptr),
     llvm_utils(std::make_unique<LLVMUtils>(context, builder.get(),
         current_der_type_name, name2dertype, name2dercontext, struct_type_stack,
@@ -1084,9 +1086,7 @@ public:
                 } else if (ASR::is_a<ASR::StructType_t>(*curr_arg_m_a_type)) {
                     // TODO: Implement source argument when m_source is class
                     bool m_source_is_class = m_source && ASRUtils::is_class_type(ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(m_source)));
-                    if (std::string(ASRUtils::symbol_name(ASR::down_cast<ASR::StructType_t>(curr_arg_m_a_type)->m_derived_type)) == "~abstract_type") {
-                        // TODO: implement when implementing class(*)
-                    } else if (ASR::down_cast<ASR::StructType_t>(curr_arg_m_a_type)->m_is_cstruct) {
+                    if (ASR::down_cast<ASR::StructType_t>(curr_arg_m_a_type)->m_is_cstruct) {
                         llvm::Value* malloc_size = SizeOfTypeUtil(curr_arg_m_a_type, llvm_utils->getIntType(4),
                         ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4)));
                         llvm::Value* malloc_ptr = LLVMArrUtils::lfortran_malloc(
@@ -1127,10 +1127,17 @@ public:
                         builder->CreateMemSet(malloc_ptr, llvm::ConstantInt::get(context, llvm::APInt(8, 0)), malloc_size, llvm::MaybeAlign());
 
                         // Set class hash in polymorphic struct
-                        ASR::symbol_t* dest_class_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructType_t>(dest_asr_type)->m_derived_type);
+                        llvm::Value* class_hash = nullptr;
+                        if (ASR::is_a<ASR::StructType_t>(*dest_asr_type)) {
+                            ASR::symbol_t* dest_class_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructType_t>(dest_asr_type)->m_derived_type);
+                            class_hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
+                                                        llvm::APInt(64, get_class_hash(dest_class_sym)));
+                        } else {
+                            class_hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
+                                llvm::APInt(64, -((int) dest_asr_type->type) -
+                                    ASRUtils::extract_kind_from_ttype_t(dest_asr_type), true));
+                        }
                         llvm::Type* src_class_type = llvm_utils->get_type_from_ttype_t_util(curr_arg_m_a_type, module.get());
-                        llvm::Value* class_hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
-                            llvm::APInt(64, get_class_hash(dest_class_sym)));
                         llvm::Value* t = llvm_utils->create_gep2(src_class_type, x_arr, 0);
                         builder->CreateStore(class_hash, t);
 
@@ -1146,7 +1153,11 @@ public:
                         llvm::Type* dest_type = llvm_utils->get_type_from_ttype_t_util(dest_asr_type, module.get());
                         x_arr = llvm_utils->CreateLoad2(src_struct_type, x_arr);
                         x_arr = builder->CreateBitCast(x_arr, dest_type->getPointerTo());
-                        allocate_array_members_of_struct(x_arr, dest_asr_type);
+
+                        if (ASR::is_a<ASR::StructType_t>(*dest_asr_type)) {
+                            allocate_array_members_of_struct(x_arr, dest_asr_type);
+                        }
+
                         if (m_source && !m_source_is_class) {
                             int64_t ptr_loads_copy = ptr_loads;
                             if (ASRUtils::is_allocatable(m_source)) {
@@ -2904,7 +2915,11 @@ public:
         }
         this->visit_expr(*x.m_v);
         ptr_loads = ptr_loads_copy;
-        if( ASRUtils::is_class_type(ASRUtils::type_get_past_pointer(
+        if (ASRUtils::is_abstract_class_type(ASRUtils::extract_type(x_m_v_type))) {
+            if( current_select_type_block_type ) {
+                current_der_type_name = current_select_type_block_der_type;
+            }
+        } else if (ASRUtils::is_class_type(ASRUtils::type_get_past_pointer(
                 ASRUtils::type_get_past_allocatable(x_m_v_type))) ) {
             if (ASRUtils::is_allocatable(x_m_v_type)) {
                 ASR::ttype_t* wrapped_struct_type = ASRUtils::TYPE(
@@ -5790,21 +5805,6 @@ public:
 
             builder->CreateStore(value_class_ptr, target_class_ptr);
             return;
-        } else if (!is_target_class && is_value_class) {
-            int64_t ptr_loads_copy = ptr_loads;
-            ptr_loads = 0;
-            this->visit_expr(*x.m_value);
-            llvm::Value* value_struct = tmp;
-            this->visit_expr(*x.m_target);
-            llvm::Value* target = tmp;
-            ptr_loads = ptr_loads_copy;
-
-            value_struct = get_current_select_type(asr_value_type, value_struct, module.get(), current_select_type_block_type);
-            llvm::Type* target_llvm_type = llvm_utils->get_type_from_ttype_t_util(asr_target_type, module.get());
-            value_struct = llvm_utils->CreateLoad2(target_llvm_type, value_struct);
-
-            builder->CreateStore(value_struct, target);
-            return;
         } else if (ASR::is_a<ASR::Allocatable_t>(*asr_target_type) &&
                    ASRUtils::is_class_type(ASRUtils::type_get_past_allocatable(asr_target_type)) &&
                    is_value_struct) {
@@ -6566,12 +6566,13 @@ public:
         LCOMPILERS_ASSERT(x.n_body == select_type_stmts.size());
         ASR::Var_t* selector_var = nullptr;
         ASR::StructInstanceMember_t* selector_struct = nullptr;
+        std::string selector_var_name;
         if (ASR::is_a<ASR::Var_t>(*x.m_selector)) {
             selector_var = ASR::down_cast<ASR::Var_t>(x.m_selector);
-            current_selector_var_name = ASRUtils::symbol_name(selector_var->m_v);
+            selector_var_name = ASRUtils::symbol_name(selector_var->m_v);
         } else if (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_selector)) {
             selector_struct = ASR::down_cast<ASR::StructInstanceMember_t>(x.m_selector);
-            current_selector_var_name = ASRUtils::symbol_name(selector_struct->m_m);
+            selector_var_name = ASRUtils::symbol_name(selector_struct->m_m);
         }
         uint64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
@@ -6654,6 +6655,7 @@ public:
                     ASR::TypeStmtType_t* type_stmt_type_t = ASR::down_cast<ASR::TypeStmtType_t>(select_type_stmts[i]);
                     ASR::ttype_t* type_stmt_type = type_stmt_type_t->m_type;
                     current_select_type_block_type = llvm_utils->get_type_from_ttype_t_util(type_stmt_type, module.get());
+                    current_select_type_block_type_asr = type_stmt_type;
                     llvm::Value* intrinsic_type_id = llvm::ConstantInt::get(llvm_utils->getIntType(8),
                         llvm::APInt(64, -((int) type_stmt_type->type) -
                             ASRUtils::extract_kind_from_ttype_t(type_stmt_type), true));
@@ -6678,6 +6680,23 @@ public:
             }
             builder->CreateCondBr(cond, thenBB, elseBB);
             builder->SetInsertPoint(thenBB);
+            // TODO: change symtab for arrays too
+            bool change_symtab = ASRUtils::is_abstract_class_type(ASRUtils::extract_type(ASRUtils::expr_type(x.m_selector)))
+                && !ASRUtils::is_array(ASRUtils::expr_type(x.m_selector));
+            // For class(*) selector variables cast to current select block type and update llvm_symtab temporarily
+            // while executing blocks.
+            if (change_symtab) {
+                llvm::Type* src_type = llvm_utils->get_type_from_ttype_t_util(expr_type(x.m_selector), module.get());
+                llvm::Value* llvm_selector_new = llvm_utils->create_gep2(src_type, llvm_selector, 1);
+                llvm_selector_new = llvm_utils->CreateLoad2(llvm::Type::getVoidTy(context)->getPointerTo(),llvm_selector_new);
+                llvm_selector_new = builder->CreateBitCast(llvm_selector_new, current_select_type_block_type->getPointerTo());
+                if (current_select_type_block_type_asr &&
+                    !ASRUtils::is_character(*current_select_type_block_type_asr)) {
+                    llvm_selector_new = llvm_utils->CreateLoad2(current_select_type_block_type, llvm_selector_new);
+                }
+                uint32_t h = get_hash((ASR::asr_t*)ASR::down_cast<ASR::Variable_t>(current_scope->resolve_symbol(selector_var_name)));
+                llvm_symtab[h] = llvm_selector_new;
+            }
             {
                 if( n_type_block == 1 && ASR::is_a<ASR::BlockCall_t>(*type_block[0]) ) {
                     ASR::BlockCall_t* block_call = ASR::down_cast<ASR::BlockCall_t>(type_block[0]);
@@ -6689,9 +6708,14 @@ public:
                 }
             }
             builder->CreateBr(mergeBB);
+            if (change_symtab) {
+                uint32_t h = get_hash((ASR::asr_t*)ASR::down_cast<ASR::Variable_t>(current_scope->resolve_symbol(selector_var_name)));
+                llvm_symtab[h] = llvm_selector;
+            }
 
             start_new_block(elseBB);
             current_select_type_block_type = nullptr;
+            current_select_type_block_type_asr = nullptr;
             current_select_type_block_der_type.clear();
         }
         if( x.n_default > 0 ) {
@@ -8226,7 +8250,14 @@ public:
                             current_der_type_name = ASRUtils::symbol_name(
                                 ASRUtils::symbol_get_past_external(d->m_derived_type));
                         }
-                        fetch_ptr(x);
+                        if (ASRUtils::is_abstract_class_type(t2)) {
+                            uint32_t h = get_hash((ASR::asr_t*)x);
+                            if( llvm_symtab.find(h) != llvm_symtab.end() ) {
+                                tmp = llvm_symtab[h];
+                            }
+                        } else {
+                            fetch_ptr(x);
+                        }
                         break;
                     }
                     default:
@@ -9691,6 +9722,15 @@ public:
         std::string res {};
         type = ASRUtils::type_get_past_allocatable(
                 ASRUtils::type_get_past_pointer(type));
+        if (ASRUtils::is_abstract_class_type(type)) {
+            if (current_select_type_block_type_asr) {
+                type = current_select_type_block_type_asr;
+            } else if (!current_select_type_block_der_type.empty()) {
+                type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(
+                                    al, type->base.loc,
+                                    current_scope->resolve_symbol(current_select_type_block_der_type)));
+            }
+        }
         if (ASR::is_a<ASR::Integer_t>(*type)) {
             res += "I";
             res += std::to_string(ASRUtils::extract_kind_from_ttype_t(type));
@@ -10169,6 +10209,8 @@ public:
 
                                 if (ASRUtils::is_class_type(
                                         ASRUtils::type_get_past_allocatable(arg->m_type))
+                                    && !ASRUtils::is_abstract_class_type(
+                                        ASRUtils::type_get_past_allocatable(arg->m_type))
                                     && !ASRUtils::is_class_type(
                                         ASRUtils::type_get_past_allocatable(orig_arg->m_type))) {
                                     tmp = convert_class_to_type(x.m_args[i].m_value, orig_arg->m_type, tmp);
@@ -10585,6 +10627,33 @@ public:
         }
 
         if( ASRUtils::is_abstract_class_type(s_m_args0_type) ) {
+            if (ASRUtils::is_class_type(arg_type)) {
+                if( ASRUtils::is_array(s_m_args0_type) ) {
+                    // TODO: Handle this case
+                    return dt;
+                } else {
+                    llvm::Type* _type = llvm_utils->get_type_from_ttype_t_util(s_m_args0_type, module.get());
+                    llvm::Type* dt_type = llvm_utils->get_type_from_ttype_t_util(arg_type, module.get());
+                    llvm::Value* abstract_ = llvm_utils->CreateAlloca(*builder, _type);
+                    llvm::Value* polymorphic_addr = llvm_utils->create_gep(abstract_, 1);
+                    builder->CreateStore(
+                        builder->CreateBitCast(llvm_utils->CreateLoad(llvm_utils->create_gep2(dt_type, dt, 1)), llvm::Type::getVoidTy(context)->getPointerTo()),
+                        polymorphic_addr);
+                    llvm::Value* type_id_addr = llvm_utils->create_gep(abstract_, 0);
+                    if (ASR::is_a<ASR::StructType_t>(*arg_type)) {
+                        llvm::Value* hash = llvm_utils->create_gep2(dt_type, dt, 0);
+                        hash = llvm_utils->CreateLoad2(llvm_utils->getIntType(8), hash);
+                        builder->CreateStore(hash, type_id_addr);
+                    } else {
+                        // Case: when integer, real, character etc. passed to class(*) argument
+                        llvm::Value* hash = llvm::ConstantInt::get(llvm_utils->getIntType(8),
+                            llvm::APInt(64, -((int) arg_type->type) -
+                            ASRUtils::extract_kind_from_ttype_t(arg_type), true));
+                        builder->CreateStore(hash, type_id_addr);
+                    }
+                    return abstract_;
+                }
+            }
             if( ASRUtils::is_array(s_m_args0_type) ) {
                 llvm::Type* array_type = llvm_utils->get_type_from_ttype_t_util(s_m_args0_type, module.get());
                 llvm::Value* abstract_array = llvm_utils->CreateAlloca(*builder, array_type);
@@ -11149,6 +11218,7 @@ public:
 
             start_new_block(elseBB);
             current_select_type_block_type = nullptr;
+            current_select_type_block_type_asr = nullptr;
             current_select_type_block_der_type.clear();
         }
         start_new_block(mergeBB);
@@ -11923,15 +11993,13 @@ public:
                         this->visit_expr_wrapper(x.m_args[i], true);
                     }
                 } else {
-                    ptr_loads = ptr_loads + LLVM::is_llvm_pointer(*expr_type(x.m_args[i]));
                     this->visit_expr_wrapper(x.m_args[i], true);
                 }
                 if(!tmp->getType()->isPointerTy() ||
                     ASR::is_a<ASR::PointerToCPtr_t>(*x.m_args[i]) ||
                     (ASRUtils::is_character(*expr_type(x.m_args[i])) &&
                         !ASRUtils::is_array(expr_type(x.m_args[i]))) ){
-                    llvm::Value* tmp_ptr = builder->CreateAlloca
-                        (llvm_utils->get_type_from_ttype_t_util(expr_type(x.m_args[i]), llvm_utils->module));
+                    llvm::Value* tmp_ptr = builder->CreateAlloca(tmp->getType());
                     builder->CreateStore(tmp, tmp_ptr);
                     tmp = tmp_ptr;
                 }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -180,7 +180,6 @@ public:
     llvm::Type* current_select_type_block_type;
     ASR::ttype_t* current_select_type_block_type_asr;
     std::string current_select_type_block_der_type;
-    std::string current_selector_var_name;
 
     SymbolTable* current_scope;
     std::unique_ptr<LLVMUtils> llvm_utils;
@@ -6724,7 +6723,6 @@ public:
             }
         }
         start_new_block(mergeBB);
-        current_selector_var_name.clear();
     }
 
     void visit_IntegerCompare(const ASR::IntegerCompare_t &x) {
@@ -8546,16 +8544,6 @@ public:
             return;
         }
         this->visit_expr_wrapper(x.m_arg, true);
-
-        int arg_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x.m_arg));
-        if (ASRUtils::is_class_type(ASRUtils::extract_type(ASRUtils::expr_type(x.m_arg))) &&
-            ASRUtils::EXPR2VAR(x.m_arg)->m_name == current_selector_var_name) {
-            tmp = get_current_select_type(ASRUtils::expr_type(x.m_arg),
-                        tmp, module.get(), current_select_type_block_type);
-            tmp = llvm_utils->CreateLoad2(current_select_type_block_type, tmp);
-            arg_kind = llvm_utils->get_kind_from_llvm_val(tmp);
-        }
-            
         switch (x.m_kind) {
             case (ASR::cast_kindType::IntegerToReal) : {
                 int a_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
@@ -10636,20 +10624,6 @@ public:
             type2vtabid[class_sym] = type2vtabid.size();
         }
         return type2vtabid[class_sym];
-    }
-
-    llvm::Value* get_current_select_type( ASR::ttype_t* t, llvm::Value* value,
-        llvm::Module* module, llvm::Type* current_type) {
-        llvm::Type* llvm_type = llvm_utils->get_type_from_ttype_t_util(t, module);
-        llvm::Value* select_value = llvm_utils->create_gep2(llvm_type, value, 1);
-        // bitcast to the current select type block's type
-        ASR::ttype_t* wrapped_value_struct_type = ASRUtils::TYPE(
-                        ASRUtils::make_StructType_t_util(al, t->base.loc,
-                            ASR::down_cast<ASR::StructType_t>(ASRUtils::extract_type(t))->m_derived_type));
-        llvm::Type* wrapper_value_llvm_type = llvm_utils->get_type_from_ttype_t_util(wrapped_value_struct_type, module);
-        select_value = llvm_utils->CreateLoad2(wrapper_value_llvm_type->getPointerTo(), select_value);
-        select_value = builder->CreateBitCast(select_value, current_type->getPointerTo());
-        return select_value;
     }
 
     llvm::Value* convert_to_polymorphic_arg(llvm::Value* dt,

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8362,6 +8362,15 @@ public:
         return ASRUtils::expr_type(expr);
     }
 
+    void extract_kinds(const ASR::Cast_t& x,
+                       int& arg_kind, int& dest_kind)
+    {
+        dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+        ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+        LCOMPILERS_ASSERT(curr_type != nullptr)
+        arg_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+    }
+
     template <typename T>
     void handle_arr_for_complex_im_re(const T& t) {
         int64_t ptr_loads_copy = ptr_loads;
@@ -8625,7 +8634,10 @@ public:
             }
             case (ASR::cast_kindType::IntegerToLogical) :
             case (ASR::cast_kindType::UnsignedIntegerToLogical) : {
-                switch (arg_kind) {
+                ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+                LCOMPILERS_ASSERT(curr_type != nullptr)
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+                switch (a_kind) {
                     case 1:
                         tmp = builder->CreateICmpNE(tmp, builder->getInt8(0));
                         break;
@@ -8643,7 +8655,10 @@ public:
             }
             case (ASR::cast_kindType::RealToLogical) : {
                 llvm::Value *zero;
-                if (arg_kind == 4) {
+                ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+                LCOMPILERS_ASSERT(curr_type != nullptr)
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+                if (a_kind == 4) {
                     zero = llvm::ConstantFP::get(context, llvm::APFloat((float)0.0));
                 } else {
                     zero = llvm::ConstantFP::get(context, llvm::APFloat(0.0));
@@ -8666,7 +8681,10 @@ public:
             case (ASR::cast_kindType::ComplexToLogical) : {
                 // !(c.real == 0.0 && c.imag == 0.0)
                 llvm::Value *zero;
-                if (arg_kind == 4) {
+                ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+                LCOMPILERS_ASSERT(curr_type != nullptr)
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+                if (a_kind == 4) {
                     zero = llvm::ConstantFP::get(context, llvm::APFloat((float)0.0));
                 } else {
                     zero = llvm::ConstantFP::get(context, llvm::APFloat(0.0));
@@ -8685,7 +8703,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::RealToReal) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 if( arg_kind > 0 && dest_kind > 0 &&
                     arg_kind != dest_kind )
                 {
@@ -8702,7 +8721,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::IntegerToInteger) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 if( arg_kind > 0 && dest_kind > 0 &&
                     arg_kind != dest_kind )
                 {
@@ -8715,7 +8735,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::UnsignedIntegerToUnsignedInteger) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 if( arg_kind > 0 && dest_kind > 0 &&
                     arg_kind != dest_kind )
                 {
@@ -8728,7 +8749,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::IntegerToUnsignedInteger) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 LCOMPILERS_ASSERT(arg_kind != -1 && dest_kind != -1)
                 if( arg_kind > 0 && dest_kind > 0 &&
                     arg_kind != dest_kind )
@@ -8742,7 +8764,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::UnsignedIntegerToInteger) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 LCOMPILERS_ASSERT(arg_kind != -1 && dest_kind != -1)
                 if( arg_kind > 0 && dest_kind > 0 &&
                     arg_kind != dest_kind )
@@ -8765,7 +8788,8 @@ public:
             }
             case (ASR::cast_kindType::ComplexToComplex) : {
                 llvm::Type *target_type;
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 llvm::Value *re, *im;
                 if( arg_kind > 0 && dest_kind > 0 &&
                     arg_kind != dest_kind )
@@ -8794,7 +8818,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::ComplexToReal) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 llvm::Value *re;
                 if( arg_kind > 0 && dest_kind > 0)
                 {
@@ -8825,7 +8850,8 @@ public:
                 break;
             }
             case (ASR::cast_kindType::ComplexToInteger) : {
-                int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
                 llvm::Value *re;
                 if (arg_kind > 0 && dest_kind > 0)
                 {
@@ -8851,11 +8877,17 @@ public:
              }
             case (ASR::cast_kindType::RealToString) : {
                 llvm::Value *arg = tmp;
+                ASR::ttype_t* arg_type = extract_ttype_t_from_expr(x.m_arg);
+                LCOMPILERS_ASSERT(arg_type != nullptr)
+                int arg_kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                 tmp = lfortran_type_to_str(arg, llvm_utils->getFPType(arg_kind), "float", arg_kind);
                 break;
             }
             case (ASR::cast_kindType::IntegerToString) : {
                 llvm::Value *arg = tmp;
+                ASR::ttype_t* arg_type = extract_ttype_t_from_expr(x.m_arg);
+                LCOMPILERS_ASSERT(arg_type != nullptr)
+                int arg_kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
                 tmp = lfortran_type_to_str(arg, llvm_utils->getIntType(arg_kind), "int", arg_kind);
                 break;
             }

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1497,30 +1497,6 @@ namespace LCompilers {
                                      m_dims_local, n_dims_local, a_kind_local, module, asr_abi);
     }
 
-    int LLVMUtils::get_kind_from_llvm_val(llvm::Value* val) {
-        llvm::Type* type = val->getType();
-        int bitWidth = 0;
-
-        switch (type->getTypeID()) {
-            case llvm::Type::IntegerTyID:
-                bitWidth = type->getIntegerBitWidth();
-                break;
-            case llvm::Type::FloatTyID:
-                bitWidth = 32;
-                break;
-            case llvm::Type::DoubleTyID:
-                bitWidth = 64;
-                break;
-            case llvm::Type::HalfTyID:
-                bitWidth = 16;
-                break;
-            default:
-                bitWidth = 0;
-                break;
-        }
-        return bitWidth / 8;
-    }
-
     llvm::Value* LLVMUtils::create_gep(llvm::Value* ds, int idx) {
         std::vector<llvm::Value*> idx_vec = {
         llvm::ConstantInt::get(context, llvm::APInt(32, 0)),

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -386,8 +386,6 @@ namespace LCompilers {
                 ASR::storage_typeType m_storage, bool arg_m_value_attr, int& n_dims,
                 int& a_kind, bool& is_array_type, ASR::intentType arg_intent, llvm::Module* module,
                 bool get_pointer=true);
-                        
-            int get_kind_from_llvm_val(llvm::Value* val);
 
             void set_dict_api(ASR::Dict_t* dict_type);
 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/7774

1. Implement allocating `class(*)` with allocate statement source argument.
2. Temporarily modify `llvm_symtab` while executing select blocks.
3. Implement class to class(*) polymorphic arg conversion (`convert_to_polymorphic_arg()`).
4. Fix printing in select type block.
5. Revert some commits from https://github.com/lfortran/lfortran/pull/7849 and fix it using `current_select_type_block_type_asr`.