### PR TITLE
Fix: array intrinsic eval optional args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1143,6 +1143,7 @@ RUN(NAME intrinsics_254 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # derfc
 RUN(NAME intrinsics_255 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dbesjn, dbesyn
 RUN(NAME intrinsics_256 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # minval
 RUN(NAME intrinsics_257 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # product
+RUN(NAME intrinsics_product_nodes_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # product
 RUN(NAME intrinsics_258 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # abs
 RUN(NAME intrinsics_259 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # lgt, llt, lge, lle
 RUN(NAME intrinsics_260 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # sum

--- a/integration_tests/intrinsics_product_nodes_01.f90
+++ b/integration_tests/intrinsics_product_nodes_01.f90
@@ -1,0 +1,10 @@
+program intrinsics_product_nodes
+    use, intrinsic :: iso_fortran_env, only: int32
+    implicit none
+
+    integer, parameter :: ndim = 1
+    integer(int32), dimension(ndim), parameter :: nodes = [10_int32]
+    integer(int32), parameter :: ncol = product(nodes)
+
+    if (ncol /= 10_int32) error stop
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -329,21 +329,23 @@ static inline ASR::expr_t *eval_ArrIntrinsic(Allocator & al,
     }
     ASR::ArrayConstant_t *mask = nullptr;
     ASR::expr_t* dim = b.i32(1);
-    if (args[1] && is_logical(*ASRUtils::expr_type(args[1]))) {
-        if (ASR::is_a<ASR::ArrayConstant_t>(*args[1])) {
-            mask = ASR::down_cast<ASR::ArrayConstant_t>(args[1]);
-        } else if (ASR::is_a<ASR::LogicalConstant_t>(*args[1])) {
-            std::vector<ASR::expr_t*> mask_values(size, args[1]);
+    ASR::expr_t* arg1 = (args.size() > 1) ? args[1] : nullptr;
+    ASR::expr_t* arg2 = (args.size() > 2) ? args[2] : nullptr;
+    if (arg1 && is_logical(*ASRUtils::expr_type(arg1))) {
+        if (ASR::is_a<ASR::ArrayConstant_t>(*arg1)) {
+            mask = ASR::down_cast<ASR::ArrayConstant_t>(arg1);
+        } else if (ASR::is_a<ASR::LogicalConstant_t>(*arg1)) {
+            std::vector<ASR::expr_t*> mask_values(size, arg1);
             ASR::expr_t *arr = b.ArrayConstant(mask_values, logical, false);
             mask = ASR::down_cast<ASR::ArrayConstant_t>(arr);
         } else {
             return nullptr;
         }
-    } else if(args[2]) {
-        if (ASR::is_a<ASR::ArrayConstant_t>(*args[2])) {
-            mask = ASR::down_cast<ASR::ArrayConstant_t>(args[2]);
-        } else if (ASR::is_a<ASR::LogicalConstant_t>(*args[2])) {
-            std::vector<ASR::expr_t*> mask_values(size, args[2]);
+    } else if (arg2) {
+        if (ASR::is_a<ASR::ArrayConstant_t>(*arg2)) {
+            mask = ASR::down_cast<ASR::ArrayConstant_t>(arg2);
+        } else if (ASR::is_a<ASR::LogicalConstant_t>(*arg2)) {
+            std::vector<ASR::expr_t*> mask_values(size, arg2);
             ASR::expr_t *arr = b.ArrayConstant(mask_values, logical, false);
             mask = ASR::down_cast<ASR::ArrayConstant_t>(arr);
         } else {


### PR DESCRIPTION
## Summary
Fix compile-time evaluation of array intrinsics to not read missing optional arguments.

This prevents out-of-bounds access of `Vec` inside `eval_ArrIntrinsic()` when an intrinsic
is called with only the present arguments (e.g. `product(nodes)`).

## Repro (LLVM11, assertions enabled)
- `test/splpak_test_linear.f90` from `splpak` triggers `LCOMPILERS_ASSERT(pos < n)` while evaluating `product(nodes)` at compile time.
  - Backtrace: `/tmp/lfortran-dev/7738/gdb_bt_splpak_test_linear_2025-12-12_231633.txt`

## Fix
- Guard access to `args[1]` / `args[2]` in `eval_ArrIntrinsic()` using `args.size()`.

## Tests / evidence
- New integration test: `integration_tests/intrinsics_product_nodes_01.f90`.
  - Run log: `/tmp/lfortran-dev/7738/integration_intrinsics_product_nodes_2025-12-12_231941.txt`
- `splpak_test_linear.f90` compiles after the fix:
  - Log: `/tmp/lfortran-dev/7738/compile_splpak_test_linear_after_fix_2025-12-12_231942.txt`

Refs: #7738
