### PR TITLE
fix: handle unallocated struct temporaries passed to subCall correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2070,6 +2070,7 @@ RUN(NAME class_81 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_82 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_83 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME class_84 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME class_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_85.f90
+++ b/integration_tests/class_85.f90
@@ -1,0 +1,30 @@
+module class_85_mod
+    implicit none
+    type :: string_t
+        character(:), allocatable :: s
+    end type string_t
+  type :: string_list_t
+      type(string_t), allocatable :: items(:)
+      type(string_t), allocatable :: item
+  end type string_list_t
+contains
+    subroutine set_list(list)
+        type(string_t), allocatable, intent(in) :: list(:)
+        if (allocated(list)) error stop "list allocated"
+    end subroutine set_list
+    subroutine set_list_scalar(list_mem)
+        type(string_t), allocatable, intent(in) :: list_mem
+        if (allocated(list_mem)) error stop "list allocated"
+    end subroutine set_list_scalar
+end module class_85_mod
+
+
+program class_85
+    use class_85_mod
+    implicit none
+    type(string_list_t) :: mylist
+    call set_list(mylist%items)
+    call set_list_scalar(mylist%item)
+    if (allocated(mylist%items)) error stop "mylist%items allocated"
+    if (allocated(mylist%item)) error stop "mylist%item allocated"
+end program class_85


### PR DESCRIPTION
Fixes #8976 
Fixes #9056 