### PR TITLE
Fix : Check open and FileWrite format match

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2269,6 +2269,7 @@ RUN(NAME write_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME write_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME do_loop_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/write_11.f90
+++ b/integration_tests/write_11.f90
@@ -1,0 +1,16 @@
+program write_11
+    implicit none
+
+    character(len=*), parameter :: temp_file = "_lfortran_temporary_file"
+    character(len=*), parameter :: test_line = "HelloWorld!"
+    integer :: unit, ios
+    ios = 0
+    unit = 1
+
+    open(newunit=unit, file=temp_file)
+    write(unit, iostat=ios) test_line
+    close(unit)
+    print *, ios
+    if(ios <= 0) error stop "IOS should be positive -- as a runtime error should occur"
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -12018,9 +12018,13 @@ public:
             args.push_back(end_data);
             args.push_back(end_len);
         }
-        std::string fmt_str;
-        for (size_t i=0; i<fmt.size(); i++) {
-            fmt_str += fmt[i];
+        std::string fmt_str {};
+        if(x.m_is_formatted){
+            for (size_t i=0; i<fmt.size(); i++) {
+                fmt_str += fmt[i];
+            }
+        } else {
+            // Don't provide format.
         }
         llvm::Value *fmt_data = LCompilers::create_global_string_ptr(context, *module, *builder, fmt_str);
         llvm::Value *fmt_len = llvm::ConstantInt::get(context, llvm::APInt(64, fmt_str.length()));

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5184,6 +5184,19 @@ LFORTRAN_API char* _lpython_read(int64_t fd, int64_t n)
     return c;
 }
 
+/**
+ * @brief Checks Format match for File Write statement and OpenFile statement
+ * OpenFile -> 'Unformatted' + FileWrite -> Binary Format (no format provided) => Match
+ * OpenFile -> 'Formatted' + FileWrite -> Formatted Format (format provided) => Match
+ * Otherwise => No Match
+ */
+bool is_write_and_open_format_match(bool unit_file_bin, const char* format_data){
+    ASSERT(format_data)
+    const bool is_openFile_formatted =  unit_file_bin == false;
+    const bool is_fileWrite_formatted =  format_data[0] != '\0';
+    return is_openFile_formatted == is_fileWrite_formatted;
+}
+
 LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const char* format_data, int64_t format_len, ...)
 {
     bool unit_file_bin;
@@ -5191,10 +5204,22 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
     bool read_access, write_access;
     int delim;
     FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin, &access_id, &read_access, &write_access, &delim);
+
+    if(!is_write_and_open_format_match(unit_file_bin, format_data)){
+        if(iostat) {
+            *iostat = 5001;
+            return;
+        } else {
+            fprintf(stderr, "Runtime Error: Format mismatch between"
+                "OPEN statement and WRITE statement on unit %d.\n", unit_num);
+            exit(1);
+        }
+    }
+    
     if (!filep) {
         filep = stdout;
     }
-    if (unit_file_bin) {
+    if (unit_file_bin) { // Unformatted
         fseek(filep, 0, SEEK_END);
         va_list args;
         va_start(args, format_len);
@@ -5245,7 +5270,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
         } else {
             if(iostat != NULL) *iostat = 0;
         }
-    } else {
+    } else { // Formatted
         va_list args;
         va_start(args, format_len);
         char* str = va_arg(args, char*);


### PR DESCRIPTION
#closes #8989
Fix : Check Open Format ('formatted' OR 'unformatted') against Write format ('(I0)' OR '*' OR NONE)

# Changes
- Don't pass any formatting if node `FileWrite.is_formatted` == FALSE.
- Check at runtime the formatting match for FileWrite and opened filed using `is_write_and_open_format_match`
- If `iostat` provided and mismatch occur, Don't exit program and just report error code the `iostat` variable. 