### PR TITLE
fix: proper logical operation for like datatypes

### DIFF
--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -178,13 +178,30 @@ program continue_compilation_3
 
     ! adding the new test for performing logical .and. between int-logical type.
     !and_mismatch_int_logical
-    5 .and. .true.
+    print *, 5 .and. .true.
 
     !and_mismatch_real_logical
-    3.14 .and. .false.
+    print *, 3.14 .and. .false.
 
     !and_okay_int_int
     print *, 5 .and. 6
+
+    !adding a few more cases
+    print *, 5 .or. 6
+    print *, 5 .eqv. 6
+    print *, .true. .neqv. 6
+    print *, 3.14 .and. "abcd"
+    print *, "abcd" .neqv. "cdef"
+    print *, 1 .neqv. 2
+    print *, [1,2,3] .and. .true.
+    print *, [1.0, 2.0] .or. [3.0, 4.0]
+    print *, "str1" .or. "str2"
+    print *, "x" .and. .false.
+    print *, .NOT. "lf"
+    print *, "8356" .or. 8356
+    print *, "8356" .eqv. 8356.00
+    print *, ['c', 'o', 'd', 'e'] .or. ['m', 'a', 's']
+    print *, ["welcome", "to", "lf"] .and. "contributors"  !even size diff of array element must be caught
 
     contains 
     subroutine bpe()

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "c42198e208380452a6a30aa7fb901a4e21a96d840bce150681d76ac9",
+    "infile_hash": "d0ec11ede4ae76dc218b3ae43ed0843dd9986d28a53dc9adb318e3d7",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "d7aa6825397311c2d34349685e4eb749a62facf141e702e4a1869ff2",
+    "stderr_hash": "19d4ec68447994072df3fe5de5a9e3f150852c80dbbf3d88160b6a2a",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -1,46 +1,398 @@
-Internal Compiler Error: Unhandled exception
-Traceback (most recent call last):
-[2m  Binary file "[0m[1m[35m$DIR/src/bin/lfortran[39m[0m[2m", in _start[0m
-[2m  File "[0m[1m[35m./csu/../csu/libc-start.c[39m[0m[2m", line 360, in __libc_start_main[0m
-[2m  File "[0m[1m[35m./csu/../sysdeps/nptl/libc_start_call_main.h[39m[0m[2m", line 58, in __libc_start_call_main[0m
-[2m  File "[0m[1m[35m$DIR/src/bin/lfortran.cpp[39m[0m[2m", line 2750, in main[0m
-    return main_app(argc, argv);
-[2m  File "[0m[1m[35m$DIR/src/bin/lfortran.cpp[39m[0m[2m", line 2550, in main_app(int, char**)[0m
-    return run_parser_and_semantics(opts.arg_file, compiler_options);
-[2m  File "[0m[1m[35m$DIR/src/bin/lfortran.cpp[39m[0m[2m", line 737, in (anonymous namespace)::run_parser_and_semantics(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, LCompilers::CompilerOptions&)[0m
-    r = fe.get_asr2(input, lm, diagnostics);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/fortran_evaluator.cpp[39m[0m[2m", line 276, in LCompilers::FortranEvaluator::get_asr2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, LCompilers::LocationManager&, LCompilers::diag::Diagnostics&)[0m
-    Result<ASR::TranslationUnit_t*> res2 = get_asr3(*ast, diagnostics, lm);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/fortran_evaluator.cpp[39m[0m[2m", line 298, in LCompilers::FortranEvaluator::get_asr3(LCompilers::LFortran::AST::TranslationUnit_t&, LCompilers::diag::Diagnostics&, LCompilers::LocationManager&)[0m
-    compiler_options.symtab_only, compiler_options, lm);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_to_asr.cpp[39m[0m[2m", line 111, in LCompilers::LFortran::ast_to_asr(Allocator&, LCompilers::LFortran::AST::TranslationUnit_t&, LCompilers::diag::Diagnostics&, LCompilers::SymbolTable*, bool, LCompilers::CompilerOptions&, LCompilers::LocationManager&)[0m
-    );
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_body_visitor.cpp[39m[0m[2m", line 5837, in LCompilers::LFortran::body_visitor(Allocator&, LCompilers::LFortran::AST::TranslationUnit_t&, LCompilers::diag::Diagnostics&, LCompilers::ASR::asr_t*, LCompilers::CompilerOptions&, std::map<unsigned long, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, LCompilers::ASR::ttype_t*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, LCompilers::ASR::ttype_t*> > >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, LCompilers::ASR::ttype_t*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, LCompilers::ASR::ttype_t*> > > > > >&, std::map<unsigned long, LCompilers::ASR::symbol_t*, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, LCompilers::ASR::symbol_t*> > >&, std::map<unsigned long, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >&, std::map<unsigned long, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >&, std::map<unsigned int, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<LCompilers::ASR::ttype_t*, LCompilers::ASR::symbol_t*>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::pair<LCompilers::ASR::ttype_t*, LCompilers::ASR::symbol_t*> > > >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<LCompilers::ASR::ttype_t*, LCompilers::ASR::symbol_t*>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::pair<LCompilers::ASR::ttype_t*, LCompilers::ASR::symbol_t*> > > > > > >&, std::map<unsigned int, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, LCompilers::ASR::symbol_t*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, LCompilers::ASR::symbol_t*> > >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, LCompilers::ASR::symbol_t*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, LCompilers::ASR::symbol_t*> > > > > >&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<LCompilers::LFortran::AST::stmt_t*, std::allocator<LCompilers::LFortran::AST::stmt_t*> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<LCompilers::LFortran::AST::stmt_t*, std::allocator<LCompilers::LFortran::AST::stmt_t*> > > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<LCompilers::LFortran::AST::stmt_t*, std::allocator<LCompilers::LFortran::AST::stmt_t*> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<LCompilers::LFortran::AST::stmt_t*, std::allocator<LCompilers::LFortran::AST::stmt_t*> > > > > > > >&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<int, std::allocator<int> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<int, std::allocator<int> > > > >&, std::vector<LCompilers::ASR::stmt_t*, std::allocator<LCompilers::ASR::stmt_t*> >&, LCompilers::LocationManager&)[0m
-    b.visit_TranslationUnit(ast);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_body_visitor.cpp[39m[0m[2m", line 175, in LCompilers::LFortran::BodyVisitor::visit_TranslationUnit(LCompilers::LFortran::AST::TranslationUnit_t const&)[0m
-    visit_ast(*x.m_items[i]);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 5016, in LCompilers::LFortran::AST::BaseVisitor<LCompilers::LFortran::BodyVisitor>::visit_ast(LCompilers::LFortran::AST::ast_t const&)[0m
-    void visit_ast(const ast_t &b) { visit_ast_t(b, self()); }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 4972, in void LCompilers::LFortran::AST::visit_ast_t<LCompilers::LFortran::BodyVisitor>(LCompilers::LFortran::AST::ast_t const&, LCompilers::LFortran::BodyVisitor&)[0m
-    case astType::mod: { v.visit_mod((const mod_t &)x); return; }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 5019, in LCompilers::LFortran::AST::BaseVisitor<LCompilers::LFortran::BodyVisitor>::visit_mod(LCompilers::LFortran::AST::mod_t const&)[0m
-    void visit_mod(const mod_t &b) { visit_mod_t(b, self()); }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 4594, in void LCompilers::LFortran::AST::visit_mod_t<LCompilers::LFortran::BodyVisitor>(LCompilers::LFortran::AST::mod_t const&, LCompilers::LFortran::BodyVisitor&)[0m
-    case modType::Program: { v.visit_Program((const Program_t &)x); return; }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_body_visitor.cpp[39m[0m[2m", line 2356, in LCompilers::LFortran::BodyVisitor::visit_Program(LCompilers::LFortran::AST::Program_t const&)[0m
-    transform_stmts(body, x.n_body, x.m_body);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_body_visitor.cpp[39m[0m[2m", line 135, in LCompilers::LFortran::BodyVisitor::transform_stmts(LCompilers::Vec<LCompilers::ASR::stmt_t*>&, unsigned long, LCompilers::LFortran::AST::stmt_t**)[0m
-    this->visit_stmt(*m_body[i]);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 5065, in LCompilers::LFortran::AST::BaseVisitor<LCompilers::LFortran::BodyVisitor>::visit_stmt(LCompilers::LFortran::AST::stmt_t const&)[0m
-    void visit_stmt(const stmt_t &b) { visit_stmt_t(b, self()); }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 4730, in void LCompilers::LFortran::AST::visit_stmt_t<LCompilers::LFortran::BodyVisitor>(LCompilers::LFortran::AST::stmt_t const&, LCompilers::LFortran::BodyVisitor&)[0m
-    case stmtType::Print: { v.visit_Print((const Print_t &)x); return; }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_body_visitor.cpp[39m[0m[2m", line 4639, in LCompilers::LFortran::BodyVisitor::visit_Print(LCompilers::LFortran::AST::Print_t const&)[0m
-    this->visit_expr(*x.m_values[i]);
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 5117, in LCompilers::LFortran::AST::BaseVisitor<LCompilers::LFortran::BodyVisitor>::visit_expr(LCompilers::LFortran::AST::expr_t const&)[0m
-    void visit_expr(const expr_t &b) { visit_expr_t(b, self()); }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/ast.h[39m[0m[2m", line 4761, in void LCompilers::LFortran::AST::visit_expr_t<LCompilers::LFortran::BodyVisitor>(LCompilers::LFortran::AST::expr_t const&, LCompilers::LFortran::BodyVisitor&)[0m
-    case exprType::BoolOp: { v.visit_BoolOp((const BoolOp_t &)x); return; }
-[2m  File "[0m[1m[35m$DIR/src/lfortran/semantics/ast_common_visitor.h[39m[0m[2m", line 10974, in LCompilers::LFortran::CommonVisitor<LCompilers::LFortran::BodyVisitor>::visit_BoolOp(LCompilers::LFortran::AST::BoolOp_t const&)[0m
-    LCOMPILERS_ASSERT(x.m_op == AST::Concat)
-AssertFailed: ASR::is_a<ASR::Logical_t>(*ASRUtils::extract_type(left_type))
+syntax error: Token '::' is unexpected here
+  --> tests/errors/continue_compilation_3.f90:57:9
+   |
+57 |     rea :: test_real(12)
+   |         ^^ 
+
+syntax error: Token ')' is unexpected here
+  --> tests/errors/continue_compilation_3.f90:58:21
+   |
+58 |     real :: test_re()
+   |                     ^ 
+
+syntax error: The LFortran pragma !LF$ must be followed by a space
+   --> tests/errors/continue_compilation_3.f90:171:9
+    |
+171 |         !LF$unroll 4  ! Error: Missing space after `!LF$`
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Module 'continue_compilation_3_fake_module' modfile was not found
+  --> tests/errors/continue_compilation_3.f90:48:5
+   |
+48 |     use continue_compilation_3_fake_module
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Empty array constructor is not allowed
+  --> tests/errors/continue_compilation_3.f90:91:9
+   |
+91 |     a = []
+   |         ^^ 
+
+semantic error: Empty array constructor is not allowed
+  --> tests/errors/continue_compilation_3.f90:93:16
+   |
+93 |     print *, [[[], [[]]], [[]], []]
+   |                ^^ 
+
+semantic error: Empty array constructor is not allowed
+  --> tests/errors/continue_compilation_3.f90:94:16
+   |
+94 |     print *, [[[], [[]]], []]
+   |                ^^ 
+
+semantic error: Rank mismatch in array reference: the array `b` has rank `1`, but is referenced as rank `2`
+  --> tests/errors/continue_compilation_3.f90:96:5
+   |
+96 |     b(:,:) = 1
+   |     ^^^^^^ 
+
+semantic error: Rank mismatch in array reference: the array `b` has rank `1`, but is referenced as rank `2`
+  --> tests/errors/continue_compilation_3.f90:97:5
+   |
+97 |     b(:,:) = 2
+   |     ^^^^^^ 
+
+semantic error: Type member xx is not an array so it cannot be indexed.
+  --> tests/errors/continue_compilation_3.f90:99:5
+   |
+99 |     y%xx(:) = 1
+   |     ^^^^^^^ 
+
+semantic error: Rank mismatch in array reference: the array `str` has rank `1`, but is referenced as rank `2`
+   --> tests/errors/continue_compilation_3.f90:101:5
+    |
+101 |     str(1, 2)(:) = '1234'
+    |     ^^^^^^^^^^^^ 
+
+semantic error: Rank mismatch in array reference: the array `str` has rank `1`, but is referenced as rank `3`
+   --> tests/errors/continue_compilation_3.f90:102:5
+    |
+102 |     str(1,2,3)(:) = '1234'
+    |     ^^^^^^^^^^^^^ 
+
+semantic error: Type-spec cannot contain an asterisk for a type parameter
+   --> tests/errors/continue_compilation_3.f90:104:14
+    |
+104 |     print *, [character(*) :: "a", "b", "ball", "cat"]
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Type-spec cannot contain an asterisk for a type parameter
+   --> tests/errors/continue_compilation_3.f90:105:14
+    |
+105 |     print *, [character(*) :: "a2", "b2", "ball2", "cat2"]
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Different shape for array assignment on dimension 1(3 and 2)
+   --> tests/errors/continue_compilation_3.f90:107:5
+    |
+107 |     x1 = reshape([1,2,3,4],[2,2])
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Different shape for array assignment on dimension 1(3 and 1)
+   --> tests/errors/continue_compilation_3.f90:108:5
+    |
+108 |     x1 = reshape([1,2,3,4],[1,2])
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Arithmetic if (x) requires an integer or real for `x`
+   --> tests/errors/continue_compilation_3.f90:112:9
+    |
+112 |     if ("yy") 1, 2, 3
+    |         ^^^^ 
+
+semantic error: Incorrect number of arguments passed to the 'size' intrinsic. It accepts at least 1 and at most 3 arguments.
+   --> tests/errors/continue_compilation_3.f90:119:9
+    |
+119 |     i = size(a1, 1, 4, kind=4)
+    |         ^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Incorrect number of arguments passed to the 'size' intrinsic. It accepts at least 1 and at most 3 arguments.
+   --> tests/errors/continue_compilation_3.f90:120:9
+    |
+120 |     i = size()
+    |         ^^^^^^ 
+
+semantic error: Cannot assign to a constant variable
+   --> tests/errors/continue_compilation_3.f90:122:5
+    |
+122 |     x3 = 1
+    |     ^^^^^^ assignment here
+    |
+ 55 |     integer, parameter :: x3 = 2
+    |                           ~~~~~~ declared as constant
+
+semantic error: The end variable of the data implied do loop must be constants
+   --> tests/errors/continue_compilation_3.f90:125:22
+    |
+125 |     data(a1(i), i=1, k) / 1, 2, 3 /
+    |                      ^ 
+
+semantic error: The increment variable of the data implied do loop must be a constant
+   --> tests/errors/continue_compilation_3.f90:127:25
+    |
+127 |     data(a1(i), i=1, 3, k) / 1, 2, 3 /
+    |                         ^ 
+
+semantic error: The start variable of the data implied do loop must be constants
+   --> tests/errors/continue_compilation_3.f90:129:19
+    |
+129 |     data(a1(i), i=k, 3) / 1, 2, 3 /
+    |                   ^ 
+
+semantic error: Variable 'foo' is not declared
+   --> tests/errors/continue_compilation_3.f90:132:9
+    |
+132 |     i = foo
+    |         ^^^ 'foo' is undeclared
+
+semantic error: Invalid argument `end` supplied
+   --> tests/errors/continue_compilation_3.f90:134:5
+    |
+134 |     rewind(end="world")
+    |     ^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: same_type_as is not implemented yet
+   --> tests/errors/continue_compilation_3.f90:136:14
+    |
+136 |     print *, same_type_as(1.0, 1.0)
+    |              ^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Kind of all the arguments of Sign must be the same
+   --> tests/errors/continue_compilation_3.f90:138:14
+    |
+138 |     print *, sign(1, 1_8)
+    |              ^^^^^^^^^^^^ 
+
+semantic error: Argument 1 of dabs must be of double precision real type
+   --> tests/errors/continue_compilation_3.f90:140:13
+    |
+140 |     print*, dabs(1)
+    |             ^^^^^^^ 
+
+semantic error: Argument of `sqrt` has a negative argument
+   --> tests/errors/continue_compilation_3.f90:142:14
+    |
+142 |     print *, sqrt(-1.0)
+    |              ^^^^^^^^^^ 
+
+semantic error: Binary numeric operators cannot be used on strings
+   --> tests/errors/continue_compilation_3.f90:144:14
+    |
+144 |     print *, "a" + "b"
+    |              ^^^^^^^^^ help: use '//' for string concatenation
+
+semantic error: The first index in string section is less than 1
+   --> tests/errors/continue_compilation_3.f90:147:19
+    |
+147 |     print*, "s:", s(-1:4)
+    |                   ^^^^^^^ 
+
+semantic error: Substring `start` is less than one
+   --> tests/errors/continue_compilation_3.f90:149:13
+    |
+149 |     print*, s1(-2:6)
+    |             ^^^^^^^^ 
+
+semantic error: Substring end index exceeds the string length
+   --> tests/errors/continue_compilation_3.f90:152:13
+    |
+152 |     print*, s1(1: 9)
+    |             ^^^^^^^^ 
+
+semantic error: Substring end index at must be of type integer
+   --> tests/errors/continue_compilation_3.f90:154:18
+    |
+154 |     print*, s1(1:5.2)
+    |                  ^^^ 
+
+semantic error: Substring start index at must be of type integer
+   --> tests/errors/continue_compilation_3.f90:156:16
+    |
+156 |     print*, s1(1.1:5)
+    |                ^^^ 
+
+semantic error: Substring stride must be of type integer
+   --> tests/errors/continue_compilation_3.f90:158:19
+    |
+158 |     print*, s(1:5:2.2)
+    |                   ^^^ 
+
+semantic error: Type mismatch in assignment, the types must be compatible
+   --> tests/errors/continue_compilation_3.f90:160:5
+    |
+160 |     x = "x"
+    |     ^   ^^^ type mismatch (integer and string)
+
+semantic error: Type mismatch in binary operator, the types must be compatible
+   --> tests/errors/continue_compilation_3.f90:162:9
+    |
+162 |     x = 5 + "x"
+    |         ^   ^^^ type mismatch (integer and string)
+
+semantic error: Type mismatch in assignment, the types must be compatible
+   --> tests/errors/continue_compilation_3.f90:162:5
+    |
+162 |     x = 5 + "x"
+    |     ^       ^^^ type mismatch (integer and string)
+
+semantic error: Subroutine `bpe` called as a function
+   --> tests/errors/continue_compilation_3.f90:165:9
+    |
+165 |     i = bpe()
+    |         ^^^^^ 
+
+semantic error: Variable 'xx' is not declared
+   --> tests/errors/continue_compilation_3.f90:166:14
+    |
+166 |     print *, xx
+    |              ^^ 'xx' is undeclared
+
+semantic error: Variable 'test_re' is not declared
+   --> tests/errors/continue_compilation_3.f90:167:5
+    |
+167 |     test_re = 1245.13
+    |     ^^^^^^^ 'test_re' is undeclared
+
+semantic error: Array reference is not allowed on scalar variable
+   --> tests/errors/continue_compilation_3.f90:168:5
+    |
+168 |     c(1) = 1
+    |     ^^^^ 
+
+semantic error: Kind of all the arguments of Mergebits must be the same
+   --> tests/errors/continue_compilation_3.f90:176:14
+    |
+176 |     print *, merge_bits(1, 2, 3_8)
+    |              ^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Kind of all the arguments of Mergebits must be the same
+   --> tests/errors/continue_compilation_3.f90:177:14
+    |
+177 |     print *, merge_bits(merge_i,merge_j,merge_k)
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:181:14
+    |
+181 |     print *, 5 .and. .true.
+    |              ^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:184:14
+    |
+184 |     print *, 3.14 .and. .false.
+    |              ^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:187:14
+    |
+187 |     print *, 5 .and. 6
+    |              ^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:190:14
+    |
+190 |     print *, 5 .or. 6
+    |              ^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:191:14
+    |
+191 |     print *, 5 .eqv. 6
+    |              ^ 
+
+semantic error: Right operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:192:28
+    |
+192 |     print *, .true. .neqv. 6
+    |                            ^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:193:14
+    |
+193 |     print *, 3.14 .and. "abcd"
+    |              ^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:194:14
+    |
+194 |     print *, "abcd" .neqv. "cdef"
+    |              ^^^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:195:14
+    |
+195 |     print *, 1 .neqv. 2
+    |              ^ 
+
+semantic error: Left operand's array element type must be LOGICAL
+   --> tests/errors/continue_compilation_3.f90:196:14
+    |
+196 |     print *, [1,2,3] .and. .true.
+    |              ^^^^^^^ 
+
+semantic error: Left operand's array element type must be LOGICAL
+   --> tests/errors/continue_compilation_3.f90:197:14
+    |
+197 |     print *, [1.0, 2.0] .or. [3.0, 4.0]
+    |              ^^^^^^^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:198:14
+    |
+198 |     print *, "str1" .or. "str2"
+    |              ^^^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:199:14
+    |
+199 |     print *, "x" .and. .false.
+    |              ^^^ 
+
+semantic error: Operand of .not. operator is string
+   --> tests/errors/continue_compilation_3.f90:200:14
+    |
+200 |     print *, .NOT. "lf"
+    |              ^^^^^^^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:201:14
+    |
+201 |     print *, "8356" .or. 8356
+    |              ^^^^^^ 
+
+semantic error: Left operand must be LOGICAL or LOGICAL array
+   --> tests/errors/continue_compilation_3.f90:202:14
+    |
+202 |     print *, "8356" .eqv. 8356.00
+    |              ^^^^^^ 
+
+semantic error: Left operand's array element type must be LOGICAL
+   --> tests/errors/continue_compilation_3.f90:203:14
+    |
+203 |     print *, ['c', 'o', 'd', 'e'] .or. ['m', 'a', 's']
+    |              ^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Different `character` lengths 7 and 2 in array constructor
+   --> tests/errors/continue_compilation_3.f90:204:26
+    |
+204 |     print *, ["welcome", "to", "lf"] .and. "contributors"  !even size diff of array element must be caught
+    |                          ^^^^ 
+
+semantic error: Argument of 'size' must be an array
+   --> tests/errors/continue_compilation_3.f90:208:23
+    |
+208 |         print *, size(bpe)
+    |                       ^^^ 
+
+semantic error: Variable 'd' is not declared
+   --> tests/errors/continue_compilation_3.f90:209:15
+    |
+209 |         bpe = d
+    |               ^ 'd' is undeclared
+
+semantic error: Assignment to subroutine is not allowed
+   --> tests/errors/continue_compilation_3.f90:209:9
+    |
+209 |         bpe = d
+    |         ^^^ 


### PR DESCRIPTION
The following is a fix for case when we try to perform `.and.` between `int` and `logical`. 

Following is the code that tests the same:-
```
program test_invalid_and
    implicit none
    integer :: i
    logical :: l

    i = 5
    l = .true.

    if (i .and. l) then
        print *, "This should never print."
    end if
end program test_invalid_and
```

When running with the changes, we get the following output:-
<img width="1002" height="176" alt="image" src="https://github.com/user-attachments/assets/462257b5-c4e0-4aad-ba2b-7e508f3390f9" />

And without the same, I got:-
<img width="1573" height="904" alt="image" src="https://github.com/user-attachments/assets/938f6596-802e-42ff-a262-bd318f888b7d" />

Please do let me know if the following code works well along with changes, if needed. If all seems well, then will add a `test` for the same.