### PR TITLE
fix : Update current scope to parent scope after visiting procedure in ast symboltable visitor

### DIFF
--- a/integration_tests/separate_compilation_21.f90
+++ b/integration_tests/separate_compilation_21.f90
@@ -4,10 +4,15 @@ program separate_compilation_21
 
     integer, parameter :: n = 2
     integer, parameter :: base = 1
-    real :: result(n)
 
-    result = func(n, base)
+    real :: result1(n)
+    integer :: result2(n)
 
-    print *, result
-    if (.not. all(result == [1.0, 2.0])) error stop
+    result1 = logspace(n, base)
+    result2 = logspace(n, base)
+
+    print *, result1
+    print *, result2
+    if (.not. all(result1 == [1.0, 2.0])) error stop
+    if (.not. all(result2 == [1, 2])) error stop
 end program

--- a/integration_tests/separate_compilation_21a.f90
+++ b/integration_tests/separate_compilation_21a.f90
@@ -1,12 +1,18 @@
 module math_separate_compilation_21
     implicit none
 
-    interface
-        module function func(n, base) result(res)
+    interface logspace
+        module function func1(n, base) result(res)
             integer, intent(in) :: n
             integer, intent(in) :: base
             real :: res(max(n,0))
-        end function func
+        end function func1
+
+        module function func2(n, base) result(res)
+            integer, intent(in) :: n
+            real, intent(in) :: base
+            integer :: res(max(n, 0))
+        end function func2
     end interface
 
 end module

--- a/integration_tests/separate_compilation_21b.f90
+++ b/integration_tests/separate_compilation_21b.f90
@@ -3,8 +3,13 @@ submodule (math_separate_compilation_21) log_separate_compilation_21
 
 contains
 
-  module procedure func
+  module procedure func1
     real, parameter :: array(2) = [1.0 , 2.0]
+    res = array
+  end procedure
+
+  module procedure func2
+    integer, parameter :: array(2) = [1 , 2]
     res = array
   end procedure
 

--- a/integration_tests/submodule_10.f90
+++ b/integration_tests/submodule_10.f90
@@ -1,12 +1,18 @@
 module math_submodule_10
     implicit none
 
-    interface
-        module function func(n, base) result(res)
+    interface logspace
+        module function func1(n, base) result(res)
             integer, intent(in) :: n
             integer, intent(in) :: base
             real :: res(max(n,0))
-        end function func
+        end function func1
+
+        module function func2(n, base) result(res)
+            integer, intent(in) :: n
+            real, intent(in) :: base
+            integer :: res(max(n, 0))
+        end function func2
     end interface
 
 end module
@@ -16,8 +22,13 @@ submodule (math_submodule_10) log_submodule_10
 
 contains
 
-  module procedure func
+  module procedure func1
     real, parameter :: array(2) = [1.0 , 2.0]
+    res = array
+  end procedure
+
+  module procedure func2
+    integer, parameter :: array(2) = [1 , 2]
     res = array
   end procedure
 
@@ -29,10 +40,15 @@ program submodule_10
 
     integer, parameter :: n = 2
     integer, parameter :: base = 1
-    real :: result(n)
 
-    result = func(n, base)
+    real :: result1(n)
+    integer :: result2(n)
 
-    print *, result
-    if (.not. all(result == [1.0, 2.0])) error stop
+    result1 = logspace(n, base)
+    result2 = logspace(n, base)
+
+    print *, result1
+    print *, result2
+    if (.not. all(result1 == [1.0, 2.0])) error stop
+    if (.not. all(result2 == [1, 2])) error stop
 end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -870,8 +870,8 @@ public:
         }
         ASR::expr_t* new_func_return_var = exprstmt_duplicator.duplicate_expr(proc_interface->m_return_var);
 
+        is_Function = true;
         for (size_t i=0; i<x.n_decl; i++) {
-            is_Function = true;
             if (!AST::is_a<AST::Require_t>(*x.m_decl[i])) {
                 try {
                     visit_unit_decl2(*x.m_decl[i]);
@@ -879,8 +879,8 @@ public:
                     if ( !compiler_options.continue_compilation ) throw e;
                 }
             }
-            is_Function = false;
         }
+        is_Function = false;
 
         tmp = ASR::make_Function_t(al, x.base.base.loc, current_scope,
                                    proc_interface->m_name,
@@ -899,6 +899,7 @@ public:
         func_type->m_abi = ASR::abiType::Source;
         func_type->m_deftype = ASR::deftypeType::Implementation;
         parent_scope->overwrite_symbol(x.m_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        current_scope = parent_scope;
     }
 
     void visit_Subroutine(const AST::Subroutine_t &x) {


### PR DESCRIPTION
Towards #536 
Fixes #8208 
Addresses https://github.com/lfortran/lfortran/pull/8142#discussion_r2233019689