### PR TITLE
CI: cd to root `wasm_builds` dir

### DIFF
--- a/ci/upload_lfortran_wasm.sh
+++ b/ci/upload_lfortran_wasm.sh
@@ -48,6 +48,10 @@ cp $D/src/bin/lfortran.data ${dest_dir}/${git_hash}/lfortran.data
 echo "$git_hash" > ${dest_dir}/latest_commit # overwrite the file instead of appending to it
 python $D/ci/wasm_builds_update_json.py ${dest_dir} ${lfortran_version} ${git_hash}
 
+# Move back to wasm_builds/ directory to perform git operations
+# This ensures docs/ remains as a subdirectory in the committed structure
+cd ..
+
 # Wipe git history to keep repository size small
 # This ensures only one commit exists, making old builds unreachable for GitHub GC
 echo "Wiping git history and creating fresh orphaned commit..."


### PR DESCRIPTION
The WASM build deployment script was executing git operations (git init, git add, git commit) from inside the wasm_builds/docs/ directory, which caused docs/ to become the new repository root during the force push, effectively flattening the directory structure on each deployment. This meant that on the next clone, the repository structure had data.json at the root level instead of inside a docs/ subdirectory, but the script would then create a fresh docs/ directory and look for data.json there, never finding the existing file from the previous deployment. The fix moves the git operations to the parent wasm_builds/ directory by adding cd .. before git init, ensuring that docs/ remains as a subdirectory in the committed repository structure, which allows the script to correctly find and update the existing data.json file across deployments.