### PR TITLE
Add LFortran specific test (`_lfortran_str`)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2664,3 +2664,7 @@ RUN(NAME union_test_03 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
 
 # LFortran extensions (unsigned int)
 RUN(NAME test_unsigned LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 
+
+# LFortran extenstion (Python's str)
+
+RUN(NAME test_str LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran 

--- a/integration_tests/test_str.f90
+++ b/integration_tests/test_str.f90
@@ -1,0 +1,48 @@
+! Testing Python's str casting
+! -- Example --
+! i = 10
+! s = "Hi"
+! s = str(i) # Equivalent in LFortran is `lfortran_str()`
+
+program test_str
+    character(30) :: str
+    integer :: i
+    real  :: r
+
+    i = 11
+    str =  "HI"//_lfortran_str(9) // _lfortran_str(i)
+    print *, str, "|"
+    if(trim(str) /= "HI911") error stop
+  ! --------------------------------------------------------------------------- !
+    
+    r = 2.3
+    str =  trim(str) // "World" //_lfortran_str(r) // "--"// _lfortran_str(22.5) 
+    print *, str,"|"
+    if(trim(str) /= "HI911World2.300000--22.500000") error stop
+    
+    ! --------------------------------------------------------------------------- !
+    
+    call test(_lfortran_str(112233) ,"112233")
+    call test(_lfortran_str(i) ,"11")
+    
+    
+    ! --------------------------------------------------------------------------- !
+    ! --------------------------------------------------------------------------- !
+    ! --------------------------------------------------------------------------- !
+
+    CONTAINS
+    
+    subroutine test (str_from_cast, test_against_str)
+        character(*) :: str_from_cast
+        character(*) :: test_against_str
+
+        print *, len(str_from_cast)
+        print *, str_from_cast
+
+        print *, len(test_against_str)
+        print *, test_against_str
+
+        if(str_from_cast /= test_against_str) error stop
+    end subroutine
+  
+  end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8388,6 +8388,80 @@ public:
                                                                          type_vec.p, type_vec.n)));
     }
 
+    ASR::asr_t* create_CastToStr(const AST::FuncCallOrArray_t& x){
+        if(x.n_keywords > 0 || x.n_args != 1) throw LCompilersException("Unexpected arguments");
+
+        /* Visit Argument */
+        ASR::expr_t* argument {};
+        {
+            AST::BaseVisitor<Derived>::visit_expr(*(x.m_args[0].m_end));
+            argument = ASRUtils::EXPR(tmp);
+            tmp = nullptr;
+        }
+
+        /* Set `cast_kind` + `compile_time_value` (If Exist) */
+        int cast_kind = INT32_MAX;
+        std::string compile_time_value {};
+
+        switch (ASRUtils::expr_type(argument)->type)
+        {
+            case ASR::Integer:
+                cast_kind = ASR::cast_kindType::IntegerToString;
+                if(ASRUtils::is_value_constant(argument)){ // Set value
+                    int64_t i_val {};
+                    ASRUtils::extract_value_(ASRUtils::expr_value(argument), i_val);
+                    compile_time_value = std::to_string(i_val);
+                }
+            break;
+            case ASR::Real:
+                cast_kind = ASR::cast_kindType::RealToString;
+                if(ASRUtils::is_value_constant(argument)){ // Set value
+                    double d_val {};
+                    ASRUtils::extract_value_(ASRUtils::expr_value(argument), d_val);
+                    compile_time_value = std::to_string(d_val);
+                }
+            break;
+            default:
+                throw LCompilersException("Unhandled case");
+            break;
+        }
+
+        /* Set Value Expression + Set string type */
+        ASR::expr_t*  value    {};
+        ASR::ttype_t* str_type {};
+
+        if(!compile_time_value.empty()){
+            ASRUtils::ASRBuilder b(al, x.base.base.loc);
+
+            Str c_style_string;
+            c_style_string.from_str_view(compile_time_value);
+            value = b.StringConstant(
+                c_style_string.c_str(al),
+                b.String(
+                    b.i64(compile_time_value.size()),
+                    ASR::ExpressionLength));
+
+            str_type = b.String(
+                b.i64(compile_time_value.size()),
+                ASR::ExpressionLength);
+        } else {
+            value = nullptr;
+
+            str_type = 
+                ASRUtils::ASRBuilder(al, x.base.base.loc)
+                    .String(nullptr, ASR::DeferredLength);
+        }
+
+        /* Create Cast + Return it */
+        return ASR::make_Cast_t(
+            al, x.base.base.loc,
+            argument,
+            (ASR::cast_kindType)cast_kind, 
+            str_type,
+            value);
+    }
+    
+
     ASR::asr_t* create_BitCast(const AST::FuncCallOrArray_t& x) {
         Vec<ASR::expr_t*> args;
         std::vector<std::string> kwarg_names = {"source", "mold", "size"};
@@ -9195,6 +9269,9 @@ public:
                     tmp = create_DictConstant(x);
                 else if ( var_name == "_lfortran_tuple_constant")
                     tmp = create_TupleConstant(x);
+                else if (var_name == "_lfortran_str"){
+                    tmp = create_CastToStr(x);
+                }
             } else {
                 throw LCompilersException("create_" + var_name + " not implemented yet.");
             }

--- a/src/lfortran/semantics/comptime_eval.h
+++ b/src/lfortran/semantics/comptime_eval.h
@@ -35,7 +35,7 @@ struct IntrinsicProceduresAsASRNodes {
                 "_lfortran_list_constant", "_lfortran_list_count",
                 "_lfortran_set_constant",
                 "_lfortran_dict_constant",
-                "_lfortran_tuple_constant"};
+                "_lfortran_tuple_constant", "_lfortran_str"};
 
             kind_based_intrinsics = {};
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9605,44 +9605,91 @@ public:
                 break;
              }
             case (ASR::cast_kindType::RealToString) : {
-                llvm::Value *arg = tmp;
-                ASR::ttype_t* arg_type = extract_ttype_t_from_expr(x.m_arg);
-                LCOMPILERS_ASSERT(arg_type != nullptr)
-                int arg_kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
-                tmp = lfortran_type_to_str(arg, llvm_utils->getFPType(arg_kind), "float", arg_kind);
+                /* Call Runtime Function `lfortran_float_to_str` */
+                llvm::Value* casted_float {}; // float -> string
+                { 
+                    llvm::Value *arg = tmp;
+                    ASR::ttype_t* arg_type = extract_ttype_t_from_expr(x.m_arg);
+                    LCOMPILERS_ASSERT(arg_type != nullptr)
+                    int arg_kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
+                    if (arg->getType()->isPointerTy()) {arg = llvm_utils->CreateLoad2(llvm_utils->getFPType(arg_kind), arg);}
+
+                    casted_float = lfortran_type_to_str(arg, llvm_utils->getFPType(arg_kind), "float", arg_kind); // Returns i8*
+                }
+
+
+                /* Create A String To Hold The Runtime Function Return */
+                llvm::Value* str {};
+                {
+                    str = llvm_utils->create_string(ASRUtils::get_string_type(x.m_type), "FloatToStringCast");
+                    setup_string(str, x.m_type);
+                    /*
+                        Now we have an already set string matching `x.m_type`
+                        (allocatable-deferred-len OR Expression-len OR allocatable-nondeferred-len)
+                    */ 
+                }
+
+                /* Copy Runtime Function Return Into Our Created String*/
+                {
+                    llvm::Value *lhs_data, *lhs_len;
+                    llvm::Value *rhs_data, *rhs_len;
+                    std::tie(lhs_data, lhs_len) = llvm_utils->get_string_length_data(ASRUtils::get_string_type(x.m_type), str, true, true);
+                    rhs_data = casted_float;
+                    rhs_len = lfortran_str_len(casted_float);
+                    llvm_utils->lfortran_str_copy_with_data(lhs_data, lhs_len, rhs_data, rhs_len, true, true);
+                }
+                
+                /* Free Runtime Function Return */
+                {
+                    builder->CreateCall(llvm_utils->_Deallocate(), {casted_float});
+                    casted_float = nullptr;
+                }
+
+                tmp = str;
                 break;
             }
             case (ASR::cast_kindType::IntegerToString) : {
-                llvm::Value *arg = tmp;
-                ASR::ttype_t* arg_type = extract_ttype_t_from_expr(x.m_arg);
-                LCOMPILERS_ASSERT(arg_type != nullptr)
-                int arg_kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
+                /* Call Runtime Function `lfortran_int_to_str` */
+                llvm::Value* casted_int {};
+                { 
+                    llvm::Value *arg = tmp;
+                    ASR::ttype_t* arg_type = extract_ttype_t_from_expr(x.m_arg);
+                    LCOMPILERS_ASSERT(arg_type != nullptr)
+                    int arg_kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
+                    if (arg->getType()->isPointerTy()) {arg = llvm_utils->CreateLoad2(llvm_utils->getIntType(arg_kind), arg);}
 
-                if (arg->getType()->isPointerTy())
-                    arg = llvm_utils->CreateLoad2(llvm_utils->getIntType(arg_kind), arg);
+                    casted_int = lfortran_type_to_str(arg, llvm_utils->getIntType(arg_kind), "int", arg_kind); // Returns i8*
+                }
 
-                tmp = lfortran_type_to_str(arg, llvm_utils->getIntType(arg_kind), "int", arg_kind); // Returns i8*
 
-                if (ASRUtils::is_allocatable_descriptor_string(x.m_type)) {
-                    llvm::Value* temp_str = builder->CreateAlloca(string_descriptor);
-                    llvm_utils->set_string_memory_on_heap(
-                        ASR::string_physical_typeType::DescriptorString,
-                        temp_str, lfortran_str_len(tmp)
-                    );
+                /* Create A String To Hold The Runtime Function Return */
+                llvm::Value* str {};
+                {
+                    str = llvm_utils->create_string(ASRUtils::get_string_type(x.m_type), "IntegerToStringCast");
+                    setup_string(str, x.m_type);
+                    /*
+                        Now we have an already set string matching `x.m_type`
+                        (allocatable-deferred-len OR Expression-len OR allocatable-nondeferred-len)
+                    */ 
+                }
 
+                /* Copy Runtime Function Return Into Our Created String*/
+                {
                     llvm::Value *lhs_data, *lhs_len;
                     llvm::Value *rhs_data, *rhs_len;
-                    std::tie(lhs_data, lhs_len) = llvm_utils->get_string_length_data(
-                                                    ASR::down_cast<ASR::String_t>(ASRUtils::TYPE(ASR::make_String_t(
-                                                        al, x.base.base.loc, 1, nullptr,
-                                                        ASR::string_length_kindType::DeferredLength,
-                                                        ASR::string_physical_typeType::DescriptorString))),
-                                                    temp_str, true, true);
-                    rhs_data = tmp;
-                    rhs_len = lfortran_str_len(tmp);
+                    std::tie(lhs_data, lhs_len) = llvm_utils->get_string_length_data(ASRUtils::get_string_type(x.m_type), str, true, true);
+                    rhs_data = casted_int;
+                    rhs_len = lfortran_str_len(casted_int);
                     llvm_utils->lfortran_str_copy_with_data(lhs_data, lhs_len, rhs_data, rhs_len, true, true);
-                    tmp = temp_str;
                 }
+                
+                /* Free Runtime Function Return */
+                {
+                    builder->CreateCall(llvm_utils->_Deallocate(), {casted_int});
+                    casted_int = nullptr;
+                }
+
+                tmp = str;
                 break;
             }
             case (ASR::cast_kindType::LogicalToString) : {


### PR DESCRIPTION
- Registered `_lfortran_str` as an LFortran specific function, To avoid treating it as wrong functionCall
- visiting `FuncCallOrArray` of `_lfortran_str` results in `ASR::Cast` node
- Refactored LLVM implementation of the `IntegerToString` cast + `RealToString` cast (Created our string representation and copied the runtime-function-call return into it + freed the return)


closes #8439

