### PR TITLE
fix:: Handle AssumeLength arrays inside fill_array_details_() function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1886,6 +1886,7 @@ RUN(NAME string_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_87 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_88 LABELS llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays) #remove gfortran label, as functionality gave incorrect results
+RUN(NAME string_89 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_89.f90
+++ b/integration_tests/string_89.f90
@@ -1,0 +1,21 @@
+! This test checks that assignment to a slice of an array 
+! Inside Subroutine works correctly for assumed-length strings.
+program string_89
+  implicit none
+  character(len=5)              :: strings(3) = ['-----','-----','-----']
+  character(len=:), allocatable :: str(:)
+  str   = ['ABC','BEE','SEE']
+  call assign_slice(strings, str) 
+  print *,strings
+  if (strings(1) /= 'ABC') error stop
+  if (strings(2) /= 'BEE') error stop
+  if (strings(3) /= 'SEE') error stop
+
+  contains 
+  subroutine assign_slice(strings,str)
+    implicit none
+    character(len=*), intent(inout) :: strings(:)
+    character(len=:), allocatable, intent(in) :: str(:)
+    strings(:) = str
+  end subroutine
+end program string_89

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4490,6 +4490,15 @@ public:
     void fill_array_details_(ASR::expr_t* expr, llvm::Value* ptr, llvm::Type* type_, ASR::dimension_t* m_dims,
         size_t n_dims, bool is_malloc_array_type, bool is_array_type,
         bool is_list, [[maybe_unused]]ASR::ttype_t* m_type, bool is_data_only=false) {
+        // Skip function call for AssumedLength strings
+        // Their descriptors come from the original parameter inside subroutines
+        if (ASRUtils::is_character(*m_type)) {
+            ASR::String_t* str_type = ASR::down_cast<ASR::String_t>(
+                ASRUtils::extract_type(m_type));
+            if (str_type->m_len_kind == ASR::string_length_kindType::AssumedLength) {
+                return;
+            }
+        }
         ASR::ttype_t* asr_data_type = ASRUtils::type_get_past_array(
             ASRUtils::type_get_past_pointer(
                 ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(expr))));


### PR DESCRIPTION
Fixes #8341 

Since AssumeLength arrays derive their descriptors from parent array, adding logic to avoid this step of recreating descriptors inside subroutines. 

MRE:
```
program string_89
  implicit none
  character(len=5)              :: strings(3) = ['-----','-----','-----']
  character(len=:), allocatable :: str(:)
  str   = ['ABC','BEE','SEE']
  call assign_slice(strings, str) 
  print *,strings
  if (strings(1) /= 'ABC') error stop
  if (strings(2) /= 'BEE') error stop
  if (strings(3) /= 'SEE') error stop

  contains 
  subroutine assign_slice(strings,str)
    implicit none
    character(len=*), intent(inout) :: strings(:)
    character(len=:), allocatable, intent(in) :: str(:)
    strings(:) = str
  end subroutine
end program string_89
```

Updated Main:
```
$ lfortran a.f90 --realloc-lhs-arrays
ABC      BEE      SEE  
```

Gfortran
```
$ gfortran a.f90 & ./a.out
[1]+  Done                    gfortran a.f90
[1] 320962
 ABC  BEE  SEE  
```