### PR TITLE
Enh : Use `transfer` (`ASR::bitcast`) instead of `ASR::StringChr`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2422,6 +2422,7 @@ RUN(NAME transfer_02 LABELS gfortran llvm)
 RUN(NAME transfer_03 LABELS gfortran llvm)
 RUN(NAME transfer_04 LABELS gfortran llvm)
 RUN(NAME transfer_05 LABELS gfortran llvm)
+RUN(NAME transfer_06 LABELS gfortran llvm)
 
 RUN(NAME present_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME present_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/transfer_06.f90
+++ b/integration_tests/transfer_06.f90
@@ -1,0 +1,13 @@
+program transfer_06
+    integer :: i
+    character(1) :: res
+    i = 321
+    res = transfer(i, res)
+    print *, res
+    if(res /= 'A') error stop
+    ! -------------------------------------------- !
+    i = 65
+    res = transfer(i, res)
+    print *, res
+    if(res /= 'A') error stop
+end program

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -480,6 +480,10 @@ class ASRBuilder {
         return EXPR(ASR::make_IntegerBinOp_t(al, loc, n, ASR::binopType::LBitRShift, bits, t, nullptr));
     }
 
+    ASR::expr_t* BitCast(ASR::expr_t* src, ASR::expr_t* mold /*Dest*/, ASR::expr_t* size = nullptr){
+        return EXPR(ASR::make_BitCast_t(al, loc, src, mold, size, ASRUtils::duplicate_type(al, expr_type(mold)), nullptr));
+    }
+
     ASR::expr_t *And(ASR::expr_t *left, ASR::expr_t *right) {
         LCOMPILERS_ASSERT(check_equal_type(expr_type(left), expr_type(right), left, right));
         ASR::ttype_t *type = type_get_past_allocatable_pointer(expr_type(left));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9570,10 +9570,34 @@ public:
             source_ptr = llvm_utils->CreateAlloca(source_type, nullptr, "bitcast_source");
             builder->CreateStore(source, source_ptr);
         }
+
+        /* Handle The Return Of The Expression (String, Array, Integer_8, etc.) */
+        switch(ASRUtils::type_get_past_allocatable_pointer(expr_type(x.m_mold))->type){
+            case(ASR::String) : {
+                llvm::Value* str;
+                { // Create String Based On PhysicalType + Setup
+                    str = llvm_utils->create_string(ASRUtils::get_string_type(x.m_mold), "bit_cast_expr_return");
+                    setup_string(str, ASRUtils::expr_type(x.m_mold));
+                }
+
+                { // Cast Ptr + Store In String
+                    llvm::Value* casted_to_i8 /* i8* */  = builder->CreateBitCast(source_ptr, llvm::Type::getInt8Ty(context)->getPointerTo());
+                    llvm::Value* str_data_ptr /* i8** */ = llvm_utils->get_string_data(ASRUtils::get_string_type(x.m_mold), str, true);
+                    builder->CreateStore(casted_to_i8, str_data_ptr); // Observe that we didn't allocate memory, We used the casted ptr.
+                }
+
+                tmp = str;
+            break;
+            } default : {
+                // Do nothing for now.
+            }
+        }
+
+
         llvm::Type* target_base_type = llvm_utils->get_type_from_ttype_t_util(const_cast<ASR::expr_t*>(&x.base), ASRUtils::type_get_past_array(x.m_type), module.get());
         llvm::Type* target_llvm_type = target_base_type->getPointerTo();
         if ( !ASRUtils::types_equal(ASRUtils::extract_type(ASRUtils::expr_type(x.m_source)), ASRUtils::extract_type(x.m_type),
-             x.m_source, const_cast<ASR::expr_t*>(&x.base), false) &&
+             x.m_source, const_cast<ASR::expr_t*>(&x.base), false) && !ASRUtils::is_string_only(expr_type(x.m_mold)) &&
                 !( ASR::is_a<ASR::String_t>(*ASRUtils::extract_type(ASRUtils::expr_type(x.m_source))) && ASRUtils::is_integer(*ASRUtils::extract_type(x.m_type)) &&
                 ASR::down_cast<ASR::Integer_t>(ASRUtils::extract_type(x.m_type))->m_kind == 1 ) /*Workaround (Refer to : `transfer_05`, `array_06_transfer`), scalar mold shold have scalar LHS*/ ) {
             tmp = llvm_utils->CreateLoad2(target_base_type, builder->CreateBitCast(source_ptr, target_llvm_type));


### PR DESCRIPTION
Enhance : As part of issue #8340

- Use `transfer` in the implementation of `intrinsicElementalFunction::Char` + `intrinsicElementalFunction::AChar`
- The usage of `transfer` replaces a call to C-runtime-library function `_lfortran_str_chr()` which used to allocate memory at runtime that had no owner (we weren't able to move ownership also).
- This change removes the overhead of figuring out who is the owner of the C-runtime function return.
- Now this makes the `_lcompiler_char_###()` function created by the `intrinic_function` pass the owner of the return character, which will further be enhanced by `subroutine_from_function` pass to make the caller the owner of the string.

- Changes has been done to `bitcast` visitor for LLVM backend, to support trasnfering integer type into string type.