### PR TITLE
Throw Error when referencing BOZ with greater than 64 Bits

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11086,6 +11086,16 @@ public:
             throw SemanticAbort();
         }
         std::string boz_str = s.substr(2, s.size() - 2);
+        //Check if BOZ string has more than 64 Bits, else stoull Throws Error
+        if ((((s[0]=='b') || (s[0]=='B')) && (boz_str.size()> 65)) || 
+            (((s[0]=='o') || (s[0]=='O')) && (boz_str.size()> 22)) || 
+            (((s[0]=='z') || (s[0]=='Z')) && (boz_str.size()> 17))) {
+            std::string char_length = (s[0] == 'b' || s[0] == 'B') ? "64" : (s[0] == 'o' || s[0] == 'O') ? "21" : "16";
+            diag.add(Diagnostic("BOZ literal constants with '" + std::string(1, s[0]) + 
+                                "' prefix are only supported yet with at most '" + char_length + "' characters",
+                                Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+            throw SemanticAbort();
+        }
         uint64_t boz_unsigned_int = std::stoull(boz_str, nullptr, base);
         //If current_variable_type is Real Type, convert BOZ String to ASR::Real 
         if ((current_variable_type_ != nullptr) && (ASR::is_a<ASR::Real_t>(*current_variable_type_)) ){

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -115,7 +115,7 @@ program continue_compilation_1
       integer :: elements(n)
     end type
     type(bspline_3d) :: s3_in_program
-
+    integer:: boz_1 = int(Z'1234567890ABCDEF1')
 
 
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "3b284de72ae26f145e54c2c0b33c7b005946eb4cd8630d9b9dad56cf",
+    "infile_hash": "2e2fb994bddda528e5f24b94d3a9477d840b43c16d8573c475154151",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "697aa0bad457090b73f69405a290a6764c5b4f69f1c374bdcbe08614",
+    "stderr_hash": "4bb4b609a78aa476292ce81879e2be7096a232f082ed499420042f0a",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -123,6 +123,12 @@ semantic error: Derived type `bspline_3d` is not defined
 117 |     type(bspline_3d) :: s3_in_program
     |     ^^^^^^^^^^^^^^^^ Type used here is not defined in any scope
 
+semantic error: BOZ literal constants with 'Z' prefix are only supported yet with at most '16' characters
+   --> tests/errors/continue_compilation_1.f90:118:27
+    |
+118 |     integer:: boz_1 = int(Z'1234567890ABCDEF1')
+    |                           ^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: Assignment to loop variable `i` is not allowed
    --> tests/errors/continue_compilation_1.f90:136:8
     |


### PR DESCRIPTION
Fixes #8253 

Added a check, which throws semantic error, when large BOZ Literals are encountered. This gives a better Error Message than `std::exception: stoull` which main currently throws.