### PR TITLE
fix:: throw error when passing incompatible arguments to subroutines

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4648,6 +4648,30 @@ public:
                             throw SemanticAbort();
                         }
                     }
+                    if (i < args.size() && args[i].m_value != nullptr) {
+                        ASR::expr_t* passed_arg = args[i].m_value;
+                        ASR::ttype_t* passed_type = ASRUtils::expr_type(passed_arg);
+                        ASR::ttype_t* param_type = v->m_type;
+                        // Skip type checking for implicit argument_casting, 
+                        // polymorphic types (class), function types, and intrinsics
+                        bool skip_check = compiler_options.implicit_argument_casting ||
+                                            ASRUtils::is_class_type(ASRUtils::type_get_past_array(passed_type)) ||
+                                            ASRUtils::is_class_type(ASRUtils::type_get_past_array(param_type)) ||
+                                            ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(passed_type)) ||
+                                            ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(param_type));
+                        // Check if types are equal
+                        if (!skip_check && !ASRUtils::check_equal_type(passed_type, param_type, passed_arg, f->m_args[i+offset])) {
+                            std::string passed_type_str = ASRUtils::type_to_str_fortran_expr(passed_type, nullptr);
+                            std::string param_type_str = ASRUtils::type_to_str_fortran_expr(param_type, nullptr);
+                            diag.add(diag::Diagnostic(
+                                "Type mismatch in argument `" + std::string(v->m_name) +
+                                "`: expected `" + param_type_str + "` but got `" +passed_type_str + "`",
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                        diag::Label("", {passed_arg->base.loc})
+                                }));
+                            throw SemanticAbort();
+                        }
+                    }
                 }
             }
 

--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -9,11 +9,11 @@ module continue_compilation_3_mod
 
 
 
-
-
-
-
 contains
+
+    subroutine check_incompatible_type(i)
+      real :: i
+    end subroutine check_incompatible_type
 
     subroutine intent_out_test(x)
         integer, intent(out) :: x
@@ -69,7 +69,7 @@ program continue_compilation_3
     call intent_out_test(x + 1)  ! Error: expression with intent(out)
     call intent_inout_test(2)  ! Error: literal constant with intent(inout)
     call intent_inout_test(x * 2)  ! Error: expression with intent(inout)
-
+    call check_incompatible_type(i)  ! Error: incompatible type passed
 
 
 

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "44e6f7ccca3d078d118c1ef1c03096675ad7edbe4b7049b66482df8a",
+    "infile_hash": "626e427aa8377506e049aa3282766ce16b7587f15a76d70eb125f377",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "1265fb63634e76f34eeb4fef17f056f70bc64a0cf66d2b9426ef4fa7",
+    "stderr_hash": "e815b1d129c484727e7509ae9ee04a2a89c12dde33fe011f236c0d32",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -46,6 +46,12 @@ semantic error: Non-variable expression in variable definition context (actual a
 71 |     call intent_inout_test(x * 2)  ! Error: expression with intent(inout)
    |                            ^^^^^ 
 
+semantic error: Type mismatch in argument `i`: expected `real` but got `integer`
+  --> tests/errors/continue_compilation_3.f90:72:34
+   |
+72 |     call check_incompatible_type(i)  ! Error: incompatible type passed
+   |                                  ^ 
+
 semantic error: Empty array constructor is not allowed
   --> tests/errors/continue_compilation_3.f90:91:9
    |


### PR DESCRIPTION
Fixes #8719 addressing comments of #8720

Added Test-Case:
```
program test
  integer::j
  call ss(j)
  contains 
  subroutine ss (i)
    real :: i
  end subroutine
end program test
```

Updated Main:
```
$ lfortran a.f90
semantic error: Type mismatch in argument `i`: expected `real` but got `integer`
 --> a.f90:3:11
  |
3 |   call ss(j)
  |           ^ 


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

Gfortran:
```
$ gfortran a.f90
a.f90:3:12:

    3 |   call ss(j)
      |            1
Error: Type mismatch in argument ‘i’ at (1); passed INTEGER(4) to REAL(4)
```