### PR TITLE
fix: fix legacy array sections to skip scalar promotion for elemental functions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2342,6 +2342,7 @@ RUN(NAME legacy_array_sections_04 LABELS gfortran llvm2 EXTRA_ARGS --implicit-in
 RUN(NAME legacy_array_sections_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
+RUN(NAME legacy_array_sections_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/legacy_array_sections_08.f90
+++ b/integration_tests/legacy_array_sections_08.f90
@@ -1,0 +1,13 @@
+program legacy_array_sections_08
+    implicit none
+    real(4) :: x(2)
+    x = [1.0, 2.0]
+    print *, f1(x)
+    if (any(f1(x) - [0.841470957, 0.909297407] > 1e-6)) error stop
+    contains
+        pure elemental real(4) function f1(x) 
+            implicit none
+            real(4),intent(in) :: x
+            f1 = sin(x)
+        end function f1
+end program legacy_array_sections_08

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6646,7 +6646,10 @@ public:
             // bool visit_required = false;
             for ( auto it: array_arg_idx ) {
                 ASR::expr_t* func_arg = f->m_args[it.first];
-                if ( !ASRUtils::is_array(ASRUtils::EXPR2VAR(func_arg)->m_type) ) {
+                ASR::FunctionType_t* f_type =
+                    ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                bool is_elemental = (f_type->m_abi == ASR::abiType::Source && f_type->m_elemental);
+                if (!is_elemental && !ASRUtils::is_array(ASRUtils::EXPR2VAR(func_arg)->m_type)) {
                     // create array type with empty dimensions and physical type as PointerToDataArray
                     ASR::ttype_t* new_type = ASRUtils::duplicate_type_with_empty_dims(al, it.second, ASR::array_physical_typeType::PointerToDataArray, true);
                     ASRUtils::EXPR2VAR(func_arg)->m_type = new_type;


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/8300