### PR TITLE
refactor: differentiate compilation ID creation for monolithic and separate compilation

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -80,7 +80,7 @@
 #define MAGENTA "\033[35m"   // Magenta for 'File reading' and 'Src -> ASR'
 #define RED        "\033[31m"   // Red for 'Time taken by pass' and 'ASR -> ASR passes'
 
-extern std::string lcompilers_unique_ID;
+extern std::string lcompilers_unique_ID_separate_compilation;   // Used in naming unique symbols during separate compilation
 extern std::string lcompilers_commandline_options;
 
 namespace {
@@ -129,7 +129,8 @@ std::string get_unique_ID() {
 }
 
 // The unique compilation ID for this invocation of the compiler.
-const std::string LFORTRAN_COMPILATION_ID = get_unique_ID();
+// Used in naming unique intermediate object files during both compilation modes.
+const std::string LCOMPILERS_UNIQUE_ID = get_unique_ID();
 
 void print_one_component(std::string component) {
     std::istringstream ss(component);
@@ -1146,7 +1147,7 @@ int compile_src_to_object_file(const std::string &infile,
     t1 = std::chrono::high_resolution_clock::now();
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
-    lcompilers_unique_ID = compiler_options.separate_compilation ? get_unique_ID() : "";
+    lcompilers_unique_ID_separate_compilation = compiler_options.separate_compilation ? LCOMPILERS_UNIQUE_ID : "";
 
     time_src_to_asr = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
     bool has_error_w_cc = compiler_options.continue_compilation && diagnostics.has_error();
@@ -1235,7 +1236,7 @@ int compile_src_to_object_file(const std::string &infile,
                 if (mlir_res.ok) {
                     mlir_res.result->mlir_to_llvm(*mlir_res.result->llvm_ctx);
                     std::string mlir_tmp_o = (std::filesystem::path(LFORTRAN_TEMP_DIR) / std::filesystem::path(infile)
-                        .filename().replace_extension(".mlir.tmp_" + LFORTRAN_COMPILATION_ID + ".o")).string();
+                        .filename().replace_extension(".mlir.tmp_" + LCOMPILERS_UNIQUE_ID + ".o")).string();
                     e.save_object_file(*(mlir_res.result->llvm_m), mlir_tmp_o);
                 } else {
                     LCOMPILERS_ASSERT(diagnostics.has_error())
@@ -1968,7 +1969,7 @@ int link_executable(const std::vector<std::string> &infiles,
                         std::regex_match(s, std::regex(R"(.*\.tmp_\w+\.o)"))) {
                     std::string file_path = std::filesystem::path(s.substr(0, s.size() - 2)).string();    // strip ".o" from end
                     std::string mlir_tmp_o = std::filesystem::path(file_path).replace_extension(
-                        ".mlir.tmp_" + LFORTRAN_COMPILATION_ID + ".o").string();
+                        ".mlir.tmp_" + LCOMPILERS_UNIQUE_ID + ".o").string();
                     compile_cmd += mlir_tmp_o + " ";
                     mlir_temp_object_files.push_back(mlir_tmp_o);
                 }
@@ -2361,7 +2362,7 @@ int main_app(int argc, char *argv[]) {
         }
     }
 
-    lcompilers_unique_ID = ( parser.opts.compiler_options.separate_compilation || compiler_options.generate_code_for_global_procedures ) ? get_unique_ID() : "";
+    lcompilers_unique_ID_separate_compilation = ( parser.opts.compiler_options.separate_compilation || compiler_options.generate_code_for_global_procedures ) ? LCOMPILERS_UNIQUE_ID : "";
     if (parser.opts.compiler_options.separate_compilation) {
         compiler_options.po.intrinsic_symbols_mangling = true;
         compiler_options.po.intrinsic_module_name_mangling = true;
@@ -2661,7 +2662,7 @@ int main_app(int argc, char *argv[]) {
     for (const auto &arg_file : opts.arg_files) {
         int err = 0;
         std::string tmp_o = (std::filesystem::path(LFORTRAN_TEMP_DIR) / std::filesystem::path(arg_file)
-                                .filename().replace_extension(".tmp_" + LFORTRAN_COMPILATION_ID + ".o")).string();
+                                .filename().replace_extension(".tmp_" + LCOMPILERS_UNIQUE_ID + ".o")).string();
         temp_object_files.push_back(tmp_o);
         if (endswith(arg_file, ".f90") || endswith(arg_file, ".f") ||
             endswith(arg_file, ".F90") || endswith(arg_file, ".F")) {

--- a/src/libasr/asr_scopes.cpp
+++ b/src/libasr/asr_scopes.cpp
@@ -5,7 +5,7 @@
 #include <libasr/asr_utils.h>
 #include <libasr/pass/pass_utils.h>
 
-std::string lcompilers_unique_ID;
+std::string lcompilers_unique_ID_separate_compilation;
 std::string lcompilers_commandline_options;
 
 namespace LCompilers  {
@@ -100,8 +100,8 @@ ASR::symbol_t *SymbolTable::find_scoped_symbol(const std::string &name,
 
 std::string SymbolTable::get_unique_name(const std::string &name, bool use_unique_id) {
     std::string unique_name = name;
-    if( use_unique_id && !lcompilers_unique_ID.empty()) {
-        unique_name += "_" + lcompilers_unique_ID;
+    if( use_unique_id && !lcompilers_unique_ID_separate_compilation.empty()) {
+        unique_name += "_" + lcompilers_unique_ID_separate_compilation;
     }
     int counter = 1;
     while (scope.find(unique_name) != scope.end()) {

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -9,7 +9,7 @@
 #include<unordered_set>
 
 
-extern std::string lcompilers_unique_ID;
+extern std::string lcompilers_unique_ID_separate_compilation;
 
 /*
 ASR pass for replacing symbol names with some new name, mostly because
@@ -81,16 +81,16 @@ class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
         } else if (startswith(curr_name, "_lcompilers_") && current_scope) {
             // mangle intrinsic functions
             uint64_t hash = get_hash(current_scope->asr_owner);
-            return module_name + curr_name + "_" + std::to_string(hash) + "_" + lcompilers_unique_ID;
+            return module_name + curr_name + "_" + std::to_string(hash) + "_" + lcompilers_unique_ID_separate_compilation;
         } else if (parent_function_name.size() > 0) {
             // add parent function name to suffix
             std::string name = module_name + curr_name + "_";
             for (auto &a: parent_function_name) {
                 name += a + "_";
             }
-            return name + lcompilers_unique_ID;
+            return name + lcompilers_unique_ID_separate_compilation;
         }
-        return module_name + curr_name + "_" + lcompilers_unique_ID;
+        return module_name + curr_name + "_" + lcompilers_unique_ID_separate_compilation;
     }
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
@@ -545,13 +545,13 @@ void pass_unique_symbols(Allocator &al, ASR::TranslationUnit_t &unit,
                     pass_options.intrinsic_symbols_mangling || pass_options.all_symbols_mangling ||
                     pass_options.bindc_mangling || pass_options.fortran_mangling);
     if (pass_options.mangle_underscore) {
-        lcompilers_unique_ID = "";
+        lcompilers_unique_ID_separate_compilation = "";
     }
     if ((!any_present || (!(pass_options.mangle_underscore ||
-            pass_options.fortran_mangling) && lcompilers_unique_ID.empty())) &&
+            pass_options.fortran_mangling) && lcompilers_unique_ID_separate_compilation.empty())) &&
                 !pass_options.c_mangling) {
-        // `--mangle-underscore` doesn't require `lcompilers_unique_ID`
-        // `lcompilers_unique_ID` is not mandatory for `--apply-fortran-mangling`
+        // `--mangle-underscore` doesn't require `lcompilers_unique_ID_separate_compilation`
+        // `lcompilers_unique_ID_separate_compilation` is not mandatory for `--apply-fortran-mangling`
         return;
     }
     SymbolRenameVisitor v(pass_options.intrinsic_module_name_mangling,


### PR DESCRIPTION
Implementing suggestion in https://github.com/lfortran/lfortran/pull/8338#discussion_r2276618717.

- We use `LCOMPILERS_UNIQUE_ID` for uniquely naming intermediate object files during both compilation modes. 
- We use `lcompilers_unique_ID_separate_compilation` for uniquely naming symbols during separate compilation.