### PR TITLE
fix: handle polymorphic scalar variables inside select-block expressions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2066,6 +2066,7 @@ RUN(NAME class_78 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME class_79 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_80 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_81 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_82 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_82.f90
+++ b/integration_tests/class_82.f90
@@ -1,0 +1,41 @@
+program class_82
+    implicit none
+    class(*), allocatable :: xi, xr, xl
+    integer :: i
+    real :: r
+    logical :: l
+    ! Test integer binary operations
+    allocate(xi, source=5)
+    select type (xi)
+    type is (integer)
+        i = xi * 2
+        print *, i, xi
+        if (i /= 10) error stop "Integer multiply failed"
+        i = xi + 3
+        print *, i, xi
+        if (i /= 8) error stop "Integer add failed"
+    end select
+    ! Test real binary operations
+    allocate(xr, source=3.0)
+    select type (xr)
+    type is (real)
+        r = xr * 2.0
+        print *, r, xr
+        if (abs(r - 6.0) > 1e-5) error stop "Real multiply failed"
+        r = xr + 1.5
+        print *, r, xr
+        if (abs(r - 4.5) > 1e-5) error stop "Real add failed"
+    end select
+    ! Test logical binary operations
+    allocate(xl, source=.true.)
+    select type (xl)
+    type is (logical)
+        l = xl .and. .false.
+        print *, l, xl
+        if (l) error stop "Logical AND failed"
+        l = xl .or. .false.
+        print *, l, xl
+        if (.not. l) error stop "Logical OR failed"
+    end select
+    print *, "PASSED"
+end program class_82

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9040,6 +9040,8 @@ public:
         llvm::Value *left_val = tmp;
         this->visit_expr_wrapper(x.m_right, true);
         llvm::Value *right_val = tmp;
+        load_unlimited_polymorpic_value(x.m_left, left_val);
+        load_unlimited_polymorpic_value(x.m_right, right_val);
         llvm::Value *zero, *cond;
         if (ASRUtils::is_integer(*x.m_type)) {
             int a_kind = down_cast<ASR::Integer_t>(x.m_type)->m_kind;
@@ -9368,6 +9370,8 @@ public:
         llvm::Value *left_val = tmp;
         this->visit_expr_load_wrapper(x.m_right, LLVM::is_llvm_pointer(*expr_type(x.m_right)) ? 2 : 1, true);
         llvm::Value *right_val = tmp;
+        load_unlimited_polymorpic_value(x.m_left, left_val);
+        load_unlimited_polymorpic_value(x.m_right, right_val);
         LCOMPILERS_ASSERT(ASRUtils::is_integer(*x.m_type) ||
             ASRUtils::is_unsigned_integer(*x.m_type))
         switch (x.m_op) {
@@ -9472,6 +9476,8 @@ public:
         this->visit_expr_wrapper(x.m_right, true);
         llvm::Value *right_val = tmp;
         lookup_enum_value_for_nonints = false;
+        load_unlimited_polymorpic_value(x.m_left, left_val);
+        load_unlimited_polymorpic_value(x.m_right, right_val);
         LCOMPILERS_ASSERT(ASRUtils::is_real(*x.m_type))
         if (ASRUtils::is_simd_array(x.m_right) && is_a<ASR::Var_t>(*x.m_right)) {
             llvm::Type *right_type = llvm_utils->get_type_from_ttype_t_util(x.m_right, ASRUtils::expr_type(x.m_right), module.get());


### PR DESCRIPTION
Fixes #9010 

Added checks in Integer, Real, Binary Operations to Load Polymorphic Variables correctly, if accessed from select-block.

Added Test-Case:
```
program class_82
    implicit none
    class(*), allocatable :: xi, xr, xl
    integer :: i
    real :: r
    logical :: l
    ! Test integer binary operations
    allocate(xi, source=5)
    select type (xi)
    type is (integer)
        i = xi * 2
        print *, i, xi
        if (i /= 10) error stop "Integer multiply failed"
        i = xi + 3
        print *, i, xi
        if (i /= 8) error stop "Integer add failed"
    end select
    ! Test real binary operations
    allocate(xr, source=3.0)
    select type (xr)
    type is (real)
        r = xr * 2.0
        print *, r, xr
        if (abs(r - 6.0) > 1e-5) error stop "Real multiply failed"
        r = xr + 1.5
        print *, r, xr
        if (abs(r - 4.5) > 1e-5) error stop "Real add failed"
    end select
    ! Test logical binary operations
    allocate(xl, source=.true.)
    select type (xl)
    type is (logical)
        l = xl .and. .false.
        print *, l, xl
        if (l) error stop "Logical AND failed"
        l = xl .or. .false.
        print *, l, xl
        if (.not. l) error stop "Logical OR failed"
    end select
    print *, "PASSED"
end program class_82

```

Updated Main:
```
$ lfortran a.f90
10    5
8    5
6.00000000e+00    3.00000000e+00
4.50000000e+00    3.00000000e+00
F    T
T    T
PASSED
```

Gfortran:
```
$ gfortran a.f90 & ./a.out
[1]+  Done                    gfortran a.f90
[1] 113434
          10           5
           8           5
   6.00000000       3.00000000    
   4.50000000       3.00000000    
 F T
 T T
 PASSED
```
