### PR TITLE
ci: set `-x` for third party test script

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e  # Exit immediately on any error
+set -ex  # Exit immediately on any error
 
 # Default to gfortran if FC is not set
 : "${FC:=gfortran}"


### PR DESCRIPTION
Fixes #8167 