### PR TITLE
fix : Load all the dependent Submodules for a module that is already loaded in global scope

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2598,6 +2598,7 @@ RUN(NAME separate_compilation_20 LABELS gfortran llvm_submodule EXTRAFILES separ
 RUN(NAME separate_compilation_21 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_21a.f90 separate_compilation_21b.f90)
 RUN(NAME separate_compilation_22 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_22a.f90 separate_compilation_22b.f90)
 RUN(NAME separate_compilation_23 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_23a.f90 separate_compilation_23b.f90)
+RUN(NAME separate_compilation_24 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_24a.f90 separate_compilation_24b.f90)
 
 
 

--- a/integration_tests/separate_compilation_24.f90
+++ b/integration_tests/separate_compilation_24.f90
@@ -1,0 +1,16 @@
+module tester_separate_compilation_24
+    use sorting_separate_compilation_24
+    implicit none
+end module tester_separate_compilation_24
+
+program separate_compilation_24
+    use tester_separate_compilation_24
+
+    implicit none
+
+    integer :: n = 1
+    call sort( n )
+
+    print *, n
+    if (n /= 5) error stop
+end program

--- a/integration_tests/separate_compilation_24a.f90
+++ b/integration_tests/separate_compilation_24a.f90
@@ -1,0 +1,10 @@
+module sorting_separate_compilation_24
+    implicit none
+
+    interface
+        module subroutine sort(n)
+            integer, intent(inout) :: n
+        end subroutine
+    end interface
+    
+end module sorting_separate_compilation_24

--- a/integration_tests/separate_compilation_24b.f90
+++ b/integration_tests/separate_compilation_24b.f90
@@ -1,0 +1,10 @@
+submodule(sorting_separate_compilation_24) radix_sort_separate_compilation_24
+    implicit none
+contains
+
+    module subroutine sort(n)
+        integer, intent(inout) :: n
+        n = 5
+    end subroutine
+
+end submodule radix_sort_separate_compilation_24

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -35,6 +35,7 @@ public:
     std::vector<std::string> assgn_proc_names;
     std::vector<std::pair<std::string,Location>> simd_variables;
     std::map<std::string, std::vector<AST::arg_t>> entry_function_args;
+    std::set<std::string> loaded_submodules;
     std::string dt_name;
     bool in_submodule = false;
     bool is_interface = false;
@@ -3374,7 +3375,7 @@ public:
             ASR::Module_t* mod = ASR::down_cast<ASR::Module_t>(t);
             if (load_submodules) {
                 ASRUtils::load_dependent_submodules(al, tu_symtab, mod, x.base.base.loc,
-                                                    compiler_options.po, true,
+                                                    loaded_submodules, compiler_options.po, true,
                                                     [&](const std::string &msg, const Location &loc) { 
                                                         diag.add(diag::Diagnostic(
                                                             msg, diag::Level::Error, diag::Stage::Semantic, {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1041,6 +1041,7 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
 
 void load_dependent_submodules(Allocator &al, SymbolTable *symtab,
                                ASR::Module_t* mod, const Location &loc,
+                               std::set<std::string> &loaded_submodules,
                                LCompilers::PassOptions& pass_options,
                                bool run_verify,
                                const std::function<void (const std::string &, const Location &)> err,
@@ -1049,10 +1050,15 @@ void load_dependent_submodules(Allocator &al, SymbolTable *symtab,
         return ;
     }
 
+    if (loaded_submodules.count(std::string(mod->m_name))) {
+        return ;
+    }
+    loaded_submodules.insert(std::string(mod->m_name));
+
     for (size_t i=0;i<mod->n_dependencies;i++) {
         ASR::Module_t* dep_mod = ASR::down_cast<ASR::Module_t>(symtab->get_symbol(std::string(mod->m_dependencies[i])));
         load_dependent_submodules(al, symtab, dep_mod, loc,
-                                  pass_options, 
+                                  loaded_submodules, pass_options,
                                   run_verify, err, lm);
     }
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2476,6 +2476,7 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
 
 void load_dependent_submodules(Allocator &al, SymbolTable *symtab,
                                ASR::Module_t* mod, const Location &loc,
+                               std::set<std::string> &loaded_submodules,
                                LCompilers::PassOptions& pass_options,
                                bool run_verify,
                                const std::function<void (const std::string &, const Location &)> err,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2474,6 +2474,13 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
                             bool generate_object_code = false,
                             bool load_submodules = false);
 
+void load_dependent_submodules(Allocator &al, SymbolTable *symtab,
+                               ASR::Module_t* mod, const Location &loc,
+                               LCompilers::PassOptions& pass_options,
+                               bool run_verify,
+                               const std::function<void (const std::string &, const Location &)> err,
+                               LCompilers::LocationManager &lm);
+
 Result<ASR::TranslationUnit_t*, ErrorMessage> find_and_load_module(Allocator &al, const std::string &msym,
                                                 SymbolTable &symtab, bool intrinsic,
                                                 LCompilers::PassOptions& pass_options,


### PR DESCRIPTION
Fixes https://github.com/lfortran/lfortran/issues/8264