### PR TITLE
fix: prioritize direct arg matching, then look for elemental while selecting generic procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2104,6 +2104,7 @@ RUN(NAME procedure_17 LABELS gfortran llvm)
 RUN(NAME procedure_18 LABELS gfortran llvm)
 RUN(NAME procedure_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_20 LABELS gfortran llvm)
+RUN(NAME procedure_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocated_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_21.f90
+++ b/integration_tests/procedure_21.f90
@@ -1,0 +1,31 @@
+module procedure_21_mod
+  implicit none
+  private
+  public :: is_valid
+
+  interface is_valid
+    module procedure is_valid_scalar
+    module procedure is_valid_array
+  end interface
+
+contains
+
+  integer function is_valid_array(arr)
+    integer, intent(in) :: arr(:)
+    is_valid_array = count(arr > 0)
+  end function
+
+  elemental integer function is_valid_scalar(x)
+    integer, intent(in) :: x
+    is_valid_scalar = -1
+  end function
+
+end module procedure_21_mod
+
+program procedure_21
+  use procedure_21_mod
+  implicit none
+  if (is_valid([1, 2, 3]) /= 3) error stop
+  if (is_valid([1, -2, -3]) /= 1) error stop
+  if (is_valid([1, -2, 3]) /= 2) error stop
+end program procedure_21


### PR DESCRIPTION
Fixes #7893 