### PR TITLE
fix: get rhs class type object and store in rhs using bitcast

### DIFF
--- a/integration_tests/intrinsics_334.f90
+++ b/integration_tests/intrinsics_334.f90
@@ -58,7 +58,7 @@ program intrinsics_334
 
     select type(struct_to3)
     type is (toml_value)
-        ! if (struct_to3%x /= 123) error stop   !! TODO: casting of class types
+        if (struct_to3%x /= 123) error stop
     end select
 
     allocate(struct_from)

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6314,13 +6314,14 @@ public:
 
 
             llvm::Value* value_class_ptr = llvm_utils->create_gep2(value_llvm_type, value_struct, 1);
+            // Get value object of value_class_type pointer
             value_class_ptr = llvm_utils->CreateLoad2(wrapper_value_llvm_type->getPointerTo(), value_class_ptr);
-            // bitcast to the correct type
-            value_class_ptr = builder->CreateBitCast(value_class_ptr, wrapper_target_llvm_type->getPointerTo());
-            value_class_ptr = llvm_utils->CreateLoad2(wrapper_target_llvm_type, value_class_ptr);
+            value_class_ptr = llvm_utils->CreateLoad2(wrapper_value_llvm_type, value_class_ptr);
 
             llvm::Value* target_class_ptr = llvm_utils->create_gep2(target_llvm_type, target_struct, 1);
+            // Bitcast target_class_type to value_class_type and then store value object in it
             target_class_ptr = llvm_utils->CreateLoad2(wrapper_target_llvm_type->getPointerTo(), target_class_ptr);
+            target_class_ptr = builder->CreateBitCast(target_class_ptr, wrapper_value_llvm_type->getPointerTo());
 
             builder->CreateStore(value_class_ptr, target_class_ptr);
             return;

--- a/tests/reference/asr-intrinsics_334-6d740cf.json
+++ b/tests/reference/asr-intrinsics_334-6d740cf.json
@@ -2,11 +2,11 @@
     "basename": "asr-intrinsics_334-6d740cf",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/intrinsics_334.f90",
-    "infile_hash": "0976a5bff0a332957242f6a901d6eb885e5c0e8cff84768da2906943",
+    "infile_hash": "9d3c71d960ed15ecd218cd0ba4b7bc62d11c3da94757e5cab5ffff7a",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_334-6d740cf.stdout",
-    "stdout_hash": "0b2eb84018a666cea871fd6d61f5d94441147bcc1ce7644065dc9187",
+    "stdout_hash": "6524357308ace17d799b44410757202e74d8cc50554d40573d786688",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_334-6d740cf.stdout
+++ b/tests/reference/asr-intrinsics_334-6d740cf.stdout
@@ -367,10 +367,37 @@
                                     (SymbolTable
                                         5
                                         {
-                                            
+                                            1_toml_value_x:
+                                                (ExternalSymbol
+                                                    5
+                                                    1_toml_value_x
+                                                    4 x
+                                                    toml_value
+                                                    []
+                                                    x
+                                                    Public
+                                                )
                                         })
                                     ~select_type_block_
-                                    []
+                                    [(If
+                                        ()
+                                        (IntegerCompare
+                                            (StructInstanceMember
+                                                (Var 2 struct_to3)
+                                                5 1_toml_value_x
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            NotEq
+                                            (IntegerConstant 123 (Integer 4) Decimal)
+                                            (Logical 4)
+                                            ()
+                                        )
+                                        [(ErrorStop
+                                            ()
+                                        )]
+                                        []
+                                    )]
                                 ),
                             ~select_type_block_1:
                                 (Block


### PR DESCRIPTION
Fixes #8334 

```fortran
! Fortran code after applying the pass: unique_symbols
program intrinsics_334
implicit none
type, abstract :: base
    integer(4) :: id
end type base
type, extends(base) :: toml_value
    integer(4) :: x = 0
end type toml_value
class(toml_value), allocatable :: struct_from3
class(base), allocatable :: struct_to3
allocate(struct_from3)
allocate(toml_value::struct_to3)
struct_from3%id = 123
struct_from3%x = 456
struct_to3 = struct_from3
select type(struct_to3)
  type is (toml_value)
      print *, struct_to3%x
      if (struct_to3%x /= 456) error stop
  end select
end program intrinsics_334
```

For classType assignments:
Previous:
```llvm
  %37 = getelementptr %toml_value_polymorphic, %toml_value_polymorphic* %struct_from3, i32 0, i32 1
  %38 = load %toml_value*, %toml_value** %37, align 8
  %39 = bitcast %toml_value* %38 to %base*
  %40 = load %base, %base* %39, align 1
  %41 = getelementptr %base_polymorphic, %base_polymorphic* %struct_to3, i32 0, i32 1
  %42 = load %base*, %base** %41, align 8
  store %base %40, %base* %42, align 1
```

New:
```llvm
  %37 = getelementptr %toml_value_polymorphic, %toml_value_polymorphic* %struct_from3, i32 0, i32 1
  %38 = load %toml_value*, %toml_value** %37, align 8
  %39 = load %toml_value, %toml_value* %38, align 1
  %40 = getelementptr %base_polymorphic, %base_polymorphic* %struct_to3, i32 0, i32 1
  %41 = load %base*, %base** %40, align 8
  %42 = bitcast %base* %41 to %toml_value*
  store %toml_value %39, %toml_value* %42, align 1
```