### PR TITLE
Fix: Incorrect GEP type for struct member access in array of derived types 

### DIFF
--- a/integration_tests/struct_type_07.f90
+++ b/integration_tests/struct_type_07.f90
@@ -1,4 +1,4 @@
-module m
+module struct_type_07_m
   implicit none
   type :: t
      real :: a
@@ -8,10 +8,10 @@ contains
     type(t) :: res(2,2)
     res%a = reshape([1.0,2.0,3.0,4.0],[2,2])
   end function f
-end module m
+end module struct_type_07_m
 
 program struct_type_07
-  use m
+  use struct_type_07_m
   implicit none
   type(t) :: result(2,2)
   

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3589,14 +3589,6 @@ public:
         member_idx = name2memidx[current_der_type_name][member_name];
 
         xtype = name2dertype[current_der_type_name];
-        // Check if tmp points to an array of the struct type
-        if (tmp->getType()->isPointerTy()) {
-            llvm::Type* pointee_type = llvm::cast<llvm::PointerType>(tmp->getType())->getElementType();
-            if (pointee_type->isArrayTy() && pointee_type->getArrayElementType() == xtype) {
-                // tmp points to an array of structs, use the array type for GEP
-                xtype = pointee_type;
-            }
-        }
         tmp = llvm_utils->create_gep2(xtype, tmp, member_idx);
         ASR::ttype_t* member_type = ASRUtils::type_get_past_pointer(
             ASRUtils::type_get_past_allocatable(member->m_type));


### PR DESCRIPTION
## **Issue Fixed**
#9064 ICE: create_gep2 type mismatch of derived type in LLVM backend 

## **Summary**
The issue occurred because the GEP instruction was using the wrong type it used the struct type instead of the array of structs type, leading to incorrect pointer .

## **Reference Code**
```
module m
  implicit none
  type :: t
     real :: a
  end type t
contains
  function f() result(res)
    type(t) :: res(2,2)
    res%a = reshape([1.0,2.0,3.0,4.0],[2,2])
  end function f
end module m

program p
  use m
  implicit none
  print *, f()
end program p

```

## **Behaviour before this PR**
```
ICE: Type mismatch in create_gep2: ... Target type: %t = type { float }, Pointer pointee type: [4 x %t]

```


## **Behaviour after this PR**
```
(lf) opixdown@Atharvs-MacBook-Air lfortran % lfortran ./t.f90
1.00000000e+00    2.00000000e+00    3.00000000e+00    4.00000000e+00
  
```

