### PR TITLE
Solved the error of Implied loop array print

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4655,7 +4655,8 @@ public:
 
             tmp = ASR::make_Print_t(al, x.base.base.loc, string_format);
         } else if (!fmt && body.size() == 1
-                        && ASR::is_a<ASR::String_t>(*ASRUtils::expr_type(body[0]))) {
+                        && ASR::is_a<ASR::String_t>(*ASRUtils::expr_type(body[0]))
+                        && !ASR::is_a<ASR::ImpliedDoLoop_t>(*body[0])) {
             tmp = ASR::make_Print_t(al, x.base.base.loc, body[0]);
         } else {
             ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc,

--- a/tests/implied_do_loop2.f90
+++ b/tests/implied_do_loop2.f90
@@ -1,0 +1,6 @@
+program implied_do_loop2
+  implicit none
+  character(len=5) :: s = "Hello"
+  integer :: i
+  print *, (s, i = 1, 3)
+end program implied_do_loop2

--- a/tests/reference/run-implied_do_loop2-a8638e0.json
+++ b/tests/reference/run-implied_do_loop2-a8638e0.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-implied_do_loop2-a8638e0",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/implied_do_loop2.f90",
+    "infile_hash": "9f1322fbfc43cf221a57e13012a98248cd6c507ae07b15388d5958d1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "run-implied_do_loop2-a8638e0.stdout",
+    "stdout_hash": "56f680f2dc3802df62021dbd4fc18a2470cd6737c1f726578670814c",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/run-implied_do_loop2-a8638e0.stdout
+++ b/tests/reference/run-implied_do_loop2-a8638e0.stdout
@@ -1,0 +1,1 @@
+Hello    Hello    Hello

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4779,3 +4779,7 @@ llvm_new_classes = true
 [[test]]
 filename = "classes2.f90"
 llvm_new_classes = true
+
+[[test]]
+filename = "implied_do_loop2.f90"
+run = true


### PR DESCRIPTION
```
program test_char
  implicit none
  character(len=5) :: s = "Hello"
  integer :: i
  print *, (s, i = 1, 3)
end program test_char
```
Initial Output :
```
Hello
```

New Output:
```
Hello    Hello    Hello
```
I have added this case as test case too.
This error was only visible for arrays created due to implied loop for strings.