### PR TITLE
feat: add new `disable_implicit_typing` CLI option

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -48,6 +48,8 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     asr = is_included("asr")
     asr_ignore_pragma = is_included("asr_ignore_pragma")
     asr_implicit_typing = is_included("asr_implicit_typing")
+    asr_disable_implicit_typing = is_included("asr_disable_implicit_typing")
+    enable_and_disable_implicit_typing = is_included("enable_and_disable_implicit_typing")
     asr_implicit_interface = is_included("asr_implicit_interface")
     asr_implicit_interface_and_typing = is_included("asr_implicit_interface_and_typing")
     asr_implicit_argument_casting = is_included("asr_implicit_argument_casting")
@@ -168,6 +170,16 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
             update_reference,
             verify_hash,
             extra_args)
+        
+    if enable_and_disable_implicit_typing:
+        if no_llvm:
+            log.info(f"{filename} * obj    SKIPPED as requested")
+        else:
+            run_test(filename, "run", "lfortran --implicit-typing --disable-implicit-typing --no-color {infile}",
+                filename,
+                update_reference,
+                verify_hash,
+                extra_args)
 
     if ast_json:
         run_test(
@@ -455,6 +467,18 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
             filename,
             "asr",
             "lfortran --show-asr --implicit-typing --no-color {infile} -o {outfile}",
+            filename,
+            update_reference,
+            verify_hash,
+            extra_args)
+    
+    if asr_disable_implicit_typing:
+        if no_llvm:
+            log.info(f"{filename} * llvm   SKIPPED as requested")
+        run_test(
+            filename,
+            "asr",
+            "lfortran --std=f23 --show-asr --disable-implicit-typing --no-color {infile} -o {outfile}",
             filename,
             update_reference,
             verify_hash,

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -78,6 +78,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--fixed-form-infer", opts.fixed_form_infer, "Use heuristics to infer if a file is in fixed form")->group(group_language_options);
         app.add_option("--std", opts.arg_standard, "Select standard conformance (lf, f23, legacy)")->group(group_language_options);
         app.add_flag("--implicit-typing", compiler_options.implicit_typing, "Allow implicit typing")->group(group_language_options);
+        app.add_flag("--disable-implicit-typing", opts.disable_implicit_typing, "Disable implicit typing")->group(group_language_options);
         app.add_flag("--implicit-interface", compiler_options.implicit_interface, "Allow implicit interface")->group(group_language_options);
         app.add_flag("--implicit-argument-casting", compiler_options.implicit_argument_casting, "Allow implicit argument casting")->group(group_language_options);
         app.add_flag("--logical-casting", compiler_options.logical_casting, "Allow logical casting")->group(group_language_options);
@@ -217,14 +218,6 @@ namespace LCompilers::CommandLineInterface {
             app.parse(args);
         }
 
-        if (opts.disable_style_suggestions) {
-            compiler_options.show_style_suggestions = false;
-        }
-
-        if (disable_warnings) {
-            compiler_options.show_warnings = false;
-        }
-
         if (opts.arg_standard == "" || opts.arg_standard == "lf") {
             // The default LFortran behavior, do nothing
         } else if (opts.arg_standard == "f23") {
@@ -233,6 +226,9 @@ namespace LCompilers::CommandLineInterface {
                 compiler_options.show_style_suggestions = true;
             }
             compiler_options.implicit_typing = true;
+            if (opts.disable_implicit_typing) {
+                compiler_options.implicit_typing = false;
+            }
             compiler_options.implicit_argument_casting = true;
             compiler_options.implicit_interface = true;
             compiler_options.print_leading_space = true;
@@ -241,7 +237,13 @@ namespace LCompilers::CommandLineInterface {
         } else if (opts.arg_standard == "legacy") {
             // f23
             compiler_options.show_style_suggestions = false;
+            if (style_suggestions) {
+                compiler_options.show_style_suggestions = true;
+            }
             compiler_options.implicit_typing = true;
+            if (opts.disable_implicit_typing) {
+                compiler_options.implicit_typing = false;
+            }
             compiler_options.implicit_argument_casting = true;
             compiler_options.implicit_interface = true;
             compiler_options.print_leading_space = true;
@@ -300,10 +302,26 @@ namespace LCompilers::CommandLineInterface {
             throw lc::LCompilersException("Cannot use --no-style-warnings and --style-warnings at the same time");
         }
 
+        if (opts.disable_implicit_typing && compiler_options.implicit_typing) {
+            throw lc::LCompilersException("Cannot use --disable-implicit-typing and --implicit-typing at the same time");
+        }
+
         // Decide if a file is fixed format based on the extension
         // Gfortran does the same thing
         if (opts.fixed_form_infer && endswith(opts.arg_file, ".f")) {
             compiler_options.fixed_form = true;
+        }
+
+        if (opts.disable_implicit_typing) {
+            compiler_options.implicit_typing = false;
+        }
+
+        if (opts.disable_style_suggestions) {
+            compiler_options.show_style_suggestions = false;
+        }
+
+        if (disable_warnings) {
+            compiler_options.show_warnings = false;
         }
 
         if (opts.cpp && opts.no_cpp) {

--- a/src/bin/lfortran_command_line_parser.h
+++ b/src/bin/lfortran_command_line_parser.h
@@ -66,6 +66,9 @@ namespace LCompilers::CommandLineInterface {
         bool show_errors = false;
         bool show_document_symbols = false;
 
+        //no flags
+        bool disable_implicit_typing = false;
+
         // Style suggestions and warnings
         bool disable_style_suggestions = false;
 

--- a/tests/reference/asr-implicit_typing1-7a0ea7d.json
+++ b/tests/reference/asr-implicit_typing1-7a0ea7d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-implicit_typing1-7a0ea7d",
+    "cmd": "lfortran --std=f23 --show-asr --disable-implicit-typing --no-color {infile} -o {outfile}",
+    "infile": "tests/implicit_typing1.f90",
+    "infile_hash": "e6d1a0c4cb70b6dec80c447e80d4567c3a25f29c7164e956ddfba662",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-implicit_typing1-7a0ea7d.stderr",
+    "stderr_hash": "6341b8dd45d0fd22c074531e4e4fa272486a24c10288fb90b558cf7e",
+    "returncode": 2
+}

--- a/tests/reference/asr-implicit_typing1-7a0ea7d.stderr
+++ b/tests/reference/asr-implicit_typing1-7a0ea7d.stderr
@@ -1,0 +1,5 @@
+semantic error: Variable 'l' is not declared
+ --> tests/implicit_typing1.f90:2:1
+  |
+2 | L = 3
+  | ^ 'l' is undeclared

--- a/tests/reference/run-implicit_typing1-40bb07b.json
+++ b/tests/reference/run-implicit_typing1-40bb07b.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-implicit_typing1-40bb07b",
+    "cmd": "lfortran --implicit-typing --disable-implicit-typing --no-color {infile}",
+    "infile": "tests/implicit_typing1.f90",
+    "infile_hash": "e6d1a0c4cb70b6dec80c447e80d4567c3a25f29c7164e956ddfba662",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-implicit_typing1-40bb07b.stderr",
+    "stderr_hash": "fb96f08b2d0e268a7652c10ceee84208546b1e2f786812f42c656613",
+    "returncode": 1
+}

--- a/tests/reference/run-implicit_typing1-40bb07b.stderr
+++ b/tests/reference/run-implicit_typing1-40bb07b.stderr
@@ -1,0 +1,1 @@
+Cannot use --disable-implicit-typing and --implicit-typing at the same time

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3252,6 +3252,8 @@ asr = true
 [[test]]
 filename = "implicit_typing1.f90"
 asr_implicit_typing = true
+asr_disable_implicit_typing = true
+enable_and_disable_implicit_typing = true
 
 [[test]]
 filename = "implicit_typing2.f90"


### PR DESCRIPTION
Towards: #7937 
This pull request introduces a new CLI option, `--disable-implicit-typing`, to disable implicit typing. With this change, one can now combine the `--std=f23` or `--std=legacy` CLI flags with the `--disable-implicit-typing` option.

Test Cases:
I have added two test cases:
1) Using `--std=f23` with `--disable-implicit-typing` (disables implicit typing while retaining other default options).
2) Using `--disable-implicit-typing` with `--implicit-typing` (this is an error condition).