### PR TITLE
feat: allow a submodule to use the same module as the parent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -762,6 +762,7 @@ RUN(NAME submodule_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME submodule_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME submodule_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME submodule_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) 
+RUN(NAME submodule_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME floor_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran) # floor body
 RUN(NAME floor_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran) # floor symboltable

--- a/integration_tests/submodule_07.f90
+++ b/integration_tests/submodule_07.f90
@@ -1,0 +1,28 @@
+module mod_wrapper_submodule_07
+    implicit none
+    private
+
+    public :: key_type
+
+    type :: key_type
+        integer :: value
+    end type key_type
+end module mod_wrapper_submodule_07
+
+
+module mod_submodule_07
+    use mod_wrapper_submodule_07
+
+contains
+    module subroutine sub()
+        print *, "Hello World"
+    end subroutine
+end module mod_submodule_07
+
+submodule(mod_submodule_07) submod_submodule_07
+    use mod_wrapper_submodule_07
+end submodule submod_submodule_07
+
+program main
+    use mod_submodule_07
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2759,8 +2759,7 @@ public:
                            item.first) != symbols_already_imported_with_renaming.end() ) {
                 continue;
             }
-            if( current_scope->get_symbol(item.first) != nullptr &&
-                !in_submodule ) {
+            if( current_scope->get_symbol(item.first) != nullptr) {
                 continue;
             }
             // TODO: only import "public" symbols from the module


### PR DESCRIPTION
fixes #7229

For now, this should work, but I suggest that we need to change the way `use` includes symbols in a module. Right now, `use` adds the symbols of the target module to the symbol table's scope of the module in which it is used. However, I think we need to separate the used symbols from those that are defined inside the module.