### PR TITLE
Fix assumed-size arrays with null start bounds (Fortran 77 style)

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2888,6 +2888,11 @@ static inline bool is_only_upper_bound_empty(ASR::dimension_t& dim) {
     return (dim.m_start != nullptr && dim.m_length == nullptr);
 }
 
+// Returns true if dimension has no length (assumed-size), regardless of start
+static inline bool is_dimension_assumed_size(ASR::dimension_t& dim) {
+    return (dim.m_length == nullptr);
+}
+
 inline bool is_assumed_rank_array(ASR::ttype_t* x) {
     if (!ASR::is_a<ASR::Array_t>(*x)) {
         return false;
@@ -3145,7 +3150,12 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
                 }
             } else if( !ASRUtils::is_dimension_empty(m_dims, n_dims) ) {
                 physical_type = ASR::array_physical_typeType::PointerArray;
-            } else if ( is_dimension_star && ASRUtils::is_only_upper_bound_empty(m_dims[n_dims-1]) ) {
+            } else if ( is_argument && is_dimension_star && ASRUtils::is_dimension_assumed_size(m_dims[n_dims-1]) ) {
+                // Assumed-size dummy arrays (x(*)) use UnboundedPointerArray.
+                // Must check is_argument to avoid implied-shape arrays (parameter arrays).
+                // This handles both cases:
+                // - x(*) where only upper bound is empty (m_start != nullptr)
+                // - x(*) where both bounds are empty (Fortran 77 style)
                 physical_type = ASR::array_physical_typeType::UnboundedPointerArray;
             }
         }


### PR DESCRIPTION
## Summary
Fix assumed-size arrays with null start bounds (Fortran 77 style) that were causing crashes in LLVM codegen.

## Problem
FORTRAN 77 style assumed-size array declarations like `INTEGER IPIV(*)` in LAPACK's dlaswap have both `m_start` and `m_length` set to null in the ASR dimension info. The previous code only recognized assumed-size arrays when `m_start != nullptr && m_length == nullptr`, causing F77 style arrays to fall through to `DescriptorArray` handling instead of `UnboundedPointerArray`, resulting in LLVM codegen crashes.

## Changes
- Add `is_dimension_assumed_size()` helper that checks `m_length == nullptr`
- Check `is_argument` to distinguish assumed-size dummy arrays from implied-shape parameter arrays
- Add null check for `m_dims[idim].m_start` in `UnboundedPointerArray` codegen with default lower bound of 1
- Add `UnboundedPointerArray` case in `visit_ArrayPhysicalCastUtil` and `visit_ArraySizeUtil`

## Test plan
- [x] `dlaswap.f90` passes (both LLVM 21 and LLVM 11)
- [x] `arrays_reshape_21.f90` passes (implied-shape arrays still work)
- [x] `functions_25.f90` passes (no regression)
- [x] Integration tests: 99% pass rate (pre-existing failures only)

Fixes: #8916