### PR TITLE
ci: pin package versions with build hash

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -217,30 +217,27 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
-        llvm-version: ["7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"]
-        python-version: ["3.10"]
+        llvm-version: [
+                        "7.0.1=h6bb024c_1002",
+                        "8.0.1=hc9558a2_0", 
+                        "9.0.1=default_hc23dcda_7",
+                        "10.0.0=hc9558a2_0", 
+                        "11.1.0=he0ac6c6_5", 
+                        "12.0.1=hf817b99_2", 
+                        "13.0.1=hf817b99_2", 
+                        "14.0.6=hcd5def8_4", 
+                        "15.0.7=ha7bfdaf_5", 
+                        "16.0.6=ha7bfdaf_4", 
+                        "17.0.6=ha7bfdaf_3", 
+                        "18.1.8=ha7bfdaf_3", 
+                        "19.1.7=h48f18f5_1", 
+                        "20.1.8=h3b15d91_0", 
+                        "21.1.0=h3b15d91_0"
+                      ]
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: mamba-org/setup-micromamba@v2.0.2
-        if: contains(matrix.llvm-version, '19')
-        with:
-          micromamba-version: '2.0.4-0'
-          environment-file: ci/environment_linux_llvm.yml
-          create-args: >-
-            python=${{ matrix.python-version }}
-            llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            nodejs=18.20.4
-            openmpi=5.0.6=hb85ec53_102
-            xonsh=0.16.0
-            zlib=1.3.1
-            zstd-static=1.5.6
 
       - uses: mamba-org/setup-micromamba@v2.0.2
         if: contains(matrix.llvm-version, '10')
@@ -248,93 +245,28 @@ jobs:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
-            python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            nodejs=18.20.2
-            openmpi=5.0.6=hb85ec53_102
-            zlib=1.3.1
-            zstd-static=1.5.6
-            xonsh=0.16.0
+            nodejs=18.20.2=h84e79e0_0
+            llvm-openmp=14.0.4=he0ac6c6_0
 
       - uses: mamba-org/setup-micromamba@v2.0.2
-        if: contains(matrix.llvm-version, '18')
+        if: contains(matrix.llvm-version, '19')
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
-            python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            xonsh=0.16.0
-            zlib=1.3.1
-            zstd-static=1.5.6
-            openmpi=5.0.6=hb85ec53_102
+            nodejs=18.20.4=hc55a1b2_1
+            llvm-openmp=14.0.4=he0ac6c6_0
 
       - uses: mamba-org/setup-micromamba@v2.0.2
-        if: contains(matrix.llvm-version, '20')
+        if: ${{! (startsWith(matrix.llvm-version, '10') || startsWith(matrix.llvm-version, '19'))}}
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
-            python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            openmpi=5.0.6=hb85ec53_102
-            xonsh=0.16.0
-            zlib=1.3.1
-            zstd-static=1.5.7
-
-      - uses: mamba-org/setup-micromamba@v2.0.2
-        if: contains(matrix.llvm-version, '21')
-        with:
-          micromamba-version: '2.0.4-0'
-          environment-file: ci/environment_linux_llvm.yml
-          create-args: >-
-            llvmdev=21.1.0 
-            python=${{ matrix.python-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            openmpi=5.0.6=hb85ec53_102
-
-      - uses: mamba-org/setup-micromamba@v2.0.2
-        if: contains(matrix.llvm-version, '12')
-        with:
-          micromamba-version: '2.0.4-0'
-          environment-file: ci/environment_linux_llvm.yml
-          create-args: >-
-            python=${{ matrix.python-version }}
-            llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            openmpi=5.0.3
-
-      - uses: mamba-org/setup-micromamba@v2.0.2
-        if: ${{! (contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '12') || contains(matrix.llvm-version, '18') || contains(matrix.llvm-version, '19') || contains(matrix.llvm-version, '20') || contains(matrix.llvm-version, '21'))}}
-        with:
-          micromamba-version: '2.0.4-0'
-          environment-file: ci/environment_linux_llvm.yml
-          create-args: >-
-            python=${{ matrix.python-version }}
-            llvmdev=${{ matrix.llvm-version }}
-            bison=3.4
-            openblas=0.3.21
-            llvm-openmp=14.0.4
-            make=4.3
-            openmpi=5.0.6=hb85ec53_102
+            llvm-openmp=14.0.4=he0ac6c6_0
 
       - uses: hendrikmuhs/ccache-action@main
         with:
@@ -342,11 +274,11 @@ jobs:
           key: ${{ github.job }}-${{ matrix.llvm-version }}
 
       - name: Install libunwind
-        if: matrix.llvm-version > 11
-        run: micromamba install -y -n lf libunwind=1.7.2
+        if: ${{! (startsWith(matrix.llvm-version, '7') || startsWith(matrix.llvm-version, '8') || startsWith(matrix.llvm-version, '9') || startsWith(matrix.llvm-version, '10') || startsWith(matrix.llvm-version, '11'))}}
+        run: micromamba install -y -n lf libunwind=1.7.2=he02047a_0
 
       - name: Setup WASI SDK
-        if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        if: startsWith(matrix.llvm-version, '10') || startsWith(matrix.llvm-version, '19')
         shell: bash -e -l {0}
         run: |
           mkdir -p $HOME/ext
@@ -632,11 +564,10 @@ jobs:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
-            python=3.10
-            mlir=19.1.6
-            llvm=19.1.6
-            llvm-openmp=19.1.6
-            libunwind=1.7.2
+            mlir=19.1.6=h629725b_0
+            llvm=19.1.6=h1c4df35_0
+            llvm-openmp=19.1.6=h024ca30_0
+            libunwind=1.7.2=he02047a_0
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/ci/environment_linux_llvm.yml
+++ b/ci/environment_linux_llvm.yml
@@ -2,17 +2,23 @@ name: lf
 channels:
   - conda-forge
 dependencies:
-  - toml=0.10.2
-  - pytest=8.1.1
-  - jupyter=1.0.0
-  - xeus=5.1.0
-  - xeus-zmq=3.0.0
-  - nlohmann_json=3.11.3
-  - jupyter_kernel_test=0.7.0
-  - re2c=3.1
-  - numpy=1.26.4
-  - bison=3.4
-  - rapidjson=1.1.0
-  - ninja=1.11.1
-  - zlib
-  - cmake=3.29.1
+  - bison=3.4=h58526e2_1
+  - cmake=3.29.1=hcfe8598_0
+  - jupyter=1.0.0=pyhd8ed1ab_10
+  - jupyter_kernel_test=0.7.0=pyhd8ed1ab_1
+  - make=4.3=hd18ef5c_1
+  - ninja=1.11.1=h924138e_0
+  - nlohmann_json=3.11.3=he02047a_1
+  - numpy=1.26.4=py310hb13e2d6_0
+  - openblas=0.3.21=pthreads_h320a7e8_3
+  - openmpi=5.0.6=hb85ec53_102
+  - pytest=8.1.1=pyhd8ed1ab_0
+  - python=3.10 # No exact build specified to match compatibility across `zlib` versions
+  - rapidjson=1.1.0.post20240409=h3f2d84a_2
+  - re2c=3.1=h59595ed_0
+  - toml=0.10.2=pyhcf101f3_3
+  - xeus=5.1.0=ha0a95de_0
+  - xeus-zmq=3.0.0=h130ccd7_1
+  - xonsh=0.16.0=py310hff52083_0
+  - zlib # No exact version specified to match compatibility across LLVM versions
+  


### PR DESCRIPTION
- Pin exact package versions in `environment_linux_llvm.yml` with build hash and order them alphabetically.
- Clean up `Exhaustive-Checks-CI.yml` to remove redundancy with package installations based on LLVM version.