### PR TITLE
fix: Handle mold sizes for compile time array values, inside transfer function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2548,6 +2548,7 @@ RUN(NAME transfer_05 LABELS gfortran llvm)
 RUN(NAME transfer_06 LABELS gfortran llvm)
 RUN(NAME transfer_07 LABELS gfortran llvm fortran)
 RUN(NAME transfer_08 LABELS gfortran llvm fortran)
+RUN(NAME transfer_09 LABELS gfortran llvm fortran)
 
 RUN(NAME present_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME present_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/transfer_09.f90
+++ b/integration_tests/transfer_09.f90
@@ -1,0 +1,21 @@
+program transfer_09
+  integer, dimension(3) :: lhs, rhs
+  real, dimension(3):: r1 
+  real:: a,b,c 
+
+  rhs = [10, 20, 30]
+
+  a = transfer(rhs(1), a)
+  b = transfer(rhs(2), b)
+  c = transfer(rhs(3), c)
+  r1(1:3) = transfer(rhs, r1)
+  lhs(1:3) = transfer(rhs, lhs)
+  print *, "Correct Values", rhs, a, b, c
+  print *, "Transferred Values", lhs, r1
+
+  ! Check aray transfer of same type
+  if (lhs(1) /= rhs(1) .or. lhs(2) /= rhs(2) .or. lhs(3) /= rhs(3)) error stop
+
+  !Check with scalar transfers for real type
+  if (r1(1) /= a .or. r1(2) /= b .or. r1(3) /= c) error stop
+end program transfer_09

--- a/tests/reference/asr-array_02_transfer-1bcc806.json
+++ b/tests/reference/asr-array_02_transfer-1bcc806.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_transfer-1bcc806.stdout",
-    "stdout_hash": "244f06cafdb774fd07e60c1681f15b0e43c4ef973df98f6684e9f7f5",
+    "stdout_hash": "2c486dc018ede2d0221bb845dc9e7c3f2f80f70036925d3fbac91ff4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_transfer-1bcc806.stdout
+++ b/tests/reference/asr-array_02_transfer-1bcc806.stdout
@@ -73,7 +73,7 @@
                                 (Array
                                     (Real 4)
                                     [((IntegerConstant 1 (Integer 4) Decimal)
-                                    (IntegerConstant 64 (Integer 4) Decimal))]
+                                    (IntegerConstant 7 (Integer 4) Decimal))]
                                     FixedSizeArray
                                 )
                                 ()

--- a/tests/reference/asr-transfer_09-a440034.json
+++ b/tests/reference/asr-transfer_09-a440034.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-transfer_09-a440034",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/transfer_09.f90",
+    "infile_hash": "e76993559a0b5a14c872b6b2ee4229f7d830997c80a68a73a9a1ccad",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-transfer_09-a440034.stdout",
+    "stdout_hash": "0d783ceaeddb725aa556f7eeb514ba8789c8410378fe35e7a329bfb9",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-transfer_09-a440034.stdout
+++ b/tests/reference/asr-transfer_09-a440034.stdout
@@ -1,0 +1,479 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            transfer_09:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            a:
+                                (Variable
+                                    2
+                                    a
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            b:
+                                (Variable
+                                    2
+                                    b
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            c:
+                                (Variable
+                                    2
+                                    c
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Real 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            lhs:
+                                (Variable
+                                    2
+                                    lhs
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Integer 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            r1:
+                                (Variable
+                                    2
+                                    r1
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Real 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                ),
+                            rhs:
+                                (Variable
+                                    2
+                                    rhs
+                                    []
+                                    Local
+                                    ()
+                                    ()
+                                    Default
+                                    (Array
+                                        (Integer 4)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 3 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                )
+                        })
+                    transfer_09
+                    []
+                    [(Assignment
+                        (Var 2 rhs)
+                        (ArrayConstant
+                            12
+                            [10, 20, 30]
+                            (Array
+                                (Integer 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            ColMajor
+                        )
+                        ()
+                        .false.
+                        .false.
+                    )
+                    (Assignment
+                        (Var 2 a)
+                        (BitCast
+                            (ArrayItem
+                                (Var 2 rhs)
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (Integer 4)
+                                ColMajor
+                                ()
+                            )
+                            (Var 2 a)
+                            ()
+                            (Real 4)
+                            ()
+                        )
+                        ()
+                        .false.
+                        .false.
+                    )
+                    (Assignment
+                        (Var 2 b)
+                        (BitCast
+                            (ArrayItem
+                                (Var 2 rhs)
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())]
+                                (Integer 4)
+                                ColMajor
+                                ()
+                            )
+                            (Var 2 b)
+                            ()
+                            (Real 4)
+                            ()
+                        )
+                        ()
+                        .false.
+                        .false.
+                    )
+                    (Assignment
+                        (Var 2 c)
+                        (BitCast
+                            (ArrayItem
+                                (Var 2 rhs)
+                                [(()
+                                (IntegerConstant 3 (Integer 4) Decimal)
+                                ())]
+                                (Integer 4)
+                                ColMajor
+                                ()
+                            )
+                            (Var 2 c)
+                            ()
+                            (Real 4)
+                            ()
+                        )
+                        ()
+                        .false.
+                        .false.
+                    )
+                    (Assignment
+                        (ArraySection
+                            (Var 2 r1)
+                            [((IntegerConstant 1 (Integer 4) Decimal)
+                            (IntegerConstant 3 (Integer 4) Decimal)
+                            (IntegerConstant 1 (Integer 4) Decimal))]
+                            (Array
+                                (Real 4)
+                                [(()
+                                ())]
+                                DescriptorArray
+                            )
+                            ()
+                        )
+                        (BitCast
+                            (Var 2 rhs)
+                            (Var 2 r1)
+                            ()
+                            (Array
+                                (Real 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            ()
+                        )
+                        ()
+                        .false.
+                        .false.
+                    )
+                    (Assignment
+                        (ArraySection
+                            (Var 2 lhs)
+                            [((IntegerConstant 1 (Integer 4) Decimal)
+                            (IntegerConstant 3 (Integer 4) Decimal)
+                            (IntegerConstant 1 (Integer 4) Decimal))]
+                            (Array
+                                (Integer 4)
+                                [(()
+                                ())]
+                                DescriptorArray
+                            )
+                            ()
+                        )
+                        (BitCast
+                            (Var 2 rhs)
+                            (Var 2 lhs)
+                            ()
+                            (Array
+                                (Integer 4)
+                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                (IntegerConstant 3 (Integer 4) Decimal))]
+                                FixedSizeArray
+                            )
+                            ()
+                        )
+                        ()
+                        .false.
+                        .false.
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(StringConstant
+                                "Correct Values"
+                                (String 1 (IntegerConstant 14 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                            )
+                            (Var 2 rhs)
+                            (Var 2 a)
+                            (Var 2 b)
+                            (Var 2 c)]
+                            FormatFortran
+                            (Allocatable
+                                (String 1 () DeferredLength DescriptorString)
+                            )
+                            ()
+                        )
+                    )
+                    (Print
+                        (StringFormat
+                            ()
+                            [(StringConstant
+                                "Transferred Values"
+                                (String 1 (IntegerConstant 18 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                            )
+                            (Var 2 lhs)
+                            (Var 2 r1)]
+                            FormatFortran
+                            (Allocatable
+                                (String 1 () DeferredLength DescriptorString)
+                            )
+                            ()
+                        )
+                    )
+                    (If
+                        ()
+                        (LogicalBinOp
+                            (LogicalBinOp
+                                (IntegerCompare
+                                    (ArrayItem
+                                        (Var 2 lhs)
+                                        [(()
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        ())]
+                                        (Integer 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    NotEq
+                                    (ArrayItem
+                                        (Var 2 rhs)
+                                        [(()
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        ())]
+                                        (Integer 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    (Logical 4)
+                                    ()
+                                )
+                                Or
+                                (IntegerCompare
+                                    (ArrayItem
+                                        (Var 2 lhs)
+                                        [(()
+                                        (IntegerConstant 2 (Integer 4) Decimal)
+                                        ())]
+                                        (Integer 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    NotEq
+                                    (ArrayItem
+                                        (Var 2 rhs)
+                                        [(()
+                                        (IntegerConstant 2 (Integer 4) Decimal)
+                                        ())]
+                                        (Integer 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    (Logical 4)
+                                    ()
+                                )
+                                (Logical 4)
+                                ()
+                            )
+                            Or
+                            (IntegerCompare
+                                (ArrayItem
+                                    (Var 2 lhs)
+                                    [(()
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    ())]
+                                    (Integer 4)
+                                    ColMajor
+                                    ()
+                                )
+                                NotEq
+                                (ArrayItem
+                                    (Var 2 rhs)
+                                    [(()
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    ())]
+                                    (Integer 4)
+                                    ColMajor
+                                    ()
+                                )
+                                (Logical 4)
+                                ()
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (LogicalBinOp
+                            (LogicalBinOp
+                                (RealCompare
+                                    (ArrayItem
+                                        (Var 2 r1)
+                                        [(()
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        ())]
+                                        (Real 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    NotEq
+                                    (Var 2 a)
+                                    (Logical 4)
+                                    ()
+                                )
+                                Or
+                                (RealCompare
+                                    (ArrayItem
+                                        (Var 2 r1)
+                                        [(()
+                                        (IntegerConstant 2 (Integer 4) Decimal)
+                                        ())]
+                                        (Real 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    NotEq
+                                    (Var 2 b)
+                                    (Logical 4)
+                                    ()
+                                )
+                                (Logical 4)
+                                ()
+                            )
+                            Or
+                            (RealCompare
+                                (ArrayItem
+                                    (Var 2 r1)
+                                    [(()
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    ())]
+                                    (Real 4)
+                                    ColMajor
+                                    ()
+                                )
+                                NotEq
+                                (Var 2 c)
+                                (Logical 4)
+                                ()
+                            )
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4875,3 +4875,7 @@ llvm = true
 [[test]]
 filename = "unlimited_polymorphic_intrinsic_type_allocate.f90"
 llvm = true
+
+[[test]]
+filename = "../integration_tests/transfer_09.f90"
+asr = true


### PR DESCRIPTION
Fixes #9057 
Towards #8182

Added in ASR Tests, so that we can compare mold sizes being changed for arrays inside ASR.

MRE:
```
program test_transfer
  integer, dimension(3) :: lhs, rhs
  rhs = [10, 20, 30]
  lhs(1:3) = transfer(rhs, lhs)
  if (lhs(1) /= rhs(1) .or. lhs(2) /= rhs(2) .or. lhs(3) /= rhs(3)) error stop
  print *, lhs, rhs
end program test_transfer
```

Updated main & gfortran:
```
$ gfortran a.f90 & ./a.out
[1]+  Done                    gfortran a.f90
[1] 72225
          10          20          30          10          20          30
          
$ lfortran a.f90 
10    20    30    10    20    30
```