### PR TITLE
ref: rename `~abstract_type` to `~unlimited_polymorphic_type`

### DIFF
--- a/doc/src/asr/asr_nodes/statement_nodes/associate.md
+++ b/doc/src/asr/asr_nodes/statement_nodes/associate.md
@@ -129,7 +129,7 @@ ASR:
                                                                     Default
                                                                     (Pointer
                                                                         (Class
-                                                                            3 ~abstract_type
+                                                                            3 ~unlimited_polymorphic_type
                                                                             []
                                                                         )
                                                                     )
@@ -155,7 +155,7 @@ ASR:
                                                     ()
                                                     Default
                                                     (Class
-                                                        3 ~abstract_type
+                                                        3 ~unlimited_polymorphic_type
                                                         []
                                                     )
                                                     Source
@@ -163,14 +163,14 @@ ASR:
                                                     Required
                                                     .false.
                                                 ),
-                                            ~abstract_type:
+                                            ~unlimited_polymorphic_type:
                                                 (StructType
                                                     (SymbolTable
                                                         4
                                                         {
 
                                                         })
-                                                    ~abstract_type
+                                                    ~unlimited_polymorphic_type
                                                     []
                                                     Source
                                                     Public

--- a/doc/src/asr/asr_nodes/statement_nodes/associateblockcall.md
+++ b/doc/src/asr/asr_nodes/statement_nodes/associateblockcall.md
@@ -124,7 +124,7 @@ ASR:
                                                                     Default
                                                                     (Pointer
                                                                         (Class
-                                                                            3 ~abstract_type
+                                                                            3 ~unlimited_polymorphic_type
                                                                             []
                                                                         )
                                                                     )
@@ -150,7 +150,7 @@ ASR:
                                                     ()
                                                     Default
                                                     (Class
-                                                        3 ~abstract_type
+                                                        3 ~unlimited_polymorphic_type
                                                         []
                                                     )
                                                     Source
@@ -158,14 +158,14 @@ ASR:
                                                     Required
                                                     .false.
                                                 ),
-                                            ~abstract_type:
+                                            ~unlimited_polymorphic_type:
                                                 (StructType
                                                     (SymbolTable
                                                         4
                                                         {
 
                                                         })
-                                                    ~abstract_type
+                                                    ~unlimited_polymorphic_type
                                                     []
                                                     Source
                                                     Public

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4914,13 +4914,13 @@ public:
         } else if (sym_type->m_type == AST::decl_typeType::TypeClass) {
             std::string derived_type_name;
             if( !sym_type->m_name ) {
-                derived_type_name = "~abstract_type";
+                derived_type_name = "~unlimited_polymorphic_type";
             } else {
                 derived_type_name = to_lower(sym_type->m_name);
             }
             ASR::symbol_t *v = current_scope->resolve_symbol(derived_type_name);
             if( !v ) {
-                if( derived_type_name != "~abstract_type" ) {
+                if( derived_type_name != "~unlimited_polymorphic_type" ) {
                     diag.add(Diagnostic(
                         "Derived type '" + derived_type_name
                         + "' not declared",

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1931,7 +1931,7 @@ public:
                 continue;
             }
             char* aggregate_type_name = nullptr;
-            if (item.first != "~abstract_type") {
+            if (item.first != "~unlimited_polymorphic_type") {
                 ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(item.second));
                 if( ASR::is_a<ASR::StructType_t>(*var_type) ) {
                     ASR::symbol_t* sym = ASR::down_cast<ASR::StructType_t>(var_type)->m_derived_type;
@@ -1993,7 +1993,7 @@ public:
                 continue;
             }
             char* aggregate_type_name = nullptr;
-            if (item.first != "~abstract_type") {
+            if (item.first != "~unlimited_polymorphic_type") {
                 ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(item.second));
                 if( ASR::is_a<ASR::StructType_t>(*var_type) ) {
                     ASR::symbol_t* sym = ASR::down_cast<ASR::StructType_t>(var_type)->m_derived_type;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -337,7 +337,7 @@ namespace LCompilers {
         } else {
             std::vector<llvm::Type*> member_types;
             member_types.push_back(getIntType(8));
-            if( der_sym_name == "~abstract_type" ) {
+            if( der_sym_name == "~unlimited_polymorphic_type" ) {
                 member_types.push_back(llvm::Type::getVoidTy(context)->getPointerTo());
             } else if( ASR::is_a<ASR::Struct_t>(*der_sym) ) {
                 ASR::Struct_t* struct_type_t = ASR::down_cast<ASR::Struct_t>(der_sym);

--- a/tests/reference/asr-derived_types_06-5ae916e.json
+++ b/tests/reference/asr-derived_types_06-5ae916e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-5ae916e.stdout",
-    "stdout_hash": "31c42888728ac2060ad8407fec4e334b8c3de6c05b4b58878cb731b0",
+    "stdout_hash": "f8d8dfa747cc968ba999f350130c3fb0bbabb0333630f47761c187d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-5ae916e.stdout
+++ b/tests/reference/asr-derived_types_06-5ae916e.stdout
@@ -25,7 +25,7 @@
                                                         []
                                                         []
                                                         .false.
-                                                        3 ~abstract_type
+                                                        3 ~unlimited_polymorphic_type
                                                     )
                                                     ()
                                                     Source
@@ -38,14 +38,14 @@
                                                     .false.
                                                     .false.
                                                 ),
-                                            ~abstract_type:
+                                            ~unlimited_polymorphic_type:
                                                 (Struct
                                                     (SymbolTable
                                                         4
                                                         {
                                                             
                                                         })
-                                                    ~abstract_type
+                                                    ~unlimited_polymorphic_type
                                                     []
                                                     []
                                                     []
@@ -64,7 +64,7 @@
                                             []
                                             []
                                             .false.
-                                            3 ~abstract_type
+                                            3 ~unlimited_polymorphic_type
                                         )]
                                         ()
                                         Source

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_arguments_02-bb6f3e2.stdout",
-    "stdout_hash": "35803aa22300b301f4b20cacbd4b759d3c6d80a3db39f43dfb334229",
+    "stdout_hash": "5a73f4ef6788fe0b2d87f87766bf1b2370be8628e8956bfdc4120076",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
@@ -139,7 +139,7 @@
                                                         []
                                                         []
                                                         .false.
-                                                        3 ~abstract_type
+                                                        3 ~unlimited_polymorphic_type
                                                     )
                                                     ()
                                                     Source
@@ -173,14 +173,14 @@
                                                     .false.
                                                     .false.
                                                 ),
-                                            ~abstract_type:
+                                            ~unlimited_polymorphic_type:
                                                 (Struct
                                                     (SymbolTable
                                                         4
                                                         {
                                                             
                                                         })
-                                                    ~abstract_type
+                                                    ~unlimited_polymorphic_type
                                                     []
                                                     []
                                                     []
@@ -199,7 +199,7 @@
                                             []
                                             []
                                             .false.
-                                            3 ~abstract_type
+                                            3 ~unlimited_polymorphic_type
                                         )]
                                         (Integer 4)
                                         Source

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_class_in_derived_type-15eb7b6.stdout",
-    "stdout_hash": "5cc71082aa5b532d41332cad1bc7e84f2ec1596ca576405fad006cf6",
+    "stdout_hash": "271bd8d4251b0e6a0afea69a846dce821593e2065cd117a0128ce222",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
@@ -26,7 +26,7 @@
                                                             []
                                                             []
                                                             .false.
-                                                            3 ~abstract_type
+                                                            3 ~unlimited_polymorphic_type
                                                         )
                                                     )
                                                     ()
@@ -54,7 +54,7 @@
                                                             []
                                                             []
                                                             .false.
-                                                            3 ~abstract_type
+                                                            3 ~unlimited_polymorphic_type
                                                         )
                                                     )
                                                     ()
@@ -68,14 +68,14 @@
                                                     .false.
                                                     .false.
                                                 ),
-                                            ~abstract_type:
+                                            ~unlimited_polymorphic_type:
                                                 (Struct
                                                     (SymbolTable
                                                         4
                                                         {
                                                             
                                                         })
-                                                    ~abstract_type
+                                                    ~unlimited_polymorphic_type
                                                     []
                                                     []
                                                     []


### PR DESCRIPTION
This PR patches a parallel refactoring done as a part of #5791 ( struct refactoring ). We don't want to manage two refactoring in same PR, this leads to lot of manual effort while rebasing to get LFortran binary working.