### PR TITLE
fix: create allocatable temporary if string len is runtime

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1782,6 +1782,7 @@ RUN(NAME string_65 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_66 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_67 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_68 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_69 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_69.f90
+++ b/integration_tests/string_69.f90
@@ -1,0 +1,14 @@
+program string_69
+  implicit none
+  character(len=7) :: value
+  character(len=:), allocatable :: keywords(:)
+  integer :: ii
+   ii = 7
+  value = "version"
+  keywords = [character(len=ii) :: value]
+  if (len(keywords) /= 7) error stop
+  if (keywords(1) /= "version") error stop
+  value = "usage"
+  keywords = [character(len=ii) :: keywords, value]
+  if (keywords(2) /= "usage") error stop
+end program

--- a/tests/reference/pass_implied_do_loops-modules_35-c089638.json
+++ b/tests/reference/pass_implied_do_loops-modules_35-c089638.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_implied_do_loops-modules_35-c089638.stdout",
-    "stdout_hash": "71dc1e50f3253cd6982bc3bd4a5a01f7757d1de9cc3105c870ba451c",
+    "stdout_hash": "ca5c7b3d80c0ccae290d7913fda66c6d16737d3a98f229e7d1888557",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_implied_do_loops-modules_35-c089638.stdout
+++ b/tests/reference/pass_implied_do_loops-modules_35-c089638.stdout
@@ -58,32 +58,14 @@
                                                 (Variable
                                                     3
                                                     __libasr__created__var__0__array_constructor_
-                                                    [strings]
+                                                    []
                                                     Local
                                                     ()
                                                     ()
                                                     Default
                                                     (Allocatable
                                                         (Array
-                                                            (String 1 (StringLen
-                                                                (ArrayItem
-                                                                    (Var 3 strings)
-                                                                    [(()
-                                                                    (ArrayBound
-                                                                        (Var 3 strings)
-                                                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                                                        (Integer 4)
-                                                                        LBound
-                                                                        ()
-                                                                    )
-                                                                    ())]
-                                                                    (String 1 () AssumedLength DescriptorString)
-                                                                    ColMajor
-                                                                    ()
-                                                                )
-                                                                (Integer 4)
-                                                                ()
-                                                            ) ExpressionLength DescriptorString)
+                                                            (String 1 () DeferredLength DescriptorString)
                                                             [(()
                                                             ())]
                                                             DescriptorArray
@@ -104,32 +86,14 @@
                                                 (Variable
                                                     3
                                                     __libasr__created__var__1__array_constructor_
-                                                    [strings]
+                                                    []
                                                     Local
                                                     ()
                                                     ()
                                                     Default
                                                     (Allocatable
                                                         (Array
-                                                            (String 1 (StringLen
-                                                                (ArrayItem
-                                                                    (Var 3 strings)
-                                                                    [(()
-                                                                    (ArrayBound
-                                                                        (Var 3 strings)
-                                                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                                                        (Integer 4)
-                                                                        LBound
-                                                                        ()
-                                                                    )
-                                                                    ())]
-                                                                    (String 1 () AssumedLength DescriptorString)
-                                                                    ColMajor
-                                                                    ()
-                                                                )
-                                                                (Integer 4)
-                                                                ()
-                                                            ) ExpressionLength DescriptorString)
+                                                            (String 1 () DeferredLength DescriptorString)
                                                             [(()
                                                             ())]
                                                             DescriptorArray
@@ -326,7 +290,25 @@
                                                 [((Var 3 __libasr__created__var__0__array_constructor_)
                                                 [((IntegerConstant 1 (Integer 4) Decimal)
                                                 (IntegerConstant 0 (Integer 4) Decimal))]
-                                                ()
+                                                (StringLen
+                                                    (ArrayItem
+                                                        (Var 3 strings)
+                                                        [(()
+                                                        (ArrayBound
+                                                            (Var 3 strings)
+                                                            (IntegerConstant 1 (Integer 4) Decimal)
+                                                            (Integer 4)
+                                                            LBound
+                                                            ()
+                                                        )
+                                                        ())]
+                                                        (String 1 () AssumedLength DescriptorString)
+                                                        ColMajor
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
                                                 ()
                                                 ())]
                                                 ()
@@ -370,7 +352,25 @@
                                             [((Var 3 __libasr__created__var__1__array_constructor_)
                                             [((IntegerConstant 1 (Integer 4) Decimal)
                                             (IntegerConstant 0 (Integer 4) Decimal))]
-                                            ()
+                                            (StringLen
+                                                (ArrayItem
+                                                    (Var 3 strings)
+                                                    [(()
+                                                    (ArrayBound
+                                                        (Var 3 strings)
+                                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                                        (Integer 4)
+                                                        LBound
+                                                        ()
+                                                    )
+                                                    ())]
+                                                    (String 1 () AssumedLength DescriptorString)
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (Integer 4)
+                                                ()
+                                            )
                                             ()
                                             ())]
                                             ()


### PR DESCRIPTION
Fixes #8343

Original code:
```fortran
program m
  implicit none
  character(len=7) :: value
  character(len=:), allocatable :: keywords(:)
  integer :: ii
   ii = 7
  value = "version"
      keywords = [character(len=ii) :: value]
  print *, len(keywords), keywords(1)
end program
```


Code after `implied do loop` pass:
Before:
```fortran
! Fortran code after applying the pass: implied_do_loops
program m
implicit none
integer(4) :: __1__libasr_index_
integer(4) :: ii
character(len=ii, kind=1), dimension(1) :: __libasr__created__var__0__array_constructor_
character(len=:, kind=1), dimension(:), allocatable :: keywords
character(len=7, kind=1) :: value
ii = 7
value = "version"
__1__libasr_index_ = lbound(__libasr__created__var__0__array_constructor_, 1)
__libasr__created__var__0__array_constructor_(__1__libasr_index_) = value
__1__libasr_index_ = __1__libasr_index_ + 1
keywords = __libasr__created__var__0__array_constructor_
print *, len(keywords(lbound(keywords, 1))), keywords(1)
end program m
```

After:
```fortran
! Fortran code after applying the pass: implied_do_loops
program m
implicit none
integer(4) :: __1__libasr_index_
character(len=:, kind=1), dimension(:), allocatable :: __libasr__created__var__0__array_constructor_
integer(4) :: ii
character(len=:, kind=1), dimension(:), allocatable :: keywords
character(len=7, kind=1) :: value
ii = 7
value = "version"
deallocate(__libasr__created__var__0__array_constructor_)
allocate(character(len=ii) :: __libasr__created__var__0__array_constructor_(1))
__1__libasr_index_ = lbound(__libasr__created__var__0__array_constructor_, 1)
__libasr__created__var__0__array_constructor_(__1__libasr_index_) = value
__1__libasr_index_ = __1__libasr_index_ + 1
keywords = __libasr__created__var__0__array_constructor_
print *, len(keywords(lbound(keywords, 1))), keywords(1)
end program m
```