### PR TITLE
Add vanilla Reference-LAPACK to third-party tests

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -934,7 +934,7 @@ program test_dgesv
 end program
 TESTEOF
 
-    lfortran --implicit-interface test_dgesv.f90 -L build/lib -lblas -llapack -o test_dgesv
+    lfortran --implicit-interface test_dgesv.f90 -L build/lib -llapack -lblas -o test_dgesv
     ./test_dgesv
 '
 


### PR DESCRIPTION
## Summary
Add Section 14 to third-party tests for vanilla Reference-LAPACK v3.12.0:

- Clone official Reference-LAPACK repository (not patched fork)
- Apply minimal `sed` patch to skip `FortranCInterface_VERIFY`
- Build BLAS and LAPACK libraries with LFortran flags:
  `--fixed-form-infer --implicit-interface --legacy-array-sections --separate-compilation`
- Run DGESV linear solve test to verify runtime correctness

This validates that LFortran can build and use **unmodified** LAPACK.

## Dependencies
- Requires #9024 (Fix assumed-size dummy ABI) to be merged first
- Will need rebase after #9024 merges

## Test plan
- CI will run the LAPACK build and DGESV test
- Verify LAPACK libraries compile without errors
- Verify DGESV solves a 3x3 linear system correctly