### PR TITLE
Fix: BOZ to Real Conversions inside real() Function

### DIFF
--- a/integration_tests/boz_01.f90
+++ b/integration_tests/boz_01.f90
@@ -2,6 +2,7 @@ program boz_01
 implicit none
 
 integer :: boz_1, boz_2, boz_3, boz_4, boz_5
+real:: boz_6
 
 boz_1 = int(b'01011101')
 boz_2 = int(o'2347')
@@ -9,6 +10,8 @@ boz_3 = int(z'ABC')
 !Testing Truncation of BOZ
 boz_4 = int(Z'234567890abcdef1')
 boz_5 = int(Z'2234567890abcdef1')
+!Checking Real Conversion of BOZ
+boz_6 = real(b'01101')
 !Check with Integer Equivalent Values
 if (boz_4 /= boz_5) error stop
 if (boz_1 /= 93) error stop
@@ -17,5 +20,5 @@ if (boz_3 /= 2748) error stop
 if (boz_4 /= 180150001) error stop
 if (boz_5 /= 180150001) error stop 
 
-print *, boz_1, boz_2, boz_3, boz_4, boz_5
+print *, boz_1, boz_2, boz_3, boz_4, boz_5, boz_6
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7282,7 +7282,16 @@ public:
             args.push_back(al, nullptr);
         }
         for( size_t i = 0; i < x.n_args; i++ ) {
+            // Handle BOZ constants in real() function
+            ASR::ttype_t* temp_current_variable_type = current_variable_type_;
+            if (intrinsic_name == "real" && i == 0 && x.m_args[i].m_end && 
+                AST::is_a<AST::BOZ_t>(*x.m_args[i].m_end)) {
+                // Set current_variable_type to Real for BOZ conversion in real() function
+                current_variable_type_ = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 
+                    compiler_options.po.default_integer_kind));
+            }
             this->visit_expr(*x.m_args[i].m_end);
+            current_variable_type_ = temp_current_variable_type;
             args.p[i] = ASRUtils::EXPR(tmp);
             if (intrinsic_name == "and" || intrinsic_name == "or" || intrinsic_name == "xor" || intrinsic_name == "repeat" || intrinsic_name == "selected_int_kind"
             || intrinsic_name == "selected_real_kind" || intrinsic_name == "selected_char_kind") {

--- a/tests/reference/asr-boz_01-dedad59.json
+++ b/tests/reference/asr-boz_01-dedad59.json
@@ -2,12 +2,12 @@
     "basename": "asr-boz_01-dedad59",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/boz_01.f90",
-    "infile_hash": "c39ee395eba975ffba7c003260ba1b67393a5b06bb519c9e3a5f2442",
+    "infile_hash": "58477e3f0fbdc7b41b5892cc6f876abfc5b434abe4884789d60b2d68",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-boz_01-dedad59.stdout",
-    "stdout_hash": "60b2c8ba3b98d1fb44ba5d85d49963f87c99d3de03a38d8caddaac81",
+    "stdout_hash": "88923b847d962198443a6173044007d04ffa59ec2b9291c532835c49",
     "stderr": "asr-boz_01-dedad59.stderr",
-    "stderr_hash": "e47b37976e07fa74de67cbf8929d0974adaba30e067be31729bb6426",
+    "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0
 }

--- a/tests/reference/asr-boz_01-dedad59.stderr
+++ b/tests/reference/asr-boz_01-dedad59.stderr
@@ -1,5 +1,5 @@
 warning: BOZ literal constant with 'Z' prefix truncated to maximum 16 characters from left to fit data type
-  --> tests/../integration_tests/boz_01.f90:11:13
+  --> tests/../integration_tests/boz_01.f90:12:13
    |
-11 | boz_5 = int(Z'2234567890abcdef1')
+12 | boz_5 = int(Z'2234567890abcdef1')
    |             ^^^^^^^^^^^^^^^^^^^^ BOZ truncation

--- a/tests/reference/asr-boz_01-dedad59.stdout
+++ b/tests/reference/asr-boz_01-dedad59.stdout
@@ -111,6 +111,27 @@
                                     ()
                                     .false.
                                     .false.
+                                ),
+                            boz_6:
+                                (Variable
+                                    2
+                                    boz_6
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
                                 )
                         })
                     boz_01
@@ -171,6 +192,24 @@
                             0
                             (Integer 4)
                             (IntegerConstant 2541551403008843505 (Integer 4) Decimal)
+                        )
+                        ()
+                        .false.
+                    )
+                    (Assignment
+                        (Var 2 boz_6)
+                        (IntrinsicElementalFunction
+                            Real
+                            [(RealConstant
+                                0.000000
+                                (Real 4)
+                            )]
+                            0
+                            (Real 4)
+                            (RealConstant
+                                0.000000
+                                (Real 4)
+                            )
                         )
                         ()
                         .false.
@@ -266,7 +305,8 @@
                             (Var 2 boz_2)
                             (Var 2 boz_3)
                             (Var 2 boz_4)
-                            (Var 2 boz_5)]
+                            (Var 2 boz_5)
+                            (Var 2 boz_6)]
                             FormatFortran
                             (Allocatable
                                 (String 1 () DeferredLength DescriptorString)

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -2,12 +2,12 @@
     "basename": "llvm-boz_01-def9db5",
     "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
     "infile": "tests/../integration_tests/boz_01.f90",
-    "infile_hash": "c39ee395eba975ffba7c003260ba1b67393a5b06bb519c9e3a5f2442",
+    "infile_hash": "58477e3f0fbdc7b41b5892cc6f876abfc5b434abe4884789d60b2d68",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "d866fea5536ff17ee199358695b41161815b50b45afa779b5af16eef",
+    "stdout_hash": "dfb999750ff5454097513f780b4a8cf4f0778e225d5f12b0291a707f",
     "stderr": "llvm-boz_01-def9db5.stderr",
-    "stderr_hash": "e47b37976e07fa74de67cbf8929d0974adaba30e067be31729bb6426",
+    "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0
 }

--- a/tests/reference/llvm-boz_01-def9db5.stderr
+++ b/tests/reference/llvm-boz_01-def9db5.stderr
@@ -1,5 +1,5 @@
 warning: BOZ literal constant with 'Z' prefix truncated to maximum 16 characters from left to fit data type
-  --> tests/../integration_tests/boz_01.f90:11:13
+  --> tests/../integration_tests/boz_01.f90:12:13
    |
-11 | boz_5 = int(Z'2234567890abcdef1')
+12 | boz_5 = int(Z'2234567890abcdef1')
    |             ^^^^^^^^^^^^^^^^^^^^ BOZ truncation

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -17,7 +17,7 @@ source_filename = "LFortran"
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [15 x i8] c"I4,I4,I4,I4,I4\00", align 1
+@serialization_info = private unnamed_addr constant [18 x i8] c"I4,I4,I4,I4,I4,R4\00", align 1
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define i32 @main(i32 %0, i8** %1) {
@@ -33,11 +33,13 @@ define i32 @main(i32 %0, i8** %1) {
   %boz_33 = alloca i32, align 4
   %boz_44 = alloca i32, align 4
   %boz_55 = alloca i32, align 4
+  %boz_6 = alloca float, align 4
   store i32 93, i32* %boz_11, align 4
   store i32 1255, i32* %boz_22, align 4
   store i32 2748, i32* %boz_33, align 4
   store i32 180150001, i32* %boz_44, align 4
   store i32 180150001, i32* %boz_55, align 4
+  store float 0x36DA000000000000, float* %boz_6, align 4
   %2 = load i32, i32* %boz_44, align 4
   %3 = load i32, i32* %boz_55, align 4
   %4 = icmp ne i32 %2, %3
@@ -117,7 +119,7 @@ else19:                                           ; preds = %ifcont17
   br label %ifcont20
 
 ifcont20:                                         ; preds = %else19, %then18
-  %15 = call i8* (i8*, i64, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %boz_11, i32* %boz_22, i32* %boz_33, i32* %boz_44, i32* %boz_55)
+  %15 = call i8* (i8*, i64, i8*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i32 0, i32 0, i32* %boz_11, i32* %boz_22, i32* %boz_33, i32* %boz_44, i32* %boz_55, float* %boz_6)
   %16 = call i64 @_lfortran_str_len(i8* %15)
   %17 = call i8* @_lfortran_malloc(i64 16)
   %stringFormat_desc = bitcast i8* %17 to %string_descriptor*


### PR DESCRIPTION
Fixes #8543 , Towards #7839

Added Test Case:
```
program real_boz
implicit none
real::a
a = real(b'01101')
print *,a
end program real_boz
```
Main:
```
$ lfortran a.f90 
1.30000000e+01
```


Updated Main:
```
$ lfortran a.f90 
1.82168800e-44
```

AMD Flang:
```
$ flang a.f90 & ./a.out
[1]+  Done                    flang a.f90
[1] 132926
   1.8216880E-44
```

Gfortran:
```
$ gfortran a.f90 & ./a.out
[1]+  Done                    gfortran a.f90
[1] 132776
   1.82168800E-44
```
