### PR TITLE
CI: enable bounds checking for C++ stdlib

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash -e -l {0}
         run: |
             ( cd src && ./build0.sh )
-            export CXXFLAGS="-Werror"
+            export CXXFLAGS="-Werror -D_GLIBCXX_ASSERTIONS"
             cmake -S src -B builddir -GNinja \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DWITH_LLVM=yes \
@@ -335,6 +335,7 @@ jobs:
         run: |
             export WASI_SDK_PATH=$HOME/ext/wasi-sdk
             export EMSDK_PATH=$HOME/ext/emsdk
+            export CXXFLAGS="-Werror -D_GLIBCXX_ASSERTIONS"
             ./build0.sh
             cmake . -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
@@ -638,7 +639,7 @@ jobs:
         shell: bash -e -l {0}
         run: |
           ./build0.sh
-          export CXXFLAGS="-Werror"
+          export CXXFLAGS="-Werror -D_GLIBCXX_ASSERTIONS"
           cmake . -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DWITH_LLVM=yes \

--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -102,8 +102,8 @@ jobs:
         shell: bash -e -l {0}
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
-            export CXXFLAGS="-Werror"
-            export CFLAGS="-Werror"
+            export CXXFLAGS="-Werror -D_GLIBCXX_ASSERTIONS -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG"
+            export CFLAGS="-Werror -D_GLIBCXX_ASSERTIONS -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG"
             export WIN=0
             shell ci/build.sh
 


### PR DESCRIPTION
On macOS use:

    -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG

on Linux use:

    -D_GLIBCXX_ASSERTIONS

And check all Debug builds. The Release build we build without it, to ensure it works too.