### PR TITLE
enh : Support Declarations made in Module Procedures

### DIFF
--- a/integration_tests/separate_compilation_20b.f90
+++ b/integration_tests/separate_compilation_20b.f90
@@ -4,7 +4,8 @@ implicit none
 contains
 
     module procedure error_stop
-        code = 3
+        integer, parameter :: i = 3
+        code = i
     end procedure
 
 end submodule f18estop_separate_compilation_20

--- a/integration_tests/submodule_09.f90
+++ b/integration_tests/submodule_09.f90
@@ -15,7 +15,8 @@ implicit none
 contains
 
     module procedure error_stop
-        code = 3
+        integer, parameter :: i = 3
+        code = i
     end procedure
 
 end submodule f18estop_submodule_09

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -838,15 +838,7 @@ public:
 
         ASRUtils::SymbolDuplicator symbol_duplicator(al);
         ASRUtils::ExprStmtWithScopeDuplicator exprstmt_duplicator(al, current_scope);
-
-        for (auto &item : proc_interface->m_symtab->get_scope()) {
-            if (ASR::is_a<ASR::Variable_t>(*item.second)) {
-                ASR::Variable_t* proc_interface_vari = ASR::down_cast<ASR::Variable_t>(item.second);
-                ASR::symbol_t* new_sym = symbol_duplicator.duplicate_Variable(proc_interface_vari, current_scope);
-                current_scope->add_symbol(std::string(ASRUtils::symbol_name(new_sym)), new_sym);
-            }
-        }
-
+        symbol_duplicator.duplicate_SymbolTable(proc_interface->m_symtab, current_scope);
         Vec<ASR::expr_t*> new_func_args;
         new_func_args.reserve(al, proc_interface->n_args);
         for (size_t i=0;i<proc_interface->n_args;i++) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -846,6 +846,18 @@ public:
         }
         ASR::expr_t* new_func_return_var = exprstmt_duplicator.duplicate_expr(proc_interface->m_return_var);
 
+        for (size_t i=0; i<x.n_decl; i++) {
+            is_Function = true;
+            if (!AST::is_a<AST::Require_t>(*x.m_decl[i])) {
+                try {
+                    visit_unit_decl2(*x.m_decl[i]);
+                } catch (SemanticAbort &e) {
+                    if ( !compiler_options.continue_compilation ) throw e;
+                }
+            }
+            is_Function = false;
+        }
+
         tmp = ASR::make_Function_t(al, x.base.base.loc, current_scope,
                                    proc_interface->m_name,
                                    proc_interface->m_function_signature,


### PR DESCRIPTION
Addresses https://github.com/lfortran/lfortran/pull/8126#discussion_r2231316807
PR also adds support for declarations made in module procedures. For eg :- 
```.f90
submodule (stdlib_error) f18estop
implicit none

contains

    module procedure error_stop
        integer, parameter :: i = 3 
        code = i
    end procedure

end submodule f18estop
```