### PR TITLE
fix : Do not return from instantiate function and populate llvm_symtab_fn for class interfaces

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2435,6 +2435,9 @@ RUN(NAME separate_compilation_12 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_13 LABELS gfortran llvm EXTRAFILES separate_compilation_13a.f90)
 RUN(NAME separate_compilation_14 LABELS gfortran llvm EXTRAFILES separate_compilation_14a.f90)
 RUN(NAME separate_compilation_15 LABELS gfortran llvm EXTRAFILES separate_compilation_15a.f90)
+RUN(NAME separate_compilation_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_16a.f90 separate_compilation_16b.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_17a.f90 separate_compilation_17b.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_18a.f90 separate_compilation_18b.f90 EXTRA_ARGS --separate-compilation)
 
 
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -759,7 +759,7 @@ RUN(NAME format_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran fortran)
 RUN(NAME submodule_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) 
-RUN(NAME submodule_04 LABELS gfortran)
+RUN(NAME submodule_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME submodule_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME submodule_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) 
 
@@ -2438,6 +2438,7 @@ RUN(NAME separate_compilation_15 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_16a.f90 separate_compilation_16b.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_17a.f90 separate_compilation_17b.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_18a.f90 separate_compilation_18b.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES separate_compilation_19a.f90 separate_compilation_19b.f90 EXTRA_ARGS --separate-compilation)
 
 
 

--- a/integration_tests/separate_compilation_16.f90
+++ b/integration_tests/separate_compilation_16.f90
@@ -1,0 +1,11 @@
+program separate_compilation_16
+    use mod_separate_compilation_16
+
+    implicit none
+
+    integer :: key = 5
+    call map_open_entry( key )
+
+    print *, key
+    if (key /= 1) error stop
+end program

--- a/integration_tests/separate_compilation_16a.f90
+++ b/integration_tests/separate_compilation_16a.f90
@@ -1,0 +1,10 @@
+module mod_separate_compilation_16
+    implicit none
+
+    interface
+        module subroutine map_open_entry(key)
+            integer, intent(inout) :: key
+        end subroutine map_open_entry
+    end interface
+    
+end module mod_separate_compilation_16

--- a/integration_tests/separate_compilation_16b.f90
+++ b/integration_tests/separate_compilation_16b.f90
@@ -1,0 +1,11 @@
+submodule(mod_separate_compilation_16) submod_separate_compilation_16
+    implicit none
+contains
+
+    module subroutine map_open_entry(key)
+        integer, intent(inout) :: key
+        integer, parameter :: i = 1
+        key = i
+    end subroutine map_open_entry
+
+end submodule submod_separate_compilation_16

--- a/integration_tests/separate_compilation_17.f90
+++ b/integration_tests/separate_compilation_17.f90
@@ -1,0 +1,17 @@
+program separate_compilation_17
+
+    use mod_separate_compilation_17
+
+    implicit none
+
+    integer(4) :: fnv_1_hasher = 1
+    type(key_type) :: key
+
+    allocate(key % value(4))
+    fnv_1_hasher = fnv_1_hash( key % value )
+    
+    print *, fnv_1_hasher
+    print *, key % value
+    if (fnv_1_hasher /= 5) error stop
+    if (.not. all(key % value == [1, 2, 3, 4])) error stop
+end program

--- a/integration_tests/separate_compilation_17a.f90
+++ b/integration_tests/separate_compilation_17a.f90
@@ -1,0 +1,16 @@
+module mod_separate_compilation_17
+
+    implicit none
+
+    type :: key_type
+        integer(1), allocatable :: value(:)
+    end type key_type
+
+    interface fnv_1_hash
+        module function int8_fnv_1( key ) result(hash_code)
+            integer(1), intent(inout) :: key(:)
+            integer(4)             :: hash_code
+        end function int8_fnv_1
+    end interface fnv_1_hash
+
+end module mod_separate_compilation_17

--- a/integration_tests/separate_compilation_17b.f90
+++ b/integration_tests/separate_compilation_17b.f90
@@ -1,0 +1,16 @@
+submodule(mod_separate_compilation_17) submod_separate_compilation_17
+
+    implicit none
+
+contains
+
+    module function int8_fnv_1( key ) result(hash_code)
+        integer(1), intent(inout) :: key(:)
+        integer(4)             :: hash_code
+        integer(1), parameter :: array(4) = [1, 2, 3, 4]
+        integer(4), parameter :: result = 5
+        hash_code = result
+        key = array
+    end function int8_fnv_1
+
+end submodule submod_separate_compilation_17

--- a/integration_tests/separate_compilation_18.f90
+++ b/integration_tests/separate_compilation_18.f90
@@ -1,0 +1,8 @@
+program separate_compilation_18
+use mod_separate_compilation_18, only: f
+implicit none
+integer :: i
+i = f(5)
+print *, i
+if (i /= 6) error stop
+end program

--- a/integration_tests/separate_compilation_18a.f90
+++ b/integration_tests/separate_compilation_18a.f90
@@ -1,0 +1,9 @@
+module mod_separate_compilation_18
+    implicit none
+    interface
+        module function f(a) result(r)
+        integer, intent(in) :: a
+        integer :: r
+        end function
+    end interface
+end module

--- a/integration_tests/separate_compilation_18b.f90
+++ b/integration_tests/separate_compilation_18b.f90
@@ -1,0 +1,8 @@
+submodule (mod_separate_compilation_18) submod_separate_compilation_18
+contains
+    module function f(a) result(r)
+    integer, intent(in) :: a
+    integer :: r
+    r = a + 1
+    end function
+end submodule

--- a/integration_tests/separate_compilation_19.f90
+++ b/integration_tests/separate_compilation_19.f90
@@ -1,0 +1,12 @@
+program separate_compilation_19
+    use mod_separate_compilation_19, only : open_hashmap_type
+
+    implicit none
+
+    type(open_hashmap_type)   :: map
+    integer :: key = 1
+    call map % map_entry( key )
+
+    print *, key
+    if (key /= 5) error stop
+end program

--- a/integration_tests/separate_compilation_19a.f90
+++ b/integration_tests/separate_compilation_19a.f90
@@ -1,0 +1,19 @@
+module mod_separate_compilation_19
+    implicit none
+    private
+
+    public ::  open_hashmap_type
+
+    type :: open_hashmap_type
+    contains
+        procedure :: map_entry => map_open_entry
+    end type open_hashmap_type
+
+    interface
+        module subroutine map_open_entry(map, key)
+            class(open_hashmap_type), intent(inout) :: map
+            integer, intent(inout) :: key
+        end subroutine map_open_entry
+    end interface
+    
+end module mod_separate_compilation_19

--- a/integration_tests/separate_compilation_19b.f90
+++ b/integration_tests/separate_compilation_19b.f90
@@ -1,0 +1,12 @@
+submodule(mod_separate_compilation_19) submod_separate_compilation_19
+    implicit none
+contains
+
+    module subroutine map_open_entry(map, key)
+        class(open_hashmap_type), intent(inout) :: map
+        integer, intent(inout) :: key
+        integer, parameter :: i = 5
+        key = i
+    end subroutine map_open_entry
+
+end submodule submod_separate_compilation_19

--- a/integration_tests/submodule_04.f90
+++ b/integration_tests/submodule_04.f90
@@ -12,7 +12,7 @@ module mod_submodule_04
     interface
         module subroutine map_open_entry(map, key)
             class(open_hashmap_type), intent(inout) :: map
-            integer, intent(in) :: key
+            integer, intent(inout) :: key
         end subroutine map_open_entry
     end interface
     
@@ -24,7 +24,9 @@ contains
 
     module subroutine map_open_entry(map, key)
         class(open_hashmap_type), intent(inout) :: map
-        integer, intent(in) :: key
+        integer, intent(inout) :: key
+        integer, parameter :: i = 5
+        key = i
     end subroutine map_open_entry
 
 end submodule submod_submodule_04
@@ -35,7 +37,9 @@ program submodule_04
     implicit none
 
     type(open_hashmap_type)   :: map
-    integer :: key
+    integer :: key = 1
     call map % map_entry( key )
 
+    print *, key
+    if (key /= 5) error stop
 end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4668,7 +4668,7 @@ public:
             F = llvm_symtab_fn[h];
         } else {
             llvm::FunctionType* function_type = llvm_utils->get_function_type(x, module.get());
-            if( ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface ) {
+            if( ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface && !ASRUtils::get_FunctionType(x)->m_module ) {
                 ASR::FunctionType_t* asr_function_type = ASRUtils::get_FunctionType(x);
                 for( size_t i = 0; i < asr_function_type->n_arg_types; i++ ) {
                     if( ASRUtils::is_class_type(asr_function_type->m_arg_types[i]) ) {

--- a/tests/reference/asr-submodule_04-987b68b.json
+++ b/tests/reference/asr-submodule_04-987b68b.json
@@ -2,11 +2,11 @@
     "basename": "asr-submodule_04-987b68b",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/submodule_04.f90",
-    "infile_hash": "1ee184e69f2fa86a356dae9c4120b52fba811ff7b0ed2063fd50c544",
+    "infile_hash": "642c924ba406c1301d4f17d3aa23330c0c88836827e2ccc9a223fe50",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_04-987b68b.stdout",
-    "stdout_hash": "f833a0cfa6f22b6e57a9876a4fd0c9734fffe2703b046bf5ca6e98da",
+    "stdout_hash": "2bd6118d1e89b4736bd45ad6e2a8169cb2639e44417f87ce9de3d972",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_04-987b68b.stdout
+++ b/tests/reference/asr-submodule_04-987b68b.stdout
@@ -17,7 +17,7 @@
                                                     4
                                                     key
                                                     []
-                                                    In
+                                                    InOut
                                                     ()
                                                     ()
                                                     Default
@@ -137,12 +137,33 @@
                                     (SymbolTable
                                         6
                                         {
+                                            i:
+                                                (Variable
+                                                    6
+                                                    i
+                                                    []
+                                                    Local
+                                                    (IntegerConstant 5 (Integer 4) Decimal)
+                                                    (IntegerConstant 5 (Integer 4) Decimal)
+                                                    Parameter
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                    .false.
+                                                    .false.
+                                                ),
                                             key:
                                                 (Variable
                                                     6
                                                     key
                                                     []
-                                                    In
+                                                    InOut
                                                     ()
                                                     ()
                                                     Default
@@ -209,7 +230,12 @@
                                     []
                                     [(Var 6 map)
                                     (Var 6 key)]
-                                    []
+                                    [(Assignment
+                                        (Var 6 key)
+                                        (Var 6 i)
+                                        ()
+                                        .false.
+                                    )]
                                     ()
                                     Public
                                     .false.
@@ -254,9 +280,9 @@
                                     key
                                     []
                                     Local
-                                    ()
-                                    ()
-                                    Default
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    Save
                                     (Integer 4)
                                     ()
                                     Source
@@ -313,6 +339,29 @@
                         ()
                         [((Var 7 key))]
                         (Var 7 map)
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(Var 7 key)]
+                            FormatFortran
+                            (String 1 () ExpressionLength CString)
+                            ()
+                        )
+                    )
+                    (If
+                        ()
+                        (IntegerCompare
+                            (Var 7 key)
+                            NotEq
+                            (IntegerConstant 5 (Integer 4) Decimal)
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
                     )]
                 )
         })


### PR DESCRIPTION
Towards #536 
Fixes #7270
Addresses https://github.com/lfortran/lfortran/pull/8010#pullrequestreview-3004223332