### PR TITLE
fix:: Throw error when using BOZ Literals in Binary Operations

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11034,6 +11034,11 @@ public:
     }
 
     void visit_BinOp(const AST::BinOp_t &x) {
+        if (AST::is_a<AST::BOZ_t>(*x.m_left) || AST::is_a<AST::BOZ_t>(*x.m_right)) {
+            diag.add(Diagnostic("BOZ literal constant cannot be used in binary operations",
+                Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+            throw SemanticAbort();
+        }
         this->visit_expr(*x.m_left);
         ASR::expr_t *left = ASRUtils::EXPR(tmp);
         this->visit_expr(*x.m_right);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -116,7 +116,7 @@ program continue_compilation_1
     end type
     type(bspline_3d) :: s3_in_program
     integer :: j2, i2, k2(2), x2(2), y2(3)    
-
+    integer::tt = b'01' * 3
 
 
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "34749eca2a3f0cfcc498ab683b3ad9020d2356bd1b85aa4449ce1d3c",
+    "infile_hash": "0cb68152ef458747cdd1216d866d2cecb3c86dd01f26e3224d710068",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "d546f61678545183a562a5e31608c67fbafb86351dcdc3da55fe4e45",
+    "stderr_hash": "e0f422b9d53dd54f4aa9adb12c8f1ab5df434724e9a491c091f65032",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -123,6 +123,12 @@ semantic error: Derived type `bspline_3d` is not defined
 117 |     type(bspline_3d) :: s3_in_program
     |     ^^^^^^^^^^^^^^^^ Type used here is not defined in any scope
 
+semantic error: BOZ literal constant cannot be used in binary operations
+   --> tests/errors/continue_compilation_1.f90:119:19
+    |
+119 |     integer::tt = b'01' * 3
+    |                   ^^^^^^^^^ 
+
 semantic error: Assignment to loop variable `i` is not allowed
    --> tests/errors/continue_compilation_1.f90:136:8
     |


### PR DESCRIPTION
fixes #6764  & towards #7839

Added Test-Case:
```
program real_boz
    implicit none
    integer::a = b'01' * 3
end program
```

Gfortran:
```
$ gfortran a.f90
a.f90:3:16:

    3 |     integer::a = b'01' * 3
      |                1
Error: Operands of binary numeric operator ‘*’ at (1) are BOZ/INTEGER(4)
```

Updated main:
```
$ lfortran a.f90 
semantic error: BOZ literal constant cannot be used in binary operations
 --> a.f90:3:18
  |
3 |     integer::a = b'01' * 3
  |                  ^^^^^^^^^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```