### PR TITLE
Add atomic to OpenMP tests

### DIFF
--- a/integration_tests/openmp_55.f90
+++ b/integration_tests/openmp_55.f90
@@ -5,10 +5,11 @@ program openmp_55
     integer :: i,n=10,counter
     call omp_set_num_threads(8)
 counter=0
-  !$OMP PARALLEL 
+  !$OMP PARALLEL
     !$OMP MASTER
       do i = 1, n
           !$OMP TASK shared(counter)
+                !$OMP ATOMIC
                 counter=counter+1
               print *, "Task Done by TID:-",omp_get_thread_num()
           !$OMP END TASK

--- a/integration_tests/openmp_56.f90
+++ b/integration_tests/openmp_56.f90
@@ -7,6 +7,7 @@ program openmp_56
 
     !$omp parallel
         !$omp task shared(counter)
+            !$omp atomic
             counter=counter+1
             print *, "Task done by TID:-",omp_get_thread_num()
         !$omp end task


### PR DESCRIPTION
Increasing the counter without atomic caused occational flakiness with gfortran (e.g. https://github.com/lfortran/lfortran/actions/runs/20157490705/job/57862907040 ) This should fix it.

Fixes #9026. Towards #9027.