### PR TITLE
fix:: Array Assignments inside data statements

### DIFF
--- a/integration_tests/data_10.f90
+++ b/integration_tests/data_10.f90
@@ -1,5 +1,5 @@
 program data_10
-    integer :: i, j, x(5), y(5)
+    integer :: a, i, j, x(5), y(5), z(5)
     real :: k, l
     data x, j / 1, 2, 3, 4, 5, 3 /
     print *, x, j
@@ -17,4 +17,12 @@ program data_10
     if (y(4) /= 4) error stop
     if (y(5) /= 5) error stop
     if (abs(k - 10.0) > 1e-8) error stop
+    data a, z / 1, 2, 3,4, 2*5 /
+    print *, a, z
+    if (a /= 1) error stop
+    if (z(1) /= 2) error stop
+    if (z(2) /= 3) error stop
+    if (z(3) /= 4) error stop
+    if (z(4) /= 5) error stop
+    if (z(5) /= 5) error stop
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2369,8 +2369,9 @@ public:
             if (size_of_array == -1) {
                 throw LCompilersException("ICE: Array size could not be computed");
             }
+            int tmp_curr_value = (int) curr_value;
             curr_value += size_of_array;
-            for (int j=0; j < size_of_array; j++) {
+            for (int j= tmp_curr_value; j < (int) curr_value; j++) {
                 // Get the Type of Object
                 // If object is Real, set current_variable_type to Real
                 // This type flag is passed to Visit_BOZ, 


### PR DESCRIPTION
Fixes #8539 

Added Test-Cases:
```
program test_data
    implicit none
    integer :: a, z(5)
    data a, z / 1, 2, 3,4, 2*5 /
    print *, a,z
end program
```

Main:
```
$ lfortran a.f90
1    1    2    3    4    5
```

Updated Main:
```
$ lfortran a.f90
1    2    3    4    5    5
```

Gfortran:
```
$ gfortran a.f90 & ./a.out 
[1]+  Done                    gfortran a.f90
[1] 81896
           1           2           3           4           5           5
```