### PR TITLE
Enh : Introduce StringToArray casting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1879,6 +1879,7 @@ RUN(NAME string_83 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_84 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_87 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_87.f90
+++ b/integration_tests/string_87.f90
@@ -1,0 +1,14 @@
+program string_87
+    character(10) :: str
+    str = "HelloWorld"
+    call ff(str)
+    if(str /= "HelloWTrld") error stop 3 
+    contains
+    
+    subroutine ff(s)
+      character(5) :: s(2)
+      if(s(1) /= "Hello") error stop 1
+      if(s(2) /= "World") error stop 2
+      s(2)(2:2) = "T"
+    end subroutine
+end program 

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -221,7 +221,7 @@ ttype
     | Array(ttype type, dimension* dims, array_physical_type physical_type)
     | FunctionType(ttype* arg_types, ttype? return_var_type, abi abi, deftype deftype, string? bindc_name, bool elemental, bool pure, bool module, bool inline, bool static, symbol* restrictions, bool is_restriction)
 
-cast_kind = RealToInteger | IntegerToReal | LogicalToReal | RealToReal | IntegerToInteger | RealToComplex | IntegerToComplex | IntegerToLogical | RealToLogical | StringToLogical | StringToInteger | StringToList | ComplexToLogical | ComplexToComplex | ComplexToReal | ComplexToInteger | LogicalToInteger | RealToString | IntegerToString | LogicalToString | UnsignedIntegerToInteger | UnsignedIntegerToUnsignedInteger | UnsignedIntegerToReal | UnsignedIntegerToLogical | IntegerToUnsignedInteger | RealToUnsignedInteger | CPtrToUnsignedInteger | UnsignedIntegerToCPtr | IntegerToSymbolicExpression | ListToArray | PointerToInteger
+cast_kind = RealToInteger | IntegerToReal | LogicalToReal | RealToReal | IntegerToInteger | RealToComplex | IntegerToComplex | IntegerToLogical | RealToLogical | StringToLogical | StringToInteger | StringToList | ComplexToLogical | ComplexToComplex | ComplexToReal | ComplexToInteger | LogicalToInteger | RealToString | IntegerToString | LogicalToString | UnsignedIntegerToInteger | UnsignedIntegerToUnsignedInteger | UnsignedIntegerToReal | UnsignedIntegerToLogical | IntegerToUnsignedInteger | RealToUnsignedInteger | CPtrToUnsignedInteger | UnsignedIntegerToCPtr | IntegerToSymbolicExpression | ListToArray | StringToArray |PointerToInteger
 storage_type = Default | Save | Parameter
 access = Public | Private
 intent = Local | In | Out | InOut | ReturnVar | Unspecified

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1254,20 +1254,8 @@ namespace LCompilers {
                         break;
                     }
                     case ASR::array_physical_typeType::StringArraySinglePointer: {
-                        if (ASRUtils::is_fixed_size_array(v_type->m_dims, v_type->n_dims)) {
-                            llvm_type = llvm::ArrayType::get(character_type,
-                                ASRUtils::get_fixed_size_of_array(v_type->m_dims, v_type->n_dims));
-                            break;
-                        } else if (ASRUtils::is_dimension_empty(v_type->m_dims, v_type->n_dims)) {
-                            // Treat it as a DescriptorArray
-                            is_array_type = true;
-                            llvm::Type* el_type = character_type;
-                            llvm_type = arr_api->get_array_type(arg_expr, asr_type, el_type);
-                            break;
-                        } else {
-                            LCOMPILERS_ASSERT(false);
-                            break;
-                        }
+                        llvm_type = character_type;
+                        break;
                     }
                     case ASR::array_physical_typeType::AssumedRankArray: {
                         llvm::Type* el_type = get_el_type(arg_expr, v_type->m_type, module);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -405,7 +405,23 @@ class ASRToLLVMVisitor;
             */
             bool is_string_length_setable(ASR::String_t* string_t);
 
+            /**
+             * Gets string's consecutive memory data (char*).
+             * @param str_type ASR string type node of the string you're operating on.
+             * @param str LLVM physical-string. Pass it in one of these forms (`string_descriptor*`, `char*`)
+             * @param get_pointer_to_data flag to get a reference to the `char*` (`char**`). 
+             * @return an LLVM value of `char*` or `char**` (based on `get_pointer_to_data` flag)
+            */
+
             llvm::Value* get_string_data(ASR::String_t* str_type, llvm::Value* str, bool get_pointer_to_data=false);
+
+            /**
+             * Gets string's length
+             * @param str_type ASR string type node of the string you're operating on.
+             * @param str LLVM physical-string. Pass it in one of these forms (`string_descriptor*`, `char*`)
+             * @param get_pointer_to_data flag to get the length `i64` by reference (`i64*`). 
+             * @return an LLVM value of `i64` or `i64*` (based on `get_pointer_to_data` flag)
+            */
             llvm::Value* get_string_length(ASR::String_t* str_type, llvm::Value* str, bool get_pointer_to_len=false);
 
             // Gets string's length and data

--- a/src/libasr/pass/array_passed_in_function_call.cpp
+++ b/src/libasr/pass/array_passed_in_function_call.cpp
@@ -788,7 +788,8 @@ public:
             ASR::expr_t* arg_expr = x_m_args[i].m_value;
             if ( x_m_args[i].m_value && is_descriptor_array_casted_to_pointer_to_data(x_m_args[i].m_value) &&
                  !is_func_bind_c && !ASRUtils::is_pointer(ASRUtils::expr_type(x_m_args[i].m_value)) &&
-                 !ASR::is_a<ASR::FunctionParam_t>(*ASRUtils::get_past_array_physical_cast(x_m_args[i].m_value)) ) {
+                 !ASR::is_a<ASR::FunctionParam_t>(*ASRUtils::get_past_array_physical_cast(x_m_args[i].m_value)) 
+                 && !ASRUtils::is_stringToArray_cast(ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr)->m_arg)) {
                 ASR::ArrayPhysicalCast_t* array_physical_cast = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr);
                 ASR::expr_t* arg_expr_past_cast = ASRUtils::get_past_array_physical_cast(arg_expr);
                 const Location& loc = arg_expr->base.loc;

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -1093,13 +1093,16 @@ bool is_elemental_expr(ASR::expr_t* value) {
 }
 
 bool is_temporary_needed(ASR::expr_t* value) {
-    bool is_expr_with_no_type = value && (std::find(exprs_with_no_type.begin(), exprs_with_no_type.end(),
+    if(!value) { return false; }
+    bool is_expr_with_no_type = (std::find(exprs_with_no_type.begin(), exprs_with_no_type.end(),
         value->type) == exprs_with_no_type.end()) && ASRUtils::is_array(ASRUtils::expr_type(value));
-    bool is_non_empty_fixed_size_array = value && (!ASRUtils::is_fixed_size_array(ASRUtils::expr_type(value)) ||
+    bool is_non_empty_fixed_size_array = (!ASRUtils::is_fixed_size_array(ASRUtils::expr_type(value)) ||
         (ASRUtils::is_fixed_size_array(ASRUtils::expr_type(value)) &&
         ASRUtils::get_fixed_size_of_array(ASRUtils::expr_type(value)) > 0));
-    return value && is_expr_with_no_type &&
-            !is_elemental_expr(value) && is_non_empty_fixed_size_array;
+    return is_expr_with_no_type 
+        && !ASRUtils::is_stringToArray_cast(value)
+        && !is_elemental_expr(value) 
+        && is_non_empty_fixed_size_array;
 }
 
 ASR::symbol_t* extract_symbol(ASR::expr_t* expr) {

--- a/tests/reference/llvm-execute_command_line-0e9cd63.json
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-execute_command_line-0e9cd63.stdout",
-    "stdout_hash": "ec79c2b68039edb9ca7cd6eb23465afd7d638b68ec7bb7a940c824fd",
+    "stdout_hash": "66bd10c02e3b7c0a9babd5b7b5269709dbe27cb55d320e4fd98f0bce",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-execute_command_line-0e9cd63.stdout
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.stdout
@@ -13,11 +13,13 @@ define void @_lcompilers_execute_command_line_(%string_descriptor* %command, i1*
   %_lcompilers_exit_status = alloca i32, align 4
   %0 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
   %1 = load i8*, i8** %0, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 1
-  %3 = load i64, i64* %2, align 4
-  %4 = trunc i64 %3 to i32
-  %5 = call i32 @_lfortran_exec_command(i8* %1, i32 %4)
-  store i32 %5, i32* %_lcompilers_exit_status, align 4
+  %2 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
+  %3 = load i8*, i8** %2, align 8
+  %4 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 1
+  %5 = load i64, i64* %4, align 4
+  %6 = trunc i64 %5 to i32
+  %7 = call i32 @_lfortran_exec_command(i8* %3, i32 %6)
+  store i32 %7, i32* %_lcompilers_exit_status, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -34,11 +36,13 @@ define void @_lcompilers_execute_command_line_1(%string_descriptor* %command, i1
   %_lcompilers_exit_status = alloca i32, align 4
   %0 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
   %1 = load i8*, i8** %0, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 1
-  %3 = load i64, i64* %2, align 4
-  %4 = trunc i64 %3 to i32
-  %5 = call i32 @_lfortran_exec_command(i8* %1, i32 %4)
-  store i32 %5, i32* %_lcompilers_exit_status, align 4
+  %2 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
+  %3 = load i8*, i8** %2, align 8
+  %4 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 1
+  %5 = load i64, i64* %4, align 4
+  %6 = trunc i64 %5 to i32
+  %7 = call i32 @_lfortran_exec_command(i8* %3, i32 %6)
+  store i32 %7, i32* %_lcompilers_exit_status, align 4
   br label %return
 
 return:                                           ; preds = %.entry


### PR DESCRIPTION
closes #7136

In case of passing a string to a function expecting an array of strings, We'll do a cast.

What is the length and size of resulting array? let's consider all possible variations (length->exist or not, size->exist or not).
```
STRING PASSED --> `character(20) :: str`
- `character(10) :: arr(2)`   -> array of size=2, length=10 
- `character(10) :: arr(*)`   -> array of size=20/2, length =10
- `character(*) :: arr(2)`    -> array of size = 1, length = 20/2
- `character(*) :: arr(*)`    -> array of size = 1, length = 20
- `character(*) :: arr(n)`    -> array of size = n, length = 20 (undefined behavior)
```
Notice that almost all of them could lead to wrong behavior if length and size don't fit with the whole length of passed string. Rules here a bit vague, but gfortran can do the cast (it's native to string and array of string actual phsyicalTypes when gfortran lowers the code) + some codes use that feature, so we need to support that weird casting . 