### PR TITLE
Minor fixes for powerpc-darwin

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1941,7 +1941,8 @@ int link_executable(const std::vector<std::string> &infiles,
 
             if (static_executable) {
                 if (compiler_options.platform != LCompilers::Platform::macOS_Intel
-                && compiler_options.platform != LCompilers::Platform::macOS_ARM) {
+                && compiler_options.platform != LCompilers::Platform::macOS_ARM
+                && compiler_options.platform != LCompilers::Platform::macOS_PowerPC) {
                     options += " -static ";
                 }
                 runtime_lib = "lfortran_runtime_static";

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1972,7 +1972,7 @@ int link_executable(const std::vector<std::string> &infiles,
                 compile_cmd += extra_linker_flags;
             }
             compile_cmd += " -l" + runtime_lib + " -lm";
-            if (compiler_options.openmp) {
+            if (compiler_options.openmp && CC.find("clang" ) != std::string::npos) {
                 std::string openmp_shared_library = compiler_options.openmp_lib_dir;
                 std::string omp_cmd =  " -L" + openmp_shared_library + " -Wl,-rpath," + openmp_shared_library + " -lomp";
                 if (!openmp_shared_library.empty()) {

--- a/src/lfortran/parser/preprocessor.re
+++ b/src/lfortran/parser/preprocessor.re
@@ -42,12 +42,16 @@ CPreprocessor::CPreprocessor(CompilerOptions &compiler_options)
         md.expansion = "1";
         macro_definitions["_WIN32"] = md;
     } else if (compiler_options.platform == Platform::macOS_ARM
+        || compiler_options.platform == Platform::macOS_PowerPC
         || compiler_options.platform == Platform::macOS_Intel) {
         md.expansion = "1";
         macro_definitions["__APPLE__"] = md;
         if (compiler_options.platform == Platform::macOS_ARM) {
             md.expansion = "1";
             macro_definitions["__aarch64__"] = md;
+        } else if (compiler_options.platform == Platform::macOS_PowerPC) {
+            md.expansion = "1";
+            macro_definitions["__POWERPC__"] = md;
         } else {
             md.expansion = "1";
             macro_definitions["__x86_64__"] = md;

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -12,6 +12,7 @@ enum Platform {
     Linux,
     macOS_Intel,
     macOS_ARM,
+    macOS_PowerPC,
     Windows,
     FreeBSD,
     OpenBSD,

--- a/src/libasr/utils2.cpp
+++ b/src/libasr/utils2.cpp
@@ -229,6 +229,7 @@ std::string pf2s(Platform p) {
         case (Platform::Linux) : return "Linux";
         case (Platform::macOS_Intel) : return "macOS Intel";
         case (Platform::macOS_ARM) : return "macOS ARM";
+        case (Platform::macOS_PowerPC) : return "macOS PowerPC";
         case (Platform::Windows) : return "Windows";
         case (Platform::FreeBSD) : return "FreeBSD";
         case (Platform::OpenBSD) : return "OpenBSD";
@@ -243,6 +244,8 @@ Platform get_platform()
 #elif defined(__APPLE__)
 #    ifdef __aarch64__
     return Platform::macOS_ARM;
+#    elif defined(__POWERPC__)
+    return Platform::macOS_PowerPC;
 #    else
     return Platform::macOS_Intel;
 #    endif


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/7219

@certik There are a couple of instances where `Platform::macOS_*` is used elsewhere in the code (`llvm_utils.cpp` and `asr_to_llvm.cpp`). Could you say if those need a case for powerpc or not? 

P. S. This perhaps should rather use “OS + arch” (detected independently) logic, but for now at least fix misreporting of powerpc as Intel, that’s really confusing.