### PR TITLE
Verify number of elements on LHS and RHS of Data Statements

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -115,7 +115,7 @@ program continue_compilation_1
       integer :: elements(n)
     end type
     type(bspline_3d) :: s3_in_program
-    
+    integer :: j2, i2, k2(2), x2(2), y2(3)    
 
 
 
@@ -342,4 +342,7 @@ program continue_compilation_1
     arr = [type(MyClass) :: v1, v2, v3]
 
     arr = [NonExistingType :: v1, v2, v3]
+
+    !Data Statements with different number of arguments on LHS and RHS
+    data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,3*8 /
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "7ead5d6a8359aac47a70f16b554980ef09869ad83fe5ef73ab85c73f",
+    "infile_hash": "34749eca2a3f0cfcc498ab683b3ad9020d2356bd1b85aa4449ce1d3c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "f82f35cb4623bd17d36033c5e81a070a68ae8aae412eb7a96df791a0",
+    "stderr_hash": "d546f61678545183a562a5e31608c67fbafb86351dcdc3da55fe4e45",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -798,3 +798,9 @@ semantic error: Class type `NonExistingType` is not defined
     |
 344 |     arr = [NonExistingType :: v1, v2, v3]
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: DATA statement element count mismatch: 8 elements on left-hand side, 10 values on right-hand side
+   --> tests/errors/continue_compilation_1.f90:347:5
+    |
+347 |     data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,3*8 /
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
Fixes #8499 

MRE::
```
program test_data
    implicit none
    integer :: j2, i2, k2(2), x2(2), y2(3)
    data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,2*8 /
    print *, j2, x2, y2, k2
end program
```

Main::
```
$ lfortran a.f90
1    1    2    4    5    6    1    2
```

Updated main::
```
$ lfortran a.f90
semantic error: DATA statement element count mismatch: 8 elements on left-hand side, 9 values on right-hand side
 --> a.f90:5:5
  |
5 |     data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,2*8 /
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

Gfortran::
```
$ gfortran a.f90
a.f90:5:8:

    5 |     data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,2*8 /
      |        1
Error: DATA statement at (1) has more values than variables
```
