### PR TITLE
semantics: reject non-variable actuals for INTENT(OUT/INOUT) dummies (fixes #4611)

### DIFF
--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -13,17 +13,17 @@ module continue_compilation_3_mod
 
 
 
+contains
 
+    subroutine intent_out_test(x)
+        integer, intent(out) :: x
+        x = 42
+    end subroutine intent_out_test
 
-
-
-
-
-
-
-
-
-
+    subroutine intent_inout_test(y)
+        integer, intent(inout) :: y
+        y = y + 1
+    end subroutine intent_inout_test
 
 
 
@@ -65,10 +65,10 @@ program continue_compilation_3
     integer :: merge_i = 4, merge_j = 5
     integer(8) :: merge_k = 8
 
-
-
-
-
+    call intent_out_test(1)  ! Error: literal constant with intent(out)
+    call intent_out_test(x + 1)  ! Error: expression with intent(out)
+    call intent_inout_test(2)  ! Error: literal constant with intent(inout)
+    call intent_inout_test(x * 2)  ! Error: expression with intent(inout)
 
 
 

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "d0ec11ede4ae76dc218b3ae43ed0843dd9986d28a53dc9adb318e3d7",
+    "infile_hash": "44e6f7ccca3d078d118c1ef1c03096675ad7edbe4b7049b66482df8a",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "19d4ec68447994072df3fe5de5a9e3f150852c80dbbf3d88160b6a2a",
+    "stderr_hash": "1265fb63634e76f34eeb4fef17f056f70bc64a0cf66d2b9426ef4fa7",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -22,6 +22,30 @@ semantic error: Module 'continue_compilation_3_fake_module' modfile was not foun
 48 |     use continue_compilation_3_fake_module
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
+semantic error: Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
+  --> tests/errors/continue_compilation_3.f90:68:26
+   |
+68 |     call intent_out_test(1)  ! Error: literal constant with intent(out)
+   |                          ^ 
+
+semantic error: Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
+  --> tests/errors/continue_compilation_3.f90:69:26
+   |
+69 |     call intent_out_test(x + 1)  ! Error: expression with intent(out)
+   |                          ^^^^^ 
+
+semantic error: Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
+  --> tests/errors/continue_compilation_3.f90:70:28
+   |
+70 |     call intent_inout_test(2)  ! Error: literal constant with intent(inout)
+   |                            ^ 
+
+semantic error: Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
+  --> tests/errors/continue_compilation_3.f90:71:28
+   |
+71 |     call intent_inout_test(x * 2)  ! Error: expression with intent(inout)
+   |                            ^^^^^ 
+
 semantic error: Empty array constructor is not allowed
   --> tests/errors/continue_compilation_3.f90:91:9
    |


### PR DESCRIPTION
Reject non-variable actuals for `INTENT(OUT/INOUT)` dummy arguments.

Semantics
- Use `ASRUtils::is_variable()` to allow assignable entities only.

Test
- `integration_tests/intent_out_nonvariable_01.f90` marked FAIL to ensure compile-time rejection.