### PR TITLE
Add vanilla Reference-LAPACK v3.12.0 to third-party tests

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -879,6 +879,54 @@ time_section "🧪 Testing LAPACK" '
 '
 
 
+##########################
+# Section 14: Vanilla Reference-LAPACK
+##########################
+time_section "🧪 Testing Vanilla Reference-LAPACK v3.12.0" '
+    export PATH="$(pwd)/../src/bin:$PATH"
+    git clone --depth 1 --branch v3.12.0 https://github.com/Reference-LAPACK/lapack.git lapack-vanilla
+    cd lapack-vanilla
+
+    # Patch CMakeLists.txt to skip FortranCInterface_VERIFY (requires mixed Fortran/C linking)
+    sed -i "/FortranCInterface_VERIFY/d" CMakeLists.txt
+
+    # Configure with LFortran
+    cmake -S . -B build -G Ninja \
+      -DCMAKE_Fortran_COMPILER=lfortran \
+      -DCMAKE_Fortran_FLAGS="--fixed-form-infer --implicit-interface --legacy-array-sections --separate-compilation" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_INDEX64=OFF \
+      -DBUILD_INDEX64_EXT_API=OFF \
+      -DBUILD_TESTING=OFF
+
+    # Build BLAS and LAPACK libraries
+    cmake --build build --target blas lapack -j8
+
+    # Test DGESV: solve 3x3 linear system
+    cat > test_dgesv.f90 << "TESTEOF"
+program test_dgesv
+    implicit none
+    integer, parameter :: n = 3
+    double precision :: A(n,n), b(n), x_expected(n)
+    integer :: ipiv(n), info, i
+    A(1,:) = [2.0d0, 1.0d0, 1.0d0]
+    A(2,:) = [4.0d0, 3.0d0, 3.0d0]
+    A(3,:) = [8.0d0, 7.0d0, 9.0d0]
+    b = [4.0d0, 10.0d0, 24.0d0]
+    x_expected = [1.0d0, 1.0d0, 1.0d0]
+    call dgesv(n, 1, A, n, ipiv, b, n, info)
+    if (info /= 0) error stop "DGESV failed"
+    do i = 1, n
+        if (abs(b(i) - x_expected(i)) > 1.0d-10) error stop "Wrong solution"
+    end do
+    print *, "DGESV test passed!"
+end program
+TESTEOF
+
+    lfortran --implicit-interface test_dgesv.f90 -L build/lib -lblas -llapack -o test_dgesv
+    ./test_dgesv
+'
+
 ##################################
 # Final Summary and Cleanup
 ##################################


### PR DESCRIPTION
Section 14 tests building unmodified LAPACK with LFortran:
- Clone official Reference-LAPACK v3.12.0 (not patched fork)
- Patch out FortranCInterface_VERIFY (mixed Fortran/C linking)
- Build BLAS and LAPACK with --fixed-form-infer --implicit-interface --legacy-array-sections --separate-compilation flags
- Run DGESV linear solve test to verify runtime correctness

Depends on #9024 for assumed-size dummy ABI fix.