### PR TITLE
ci: enable libstdc++ assertions in quick checks

### DIFF
--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -102,7 +102,6 @@ jobs:
         shell: bash -e -l {0}
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
-            # Enable libstdc++ assertions to surface latent bounds bugs (needed to repro mod_cpp_modfile_crash)
             export CXXFLAGS="-Werror -D_GLIBCXX_ASSERTIONS"
             export CFLAGS="-Werror -D_GLIBCXX_ASSERTIONS"
             export WIN=0


### PR DESCRIPTION
Update Quick-Checks-CI to build and run tests with -D_GLIBCXX_ASSERTIONS in both C and C++. This is intended to land after the tests PR (#8955) and the fixes for empty-file handling (#8956) and modfile locations (#8957), so that CI catches latent bounds/UB issues without new failures.