### PR TITLE
fix: create load correctly for array item in `type-bound` procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1999,6 +1999,7 @@ RUN(NAME class_68 LABELS gfortran)
 RUN(NAME class_69 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_70 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_71 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_72 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_72.f90
+++ b/integration_tests/class_72.f90
@@ -1,0 +1,36 @@
+module class_72_mod
+    implicit none
+    private
+    public :: version_t
+
+    type :: version_t
+        integer :: major
+    contains
+        procedure :: greater
+        generic, public :: operator(>) => greater
+    end type version_t
+
+contains
+
+    elemental function greater(lhs, rhs) result(is_greater)
+        class(version_t), intent(in) :: lhs, rhs
+        logical :: is_greater
+        is_greater = lhs%major > rhs%major
+    end function greater
+
+end module class_72_mod
+
+
+program class_72
+    use class_72_mod
+    implicit none
+
+    type(version_t), allocatable :: v1(:)
+    type(version_t) :: v2
+
+    allocate(v1(2))
+    v1(1) = version_t(5)
+    v2 = version_t(6)
+
+    if (v1(1) > v2) error stop
+end program class_72

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -13518,7 +13518,10 @@ public:
             // Get Runtime VTable Pointer
             if (ASR::is_a<ASR::ArrayItem_t>(*x.m_dt)) {
                 ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(x.m_dt);
+                ptr_loads_copy = ptr_loads;
+                ptr_loads = LLVM::is_llvm_pointer(*ASRUtils::expr_type(array_item->m_v));
                 this->visit_expr_wrapper(array_item->m_v, true);
+                ptr_loads = ptr_loads_copy;
                 llvm::Type* struct_llvm_type = llvm_utils->get_type_from_ttype_t_util(
                     array_item->m_v, ASRUtils::extract_type(array_item->m_type), module.get());
                 if (ASRUtils::extract_physical_type(


### PR DESCRIPTION
Fixes #8743 