### PR TITLE
equivalence with two array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2496,6 +2496,7 @@ RUN(NAME equivalence_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME equivalence_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME fortran_primes_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/equivalence_11.f90
+++ b/integration_tests/equivalence_11.f90
@@ -1,0 +1,34 @@
+      program two_array_equiv
+
+      implicit none
+
+!
+
+! This creates a 6 integer structure with 
+
+! ia2(3) and ia2(4) overlapping ('unioned') with ia1(1) and ia1(2)
+
+      integer ia1(4), ia2(4)
+
+      equivalence (ia1, ia2(3))
+
+      logical :: pf
+
+      ia1 = [11, 12, 13, 14]
+
+      ia2 = [ 1,  2,  3,  4]  ! 3 and 4 replace 11 and 12 in ia1
+
+      print *, 'ia1 =', ia1
+
+      print *, 'ia2 =', ia2
+
+      pf = all (ia1 == [3, 4, 13, 14]) .and.  &
+
+           all (ia2 == [1, 2,  3,  4])
+
+      print *, 'test: ', merge ('passed', 'failed', pf)
+
+      if (.not. pf) error stop
+
+      end program
+

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3578,9 +3578,11 @@ public:
                                         "ignored for now"
                                     );
                                 }
-                                type = ASRUtils::make_Array_t_util(al, asr_eq2->base.loc, type, dim2.p, dim2.size(), ASR::abiType::Source, false, ASR::array_physical_typeType::DescriptorArray, false, false);
-                                ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, type));
-                                var__->m_type = ptr;
+                                if (type != nullptr) {
+                                    type = ASRUtils::make_Array_t_util(al, asr_eq2->base.loc, type, dim2.p, dim2.size(), ASR::abiType::Source, false, ASR::array_physical_typeType::DescriptorArray, false, false);
+                                    ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, type));
+                                    var__->m_type = ptr;
+                                }
 
                                 Vec<ASR::expr_t*> args;
                                 args.reserve(al, arr->n_dims);
@@ -3609,9 +3611,12 @@ public:
                                     ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(asr_eq2);
                                     ASR::Variable_t *var__ = ASR::down_cast<ASR::Variable_t>(var->m_v);
                                     ASR::ttype_t* type = nullptr;
-                                    if (ASR::is_a<ASR::Real_t>(*arg_type2)) {
+                                    ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
+                                        ASRUtils::type_get_past_allocatable(
+                                            ASRUtils::type_get_past_pointer(arg_type2)));
+                                    if (ASR::is_a<ASR::Real_t>(*element_type)) {
                                         type = ASRUtils::TYPE(ASR::make_Real_t(al, asr_eq2->base.loc, 4));
-                                    } else if (ASR::is_a<ASR::Integer_t>(*arg_type2)) {
+                                    } else if (ASR::is_a<ASR::Integer_t>(*element_type)) {
                                         type = ASRUtils::TYPE(ASR::make_Integer_t(al, asr_eq2->base.loc, compiler_options.po.default_integer_kind));
                                     } else {
                                         diag.semantic_warning_label(
@@ -3620,8 +3625,10 @@ public:
                                             "ignored for now"
                                         );
                                     }
-                                    ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, type));
-                                    var__->m_type = ptr;
+                                    if (type != nullptr) {
+                                        ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, type));
+                                        var__->m_type = ptr;
+                                    }
 
                                     ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(al, asr_eq1->base.loc, ASRUtils::EXPR(pointer_to_cptr),asr_eq2, nullptr, nullptr);
                                     ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
@@ -3638,9 +3645,12 @@ public:
                                     ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(asr_eq1);
                                     ASR::Variable_t *var__ = ASR::down_cast<ASR::Variable_t>(var->m_v);
                                     ASR::ttype_t* type = nullptr;
-                                    if (ASR::is_a<ASR::Real_t>(*arg_type1)) {
+                                    ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
+                                        ASRUtils::type_get_past_allocatable(
+                                            ASRUtils::type_get_past_pointer(arg_type1)));
+                                    if (ASR::is_a<ASR::Real_t>(*element_type)) {
                                         type = ASRUtils::TYPE(ASR::make_Real_t(al, asr_eq1->base.loc, 4));
-                                    } else if (ASR::is_a<ASR::Integer_t>(*arg_type1)) {
+                                    } else if (ASR::is_a<ASR::Integer_t>(*element_type)) {
                                         type = ASRUtils::TYPE(ASR::make_Integer_t(al, asr_eq1->base.loc, compiler_options.po.default_integer_kind));
                                     } else {
                                         diag.semantic_warning_label(
@@ -3649,8 +3659,10 @@ public:
                                             "ignored for now"
                                         );
                                     }
-                                    ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type));
-                                    var__->m_type = ptr;
+                                    if (type != nullptr) {
+                                        ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type));
+                                        var__->m_type = ptr;
+                                    }
 
                                     ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(al, asr_eq2->base.loc, ASRUtils::EXPR(pointer_to_cptr),asr_eq1, nullptr, nullptr);
                                     ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -244,6 +244,9 @@ static inline ASR::ttype_t *type_get_past_pointer(ASR::ttype_t *f)
 {
     if (ASR::is_a<ASR::Pointer_t>(*f)) {
         ASR::Pointer_t *e = ASR::down_cast<ASR::Pointer_t>(f);
+        if (e->m_type == nullptr) {
+            return f;
+        }
         LCOMPILERS_ASSERT(!ASR::is_a<ASR::Pointer_t>(*e->m_type));
         return e->m_type;
     } else {


### PR DESCRIPTION
#8921 Fixes 

This PR fixes a segmentation fault caused by EQUIVALENCE generating pointer types with nullptr m_type fields.
ASR verification crashed when type_get_past_pointer() dereferenced these null types.

Key fixes:

Added a null check in type_get_past_pointer() to avoid dereferencing nullptr.

Updated EQUIVALENCE handling to only create pointer types when the base type is non-null

Corrected element-type extraction for array variables, ensuring correct type deduction during EQUIVALENCE