### PR TITLE
feat: throw spacing not implemented error in AST->ASR

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8715,6 +8715,10 @@ public:
                 }
                 if( ASRUtils::IntrinsicElementalFunctionRegistry::is_intrinsic_function(var_name) ) {
                     const bool are_all_args_evaluated { ASRUtils::all_args_evaluated(args, true) };
+                    if (!are_all_args_evaluated && var_name == "spacing") {
+                        diag.add(Diagnostic("`Spacing` intrinsic is not yet implemented for runtime values", Level::Error,
+                            Stage::Semantic, {Label("", { x.base.base.loc })}));
+                    }
                     fill_optional_kind_arg(var_name, args);
                     tmp = nullptr;
                     scalar_kind_arg(var_name, args);

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -3761,8 +3761,7 @@ namespace Spacing {
             result = abs(nextafter(x, infinity) - x)
         end function
         */
-       throw LCompilersException("`Spacing` intrinsic is not yet implemented for runtime values");
-
+        LCOMPILERS_ASSERT(false);
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);
@@ -6213,10 +6212,6 @@ namespace Max {
         declare_basic_variables("_lcompilers_max0_" + type_to_str_python(arg_types[0]));
         int64_t kind = extract_kind_from_ttype_t(arg_types[0]);
 
-        LCOMPILERS_ASSERT((ASR::is_a<ASR::String_t>(*arg_types[0]) || 
-                ASR::is_a<ASR::Real_t>(*arg_types[0]) ||
-                ASR::is_a<ASR::Integer_t>(*arg_types[0])));
-
         if (ASR::is_a<ASR::String_t>(*arg_types[0])) {
             for (size_t i = 0; i < new_args.size(); i++) {
                 fill_func_arg("x" + std::to_string(i), ASRUtils::TYPE(ASR::make_String_t(al, loc, 1,
@@ -6236,11 +6231,10 @@ namespace Max {
             for (size_t i = 0; i < new_args.size(); i++) {
                 fill_func_arg("x" + std::to_string(i), ASRUtils::TYPE(ASR::make_Integer_t(al, loc, kind)));
             }
+        } else {
+            LCOMPILERS_ASSERT(false);
         }
         return_type = ASRUtils::extract_type(return_type);
-        LCOMPILERS_ASSERT((ASR::is_a<ASR::String_t>(*return_type) || 
-                ASR::is_a<ASR::Real_t>(*return_type) ||
-                ASR::is_a<ASR::Integer_t>(*return_type)));
         auto result = declare(fn_name, return_type, ReturnVar);
         body.push_back(al, b.Assignment(result, args[0]));
         if (ASR::is_a<ASR::Integer_t>(*return_type)) {
@@ -6265,6 +6259,8 @@ namespace Max {
                 EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
                 ASR::string_length_kindType::ExpressionLength,
                 ASR::string_physical_typeType::PointerString));
+        } else {
+            LCOMPILERS_ASSERT(false);
         }
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
@@ -6394,9 +6390,6 @@ namespace Min {
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
         declare_basic_variables("_lcompilers_min0_" + type_to_str_python(arg_types[0]));
         int64_t kind = extract_kind_from_ttype_t(arg_types[0]);
-        LCOMPILERS_ASSERT((ASR::is_a<ASR::String_t>(*arg_types[0]) || 
-                ASR::is_a<ASR::Real_t>(*arg_types[0]) ||
-                ASR::is_a<ASR::Integer_t>(*arg_types[0])));
 
         if (ASR::is_a<ASR::String_t>(*arg_types[0])) {
             for (size_t i = 0; i < new_args.size(); i++) {
@@ -6417,11 +6410,10 @@ namespace Min {
             for (size_t i = 0; i < new_args.size(); i++) {
                 fill_func_arg("x" + std::to_string(i), ASRUtils::TYPE(ASR::make_Integer_t(al, loc, kind)));
             }
+        } else {
+            LCOMPILERS_ASSERT(false);
         }
         return_type = ASRUtils::extract_type(return_type);
-        LCOMPILERS_ASSERT((ASR::is_a<ASR::String_t>(*return_type) || 
-                ASR::is_a<ASR::Real_t>(*return_type) ||
-                ASR::is_a<ASR::Integer_t>(*return_type)));
         auto result = declare(fn_name, return_type, ReturnVar);
         body.push_back(al, b.Assignment(result, args[0]));
         if (ASR::is_a<ASR::Integer_t>(*return_type)) {
@@ -6446,6 +6438,8 @@ namespace Min {
                 EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
                 ASR::string_length_kindType::ExpressionLength,
                 ASR::string_physical_typeType::PointerString));
+        } else {
+            LCOMPILERS_ASSERT(false);
         }
 
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,

--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -204,7 +204,7 @@ program continue_compilation_2
     real(4) ::idnint_runtime = 3.5
     real(8) :: ifix_runtime = 4.23
     logical :: min_max = .true.
-
+    real(4) :: spacing_runtime = 1.0_4
 
     
 
@@ -456,6 +456,8 @@ program continue_compilation_2
     !max
     print *, max(.true., .false.)
     print *, max(min_max, min_max)
+    !spacing
+    print *, spacing(spacing_runtime)
     contains
     logical function f(x)
         integer, intent(in), optional :: x

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "be6881cd51af5dde4cb08499496f44b18b18f90bd2b47b356f3834ff",
+    "infile_hash": "12cf36ccd31ce658aa9c2195b4f00e6ef7a205fabbc62cb3349dd3a5",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "011dcd9801e0cf0c4275776e961972454a65fd09a5372f00ed8073da",
+    "stderr_hash": "966c4ad229d1b18cfd6a5fa06a830788de38ba6bdc5dc9c58833fe75",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -832,3 +832,9 @@ semantic error: Arguments to min0 must be of real, integer or character type
     |
 458 |     print *, max(min_max, min_max)
     |              ^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: `Spacing` intrinsic is not yet implemented for runtime values
+   --> tests/errors/continue_compilation_2.f90:460:14
+    |
+460 |     print *, spacing(spacing_runtime)
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
This pull request introduces changes to enhance intrinsic function handling and error reporting in the compiler, particularly for the `Spacing`, `Max`, and `Min` intrinsics. It also updates test cases to reflect these changes. The most important changes include adding diagnostic messages for unsupported runtime values, simplifying assertions, and extending test coverage for the `Spacing` intrinsic.

Refs: https://github.com/lfortran/lfortran/pull/7881#pullrequestreview-2958861348