### PR TITLE
fix: check current selector name for deciding is_polymorphic in `visit_Arrayitem`

### DIFF
--- a/integration_tests/select_type_06.f90
+++ b/integration_tests/select_type_06.f90
@@ -10,7 +10,8 @@ program select_type_06_m
     end type
 
     class(string_value), allocatable :: val  ! Polymorphic variable
-
+    logical :: defer(2)
+    defer = .false.
     allocate(val)
     select type(val)
     type is(string_value)
@@ -24,6 +25,8 @@ program select_type_06_m
   
     select type(val)
     class is(toml_keyval)
+        defer(1) = .true.
         if (val%key /= "example") error stop
     end select
+    if (any(defer .neqv. [.true., .false.])) error stop
 end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2635,7 +2635,8 @@ public:
                 ptr_loads = ptr_loads_copy;
             }
             LCOMPILERS_ASSERT(ASRUtils::extract_n_dims_from_ttype(x_mv_type) > 0);
-            bool is_polymorphic = current_select_type_block_type != nullptr;
+            bool is_polymorphic = (current_select_type_block_type != nullptr) && ASR::is_a<ASR::Var_t>(*x.m_v) &&
+                    (ASRUtils::EXPR2VAR(x.m_v)->m_name == current_selector_var_name);
             if (array_t->m_physical_type == ASR::array_physical_typeType::UnboundedPointerToDataArray) {
                 llvm::Type* type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::extract_type(x_mv_type), module.get());
                 tmp = arr_descr->get_single_element(type, array, indices, x.n_args,


### PR DESCRIPTION
Fixes #7989 