### PR TITLE
Refined Rank mismatch error

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4133,8 +4133,8 @@ public:
                             = ASR::down_cast<ASR::Array_t>(ASRUtils::expr_type(tmp_init));
                         if (lhs_array->n_dims != rhs_array->n_dims) {
                             diag.add(Diagnostic(
-                                "Incompatible ranks `"+ std::to_string(lhs_array->n_dims) + "` and `"
-                                                                  + std::to_string(rhs_array->n_dims) + "` in assignment",
+                                "Incompatible ranks "+ std::to_string(lhs_array->n_dims) + " and "
+                                                                  + std::to_string(rhs_array->n_dims) + " in assignment",
                                                 Level::Error,
                                                 Stage::Semantic,
                                                 { Label("", { tmp_init->base.loc }) }));

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "fa2a4ab45bc605c7fa574dca3bc46444ed6fde421549d8f1dd11a6f5",
+    "stderr_hash": "db68f777286058817496e5a0532f129985defed0ec79e8cde68e777b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -242,7 +242,7 @@ semantic error: Keyword argument not found
 196 |     type(Circle) :: myCircle3 = Circle(mykeyword=10)
     |                                 ^^^^^^^^^^^^^^^^^^^^ 'mykeyword' keyword argument not found
 
-semantic error: Incompatible ranks `2` and `1` in assignment
+semantic error: Incompatible ranks 2 and 1 in assignment
    --> tests/errors/continue_compilation_2.f90:199:36
     |
 199 |     integer, dimension(3,2) :: m = [ 1, 0, 0, 2, 4, 6 ]


### PR DESCRIPTION
fixes #6576
Improving PR #6581

- Highlights **only the RHS initializer** in the error (previously, the entire line was highlighted)
- Displays the **actual ranks** of both the LHS and RHS in the error message