### PR TITLE
fix: get `i8*` from string desc if it is structInstanceMember

### DIFF
--- a/integration_tests/inquire_02.f90
+++ b/integration_tests/inquire_02.f90
@@ -1,12 +1,20 @@
 program inquire_02
+    type :: string_t
+        character(:), allocatable :: s
+    end type
     integer :: unit, pos_value
     character(len=1) :: ch
+    logical :: ex
+    type(string_t) :: temp
+    temp%s = "data.txt"
 
     open(unit=10, file="data.txt")
     write(10, '(A)', advance='no') 'abcd'  ! writes 4 characters, no newline
     rewind(10)                            ! go back to start
     read(10, '(A)', advance='no') ch      ! read 1 character (1 byte)
     inquire(unit=10, pos=pos_value)
+    inquire(file="data.txt", exist=ex)
     print *, "Position:", pos_value
     if(pos_value /= 2) error stop
+    if(ex .neqv. .true.) error stop
 end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9573,6 +9573,10 @@ public:
         if (x.m_file) {
             this->visit_expr_wrapper(x.m_file, true);
             f_name = tmp;
+            if (ASRUtils::is_descriptorString(ASRUtils::expr_type(x.m_file)) &&
+                ASR::is_a<ASR::StructInstanceMember_t>(*x.m_file)) {
+                f_name = llvm_utils->CreateLoad2(character_type, llvm_utils->create_gep2(string_descriptor, tmp, 0));
+            }
         } else {
             f_name = llvm::Constant::getNullValue(character_type);
         }


### PR DESCRIPTION
Fixes #8067