### PR TITLE
fix: get struct vtab correctly if not present in scope

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1805,6 +1805,7 @@ RUN(NAME class_52 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --rea
 RUN(NAME class_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME class_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_55 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
+RUN(NAME class_56 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_56.f90
+++ b/integration_tests/class_56.f90
@@ -1,0 +1,68 @@
+module class_56_mod1
+  implicit none
+  type :: toml_value
+    integer :: x = 0
+  contains 
+    procedure :: accept
+  end type
+
+contains
+
+  subroutine accept(self)
+    class(toml_value), intent(inout) :: self
+    self%x = self%x + 1
+  end subroutine
+
+end module
+
+module class_56_mod2
+  use class_56_mod1
+  implicit none
+
+  type :: ser_config
+  contains 
+    procedure :: temp
+    procedure :: temp2
+  end type
+
+contains
+
+  subroutine temp(self, val)
+    class(ser_config), intent(inout) :: self
+    class(toml_value), intent(inout) :: val
+
+    select type(val)
+    type is (toml_value)
+      call val%accept()
+    class default
+      print *, "Unknown type"
+    end select
+  end subroutine
+
+  subroutine temp2(self, val)
+    class(ser_config), intent(inout) :: self
+    class(toml_value), intent(inout) :: val
+
+    select type(val)
+    class is (toml_value)
+      call val%accept()
+    class default
+      print *, "Unknown type"
+    end select
+  end subroutine
+
+end module
+
+program class_56
+  use class_56_mod2
+  implicit none
+
+  type(ser_config) :: cfg
+  type(toml_value) :: v
+
+  v%x = 1
+  call cfg%temp(v)
+  if (v%x /= 2) error stop
+  call cfg%temp2(v)
+  if (v%x /= 3) error stop
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6687,8 +6687,8 @@ public:
                     } else {
                         LCOMPILERS_ASSERT(false);
                     }
-                    if (type2vtab.find(type_sym) == type2vtab.end() &&
-                        type2vtab[type_sym].find(current_scope) == type2vtab[type_sym].end()) {
+                    if ((type2vtab.find(type_sym) == type2vtab.end()) ||
+                        (type2vtab[type_sym].find(current_scope) == type2vtab[type_sym].end())) {
                         create_vtab_for_struct_type(type_sym, current_scope);
                     }
                     llvm::Value* type_sym_vtab = type2vtab[type_sym][current_scope];
@@ -6714,6 +6714,10 @@ public:
                     std::vector<llvm::Value*>& class_sym_vtabs = class2vtab[class_sym][current_scope];
                     std::vector<llvm::Value*> conds;
                     if (class_sym_vtabs.size() == 0) {
+                        if ((type2vtab.find(class_sym) == type2vtab.end()) ||
+                            (type2vtab[class_sym].find(current_scope) == type2vtab[class_sym].end())) {
+                            create_vtab_for_struct_type(class_sym, current_scope);
+                        }
                         class_sym_vtabs.push_back(type2vtab[class_sym][current_scope]);
                     }
                     conds.reserve(class_sym_vtabs.size());


### PR DESCRIPTION
Fixes #7974