### PR TITLE
refactor: CreateLoad to CreateLoad2

### DIFF
--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1332,23 +1332,6 @@ namespace LCompilers {
                                      m_dims_local, n_dims_local, a_kind_local, module, asr_abi);
     }
 
-    llvm::Type * LLVMUtils::get_type_from_ttype_t_util_from_symbol(ASR::symbol_t* sym, ASR::ttype_t* asr_type,
-         llvm::Module * module, ASR::abiType asr_abi) {
-        ASR::storage_typeType m_storage_local = ASR::storage_typeType::Default;
-        bool is_array_type_local, is_malloc_array_type_local;
-        bool is_list_local;
-        ASR::dimension_t* m_dims_local;
-        int n_dims_local = 0, a_kind_local = 0;
-        ASR::symbol_t* sym_ = sym;
-        if (ASR::is_a<ASR::Variable_t>(*sym)) {
-            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-            sym_ = var->m_type_declaration;
-        }
-        return get_type_from_ttype_t(nullptr, asr_type, sym_, m_storage_local, is_array_type_local,
-                                     is_malloc_array_type_local, is_list_local,
-                                     m_dims_local, n_dims_local, a_kind_local, module, asr_abi);
-    }
-
     llvm::Value* LLVMUtils::create_gep(llvm::Value* ds, int idx) {
         std::vector<llvm::Value*> idx_vec = {
         llvm::ConstantInt::get(context, llvm::APInt(32, 0)),


### PR DESCRIPTION
Refactored `CreateLoad` to `CreateLoad2` in 
* `visit_FunctionCall`
* `visit_ArraySizeUtil`
* `lfortran_compiler_bin_op`
* `lfortran_strrepeat`
* `visit_AllocateUtil`
* `call_lfortran_free`
* `visit_Deallocate`
* `visit_UnionInstanceMember`
* `visit_ArrayItem`
* `allocate_array_members_of_struct_arrays`
* `set_variableInitial_value`
* `define_function_exit`
* `generate_function`
* `GetPointerCptrUtil`
* `visit_CptrToPointer`
*  `visit_PointerAssociated`
* `handle_array_associated`
* `visit_Associate`
* `visit_ArrayPhysicalCast`
* `visit_SelectType`
* `visit_IfExp`
* `visit_RealBinOp`
* visit_ComplexBinOp`
* `fetch_ptr`
* `visit_Cast`
* `visit_FileRead`  