### PR TITLE
fix: store pointer of current select type (for `class(*)` vars) in symtab and load whenever needed

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1886,6 +1886,7 @@ RUN(NAME class_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_61 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs)
+RUN(NAME class_62 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)

--- a/integration_tests/class_62.f90
+++ b/integration_tests/class_62.f90
@@ -1,0 +1,28 @@
+module class_62_mod
+  implicit none
+contains
+
+  subroutine handle_generic(generic)
+    class(*), intent(inout) :: generic
+
+    select type(generic)
+    type is (integer)
+      call get_args(generic)
+    end select
+  end subroutine handle_generic
+
+  subroutine get_args(x)
+    integer, intent(out) :: x
+    x = 3
+  end subroutine get_args
+
+end module class_62_mod
+
+
+program class_62
+  use class_62_mod
+  implicit none
+  integer :: value
+  call handle_generic(value)
+  if (value /= 3) error stop
+end program class_62


### PR DESCRIPTION
Fixes #8188 