### PR TITLE
BOZ Conversion to Real Inside Declaration Statements

### DIFF
--- a/integration_tests/boz_02.f90
+++ b/integration_tests/boz_02.f90
@@ -1,25 +1,32 @@
+!This file contains tests for BOZ, which are not yet supported in gfortran
 program real_boz
 implicit none
-
 integer :: i
 real :: boz_1, matrix1(5), matrix2(2), arr1(2)
 integer :: arr2(2)
-
 !Check Scalar Assigment
 data boz_1 /b'01011101'/  
-
 !Check Multiple Assigments of Real array with BOZ Values
 data matrix1 / b'10', 2*o'100', 3.12, z'ABC' / 
-
 !Check Data Broadcasting to all elements of array
 data matrix2 / 2*b'10' /
-
 !Check Implied Do loop Assignments, with real assigments along with integer assignments
 data (arr1(i), arr2(i), i=1,2) / 1.2, z'02', z'01', 3 /
-
 print *, boz_1
 print *, matrix1
 print *, matrix2
 print *, arr1, arr2
-
 end program
+
+program declare_boz
+implicit none
+!Check Scalar Assigment
+real::a = o'10'
+integer::b = z'10'
+!Check Parameter Initializations
+real,parameter::c = b'01'
+!Check Array Initializations
+real:: d(3) = [real::b'01', z'10', 3.4]
+integer:: e(3) = [integer::1, b'10', 4]
+PRINT *,a,b,c,d,e
+end

--- a/integration_tests/boz_02.f90
+++ b/integration_tests/boz_02.f90
@@ -1,6 +1,8 @@
 !This file contains tests for BOZ, which are not yet supported in gfortran
 program real_boz
 implicit none
+
+!check DATA Assignments
 integer :: i
 real :: boz_1, matrix1(5), matrix2(2), arr1(2)
 integer :: arr2(2)
@@ -12,21 +14,23 @@ data matrix1 / b'10', 2*o'100', 3.12, z'ABC' /
 data matrix2 / 2*b'10' /
 !Check Implied Do loop Assignments, with real assigments along with integer assignments
 data (arr1(i), arr2(i), i=1,2) / 1.2, z'02', z'01', 3 /
-print *, boz_1
-print *, matrix1
-print *, matrix2
-print *, arr1, arr2
-end program
 
-program declare_boz
-implicit none
+
+!Check Declaration Statements
 !Check Scalar Assigment
 real::a = o'10'
 integer::b = z'10'
 !Check Parameter Initializations
 real,parameter::c = b'01'
+integer,parameter::d = z'02'
 !Check Array Initializations
-real:: d(3) = [real::b'01', z'10', 3.4]
-integer:: e(3) = [integer::1, b'10', 4]
-PRINT *,a,b,c,d,e
-end
+real:: e(3) = [real::b'01', z'10', 3.4]
+integer:: f(3) = [integer::1, b'10', 4]
+
+print *, boz_1
+print *, matrix1
+print *, matrix2
+print *, arr1, arr2
+PRINT *, a,b,c,d,e,f
+end program
+

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4122,7 +4122,23 @@ public:
                         }
                     }
                 } else if (s.m_initializer != nullptr) {
+                    ASR::ttype_t* temp_current_variable_type_ = current_variable_type_;
+                    if (s.m_initializer!=nullptr && s.m_initializer->type==AST::ArrayInitializer) {
+                        // This is an array initializer, we need to handle it separately
+                        AST::ArrayInitializer_t *array_init1 = AST::down_cast<AST::ArrayInitializer_t>(s.m_initializer);
+                        if (array_init1->m_vartype && array_init1->m_vartype->type == AST::decl_attributeType::AttrType) {
+                            AST::AttrType_t *attr_type = AST::down_cast<AST::AttrType_t>(array_init1->m_vartype);
+                            if (attr_type->m_type == AST::decl_typeType::TypeReal) {
+                                for (size_t i = 0; i < array_init1->n_args; i++) {
+                                    if (array_init1->m_args[i]->type == AST::exprType::BOZ){
+                                        current_variable_type_ = ASRUtils::TYPE(ASR::make_Real_t(al, (array_init1->base).base.loc, compiler_options.po.default_integer_kind));
+                                    }
+                                }
+                            }
+                        }
+                    }
                     this->visit_expr(*s.m_initializer);
+                    current_variable_type_ = temp_current_variable_type_;
                     if (is_compile_time && AST::is_a<AST::ArrayInitializer_t>(*s.m_initializer)) {
                         AST::ArrayInitializer_t *temp_array =
                             AST::down_cast<AST::ArrayInitializer_t>(s.m_initializer);


### PR DESCRIPTION
Towards #7839 

Working towards the second statement for BOZ Usage under Fortran 2023 ie **A boz-literal-constant shall appear only as the initialization for a named constant or variable of type integer or real**. 

Evaluated BOZ with respect to Declarations, and found that inside array declarations of type real, BOZ Literals were incorrectly casted. For other cases of declarations considered (Included in Test File _boz_02.f90_), current main is correctly able to convert to Equivalent Values. Verified using AMD Compiler, attached output below:

Kindly suggest if any improvements needed, or any other cases missed. Thank you for your valuable time!

MRE:
```
program declare_boz
implicit none

!Check Scalar Assigment
real::a = o'10'
integer::b = z'10'
!Check Parameter Initializations
real,parameter::c = b'01'
integer,parameter::d = z'02'
!Check Array Initializations
real:: e(3) = [real::b'01', z'10', 3.4]  
integer:: f(3) = [integer::1, b'10', 4]
PRINT *, a,b,c,d
PRINT*, e,f
end program
```

Flang:
```
$ flang a.f90 & ./a.out
   1.1210388E-44      16   1.4012985E-45      2
   1.4012985E-45   2.2420775E-44    3.400000      1      2     4
  ```

Main:
```
$ lfortran a.f90
1.12103877e-44    16    1.40129846e-45    2
1.00000000e+00    1.60000000e+01    3.40000010e+00    1    2    4
```

Updated Code Results:
```
$ lfortran a.f90
1.12103877e-44    16    1.40129846e-45    2
1.40129846e-45    2.24207754e-44    3.40000010e+00    1    2    4
```