### PR TITLE
fix: check if Struct member is fixed size array while creating temporary

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1536,6 +1536,7 @@ RUN(NAME derived_types_66 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_67 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_68 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_69 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
+RUN(NAME derived_types_70 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_70.f90
+++ b/integration_tests/derived_types_70.f90
@@ -1,0 +1,27 @@
+program derived_types_70
+
+  implicit none
+  type :: task
+    logical :: done
+  end type task
+  type :: container
+    type(task), allocatable :: deps(:)
+  end type container
+  class(container), allocatable :: x
+  logical :: finished
+  integer :: i
+  allocate(x)
+  allocate(x%deps(3))
+  call temp(x)
+  if (any(x%deps(:)%done .neqv. [.true., .false., .true.])) error stop
+
+contains 
+
+  subroutine temp(tab)
+    class(container), intent(in) :: tab
+    tab%deps(1)%done = .true.
+    tab%deps(2)%done = .false.
+    tab%deps(3)%done = .true.
+  end subroutine
+
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2776,6 +2776,14 @@ class ExprDependentOnlyOnArguments: public ASR::BaseWalkVisitor<ExprDependentOnl
                 is_dependent_only_on_argument = false;
             }
         }
+
+        void visit_StructInstanceMember(const ASR::StructInstanceMember_t &x) {
+            ASR::BaseWalkVisitor<ExprDependentOnlyOnArguments>::visit_StructInstanceMember(x);
+            if (ASRUtils::is_array(ASRUtils::symbol_type(x.m_m)) &&
+                !ASRUtils::is_fixed_size_array(ASRUtils::symbol_type(x.m_m)) ) {
+                is_dependent_only_on_argument = false;
+            }
+        }
 };
 
 static inline bool is_dimension_dependent_only_on_arguments(ASR::dimension_t* m_dims, size_t n_dims, bool only_intent_in_args=false) {


### PR DESCRIPTION
Fixes #8048 