### PR TITLE
feat: add `struct_signature` to struct. 

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2625,8 +2625,13 @@ public:
             SymbolTable* struct_scope = al.make_new<SymbolTable>(current_scope);
             ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(make_Struct_t(
                 al, loc, struct_scope, s2c(al,common_block_name),
+                nullptr,
                 nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false,
                 nullptr, 0, nullptr, nullptr));
+            ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, true);
+            ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
+            struct_->m_struct_signature = struct_type;
+            struct_symbol = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*) struct_);
             current_scope->add_symbol(common_block_name, struct_symbol);
 
             // create a struct instance
@@ -5125,9 +5130,14 @@ public:
                 SymbolTable *parent_scope = current_scope;
                 current_scope = al.make_new<SymbolTable>(parent_scope);
                 ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, current_scope,
-                                                s2c(al, to_lower(derived_type_name)), nullptr, 0, nullptr, 0,
+                                                s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
                                                 nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
                                                 nullptr, 0, nullptr, nullptr);
+                ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
+                ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
+                ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
+                struct_->m_struct_signature = struct_type;
+                struct_symbol = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)struct_);
                 v = ASR::down_cast<ASR::symbol_t>(dtype);
                 parent_scope->add_symbol(derived_type_name, v);
                 current_scope = parent_scope;

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1998,11 +1998,16 @@ public:
             }
         }
         tmp = ASR::make_Struct_t(al, x.base.base.loc, current_scope,
-            s2c(al, to_lower(x.m_name)), struct_dependencies.p, struct_dependencies.size(),
+            s2c(al, to_lower(x.m_name)), nullptr, struct_dependencies.p, struct_dependencies.size(),
             data_member_names.p, data_member_names.size(), nullptr, 0,
             ASR::abiType::Source, dflt_access, false, is_abstract, nullptr, 0, nullptr, parent_sym);
 
         ASR::symbol_t* derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);
+        ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x.base.base.loc, derived_type_sym, true);
+        ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(derived_type_sym);
+        struct_->m_struct_signature = struct_signature;
+        tmp = (ASR::asr_t*) derived_type_sym;
+        derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);
         if (compiler_options.implicit_typing) {
             parent_scope->add_or_overwrite_symbol(sym_name, derived_type_sym);
         } else {

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -15,7 +15,7 @@ symbol
     | GenericProcedure(symbol_table parent_symtab, identifier name, symbol* procs, access access)
     | CustomOperator(symbol_table parent_symtab, identifier name, symbol* procs, access access)
     | ExternalSymbol(symbol_table parent_symtab, identifier name, symbol external, identifier module_name, identifier* scope_names, identifier original_name, access access)
-    | Struct(symbol_table symtab, identifier name, identifier* dependencies, identifier* members, identifier* member_functions, abi abi, access access, bool is_packed, bool is_abstract, call_arg* initializers, expr? alignment, symbol? parent)
+    | Struct(symbol_table symtab, identifier name, ttype struct_signature, identifier* dependencies, identifier* members, identifier* member_functions, abi abi, access access, bool is_packed, bool is_abstract, call_arg* initializers, expr? alignment, symbol? parent)
     | Enum(symbol_table symtab, identifier name, identifier* dependencies, identifier* members, abi abi, access access, enumtype enum_value_type, ttype type, symbol? parent)
     | Union(symbol_table symtab, identifier name, identifier* dependencies, identifier* members, abi abi, access access, call_arg* initializers, symbol? parent)
     | Variable(symbol_table parent_symtab, identifier name, identifier* dependencies, intent intent,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3020,49 +3020,10 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
         al, loc, type, m_dims, n_dims, physical_type));
 }
 
-static inline ASR::ttype_t* make_StructType_t_util(Allocator& al,
+ASR::ttype_t* make_StructType_t_util(Allocator& al,
                                                  Location loc,
                                                  ASR::symbol_t* derived_type_sym,
-                                                 bool is_cstruct)
-{
-    ASR::Struct_t* derived_type = ASR::down_cast<ASR::Struct_t>(
-        ASRUtils::symbol_get_past_external(derived_type_sym));
-
-    std::string derived_type_name = derived_type->m_name;
-
-    Vec<ASR::ttype_t*> member_types;
-    member_types.reserve(al, derived_type->m_symtab->get_scope().size());
-
-    for (auto const& sym : derived_type->m_symtab->get_scope()) {
-        if (ASR::is_a<ASR::Variable_t>(*sym.second)) {
-            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(
-                ASRUtils::symbol_get_past_external(sym.second));
-            if (ASRUtils::symbol_get_past_external(derived_type_sym) == ASRUtils::symbol_get_past_external(var->m_type_declaration)) {
-                // this is self referential, so we can directly take it
-                ASR::StructType_t* stype = ASR::down_cast<ASR::StructType_t>(ASRUtils::extract_type(var->m_type));
-                return ASRUtils::TYPE(
-                    ASR::make_StructType_t(al, loc, stype->m_data_member_types,
-                                           stype->n_data_member_types,
-                                           nullptr,
-                                           0,
-                                           is_cstruct == false ? false : stype->m_is_cstruct,
-                                           stype->m_is_unlimited_polymorphic
-                                           )
-                );
-            }
-            member_types.push_back(al, var->m_type);
-        }
-    }
-    return ASRUtils::TYPE(
-        ASR::make_StructType_t(al,
-                               loc,
-                               member_types.p,
-                               member_types.n,
-                               nullptr,
-                               0,
-                               is_cstruct,
-                               derived_type_name == "~unlimited_polymorphic_type" ? true : false));
-}
+                                                 bool is_cstruct);
 
 // Sets the dimension member of `ttype_t`. Returns `true` if dimensions set.
 // Returns `false` if the `ttype_t` does not have a dimension member.
@@ -4988,7 +4949,7 @@ class SymbolDuplicator {
         duplicate_SymbolTable(struct_type_t->m_symtab, struct_type_symtab);
         return ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(
             al, struct_type_t->base.base.loc, struct_type_symtab,
-            struct_type_t->m_name, struct_type_t->m_dependencies, struct_type_t->n_dependencies,
+            struct_type_t->m_name, struct_type_t->m_struct_signature, struct_type_t->m_dependencies, struct_type_t->n_dependencies,
             struct_type_t->m_members, struct_type_t->n_members,
             struct_type_t->m_member_functions, struct_type_t->n_member_functions, struct_type_t->m_abi,
             struct_type_t->m_access, struct_type_t->m_is_packed, struct_type_t->m_is_abstract,

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1290,7 +1290,7 @@ public:
                             dest_asr_type = ASRUtils::make_StructType_t_util(al, curr_arg_m_a_type->base.loc, dest_class_sym, true);
                             malloc_size = SizeOfTypeUtil(curr_arg.m_a, dest_asr_type, llvm_utils->getIntType(4),
                                 ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4)));
-                        } else {                            
+                        } else {
                             llvm::Type* llvm_type = nullptr;
                             dest_class_sym = ASRUtils::symbol_get_past_external(curr_arg.m_sym_subclass);
                             ASR::Struct_t* dest_struct = ASR::down_cast<ASR::Struct_t>(dest_class_sym);
@@ -1343,7 +1343,7 @@ public:
                         x_arr = builder->CreateBitCast(x_arr, dest_type->getPointerTo());
 
                         if (ASR::is_a<ASR::StructType_t>(*dest_asr_type)) {
-                            allocate_array_members_of_struct(ASR::down_cast<ASR::Struct_t>(dest_class_sym), x_arr, dest_asr_type);                        
+                            allocate_array_members_of_struct(ASR::down_cast<ASR::Struct_t>(dest_class_sym), x_arr, dest_asr_type);
                         }
                         if (m_source && !m_source_is_class) {
                             int64_t ptr_loads_copy = ptr_loads;

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -332,10 +332,16 @@ public:
 
         ASR::asr_t *result = ASR::make_Struct_t(al, x->base.base.loc,
             current_scope, s2c(al, new_sym_name),
+            nullptr,
             nullptr, 0,
             data_member_names.p, data_member_names.size(), nullptr, 0,
             x->m_abi, x->m_access, x->m_is_packed, x->m_is_abstract,
             nullptr, 0, m_alignment, nullptr);
+        ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
+        ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
+        ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);
+        struct_->m_struct_signature = struct_signature;
+        result = (ASR::asr_t*) struct_sym;
 
         ASR::symbol_t *t = ASR::down_cast<ASR::symbol_t>(result);
         func_scope->add_symbol(new_sym_name, t);
@@ -1296,9 +1302,14 @@ public:
         ASR::expr_t* m_alignment = duplicate_expr(x->m_alignment);
 
         ASR::asr_t* result = ASR::make_Struct_t(al, x->base.base.loc,
-            new_scope, s2c(al, new_sym_name), nullptr, 0, data_member_names.p,
+            new_scope, s2c(al, new_sym_name), nullptr, nullptr, 0, data_member_names.p,
             data_member_names.size(), nullptr, 0, x->m_abi, x->m_access, x->m_is_packed,
             x->m_is_abstract, nullptr, 0, m_alignment, nullptr);
+        ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
+        ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
+        ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);
+        struct_->m_struct_signature = struct_type;
+        result = (ASR::asr_t*) struct_;
 
         ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(result);
         target_scope->add_symbol(new_sym_name, s);

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -865,8 +865,12 @@ class ParallelRegionVisitor :
             std::string suffix = thread_data_module_name.substr(data_struct_name.size()+7);
             std::string thread_data_name = data_struct_name + suffix;
             ASR::symbol_t* thread_data_struct = ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(al, loc,
-                current_scope, s2c(al, thread_data_name), nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
+                current_scope, s2c(al, thread_data_name), nullptr, nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
                 ASR::accessType::Public, false, false, nullptr, 0, nullptr, nullptr));
+            ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, thread_data_struct, true);
+            ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(thread_data_struct);
+            struct_->m_struct_signature = struct_type;
+            thread_data_struct = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*) struct_);
             current_scope->parent->add_symbol(thread_data_name, thread_data_struct);
             current_scope = parent_scope;
             ASR::symbol_t* thread_data_module = ASR::down_cast<ASR::symbol_t>(ASR::make_Module_t(al, loc,
@@ -2044,8 +2048,12 @@ class ParallelRegionVisitor :
             std::string thread_data_name = data_struct_name + suffix;
             
             ASR::symbol_t* thread_data_struct = ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(al, loc,
-                current_scope, s2c(al, thread_data_name), nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
+                current_scope, s2c(al, thread_data_name), nullptr, nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
                 ASR::accessType::Public, false, false, nullptr, 0, nullptr, nullptr));
+            ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, thread_data_struct, true);
+            ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(thread_data_struct);
+            struct_->m_struct_signature = struct_type;
+            thread_data_struct = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)struct_);
             current_scope->parent->add_symbol(thread_data_name, thread_data_struct);
             current_scope = parent_scope;
             

--- a/tests/reference/asr-arrays_23-a731033.json
+++ b/tests/reference/asr-arrays_23-a731033.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_23-a731033.stdout",
-    "stdout_hash": "66b82ab657d753a085f0833d14cf3a08923035245ad7c5c4cc958390",
+    "stdout_hash": "ec75f751188ba58fd2fedf02a18fbbce50afd46ca929a02ae99352f1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_23-a731033.stdout
+++ b/tests/reference/asr-arrays_23-a731033.stdout
@@ -395,6 +395,16 @@
                                                 )
                                         })
                                     toml_context
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)
+                                        (Pointer
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [pos
                                     num

--- a/tests/reference/asr-associate_08-570ac7d.json
+++ b/tests/reference/asr-associate_08-570ac7d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-associate_08-570ac7d.stdout",
-    "stdout_hash": "2c8e1bd2104e54d7277f697e79fc72a68d9703aa4ac9c1d2dc8b8c2d",
+    "stdout_hash": "2e5e00ae916e3594345b0043443adc5008ca7c95fe131cd66cf60b6b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-associate_08-570ac7d.stdout
+++ b/tests/reference/asr-associate_08-570ac7d.stdout
@@ -731,6 +731,12 @@
                                                 )
                                         })
                                     t_1
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []
@@ -782,6 +788,24 @@
                                                 )
                                         })
                                     t_2
+                                    (StructType
+                                        [(Pointer
+                                            (Array
+                                                (StructType
+                                                    [(Integer 4)]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [type_2]
                                     []

--- a/tests/reference/asr-c_ptr_02-fce1b0e.json
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-c_ptr_02-fce1b0e.stdout",
-    "stdout_hash": "7c9a0153e96697a7da7582e59881d45c38b1356d7b052203474e04f2",
+    "stdout_hash": "370497903438cc2fe8349fa11f12b2813e341adb7df8aabba62dd5de",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-c_ptr_02-fce1b0e.stdout
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.stdout
@@ -424,6 +424,12 @@
                                                 )
                                         })
                                     test_obj
+                                    (StructType
+                                        [(CPtr)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [ptr]
                                     []

--- a/tests/reference/asr-class_01-704dee8.json
+++ b/tests/reference/asr-class_01-704dee8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_01-704dee8.stdout",
-    "stdout_hash": "299aa81d49c61619f878a3a81c01b27b7945400821e701963f380a0b",
+    "stdout_hash": "b927d39609410a79de8b443e94fefe89b7f1e9037a22ef0156f9077b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_01-704dee8.stdout
+++ b/tests/reference/asr-class_01-704dee8.stdout
@@ -167,6 +167,12 @@
                                                 )
                                         })
                                     circle
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [radius]
                                     []

--- a/tests/reference/asr-class_02-b56b852.json
+++ b/tests/reference/asr-class_02-b56b852.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_02-b56b852.stdout",
-    "stdout_hash": "4c433f500a1c2429d7f9b6a6210e613765497c6346f1ab5e4a25513b",
+    "stdout_hash": "1ca8925f1c4c69c381474826deff36f8b29979559938b31546dc995e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_02-b56b852.stdout
+++ b/tests/reference/asr-class_02-b56b852.stdout
@@ -82,6 +82,12 @@
                                                 )
                                         })
                                     circle
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [radius]
                                     []

--- a/tests/reference/asr-class_04-285a1df.json
+++ b/tests/reference/asr-class_04-285a1df.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_04-285a1df.stdout",
-    "stdout_hash": "656ace77db84f85d866030d2d3159703de751af2947ef5ed922db029",
+    "stdout_hash": "ec49e38e60eef70388fefdbccba911d1336e67c00cb9798a7f06c589",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_04-285a1df.stdout
+++ b/tests/reference/asr-class_04-285a1df.stdout
@@ -95,6 +95,12 @@
                                                 )
                                         })
                                     bar_a
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [a]
                                     []
@@ -134,6 +140,12 @@
                                                 )
                                         })
                                     bar_b
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [b]
                                     []
@@ -173,6 +185,12 @@
                                                 )
                                         })
                                     bar_c
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [c]
                                     []
@@ -248,6 +266,17 @@
                                                 )
                                         })
                                     foo_a
+                                    (StructType
+                                        [(StructType
+                                            [(Integer 4)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [bar_a]
                                     [m_bar_a]
                                     []
@@ -292,6 +321,17 @@
                                                 )
                                         })
                                     foo_b
+                                    (StructType
+                                        [(StructType
+                                            [(Integer 4)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [bar_b]
                                     [m_bar_b]
                                     []
@@ -336,6 +376,17 @@
                                                 )
                                         })
                                     foo_c
+                                    (StructType
+                                        [(StructType
+                                            [(Integer 4)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [bar_c]
                                     [m_bar_c]
                                     []

--- a/tests/reference/asr-common2-64c97b2.json
+++ b/tests/reference/asr-common2-64c97b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common2-64c97b2.stdout",
-    "stdout_hash": "5931234cad81f176aef4cd42c0a954572c237fe3bc5c9f81d8c0f815",
+    "stdout_hash": "385e5e7bcb13c2d25b614dec3b6ced183f4f32334aaf1b8dc65433bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common2-64c97b2.stdout
+++ b/tests/reference/asr-common2-64c97b2.stdout
@@ -108,6 +108,12 @@
                                                 )
                                         })
                                     block_1
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [a
                                     b
@@ -209,6 +215,12 @@
                                                 )
                                         })
                                     block_2
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [c
                                     d]
@@ -309,6 +321,12 @@
                                                 )
                                         })
                                     block_3
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [e
                                     g]
@@ -388,6 +406,12 @@
                                                 )
                                         })
                                     block_4
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []
@@ -487,6 +511,12 @@
                                                 )
                                         })
                                     block_5
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [j
                                     k]

--- a/tests/reference/asr-common_03-9052466.json
+++ b/tests/reference/asr-common_03-9052466.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_03-9052466.stdout",
-    "stdout_hash": "2f0828942e05a26358cf25ab5e0eca09132eff38121916457e2e6e6d",
+    "stdout_hash": "a23718684e067cadea7e558d8f037730db49b07566882d7b1eb08501",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_03-9052466.stdout
+++ b/tests/reference/asr-common_03-9052466.stdout
@@ -203,6 +203,12 @@
                                                 )
                                         })
                                     b
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [d
                                     e
@@ -304,6 +310,12 @@
                                                 )
                                         })
                                     blank#block
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [z1
                                     z2]
@@ -446,6 +458,12 @@
                                                 )
                                         })
                                     c
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [c
                                     g
@@ -579,6 +597,12 @@
                                                 )
                                         })
                                     sample
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [a
                                     b

--- a/tests/reference/asr-common_04-b603709.json
+++ b/tests/reference/asr-common_04-b603709.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_04-b603709.stdout",
-    "stdout_hash": "0639e5deaba1ad69fea03fe00f60a6d52960a83c799ba27906cab613",
+    "stdout_hash": "8dc7badc0bc58eea3fce3b46d7b05af20f6dc8b72f804d320c9abb4e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_04-b603709.stdout
+++ b/tests/reference/asr-common_04-b603709.stdout
@@ -82,6 +82,12 @@
                                                 )
                                         })
                                     block_1
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [a
                                     b

--- a/tests/reference/asr-common_05-f767179.json
+++ b/tests/reference/asr-common_05-f767179.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_05-f767179.stdout",
-    "stdout_hash": "82feb873f7c2f3a7f917981b8c8d498368b46f2886ce3604bc175f8f",
+    "stdout_hash": "26de42e2058f8e293dde25f4b83d330a375be96933362efd33478557",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_05-f767179.stdout
+++ b/tests/reference/asr-common_05-f767179.stdout
@@ -82,6 +82,12 @@
                                                 )
                                         })
                                     block_1
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [a
                                     b

--- a/tests/reference/asr-common_06-4a72d58.json
+++ b/tests/reference/asr-common_06-4a72d58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_06-4a72d58.stdout",
-    "stdout_hash": "93ef6784caa2a735d5f0ec2eb1ba0bd134f7524ef1272f9cfee4fd7e",
+    "stdout_hash": "7aba583cd94caff48ea804c862bd2ebc3f2d1937606770b47feeff29",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_06-4a72d58.stdout
+++ b/tests/reference/asr-common_06-4a72d58.stdout
@@ -56,6 +56,12 @@
                                                 )
                                         })
                                     ls0001
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [rowns]
                                     []

--- a/tests/reference/asr-common_13-fa7cbf0.json
+++ b/tests/reference/asr-common_13-fa7cbf0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_13-fa7cbf0.stdout",
-    "stdout_hash": "3b0233169ca44bc64035cd56f1423eb6d18f76a7a8d0a71b8e678097",
+    "stdout_hash": "f023079e18db70f9e19dd3664962ba6ac1d50c195dfb0559b6e3c863",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_13-fa7cbf0.stdout
+++ b/tests/reference/asr-common_13-fa7cbf0.stdout
@@ -203,6 +203,12 @@
                                                 )
                                         })
                                     arrblock
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [myarr]
                                     []
@@ -234,12 +240,7 @@
                                             ColMajor
                                         ))]
                                         (StructType
-                                            [(Array
-                                                (Integer 4)
-                                                [((IntegerConstant 1 (Integer 4) Decimal)
-                                                (IntegerConstant 10 (Integer 4) Decimal))]
-                                                FixedSizeArray
-                                            )]
+                                            []
                                             []
                                             .true.
                                             .false.
@@ -259,12 +260,7 @@
                                             ColMajor
                                         ))]
                                         (StructType
-                                            [(Array
-                                                (Integer 4)
-                                                [((IntegerConstant 1 (Integer 4) Decimal)
-                                                (IntegerConstant 10 (Integer 4) Decimal))]
-                                                FixedSizeArray
-                                            )]
+                                            []
                                             []
                                             .true.
                                             .false.
@@ -350,6 +346,12 @@
                                                 )
                                         })
                                     myblock
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [myint
                                     myzero]
@@ -373,8 +375,7 @@
                                         [((IntegerConstant 44 (Integer 4) Decimal))
                                         (())]
                                         (StructType
-                                            [(Integer 4)
-                                            (Integer 4)]
+                                            []
                                             []
                                             .true.
                                             .false.
@@ -385,8 +386,7 @@
                                         [((IntegerConstant 44 (Integer 4) Decimal))
                                         (())]
                                         (StructType
-                                            [(Integer 4)
-                                            (Integer 4)]
+                                            []
                                             []
                                             .true.
                                             .false.

--- a/tests/reference/asr-dependency_test_01-280d5b3.json
+++ b/tests/reference/asr-dependency_test_01-280d5b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-dependency_test_01-280d5b3.stdout",
-    "stdout_hash": "09df36221898030a0270d3c9f5550b35ce17d3708499fb8134ef6a24",
+    "stdout_hash": "36db1e6b8c135af0c5dff7665813409c6d451e8d97906f8cb2b31077",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-dependency_test_01-280d5b3.stdout
+++ b/tests/reference/asr-dependency_test_01-280d5b3.stdout
@@ -264,6 +264,17 @@
                                                 )
                                         })
                                     dependency_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     path]
@@ -383,6 +394,19 @@
                                                 )
                                         })
                                     dependency_node_t
+                                    (StructType
+                                        [(Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [proj_dir
                                     revision
@@ -589,6 +613,40 @@
                                                 )
                                         })
                                     dependency_tree_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (Array
+                                                (StructType
+                                                    [(Logical 4)
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [unit
                                     verbosity

--- a/tests/reference/asr-derived_type1-c109ce6.json
+++ b/tests/reference/asr-derived_type1-c109ce6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_type1-c109ce6.stdout",
-    "stdout_hash": "1f8c40496c8fc0fa7d687d27d183566e9793295944be84f3794dc002",
+    "stdout_hash": "fc58fb27e3d47130bd10fed5f7e8ebd4192e06ade1fa213e8b08bce5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_type1-c109ce6.stdout
+++ b/tests/reference/asr-derived_type1-c109ce6.stdout
@@ -57,6 +57,12 @@
                                                 )
                                         })
                                     enum_escape
+                                    (StructType
+                                        [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [newline]
                                     []

--- a/tests/reference/asr-derived_types_01-960dafe.json
+++ b/tests/reference/asr-derived_types_01-960dafe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_01-960dafe.stdout",
-    "stdout_hash": "ea9dd7274e107372d039dc61e7d4c39662c5659db013cc278c1d49e0",
+    "stdout_hash": "d18a0e870ea9bf9ea160ec7be2744cc53ca178c0ffab4c43f81a1066",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_01-960dafe.stdout
+++ b/tests/reference/asr-derived_types_01-960dafe.stdout
@@ -713,6 +713,13 @@
                                                 )
                                         })
                                     x
+                                    (StructType
+                                        [(Integer 4)
+                                        (Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [r
                                     i]
@@ -780,6 +787,19 @@
                                                 )
                                         })
                                     y
+                                    (StructType
+                                        [(Complex 4)
+                                        (StructType
+                                            [(Integer 4)
+                                            (Real 4)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [x]
                                     [c
                                     d]
@@ -876,6 +896,25 @@
                                                 )
                                         })
                                     z
+                                    (StructType
+                                        [(Complex 4)
+                                        (StructType
+                                            [(Complex 4)
+                                            (StructType
+                                                [(Integer 4)
+                                                (Real 4)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [y]
                                     [k
                                     l]

--- a/tests/reference/asr-derived_types_03-b1d32aa.json
+++ b/tests/reference/asr-derived_types_03-b1d32aa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_03-b1d32aa.stdout",
-    "stdout_hash": "c6878f75ee653cf2f1dfbcc638da34407c6ae20e8d70c458f2c698f4",
+    "stdout_hash": "eaa4e0d2b2b7ad51cc4743e620bb0a55d2cc3b33452760bed68fd93b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_03-b1d32aa.stdout
+++ b/tests/reference/asr-derived_types_03-b1d32aa.stdout
@@ -61,6 +61,12 @@
                                                 )
                                         })
                                     x
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []
@@ -105,6 +111,12 @@
                                                                 )
                                                         })
                                                     a
+                                                    (StructType
+                                                        [(Integer 4)]
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [i]
                                                     []
@@ -200,6 +212,12 @@
                                                                 )
                                                         })
                                                     a
+                                                    (StructType
+                                                        [(Integer 4)]
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [i]
                                                     []

--- a/tests/reference/asr-derived_types_04-b960162.json
+++ b/tests/reference/asr-derived_types_04-b960162.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-b960162.stdout",
-    "stdout_hash": "47f294be59a89386e21c56faffb95f10e8d817f1f8c157ca1753568c",
+    "stdout_hash": "c670f9c3bf08fa357f3ed3ac620b8ca489005399c200cf554549806e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-b960162.stdout
+++ b/tests/reference/asr-derived_types_04-b960162.stdout
@@ -139,6 +139,12 @@
                                                 )
                                         })
                                     bitset_type
+                                    (StructType
+                                        [(Integer 8)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [num_bits]
                                     []

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "2aa7a01197b74cceced98ce8a72ad2d71141f7c0c200420edd773077",
+    "stdout_hash": "d6bebf6cadab69368a4364eb38d67592d59df5127c263d31e9f1ec6f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -1340,6 +1340,14 @@
                                                 )
                                         })
                                     toml_date
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [year
                                     month
@@ -1444,6 +1452,37 @@
                                                 )
                                         })
                                     toml_datetime
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                [(Integer 4)
+                                                (Integer 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )
+                                        (Allocatable
+                                            (StructType
+                                                [(Integer 4)
+                                                (Allocatable
+                                                    (Integer 4)
+                                                )
+                                                (Integer 4)
+                                                (Integer 4)
+                                                (Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [date
                                     time]
@@ -1590,6 +1629,20 @@
                                                 )
                                         })
                                     toml_time
+                                    (StructType
+                                        [(Integer 4)
+                                        (Allocatable
+                                            (Integer 4)
+                                        )
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [hour
                                     minute

--- a/tests/reference/asr-derived_types_05-35150cd.json
+++ b/tests/reference/asr-derived_types_05-35150cd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_05-35150cd.stdout",
-    "stdout_hash": "a218b7d9da3028907d38e40f68d8b16553d521ce22c0d58340a7b2bc",
+    "stdout_hash": "045c13c65a2a20ec4d967d328d9f0c8825f4db8d424b325c37b2ff38",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_05-35150cd.stdout
+++ b/tests/reference/asr-derived_types_05-35150cd.stdout
@@ -392,6 +392,14 @@
                                                 )
                                         })
                                     string_type
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []

--- a/tests/reference/asr-derived_types_06-5ae916e.json
+++ b/tests/reference/asr-derived_types_06-5ae916e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-5ae916e.stdout",
-    "stdout_hash": "90d47acff0e71f3191110b062626b10abf466ca7a3576f81a7beaae5",
+    "stdout_hash": "c5d76814619f689758de586428731050b76e6711986446293eb96118",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-5ae916e.stdout
+++ b/tests/reference/asr-derived_types_06-5ae916e.stdout
@@ -46,6 +46,12 @@
                                                             
                                                         })
                                                     ~unlimited_polymorphic_type
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .false.
+                                                        .true.
+                                                    )
                                                     []
                                                     []
                                                     []

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "6c1c39f894605c631ce2362914b509665723caeb99ab4f4f6b322b42",
+    "stdout_hash": "b6b1e55a713fd85a60a5f8eb2e4a814dcd4430acd5117ce1afd1f70c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -1340,6 +1340,14 @@
                                                 )
                                         })
                                     toml_date
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [year
                                     month
@@ -1444,6 +1452,37 @@
                                                 )
                                         })
                                     toml_datetime
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                [(Integer 4)
+                                                (Integer 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )
+                                        (Allocatable
+                                            (StructType
+                                                [(Integer 4)
+                                                (Allocatable
+                                                    (Integer 4)
+                                                )
+                                                (Integer 4)
+                                                (Integer 4)
+                                                (Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [date
                                     time]
@@ -1590,6 +1629,20 @@
                                                 )
                                         })
                                     toml_time
+                                    (StructType
+                                        [(Integer 4)
+                                        (Allocatable
+                                            (Integer 4)
+                                        )
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [hour
                                     minute

--- a/tests/reference/asr-derived_types_07-c5a29e3.json
+++ b/tests/reference/asr-derived_types_07-c5a29e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-c5a29e3.stdout",
-    "stdout_hash": "3b6b35c7eb447ebfab41a916a6a3346b4d6ae0cd6166e7d1132ed1d0",
+    "stdout_hash": "9c0a38d887936b4c3c743cfe3b3903ef752ff1862af3ea46f113ae02",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-c5a29e3.stdout
+++ b/tests/reference/asr-derived_types_07-c5a29e3.stdout
@@ -718,6 +718,21 @@
                                                 )
                                         })
                                     toml_node
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                [(Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )]
+                                                []
+                                                .false.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [val]
                                     []
@@ -809,6 +824,34 @@
                                                 )
                                         })
                                     toml_vector
+                                    (StructType
+                                        [(Allocatable
+                                            (Array
+                                                (StructType
+                                                    [(Allocatable
+                                                        (StructType
+                                                            [(Allocatable
+                                                                (String 1 () DeferredLength DescriptorString)
+                                                            )]
+                                                            []
+                                                            .false.
+                                                            .false.
+                                                        )
+                                                    )]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [n
                                     lst]
@@ -1015,6 +1058,14 @@
                                                 )
                                         })
                                     toml_keyval
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []
@@ -1329,6 +1380,14 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []

--- a/tests/reference/asr-derived_types_07-ccfd81f.json
+++ b/tests/reference/asr-derived_types_07-ccfd81f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-ccfd81f.stdout",
-    "stdout_hash": "1b8fa241e23c3a19dcf0ff3bea67c21e9dc905b487b20d5ac915a931",
+    "stdout_hash": "0105d63d7ab55f30df2eecf129cfadee504ebca95781fc8803a56056",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-ccfd81f.stdout
+++ b/tests/reference/asr-derived_types_07-ccfd81f.stdout
@@ -243,6 +243,21 @@
                                                 )
                                         })
                                     logger_type
+                                    (StructType
+                                        [(Logical 4)
+                                        (Allocatable
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [add_blank_line
                                     log_units

--- a/tests/reference/asr-derived_types_08-3680946.json
+++ b/tests/reference/asr-derived_types_08-3680946.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_08-3680946.stdout",
-    "stdout_hash": "53d404b5384adaabed03aa6f2690e61097b271f04181bd049dad1689",
+    "stdout_hash": "63d9002a07bcabadbfc0774bf55133784b71d6dcfc031cead6d0cc08",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_08-3680946.stdout
+++ b/tests/reference/asr-derived_types_08-3680946.stdout
@@ -599,6 +599,13 @@
                                                 )
                                         })
                                     rectangle
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [length
                                     width]
@@ -713,6 +720,15 @@
                                                 )
                                         })
                                     shape
+                                    (StructType
+                                        [(Integer 4)
+                                        (Logical 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [color
                                     filled

--- a/tests/reference/asr-derived_types_10-526e3f4.json
+++ b/tests/reference/asr-derived_types_10-526e3f4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_10-526e3f4.stdout",
-    "stdout_hash": "61eaca359340705086d3670a3863ec02b3d2a0bf0c1dedf23abab1ce",
+    "stdout_hash": "7adb50f561ac31cbc66290ab3ae3e9bcf4e38a4b75a6a6de9085eef4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_10-526e3f4.stdout
+++ b/tests/reference/asr-derived_types_10-526e3f4.stdout
@@ -108,6 +108,12 @@
                                                 )
                                         })
                                     my_super_type
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [x]
                                     []
@@ -222,6 +228,18 @@
                                                 )
                                         })
                                     my_type
+                                    (StructType
+                                        [(StructType
+                                            [(Integer 4)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [my_super_type]
                                     [x
                                     super]

--- a/tests/reference/asr-derived_types_11-c169ea7.json
+++ b/tests/reference/asr-derived_types_11-c169ea7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_11-c169ea7.stdout",
-    "stdout_hash": "fdd0154156f2015d575a1addcec6e5adc5d359d00627d7ad560a9ba0",
+    "stdout_hash": "34d439e632992355b7bd044b273460f413e9bed1fbe0267f9f49035a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_11-c169ea7.stdout
+++ b/tests/reference/asr-derived_types_11-c169ea7.stdout
@@ -144,6 +144,12 @@
                                                 )
                                         })
                                     y
+                                    (StructType
+                                        [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [backslash]
                                     []

--- a/tests/reference/asr-derived_types_14-75884fe.json
+++ b/tests/reference/asr-derived_types_14-75884fe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_14-75884fe.stdout",
-    "stdout_hash": "8ab5f209e3f0fa19ebf18577db031d4b686a0eb180b93f264f4bdacd",
+    "stdout_hash": "40eedfcbee9e492fe7214af9e6a45fb29fef7cfac9912dd87767cf9f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_14-75884fe.stdout
+++ b/tests/reference/asr-derived_types_14-75884fe.stdout
@@ -140,6 +140,17 @@
                                                 )
                                         })
                                     enum_type
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [invalid
                                     string

--- a/tests/reference/asr-derived_types_15-7fde02a.json
+++ b/tests/reference/asr-derived_types_15-7fde02a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_15-7fde02a.stdout",
-    "stdout_hash": "617b2a4339bf9d31c61cfeb28f04ac26a0f9d81bfcffc94e8c2a6773",
+    "stdout_hash": "86b06740198b21c7cf47de944264df36b1fbcae4936ad8fbf4a77b71",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_15-7fde02a.stdout
+++ b/tests/reference/asr-derived_types_15-7fde02a.stdout
@@ -341,6 +341,12 @@
                                                 )
                                         })
                                     t_1
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []

--- a/tests/reference/asr-derived_types_16_module-4aac273.json
+++ b/tests/reference/asr-derived_types_16_module-4aac273.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_16_module-4aac273.stdout",
-    "stdout_hash": "a5b631a3a4c12b56236f667beebe93636cf417d22766966fbcfb38da",
+    "stdout_hash": "aaa6357ab7290886508f281507900f12fb40800dcfb85c5ccff7f5d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_16_module-4aac273.stdout
+++ b/tests/reference/asr-derived_types_16_module-4aac273.stdout
@@ -263,6 +263,14 @@
                                                 )
                                         })
                                     fpm_run_settings
+                                    (StructType
+                                        [(Logical 4)
+                                        (Real 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [int
                                     float

--- a/tests/reference/asr-derived_types_17-17c3d46.json
+++ b/tests/reference/asr-derived_types_17-17c3d46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_17-17c3d46.stdout",
-    "stdout_hash": "62f170b7b756e0586455a27e18715b2ebb13d34fd292ba3806cee817",
+    "stdout_hash": "f138b520d710cc9a499d99f0719c433939dabfc5297c5d50df5d6b56",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_17-17c3d46.stdout
+++ b/tests/reference/asr-derived_types_17-17c3d46.stdout
@@ -254,6 +254,12 @@
                                                 )
                                         })
                                     t_1
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [num]
                                     []

--- a/tests/reference/asr-derived_types_18-e69cac3.json
+++ b/tests/reference/asr-derived_types_18-e69cac3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_18-e69cac3.stdout",
-    "stdout_hash": "edc60378b9260720b5b8bb375bc12e48ab65c177756f057021b664ab",
+    "stdout_hash": "b32b0564774c49ab8f801f8d3a41e4346a6384729b84541b240d044e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_18-e69cac3.stdout
+++ b/tests/reference/asr-derived_types_18-e69cac3.stdout
@@ -228,6 +228,12 @@
                                                 )
                                         })
                                     t_1
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []
@@ -267,6 +273,12 @@
                                                 )
                                         })
                                     t_2
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [r]
                                     []

--- a/tests/reference/asr-derived_types_19-26385d4.json
+++ b/tests/reference/asr-derived_types_19-26385d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_19-26385d4.stdout",
-    "stdout_hash": "cf2ddd8d09ef6bb2d7e20dad62292c85d1985dd1efc1073a5bd9cfb7",
+    "stdout_hash": "8adc9850110270921fcde3d59da320fa244d7d14a38475908a23d732",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_19-26385d4.stdout
+++ b/tests/reference/asr-derived_types_19-26385d4.stdout
@@ -189,6 +189,12 @@
                                                 )
                                         })
                                     child_value
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [ok]
                                     []
@@ -309,6 +315,14 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []

--- a/tests/reference/asr-derived_types_41-d6b8ce9.json
+++ b/tests/reference/asr-derived_types_41-d6b8ce9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_41-d6b8ce9.stdout",
-    "stdout_hash": "cc18e33bdaa580405a3e02dd08df92c3432adddceb16e95d2ebc05b9",
+    "stdout_hash": "8a81582f8756eda2b3c19e360ed66b14dd8ec2a076d51b302f93c27f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_41-d6b8ce9.stdout
+++ b/tests/reference/asr-derived_types_41-d6b8ce9.stdout
@@ -277,6 +277,24 @@
                                                 )
                                         })
                                     mytype
+                                    (StructType
+                                        [(Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        (Integer 4)
+                                        (Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [a
                                     b

--- a/tests/reference/asr-function_call1-0b992da.json
+++ b/tests/reference/asr-function_call1-0b992da.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-function_call1-0b992da.stdout",
-    "stdout_hash": "ff70d7a885d98fbc099f0b958b33bffb1695dee13e43fdafc3737051",
+    "stdout_hash": "dd23ae75bd20d1c0d65c4ac52bc6c90d60df6ca61a67f523e2ea284d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-function_call1-0b992da.stdout
+++ b/tests/reference/asr-function_call1-0b992da.stdout
@@ -356,6 +356,12 @@
                                                 )
                                         })
                                     softmax
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/asr-functions_16-3e10090.json
+++ b/tests/reference/asr-functions_16-3e10090.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_16-3e10090.stdout",
-    "stdout_hash": "240c27fba554acfc783dbf9f87f432b281bfe8086da06d748b48bf97",
+    "stdout_hash": "b492401fb28a5b957b7c4344de506f1fdc6129f0f5baf43b06bce5d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_16-3e10090.stdout
+++ b/tests/reference/asr-functions_16-3e10090.stdout
@@ -1515,6 +1515,14 @@
                                                 )
                                         })
                                     toml_key
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []

--- a/tests/reference/asr-generic_name_01-9f2fd25.json
+++ b/tests/reference/asr-generic_name_01-9f2fd25.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generic_name_01-9f2fd25.stdout",
-    "stdout_hash": "e6b5979f549b3ac9b49959e3db7644ad7dc0129c4a1fc41339df0316",
+    "stdout_hash": "6d7b9798c992e330d7dd10aa0e54892f2f33d98009e4531b2e6e0b98",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generic_name_01-9f2fd25.stdout
+++ b/tests/reference/asr-generic_name_01-9f2fd25.stdout
@@ -86,6 +86,13 @@
                                                 )
                                         })
                                     complextype
+                                    (StructType
+                                        [(Real 4)
+                                        (Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [r
                                     i]

--- a/tests/reference/asr-intrinsics_334-6d740cf.json
+++ b/tests/reference/asr-intrinsics_334-6d740cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_334-6d740cf.stdout",
-    "stdout_hash": "08e743717a3b37275b07529db999d34bb545eac01ca01bbefaa7ef10",
+    "stdout_hash": "8ae45856bd269db78d6644b6fa12e6a6f7bfea649a0db213d194883d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_334-6d740cf.stdout
+++ b/tests/reference/asr-intrinsics_334-6d740cf.stdout
@@ -244,6 +244,12 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [x]
                                     []

--- a/tests/reference/asr-kwargs_02-1588831.json
+++ b/tests/reference/asr-kwargs_02-1588831.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-kwargs_02-1588831.stdout",
-    "stdout_hash": "f144f403996635bbf8a7725f7b690f478336d8e6ad819d3cf5ca9eb8",
+    "stdout_hash": "42bc93911cd6010f226bc1599d5ac7711de0ae190a368d93deea54ab",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-kwargs_02-1588831.stdout
+++ b/tests/reference/asr-kwargs_02-1588831.stdout
@@ -301,6 +301,12 @@
                                                 )
                                         })
                                     logger_type
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/asr-modules1-d3dc674.json
+++ b/tests/reference/asr-modules1-d3dc674.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules1-d3dc674.stdout",
-    "stdout_hash": "00c89469560e23ef4429146fd80230e11649e7bbb0b867cec3f91a7c",
+    "stdout_hash": "cb6397e7475eebf65c98e66ffc57201cb5132893dfcdba602299b510",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules1-d3dc674.stdout
+++ b/tests/reference/asr-modules1-d3dc674.stdout
@@ -107,6 +107,12 @@
                                                 )
                                         })
                                     t1
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -325,6 +331,19 @@
                                                 )
                                         })
                                     t2
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                []
+                                                []
+                                                .false.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [val]
                                     []

--- a/tests/reference/asr-modules2-98d8120.json
+++ b/tests/reference/asr-modules2-98d8120.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules2-98d8120.stdout",
-    "stdout_hash": "f3c8cc49af7be14f80b9b6528adad595a36052d00a2452ebfd5685d6",
+    "stdout_hash": "478143dc709f1562bcccc863fe5a044e9789c1a0a694bf4ff1e4718d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules2-98d8120.stdout
+++ b/tests/reference/asr-modules2-98d8120.stdout
@@ -109,6 +109,12 @@
                                             
                                         })
                                     toml_ordered
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -138,6 +144,12 @@
                                                 )
                                         })
                                     toml_structure
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -488,6 +500,19 @@
                                                 )
                                         })
                                     toml_array
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                []
+                                                []
+                                                .false.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [list]
                                     []
@@ -640,6 +665,14 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []

--- a/tests/reference/asr-modules3-8936416.json
+++ b/tests/reference/asr-modules3-8936416.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules3-8936416.stdout",
-    "stdout_hash": "272e2d91ed6ca8687d27971e8001e1a2b8a86c4fc77dfd77bfed0944",
+    "stdout_hash": "10668eb1c363f1dbc51ab4bf97b7b8bff58393f73b215f0aae65d2a8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules3-8936416.stdout
+++ b/tests/reference/asr-modules3-8936416.stdout
@@ -109,6 +109,12 @@
                                             
                                         })
                                     toml_ordered
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -138,6 +144,12 @@
                                                 )
                                         })
                                     toml_structure
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -561,6 +573,19 @@
                                                 )
                                         })
                                     toml_array
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                []
+                                                []
+                                                .false.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [list]
                                     []
@@ -713,6 +738,14 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []

--- a/tests/reference/asr-modules4-22712cd.json
+++ b/tests/reference/asr-modules4-22712cd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules4-22712cd.stdout",
-    "stdout_hash": "ae98d1c033acd1c5e4bfc81e3aed5ed16b892d048f5767293de8d895",
+    "stdout_hash": "2b92622545dfbf8417241ebf7990df913ca074856b01644312d830c5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules4-22712cd.stdout
+++ b/tests/reference/asr-modules4-22712cd.stdout
@@ -109,6 +109,12 @@
                                             
                                         })
                                     toml_ordered
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -138,6 +144,12 @@
                                                 )
                                         })
                                     toml_structure
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -551,6 +563,19 @@
                                                 )
                                         })
                                     toml_array
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                []
+                                                []
+                                                .false.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [list]
                                     []
@@ -850,6 +875,14 @@
                                                 )
                                         })
                                     toml_keyval
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []
@@ -902,6 +935,14 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []
@@ -1032,6 +1073,14 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []

--- a/tests/reference/asr-modules_24-996af24.json
+++ b/tests/reference/asr-modules_24-996af24.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_24-996af24.stdout",
-    "stdout_hash": "7d78e42a3a31698e898c72a479a70f3bde4deba275c31351daed9874",
+    "stdout_hash": "7f0ddd46a032d9c385110cb533a3921b09e9358e4d420ecfcb0b2f86",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_24-996af24.stdout
+++ b/tests/reference/asr-modules_24-996af24.stdout
@@ -292,6 +292,12 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [inline]
                                     []
@@ -358,6 +364,19 @@
                                                 )
                                         })
                                     toml_tokenizer
+                                    (StructType
+                                        [(Pointer
+                                            (StructType
+                                                [(Logical 4)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [toml_table]
                                     [current]
                                     []
@@ -377,6 +396,12 @@
                                             
                                         })
                                     toml_tokenizer_
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/asr-modules_25-b0e87c0.json
+++ b/tests/reference/asr-modules_25-b0e87c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_25-b0e87c0.stdout",
-    "stdout_hash": "bd06d273a95afdd3c3bb816af1fa654193fbc897e16c06f23bdface7",
+    "stdout_hash": "a193daba9aa2316969f80fa7aefba9ce7ecf33e544f30136241a4b98",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_25-b0e87c0.stdout
+++ b/tests/reference/asr-modules_25-b0e87c0.stdout
@@ -191,6 +191,14 @@
                                                 )
                                         })
                                     toml_character_tokenizer
+                                    (StructType
+                                        [(Pointer
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [conf]
                                     []
@@ -508,6 +516,12 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [inline]
                                     []
@@ -585,6 +599,19 @@
                                                 )
                                         })
                                     toml_tokenizer
+                                    (StructType
+                                        [(Pointer
+                                            (StructType
+                                                [(Logical 4)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [toml_table]
                                     [current]
                                     []
@@ -604,6 +631,12 @@
                                             
                                         })
                                     toml_tokenizer_
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/asr-modules_28-9506bba.json
+++ b/tests/reference/asr-modules_28-9506bba.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_28-9506bba.stdout",
-    "stdout_hash": "f698c76dcb549850d427032344450379cf36cb17928d651fead88449",
+    "stdout_hash": "49ed4230d011a5ee10f2a1543a02dbabd74c67bd73f2f900965031c8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_28-9506bba.stdout
+++ b/tests/reference/asr-modules_28-9506bba.stdout
@@ -220,6 +220,17 @@
                                                 )
                                         })
                                     git_target_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [url
                                     object]
@@ -331,6 +342,30 @@
                                                 )
                                         })
                                     dependency_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                [(Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )
+                                                (Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     path
@@ -374,6 +409,14 @@
                                                 )
                                         })
                                     error_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [message]
                                     []
@@ -840,6 +883,12 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [inline]
                                     []

--- a/tests/reference/asr-modules_29-dc71c55.json
+++ b/tests/reference/asr-modules_29-dc71c55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_29-dc71c55.stdout",
-    "stdout_hash": "2df522c4a9dd4b491792f080a5364236abdf05e140835a064de9f10d",
+    "stdout_hash": "982b0e6e388747cabe6253febf8703cbd30faf8fe4a3b3cb1d99838d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_29-dc71c55.stdout
+++ b/tests/reference/asr-modules_29-dc71c55.stdout
@@ -220,6 +220,17 @@
                                                 )
                                         })
                                     git_target_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [url
                                     object]
@@ -331,6 +342,30 @@
                                                 )
                                         })
                                     dependency_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                [(Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )
+                                                (Allocatable
+                                                    (String 1 () DeferredLength DescriptorString)
+                                                )]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     path
@@ -374,6 +409,14 @@
                                                 )
                                         })
                                     error_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [message]
                                     []
@@ -840,6 +883,12 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [inline]
                                     []
@@ -1011,6 +1060,51 @@
                                                 )
                                         })
                                     executable_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (Array
+                                                (StructType
+                                                    [(Allocatable
+                                                        (StructType
+                                                            [(Allocatable
+                                                                (String 1 () DeferredLength DescriptorString)
+                                                            )
+                                                            (Allocatable
+                                                                (String 1 () DeferredLength DescriptorString)
+                                                            )]
+                                                            []
+                                                            .true.
+                                                            .false.
+                                                        )
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     source_dir

--- a/tests/reference/asr-modules_30-9f519b4.json
+++ b/tests/reference/asr-modules_30-9f519b4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_30-9f519b4.stdout",
-    "stdout_hash": "9891a5c4ddf065fee8692484bab1fc6927afb0e15274b92a06a3a0ef",
+    "stdout_hash": "ed8ce5625497832e7d10d1e0fc1dba78b8cec392160139019ae0e5bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_30-9f519b4.stdout
+++ b/tests/reference/asr-modules_30-9f519b4.stdout
@@ -257,6 +257,20 @@
                                                 )
                                         })
                                     executable_config
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     source_dir
@@ -643,6 +657,35 @@
                                                 )
                                         })
                                     package_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (Array
+                                                (StructType
+                                                    [(Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     executable]

--- a/tests/reference/asr-modules_31-cd9bfef.json
+++ b/tests/reference/asr-modules_31-cd9bfef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_31-cd9bfef.stdout",
-    "stdout_hash": "a79c950a68c90a21f453f167bc3732aab7603f79fd3057192f8d3e0d",
+    "stdout_hash": "ff8a2dc284def7333cd59f5f9bc6b1e0eced059b4a97cf5bf586837a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_31-cd9bfef.stdout
+++ b/tests/reference/asr-modules_31-cd9bfef.stdout
@@ -375,6 +375,15 @@
                                                 )
                                         })
                                     fpm_cmd_settings
+                                    (StructType
+                                        [(Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [working_dir
                                     verbose]
@@ -464,6 +473,21 @@
                                                 )
                                         })
                                     fpm_update_settings
+                                    (StructType
+                                        [(Logical 4)
+                                        (Logical 4)
+                                        (Allocatable
+                                            (Array
+                                                (String 1 (IntegerConstant 5 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     fetch_only
@@ -543,6 +567,17 @@
                                                 )
                                         })
                                     dependency_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     path]
@@ -662,6 +697,19 @@
                                                 )
                                         })
                                     dependency_node_t
+                                    (StructType
+                                        [(Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [proj_dir
                                     revision
@@ -850,6 +898,40 @@
                                                 )
                                         })
                                     dependency_tree_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (Array
+                                                (StructType
+                                                    [(Logical 4)
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [unit
                                     verbosity
@@ -896,6 +978,14 @@
                                                 )
                                         })
                                     error_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [message]
                                     []

--- a/tests/reference/asr-modules_32-ca5fb91.json
+++ b/tests/reference/asr-modules_32-ca5fb91.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_32-ca5fb91.stdout",
-    "stdout_hash": "6df38c561a637675fea8bbda687ee4ac1edc2156d0685d4481ad2dfa",
+    "stdout_hash": "d4187ef2143bc2f02b5cd882152644f781d9f8d9f256c66169c3ce06",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_32-ca5fb91.stdout
+++ b/tests/reference/asr-modules_32-ca5fb91.stdout
@@ -77,6 +77,19 @@
                                                 )
                                         })
                                     build_target_ptr
+                                    (StructType
+                                        [(Pointer
+                                            (StructType
+                                                []
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [build_target_t]
                                     [ptr]
                                     []
@@ -141,6 +154,17 @@
                                                 )
                                         })
                                     build_target_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [output_file
                                     version]

--- a/tests/reference/asr-modules_33-b589c22.json
+++ b/tests/reference/asr-modules_33-b589c22.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_33-b589c22.stdout",
-    "stdout_hash": "695656567db4fc7bc31b0328b0caaf6ab2f21d9efd6dbca21a756d10",
+    "stdout_hash": "0f399b696457f4291f569f30561502a747264cfd18c380aef046597a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_33-b589c22.stdout
+++ b/tests/reference/asr-modules_33-b589c22.stdout
@@ -482,6 +482,17 @@
                                                 )
                                         })
                                     dependency_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name
                                     path]
@@ -601,6 +612,19 @@
                                                 )
                                         })
                                     dependency_node_t
+                                    (StructType
+                                        [(Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [proj_dir
                                     revision
@@ -819,6 +843,40 @@
                                                 )
                                         })
                                     dependency_tree_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (Array
+                                                (StructType
+                                                    [(Logical 4)
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Allocatable
+                                                        (String 1 () DeferredLength DescriptorString)
+                                                    )
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Integer 4)
+                                        (Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [unit
                                     verbosity
@@ -865,6 +923,14 @@
                                                 )
                                         })
                                     error_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [message]
                                     []
@@ -906,6 +972,14 @@
                                                 )
                                         })
                                     package_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name]
                                     []
@@ -1347,6 +1421,64 @@
                                                 )
                                         })
                                     fpm_model_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (StructType
+                                            [(Allocatable
+                                                (String 1 () DeferredLength DescriptorString)
+                                            )
+                                            (Allocatable
+                                                (Array
+                                                    (StructType
+                                                        [(Logical 4)
+                                                        (Allocatable
+                                                            (String 1 () DeferredLength DescriptorString)
+                                                        )
+                                                        (Allocatable
+                                                            (String 1 () DeferredLength DescriptorString)
+                                                        )
+                                                        (Logical 4)]
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
+                                                    [(()
+                                                    ())]
+                                                    DescriptorArray
+                                                )
+                                            )
+                                            (Allocatable
+                                                (String 1 () DeferredLength DescriptorString)
+                                            )
+                                            (Integer 4)
+                                            (Integer 4)
+                                            (Integer 4)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [dependency_tree_t]
                                     [package_name
                                     fortran_compile_flags

--- a/tests/reference/asr-modules_34-f98f7e3.json
+++ b/tests/reference/asr-modules_34-f98f7e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_34-f98f7e3.stdout",
-    "stdout_hash": "25b1ecd4107ef50fe0b8120b335c14b2537f39001dac462e9f6a0211",
+    "stdout_hash": "eb8d1971fd9b1a2f4140adf3030b2b13b16ffec634cb19293d2f8634",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_34-f98f7e3.stdout
+++ b/tests/reference/asr-modules_34-f98f7e3.stdout
@@ -116,6 +116,27 @@
                                                 )
                                         })
                                     package_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (StructType
+                                            [(Allocatable
+                                                (Array
+                                                    (Integer 4)
+                                                    [(()
+                                                    ())]
+                                                    DescriptorArray
+                                                )
+                                            )]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [version_t]
                                     [name
                                     version]
@@ -681,6 +702,19 @@
                                                 )
                                         })
                                     version_t
+                                    (StructType
+                                        [(Allocatable
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [num]
                                     []

--- a/tests/reference/asr-modules_37-7eba027.json
+++ b/tests/reference/asr-modules_37-7eba027.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_37-7eba027.stdout",
-    "stdout_hash": "57e0b097f6b92137f5f626c2e200512e1c72718ea41487c076858fd9",
+    "stdout_hash": "e9e2e1b52b4db4ad0c5ee043c021a70f12bd5f8c470dfd56cfee3165",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_37-7eba027.stdout
+++ b/tests/reference/asr-modules_37-7eba027.stdout
@@ -106,9 +106,7 @@
                                                                 (StructType
                                                                     [(Pointer
                                                                         (StructType
-                                                                            [(Allocatable
-                                                                                (String 1 () DeferredLength DescriptorString)
-                                                                            )]
+                                                                            []
                                                                             []
                                                                             .true.
                                                                             .false.
@@ -300,9 +298,7 @@
                                                         (StructType
                                                             [(Pointer
                                                                 (StructType
-                                                                    [(Allocatable
-                                                                        (String 1 () DeferredLength DescriptorString)
-                                                                    )]
+                                                                    []
                                                                     []
                                                                     .true.
                                                                     .false.
@@ -383,9 +379,7 @@
                                             (StructType
                                                 [(Pointer
                                                     (StructType
-                                                        [(Allocatable
-                                                            (String 1 () DeferredLength DescriptorString)
-                                                        )]
+                                                        []
                                                         []
                                                         .true.
                                                         .false.
@@ -516,6 +510,19 @@
                                                 )
                                         })
                                     build_target_ptr
+                                    (StructType
+                                        [(Pointer
+                                            (StructType
+                                                []
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [build_target_t]
                                     [ptr]
                                     []
@@ -557,6 +564,14 @@
                                                 )
                                         })
                                     build_target_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [output_dir]
                                     []
@@ -649,9 +664,7 @@
                                                             (StructType
                                                                 [(Pointer
                                                                     (StructType
-                                                                        [(Allocatable
-                                                                            (String 1 () DeferredLength DescriptorString)
-                                                                        )]
+                                                                        []
                                                                         []
                                                                         .true.
                                                                         .false.
@@ -727,6 +740,12 @@
                                             
                                         })
                                     fpm_build_settings
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -772,6 +791,12 @@
                                                 )
                                         })
                                     fpm_cmd_settings
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [verbose]
                                     []
@@ -791,6 +816,12 @@
                                             
                                         })
                                     fpm_model_t
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -832,6 +863,14 @@
                                                 )
                                         })
                                     string_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [s]
                                     []

--- a/tests/reference/asr-modules_40-d3a41b5.json
+++ b/tests/reference/asr-modules_40-d3a41b5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_40-d3a41b5.stdout",
-    "stdout_hash": "b9dc7c0a72c6644dee88af64f299f48647e5eacb0425c6c70cde6b8d",
+    "stdout_hash": "e6e0f082b1af0ca0609b70ef29eab837fbde89762bf436cbad735ec6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_40-d3a41b5.stdout
+++ b/tests/reference/asr-modules_40-d3a41b5.stdout
@@ -402,6 +402,14 @@
                                                 )
                                         })
                                     toml_key
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []
@@ -431,6 +439,12 @@
                                                 )
                                         })
                                     toml_tokenizer
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/asr-modules_43-d01691f.json
+++ b/tests/reference/asr-modules_43-d01691f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_43-d01691f.stdout",
-    "stdout_hash": "503e3526d35db19c61b7e93fa94e9355f6fc7acb5313e9d0aefbf575",
+    "stdout_hash": "12fa2bc2bd1fcdd292063e96e2d171c734285790666b809def4c7e36",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_43-d01691f.stdout
+++ b/tests/reference/asr-modules_43-d01691f.stdout
@@ -468,6 +468,18 @@
                                                 )
                                         })
                                     srcfile_t
+                                    (StructType
+                                        [(Integer 8)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [file_name
                                     exe_name

--- a/tests/reference/asr-modules_44-ec0baa3.json
+++ b/tests/reference/asr-modules_44-ec0baa3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_44-ec0baa3.stdout",
-    "stdout_hash": "fe5bbef29ba8a939bb4c4728712793b7513967184f62648fe1c427a4",
+    "stdout_hash": "45eacd9bd61d576c03bf049af86bb6c66f5354b2ee0e499d6082f1d1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_44-ec0baa3.stdout
+++ b/tests/reference/asr-modules_44-ec0baa3.stdout
@@ -252,6 +252,14 @@
                                                 )
                                         })
                                     fpm_cmd_settings
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [working_dir]
                                     []
@@ -293,6 +301,14 @@
                                                 )
                                         })
                                     fpm_new_settings
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name]
                                     []

--- a/tests/reference/asr-modules_45-c69c75f.json
+++ b/tests/reference/asr-modules_45-c69c75f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_45-c69c75f.stdout",
-    "stdout_hash": "b5c960ea2cb361d0f5271ee0145eb8733d7d6aafd8e6b6ffd766eeec",
+    "stdout_hash": "7b9960bc1ba94cb114d923fb6bead00bdb69bfbf09a519b76e20708d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_45-c69c75f.stdout
+++ b/tests/reference/asr-modules_45-c69c75f.stdout
@@ -280,6 +280,12 @@
                                             
                                         })
                                     file_scope_flag
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -1538,6 +1544,44 @@
                                                 )
                                         })
                                     profile_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (Array
+                                                (StructType
+                                                    []
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Integer 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [profile_name
                                     compiler

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "25482b725a43f40b239f6f97548e4f2cfdcb57234f6e85a400cd0175",
+    "stdout_hash": "488f130d1ad42078bf511d352481c9a6c2c63c499771e0194d280693",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -1839,6 +1839,14 @@
                                                 )
                                         })
                                     string_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [s]
                                     []

--- a/tests/reference/asr-modules_52-5261d38.json
+++ b/tests/reference/asr-modules_52-5261d38.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_52-5261d38.stdout",
-    "stdout_hash": "102c06910d67c1fbcad897596a399c1fe1281f9637e45e756e4d7e2c",
+    "stdout_hash": "4d104cd15187193355a256c784e06ed27354e440e587a256d74132eb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_52-5261d38.stdout
+++ b/tests/reference/asr-modules_52-5261d38.stdout
@@ -558,6 +558,15 @@
                                                 )
                                         })
                                     toml_error
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [stat
                                     message]
@@ -644,6 +653,13 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)
+                                        (Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [implicit
                                     inline]

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.json
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nested_struct_proc_01-3b9017b.stdout",
-    "stdout_hash": "29f4bd1d3e83ab228db102e5a5447467363358db2ac4e20fba8220fb",
+    "stdout_hash": "f6efd0934df35d5dc28d5ad7a02a42738d2338af173a3500b0abfc73",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
@@ -175,6 +175,23 @@
                                                 )
                                         })
                                     integer32complex32orderedmap
+                                    (StructType
+                                        [(StructType
+                                            [(Complex 4)
+                                            (StructType
+                                                []
+                                                []
+                                                .true.
+                                                .false.
+                                            )]
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [omap_map]
                                     [map]
                                     []
@@ -412,6 +429,12 @@
                                             
                                         })
                                     omap_i_set
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -862,6 +885,18 @@
                                                 )
                                         })
                                     omap_map
+                                    (StructType
+                                        [(Complex 4)
+                                        (StructType
+                                            []
+                                            []
+                                            .true.
+                                            .false.
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [omap_i_set]
                                     [tree
                                     stored_value]

--- a/tests/reference/asr-nullify_03-e2c1d62.json
+++ b/tests/reference/asr-nullify_03-e2c1d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nullify_03-e2c1d62.stdout",
-    "stdout_hash": "fa2b8e026c6a4e277d03b7cdac3a89208f20036d237533ff7f655a66",
+    "stdout_hash": "a3344f85b64bedeed43abbe0511b96e6cfce0269b67ac4a15a656654",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nullify_03-e2c1d62.stdout
+++ b/tests/reference/asr-nullify_03-e2c1d62.stdout
@@ -63,6 +63,19 @@
                                                 )
                                         })
                                     rp1d
+                                    (StructType
+                                        [(Pointer
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [f]
                                     []
@@ -219,6 +232,49 @@
                                                 )
                                         })
                                     sds
+                                    (StructType
+                                        [(Array
+                                            (Integer 4)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 3 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        (Pointer
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())
+                                                (()
+                                                ())
+                                                (()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Logical 4)
+                                        (Integer 4)
+                                        (Array
+                                            (StructType
+                                                [(Pointer
+                                                    (Array
+                                                        (Real 8)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                )]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 3 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [ndim
                                     dims

--- a/tests/reference/asr-nullify_04-a75db8a.json
+++ b/tests/reference/asr-nullify_04-a75db8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nullify_04-a75db8a.stdout",
-    "stdout_hash": "c15a4343839c386b475c9eb62346b80d82541f670874bfa99c10ef50",
+    "stdout_hash": "85713d93f03344f9352d97e32a27705db6377531e8dcabeb26916728",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nullify_04-a75db8a.stdout
+++ b/tests/reference/asr-nullify_04-a75db8a.stdout
@@ -42,6 +42,19 @@
                                                 )
                                         })
                                     scaled_data_structure
+                                    (StructType
+                                        [(Pointer
+                                            (Array
+                                                (Real 4)
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [one_d_real_pointer]
                                     []

--- a/tests/reference/asr-operator_overloading_04-e28fb55.json
+++ b/tests/reference/asr-operator_overloading_04-e28fb55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-operator_overloading_04-e28fb55.stdout",
-    "stdout_hash": "dea01d467bc6752c1c8936614caadba6ecd090ea0d20ebbda8291251",
+    "stdout_hash": "58c633b98ee36db6c81927fdb9a551bc5783f54df46310abec0c90c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-operator_overloading_04-e28fb55.stdout
+++ b/tests/reference/asr-operator_overloading_04-e28fb55.stdout
@@ -147,6 +147,14 @@
                                                 )
                                         })
                                     string_type
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []

--- a/tests/reference/asr-operator_overloading_08-52825a6.json
+++ b/tests/reference/asr-operator_overloading_08-52825a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-operator_overloading_08-52825a6.stdout",
-    "stdout_hash": "e2fba05fc634a174088145444a45a64e583e9cbf13d152055cfd3307",
+    "stdout_hash": "66f1f96a866d89704926461271724833968933cb0afb97f011326999",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-operator_overloading_08-52825a6.stdout
+++ b/tests/reference/asr-operator_overloading_08-52825a6.stdout
@@ -304,6 +304,12 @@
                                                 )
                                         })
                                     custom_int
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [value]
                                     []

--- a/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.json
+++ b/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-optional_argument_subroutine_in_type-0d81d24.stdout",
-    "stdout_hash": "aea4efcb48e436ecdaf38c059269031ce8867a7949fc686f3d1bf6e9",
+    "stdout_hash": "ef98f79820a1b321281a0b5f2fe4c56a44f996fc2eaf5e6cc2e0bbd3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.stdout
+++ b/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.stdout
@@ -173,6 +173,12 @@
                                                 )
                                         })
                                     test_type
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [test_real_value]
                                     []

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_arguments_02-bb6f3e2.stdout",
-    "stdout_hash": "9b9f18c9023430ba31ee01ca0417042aedfe1f4fda76721c9a2df483",
+    "stdout_hash": "e0b2271dff761ed9736269fb33b177d362410c17d096b8978905dd2f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
@@ -181,6 +181,12 @@
                                                             
                                                         })
                                                     ~unlimited_polymorphic_type
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .false.
+                                                        .true.
+                                                    )
                                                     []
                                                     []
                                                     []

--- a/tests/reference/asr-polymorphic_class_compare-e58def6.json
+++ b/tests/reference/asr-polymorphic_class_compare-e58def6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_class_compare-e58def6.stdout",
-    "stdout_hash": "8d8390e8c80dd1b41a127a402906ab50779a160f942464a328984949",
+    "stdout_hash": "33aa3871240774530a6b543e411875b8987e3a3a6d8cf451e83ccd50",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_class_compare-e58def6.stdout
+++ b/tests/reference/asr-polymorphic_class_compare-e58def6.stdout
@@ -326,6 +326,12 @@
                                                 )
                                         })
                                     map_setiterator
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_class_in_derived_type-15eb7b6.stdout",
-    "stdout_hash": "fb7d4ce6163605394ef868a9791534c1930013c9815091aeeb61c71b",
+    "stdout_hash": "4ebf01cede991bbc81476b9bca277fda99b25c80fbc5285d0b6848e8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
@@ -76,6 +76,12 @@
                                                             
                                                         })
                                                     ~unlimited_polymorphic_type
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .false.
+                                                        .true.
+                                                    )
                                                     []
                                                     []
                                                     []
@@ -89,6 +95,27 @@
                                                 )
                                         })
                                     dict_item
+                                    (StructType
+                                        [(Allocatable
+                                            (StructType
+                                                []
+                                                []
+                                                .false.
+                                                .true.
+                                            )
+                                        )
+                                        (Allocatable
+                                            (StructType
+                                                []
+                                                []
+                                                .false.
+                                                .true.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [value
                                     value2]

--- a/tests/reference/asr-select_type_01-204dfa1.json
+++ b/tests/reference/asr-select_type_01-204dfa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_01-204dfa1.stdout",
-    "stdout_hash": "745b6c6702f115662ac8d51e6a33a5fe614ec4f3a1e6ddaa207e5656",
+    "stdout_hash": "9f4f00f915557f30ee8e619e15193a03fe37263cff17e6e3e90ffa26",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_01-204dfa1.stdout
+++ b/tests/reference/asr-select_type_01-204dfa1.stdout
@@ -55,6 +55,12 @@
                                                 )
                                         })
                                     base
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [i]
                                     []
@@ -158,6 +164,12 @@
                                                 )
                                         })
                                     child
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [j]
                                     []

--- a/tests/reference/asr-select_type_02-6e04a0b.json
+++ b/tests/reference/asr-select_type_02-6e04a0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_02-6e04a0b.stdout",
-    "stdout_hash": "2a4bfb9d7a34ecbda64754d8d4afe0276a3927b8a66ee3d420aada2e",
+    "stdout_hash": "1fb344ba2dc75c4df198abe01e713fd90585fc72541bd4d2db7029b5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_02-6e04a0b.stdout
+++ b/tests/reference/asr-select_type_02-6e04a0b.stdout
@@ -56,6 +56,13 @@
                                                 )
                                         })
                                     point
+                                    (StructType
+                                        [(Real 4)
+                                        (Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [x
                                     y]
@@ -149,6 +156,12 @@
                                                 )
                                         })
                                     color_point
+                                    (StructType
+                                        [(Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [color]
                                     []
@@ -306,6 +319,12 @@
                                                 )
                                         })
                                     point_3d
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [z]
                                     []

--- a/tests/reference/asr-select_type_03-f21585a.json
+++ b/tests/reference/asr-select_type_03-f21585a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_03-f21585a.stdout",
-    "stdout_hash": "81a3623f031ecde55a0b288540b24640f586b51a3df7cf4f745bf3ca",
+    "stdout_hash": "c5aece05f3313f3c373750e55559ca75e7f8a1355d9a08438f060384",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_03-f21585a.stdout
+++ b/tests/reference/asr-select_type_03-f21585a.stdout
@@ -60,6 +60,13 @@
                                                 )
                                         })
                                     enum_stat
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [success
                                     fatal]
@@ -541,6 +548,13 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)
+                                        (Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [implicit
                                     inline]
@@ -602,6 +616,13 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Real 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [int
                                     float]

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "2bde35475e32ec12a47da881730fc0493cfda61d6a666af926029018",
+    "stdout_hash": "d6aa5aad78e347213d41c553ea4f8a1c4acd1cb26b8171550d5a1298",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -60,6 +60,13 @@
                                                 )
                                         })
                                     enum_stat
+                                    (StructType
+                                        [(Integer 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [success
                                     fatal]
@@ -541,6 +548,13 @@
                                                 )
                                         })
                                     toml_table
+                                    (StructType
+                                        [(Logical 4)
+                                        (Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [implicit
                                     inline]
@@ -602,6 +616,13 @@
                                                 )
                                         })
                                     toml_value
+                                    (StructType
+                                        [(Real 4)
+                                        (Integer 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [int
                                     float]

--- a/tests/reference/asr-string1-f6332d9.json
+++ b/tests/reference/asr-string1-f6332d9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string1-f6332d9.stdout",
-    "stdout_hash": "5180ef23c7b0a534ad181e540418e5822ea59893ca0f6a33d30ade7e",
+    "stdout_hash": "49ad7537c9826e747e996946c7ca8e500d0d85e640759c04a2bcfadf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string1-f6332d9.stdout
+++ b/tests/reference/asr-string1-f6332d9.stdout
@@ -436,6 +436,14 @@
                                                 )
                                         })
                                     string_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [s]
                                     []

--- a/tests/reference/asr-string2-3425046.json
+++ b/tests/reference/asr-string2-3425046.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-3425046.stdout",
-    "stdout_hash": "6752d0675e13a06cac2f9ec7f84e5b6d911246538cbccec772d921be",
+    "stdout_hash": "68155875d1a40a8b417d393b3b3d40f1e88a637841a982fcc2957108",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-3425046.stdout
+++ b/tests/reference/asr-string2-3425046.stdout
@@ -770,6 +770,14 @@
                                                 )
                                         })
                                     string_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [s]
                                     []

--- a/tests/reference/asr-string_14-861794e.json
+++ b/tests/reference/asr-string_14-861794e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_14-861794e.stdout",
-    "stdout_hash": "83c30b101973917bce8e33d28b8b08c743d62d27552b21fd8b944f93",
+    "stdout_hash": "0531d8272493daa8c813ad19de7e9997bf303d0f80401c3c5e6d63af",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_14-861794e.stdout
+++ b/tests/reference/asr-string_14-861794e.stdout
@@ -261,6 +261,14 @@
                                                 )
                                         })
                                     string_type
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []

--- a/tests/reference/asr-string_17-29e01e3.json
+++ b/tests/reference/asr-string_17-29e01e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_17-29e01e3.stdout",
-    "stdout_hash": "5ab3b05323eb5999cfeb6078167801b593b193548d64a7593b0bd65b",
+    "stdout_hash": "50498aa7fce13c484919bf857be60c0fcc73a8452e0859661c9fd44c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_17-29e01e3.stdout
+++ b/tests/reference/asr-string_17-29e01e3.stdout
@@ -339,6 +339,14 @@
                                                 )
                                         })
                                     string_type
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []

--- a/tests/reference/asr-string_19-d880475.json
+++ b/tests/reference/asr-string_19-d880475.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_19-d880475.stdout",
-    "stdout_hash": "438bb8154fb3399d9fd9e43ccf9b8836d9fcd337df84487e4ee8b5f8",
+    "stdout_hash": "70f2a27661be020eb9ad5030b4b40556ca9de28a9b40b7dbbb271f5f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_19-d880475.stdout
+++ b/tests/reference/asr-string_19-d880475.stdout
@@ -389,6 +389,14 @@
                                                 )
                                         })
                                     string_type
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [raw]
                                     []

--- a/tests/reference/asr-struct_allocate-606e066.json
+++ b/tests/reference/asr-struct_allocate-606e066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-struct_allocate-606e066.stdout",
-    "stdout_hash": "d7d01fb26508eec84f50ca48550dbd90e7f7afb36999bd5a8c7100fa",
+    "stdout_hash": "81ed148aa87bde3b5125950e28b23f062b732c6a453fc4483b98b819",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-struct_allocate-606e066.stdout
+++ b/tests/reference/asr-struct_allocate-606e066.stdout
@@ -63,6 +63,19 @@
                                                 )
                                         })
                                     rp1d
+                                    (StructType
+                                        [(Pointer
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [f]
                                     []
@@ -119,6 +132,29 @@
                                                 )
                                         })
                                     sds
+                                    (StructType
+                                        [(Array
+                                            (StructType
+                                                [(Pointer
+                                                    (Array
+                                                        (Real 8)
+                                                        [(()
+                                                        ())]
+                                                        DescriptorArray
+                                                    )
+                                                )]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 3 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [scales]
                                     []

--- a/tests/reference/asr-submodule_02-9152b7b.json
+++ b/tests/reference/asr-submodule_02-9152b7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_02-9152b7b.stdout",
-    "stdout_hash": "73579341d5350cea8199ee93684b3316f5c33424548c0d61c3fbbda3",
+    "stdout_hash": "3ac9a1755676b216543ee05d775c8b6b050981880e6197fa528e7497",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_02-9152b7b.stdout
+++ b/tests/reference/asr-submodule_02-9152b7b.stdout
@@ -58,6 +58,13 @@
                                                 )
                                         })
                                     point
+                                    (StructType
+                                        [(Real 4)
+                                        (Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [x
                                     y]

--- a/tests/reference/asr-submodule_04-987b68b.json
+++ b/tests/reference/asr-submodule_04-987b68b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_04-987b68b.stdout",
-    "stdout_hash": "7f8f29dbf74b48c150bab75c85f70b0dd7695a6d57fe22a0ea16a08e",
+    "stdout_hash": "35d20993dc177ee142201d1027afe913442bf651f3c6b44d090c3b7e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_04-987b68b.stdout
+++ b/tests/reference/asr-submodule_04-987b68b.stdout
@@ -109,6 +109,12 @@
                                                 )
                                         })
                                     open_hashmap_type
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/asr-template_sort_01-b412f73.json
+++ b/tests/reference/asr-template_sort_01-b412f73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_sort_01-b412f73.stdout",
-    "stdout_hash": "8764264211dcdeaf707bf97c4ee239ed063edb72b699bbc77751d736",
+    "stdout_hash": "db23580cf4c2295cca83abede67d88e0843f4601f08ad9f12bfb5668",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_sort_01-b412f73.stdout
+++ b/tests/reference/asr-template_sort_01-b412f73.stdout
@@ -3112,6 +3112,12 @@
                                                 )
                                         })
                                     my_type
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [d]
                                     []

--- a/tests/reference/asr-template_sort_02-0aa4518.json
+++ b/tests/reference/asr-template_sort_02-0aa4518.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_sort_02-0aa4518.stdout",
-    "stdout_hash": "df87191975f4c7f6b06089bfc5fde9b58cf1f9681e84ebb381a73ed2",
+    "stdout_hash": "305166fca301e960693c05665fd2eb32d11f01a282806942d85f5dba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_sort_02-0aa4518.stdout
+++ b/tests/reference/asr-template_sort_02-0aa4518.stdout
@@ -3989,6 +3989,12 @@
                                                 )
                                         })
                                     my_type
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [d]
                                     []

--- a/tests/reference/asr-template_struct_01-c320d7d.json
+++ b/tests/reference/asr-template_struct_01-c320d7d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_struct_01-c320d7d.stdout",
-    "stdout_hash": "7ef21e325302bbe182122cf39940d791e59b0c64832a8f7d37c964ba",
+    "stdout_hash": "ba3a82b3d81ae0ed7cea5e9dabd2237653289ad1734df272e7f60c0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_struct_01-c320d7d.stdout
+++ b/tests/reference/asr-template_struct_01-c320d7d.stdout
@@ -402,6 +402,17 @@
                                                                 )
                                                         })
                                                     tuple
+                                                    (StructType
+                                                        [(TypeParameter
+                                                            t
+                                                        )
+                                                        (TypeParameter
+                                                            t
+                                                        )]
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [fst
                                                     snd]
@@ -492,8 +503,7 @@
                                                                     ()
                                                                     Default
                                                                     (StructType
-                                                                        [(Integer 4)
-                                                                        (Integer 4)]
+                                                                        []
                                                                         []
                                                                         .true.
                                                                         .false.
@@ -534,8 +544,7 @@
                                                     get_int_fst
                                                     (FunctionType
                                                         [(StructType
-                                                            [(Integer 4)
-                                                            (Integer 4)]
+                                                            []
                                                             []
                                                             .true.
                                                             .false.
@@ -596,8 +605,7 @@
                                                                     ()
                                                                     Default
                                                                     (StructType
-                                                                        [(Integer 4)
-                                                                        (Integer 4)]
+                                                                        []
                                                                         []
                                                                         .true.
                                                                         .false.
@@ -638,8 +646,7 @@
                                                     get_int_snd
                                                     (FunctionType
                                                         [(StructType
-                                                            [(Integer 4)
-                                                            (Integer 4)]
+                                                            []
                                                             []
                                                             .true.
                                                             .false.
@@ -700,8 +707,7 @@
                                                                     ()
                                                                     Default
                                                                     (StructType
-                                                                        [(Real 4)
-                                                                        (Real 4)]
+                                                                        []
                                                                         []
                                                                         .true.
                                                                         .false.
@@ -742,8 +748,7 @@
                                                     get_real_fst
                                                     (FunctionType
                                                         [(StructType
-                                                            [(Real 4)
-                                                            (Real 4)]
+                                                            []
                                                             []
                                                             .true.
                                                             .false.
@@ -804,8 +809,7 @@
                                                                     ()
                                                                     Default
                                                                     (StructType
-                                                                        [(Real 4)
-                                                                        (Real 4)]
+                                                                        []
                                                                         []
                                                                         .true.
                                                                         .false.
@@ -846,8 +850,7 @@
                                                     get_real_snd
                                                     (FunctionType
                                                         [(StructType
-                                                            [(Real 4)
-                                                            (Real 4)]
+                                                            []
                                                             []
                                                             .true.
                                                             .false.
@@ -932,6 +935,12 @@
                                                                 )
                                                         })
                                                     int_tuple
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [fst
                                                     snd]
@@ -993,6 +1002,12 @@
                                                                 )
                                                         })
                                                     real_tuple
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [fst
                                                     snd]
@@ -1015,8 +1030,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        [(Integer 4)
-                                                        (Integer 4)]
+                                                        []
                                                         []
                                                         .true.
                                                         .false.
@@ -1042,8 +1056,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        [(Real 4)
-                                                        (Real 4)]
+                                                        []
                                                         []
                                                         .true.
                                                         .false.

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "085c407a3df4a427cc1372517ffb85c8c0f2a0eea35c553ed8330b11",
+    "stdout_hash": "829e78690ec414b9e6b5fdac692d5e2f4733e469113400c9ddcfd976",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -154,15 +154,7 @@
                                                                     ()
                                                                     Default
                                                                     (StructType
-                                                                        [(Allocatable
-                                                                            (Array
-                                                                                (Integer 4)
-                                                                                [(()
-                                                                                ())]
-                                                                                DescriptorArray
-                                                                            )
-                                                                        )
-                                                                        (Integer 4)]
+                                                                        []
                                                                         []
                                                                         .false.
                                                                         .false.
@@ -182,15 +174,7 @@
                                                     __asr_push_back
                                                     (FunctionType
                                                         [(StructType
-                                                            [(Allocatable
-                                                                (Array
-                                                                    (Integer 4)
-                                                                    [(()
-                                                                    ())]
-                                                                    DescriptorArray
-                                                                )
-                                                            )
-                                                            (Integer 4)]
+                                                            []
                                                             []
                                                             .false.
                                                             .false.
@@ -354,15 +338,7 @@
                                                                     ()
                                                                     Default
                                                                     (StructType
-                                                                        [(Allocatable
-                                                                            (Array
-                                                                                (Integer 4)
-                                                                                [(()
-                                                                                ())]
-                                                                                DescriptorArray
-                                                                            )
-                                                                        )
-                                                                        (Integer 4)]
+                                                                        []
                                                                         []
                                                                         .false.
                                                                         .false.
@@ -410,15 +386,7 @@
                                                     __asr_resize
                                                     (FunctionType
                                                         [(StructType
-                                                            [(Allocatable
-                                                                (Array
-                                                                    (Integer 4)
-                                                                    [(()
-                                                                    ())]
-                                                                    DescriptorArray
-                                                                )
-                                                            )
-                                                            (Integer 4)]
+                                                            []
                                                             []
                                                             .false.
                                                             .false.
@@ -712,6 +680,12 @@
                                                                 )
                                                         })
                                                     intvector
+                                                    (StructType
+                                                        []
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [elements
                                                     sz]
@@ -734,15 +708,7 @@
                                                     ()
                                                     Default
                                                     (StructType
-                                                        [(Allocatable
-                                                            (Array
-                                                                (Integer 4)
-                                                                [(()
-                                                                ())]
-                                                                DescriptorArray
-                                                            )
-                                                        )
-                                                        (Integer 4)]
+                                                        []
                                                         []
                                                         .true.
                                                         .false.
@@ -1531,6 +1497,22 @@
                                                                 )
                                                         })
                                                     vector
+                                                    (StructType
+                                                        [(Allocatable
+                                                            (Array
+                                                                (TypeParameter
+                                                                    t
+                                                                )
+                                                                [(()
+                                                                ())]
+                                                                DescriptorArray
+                                                            )
+                                                        )
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
+                                                        .false.
+                                                    )
                                                     []
                                                     [elements
                                                     sz]

--- a/tests/reference/asr-write7-6ba53a1.json
+++ b/tests/reference/asr-write7-6ba53a1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-write7-6ba53a1.stdout",
-    "stdout_hash": "7e72a10ceb74bb2a0c33c5711014ab30dfa45aa26c2263e17c1d604c",
+    "stdout_hash": "49debb2f215e7c133c8e14cf67efb6a810a604ee6811f2ff8d25b1bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-write7-6ba53a1.stdout
+++ b/tests/reference/asr-write7-6ba53a1.stdout
@@ -50,6 +50,12 @@
                                                 )
                                         })
                                     person
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/pass_array_op-modules_43-6930881.json
+++ b/tests/reference/pass_array_op-modules_43-6930881.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_array_op-modules_43-6930881.stdout",
-    "stdout_hash": "007525e70d8b7c5b67d89981ba54de72d095e7d9a3fae4c11e805201",
+    "stdout_hash": "ecebb724dd161cfc664a4d75a79117488405198a02dff041c1bcc2a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_array_op-modules_43-6930881.stdout
+++ b/tests/reference/pass_array_op-modules_43-6930881.stdout
@@ -726,6 +726,18 @@
                                                 )
                                         })
                                     srcfile_t
+                                    (StructType
+                                        [(Integer 8)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [file_name
                                     exe_name

--- a/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.json
+++ b/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-multiple_objects_args-2d1007e.stdout",
-    "stdout_hash": "4732e5034a328623a89e03700b660c348d5d5d349cd212c5b20546df",
+    "stdout_hash": "12959ed2d458f3de698c042e69ded8fe609c635c4ab870649b61ed84",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.stdout
+++ b/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.stdout
@@ -51,6 +51,12 @@
                                                 )
                                         })
                                     circle
+                                    (StructType
+                                        [(Real 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [radius]
                                     []

--- a/tests/reference/pass_pass_array_by_data-modules_44-cd82150.json
+++ b/tests/reference/pass_pass_array_by_data-modules_44-cd82150.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data-modules_44-cd82150.stdout",
-    "stdout_hash": "439ab290e46d794a5d7bf4ca873db4d3ee050591085d0a3b70540d23",
+    "stdout_hash": "5b25905b9d53180c0ecbdad47d01ed246d785823cdbdfacf7444a79e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data-modules_44-cd82150.stdout
+++ b/tests/reference/pass_pass_array_by_data-modules_44-cd82150.stdout
@@ -261,6 +261,14 @@
                                                 )
                                         })
                                     fpm_cmd_settings
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [working_dir]
                                     []
@@ -302,6 +310,14 @@
                                                 )
                                         })
                                     fpm_new_settings
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [name]
                                     []

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout",
-    "stdout_hash": "9d58974c77042026e1e7c45ebb8007d6d7b9a7a336fa5d63757b64fb",
+    "stdout_hash": "1f93d496d4483aadff98e5e7e48ef3d30aeb93ae8cca57cb58525cc6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
@@ -127,9 +127,7 @@
                                                                 (StructType
                                                                     [(Pointer
                                                                         (StructType
-                                                                            [(Allocatable
-                                                                                (String 1 () DeferredLength DescriptorString)
-                                                                            )]
+                                                                            []
                                                                             []
                                                                             .true.
                                                                             .false.
@@ -321,9 +319,7 @@
                                                         (StructType
                                                             [(Pointer
                                                                 (StructType
-                                                                    [(Allocatable
-                                                                        (String 1 () DeferredLength DescriptorString)
-                                                                    )]
+                                                                    []
                                                                     []
                                                                     .true.
                                                                     .false.
@@ -404,9 +400,7 @@
                                             (StructType
                                                 [(Pointer
                                                     (StructType
-                                                        [(Allocatable
-                                                            (String 1 () DeferredLength DescriptorString)
-                                                        )]
+                                                        []
                                                         []
                                                         .true.
                                                         .false.
@@ -543,6 +537,19 @@
                                                 )
                                         })
                                     build_target_ptr
+                                    (StructType
+                                        [(Pointer
+                                            (StructType
+                                                []
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     [build_target_t]
                                     [ptr]
                                     []
@@ -584,6 +591,14 @@
                                                 )
                                         })
                                     build_target_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [output_dir]
                                     []
@@ -676,9 +691,7 @@
                                                             (StructType
                                                                 [(Pointer
                                                                     (StructType
-                                                                        [(Allocatable
-                                                                            (String 1 () DeferredLength DescriptorString)
-                                                                        )]
+                                                                        []
                                                                         []
                                                                         .true.
                                                                         .false.
@@ -739,9 +752,7 @@
                                                     (StructType
                                                         [(Pointer
                                                             (StructType
-                                                                [(Allocatable
-                                                                    (String 1 () DeferredLength DescriptorString)
-                                                                )]
+                                                                []
                                                                 []
                                                                 .true.
                                                                 .false.
@@ -787,6 +798,12 @@
                                             
                                         })
                                     fpm_build_settings
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -832,6 +849,12 @@
                                                 )
                                         })
                                     fpm_cmd_settings
+                                    (StructType
+                                        [(Logical 4)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [verbose]
                                     []
@@ -851,6 +874,12 @@
                                             
                                         })
                                     fpm_model_t
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -892,6 +921,14 @@
                                                 )
                                         })
                                     string_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [s]
                                     []

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.stdout",
-    "stdout_hash": "c0d7b21d1d3615a10ad57907cd0f3f222b45d873d237ac0b16ee356a",
+    "stdout_hash": "69470a8a7e93c5471d3fcd7a73cca929e99e36fa6ea723022d962f53",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.stdout
@@ -450,6 +450,14 @@
                                                 )
                                         })
                                     toml_key
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [key]
                                     []
@@ -479,6 +487,12 @@
                                                 )
                                         })
                                     toml_tokenizer
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout",
-    "stdout_hash": "1460563dba6ed00817fa34a93a830f57763c7f0e9de9ef6da64cb9a0",
+    "stdout_hash": "19282552f5570fad671b3be4053725b7de32ddfcba5dd946ed1b7ceb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
@@ -280,6 +280,12 @@
                                             
                                         })
                                     file_scope_flag
+                                    (StructType
+                                        []
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     []
                                     []
@@ -1781,6 +1787,44 @@
                                                 )
                                         })
                                     profile_config_t
+                                    (StructType
+                                        [(Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Allocatable
+                                            (Array
+                                                (StructType
+                                                    []
+                                                    []
+                                                    .true.
+                                                    .false.
+                                                )
+                                                [(()
+                                                ())]
+                                                DescriptorArray
+                                            )
+                                        )
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Logical 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )
+                                        (Integer 4)
+                                        (Allocatable
+                                            (String 1 () DeferredLength DescriptorString)
+                                        )]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
                                     []
                                     [profile_name
                                     compiler


### PR DESCRIPTION
With this we can revert https://github.com/lfortran/lfortran/pull/8173, FPM successfully builds.

```console
% fpm --compiler=lfortran build
[...]
fpm_backend.F90                        done.
fpm.f90                                done.
publish.f90                            done.
install.f90                            done.
export.f90                             done.
libfpm.a                               done.
main.f90                               done.
fpm                                    done.
[100%] Project compiled successfully.
```

With `member_function_types`

```console
% find . -name "fpm_manifest_package.mod" -exec ls -lh {} \;

-rw-r--r--  1 pranavchiku  staff   679K Aug  2 16:57 ./build/lfortran_DCE61923E912C914/fpm_manifest_package.mod
```