### PR TITLE
Enh : Finalize Symbol Table in backend (llvm) -- Handle strings only

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1839,6 +1839,7 @@ RUN(NAME string_77 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_78 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_79 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_80 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_81 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_37.f90
+++ b/integration_tests/string_37.f90
@@ -14,7 +14,8 @@ program string_37
     end function maybe
     function cast_to_string() result(str)
         character(len=:), pointer :: str
-        character(len=5), target :: str2
+        character(len=5), pointer :: str2
+        allocate(str2)
         str2 = "Hello"
         str => str2
     end function cast_to_string

--- a/integration_tests/string_81.f90
+++ b/integration_tests/string_81.f90
@@ -1,0 +1,21 @@
+! Tests large string allocation (Bombs memory if not freed)
+module string_81_mod
+    implicit none
+    contains
+    subroutine ff()
+      character(10000) :: ss
+      character(10000) :: ss2
+      ss(1:1) = "a" ! just to use the variable
+      ss2(1:1) = "a" ! just to use the variable
+    end subroutine
+    
+end module
+  
+program string_81
+  use string_81_mod
+  integer :: i
+  do i =0 , 10000000
+    call ff()
+  end do
+
+end program

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -194,7 +194,9 @@ namespace LCompilers {
     void LLVMUtils::set_module(llvm::Module* module_) {
         module = module_;
     }
-
+    std::string LLVMUtils::get_llvm_type_as_string(llvm::Type* type){
+        return LLVM::get_type_as_string(type);
+    }
     llvm::Type* LLVMUtils::getMemberType(ASR::ttype_t* mem_type, ASR::Variable_t* member,
         llvm::Module* module) {
         llvm::Type* llvm_mem_type = nullptr;
@@ -1856,7 +1858,7 @@ namespace LCompilers {
         } else {
             throw LCompilersException("Unhandled string physical type");
         }
-        llvm::Value *s_alloc = builder->CreateAlloca(character_type, builder->CreateSExtOrTrunc(len, llvm::Type::getInt32Ty(context)));
+        llvm::Value *s_alloc = builder->CreateAlloca(llvm::Type::getInt8Ty(context), builder->CreateSExtOrTrunc(len, llvm::Type::getInt32Ty(context)));
         builder->CreateStore(s_alloc, str_data);
         builder->CreateStore(convert_kind(len, llvm::Type::getInt64Ty(context)), str_len);
     }

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -9,6 +9,9 @@
 
 namespace LCompilers {
 
+// hard code avoided types (handled by llvm backend) -- We're transitioing the deallocation process into the backend. 
+auto avoided_type = [](ASR::ttype_t* t) -> bool {return ASRUtils::extract_type(t)->type == ASR::String;};
+
 class InsertDeallocate: public ASR::CallReplacerOnExpressionsVisitor<InsertDeallocate>
 {
     private:
@@ -34,6 +37,7 @@ class InsertDeallocate: public ASR::CallReplacerOnExpressionsVisitor<InsertDeall
                 ASRUtils::is_array(ASRUtils::symbol_type(s)) ||
                 ASRUtils::is_struct(*ASRUtils::symbol_type(s))) &&
                 ASRUtils::symbol_intent(s) == ASRUtils::intent_local){
+                if(avoided_type(ASRUtils::symbol_type(s))) return false;
                 return true;
             }
             return false;
@@ -187,6 +191,7 @@ class CollectTempVarsVisitor : public ASR::BaseWalkVisitor<CollectTempVarsVisito
                 ASRUtils::is_allocatable_or_pointer(target_variable->m_type) &&
                 ASRUtils::symbol_StorageType((ASR::symbol_t *)target_variable) == ASR::storage_typeType::Default) {
                 if (std::string(target_variable->m_name).rfind("__libasr_created") != std::string::npos) {
+                    if(avoided_type(target_variable->m_type)) return;
                     res.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x.m_target->base.loc, (ASR::symbol_t *)target_variable)));
                 }
             }

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "9db7f0ce3a998cb97a04d418612951aa5a7b0d5f24b60d4fc2b15adc",
+    "stdout_hash": "24bffe052c5af6e16466f81e366df05bbe68893e96e384094fe02fd0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -41,6 +41,9 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0x4022333340000000, float* %myreal, align 4
   store float 1.500000e+00, float* %theta, align 4
   store float 0x3FD99999A0000000, float* %a, align 4
+  br label %associate_block_start
+
+associate_block_start:                            ; preds = %.entry
   %v = alloca float*, align 8
   store float* null, float** %v, align 8
   %z = alloca float, align 4
@@ -85,6 +88,9 @@ define i32 @main(i32 %0, i8** %1) {
   %31 = load float, float* %30, align 4
   %32 = fmul float %31, 0x4012666660000000
   store float %32, float* %29, align 4
+  br label %associate_block_end
+
+associate_block_end:                              ; preds = %associate_block_start
   %33 = alloca i64, align 8
   %34 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %33, i32 0, i32 0, float* %myreal)
   %35 = load i64, i64* %33, align 4
@@ -110,12 +116,12 @@ define i32 @main(i32 %0, i8** %1) {
   %50 = select i1 %49, i1 %48, i1 %45
   br i1 %50, label %then, label %else
 
-then:                                             ; preds = %.entry
+then:                                             ; preds = %associate_block_end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont
 
-else:                                             ; preds = %.entry
+else:                                             ; preds = %associate_block_end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "417291a41bd2f1c4169de976c65d53d3526abfb4710bce1555c4acde",
+    "stdout_hash": "216ab6c8f463d248b0adf5b9cfe8d497ec54d4b8de521319955a263f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -185,15 +185,15 @@ ifcont:                                           ; preds = %else, %then
   %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
   %34 = load i64, i64* %33, align 4
   call void @_lfortran_strcpy(i8** %29, i64* %30, i8 1, i8 1, i8* %32, i64 %34)
-  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %36 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  %37 = load i8*, i8** %35, align 8
-  call void @_lfortran_free(i8* %37)
-  store i8* null, i8** %35, align 8
-  store i64 0, i64* %36, align 4
   br label %return
 
 return:                                           ; preds = %ifcont
+  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %36 = load i8*, i8** %35, align 8
+  call void @_lfortran_free(i8* %36)
+  %37 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
+  %38 = load i8*, i8** %37, align 8
+  call void @_lfortran_free(i8* %38)
   ret void
 }
 
@@ -274,22 +274,16 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %29 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %30 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %31 = load i8*, i8** %29, align 8
-  call void @_lfortran_free(i8* %31)
-  store i8* null, i8** %29, align 8
-  store i64 0, i64* %30, align 4
-  %32 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %34 = load i8*, i8** %32, align 8
-  call void @_lfortran_free(i8* %34)
-  store i8* null, i8** %32, align 8
-  store i64 0, i64* %33, align 4
   call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
+  %29 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %30 = load i8*, i8** %29, align 8
+  call void @_lfortran_free(i8* %30)
+  %31 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %32 = load i8*, i8** %31, align 8
+  call void @_lfortran_free(i8* %32)
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "7e874b4bbc63fab07b9018455204f9aff2d153b894a8f68f761a9f07",
+    "stdout_hash": "45b26a947557f6320fe3b9328903cf48e090c17b6ae37af6ea5e87f1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -97,6 +97,18 @@ define i32 @main(i32 %0, i8** %1) {
   br label %return
 
 return:                                           ; preds = %.entry
+  %44 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
+  %45 = load i8*, i8** %44, align 8
+  call void @_lfortran_free(i8* %45)
+  %46 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
+  %47 = load i8*, i8** %46, align 8
+  call void @_lfortran_free(i8* %47)
+  %48 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
+  %49 = load i8*, i8** %48, align 8
+  call void @_lfortran_free(i8* %49)
+  %50 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
+  %51 = load i8*, i8** %50, align 8
+  call void @_lfortran_free(i8* %51)
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "7be908e708f520514ed802bf4b2f97b6a58b5824e27a1658bfe01527",
+    "stdout_hash": "a038d71c8aa175887aea7fe5b73330bd6e0bb2879a9cd1fde2317d4c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -306,40 +306,40 @@ ifcont12:                                         ; preds = %else11, %then10
   %104 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
   %105 = load i8*, i8** %104, align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %105, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %106 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %107 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %108 = load i8*, i8** %106, align 8
-  call void @_lfortran_free(i8* %108)
-  store i8* null, i8** %106, align 8
-  store i64 0, i64* %107, align 4
-  %109 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %110 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %111 = load i8*, i8** %109, align 8
-  call void @_lfortran_free(i8* %111)
-  store i8* null, i8** %109, align 8
-  store i64 0, i64* %110, align 4
-  %112 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %113 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  %114 = load i8*, i8** %112, align 8
-  call void @_lfortran_free(i8* %114)
-  store i8* null, i8** %112, align 8
-  store i64 0, i64* %113, align 4
-  %115 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %116 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 1
-  %117 = load i8*, i8** %115, align 8
-  call void @_lfortran_free(i8* %117)
-  store i8* null, i8** %115, align 8
-  store i64 0, i64* %116, align 4
-  %118 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %119 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
-  %120 = load i8*, i8** %118, align 8
-  call void @_lfortran_free(i8* %120)
-  store i8* null, i8** %118, align 8
-  store i64 0, i64* %119, align 4
   call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont12
+  %106 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %107 = load i8*, i8** %106, align 8
+  call void @_lfortran_free(i8* %107)
+  %108 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %109 = load i8*, i8** %108, align 8
+  call void @_lfortran_free(i8* %109)
+  %110 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %111 = load i8*, i8** %110, align 8
+  call void @_lfortran_free(i8* %111)
+  %112 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %113 = load i8*, i8** %112, align 8
+  call void @_lfortran_free(i8* %113)
+  %114 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %115 = load i8*, i8** %114, align 8
+  call void @_lfortran_free(i8* %115)
+  %116 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
+  %117 = load i8*, i8** %116, align 8
+  call void @_lfortran_free(i8* %117)
+  %118 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 0
+  %119 = load i8*, i8** %118, align 8
+  call void @_lfortran_free(i8* %119)
+  %120 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 0
+  %121 = load i8*, i8** %120, align 8
+  call void @_lfortran_free(i8* %121)
+  %122 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
+  %123 = load i8*, i8** %122, align 8
+  call void @_lfortran_free(i8* %123)
+  %124 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 0
+  %125 = load i8*, i8** %124, align 8
+  call void @_lfortran_free(i8* %125)
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "6f137299b494b020840ce254c39ce4ec4fa1582e45ddb7eaca334ac6",
+    "stdout_hash": "7494923893909f1a99bcf2425fabe29e60267b877544297faf794ef7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -211,6 +211,9 @@ ifcont:                                           ; preds = %else, %then
   br label %return
 
 return:                                           ; preds = %ifcont
+  %115 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
+  %116 = load i8*, i8** %115, align 8
+  call void @_lfortran_free(i8* %116)
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "22a3dd0ca11467c390a7461643b71bb97babf3a0629494921fba0484",
+    "stdout_hash": "93082692c13d40f3330bc8c533ae00cb442d9f47a37a1ad92f4e1d8b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -403,6 +403,12 @@ ifcont:                                           ; preds = %else, %then
   br label %return
 
 return:                                           ; preds = %ifcont
+  %29 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
+  %30 = load i8*, i8** %29, align 8
+  call void @_lfortran_free(i8* %30)
+  %31 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
+  %32 = load i8*, i8** %31, align 8
+  call void @_lfortran_free(i8* %32)
   ret i32 0
 }
 

--- a/tests/reference/llvm-string_54-06ad64c.json
+++ b/tests/reference/llvm-string_54-06ad64c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_54-06ad64c.stdout",
-    "stdout_hash": "6650d15920b330b69cf60bee0e76978be6d22a29bfabd4e1fd676d57",
+    "stdout_hash": "accb23801025eab9abcb1bd554775ee6fea02dc6aed5d2fb3235b576",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_54-06ad64c.stdout
+++ b/tests/reference/llvm-string_54-06ad64c.stdout
@@ -42,6 +42,9 @@ define i32 @main(i32 %0, i8** %1) {
   br label %return
 
 return:                                           ; preds = %.entry
+  %5 = getelementptr %string_descriptor, %string_descriptor* %char, i32 0, i32 0
+  %6 = load i8*, i8** %5, align 8
+  call void @_lfortran_free(i8* %6)
   ret i32 0
 }
 
@@ -50,3 +53,5 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lfortran_malloc(i64)
 
 declare void @_lpython_free_argv()
+
+declare void @_lfortran_free(i8*)

--- a/tests/reference/llvm-volatile_03-914e4e5.json
+++ b/tests/reference/llvm-volatile_03-914e4e5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_03-914e4e5.stdout",
-    "stdout_hash": "52b01230192452334cc394fe2517f15b4060039c6c783bf9dd3cf017",
+    "stdout_hash": "27fbc8ed8ef2fcccf0b68d432d4e91800f26b44ade627fb99fa837e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_03-914e4e5.stdout
+++ b/tests/reference/llvm-volatile_03-914e4e5.stdout
@@ -23,6 +23,9 @@ define i32 @main(i32 %0, i8** %1) {
   br label %return
 
 return:                                           ; preds = %.entry
+  %7 = getelementptr %string_descriptor, %string_descriptor* %x, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  call void @_lfortran_free(i8* %8)
   ret i32 0
 }
 
@@ -33,3 +36,5 @@ declare i8* @_lfortran_malloc(i64)
 declare void @_lfortran_strcpy(i8**, i64*, i8, i8, i8*, i64)
 
 declare void @_lpython_free_argv()
+
+declare void @_lfortran_free(i8*)

--- a/tests/reference/llvm_new_classes-select_type_13-cafec20.json
+++ b/tests/reference/llvm_new_classes-select_type_13-cafec20.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm_new_classes-select_type_13-cafec20.stdout",
-    "stdout_hash": "913914a14a77614fd440c2a007255943030291384a654a093f8bab5c",
+    "stdout_hash": "bae3cb871507d8ec233eb3096d273bcb4c78e359015a091464b72135",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm_new_classes-select_type_13-cafec20.stdout
+++ b/tests/reference/llvm_new_classes-select_type_13-cafec20.stdout
@@ -192,29 +192,35 @@ define i32 @main(i32 %0, i8** %1) {
   br i1 %12, label %then1, label %else
 
 then:                                             ; preds = %ifcont
-  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %13, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  br label %ifcont14
+  br label %"~select_type_block_.start"
 
 then1:                                            ; preds = %.entry
-  %14 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %14, align 8
-  %15 = bitcast i32 (...)*** %14 to i8*
-  %16 = call i8* @__lfortran_dynamic_cast(i8* %15, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %17 = icmp ne i8* %16, null
-  store i1 %17, i1* %9, align 1
+  %13 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
+  %14 = bitcast i32 (...)*** %13 to i8*
+  %15 = call i8* @__lfortran_dynamic_cast(i8* %14, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %16 = icmp ne i8* %15, null
+  store i1 %16, i1* %9, align 1
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %18 = bitcast %shape* %10 to i8*
-  %19 = call i8* @__lfortran_dynamic_cast(i8* %18, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %20 = icmp ne i8* %19, null
-  store i1 %20, i1* %9, align 1
+  %17 = bitcast %shape* %10 to i8*
+  %18 = call i8* @__lfortran_dynamic_cast(i8* %17, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %19 = icmp ne i8* %18, null
+  store i1 %19, i1* %9, align 1
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then1
-  %21 = load i1, i1* %9, align 1
-  br i1 %21, label %then, label %else2
+  %20 = load i1, i1* %9, align 1
+  br i1 %20, label %then, label %else2
+
+"~select_type_block_.start":                      ; preds = %then
+  %21 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %21, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  br label %"~select_type_block_.end"
+
+"~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
+  br label %ifcont14
 
 else2:                                            ; preds = %ifcont
   %22 = alloca i1, align 1
@@ -224,33 +230,39 @@ else2:                                            ; preds = %ifcont
   br i1 %25, label %then4, label %else5
 
 then3:                                            ; preds = %ifcont6
-  %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %26, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = load %shape*, %shape** %s1, align 8
-  %28 = icmp eq %shape* %27, null
-  br i1 %28, label %then7, label %else8
+  br label %"~select_type_block_1.start"
 
 then4:                                            ; preds = %else2
-  %29 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %29, align 8
-  %30 = bitcast i32 (...)*** %29 to i8*
+  %26 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %26, align 8
+  %27 = bitcast i32 (...)*** %26 to i8*
+  %28 = call i8* @__lfortran_dynamic_cast(i8* %27, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %29 = icmp ne i8* %28, null
+  store i1 %29, i1* %22, align 1
+  br label %ifcont6
+
+else5:                                            ; preds = %else2
+  %30 = bitcast %shape* %23 to i8*
   %31 = call i8* @__lfortran_dynamic_cast(i8* %30, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
   %32 = icmp ne i8* %31, null
   store i1 %32, i1* %22, align 1
   br label %ifcont6
 
-else5:                                            ; preds = %else2
-  %33 = bitcast %shape* %23 to i8*
-  %34 = call i8* @__lfortran_dynamic_cast(i8* %33, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %35 = icmp ne i8* %34, null
-  store i1 %35, i1* %22, align 1
-  br label %ifcont6
-
 ifcont6:                                          ; preds = %else5, %then4
-  %36 = load i1, i1* %22, align 1
-  br i1 %36, label %then3, label %else13
+  %33 = load i1, i1* %22, align 1
+  br i1 %33, label %then3, label %else13
 
-then7:                                            ; preds = %then3
+"~select_type_block_1.start":                     ; preds = %then3
+  %34 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %34, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %35 = load %shape*, %shape** %s1, align 8
+  %36 = icmp eq %shape* %35, null
+  br i1 %36, label %then7, label %else8
+
+"~select_type_block_1.end":                       ; preds = %ifcont12
+  br label %ifcont14
+
+then7:                                            ; preds = %"~select_type_block_1.start"
   %37 = call i8* @_lfortran_malloc(i64 8)
   call void @llvm.memset.p0i8.i32(i8* %37, i8 0, i32 8, i1 false)
   %38 = bitcast i8* %37 to %shape*
@@ -260,7 +272,7 @@ then7:                                            ; preds = %then3
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %40, align 8
   br label %ifcont9
 
-else8:                                            ; preds = %then3
+else8:                                            ; preds = %"~select_type_block_1.start"
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
@@ -305,14 +317,14 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  br label %ifcont14
+  br label %"~select_type_block_1.end"
 
 else13:                                           ; preds = %ifcont6
   %64 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %64, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   br label %ifcont14
 
-ifcont14:                                         ; preds = %else13, %ifcont12, %then
+ifcont14:                                         ; preds = %else13, %"~select_type_block_1.end", %"~select_type_block_.end"
   %65 = call i8* @_lfortran_malloc(i64 16)
   call void @llvm.memset.p0i8.i32(i8* %65, i8 0, i32 16, i1 false)
   %66 = bitcast i8* %65 to %shape*
@@ -331,29 +343,35 @@ ifcont14:                                         ; preds = %else13, %ifcont12, 
   br i1 %76, label %then16, label %else17
 
 then15:                                           ; preds = %ifcont18
-  %77 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %77, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  br label %ifcont38
+  br label %"~select_type_block_2.start"
 
 then16:                                           ; preds = %ifcont14
-  %78 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %78, align 8
-  %79 = bitcast i32 (...)*** %78 to i8*
-  %80 = call i8* @__lfortran_dynamic_cast(i8* %79, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %81 = icmp ne i8* %80, null
-  store i1 %81, i1* %73, align 1
+  %77 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %77, align 8
+  %78 = bitcast i32 (...)*** %77 to i8*
+  %79 = call i8* @__lfortran_dynamic_cast(i8* %78, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %80 = icmp ne i8* %79, null
+  store i1 %80, i1* %73, align 1
   br label %ifcont18
 
 else17:                                           ; preds = %ifcont14
-  %82 = bitcast %shape* %74 to i8*
-  %83 = call i8* @__lfortran_dynamic_cast(i8* %82, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %84 = icmp ne i8* %83, null
-  store i1 %84, i1* %73, align 1
+  %81 = bitcast %shape* %74 to i8*
+  %82 = call i8* @__lfortran_dynamic_cast(i8* %81, i8* bitcast ({ i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %83 = icmp ne i8* %82, null
+  store i1 %83, i1* %73, align 1
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %85 = load i1, i1* %73, align 1
-  br i1 %85, label %then15, label %else19
+  %84 = load i1, i1* %73, align 1
+  br i1 %84, label %then15, label %else19
+
+"~select_type_block_2.start":                     ; preds = %then15
+  %85 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %85, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  br label %"~select_type_block_2.end"
+
+"~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
+  br label %ifcont38
 
 else19:                                           ; preds = %ifcont18
   %86 = alloca i1, align 1
@@ -363,33 +381,39 @@ else19:                                           ; preds = %ifcont18
   br i1 %89, label %then21, label %else22
 
 then20:                                           ; preds = %ifcont23
-  %90 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %90, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %91 = load %shape*, %shape** %s2, align 8
-  %92 = icmp eq %shape* %91, null
-  br i1 %92, label %then24, label %else25
+  br label %"~select_type_block_3.start"
 
 then21:                                           ; preds = %else19
-  %93 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %93, align 8
-  %94 = bitcast i32 (...)*** %93 to i8*
+  %90 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %90, align 8
+  %91 = bitcast i32 (...)*** %90 to i8*
+  %92 = call i8* @__lfortran_dynamic_cast(i8* %91, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %93 = icmp ne i8* %92, null
+  store i1 %93, i1* %86, align 1
+  br label %ifcont23
+
+else22:                                           ; preds = %else19
+  %94 = bitcast %shape* %87 to i8*
   %95 = call i8* @__lfortran_dynamic_cast(i8* %94, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
   %96 = icmp ne i8* %95, null
   store i1 %96, i1* %86, align 1
   br label %ifcont23
 
-else22:                                           ; preds = %else19
-  %97 = bitcast %shape* %87 to i8*
-  %98 = call i8* @__lfortran_dynamic_cast(i8* %97, i8* bitcast ({ i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %99 = icmp ne i8* %98, null
-  store i1 %99, i1* %86, align 1
-  br label %ifcont23
-
 ifcont23:                                         ; preds = %else22, %then21
-  %100 = load i1, i1* %86, align 1
-  br i1 %100, label %then20, label %else37
+  %97 = load i1, i1* %86, align 1
+  br i1 %97, label %then20, label %else37
 
-then24:                                           ; preds = %then20
+"~select_type_block_3.start":                     ; preds = %then20
+  %98 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %98, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %99 = load %shape*, %shape** %s2, align 8
+  %100 = icmp eq %shape* %99, null
+  br i1 %100, label %then24, label %else25
+
+"~select_type_block_3.end":                       ; preds = %ifcont36
+  br label %ifcont38
+
+then24:                                           ; preds = %"~select_type_block_3.start"
   %101 = call i8* @_lfortran_malloc(i64 8)
   call void @llvm.memset.p0i8.i32(i8* %101, i8 0, i32 8, i1 false)
   %102 = bitcast i8* %101 to %shape*
@@ -399,7 +423,7 @@ then24:                                           ; preds = %then20
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %104, align 8
   br label %ifcont26
 
-else25:                                           ; preds = %then20
+else25:                                           ; preds = %"~select_type_block_3.start"
   br label %ifcont26
 
 ifcont26:                                         ; preds = %else25, %then24
@@ -488,14 +512,14 @@ else35:                                           ; preds = %ifcont33
   br label %ifcont36
 
 ifcont36:                                         ; preds = %else35, %then34
-  br label %ifcont38
+  br label %"~select_type_block_3.end"
 
 else37:                                           ; preds = %ifcont23
   %147 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.11, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %147, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   br label %ifcont38
 
-ifcont38:                                         ; preds = %else37, %ifcont36, %then15
+ifcont38:                                         ; preds = %else37, %"~select_type_block_3.end", %"~select_type_block_2.end"
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm_new_classes-unlimited_polymorphic_intrinsic_type_allocate-a7e8dd2.json
+++ b/tests/reference/llvm_new_classes-unlimited_polymorphic_intrinsic_type_allocate-a7e8dd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm_new_classes-unlimited_polymorphic_intrinsic_type_allocate-a7e8dd2.stdout",
-    "stdout_hash": "9b863cc17b47d9f55e332a00f2a48fc0fadd94e86471ea689d1de7a1",
+    "stdout_hash": "611fadd96246885c64d5066763f8d965f0d2c6aeb2af94c34444476e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm_new_classes-unlimited_polymorphic_intrinsic_type_allocate-a7e8dd2.stdout
+++ b/tests/reference/llvm_new_classes-unlimited_polymorphic_intrinsic_type_allocate-a7e8dd2.stdout
@@ -58,8 +58,14 @@ define i32 @main(i32 %0, i8** %1) {
   br i1 %16, label %then, label %else
 
 then:                                             ; preds = %.entry
+  br label %"~select_type_block_.start"
+
+"~select_type_block_.start":                      ; preds = %then
   %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  br label %"~select_type_block_.end"
+
+"~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
   br label %ifcont
 
 else:                                             ; preds = %.entry
@@ -73,8 +79,14 @@ else:                                             ; preds = %.entry
   br i1 %23, label %then2, label %else3
 
 then2:                                            ; preds = %else
+  br label %"~select_type_block_1.start"
+
+"~select_type_block_1.start":                     ; preds = %then2
   %24 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  br label %"~select_type_block_1.end"
+
+"~select_type_block_1.end":                       ; preds = %"~select_type_block_1.start"
   br label %ifcont
 
 else3:                                            ; preds = %else
@@ -88,8 +100,14 @@ else3:                                            ; preds = %else
   br i1 %30, label %then4, label %else5
 
 then4:                                            ; preds = %else3
+  br label %"~select_type_block_2.start"
+
+"~select_type_block_2.start":                     ; preds = %then4
   %31 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  br label %"~select_type_block_2.end"
+
+"~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
   br label %ifcont
 
 else5:                                            ; preds = %else3
@@ -97,7 +115,7 @@ else5:                                            ; preds = %else3
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %32, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont
 
-ifcont:                                           ; preds = %else5, %then4, %then2, %then
+ifcont:                                           ; preds = %else5, %"~select_type_block_2.end", %"~select_type_block_1.end", %"~select_type_block_.end"
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.json
+++ b/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_insert_deallocate-finalize_01-3efebdd.stdout",
-    "stdout_hash": "a07aee52d6ca0a9d301bc44613823a452fbb09ce26cdac905591a7c2",
+    "stdout_hash": "3a51d64d23071e56455768b253c668c7570ff3b54ac7b0a79441c989",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.stdout
+++ b/tests/reference/pass_insert_deallocate-finalize_01-3efebdd.stdout
@@ -165,15 +165,13 @@
                                             (Logical 4)
                                         )
                                         [(ImplicitDeallocate
-                                            [(Var 6 arr_real)
-                                            (Var 6 str)]
+                                            [(Var 6 arr_real)]
                                         )
                                         (Return)]
                                         []
                                     )
                                     (ImplicitDeallocate
-                                        [(Var 6 arr_real)
-                                        (Var 6 str)]
+                                        [(Var 6 arr_real)]
                                     )]
                                     ()
                                     Public
@@ -250,8 +248,7 @@
                         ()
                     )
                     (ImplicitDeallocate
-                        [(Var 5 arr)
-                        (Var 5 str)]
+                        [(Var 5 arr)]
                     )
                     (Return)]
                 ),
@@ -422,9 +419,6 @@
                                         ()
                                         ()
                                         ()
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 3 str)]
                                     )
                                     (Return)
                                     (DoLoop


### PR DESCRIPTION
closes #8129
towards #3770


- Feat : Introduce class `LLVMFinalize` : 
    - Handles Finalization of the whole TU.
    - Have 4 major finalize functions (that actually insert finalization instructions into LLVM)
    - For now we have `finalize_string()` implemented. `finalize_struct()`, `finalize_array()`, `finalize_scalar()` to do.
    - The class avoids finalizing any global variable (module variables , TU variables (if any), save variables)
- Map symbols with their return block (llvm basic block) to insert finalization instruction before it.
- Enh : Use `visit_blockCall` instead of doing that manually in some spots, that's to have proper return basic block
- Enh : Use basic blocks with `AssociateBlock`, that's to have proper return basic block.
- Stop handling strings in `insert_deallocate` pass, that's to avoid double freeing.
- Tests : Adjust integration test as it had a dangling pointer bug.
- Tests : Update reference tests + Add integration test for string that should explode the memory if not freed.
