### PR TITLE
enh : Use `realloc_lhs_arrays` flag as a check before allocating struct arrays members in `struct_deepcopy`

### DIFF
--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -8656,8 +8656,7 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                 LCOMPILERS_ASSERT(false);
             }
 
-            // realloc_lhs_arrays
-            if (ASRUtils::is_allocatable(src_expr)) {
+            if (llvm_utils->compiler_options.po.realloc_lhs_arrays && ASRUtils::is_allocatable(src_expr)) {
                 uint64_t data_type_size = data_layout.getTypeAllocSize(llvm_data_type);
                 llvm::Value* total_memory = builder->CreateMul(num_elements,
                     llvm::ConstantInt::get(context, llvm::APInt(32, data_type_size)));


### PR DESCRIPTION
Closes #8683
Adresses https://github.com/lfortran/lfortran/pull/8682#discussion_r2407720666

I haven't added the check using `realloc_lhs_arrays` for https://github.com/lfortran/lfortran/pull/8682#discussion_r2407717262 because I don't feel we need this check their. Also, it leads to some additional failures. So, I am ignoring this for now.