### PR TITLE
Tests : Trigger workflow with changes in commit history (rebase, new commits, ..)

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     types: 
       - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - reopened
     branches:
       - main
 


### PR DESCRIPTION
This PR just handles the cases of (PR sync, reopen, unlabel, once opened).
The case of having label `Tests:Run-Exhaustive` already set, and then adding another random label then the workflow happens to get triggered again unnecessarily **isn't handled in this PR**
as well the case of removing some random label will also the trigger the workflow to run unnecessarily, It's not a bit deal now as these cases doesn't happen so frequently (Our dependency on labels isn't intensive yet). 