### PR TITLE
Fix: C test compilation with xeus-zmq warning flags

### DIFF
--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -8,7 +8,9 @@ endmacro(ADDTEST)
 
 macro(ADDTESTC name)
     add_executable(${name} ${name}.c)
-    target_link_libraries(${name} lfortran_lib  ${ARGN})
+    # Link only to specified libraries, not lfortran_lib which brings in C++
+    # flags from xeus-zmq that are invalid for C compilation (-Wreorder)
+    target_link_libraries(${name} ${ARGN})
     add_test(${name} ${PROJECT_BINARY_DIR}/${name})
 endmacro(ADDTESTC)
 


### PR DESCRIPTION
## Summary
- Fix C test compilation failure caused by C++-only `-Wreorder` flag propagating from xeus-zmq

## Problem
The xeus-zmq conda package exports `INTERFACE_COMPILE_OPTIONS` containing `-Wunused-parameter`, `-Wextra`, and `-Wreorder`. The `-Wreorder` flag is valid for C++ but not C, causing compilation errors for C targets when `-Werror` is enabled:

```
cc1: error: command-line option '-Wreorder' is valid for C++/ObjC++ but not for C [-Werror]
```

## Solution
The `ADDTESTC` macro was linking to `lfortran_lib` which transitively depends on `xeus-zmq`, propagating these C++-only flags to C compilation.

Fixed by removing the implicit `lfortran_lib` link from the `ADDTESTC` macro. C test executables now only link to their explicitly specified libraries (like `lfortran_c`).

## Verification
- Build passes with `-Werror` and `WITH_XEUS=yes`
- `test_cwrapper` C test compiles and passes