### PR TITLE
read_file(): handle filesize==0 correctly

### DIFF
--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -136,11 +136,14 @@ bool read_file(const std::string &filename, std::string &text)
 
     std::ifstream::pos_type filesize = ifs.tellg();
     if (filesize < 0) return false;
+    if (filesize == 0) {
+        text = "";
+        return true;
+    }
 
     ifs.seekg(0, std::ios::beg);
 
     std::vector<char> bytes(filesize);
-    if (filesize == 0) bytes.reserve(1);
     ifs.read(&bytes[0], filesize);
 
     text = std::string(&bytes[0], filesize);


### PR DESCRIPTION
On macOS the bug can be triggered by:

```diff
--- a/build1.sh
+++ b/build1.sh
@@ -13,8 +13,8 @@ cmake \
     -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
     -DCMAKE_INSTALL_LIBDIR=share/lfortran/lib \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DCMAKE_C_FLAGS="${CFLAGS} -fdiagnostics-color=always" \
-    -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fdiagnostics-color=always" \
+    -DCMAKE_C_FLAGS="${CFLAGS} -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -fdiagnostics-color=always" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -fdiagnostics-color=always" \
 -G Ninja \
     .
 cmake --build .
```

The `bytes` vector was reserved, but size was still zero, so `bytes[0]` was invalid.