### PR TITLE
fix: check for default structConstructor after custom constructors

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1670,6 +1670,7 @@ RUN(NAME derived_types_83 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_84 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES derived_types_84_module.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME derived_types_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_87 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_87.f90
+++ b/integration_tests/derived_types_87.f90
@@ -1,0 +1,33 @@
+module derived_types_87_mod
+  implicit none
+
+  type :: string_t
+     character(len=:), allocatable :: s
+  end type string_t
+
+  type :: compile_command_t
+        type(string_t) :: directory
+        type(string_t), allocatable :: str_arr(:)
+    end type compile_command_t    
+
+    interface compile_command_t
+        module procedure cct_new
+    end interface compile_command_t
+
+contains
+
+    type(compile_command_t) function cct_new(directory) result(cct)
+        character(len=*), intent(in) :: directory
+    end function
+end module derived_types_87_mod
+
+
+program derived_types_87
+    use derived_types_87_mod
+    type(compile_command_t) :: cc
+    cc = compile_command_t(directory = string_t("abc"), &
+            str_arr = [string_t("def"), string_t("xyz")])
+    if (cc%str_arr(1)%s /= "def") error stop
+    if (cc%str_arr(2)%s /= "xyz") error stop
+    if (cc%directory%s /= "abc") error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10397,6 +10397,15 @@ public:
                         }
                     }
                     if( !function_found ) {
+                        // First check if default structConstructor is there
+                        ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(
+                            current_scope->resolve_symbol(var_name));
+                        if (struct_sym &&
+                                ASR::is_a<ASR::Struct_t>(*struct_sym)) {
+                            tmp = create_DerivedTypeConstructor(x.base.base.loc, x.m_args, x.n_args,
+                                                    x.m_keywords, x.n_keywords, struct_sym);
+                            return;
+                        }
                         bool is_function = true;
                         v = intrinsic_as_node(x, is_function);
                         if( !is_function ) {


### PR DESCRIPTION
Fixes #8838 