### PR TITLE
support keyword args in execute_command_line intrinsic

### DIFF
--- a/integration_tests/intrinsics_387.f90
+++ b/integration_tests/intrinsics_387.f90
@@ -10,8 +10,8 @@ program intrinsics_387
     call execute_command_line(temp)
 
     call execute_command_line(temp, exitstat=stat)
-    print *, "Exit status:", stat ! TODO: support keyword arguments in execute_command_line
-    ! if ( stat /= 0 ) error stop ! TODO: uncomment once keyword arguments are supported
+    print *, "Exit status:", stat
+    if ( stat /= 0 ) error stop 
 
 end program intrinsics_387
 

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -1006,16 +1006,16 @@ namespace ExecuteCommandLine {
         constexpr int EXITSTAT_BIT = 1 << 1;
         constexpr int CMDSTAT_BIT  = 1 << 2;
         constexpr int CMDMSG_BIT   = 1 << 3;
-
-        fill_func_arg_sub("wait", arg_types[1], InOut);
+        int optional_arg_index = 1;
+        fill_func_arg_sub("wait", arg_types[optional_arg_index++], InOut);
         if (overload_id & EXITSTAT_BIT) {
-            fill_func_arg_sub("exitstat", arg_types[2], InOut);
+            fill_func_arg_sub("exitstat", arg_types[optional_arg_index++], InOut);
         }
         if (overload_id & CMDSTAT_BIT) {
-            fill_func_arg_sub("cmdstat", arg_types[3], InOut);
+            fill_func_arg_sub("cmdstat", arg_types[optional_arg_index++], InOut);
         }
         if (overload_id & CMDMSG_BIT) {
-            fill_func_arg_sub("cmdmsg", arg_types[4], InOut);
+            fill_func_arg_sub("cmdmsg", arg_types[optional_arg_index], InOut);
         }
 
         SymbolTable *fn_symtab_1 = al.make_new<SymbolTable>(fn_symtab);
@@ -1036,7 +1036,7 @@ namespace ExecuteCommandLine {
 
         Vec<ASR::expr_t*> call_args; call_args.reserve(al, 1);
         call_args.push_back(al, args[0]);
-        int optional_arg_index = 2;
+        optional_arg_index = 2;
         if (overload_id & WAIT_BIT) {
             // TODO: handle this
         }

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -976,16 +976,24 @@ namespace ExecuteCommandLine {
 
     static inline ASR::asr_t* create_ExecuteCommandLine(Allocator& al, const Location& loc, Vec<ASR::expr_t*>& args, diag::Diagnostics& /*diag*/) {
         Vec<ASR::expr_t*> m_args; m_args.reserve(al, args.size());
+        ASRBuilder b(al, loc);
+        int64_t overload_id = 0;
+        if (args[1]) overload_id |= 1 << 0; // WAIT
+        if (args[2]) overload_id |= 1 << 1; // EXITSTAT
+        if (args[3]) overload_id |= 1 << 2; // CMDSTAT
+        if (args[4]) overload_id |= 1 << 3; // CMDMSG
         m_args.push_back(al, args[0]);
-        for (int i = 1; i < int(args.size()); i++) {
+        if (args[1]) m_args.push_back(al, args[1]);
+        else m_args.push_back(al, b.logical_true()); // default value for WAIT is true
+        for (int i = 2; i < int(args.size()); i++) {
             if(args[i]) m_args.push_back(al, args[i]);
         }
-        return ASR::make_IntrinsicImpureSubroutine_t(al, loc, static_cast<int64_t>(IntrinsicImpureSubroutines::ExecuteCommandLine), m_args.p, m_args.n, 0);
+        return ASR::make_IntrinsicImpureSubroutine_t(al, loc, static_cast<int64_t>(IntrinsicImpureSubroutines::ExecuteCommandLine), m_args.p, m_args.n, overload_id);
     }
 
     static inline ASR::stmt_t* instantiate_ExecuteCommandLine(Allocator &al, const Location &loc,
             SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types,
-            Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
+            Vec<ASR::call_arg_t>& new_args, int64_t overload_id) {
 
         std::string c_func_name = "_lfortran_exec_command";
         std::string new_name = "_lcompilers_execute_command_line_";
@@ -994,16 +1002,19 @@ namespace ExecuteCommandLine {
         declare_basic_variables(new_name);
         fill_func_arg_sub("command", str_type, InOut);
         ASR::expr_t* exit_status_local = declare("_lcompilers_exit_status", ret_type, Local);
-        if (arg_types.size() >= 2) {
-            fill_func_arg_sub("wait", arg_types[1], InOut);
-        }
-        if (arg_types.size() >= 3) {
+        constexpr int WAIT_BIT     = 1 << 0;
+        constexpr int EXITSTAT_BIT = 1 << 1;
+        constexpr int CMDSTAT_BIT  = 1 << 2;
+        constexpr int CMDMSG_BIT   = 1 << 3;
+
+        fill_func_arg_sub("wait", arg_types[1], InOut);
+        if (overload_id & EXITSTAT_BIT) {
             fill_func_arg_sub("exitstat", arg_types[2], InOut);
         }
-        if (arg_types.size() >= 4) {
+        if (overload_id & CMDSTAT_BIT) {
             fill_func_arg_sub("cmdstat", arg_types[3], InOut);
         }
-        if (arg_types.size() >= 5) {
+        if (overload_id & CMDMSG_BIT) {
             fill_func_arg_sub("cmdmsg", arg_types[4], InOut);
         }
 
@@ -1014,8 +1025,7 @@ namespace ExecuteCommandLine {
         args_1.push_back(al, arg);
 
         ASR::expr_t *return_var_1 = b.Variable(fn_symtab_1, c_func_name,
-        ret_type,
-        ASRUtils::intent_return_var, ASR::abiType::BindC, false);
+        ret_type, ASRUtils::intent_return_var, ASR::abiType::BindC, false);
 
         SetChar dep_1; dep_1.reserve(al, 1);
         Vec<ASR::stmt_t*> body_1; body_1.reserve(al, 1);
@@ -1026,9 +1036,14 @@ namespace ExecuteCommandLine {
 
         Vec<ASR::expr_t*> call_args; call_args.reserve(al, 1);
         call_args.push_back(al, args[0]);
+        int optional_arg_index = 2;
+        if (overload_id & WAIT_BIT) {
+            // TODO: handle this
+        }
         body.push_back(al, b.Assignment(exit_status_local, b.Call(s, call_args, ret_type)));
-        if ( arg_types.size() >= 3) {
-            body.push_back(al, b.Assignment(args[2], exit_status_local));
+        if (overload_id & EXITSTAT_BIT) {
+            body.push_back(al, b.Assignment(args[optional_arg_index], exit_status_local));
+            optional_arg_index++;
         }
         ASR::symbol_t *new_symbol = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);

--- a/tests/reference/asr-cmd_02-ba58262.json
+++ b/tests/reference/asr-cmd_02-ba58262.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cmd_02-ba58262.stdout",
-    "stdout_hash": "e099a231f7d6fd6851a6e89c9d94a038a16c4e0b6a3b1aa1a6b9c8b7",
+    "stdout_hash": "d6c37ffc599cfa66d0aaedc1610a8e727a07c142ca1f6b4e142ad4f3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cmd_02-ba58262.stdout
+++ b/tests/reference/asr-cmd_02-ba58262.stdout
@@ -54,6 +54,10 @@
                         [(StringConstant
                             "printenv"
                             (String 1 (IntegerConstant 8 (Integer 4) Decimal) ExpressionLength PointerString)
+                        )
+                        (LogicalConstant
+                            .true.
+                            (Logical 4)
                         )]
                         0
                     )]

--- a/tests/reference/llvm-execute_command_line-0e9cd63.json
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-execute_command_line-0e9cd63.stdout",
-    "stdout_hash": "d30a9766f161abd2a3de516fcddb56940fb6bbab90cbea18e4949aee",
+    "stdout_hash": "809222def8a9b7949d239ccd5ea7144c9374e67420a6ef221a4c65b3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-execute_command_line-0e9cd63.stdout
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.stdout
@@ -4,7 +4,7 @@ source_filename = "LFortran"
 @0 = private unnamed_addr constant [19 x i8] c"echo \22Hello World\22\00", align 1
 @1 = private unnamed_addr constant [3 x i8] c"ls\00", align 1
 
-define void @_lcompilers_execute_command_line_(i8** %command) {
+define void @_lcompilers_execute_command_line_(i8** %command, i1* %wait) {
 .entry:
   %_lcompilers_exit_status = alloca i32, align 4
   %0 = load i8*, i8** %command, align 8
@@ -18,7 +18,7 @@ return:                                           ; preds = %.entry
 
 declare i32 @_lfortran_exec_command(i8*)
 
-define void @_lcompilers_execute_command_line_1(i8** %command) {
+define void @_lcompilers_execute_command_line_1(i8** %command, i1* %wait) {
 .entry:
   %_lcompilers_exit_status = alloca i32, align 4
   %0 = load i8*, i8** %command, align 8
@@ -32,13 +32,17 @@ return:                                           ; preds = %.entry
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value1 = alloca i8*, align 8
+  %call_arg_value3 = alloca i1, align 1
+  %call_arg_value2 = alloca i8*, align 8
+  %call_arg_value1 = alloca i1, align 1
   %call_arg_value = alloca i8*, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i8* getelementptr inbounds ([19 x i8], [19 x i8]* @0, i32 0, i32 0), i8** %call_arg_value, align 8
-  call void @_lcompilers_execute_command_line_(i8** %call_arg_value)
-  store i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0), i8** %call_arg_value1, align 8
-  call void @_lcompilers_execute_command_line_1(i8** %call_arg_value1)
+  store i1 true, i1* %call_arg_value1, align 1
+  call void @_lcompilers_execute_command_line_(i8** %call_arg_value, i1* %call_arg_value1)
+  store i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0), i8** %call_arg_value2, align 8
+  store i1 true, i1* %call_arg_value3, align 1
+  call void @_lcompilers_execute_command_line_1(i8** %call_arg_value2, i1* %call_arg_value3)
   call void @_lpython_free_argv()
   br label %return
 


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/7972