### PR TITLE
Fix the branch name in build to wasm

### DIFF
--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -53,7 +53,7 @@ python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_ha
 echo "Wiping git history and creating fresh orphaned commit..."
 rm -rf .git
 
-git init
+git init -b main
 git config user.name "Deploy"
 git config user.email "noreply@deploylfortran.com"
 


### PR DESCRIPTION
Post merging of https://github.com/lfortran/lfortran/pull/8867, our CI in main fails with:

```shell
error: src refspec main does not match any
error: failed to push some refs to 'github.com:lfortran/wasm_builds.git'
```