### PR TITLE
fix: use expr instead struct_sym in getting struct default values

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1673,6 +1673,7 @@ RUN(NAME derived_types_84 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFIL
 RUN(NAME derived_types_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_87 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME derived_types_88 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/derived_types_88.f90
+++ b/integration_tests/derived_types_88.f90
@@ -1,0 +1,34 @@
+module derived_types_88_mod
+  implicit none
+
+  type :: string_t
+     character(len=:), allocatable :: s
+  end type string_t
+
+  type :: compile_command_t
+        character(:), allocatable :: directory
+        type(string_t), allocatable :: str_arr(:)
+    end type compile_command_t    
+
+contains
+
+    subroutine cct_new(cc)
+        type(compile_command_t), intent(inout) :: cc
+        call cct_inside()
+    contains 
+        subroutine cct_inside()
+            if (cc%directory /= "Home") error stop
+            if (cc%str_arr(1)%s /= "Hello") error stop
+            if (cc%str_arr(2)%s /= "World") error stop
+        end subroutine
+    end subroutine
+end module derived_types_88_mod
+
+
+program derived_types_88
+    use derived_types_88_mod
+    type(compile_command_t) :: cc
+    cc%directory = "Home" 
+    cc%str_arr = [string_t("Hello"), string_t("World")]
+    call cct_new(cc)
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4839,7 +4839,8 @@ public:
                 llvm::Constant* c = create_llvm_constant_from_asr_expr(var->m_value, orig_struct_sym);
                 field_values.push_back(c);
             } else {
-                llvm::Type* member_type = llvm_utils->get_type_from_ttype_t_util(var->m_type, struct_sym, module.get());
+                llvm::Type* member_type = llvm_utils->get_type_from_ttype_t_util(
+                    ASRUtils::EXPR(ASR::make_Var_t(al, var->base.base.loc, &var->base)),var->m_type, module.get());
                 field_values.push_back(llvm::Constant::getNullValue(member_type));
             }
         }


### PR DESCRIPTION
Fixes #8845 