### PR TITLE
Fix constructors in derived types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2013,6 +2013,7 @@ RUN(NAME class_72 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_73 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_74 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_75 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_76 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_76.f90
+++ b/integration_tests/class_76.f90
@@ -1,0 +1,30 @@
+module constructor_mod
+    implicit none
+    type :: toml_map
+    end type toml_map
+
+    type :: toml_table
+        class(toml_map), allocatable :: map
+    end type toml_table
+
+    interface toml_table
+        module procedure toml_table_init
+    end interface toml_table
+contains
+    function toml_table_init() result(this)
+        type(toml_table) :: this
+        allocate(toml_map :: this%map)
+    end function toml_table_init
+end module constructor_mod
+
+module reexport_mod
+    use constructor_mod, only: toml_table
+end module reexport_mod
+
+program main
+    use reexport_mod, only: toml_table
+    implicit none
+    type(toml_table) :: tabx
+    tabx = toml_table()
+    if (.not. allocated(tabx%map)) error stop 1
+end program main

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -3345,6 +3345,16 @@ public:
                 nullptr, 0, ext_sym->m_original_name,
                 dflt_access);
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(temp));
+            ASR::symbol_t *ext = ASRUtils::symbol_get_past_external(ext_sym->m_external);
+            if (remote_sym.size() > 0 && remote_sym[0] != '~' &&
+                    ASR::is_a<ASR::Struct_t>(*ext)) {
+                ASR::symbol_t *interface_override_s =
+                    m->m_symtab->resolve_symbol("~" + remote_sym);
+                if (interface_override_s) {
+                    to_be_imported_later.push(
+                        std::make_pair("~" + remote_sym, "~" + local_sym));
+                }
+            }
             if( ASR::is_a<ASR::GenericProcedure_t>(*ext_sym->m_external) ) {
                 process_generic_proc_custom_op<ASR::GenericProcedure_t>(local_sym,
                     ext_sym->m_external, to_be_imported_later, loc, m,


### PR DESCRIPTION
 - reexport_mod did use constructor_mod, only: toml_table. The semantic
    pass created an ExternalSymbol for the struct in constructor_mod, but it
    stopped there: the generic constructor interface ~toml_table (the interface
    toml_table block) was only queued for import when the symbol in the
    exporting module was a plain Struct_t. When the same struct was re-exported
    from another module, the importer saw the symbol as an ExternalSymbol, so
    it never pushed the matching ~toml_table. As a result the program-level use
    reexport_mod, only: toml_table brought in only the type but not its factory
    routine, and toml_table() defaulted to the intrinsic constructor—which lacks
    the allocate(toml_map :: this%map) body—so tabx%map stayed unallocated.
  - The fix extends import_symbols_util: when it encounters an ExternalSymbol,
    it now looks through to the wrapped symbol. If the wrapped symbol is a
    derived type and the remote_sym isn’t one of the synthetic ~ names, it
    checks the exporting module for ~remote_sym and, if present, enqueues
    that constructor interface for import (mirroring the logic that already
    existed for direct structs). That way both the struct and its user-defined
    constructor survive any number of USE, ONLY re-exports.

Fixes #8781.