### PR TITLE
test: allocatable array with implicit interface

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1518,6 +1518,7 @@ RUN(NAME implicit_interface_16 LABELS gfortran llvm2 EXTRA_ARGS --implicit-inter
 RUN(NAME implicit_interface_17 LABELS gfortran llvm2 EXTRA_ARGS --implicit-interface EXTRAFILES implicit_interface_17b.f90)
 RUN(NAME implicit_interface_18 LABELS gfortran llvmImplicit EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_19 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface EXTRAFILES implicit_interface_19b.f90)
+RUN(NAME implicit_interface_20 LABELS gfortran llvmImplicit)
 
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_20.f90
+++ b/integration_tests/implicit_interface_20.f90
@@ -1,0 +1,40 @@
+! Regression test: allocatable array passed to a procedure with an implicit
+! interface must not cause an LLVM type mismatch.
+! Reduced from LAPACK TESTING/LIN/schkaa.F (issue #7304 pattern).
+program implicit_interface_20
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+
+    real(dp), allocatable :: work(:)
+    external :: fill_array
+
+    allocate(work(3))
+    work = 0.0_dp
+
+    ! Passing allocatable to an implicit interface used to trigger an LLVM
+    ! verify error (callee expects pointer-to-pointer but caller passes pointer).
+    call fill_array(work, 3)
+
+    if (abs(work(1) - 1.0_dp) < 1.0e-12_dp) then
+        if (abs(work(3) - 3.0_dp) < 1.0e-12_dp) then
+            print *, "PASS"
+        else
+            print *, "FAIL"
+        end if
+    else
+        print *, "FAIL"
+    end if
+end program implicit_interface_20
+
+subroutine fill_array(arr, n)
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+
+    integer, intent(in) :: n
+    real(dp), intent(out) :: arr(*)
+    integer :: i
+
+    do i = 1, n
+        arr(i) = real(i, dp)
+    end do
+end subroutine fill_array


### PR DESCRIPTION
Summary
- Add a regression test for an LLVM type mismatch when passing an allocatable array to a procedure with an implicit interface.

Key changes
- `integration_tests/implicit_interface_20.f90`: new reduced test (LAPACK-derived; issue #7304 pattern).
- `integration_tests/CMakeLists.txt`: register the new test.

How to run
- `./run_tests.py -t implicit_interface_20 -s`
