### PR TITLE
fix: don't visit enum from module as External Symbols to enumerators are present in module

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1952,6 +1952,7 @@ RUN(NAME enum_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME enum_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
          enum_02_module.f90)
 RUN(NAME enum_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME enum_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME array_section_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME array_section_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)

--- a/integration_tests/enum_04.f90
+++ b/integration_tests/enum_04.f90
@@ -1,0 +1,24 @@
+module enum_04_mod
+  use iso_c_binding
+  implicit none
+
+  enum, bind(c)
+    enumerator :: red = 1, green = 2, blue = 3
+  end enum
+
+end module enum_04_mod
+
+program enum_04
+  use iso_c_binding
+  use enum_04_mod
+  implicit none
+
+  integer(c_int) :: c
+
+  c = red
+  if (c /= 1) error stop
+  c = green
+  if (c /= 2) error stop
+  c = blue
+  if (c /= 3) error stop
+end program enum_04

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2895,6 +2895,9 @@ public:
                     dflt_access
                     );
                 current_scope->add_symbol(item.first, ASR::down_cast<ASR::symbol_t>(v));
+            } else if( ASR::is_a<ASR::Enum_t>(*item.second) ) {
+                // Do nothing as enum variables will already be present as 
+                // External symbol in module from which we are importing
             } else {
                 return item.first;
             }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3614,9 +3614,6 @@ public:
                 ASR::Function_t *v = down_cast<ASR::Function_t>(
                         item.second);
                 instantiate_function(*v);
-            } else if (is_a<ASR::Enum_t>(*item.second)) {
-                ASR::Enum_t *et = down_cast<ASR::Enum_t>(item.second);
-                visit_Enum(*et);
             }
         }
         finish_module_init_function_prototype(x);


### PR DESCRIPTION
Fixes #7892 