### PR TITLE
fix: throw runtime error when ArrayPhysicalCast to FixedSizeArray is an argument of SubroutineCall

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -12683,7 +12683,7 @@ public:
             ASR::expr_t* arg_expr = x.m_args[i].m_value;
             if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*arg_expr)) {
                 ASR::ArrayPhysicalCast_t* arr_cast = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr);
-                if (arr_cast->m_old == ASR::DescriptorArray && arr_cast->m_new == ASR::PointerArray) {
+                if (arr_cast->m_old == ASR::DescriptorArray && (arr_cast->m_new == ASR::PointerArray || arr_cast->m_new == ASR::FixedSizeArray)) {
                     int64_t ptr_loads_copy = ptr_loads;
                     ptr_loads = 2 - LLVM::is_llvm_pointer(*ASRUtils::expr_type(arr_cast->m_arg));
                     this->visit_expr_wrapper(arr_cast->m_arg, false);

--- a/tests/errors/array_bounds_check_08.f90
+++ b/tests/errors/array_bounds_check_08.f90
@@ -1,0 +1,12 @@
+program array_bounds_check_08
+  integer, allocatable :: arr(:)
+  allocate(arr(5))
+  arr = ff()
+  print *, size(arr)
+
+  contains
+    function ff() result(res)
+        integer :: res(100000)
+        res(100000) = 9999
+    end function
+end program

--- a/tests/reference/run-array_bounds_check_08-7f7acdd.json
+++ b/tests/reference/run-array_bounds_check_08-7f7acdd.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-array_bounds_check_08-7f7acdd",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/array_bounds_check_08.f90",
+    "infile_hash": "5b4ee4c8e59df328ecfe694741c18176b47b4000ad17c194947834c4",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-array_bounds_check_08-7f7acdd.stderr",
+    "stderr_hash": "12ad66e1c6ddf4ced664c92049022e82c9d955640f372dbc91d366fb",
+    "returncode": 1
+}

--- a/tests/reference/run-array_bounds_check_08-7f7acdd.stderr
+++ b/tests/reference/run-array_bounds_check_08-7f7acdd.stderr
@@ -1,0 +1,3 @@
+Runtime error: Array shape mismatch in subroutine 'ff'
+
+Tried to match size 5 of dimension 1 of argument number 1, but expected size is 100000

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3902,6 +3902,10 @@ filename = "errors/array_bounds_check_07.f90"
 run = true
 
 [[test]]
+filename = "errors/array_bounds_check_08.f90"
+run = true
+
+[[test]]
 filename = "../integration_tests/statement_01.f90"
 asr_implicit_interface_and_typing = true
 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/8687