### PR TITLE
fix:: Intrinsic function len() usage on allocatable character arrays with size 0

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1884,6 +1884,7 @@ RUN(NAME string_84 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_87 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_88 LABELS llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays) #remove gfortran label, as functionality gave incorrect results
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_88.f90
+++ b/integration_tests/string_88.f90
@@ -1,0 +1,14 @@
+! This program checks Len Function 
+! On allocation of String Arrays with size = 0
+program string_88
+  implicit none
+  character(len=:), allocatable :: list1(:), list2(:)
+  character(len=23), pointer :: list3(:) !Using pointer allocation
+  list1 = [character(len=23):: ]
+  allocate(character(len=23) :: list2(0))
+  allocate(list3(0))
+  print *,len(list1), len(list2), len(list3)
+  if (len(list1) /= 23) error stop
+  if (len(list2) /= 23) error stop
+  if (len(list3) /= 23) error stop
+end program string_88


### PR DESCRIPTION
Fixes #8342 

Added Test-Case:
```
program string_88
  implicit none
  character(len=:), allocatable :: list1(:), list2(:)
  character(len=23), pointer :: list3(:) !Using pointer allocation
  list1 = [character(len=23):: ]
  allocate(character(len=23) :: list2(0))
  allocate(list3(0))
  print *,len(list1), len(list2), len(list3)
  if (len(list1) /= 23) error stop
  if (len(list2) /= 23) error stop
  if (len(list3) /= 23) error stop
end program string_88
```

Updated main:
```
$ lfortran a.f90 --realloc-lhs-arrays
23    23    23
```

Flang:
```
$ flang a.f90 & ./a.out
[1]+  Done                    flang a.f90
[1] 59273
           23           23           23
```