### PR TITLE
fix: check type-inheritance during element type-checking in `ArrayConstructor` declared without type-spec

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -699,6 +699,7 @@ RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wa
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_constructor_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME array_constructor_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME allocatble_c_ptr LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME hashmap_struct_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME hashmap_nested_dealloc_derived_pointer LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/array_constructor_02.f90
+++ b/integration_tests/array_constructor_02.f90
@@ -1,0 +1,27 @@
+program array_constructor_02
+   implicit none
+
+   type build_target_ptr
+
+      type(build_target_t), pointer :: ptr => null()
+
+   end type build_target_ptr
+
+   type :: build_target_t
+      type(build_target_ptr), allocatable :: dependencies(:)
+   end type
+
+   type(build_target_t) :: a, b
+   call add_dependency(a, b)
+
+contains
+   subroutine add_dependency(target, dependency)
+      type(build_target_t), intent(inout) :: target
+      type(build_target_t) , intent(in), target :: dependency
+
+      allocate(target%dependencies(2))
+
+      target%dependencies = [target%dependencies, build_target_ptr(dependency)]
+
+   end subroutine add_dependency
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5722,6 +5722,9 @@ public:
         ASR::ttype_t* extracted_type { type ? ASRUtils::extract_type(type) : nullptr };
         size_t n_elements = 0;
         for (size_t i=0; i<x.n_args; i++) {
+            this->visit_expr(*x.m_args[0]);
+            static ASR::expr_t* first_element = ASRUtils::EXPR(tmp);
+
             this->visit_expr(*x.m_args[i]);
             ASR::expr_t *expr = ASRUtils::EXPR(tmp);
 
@@ -5745,7 +5748,9 @@ public:
             } else if (is_type_spec_ommitted) {
                 // as the "type-spec" is omitted, each element should be the same type
                 ASR::ttype_t* extracted_new_type = ASRUtils::extract_type(expr_type);
-                if (!ASRUtils::check_equal_type(extracted_new_type, extracted_type)) {
+                if (!ASRUtils::check_equal_type(extracted_new_type, extracted_type)
+                    && (!ASRUtils::check_class_assignment_compatibility(first_element, expr)
+                        || !ASRUtils::check_class_assignment_compatibility(expr, first_element))) {
                     diag.add(Diagnostic("Element in `" + ASRUtils::type_to_str_with_type(extracted_type) +
                         "` array constructor is `" + ASRUtils::type_to_str_with_type(extracted_new_type) + "`",
                         Level::Error, Stage::Semantic, {Label("",{expr->base.loc})}));

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -981,8 +981,12 @@ class ASRBuilder {
     }
 
     ASR::stmt_t *Assignment(ASR::expr_t *lhs, ASR::expr_t *rhs) {
-        LCOMPILERS_ASSERT_MSG(check_equal_type(expr_type(lhs), expr_type(rhs)),
-            type_to_str_python(expr_type(lhs)) + ", " + type_to_str_python(expr_type(rhs)));
+        // FIXME: This is a hack. Revert this when type inheritance is fixed.
+        LCOMPILERS_ASSERT_MSG((check_equal_type(expr_type(lhs), expr_type(rhs))
+                               || (ASRUtils::check_class_assignment_compatibility(lhs, rhs)
+                                   || ASRUtils::check_class_assignment_compatibility(rhs, lhs))),
+                              type_to_str_python(expr_type(lhs)) + ", "
+                                  + type_to_str_python(expr_type(rhs)));
         return STMT(ASRUtils::make_Assignment_t_util(al, loc, lhs, rhs, nullptr, false));
     }
 


### PR DESCRIPTION
fixes #8211 

The current fix is hackish. I am working on a PR to fix it completely.