### PR TITLE
Fix test creating file outside project

### DIFF
--- a/tests/errors/floatStringInput.f90
+++ b/tests/errors/floatStringInput.f90
@@ -1,7 +1,7 @@
 program realStringInput
     implicit none
     real :: x
-    open(unit=10, file="../invalidInput_float.txt", status="unknown")
+    open(unit=10, file="tests/invalidInput_float.txt", status="unknown")
 
     do
         read(10, *, end=100) x

--- a/tests/errors/integerStringInput.f90
+++ b/tests/errors/integerStringInput.f90
@@ -1,7 +1,7 @@
 program integerStringInput
     implicit none
     integer :: x
-    open(unit=10, file="../invalidInput_integer.txt", status="unknown")
+    open(unit=10, file="tests/invalidInput_integer.txt", status="unknown")
 
     do
         read(10, *, end=100) x

--- a/tests/errors/integerStringInput_64.f90
+++ b/tests/errors/integerStringInput_64.f90
@@ -4,7 +4,7 @@ program integerStringInput_int64
     integer(int64) :: x                   ! Declare x as int64 explicitly
     integer :: ios
 
-    open(unit=10, file="../invalidInput_integer.txt", status="unknown")
+    open(unit=10, file="tests/invalidInput_integer.txt", status="unknown")
 
     do
         read(10, *, iostat=ios) x
@@ -14,5 +14,5 @@ program integerStringInput_int64
         print *, "Read int64 integer:", x
     end do
 
-    close(10)   
+    close(10)
 end program integerStringInput_int64

--- a/tests/reference/run-floatStringInput-95c963d.json
+++ b/tests/reference/run-floatStringInput-95c963d.json
@@ -2,7 +2,7 @@
     "basename": "run-floatStringInput-95c963d",
     "cmd": "lfortran --no-color {infile}",
     "infile": "tests/errors/floatStringInput.f90",
-    "infile_hash": "9dcbe836ab20980bd2f2d232dbedafc871b164b5f471c752d1e7a095",
+    "infile_hash": "4db92554a429fc93f7f3eb205946ec7b7539f4f4b3cf7674cb9e3434",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,

--- a/tests/reference/run-integerStringInput-16e7ff7.json
+++ b/tests/reference/run-integerStringInput-16e7ff7.json
@@ -2,7 +2,7 @@
     "basename": "run-integerStringInput-16e7ff7",
     "cmd": "lfortran --no-color {infile}",
     "infile": "tests/errors/integerStringInput.f90",
-    "infile_hash": "72f58eb9906156b68b83d4217da4e5b483e63a05b15d1d7ae23580a9",
+    "infile_hash": "04a4574d2a233b18a7a450ff6c9e574741495c363d9f3f355e8fcb6c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,

--- a/tests/reference/run-integerStringInput_64-3a7e5be.json
+++ b/tests/reference/run-integerStringInput_64-3a7e5be.json
@@ -2,7 +2,7 @@
     "basename": "run-integerStringInput_64-3a7e5be",
     "cmd": "lfortran --no-color {infile}",
     "infile": "tests/errors/integerStringInput_64.f90",
-    "infile_hash": "f40dcc9865accd82e719a7aa29f74d7fbd112f142462f194a19dfe5d",
+    "infile_hash": "dbf922c18493b34bb68224d6ff4c636025b8da211276c2fceb6c33c4",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,


### PR DESCRIPTION
The current test creates files in the parent directory of the lfortran project, i.e., outside the project directory. This behavior is undesirable. This PR updates the input file reference to ensure files are created/referenced from within the project directory. Reference tests have been updated.

Test Plan
- Verified by running ./run_tests.py successfully.
- Confirmed that no stray files are generated in the parent directory of the lfortran project.