### PR TITLE
fix : an error catch has been introduced to provide correct explanation (issue #8967)

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1175,6 +1175,19 @@ public:
         }
 
         if (a_fmt && ASR::is_a<ASR::IntegerConstant_t>(*a_fmt)) {
+
+            if (_type == AST::stmtType::Read) {
+                diag.add(Diagnostic(
+                    "FORMAT statement labels are not supported yet for formatted READ.",
+                    Level::Error, Stage::Semantic, {
+                        Label(
+                            "use a character literal instead, e.g. READ(*,'(I3)')",
+                            {loc}
+                        )
+                    }));
+                throw SemanticAbort();
+            }
+
             ASR::IntegerConstant_t* a_fmt_int = ASR::down_cast<ASR::IntegerConstant_t>(a_fmt);
             int64_t label = a_fmt_int->m_n;
             if (format_statements.find(label) == format_statements.end()) {
@@ -1190,6 +1203,9 @@ public:
                 }
                 return;
             }
+
+            std::string fmt_str = format_statements[label];
+
             ASR::ttype_t* a_fmt_type = ASRUtils::TYPE(ASR::make_String_t(
                 al, a_fmt->base.loc, 1,
                 ASRUtils::EXPR(ASR::make_IntegerConstant_t(
@@ -1199,6 +1215,7 @@ public:
                 ASR::string_physical_typeType::DescriptorString));
             a_fmt_constant = ASRUtils::EXPR(ASR::make_StringConstant_t(
                 al, a_fmt->base.loc, s2c(al, format_statements[label]), a_fmt_type));
+                a_fmt = a_fmt_constant;
         }
         // Don't use stringFormat with single character argument
         if (!a_fmt


### PR DESCRIPTION
issue #8967 

there was no check for format so check is introduced to give a proper error message in case of a integer is given in place of character 

MRE:
```  
program internal
   implicit none
   integer :: i
   character(8) :: string = '42'
   read (string,100) i
   print 100,i
100 format (I3)
 END program internal
```

BEFORE:
```
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
LCompilersException: Unsupported string physical type.
```

AFTER :
```
code generation error: use a character format string instead, e.g. READ(5, '(I3)')
 --> t1.f90:5:17
  |
5 |    read (string,100) i
  |                 ^^^ 
```

Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.


QUESTIONS:

this format can be supported on lfortran as well like in gfortran but i new to this repository so is there any function available to convert integer to character for llvm backend ?

