### PR TITLE
fix:: Implied Do Loop Assignments inside Array Initializers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2083,6 +2083,7 @@ RUN(NAME implied_do_loops8 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
 RUN(NAME implied_do_loops9 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME implied_do_loops10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME implied_do_loops11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME implied_do_loops12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES

--- a/integration_tests/implied_do_loops12.f90
+++ b/integration_tests/implied_do_loops12.f90
@@ -1,0 +1,22 @@
+!This file contains tests for implied do loops in array initializers.
+program implied_do_loop12
+    implicit none
+    integer :: k
+    integer, parameter :: MAX_ITEMS = 3
+    ! Derived type
+    type :: derived_t
+        real :: a
+    end type derived_t
+    ! Array of integers initialized via implied-DO
+    integer :: arr1(MAX_ITEMS) = (/ (k, k = 0, MAX_ITEMS-1) /)
+    type(derived_t) :: arr2(MAX_ITEMS) = (/ (derived_t(k), k = 0, MAX_ITEMS-1) /)
+    print *,arr1
+    if(arr1(1) /= 0) error stop
+    if(arr1(2) /= 1) error stop
+    if(arr1(3) /= 2) error stop
+    ! Array of derived_t objects initialized via implied-DO
+    print *, arr2
+    if (abs(arr2(1)%a - 0.0) > 1e-12) error stop
+    if (abs(arr2(2)%a - 1.0) > 1e-12) error stop
+    if (abs(arr2(3)%a - 2.0) > 1e-12) error stop
+end program implied_do_loop12


### PR DESCRIPTION
Fixes #8564 

Added Test-Case:
```
!This file contains tests for implied do loops in array initializers.
program implied_do_loop12
    implicit none
    integer :: k
    integer, parameter :: MAX_ITEMS = 3
    ! Derived type
    type :: derived_t
        real :: a
    end type derived_t
    ! Array of derived_t objects initialized via implied-DO
    type(derived_t) :: arr1(MAX_ITEMS) = (/ (derived_t(k), k = 0, MAX_ITEMS-1) /)
    print *, arr1
    if (abs(arr1(1)%a - 0.0) > 1e-12) error stop
    if (abs(arr1(2)%a - 1.0) > 1e-12) error stop
    if (abs(arr1(3)%a - 2.0) > 1e-12) error stop
end program implied_do_loop12
```

Updated Main:
```
$ lfortran a.f90 
0.00000000e+00    1.00000000e+00    2.00000000e+00
```

Gfortran:
```
$ gfortran a.f90 &./a.out
[1]+  Done                    gfortran a.f90
[1] 177919
   0.00000000       1.00000000       2.00000000    
```