### PR TITLE
fix: store data member of `Struct_t` in same order as declared while initializing global variable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1790,6 +1790,7 @@ RUN(NAME nested_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME nested_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c)

--- a/integration_tests/nested_15.f90
+++ b/integration_tests/nested_15.f90
@@ -1,0 +1,24 @@
+module nested_15_mod
+    type :: child
+        character(:), allocatable :: value
+        logical :: par = .true.
+    end type child
+contains 
+
+    subroutine temp_sub(model)
+        type(child), intent(inout) :: model
+        call nested_sub()
+    contains
+        subroutine nested_sub()
+            if (.not. model%par) error stop
+            if (model%value /= "Hello") error stop
+        end subroutine
+    end subroutine
+end module
+
+program nested_15
+    use nested_15_mod
+    type(child) :: model
+    model%value = "Hello"
+    call temp_sub(model)
+end program nested_15

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3523,9 +3523,10 @@ public:
             if (init_value == nullptr && x.m_type->type == ASR::ttypeType::StructType) {
                 ASR::Struct_t* struct_sym = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(x.m_type_declaration));
                 std::vector<llvm::Constant*> field_values;
-                for (auto& member : struct_sym->m_symtab->get_scope()) {
-                    ASR::symbol_t* sym = member.second;
-                    if (!ASR::is_a<ASR::Variable_t>(*sym))
+                for (size_t i = 0; i < struct_sym->n_members; i++) {
+                    std::string member_name = struct_sym->m_members[i];
+                    ASR::symbol_t* sym = struct_sym->m_symtab->get_symbol(member_name);
+                    if (!sym || !ASR::is_a<ASR::Variable_t>(*sym))
                         continue;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
                     if (var->m_value != nullptr) {


### PR DESCRIPTION
Fixes #8252 