### PR TITLE
fix: handle COMMON block symbol

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2658,20 +2658,27 @@ public:
     void add_sym_to_struct(ASR::Variable_t* var_, ASR::Struct_t* struct_type) {
         char* var_name = var_->m_name;
         SymbolTable* struct_scope = struct_type->m_symtab;
-        ASR::symbol_t* var_sym_new = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, var_->base.base.loc, struct_scope,
-                        var_->m_name, var_->m_dependencies, var_->n_dependencies, var_->m_intent,
-                        var_->m_symbolic_value, var_->m_value, var_->m_storage, var_->m_type,
-                        var_->m_type_declaration, var_->m_abi, var_->m_access, var_->m_presence, var_->m_value_attr));
-        struct_scope->add_symbol(var_name, var_sym_new);
+        // common based not working-so, checking if symbol already exists or no
+        if (struct_scope->resolve_symbol(var_name) == nullptr) {
+            // Only add it if it doesn't already exist
+            ASR::symbol_t* var_sym_new = ASR::down_cast<ASR::symbol_t>(
+                ASRUtils::make_Variable_t_util(al, var_->base.base.loc, struct_scope,
+                    var_->m_name, var_->m_dependencies, var_->n_dependencies,
+                    var_->m_intent, var_->m_symbolic_value, var_->m_value,
+                    var_->m_storage, var_->m_type, var_->m_type_declaration,
+                    var_->m_abi, var_->m_access, var_->m_presence, var_->m_value_attr));
 
-        Vec<char*> members;
-        members.reserve(al, struct_type->n_members+1);
-        for (size_t i=0; i<struct_type->n_members; i++) {
-            members.push_back(al, struct_type->m_members[i]);
+            struct_scope->add_symbol(var_name, var_sym_new);
+
+            Vec<char*> members;
+            members.reserve(al, struct_type->n_members + 1);
+            for (size_t i = 0; i < struct_type->n_members; i++) {
+                members.push_back(al, struct_type->m_members[i]);
+            }
+            members.push_back(al, var_name);
+            struct_type->m_members = members.p;
+            struct_type->n_members = members.size();
         }
-        members.push_back(al, var_name);
-        struct_type->m_members = members.p;
-        struct_type->n_members = members.size();
     }
 
     ASR::Variable_t * get_symtab_var_for_common(AST::var_sym_t const &s) {


### PR DESCRIPTION
While trying to compile the following code:-
```
program common_single
    implicit none
    real :: x, y

    common /coords/ x, y

    x = 5.0
    y = 10.0

    call show_coords
contains
    subroutine show_coords
        implicit none
        real :: x, y
        common /coords/ x, y
        print *, "x =", x, ", y =", y
    end subroutine show_coords
end program common_single

```

Came across the issue where the compiler was unable to handle the `common` block and gave the following error:-
<img width="1920" height="1004" alt="Screenshot From 2025-08-04 19-33-23" src="https://github.com/user-attachments/assets/5d312908-01b4-4ed4-97bb-0c479cce4a55" />

Made a few changes in the `ast_common_visitor.h`  and it seems to be working properly
<img width="1309" height="73" alt="Screenshot From 2025-08-04 19-36-48" src="https://github.com/user-attachments/assets/7e6c0c0c-7a20-4261-8715-46697a59cb2d" />

Please do let me know for the same, and will make `test` for the same