### PR TITLE
Implementing BOZ to Real Conversion

### DIFF
--- a/integration_tests/boz_01.f90
+++ b/integration_tests/boz_01.f90
@@ -1,11 +1,14 @@
 program boz_01
 implicit none
 
-integer :: boz_1, boz_2, boz_3
+integer :: boz_1, boz_2, boz_3, boz_4, boz_5, boz_6
 
 boz_1 = int(b'01011101')
 boz_2 = int(o'2347')
 boz_3 = int(z'ABC')
+Data boz_4 /b'01011101'/
+Data boz_5 /o'2347'/
+Data boz_6 /z'ABC'/
 
-print *, boz_1, boz_2, boz_3
+print *, boz_1, boz_2, boz_3, boz_4, boz_5, boz_6
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2389,7 +2389,17 @@ public:
     void handle_scalar_data_stmt(const AST::DataStmt_t &x, AST::DataStmtSet_t *a, size_t i, size_t &j) {
         this->visit_expr(*a->m_object[i]);
         ASR::expr_t* object = ASRUtils::EXPR(tmp);
+        ASR::ttype_t* obj_type = ASRUtils::expr_type(object);
+        // Get the Type of Object
+        // If object is Real, set current_variable_type to Real
+        // This type flag is passed to Visit_BOZ, 
+        // so that Real Values are correctly decoded from BOZ String
+        ASR::ttype_t* temp_current_variable_type_ = current_variable_type_;
+        if (ASR::is_a<ASR::Real_t>(*obj_type)) {
+            current_variable_type_ = obj_type;
+        }
         this->visit_expr(*a->m_value[j++]);
+        current_variable_type_ = temp_current_variable_type_;
         ASR::expr_t* value = ASRUtils::EXPR(tmp);
         // The parser ensures object is a TK_NAME
         // The `visit_expr` ensures it resolves as an expression
@@ -10901,6 +10911,7 @@ public:
         std::string s = std::string(x.m_s);
         int base = -1;
         ASR::integerbozType boz_type;
+        //Check if the argument string is correct BOZ Type
         if( s[0] == 'b' || s[0] == 'B' ) {
             boz_type = ASR::integerbozType::Binary;
             base = 2;
@@ -10919,10 +10930,25 @@ public:
         }
         std::string boz_str = s.substr(2, s.size() - 2);
         uint64_t boz_unsigned_int = std::stoull(boz_str, nullptr, base);
-        int64_t boz_int = static_cast<int64_t>(boz_unsigned_int);
-        ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
-        tmp = ASR::make_IntegerConstant_t(al, x.base.base.loc, boz_int,
-                int_type, boz_type);
+        //If current_variable_type is Real Type, convert BOZ String to ASR::Real 
+        if ((current_variable_type_ != nullptr) && (ASR::is_a<ASR::Real_t>(*current_variable_type_)) ){
+            
+            // We need the smallest positive real value, and scale the bits accordingly
+            double min_boz = std::numeric_limits<float>::denorm_min();
+            // Scale the BOZ value: each bit represents smallest_subnormal
+            double boz_double = static_cast<double>(boz_unsigned_int) * min_boz;
+            ASR::ttype_t* real_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
+            tmp = ASR::make_RealConstant_t(al, x.base.base.loc, boz_double,
+                    real_type);
+        }
+
+        //If current_variable_type is Null or INT Type, default to INT 
+        else{            
+            int64_t boz_int = static_cast<int64_t>(boz_unsigned_int);
+            ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
+            tmp = ASR::make_IntegerConstant_t(al, x.base.base.loc, boz_int,
+                    int_type, boz_type);
+        }
     }
 
     void visit_Num(const AST::Num_t &x) {

--- a/tests/reference/asr-boz_01-dedad59.json
+++ b/tests/reference/asr-boz_01-dedad59.json
@@ -2,11 +2,11 @@
     "basename": "asr-boz_01-dedad59",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/boz_01.f90",
-    "infile_hash": "0834d7e263b86abd28671af7f096f5f3359c8ff113f86332bed9c187",
+    "infile_hash": "eb51d11b212c6b3c2f1e53a3fb01d63ce87f1dd1589336c7e77adc50",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-boz_01-dedad59.stdout",
-    "stdout_hash": "0dfc3a4b8a989dd1df705a11af61122ab206a6f014ad8bf0833cb2cc",
+    "stdout_hash": "62fb5b08c86e4567bb0aa9b0b0c801ff156dbed2d0589ba00330e6b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-boz_01-dedad59.stdout
+++ b/tests/reference/asr-boz_01-dedad59.stdout
@@ -69,6 +69,69 @@
                                     ()
                                     .false.
                                     .false.
+                                ),
+                            boz_4:
+                                (Variable
+                                    2
+                                    boz_4
+                                    []
+                                    Local
+                                    (IntegerConstant 93 (Integer 4) Binary)
+                                    (IntegerConstant 93 (Integer 4) Binary)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            boz_5:
+                                (Variable
+                                    2
+                                    boz_5
+                                    []
+                                    Local
+                                    (IntegerConstant 1255 (Integer 4) Octal)
+                                    (IntegerConstant 1255 (Integer 4) Octal)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            boz_6:
+                                (Variable
+                                    2
+                                    boz_6
+                                    []
+                                    Local
+                                    (IntegerConstant 2748 (Integer 4) Hex)
+                                    (IntegerConstant 2748 (Integer 4) Hex)
+                                    Default
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
                                 )
                         })
                     boz_01
@@ -109,12 +172,33 @@
                         ()
                         .false.
                     )
+                    (Assignment
+                        (Var 2 boz_4)
+                        (IntegerConstant 93 (Integer 4) Binary)
+                        ()
+                        .false.
+                    )
+                    (Assignment
+                        (Var 2 boz_5)
+                        (IntegerConstant 1255 (Integer 4) Octal)
+                        ()
+                        .false.
+                    )
+                    (Assignment
+                        (Var 2 boz_6)
+                        (IntegerConstant 2748 (Integer 4) Hex)
+                        ()
+                        .false.
+                    )
                     (Print
                         (StringFormat
                             ()
                             [(Var 2 boz_1)
                             (Var 2 boz_2)
-                            (Var 2 boz_3)]
+                            (Var 2 boz_3)
+                            (Var 2 boz_4)
+                            (Var 2 boz_5)
+                            (Var 2 boz_6)]
                             FormatFortran
                             (String 1 () ExpressionLength CString)
                             ()

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -2,11 +2,11 @@
     "basename": "llvm-boz_01-def9db5",
     "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
     "infile": "tests/../integration_tests/boz_01.f90",
-    "infile_hash": "0834d7e263b86abd28671af7f096f5f3359c8ff113f86332bed9c187",
+    "infile_hash": "eb51d11b212c6b3c2f1e53a3fb01d63ce87f1dd1589336c7e77adc50",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "2acd084339d89801b153e64c54e6bca06c4bf12a9b577becf221c5a3",
+    "stdout_hash": "2e8957dd295142752fec7d94a54ed53641c37b0f9b8796ba835e9a48",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -2,7 +2,7 @@
 source_filename = "LFortran"
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [9 x i8] c"I4,I4,I4\00", align 1
+@serialization_info = private unnamed_addr constant [18 x i8] c"I4,I4,I4,I4,I4,I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define i32 @main(i32 %0, i8** %1) {
@@ -10,14 +10,26 @@ define i32 @main(i32 %0, i8** %1) {
   %boz_1 = alloca i32, align 4
   %boz_2 = alloca i32, align 4
   %boz_3 = alloca i32, align 4
+  %boz_4 = alloca i32, align 4
+  %boz_5 = alloca i32, align 4
+  %boz_6 = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %boz_11 = alloca i32, align 4
   %boz_22 = alloca i32, align 4
   %boz_33 = alloca i32, align 4
+  %boz_44 = alloca i32, align 4
+  %boz_55 = alloca i32, align 4
+  %boz_66 = alloca i32, align 4
+  store i32 93, i32* %boz_44, align 4
+  store i32 1255, i32* %boz_55, align 4
+  store i32 2748, i32* %boz_66, align 4
   store i32 93, i32* %boz_11, align 4
   store i32 1255, i32* %boz_22, align 4
   store i32 2748, i32* %boz_33, align 4
-  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %boz_11, i32* %boz_22, i32* %boz_33)
+  store i32 93, i32* %boz_44, align 4
+  store i32 1255, i32* %boz_55, align 4
+  store i32 2748, i32* %boz_66, align 4
+  %2 = call i8* (i8*, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %boz_11, i32* %boz_22, i32* %boz_33, i32* %boz_44, i32* %boz_55, i32* %boz_66)
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   call void @_lpython_free_argv()
   br label %return


### PR DESCRIPTION
Towards #7839 

Here, I have implemented the logic to convert BOZ Literal to Real Values. The approach, based on the AMD compiler's handling, is as follows:

1. Find the minimum float value the compiler supports on given platform (in decimal).
2. Treat this value as the lowest real value, then multiply it by the bits extracted from the BOZ literal string to obtain the final value.

I have modified the Visit_BOZ function, and tested it on a basic scalar initialization of Data Statement to check correctness. Kindly verfiy and suggest changes required. 

Once those changes are verified, it shall be easy to integrate the actual compliance towards Fortran 2023 guidelines regarding BOZ Literals.

Thank you for your valuable time!