### PR TITLE
fix for incorrect runtime allocation (issue #9062)

### DIFF
--- a/src/libasr/pass/array_passed_in_function_call.cpp
+++ b/src/libasr/pass/array_passed_in_function_call.cpp
@@ -235,11 +235,11 @@ public:
         }
         // dimensions can be different for an ArrayConstructor e.g. [1, a], where `a` is an
         // ArrayConstructor like [5, 2, 1]
-        if (ASR::is_a<ASR::ArrayConstructor_t>(*value) &&
-               !PassUtils::is_args_contains_allocatable(value)) {
+        if (ASR::is_a<ASR::ArrayConstructor_t>(*value)) {
             ASR::ArrayConstructor_t* arr_constructor = ASR::down_cast<ASR::ArrayConstructor_t>(value);
             value_m_dims->m_length = ASRUtils::get_ArrayConstructor_size(al, arr_constructor);
         }
+
 
         /*
             Handle character type with assumed length OR functioncall (to avoid duplicate calls).


### PR DESCRIPTION
issue #9062 

MRE
```
module m_mod
    implicit none

    type :: node
        integer :: id
    end type node

    type :: target_t
        type(node), allocatable :: dependencies(:)
    end type target_t

end module m_mod


program test_append
    use m_mod
    implicit none

    type(target_t) :: target

    allocate(target%dependencies(2))
    target%dependencies = [target%dependencies, node(1)]

end program test_append
```

**problem**
```
if (ASR::is_a<ASR::ArrayConstructor_t>(*value) &&
               !PassUtils::is_args_contains_allocatable(value)) {
            ASR::ArrayConstructor_t* arr_constructor = ASR::down_cast<ASR::ArrayConstructor_t>(value);
            value_m_dims->m_length = ASRUtils::get_ArrayConstructor_size(al, arr_constructor);
        }
```
i think `is_args_contains_allocatable` check rejects the runtime allocation as it remains true for both compile time resolution and realloc constructor so parameters never updates for realloc . check seems unnecessary for runtime codegen 
by removing that condition MRE passes 
please review and provide feedback if needed


