### PR TITLE
feat: implement type to string functionality for `ASR::StructType_t` using cached `ASR::StructType_t*` nodes

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1546,7 +1546,7 @@ public:
                     AST::Name_t* name_t = AST::down_cast<AST::Name_t>(x.m_args[i].m_start);
                     ASR::symbol_t *v = current_scope->resolve_symbol(to_lower(name_t->m_id));
                     if (v) {
-                        ASR::ttype_t* struct_t = ASRUtils::make_StructType_t_util(al, x.base.base.loc, v, true);
+                        ASR::ttype_t* struct_t = ASRUtils::get_struct_type(v, true);
                         new_arg.m_type = struct_t;
                         new_arg.m_sym_subclass = v;
                     } else {
@@ -2083,7 +2083,7 @@ public:
                         ASR::symbol_t* selector_m_type_declaration = nullptr;
                         ASR::symbol_t* sym_underlying = ASRUtils::symbol_get_past_external(sym);
                         if( ASR::is_a<ASR::Struct_t>(*sym_underlying) ) {
-                            selector_type = ASRUtils::make_StructType_t_util(al, sym->base.loc, sym, true);
+                            selector_type = ASRUtils::get_struct_type(sym, true);
                             selector_type = ASRUtils::make_Pointer_t_util(al, sym->base.loc, ASRUtils::extract_type(selector_type));
                             selector_m_type_declaration = sym;
                         } else {
@@ -2136,7 +2136,7 @@ public:
                         ASR::symbol_t* selector_m_type_declaration = nullptr;
                         ASR::symbol_t* sym_underlying = ASRUtils::symbol_get_past_external(sym);
                         if( ASR::is_a<ASR::Struct_t>(*sym_underlying) ) {
-                            selector_type = ASRUtils::make_StructType_t_util(al, sym->base.loc, sym, true);
+                            selector_type = ASRUtils::get_struct_type(sym, true);
                             selector_type = ASRUtils::make_Pointer_t_util(al, sym->base.loc, ASRUtils::extract_type(selector_type));
                             selector_m_type_declaration = sym;
                         } else {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2628,6 +2628,7 @@ public:
                 nullptr,
                 nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false,
                 nullptr, 0, nullptr, nullptr));
+            ASRUtils::struct_names.insert(common_block_name);
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
             struct_->m_struct_signature = struct_type;
@@ -5106,6 +5107,7 @@ public:
                         ASRUtils::symbol_name(v) == std::string("~unlimited_polymorphic_type")
                         ? true
                         : false));
+                        ASRUtils::map_struct_type_to_name(type, derived_type_name);
                     } else { 
                         diag.add(Diagnostic(
                             "Derived type `" + derived_type_name + "` is not defined",
@@ -5175,6 +5177,7 @@ public:
                                                 s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
                                                 nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
                                                 nullptr, 0, nullptr, nullptr);
+                ASRUtils::struct_names.insert(derived_type_name);
                 ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
                 ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
                 ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
@@ -5732,7 +5735,7 @@ public:
             type = determine_type(x.base.base.loc, sym, x.m_vartype, false, false,
                 dims, nullptr, type_declaration, ASR::abiType::Source);
             if (ASR::is_a<ASR::StructType_t>(*type)) {
-                std::string derived_type_name = ASRUtils::symbol_name(type_declaration);
+                std::string derived_type_name = ASRUtils::type_to_str_fortran(type);
                 diag.add(Diagnostic(
                     "Invalid syntax of derived type for array constructor",
                     Level::Error, Stage::Semantic, {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2010,6 +2010,7 @@ public:
             s2c(al, to_lower(x.m_name)), nullptr, struct_dependencies.p, struct_dependencies.size(),
             data_member_names.p, data_member_names.size(), nullptr, 0,
             ASR::abiType::Source, dflt_access, false, is_abstract, nullptr, 0, nullptr, parent_sym);
+        ASRUtils::struct_names.insert(to_lower(x.m_name));
 
         ASR::symbol_t* derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);
         ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x.base.base.loc, derived_type_sym, true);
@@ -3256,6 +3257,10 @@ public:
                 dflt_access
                 );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(v));
+            if (ASR::is_a<ASR::StructType_t>(*mv->m_type)) {
+                ASRUtils::map_struct_type_to_name(mv->m_type, 
+                    ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(mv->m_type_declaration)));
+            }
         } else if( ASR::is_a<ASR::Struct_t>(*t) ) {
             // Check for any interface overriding a constructor for the struct
             ASR::symbol_t *interface_override_s = m->m_symtab->resolve_symbol("~" + remote_sym);
@@ -3293,6 +3298,8 @@ public:
                 dflt_access
                 );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(v));
+            ASRUtils::struct_names.insert(cname);
+            ASRUtils::map_struct_type_to_name(mv->m_struct_signature, cname);
         } else if (ASR::is_a<ASR::Requirement_t>(*t)) {
             ASR::Requirement_t *mreq = ASR::down_cast<ASR::Requirement_t>(t);
             ASR::asr_t *req = ASR::make_ExternalSymbol_t(

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1621,7 +1621,7 @@ public:
                         throw SemanticAbort();
 
                     }
-                    type = ASRUtils::make_StructType_t_util(al, x.base.base.loc, v, true);
+                    type = ASRUtils::get_struct_type(v, true);
                     type_decl = v;
                     break;
                 }
@@ -2010,12 +2010,14 @@ public:
             s2c(al, to_lower(x.m_name)), nullptr, struct_dependencies.p, struct_dependencies.size(),
             data_member_names.p, data_member_names.size(), nullptr, 0,
             ASR::abiType::Source, dflt_access, false, is_abstract, nullptr, 0, nullptr, parent_sym);
-        ASRUtils::struct_names.insert(to_lower(x.m_name));
 
         ASR::symbol_t* derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);
         ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x.base.base.loc, derived_type_sym, true);
         ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(derived_type_sym);
         struct_->m_struct_signature = struct_signature;
+        ASRUtils::struct_names.insert(struct_->m_name);
+        ASRUtils::map_struct_name_to_type(struct_->m_name, struct_->m_struct_signature, true);
+        ASRUtils::map_struct_type_to_name(struct_->m_struct_signature, struct_->m_name);
         tmp = (ASR::asr_t*) derived_type_sym;
         derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);
         if (compiler_options.implicit_typing) {
@@ -2035,7 +2037,7 @@ public:
                 if ( ASR::is_a<ASR::Pointer_t>(*var_type) ) {
                     ASR::Pointer_t* ptr = ASR::down_cast<ASR::Pointer_t>(var_type);
                     ASR::StructType_t* stype = ASR::down_cast<ASR::StructType_t>(ASRUtils::extract_type(ptr->m_type));
-                    ASR::ttype_t* type = ASRUtils::make_StructType_t_util(al, x.base.base.loc, ASR::down_cast<ASR::symbol_t>(tmp), stype->m_is_cstruct);
+                    ASR::ttype_t* type = ASRUtils::get_struct_type(derived_type_sym, stype->m_is_cstruct);
                     var->m_type = ASRUtils::make_Pointer_t_util(al, x.base.base.loc, type);
                     if ( var->m_symbolic_value && ASR::is_a<ASR::PointerNullConstant_t>(*var->m_symbolic_value) ) {
                         ASR::PointerNullConstant_t* ptr_null = ASR::down_cast<ASR::PointerNullConstant_t>(var->m_symbolic_value);
@@ -2377,7 +2379,7 @@ public:
 
                             ASR::symbol_t* struct_as_sym = mod_s->m_symtab->get_symbol(common_block_name);
                             ASR::Struct_t* struct_s = ASR::down_cast<ASR::Struct_t>(struct_as_sym);
-                            ASR::ttype_t* type = ASRUtils::make_StructType_t_util(al, struct_as_sym->base.loc, struct_as_sym, true);
+                            ASR::ttype_t* type = ASRUtils::get_struct_type(struct_as_sym, true);
 
                             Vec<ASR::call_arg_t> vals;
                             auto member2sym = struct_s->m_symtab->get_scope();
@@ -3970,7 +3972,7 @@ public:
                         ASR::symbol_t *arg_sym = ASRUtils::symbol_get_past_external(arg_sym0);
                         ASR::ttype_t *arg_type = nullptr;
                         if (ASR::is_a<ASR::Struct_t>(*arg_sym)) {
-                            arg_type = ASRUtils::make_StructType_t_util(al, x.m_args[i]->base.loc, arg_sym0, true);
+                            arg_type = ASRUtils::get_struct_type(arg_sym0, true);
                             type_subs[param].second = arg_sym0;
                         } else {
                             arg_type = ASRUtils::symbol_type(arg_sym);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -149,6 +149,10 @@ class ExprStmtDuplicator: public ASR::BaseExprStmtDuplicator<ExprStmtDuplicator>
 
     ExprStmtDuplicator(Allocator &al): BaseExprStmtDuplicator(al) {}
 
+    ASR::asr_t* duplicate_StructType(ASR::StructType_t* x) {    
+        return &x->base.base;
+    }
+
 };
 
 static inline ASR::symbol_t *symbol_get_past_external(ASR::symbol_t *f)
@@ -3229,16 +3233,7 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
             break;
         }
         case ASR::ttypeType::StructType: {
-            ASR::StructType_t* tnew = ASR::down_cast<ASR::StructType_t>(t);
-
-            t_ = ASRUtils::TYPE(ASR::make_StructType_t(al,
-                                                       t->base.loc,
-                                                       tnew->m_data_member_types,
-                                                       tnew->n_data_member_types,
-                                                       nullptr,
-                                                       0,
-                                                       tnew->m_is_cstruct,
-                                                       tnew->m_is_unlimited_polymorphic));
+            t_ = const_cast<ASR::ttype_t*>(t);
             break;
         }
         case ASR::ttypeType::UnionType: {
@@ -3485,14 +3480,7 @@ static inline ASR::ttype_t* duplicate_type_without_dims(Allocator& al, const ASR
                         ASR::string_physical_typeType::DescriptorString));
         }
         case ASR::ttypeType::StructType: {
-            ASR::StructType_t* tstruct = ASR::down_cast<ASR::StructType_t>(t);
-            return ASRUtils::TYPE(ASR::make_StructType_t(al, t->base.loc,
-                tstruct->m_data_member_types,
-                tstruct->n_data_member_types,
-                nullptr,
-                0,
-                tstruct->m_is_cstruct,
-                tstruct->m_is_unlimited_polymorphic));
+            return const_cast<ASR::ttype_t*>(t);
         }
         case ASR::ttypeType::Pointer: {
             ASR::Pointer_t* ptr = ASR::down_cast<ASR::Pointer_t>(t);
@@ -4711,6 +4699,9 @@ class ExprStmtWithScopeDuplicator: public ASR::BaseExprStmtDuplicator<ExprStmtWi
         return ASR::make_Var_t(al, x->base.base.loc, m_v);
     }
 
+    ASR::asr_t* duplicate_StructType(ASR::StructType_t* x) {
+        return &x->base.base;
+    }
 };
 
 

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -337,11 +337,15 @@ public:
             data_member_names.p, data_member_names.size(), nullptr, 0,
             x->m_abi, x->m_access, x->m_is_packed, x->m_is_abstract,
             nullptr, 0, m_alignment, nullptr);
-        ASRUtils::struct_names.insert(new_sym_name);
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
         ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
         ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);
         struct_->m_struct_signature = struct_signature;
+
+        ASRUtils::struct_names.insert(struct_->m_name);
+        ASRUtils::map_struct_name_to_type(struct_->m_name, struct_->m_struct_signature, true);
+        ASRUtils::map_struct_type_to_name(struct_->m_struct_signature, struct_->m_name);
+        
         result = (ASR::asr_t*) struct_sym;
 
         ASR::symbol_t *t = ASR::down_cast<ASR::symbol_t>(result);
@@ -713,7 +717,11 @@ public:
                 if (context_map.find(struct_name) != context_map.end()) {
                     std::string new_struct_name = context_map[struct_name];
                     ASR::symbol_t *sym = func_scope->resolve_symbol(new_struct_name);
-                    return ASRUtils::make_StructType_t_util(al, s->base.base.loc, sym, s->m_is_cstruct);
+                    ttype = ASRUtils::get_struct_type(sym, s->m_is_cstruct);
+                    if (!ttype) {
+                        ttype = ASRUtils::make_StructType_t_util(al, s->base.base.loc, sym, s->m_is_cstruct);
+                    }
+                    return ttype;
                 } else {
                     return ttype;
                 }
@@ -1214,11 +1222,15 @@ public:
             new_scope, s2c(al, new_sym_name), nullptr, nullptr, 0, data_member_names.p,
             data_member_names.size(), nullptr, 0, x->m_abi, x->m_access, x->m_is_packed,
             x->m_is_abstract, nullptr, 0, m_alignment, nullptr);
-        ASRUtils::struct_names.insert(new_sym_name);
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
         ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);
         struct_->m_struct_signature = struct_type;
+
+        ASRUtils::struct_names.insert(struct_->m_name);
+        ASRUtils::map_struct_name_to_type(struct_->m_name, struct_->m_struct_signature, true);
+        ASRUtils::map_struct_type_to_name(struct_->m_struct_signature, struct_->m_name);
+
         result = (ASR::asr_t*) struct_;
 
         ASR::symbol_t* s = ASR::down_cast<ASR::symbol_t>(result);
@@ -1338,8 +1350,10 @@ public:
                 std::string struct_name = ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(expr)));
                 if (symbol_subs.find(struct_name) != symbol_subs.end()) {
                     ASR::symbol_t *sym = symbol_subs[struct_name];
-                    return ASRUtils::make_StructType_t_util(
-                        al, ttype->base.loc, sym, s->m_is_cstruct);
+                    ttype = ASRUtils::get_struct_type(sym, s->m_is_cstruct);
+                    if (!ttype) {
+                        ttype = ASRUtils::make_StructType_t_util(al, s->base.base.loc, sym, s->m_is_cstruct);
+                    }
                 }
                 return ttype;
             }
@@ -1749,8 +1763,10 @@ public:
                 std::string struct_name = ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(expr)));
                 if (symbol_subs.find(struct_name) != symbol_subs.end()) {
                     ASR::symbol_t *sym = symbol_subs[struct_name];
-                    ttype = ASRUtils::make_StructType_t_util(
-                        al, s->base.base.loc, sym, s->m_is_cstruct);
+                    ttype = ASRUtils::get_struct_type(sym, s->m_is_cstruct);
+                    if (!ttype) {
+                        ttype = ASRUtils::make_StructType_t_util(al, s->base.base.loc, sym, s->m_is_cstruct);
+                    }
                 }
                 return ttype;
             }

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -337,6 +337,7 @@ public:
             data_member_names.p, data_member_names.size(), nullptr, 0,
             x->m_abi, x->m_access, x->m_is_packed, x->m_is_abstract,
             nullptr, 0, m_alignment, nullptr);
+        ASRUtils::struct_names.insert(new_sym_name);
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
         ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
         ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);
@@ -1213,6 +1214,7 @@ public:
             new_scope, s2c(al, new_sym_name), nullptr, nullptr, 0, data_member_names.p,
             data_member_names.size(), nullptr, 0, x->m_abi, x->m_access, x->m_is_packed,
             x->m_is_abstract, nullptr, 0, m_alignment, nullptr);
+        ASRUtils::struct_names.insert(new_sym_name);
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
         ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -353,7 +353,6 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                 ASR::symbol_t* m_derived_type_or_class_type = nullptr;
                 if( ASR::is_a<ASR::StructType_t>(*var_type_)) {
                     ASR::symbol_t* derived_type_or_class_type = nullptr;
-                    ASR::StructType_t* struct_t = ASR::down_cast<ASR::StructType_t>(var_type_);
                     derived_type_or_class_type = var->m_type_declaration;
                     if( current_scope->get_counter() != ASRUtils::symbol_parent_symtab(derived_type_or_class_type)->get_counter() ) {
                         m_derived_type_or_class_type = current_scope->get_symbol(
@@ -385,11 +384,9 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                             }
                         }
                         if (ASR::is_a<ASR::StructType_t>(*var_type_)) {
-                            var_type_ = ASRUtils::make_StructType_t_util(
-                                            al,
-                                            struct_t->base.base.loc,
-                                            m_derived_type_or_class_type,
-                                            ASR::down_cast<ASR::StructType_t>(var_type_)->m_is_cstruct);
+                            var_type_ = ASRUtils::get_struct_type(
+                                m_derived_type_or_class_type,
+                                ASR::down_cast<ASR::StructType_t>(var_type_)->m_is_cstruct);
                         }
                         if( ASR::is_a<ASR::Array_t>(*var_type) ) {
                             ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(var_type);

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -867,6 +867,7 @@ class ParallelRegionVisitor :
             ASR::symbol_t* thread_data_struct = ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(al, loc,
                 current_scope, s2c(al, thread_data_name), nullptr, nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
                 ASR::accessType::Public, false, false, nullptr, 0, nullptr, nullptr));
+            ASRUtils::struct_names.insert(thread_data_name);
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, thread_data_struct, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(thread_data_struct);
             struct_->m_struct_signature = struct_type;
@@ -2050,6 +2051,7 @@ class ParallelRegionVisitor :
             ASR::symbol_t* thread_data_struct = ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(al, loc,
                 current_scope, s2c(al, thread_data_name), nullptr, nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
                 ASR::accessType::Public, false, false, nullptr, 0, nullptr, nullptr));
+            ASRUtils::struct_names.insert(thread_data_name);
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, thread_data_struct, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(thread_data_struct);
             struct_->m_struct_signature = struct_type;

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout",
-    "stdout_hash": "c6c20b2ab5cf9b51ba6622f679f0c134e068a220396a7be87993eabc",
+    "stdout_hash": "8cd274d316b7401011ba785519105e034a8221745e7e298734bf9f5e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
@@ -23,7 +23,7 @@
                     (SymbolTable
                         2
                         {
-                            build_package_derived_type____0:
+                            build_package_build_target_ptr____0:
                                 (Function
                                     (SymbolTable
                                         13
@@ -392,7 +392,7 @@
                                                     .false.
                                                 )
                                         })
-                                    build_package_derived_type____0
+                                    build_package_build_target_ptr____0
                                     (FunctionType
                                         [(Array
                                             (StructType
@@ -736,11 +736,11 @@
                                         []
                                         .false.
                                     )
-                                    [build_package_derived_type____0]
+                                    [build_package_build_target_ptr____0]
                                     [(Var 10 settings)]
                                     [(SubroutineCall
-                                        2 build_package_derived_type____0
-                                        2 build_package_derived_type____0
+                                        2 build_package_build_target_ptr____0
+                                        2 build_package_build_target_ptr____0
                                         [((ArrayPhysicalCast
                                             (Var 10 targets)
                                             DescriptorArray

--- a/tests/server/tests/test_features.py
+++ b/tests/server/tests/test_features.py
@@ -198,8 +198,7 @@ def test_document_hover(client: LFortranLspTestClient) -> None:
     assert doc.preview == Hover(
         contents=MarkupContent(
             kind=MarkupKind.Markdown,
-            # TODO: Reset string "derived type" to "softmax"
-            value="```fortran\nfunction eval_1d(self, x) result(res)\n    derived type, intent(in) :: self\n    real[:], intent(in) :: x\n    real[:] :: res\nend function\n```"
+            value="```fortran\nfunction eval_1d(self, x) result(res)\n    softmax, intent(in) :: self\n    real[:], intent(in) :: x\n    real[:] :: res\nend function\n```"
         ),
         range=Range(
             end=Position(


### PR DESCRIPTION
We create a set of all struct names and a map from `ASR::ttype_t*` to `std::string*`. The idea behind this implementation is that a `ASR::ttype_t*` can be associated to the struct it was created from, and hence get access to the name.

### Program
```fortran
program main
   implicit none

   type :: Home
      integer :: x
      integer :: y
   end type

   type :: School
      integer :: y
   end type

   type(Home) :: h
   type(School) :: s

   h = s
end program
```

### Output
#### On `main`

```console
(lf) saurabhkumar@Mac lfortran % lfortran test.f90
semantic error: Type mismatch in assignment, the types must be compatible
  --> test.f90:16:4
   |
16 |    h = s
   |    ^   ^ type mismatch (derived type and derived type)


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

#### On branch

```console
(lf) saurabhkumar@Mac lfortran % lfortran test.f90
semantic error: Type mismatch in assignment, the types must be compatible
  --> test.f90:16:4
   |
16 |    h = s
   |    ^   ^ type mismatch (home and school)


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```
