### PR TITLE
fix: create association for pointer member during replacing `StructConstructor` 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1537,6 +1537,7 @@ RUN(NAME derived_types_67 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_68 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_69 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
 RUN(NAME derived_types_70 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_71 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_71.f90
+++ b/integration_tests/derived_types_71.f90
@@ -1,0 +1,20 @@
+module derived_type_71_mod
+    type build_target_t
+        integer :: key
+    end type
+    type build_target_ptr
+        type(build_target_t), pointer :: ptr
+    end type build_target_ptr
+end module
+
+program derived_type_71
+    use derived_type_71_mod
+    type(build_target_t), pointer :: x
+    type(build_target_t), target :: z
+    type(build_target_ptr) :: y
+
+    z%key = 12
+    x => z
+    y = build_target_ptr(x)
+    if (y%ptr%key /= 12) error stop
+end program  

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -731,9 +731,15 @@ namespace LCompilers {
                         x_m_args_i = ASRUtils::EXPR(ASR::make_Cast_t(replacer->al, x->base.base.loc,
                             x_m_args_i, cast_kind, casted_type, nullptr));
                     }
-                    ASR::stmt_t* assign = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(replacer->al,
-                                                x->base.base.loc, derived_ref,
-                                                x_m_args_i, nullptr, realloc_lhs));
+                    ASR::stmt_t* assign;
+                    if (ASRUtils::is_pointer(ASRUtils::expr_type(x_m_args_i))) {
+                        assign = ASRUtils::STMT(ASRUtils::make_Associate_t_util(replacer->al, 
+                                                    x->base.base.loc, derived_ref, x_m_args_i));
+                    } else {
+                        assign = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(replacer->al,
+                                                    x->base.base.loc, derived_ref,
+                                                    x_m_args_i, nullptr, realloc_lhs));
+                    }
                     result_vec->push_back(replacer->al, assign);
                 }
             }


### PR DESCRIPTION
Fixes #8069 