### PR TITLE
enh: handle pointer string as second argument in `c_f_pointer` intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1161,6 +1161,7 @@ RUN(NAME intrinsics_386 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # product
 RUN(NAME intrinsics_387 LABELS gfortran llvm) # execute_command_line
 RUN(NAME intrinsics_388 LABELS gfortran llvm) # execute_command_line
 RUN(NAME intrinsics_389 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # loc
+RUN(NAME intrinsics_390 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # c_f_ptr
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_390.f90
+++ b/integration_tests/intrinsics_390.f90
@@ -1,0 +1,6 @@
+program intrinsics_390 
+  use iso_c_binding
+  type(c_ptr) :: cptr
+  character(len=5,kind=c_char), pointer :: sptr
+  call c_f_pointer(cptr, sptr)
+end program intrinsics_390


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/7967