### PR TITLE
fix: throw errors for rank mismatch in subroutine calls

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4525,6 +4525,26 @@ public:
                 if (ASR::is_a<ASR::Variable_t>(*var->m_v)) {
                     ASR::Variable_t* v = ASRUtils::EXPR2VAR(f->m_args[i + offset]);
 
+                    ASR::ttype_t* func_arg_type = ASRUtils::expr_type(f->m_args[i + offset]);
+                    if (ASR::is_a<ASR::Array_t>(*func_arg_type)) {
+                        ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(func_arg_type);
+                        int n_dims = arr->n_dims;
+                        visit_expr(*x.m_args[i].m_end);
+                        ASR::expr_t* call_arg = ASRUtils::EXPR(tmp);
+                        ASR::ttype_t* call_arg_type = ASRUtils::expr_type(call_arg);
+                        if (call_arg && ASR::is_a<ASR::Array_t>(*call_arg_type)) {
+                            int call_arg_n_dims = ASRUtils::extract_n_dims_from_ttype(call_arg_type);
+                            if (n_dims != call_arg_n_dims) {
+                                diag.add(diag::Diagnostic(
+                                    "Rank of array argument '" + std::string(v->m_name) +
+                                    "' mismatches in subroutine call",
+                                    diag::Level::Error, diag::Stage::Semantic, {
+                                        diag::Label("", {call_arg->base.loc}),
+                                    }));
+                                throw SemanticAbort();
+                            }
+                        }
+                    }
                     if (v->m_presence != ASR::presenceType::Optional) {
                         if (i >= args.size()) {
                             if (args.empty()) {


### PR DESCRIPTION
Towards #8319