### PR TITLE
chore: create struct API for Struct Type Utilities

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1890,7 +1890,7 @@ public:
             llvm::Value* item = tmp;
             llvm::Value* pos = llvm::ConstantInt::get(context, llvm::APInt(32, i));
             list_api->write_item(const_cast<ASR::expr_t*>(&x.base), const_list, pos, item, list_type->m_type,
-                                 false, module.get(), name2memidx);
+                                 false, module.get());
         }
         tmp = const_list;
     }
@@ -1912,7 +1912,7 @@ public:
             visit_expr_wrapper(x.m_values[i], ASRUtils::is_character(*expr_type(x.m_values[i])) ? 0 : 1);
             llvm::Value* value = tmp;
             llvm_utils->dict_api->write_item(const_cast<ASR::expr_t*>(&x.base), const_dict, key, value, module.get(),
-                                 x_dict->m_key_type, x_dict->m_value_type, name2memidx);
+                                 x_dict->m_key_type, x_dict->m_value_type);
         }
         ptr_loads = ptr_loads_copy;
         tmp = const_dict;
@@ -1932,7 +1932,7 @@ public:
             visit_expr_wrapper(x.m_elements[i], true);
             llvm::Value* element = tmp;
             llvm_utils->set_api->write_item(const_cast<ASR::expr_t*>(&x.base), const_set, element, module.get(),
-                                            x_set->m_type, name2memidx);
+                                            x_set->m_type);
         }
         ptr_loads = ptr_loads_copy;
         tmp = const_set;
@@ -1971,7 +1971,7 @@ public:
         }
         ptr_loads = ptr_loads_copy;
         tuple_api->tuple_init(const_cast<ASR::expr_t*>(&x.base), const_tuple, init_values, tuple_type,
-                              module.get(), name2memidx);
+                              module.get());
         tmp = const_tuple;
     }
 
@@ -2080,7 +2080,7 @@ public:
         this->visit_expr_wrapper(x.m_ele, true);
         llvm::Value *item = tmp;
         ptr_loads = ptr_loads_copy;
-        list_api->append(x.m_a, plist, item, asr_list->m_type, module.get(), name2memidx);
+        list_api->append(x.m_a, plist, item, asr_list->m_type, module.get());
     }
 
     void visit_UnionInstanceMember(const ASR::UnionInstanceMember_t& x) {
@@ -2272,7 +2272,7 @@ public:
             true);
         llvm::Value *item = tmp;
 
-        list_api->insert_item(x.m_a, plist, pos, item, asr_list->m_type, module.get(), name2memidx);
+        list_api->insert_item(x.m_a, plist, pos, item, asr_list->m_type, module.get());
     }
 
     void visit_DictInsert(const ASR::DictInsert_t& x) {
@@ -2296,7 +2296,7 @@ public:
         llvm_utils->set_dict_api(dict_type);
         llvm_utils->dict_api->write_item(x.m_a, pdict, key, value, module.get(),
                              dict_type->m_key_type,
-                             dict_type->m_value_type, name2memidx);
+                             dict_type->m_value_type);
     }
 
     void visit_Expr(const ASR::Expr_t& x) {
@@ -2416,7 +2416,7 @@ public:
         this->visit_expr_wrapper(m_ele, true);
         ptr_loads = ptr_loads_copy;
         llvm::Value *pos = tmp;
-        tmp = list_api->pop_position(m_arg, plist, pos, asr_el_type, module.get(), name2memidx);
+        tmp = list_api->pop_position(m_arg, plist, pos, asr_el_type, module.get());
     }
 
     void generate_ListReserve(ASR::expr_t* m_arg, ASR::expr_t* m_ele) {
@@ -2472,8 +2472,7 @@ public:
 
         llvm_utils->set_dict_api(dict_type);
         llvm_utils->dict_api->get_elements_list(m_arg, pdict, el_list, dict_type->m_key_type,
-                                                dict_type->m_value_type, module.get(),
-                                                name2memidx, key_or_value);
+                                                dict_type->m_value_type, module.get(), key_or_value);
         tmp = el_list;
     }
 
@@ -2491,7 +2490,7 @@ public:
         ptr_loads = ptr_loads_copy;
         llvm::Value *el = tmp;
         llvm_utils->set_set_api(set_type);
-        llvm_utils->set_api->write_item(m_arg, pset, el, module.get(), asr_el_type, name2memidx);
+        llvm_utils->set_api->write_item(m_arg, pset, el, module.get(), asr_el_type);
     }
 
     void generate_SetRemove(ASR::expr_t* m_arg, ASR::expr_t* m_ele) {
@@ -2836,7 +2835,7 @@ public:
         ASR::Tuple_t* tuple_type = (ASR::Tuple_t*)(ASR::make_Tuple_t(
                                     al, x.base.base.loc, v_type.p, v_type.n));
         tuple_api->concat(x.m_left, left, right, tuple_type_left, tuple_type_right, concat_tuple,
-                          tuple_type, module.get(), name2memidx);
+                          tuple_type, module.get());
         tmp = concat_tuple;
     }
 
@@ -6569,8 +6568,7 @@ public:
                                             ASRUtils::expr_type(x.m_value));
             std::string value_type_code = ASRUtils::get_type_code(value_asr_list->m_type);
             list_api->list_deepcopy(x.m_value, value_list, target_list,
-                                    value_asr_list, module.get(),
-                                    name2memidx);
+                                    value_asr_list, module.get());
             return ;
         } else if( is_target_tuple && is_value_tuple ) {
             int64_t ptr_loads_copy = ptr_loads;
@@ -6625,8 +6623,7 @@ public:
                 std::string type_code = ASRUtils::get_type_code(value_tuple_type->m_type,
                                                                 value_tuple_type->n_type);
                 tuple_api->tuple_deepcopy(x.m_value, value_tuple, target_tuple,
-                                          value_tuple_type, module.get(),
-                                          name2memidx);
+                                          value_tuple_type, module.get());
             }
             return ;
         } else if( is_target_dict && is_value_dict ) {
@@ -6643,7 +6640,7 @@ public:
             std::string key_type_code = ASRUtils::get_type_code(value_dict_type->m_key_type);
             std::string value_type_code = ASRUtils::get_type_code(value_dict_type->m_value_type);
             llvm_utils->dict_api->dict_deepcopy(nullptr, value_dict, target_dict,
-                                    value_dict_type, module.get(), name2memidx);
+                                    value_dict_type, module.get());
             return ;
         } else if( is_target_set && is_value_set ) {
             int64_t ptr_loads_copy = ptr_loads;
@@ -6656,7 +6653,7 @@ public:
             ASR::Set_t* value_set_type = ASR::down_cast<ASR::Set_t>(asr_value_type);
             llvm_utils->set_set_api(value_set_type);
             llvm_utils->set_api->set_deepcopy(x.m_value, value_set, target_set,
-                                    value_set_type, module.get(), name2memidx);
+                                    value_set_type, module.get());
             return ;
         } else if (compiler_options.new_classes &&
                     (is_target_class || is_target_struct) &&
@@ -7164,7 +7161,7 @@ public:
             // the ASR type of value. Might give issues here.
             llvm_utils->dict_api->write_item(dict_item_t->m_a, pdict, key, value, module.get(),
                                 dict_type->m_key_type,
-                                dict_type->m_value_type, name2memidx);
+                                dict_type->m_value_type);
         } else if (ASRUtils::is_allocatable(target_type)) {
             ASR::ttype_t* asr_type = ASRUtils::type_get_past_pointer(
                 ASRUtils::type_get_past_allocatable(

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -673,12 +673,10 @@ namespace LCompilers {
             llvm::Value* get_pointer_to_current_capacity_using_type(llvm::Type* list_type, llvm::Value* list);
 
             void list_deepcopy(ASR::expr_t* src_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::List_t* list_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::List_t* list_type, llvm::Module* module);
 
             void list_deepcopy(ASR::expr_t* src_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::ttype_t* element_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::ttype_t* element_type, llvm::Module* module);
 
             llvm::Value* read_item_using_ttype(ASR::ttype_t* el_asr_type, llvm::Value* list, llvm::Value* pos,
                                                    bool enable_bounds_checking,
@@ -692,21 +690,18 @@ namespace LCompilers {
 
             void write_item(ASR::expr_t* expr, llvm::Value* list, llvm::Value* pos,
                 llvm::Value* item, ASR::ttype_t* asr_type,
-                bool enable_bounds_checking, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                bool enable_bounds_checking, llvm::Module* module);
 
             void write_item_using_ttype(ASR::ttype_t* el_asr_type, llvm::Value* list, llvm::Value* pos,
                             llvm::Value* item, bool enable_bounds_checking,
                             llvm::Module* module);
 
             void append(ASR::expr_t* list_expr, llvm::Value* list, llvm::Value* item,
-                        ASR::ttype_t* asr_type, llvm::Module* module,
-                        std::map<std::string, std::map<std::string, int>>& name2memidx);
+                        ASR::ttype_t* asr_type, llvm::Module* module);
 
             void insert_item(ASR::expr_t* list_expr, llvm::Value* list, llvm::Value* pos,
                             llvm::Value* item, ASR::ttype_t* asr_type,
-                            llvm::Module* module,
-                            std::map<std::string, std::map<std::string, int>>& name2memidx);
+                            llvm::Module* module);
 
             void reserve(llvm::Value* list, llvm::Value* n,
                          ASR::ttype_t* asr_type, llvm::Module* module);
@@ -715,8 +710,7 @@ namespace LCompilers {
                         ASR::ttype_t* item_type, llvm::Module* module);
 
             llvm::Value* pop_position(ASR::expr_t* list_expr, llvm::Value* list, llvm::Value* pos,
-                                      ASR::ttype_t* list_type, llvm::Module* module,
-                                      std::map<std::string, std::map<std::string, int>>& name2memidx);
+                                      ASR::ttype_t* list_type, llvm::Module* module);
 
             llvm::Value* pop_last(llvm::Value* list, ASR::ttype_t* list_asr_type, llvm::Module* module);
 
@@ -818,8 +812,7 @@ namespace LCompilers {
                                        std::vector<llvm::Type*>& el_types);
 
             void tuple_init(ASR::expr_t* tuple_expr, llvm::Value* llvm_tuple, std::vector<llvm::Value*>& values,
-                            ASR::Tuple_t* tuple_type, llvm::Module* module,
-                            std::map<std::string, std::map<std::string, int>>& name2memidx);
+                            ASR::Tuple_t* tuple_type, llvm::Module* module);
 
             llvm::Value* read_item(llvm::Value* llvm_tuple, ASR::Tuple_t* tuple_type,
                                    size_t pos, bool get_pointer=false);
@@ -831,8 +824,7 @@ namespace LCompilers {
                                    bool get_pointer=false);
 
             void tuple_deepcopy(ASR::expr_t* tuple_expr, llvm::Value* src, llvm::Value* dest,
-                                ASR::Tuple_t* type_code, llvm::Module* module,
-                                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                                ASR::Tuple_t* type_code, llvm::Module* module);
 
             llvm::Value* check_tuple_equality(llvm::Value* t1, llvm::Value* t2,
                 ASR::Tuple_t* tuple_type, llvm::LLVMContext& context,
@@ -844,8 +836,7 @@ namespace LCompilers {
 
             void concat(ASR::expr_t* tuple_1_expr, llvm::Value* t1, llvm::Value* t2, ASR::Tuple_t* tuple_type_1,
                         ASR::Tuple_t* tuple_type_2, llvm::Value* concat_tuple,
-                        ASR::Tuple_t* concat_tuple_type, llvm::Module* module,
-                        std::map<std::string, std::map<std::string, int>>& name2memidx);
+                        ASR::Tuple_t* concat_tuple_type, llvm::Module* module);
     };
 
     class LLVMDictInterface {
@@ -911,8 +902,7 @@ namespace LCompilers {
             void resolve_collision_for_write(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key_hash,
                 llvm::Value* key, llvm::Value* value,
                 llvm::Module* module, ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::ttype_t* value_asr_type) = 0;
 
             virtual
             llvm::Value* resolve_collision_for_read(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key_hash,
@@ -931,21 +921,18 @@ namespace LCompilers {
 
             virtual
             void rehash(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Module* module,
-                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type) = 0;
 
             virtual
             void rehash_all_at_once_if_needed(ASR::expr_t* dict_expr, llvm::Value* dict,
                 llvm::Module* module,
                 ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::ttype_t* value_asr_type) = 0;
 
             virtual
             void write_item(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key,
                 llvm::Value* value, llvm::Module* module,
-                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             virtual
             llvm::Value* read_item(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key,
@@ -965,8 +952,7 @@ namespace LCompilers {
 
             virtual
             void dict_deepcopy(ASR::expr_t* src_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::Dict_t* dict_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::Dict_t* dict_type, llvm::Module* module) = 0;
 
             virtual
             llvm::Value* len(llvm::Type* type, llvm::Value* dict) = 0;
@@ -981,7 +967,6 @@ namespace LCompilers {
             void get_elements_list(ASR::expr_t* expr, llvm::Value* dict,
                 llvm::Value* elements_list, ASR::ttype_t* key_asr_type,
                 ASR::ttype_t* value_asr_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx,
                 bool key_or_value) = 0;
 
             virtual ~LLVMDictInterface() = 0;
@@ -1021,8 +1006,7 @@ namespace LCompilers {
             void resolve_collision_for_write(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key_hash,
                                           llvm::Value* key, llvm::Value* value,
                                           llvm::Module* module, ASR::ttype_t* key_asr_type,
-                                          ASR::ttype_t* value_asr_type,
-                                          std::map<std::string, std::map<std::string, int>>& name2memidx);
+                                          ASR::ttype_t* value_asr_type);
 
             void _check_key_present_or_default(ASR::expr_t* dict_expr, llvm::Module* module, llvm::Value *key, llvm::Value *key_list,
                 ASR::ttype_t* key_asr_type, llvm::Value *value_list, ASR::ttype_t* value_asr_type, llvm::Value *pos,
@@ -1042,14 +1026,12 @@ namespace LCompilers {
                                                  llvm::Value* def_value);
 
             void rehash(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Module* module,
-                        ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                        std::map<std::string, std::map<std::string, int>>& name2memidx);
+                        ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             void rehash_all_at_once_if_needed(ASR::expr_t* dict_expr, llvm::Value* dict,
                                               llvm::Module* module,
                                               ASR::ttype_t* key_asr_type,
-                                              ASR::ttype_t* value_asr_type,
-                                              std::map<std::string, std::map<std::string, int>>& name2memidx);
+                                              ASR::ttype_t* value_asr_type);
 
             llvm::Value* read_item(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key,
                                    llvm::Module* module, ASR::Dict_t* key_asr_type, bool enable_bounds_checking,
@@ -1067,15 +1049,13 @@ namespace LCompilers {
             llvm::Value* get_pointer_to_keymask(ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type, llvm::Value* dict);
 
             void dict_deepcopy(ASR::expr_t* src_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::Dict_t* dict_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::Dict_t* dict_type, llvm::Module* module);
 
             llvm::Value* len(llvm::Type* type, llvm::Value* dict);
 
             void get_elements_list(ASR::expr_t* expr, llvm::Value* dict,
                 llvm::Value* elements_list, ASR::ttype_t* key_asr_type,
                 ASR::ttype_t* value_asr_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx,
                 bool key_or_value);
 
             virtual ~LLVMDict();
@@ -1097,8 +1077,7 @@ namespace LCompilers {
             void resolve_collision_for_write(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key_hash,
                                             llvm::Value* key, llvm::Value* value,
                                             llvm::Module* module, ASR::ttype_t* key_asr_type,
-                                            ASR::ttype_t* value_asr_type,
-                                            std::map<std::string, std::map<std::string, int>>& name2memidx);
+                                            ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key_hash,
                                                     llvm::Value* key, llvm::Module* module,
@@ -1133,12 +1112,10 @@ namespace LCompilers {
                 ASR::ttype_t* value_type, llvm::Value* dict);
 
             void deepcopy_key_value_pair_linked_list(ASR::expr_t* src_expr, llvm::Value* srci, llvm::Value* desti,
-                llvm::Value* dest_key_value_pairs, ASR::Dict_t* dict_type,
-                llvm::Module* module, std::map<std::string, std::map<std::string, int>>& name2memidx);
+                llvm::Value* dest_key_value_pairs, ASR::Dict_t* dict_type, llvm::Module* module);
 
             void write_key_value_pair_linked_list(ASR::expr_t* dict_expr, llvm::Value* kv_ll, llvm::Value* dict,
-                llvm::Value* capacity, ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                llvm::Module* module, std::map<std::string, std::map<std::string, int>>& name2memidx);
+                llvm::Value* capacity, ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type, llvm::Module* module);
 
             void resolve_collision(ASR::expr_t* dict_expr, llvm::Value* capacity, llvm::Value* key_hash,
                 llvm::Value* key, llvm::Value* key_value_pair_linked_list,
@@ -1185,8 +1162,7 @@ namespace LCompilers {
                 llvm::Value* value,
                 llvm::Module* module,
                 ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::ttype_t* value_asr_type);
 
             llvm::Value* resolve_collision_for_read(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key_hash,
                 llvm::Value* key, llvm::Module* module,
@@ -1202,14 +1178,12 @@ namespace LCompilers {
                 llvm::Value* def_value);
 
             void rehash(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Module* module,
-                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type);
 
             void rehash_all_at_once_if_needed(ASR::expr_t* dict_expr, llvm::Value* dict,
                 llvm::Module* module,
                 ASR::ttype_t* key_asr_type,
-                ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::ttype_t* value_asr_type);
 
             llvm::Value* read_item(ASR::expr_t* dict_expr, llvm::Value* dict, llvm::Value* key,
                 llvm::Module* module, ASR::Dict_t* dict_type, bool enable_bounds_checking,
@@ -1226,15 +1200,13 @@ namespace LCompilers {
             llvm::Value* get_pointer_to_keymask(ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type, llvm::Value* dict);
 
             void dict_deepcopy(ASR::expr_t* src_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::Dict_t* dict_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::Dict_t* dict_type, llvm::Module* module);
 
             llvm::Value* len(llvm::Type* type, llvm::Value* dict);
 
             void get_elements_list(ASR::expr_t* expr, llvm::Value* dict,
                 llvm::Value* elements_list, ASR::ttype_t* key_asr_type,
                 ASR::ttype_t* value_asr_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx,
                 bool key_or_value);
 
             virtual ~LLVMDictSeparateChaining();
@@ -1296,24 +1268,20 @@ namespace LCompilers {
             virtual
             void resolve_collision_for_write(
                 ASR::expr_t* set_expr, llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
-                llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                llvm::Module* module, ASR::ttype_t* el_asr_type) = 0;
 
             virtual
             void rehash(
-                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type) = 0;
 
             virtual
             void rehash_all_at_once_if_needed(
-                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type) = 0;
 
             virtual
             void write_item(
                 ASR::expr_t* set_expr, llvm::Value* set, llvm::Value* el,
-                llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             virtual
             void resolve_collision_for_read_with_bound_check(
@@ -1328,8 +1296,7 @@ namespace LCompilers {
             virtual
             void set_deepcopy(
                 ASR::expr_t* set_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::Set_t* set_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                ASR::Set_t* set_type, llvm::Module* module) = 0;
 
             virtual
             llvm::Value* len(llvm::Type* type, llvm::Value* set);
@@ -1380,16 +1347,13 @@ namespace LCompilers {
 
             void resolve_collision_for_write(
                 ASR::expr_t* set_expr, llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
-                llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void rehash(
-                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void rehash_all_at_once_if_needed(
-                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void resolve_collision_for_read_with_bound_check(
                 llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
@@ -1401,8 +1365,7 @@ namespace LCompilers {
 
             void set_deepcopy(
                 ASR::expr_t* set_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::Set_t* set_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::Set_t* set_type, llvm::Module* module);
 
             ~LLVMSetLinearProbing();
     };
@@ -1429,13 +1392,11 @@ namespace LCompilers {
 
             void write_el_linked_list(
                 ASR::expr_t* set_expr, llvm::Value* el_ll, llvm::Value* set, llvm::Value* capacity,
-                ASR::ttype_t* m_el_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::ttype_t* m_el_type, llvm::Module* module);
 
             void deepcopy_el_linked_list(
                 ASR::expr_t* set_expr, llvm::Value* srci, llvm::Value* desti, llvm::Value* dest_elems,
-                ASR::Set_t* set_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::Set_t* set_type, llvm::Module* module);
 
         public:
 
@@ -1466,16 +1427,13 @@ namespace LCompilers {
 
             void resolve_collision_for_write(
                 ASR::expr_t* set_expr, llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
-                llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void rehash(
-                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void rehash_all_at_once_if_needed(
-                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::expr_t* set_expr, llvm::Value* set, llvm::Module* module, ASR::ttype_t* el_asr_type);
 
             void resolve_collision_for_read_with_bound_check(
                 llvm::Value* set, llvm::Value* el_hash, llvm::Value* el,
@@ -1487,8 +1445,7 @@ namespace LCompilers {
 
             void set_deepcopy(
                 ASR::expr_t* set_expr, llvm::Value* src, llvm::Value* dest,
-                ASR::Set_t* set_type, llvm::Module* module,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
+                ASR::Set_t* set_type, llvm::Module* module);
 
             ~LLVMSetSeparateChaining();
     };


### PR DESCRIPTION
This PR Creates an API in `llvm_utils` for struct_type utilities which will stuff stay in one single structure.