### PR TITLE
[don't merge]: expect the Quick Checks/LFortran CI (OS=ubuntu, LLVM=11) failure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1376,7 +1376,7 @@ RUN(NAME implicit_typing_05 LABELS gfortran llvm  EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --implicit-typing)
 
 
-RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME generic_name_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)


### PR DESCRIPTION
## Description

This PR isn't intended to be merged at all. We want to test that the CI works fine by inducing a failure with this PR, and if the CI job *LFortran CI (OS=ubuntu, LLVM=11)* fails (for *Test Fortran backend*), it will confirm that the CI seems to be working just fine.