### PR TITLE
enh: mangle parent name as prefix for module variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1275,6 +1275,7 @@ RUN(NAME modules_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES modules_58_module.f90)
 RUN(NAME modules_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME modules_61 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_05_module3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
     operator_overloading_05_module1.f90 operator_overloading_05_module2.f90)
 RUN(NAME operator_overloading_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/modules_61.f90
+++ b/integration_tests/modules_61.f90
@@ -1,0 +1,31 @@
+module modules_61_mod1
+  integer :: inn = 10
+end module 
+
+module modules_61_mod2
+  integer :: inn = 91
+end module 
+
+module modules_61_mod3
+  contains
+subroutine foo
+  use modules_61_mod2
+  print *, inn
+  if (inn /= 91) error stop
+  inn = 1000
+  print *, inn
+end subroutine
+
+subroutine foo2
+  use modules_61_mod1
+  print *, inn
+  if(inn /= 10) error stop
+end subroutine
+  
+end module
+
+program modules_61
+  use modules_61_mod3
+  call foo
+  call foo2
+end program modules_61

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3138,7 +3138,11 @@ public:
             // for external global variable with bindc, use the C name
             llvm_var_name = x.m_bindc_name;
         } else {
-            llvm_var_name = x.m_name;
+            if ( !( ASRUtils::is_struct(*x.m_type) || ASRUtils::is_class_type(x.m_type) ) ) {
+                llvm_var_name = mangle_prefix + x.m_name;
+            } else {
+                llvm_var_name = x.m_name;
+            }
         }
         if (x.m_type->type == ASR::ttypeType::Integer
             || x.m_type->type == ASR::ttypeType::UnsignedInteger) {

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "0f26a06768d32c2d8676838083a67562c192531b2776961317f1c8d7",
+    "stdout_hash": "fd0c97a5c22e13d4988e595585d2fbd1ff5ffc38e8b6f01a0f07eaf1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -5,7 +5,7 @@ source_filename = "LFortran"
 %circle = type <{ float }>
 %__vtab_circle = type { i64 }
 
-@pi = global float 0x400921FB60000000
+@__module_class_circle1_pi = global float 0x400921FB60000000
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [15 x i8] c"S-12,R4,S-8,R4\00", align 1
 @1 = private unnamed_addr constant [13 x i8] c"Circle: r = \00", align 1
@@ -18,7 +18,7 @@ define float @__module_class_circle1_circle_area(%circle_polymorphic* %this) {
   %1 = getelementptr %__vtab_circle, %__vtab_circle* %0, i32 0, i32 0
   store i64 0, i64* %1, align 4
   %area = alloca float, align 4
-  %2 = load float, float* @pi, align 4
+  %2 = load float, float* @__module_class_circle1_pi, align 4
   %3 = getelementptr %circle_polymorphic, %circle_polymorphic* %this, i32 0, i32 1
   %4 = load %circle*, %circle** %3, align 8
   %5 = getelementptr %circle, %circle* %4, i32 0, i32 0

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "3c46a13a2b714a854700329a2b4709a88cafe07236a85c40db6cdb82",
+    "stdout_hash": "6f70e602a205041f72f6a967b94c044cbc7640cb3c5e914f3e80281c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -5,7 +5,7 @@ source_filename = "LFortran"
 %circle = type <{ float }>
 %__vtab_circle = type { i64 }
 
-@pi = global float 0x400921FB60000000
+@__module_class_circle2_pi = global float 0x400921FB60000000
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [15 x i8] c"S-12,R4,S-8,R4\00", align 1
 @1 = private unnamed_addr constant [13 x i8] c"Circle: r = \00", align 1
@@ -18,7 +18,7 @@ define float @__module_class_circle2_circle_area(%circle_polymorphic* %this) {
   %1 = getelementptr %__vtab_circle, %__vtab_circle* %0, i32 0, i32 0
   store i64 0, i64* %1, align 4
   %circle_area = alloca float, align 4
-  %2 = load float, float* @pi, align 4
+  %2 = load float, float* @__module_class_circle2_pi, align 4
   %3 = getelementptr %circle_polymorphic, %circle_polymorphic* %this, i32 0, i32 1
   %4 = load %circle*, %circle** %3, align 8
   %5 = getelementptr %circle, %circle* %4, i32 0, i32 0

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "1c7be938a5fe073e7614bf7df0929da7ed54356ab2b428614cc1879b",
+    "stdout_hash": "49293555ac203316b1bdb584a826b50f195764cd25608c6573fc5e79",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@i = global i32 1
-@j = global i32 2
+@__module_modules_11_module11_i = global i32 1
+@__module_modules_11_module11_j = global i32 2
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [7 x i8] c"S-4,I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"i = \00", align 1
@@ -16,7 +16,7 @@ define void @__module_modules_11_module11_access_internally() {
 .entry:
   %0 = alloca i8*, align 8
   store i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8** %0, align 8
-  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i8** %0, i32* @i)
+  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i8** %0, i32* @__module_modules_11_module11_i)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   br label %return
 
@@ -33,7 +33,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i8*, align 8
   store i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8** %2, align 8
-  %3 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i8** %2, i32* @j)
+  %3 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i8** %2, i32* @__module_modules_11_module11_j)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
   call void @__module_modules_11_module11_access_internally()
   call void @_lpython_free_argv()

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "c5ecc4ba2105ade67d581711904b6f3b41c96b414426adc80b677afc",
+    "stdout_hash": "a85417f4f35de5e720e2edb651441916144c4393e0f4320133a1ba0e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__b_x = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -18,9 +18,9 @@ define void @__module_nested_03_a_b() {
   store float 6.000000e+00, float* %x, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   %0 = load float, float* %x, align 4
-  store float %0, float* @__lcompilers_created__nested_context__b_x, align 4
+  store float %0, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
   call void @b.__module_nested_03_a_c()
-  %1 = load float, float* @__lcompilers_created__nested_context__b_x, align 4
+  %1 = load float, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
   store float %1, float* %x, align 4
   br label %return
 
@@ -34,7 +34,7 @@ define void @b.__module_nested_03_a_c() {
   store i32 5, i32* %0, align 4
   %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, float* @__lcompilers_created__nested_context__b_x)
+  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "664299531f446412f3bc2eecd1361cfa8ccf83e1cc897729fee56398",
+    "stdout_hash": "53bb369dd24974d387c51b4b70354f6d8fb81e5c9d4c42a4c2ac37bf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__b_y = global i32 0
-@__lcompilers_created__nested_context__b_yy = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y = global i32 0
+@__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_yy = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -27,15 +27,15 @@ define i32 @__module_nested_04_a_b(i32* %x) {
   store i32 %0, i32* %y, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   %1 = load i32, i32* %y, align 4
-  store i32 %1, i32* @__lcompilers_created__nested_context__b_y, align 4
+  store i32 %1, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y, align 4
   %2 = load float, float* %yy, align 4
-  store float %2, float* @__lcompilers_created__nested_context__b_yy, align 4
+  store float %2, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_yy, align 4
   store i32 6, i32* %call_arg_value, align 4
   %3 = call i32 @b.__module_nested_04_a_c(i32* %call_arg_value)
   store i32 %3, i32* %b, align 4
-  %4 = load i32, i32* @__lcompilers_created__nested_context__b_y, align 4
+  %4 = load i32, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y, align 4
   store i32 %4, i32* %y, align 4
-  %5 = load float, float* @__lcompilers_created__nested_context__b_yy, align 4
+  %5 = load float, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_yy, align 4
   store float %5, float* %yy, align 4
   br label %return
 
@@ -49,9 +49,9 @@ define i32 @b.__module_nested_04_a_c(i32* %z) {
   %c = alloca i32, align 4
   %0 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %z)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i32* @__lcompilers_created__nested_context__b_y)
+  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32 0, float* @__lcompilers_created__nested_context__b_yy)
+  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_yy)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   %3 = load i32, i32* %z, align 4
   store i32 %3, i32* %c, align 4

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "ff9d11f703e4a18a6d73a92b7dab180108357995573983911d8e9dab",
+    "stdout_hash": "e738f4bed7bcfd0fde4200769be3b9a1dcb67fda81616a5d74ea2f4a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__b_x = global i32 0
-@__lcompilers_created__nested_context__b_y = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x = global i32 0
+@__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -33,13 +33,13 @@ define void @__module_nested_05_a_b() {
   %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i32 0, i32 0, float* %y)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   %2 = load i32, i32* %x, align 4
-  store i32 %2, i32* @__lcompilers_created__nested_context__b_x, align 4
+  store i32 %2, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
   %3 = load float, float* %y, align 4
-  store float %3, float* @__lcompilers_created__nested_context__b_y, align 4
+  store float %3, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y, align 4
   call void @b.__module_nested_05_a_c()
-  %4 = load i32, i32* @__lcompilers_created__nested_context__b_x, align 4
+  %4 = load i32, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
   store i32 %4, i32* %x, align 4
-  %5 = load float, float* @__lcompilers_created__nested_context__b_y, align 4
+  %5 = load float, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y, align 4
   store float %5, float* %y, align 4
   %6 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i32 0, i32 0, i32* %x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %6, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -53,12 +53,12 @@ return:                                           ; preds = %.entry
 
 define void @b.__module_nested_05_a_c() {
 .entry:
-  %0 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* @__lcompilers_created__nested_context__b_x)
+  %0 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, float* @__lcompilers_created__nested_context__b_y)
+  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  store i32 4, i32* @__lcompilers_created__nested_context__b_x, align 4
-  store float 3.500000e+00, float* @__lcompilers_created__nested_context__b_y, align 4
+  store i32 4, i32* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
+  store float 3.500000e+00, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_y, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "2823c29d0a14cbb9790a8c9a4266e952fa1da39261b01a3d7dbd5bb6",
+    "stdout_hash": "1c32a6e78a60b803d7d550a1ccd5260f59978132603ef36bd15c87ae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__b_x = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -16,9 +16,9 @@ define void @__module_nested_06_a_b(float* %x) {
 .entry:
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   %0 = load float, float* %x, align 4
-  store float %0, float* @__lcompilers_created__nested_context__b_x, align 4
+  store float %0, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
   call void @b.__module_nested_06_a_c()
-  %1 = load float, float* @__lcompilers_created__nested_context__b_x, align 4
+  %1 = load float, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x, align 4
   store float %1, float* %x, align 4
   br label %return
 
@@ -32,7 +32,7 @@ define void @b.__module_nested_06_a_c() {
   store i32 5, i32* %0, align 4
   %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %0)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, float* @__lcompilers_created__nested_context__b_x)
+  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b____lcompilers_created__nested_context__b_x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   br label %return
 

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "125d56532c096e5982a80eed486fb2088315c50e02d3e56f965022a2",
+    "stdout_hash": "0b1f5d5e39c5b8b04d829ed032483c2606f845b1ee09dbfdbc490c58",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__closuretest_z = global i32 0
+@__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -13,7 +13,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %z1 = alloca i32, align 4
   %2 = load i32, i32* %z1, align 4
-  store i32 %2, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 %2, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
   store i32 0, i32* %z1, align 4
   br label %loop.head
 
@@ -28,19 +28,19 @@ loop.body:                                        ; preds = %loop.head
   %7 = add i32 %6, 1
   store i32 %7, i32* %z1, align 4
   %8 = load i32, i32* %z1, align 4
-  store i32 %8, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 %8, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
   store i32 1, i32* %call_arg_value, align 4
   %9 = call i32 @apply(i32 (i32*)* @add_z, i32* %call_arg_value)
   %10 = alloca i32, align 4
   store i32 %9, i32* %10, align 4
   %11 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %10)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %12 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  %12 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
   store i32 %12, i32* %z1, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %13 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  %13 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
   store i32 %13, i32* %z1, align 4
   call void @_lpython_free_argv()
   br label %return
@@ -53,7 +53,7 @@ define i32 @add_z(i32* %x) {
 .entry:
   %y = alloca i32, align 4
   %0 = load i32, i32* %x, align 4
-  %1 = load i32, i32* @__lcompilers_created__nested_context__closuretest_z, align 4
+  %1 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
   %2 = add i32 %0, %1
   store i32 %2, i32* %y, align 4
   br label %return

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "15763e02eb2ba27bcf3897021a2eb08b7a1b186617beb1d8eb8c3cb5",
+    "stdout_hash": "83786ffc2169bc9fc80f952668f6eac835fc2e5c2f5e484ae8be6577",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -1,9 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__sub1_x = global i32 0
-@n = global i32 0
-@x = global i32 0
+@__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x = global i32 0
+@__module_recursion_01_n = global i32 0
+@__module_recursion_01_x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -15,9 +15,9 @@ source_filename = "LFortran"
 define void @__module_recursion_01_sub1(i32* %x) {
 .entry:
   %0 = load i32, i32* %x, align 4
-  store i32 %0, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %0, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   %1 = load i32, i32* %x, align 4
-  %2 = load i32, i32* @n, align 4
+  %2 = load i32, i32* @__module_recursion_01_n, align 4
   %3 = icmp slt i32 %1, %2
   br i1 %3, label %then, label %else
 
@@ -30,14 +30,14 @@ then:                                             ; preds = %.entry
   %7 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.1, i32 0, i32 0), i32 0, i32 0, i8** %6, i32* %x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   %8 = load i32, i32* %x, align 4
-  store i32 %8, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %8, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   call void @sub1.__module_recursion_01_sub2()
-  %9 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %9 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %9, i32* %x, align 4
   %10 = load i32, i32* %x, align 4
-  store i32 %10, i32* @__lcompilers_created__nested_context__sub1_x, align 4
-  call void @__module_recursion_01_sub1(i32* @__lcompilers_created__nested_context__sub1_x)
-  %11 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %10, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
+  call void @__module_recursion_01_sub1(i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x)
+  %11 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %11, i32* %x, align 4
   br label %ifcont
 
@@ -45,7 +45,7 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %12 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %12, i32* %x, align 4
   br label %return
 
@@ -55,12 +55,12 @@ return:                                           ; preds = %ifcont
 
 define void @sub1.__module_recursion_01_sub2() {
 .entry:
-  %0 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %0 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   %1 = add i32 %0, 1
-  store i32 %1, i32* @__lcompilers_created__nested_context__sub1_x, align 4
-  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* @__lcompilers_created__nested_context__sub1_x)
+  store i32 %1, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
+  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__module_recursion_01_sub1(i32* @__lcompilers_created__nested_context__sub1_x)
+  call void @__module_recursion_01_sub1(i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -74,8 +74,8 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 10, i32* @n, align 4
-  call void @__module_recursion_01_sub1(i32* @x)
+  store i32 10, i32* @__module_recursion_01_n, align 4
+  call void @__module_recursion_01_sub1(i32* @__module_recursion_01_x)
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "b7cbba606fee7e99281231b3620ea79daff2ca2c9f7cada540aa7b4d",
+    "stdout_hash": "49b94aa859e1b636a22f78c0e698fad17672ca96eb10e28d591ca9f6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__sub1_x = global i32 0
+@__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [7 x i8] c"S-7,I4\00", align 1
 @1 = private unnamed_addr constant [8 x i8] c"before:\00", align 1
@@ -79,16 +79,16 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
   %3 = load i32, i32* %x, align 4
-  store i32 %3, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %3, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   %4 = call i32 @sub1.__module_recursion_02_getx()
   store i32 %4, i32* %tmp, align 4
-  %5 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %5 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %5, i32* %x, align 4
   %6 = load i32, i32* %x, align 4
-  store i32 %6, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %6, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   %7 = call i32 @__module_recursion_02_solver(i32 ()* @sub1.__module_recursion_02_getx, i32* %iter)
   store i32 %7, i32* %sub1, align 4
-  %8 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %8 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %8, i32* %x, align 4
   br label %return
 
@@ -102,9 +102,9 @@ define i32 @sub1.__module_recursion_02_getx() {
   %getx = alloca i32, align 4
   %0 = alloca i8*, align 8
   store i8* getelementptr inbounds ([10 x i8], [10 x i8]* @7, i32 0, i32 0), i8** %0, align 8
-  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32 0, i8** %0, i32* @__lcompilers_created__nested_context__sub1_x)
+  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.2, i32 0, i32 0), i32 0, i32 0, i8** %0, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  %2 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %2 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %2, i32* %getx, align 4
   br label %return
 

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "7ab37ba628396fcb7a6a010aede1fac5e555d17e4c6f6c2d4bc3660d",
+    "stdout_hash": "57c2d6cd6be7cf422faa80dc2d945aa0a2dc096ab3e20939413b8004",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -1,7 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@__lcompilers_created__nested_context__sub1_x = global i32 0
+@__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [7 x i8] c"S-7,I4\00", align 1
 @1 = private unnamed_addr constant [8 x i8] c"before:\00", align 1
@@ -93,16 +93,16 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
   %3 = load i32, i32* %x, align 4
-  store i32 %3, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %3, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   %4 = call i32 @sub1.__module_recursion_03_getx()
   store i32 %4, i32* %tmp, align 4
-  %5 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %5 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %5, i32* %x, align 4
   %6 = load i32, i32* %x, align 4
-  store i32 %6, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  store i32 %6, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   %7 = call i32 @__module_recursion_03_solver_caller(i32 ()* @sub1.__module_recursion_03_getx, i32* %iter)
   store i32 %7, i32* %sub1, align 4
-  %8 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %8 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %8, i32* %x, align 4
   br label %return
 
@@ -116,9 +116,9 @@ define i32 @sub1.__module_recursion_03_getx() {
   %getx = alloca i32, align 4
   %0 = alloca i8*, align 8
   store i8* getelementptr inbounds ([10 x i8], [10 x i8]* @7, i32 0, i32 0), i8** %0, align 8
-  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i32 0, i32 0, i8** %0, i32* @__lcompilers_created__nested_context__sub1_x)
+  %1 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i32 0, i32 0, i8** %0, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @8, i32 0, i32 0), i8* %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  %2 = load i32, i32* @__lcompilers_created__nested_context__sub1_x, align 4
+  %2 = load i32, i32* @__module___lcompilers_created__nested_context__sub1____lcompilers_created__nested_context__sub1_x, align 4
   store i32 %2, i32* %getx, align 4
   br label %return
 


### PR DESCRIPTION
Fixes #8019.