### PR TITLE
create `alloca` at the entry point when used to change function return type into pointer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1708,6 +1708,7 @@ RUN(NAME string_63 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_64 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_65 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_66 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_67 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_67.f90
+++ b/integration_tests/string_67.f90
@@ -1,0 +1,25 @@
+! Test out calls to `achar` (Function returing a character) to make sure it doesn't fill the stack
+program string_67
+
+    integer :: j
+    
+    character(4) :: ssss
+    integer :: i
+    j = 1
+  do i =0, 65536
+    ssss = achar(97+i) 
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+    ssss = achar(97+j)
+  end do 
+  end program
+  

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -12195,7 +12195,12 @@ public:
             // The convention we use is that any strings is a pointer to the underlying physicalType
             // Example of StringPhysicalTypes -> `string_descriptor*`, `i8*`
             if(ASRUtils::is_string_only(return_var_type0)){ 
-                llvm::Value* string_ptr = llvm_utils->CreateAlloca(*builder, llvm_utils->get_StringType(return_var_type0));
+                // Make sure to use `alloca` at the entry point.
+                llvm::Value* string_ptr = llvm_utils->CreateAlloca(
+                                            llvm_utils->get_StringType(return_var_type0),
+                                            nullptr,
+                                            "string_ret_const"
+                                        );
                 builder->CreateStore(tmp, string_ptr);
                 tmp = string_ptr;
             }

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "547ad40424d8efcc4aa7dd4fd419563050fc79b18c6f8b504646da3c",
+    "stdout_hash": "4b329ca5aff8493eec4275e6a57f767cd792a2f251ea8ba9218418f3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -139,6 +139,7 @@ return:                                           ; preds = %.entry
 
 define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val, %string_descriptor* %string) {
 .entry:
+  %string_ret_const = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_malloc(i64 16)
   %buffer = bitcast i8* %0 to %string_descriptor*
   store %string_descriptor zeroinitializer, %string_descriptor* %buffer, align 1
@@ -168,15 +169,14 @@ define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val,
   %15 = load i8*, i8** %14, align 8
   call void (i8**, i8, i8, i64*, i32*, i8*, i64, ...) @_lfortran_string_write(i8** %4, i8 0, i8 0, i64* %5, i32* %7, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0), i64 2, i8* %15)
   %16 = call %string_descriptor @_lcompilers_trim_str(%string_descriptor* %buffer)
-  %17 = alloca %string_descriptor, align 8
-  store %string_descriptor %16, %string_descriptor* %17, align 1
-  %18 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %19 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  %20 = getelementptr %string_descriptor, %string_descriptor* %17, i32 0, i32 0
-  %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %17, i32 0, i32 1
-  %23 = load i64, i64* %22, align 4
-  call void @_lfortran_strcpy(i8** %18, i64* %19, i8 1, i8 1, i8* %21, i64 %23)
+  store %string_descriptor %16, %string_descriptor* %string_ret_const, align 1
+  %17 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
+  %18 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
+  %19 = getelementptr %string_descriptor, %string_descriptor* %string_ret_const, i32 0, i32 0
+  %20 = load i8*, i8** %19, align 8
+  %21 = getelementptr %string_descriptor, %string_descriptor* %string_ret_const, i32 0, i32 1
+  %22 = load i64, i64* %21, align 4
+  call void @_lfortran_strcpy(i8** %17, i64* %18, i8 1, i8 1, i8* %20, i64 %22)
   br label %return
 
 return:                                           ; preds = %.entry


### PR DESCRIPTION
- Make sure to allocate stack memory at entry point (for a temporary that isn't part of the ASR, hence could lead to stack overflow).
- Add an integration test
***
 closes https://github.com/lfortran/lfortran/issues/8143