### PR TITLE
Fix null pointer crash by adding null check in legacy array sections

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2330,6 +2330,8 @@ RUN(NAME legacy_array_sections_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc 
 RUN(NAME legacy_array_sections_04 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface --legacy-array-sections EXTRAFILES legacy_array_sections_04b.f90)
 RUN(NAME legacy_array_sections_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
+RUN(NAME legacy_array_sections_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
+
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/legacy_array_sections_07.f90
+++ b/integration_tests/legacy_array_sections_07.f90
@@ -1,0 +1,29 @@
+module legacy_array_sections_07_module                                                           !! [order = polynomial degree + 1]
+   interface db1ink
+      module procedure :: db1ink_default
+   end interface
+   public :: db1ink
+     contains
+   pure subroutine db1ink_default(x)
+      implicit none
+      real(4), dimension(:), intent(in) :: x
+      call check_inputs(x=x)
+   end subroutine db1ink_default
+   pure subroutine check_inputs(x, y)
+      implicit none
+      real(4), dimension(:), intent(in), optional :: x, y
+   end subroutine check_inputs
+end module legacy_array_sections_07_module
+program legacy_array_sections_07
+    use legacy_array_sections_07_module
+    implicit none
+    real :: x(5), y(2)
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y = [6.0, 7.0]
+    call db1ink_default(x)
+    print *, x
+    if (any(x - [1.0, 2.0, 3.0, 4.0, 5.0] > 1e-6)) error stop
+    call check_inputs(x, y)
+    print *, y
+    if (any(y - [6.0, 7.0] > 1e-6)) error stop
+end program legacy_array_sections_07

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6542,7 +6542,7 @@ public:
                     ASR::call_arg_t arg = args[i];
                     ASR::ttype_t* expected_arg_type = ASRUtils::duplicate_type(al, array_arg_idx[i]);
                     ASR::expr_t* arg_expr = arg.m_value;
-                    if (ASR::is_a<ASR::ArrayItem_t>(*arg_expr)) {
+                    if (arg_expr && ASR::is_a<ASR::ArrayItem_t>(*arg_expr)) {
                         ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(arg_expr);
                         ASR::expr_t* array_expr = array_item->m_v;
                         LCOMPILERS_ASSERT(array_item->n_args > 0);


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/8267