### PR TITLE
feat: add support for `no_implicit_argument_casting` CLI Flag

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -53,6 +53,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     asr_implicit_interface = is_included("asr_implicit_interface")
     asr_implicit_interface_and_typing = is_included("asr_implicit_interface_and_typing")
     asr_implicit_argument_casting = is_included("asr_implicit_argument_casting")
+    enable_disable_implicit_argument_casting = is_included("enable_disable_implicit_argument_casting")
     asr_implicit_interface_and_typing_with_llvm = is_included("asr_implicit_interface_and_typing_with_llvm")
     asr_disable_warnings = is_included("asr_disable_warnings")
     asr_disable_style_suggestion_and_warnings = is_included("asr_disable_style_suggestion_and_warnings")
@@ -176,6 +177,16 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
             log.info(f"{filename} * obj    SKIPPED as requested")
         else:
             run_test(filename, "run", "lfortran --implicit-typing --disable-implicit-typing --no-color {infile}",
+                filename,
+                update_reference,
+                verify_hash,
+                extra_args)
+
+    if enable_disable_implicit_argument_casting:
+        if no_llvm:
+            log.info(f"{filename} * obj    SKIPPED as requested")
+        else:
+            run_test(filename, "run", "lfortran --implicit-argument-casting --disable-implicit-argument-casting --no-color {infile}",
                 filename,
                 update_reference,
                 verify_hash,

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -43,6 +43,7 @@ namespace LCompilers::CommandLineInterface {
         bool disable_bounds_checking = false;
         bool style_suggestions = false;
         bool disable_warnings = false;
+        bool disable_implicit_argument_casting = false;
 
         // Standard options compatible with gfortran, gcc or clang
         // We follow the established conventions
@@ -81,6 +82,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--disable-implicit-typing", opts.disable_implicit_typing, "Disable implicit typing")->group(group_language_options);
         app.add_flag("--implicit-interface", compiler_options.implicit_interface, "Allow implicit interface")->group(group_language_options);
         app.add_flag("--implicit-argument-casting", compiler_options.implicit_argument_casting, "Allow implicit argument casting")->group(group_language_options);
+        app.add_flag("--disable-implicit-argument-casting", disable_implicit_argument_casting, "Disable implicit argument casting")->group(group_language_options);
         app.add_flag("--logical-casting", compiler_options.logical_casting, "Allow logical casting")->group(group_language_options);
         app.add_flag("--use-loop-variable-after-loop", compiler_options.po.use_loop_variable_after_loop, "Allow using loop variable after the loop")->group(group_language_options);
         app.add_flag("--legacy-array-sections", compiler_options.legacy_array_sections, "Enables passing array items as sections if required")->group(group_language_options);
@@ -238,6 +240,9 @@ namespace LCompilers::CommandLineInterface {
                 compiler_options.implicit_typing = false;
             }
             compiler_options.implicit_argument_casting = true;
+            if (disable_implicit_argument_casting) {
+                compiler_options.implicit_argument_casting = false;
+            }
             compiler_options.implicit_interface = true;
             compiler_options.print_leading_space = true;
             compiler_options.logical_casting = false;
@@ -253,6 +258,9 @@ namespace LCompilers::CommandLineInterface {
                 compiler_options.implicit_typing = false;
             }
             compiler_options.implicit_argument_casting = true;
+            if (disable_implicit_argument_casting) {
+                compiler_options.implicit_argument_casting = false;
+            }
             compiler_options.implicit_interface = true;
             compiler_options.print_leading_space = true;
             compiler_options.logical_casting = false;
@@ -314,6 +322,10 @@ namespace LCompilers::CommandLineInterface {
             throw lc::LCompilersException("Cannot use --disable-implicit-typing and --implicit-typing at the same time");
         }
 
+        if (disable_implicit_argument_casting && compiler_options.implicit_argument_casting) {
+            throw lc::LCompilersException("Cannot use --disable-implicit-argument-casting and --implicit-argument-casting at the same time");
+        }
+
         // Decide if a file is fixed format based on the extension
         // Gfortran does the same thing
         if (opts.fixed_form_infer && endswith(opts.arg_file, ".f")) {
@@ -322,6 +334,10 @@ namespace LCompilers::CommandLineInterface {
 
         if (opts.disable_implicit_typing) {
             compiler_options.implicit_typing = false;
+        }
+
+        if (disable_implicit_argument_casting) {
+            compiler_options.implicit_argument_casting = false;
         }
 
         if (opts.cpp && opts.no_cpp) {

--- a/tests/reference/run-implicit_argument_casting_01-0d962d9.json
+++ b/tests/reference/run-implicit_argument_casting_01-0d962d9.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-implicit_argument_casting_01-0d962d9",
+    "cmd": "lfortran --implicit-argument-casting --disable-implicit-argument-casting --no-color {infile}",
+    "infile": "tests/../integration_tests/implicit_argument_casting_01.f90",
+    "infile_hash": "3ed389916666e17233ec1aa288c9e7cfee00c97aacc83db1aeec5c7b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-implicit_argument_casting_01-0d962d9.stderr",
+    "stderr_hash": "79cbdb3deeefc4c8dea93fb4b13541c2b274bce36ad244f5530895b1",
+    "returncode": 1
+}

--- a/tests/reference/run-implicit_argument_casting_01-0d962d9.stderr
+++ b/tests/reference/run-implicit_argument_casting_01-0d962d9.stderr
@@ -1,0 +1,1 @@
+Cannot use --disable-implicit-argument-casting and --implicit-argument-casting at the same time

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4035,6 +4035,7 @@ asr = true
 [[test]]
 filename = "../integration_tests/implicit_argument_casting_01.f90"
 asr_implicit_argument_casting = true
+enable_disable_implicit_argument_casting = true
 
 [[test]]
 filename = "../integration_tests/valid_array_assignment_same_length_different_start.f90"


### PR DESCRIPTION
Towards: https://github.com/lfortran/lfortran/issues/7937