### PR TITLE
fix: allocatable member handling in derived type assignment 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1742,6 +1742,7 @@ RUN(NAME allocate_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME allocate_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME allocate_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME allocate_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)

--- a/integration_tests/allocate_29.f90
+++ b/integration_tests/allocate_29.f90
@@ -1,0 +1,22 @@
+module allocate_29_node_mod
+  type :: dependency_config_t
+      integer, allocatable :: arr(:)
+  end type dependency_config_t
+
+  type, extends(dependency_config_t) :: dependency_node_t
+  end type dependency_node_t
+end module allocate_29_node_mod
+
+
+program allocate_29
+  use allocate_29_node_mod
+  implicit none
+
+  type(dependency_node_t), allocatable :: a, b
+  allocate(a, b)
+
+  b = a
+
+  ! arr should not be allocated
+  if (allocated(b%arr)) stop 1
+end program allocate_29

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -9093,24 +9093,57 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                             }
                         }, [=]() {});
                     } else {
-                        // If member is allocatable string, we need to check if it is allocated before copying
-                        if (ASRUtils::is_allocatable(ASRUtils::symbol_type(mem_sym)) && !ASRUtils::is_array(ASRUtils::symbol_type(mem_sym)) &&
-                            ASR::is_a<ASR::String_t>(*ASRUtils::extract_type(ASRUtils::symbol_type(mem_sym)))) {
-                            std::vector<llvm::Value*> idx_vec = {
-                                llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
-                                llvm::ConstantInt::get(context, llvm::APInt(32, 0))};
-                            llvm::Value* src_member_char = builder->CreateGEP(mem_type, src_member, idx_vec);;
-                            src_member_char = llvm_utils->CreateLoad2(
-                                llvm::Type::getInt8Ty(context)->getPointerTo(), src_member_char);
-                            is_allocated = builder->CreateICmpNE(
-                                builder->CreatePtrToInt(src_member_char, llvm::Type::getInt64Ty(context)),
-                                llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), llvm::APInt(64, 0)));
+                        // Check if member is allocatable and needs allocation check
+                        bool needs_alloc_check = false;
+                        llvm::Value* is_allocated = llvm::ConstantInt::get(llvm::Type::getInt1Ty(context), 1);
+                        if (ASRUtils::is_allocatable(member_type) && !ASRUtils::is_array(member_type)) {
+                            // Allocatable scalar string
+                            if (ASR::is_a<ASR::String_t>(*ASRUtils::extract_type(member_type))) {
+                                std::vector<llvm::Value*> idx_vec = {
+                                    llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
+                                    llvm::ConstantInt::get(context, llvm::APInt(32, 0))};
+                                llvm::Value* src_member_char = builder->CreateGEP(mem_type, src_member, idx_vec);
+                                src_member_char = llvm_utils->CreateLoad2(
+                                    llvm::Type::getInt8Ty(context)->getPointerTo(), src_member_char);
+                                is_allocated = builder->CreateICmpNE(
+                                    builder->CreatePtrToInt(src_member_char, llvm::Type::getInt64Ty(context)),
+                                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), llvm::APInt(64, 0)));
+                                needs_alloc_check = true;
+                            }
+                        } else if (ASRUtils::is_allocatable(member_type) && ASRUtils::is_array(member_type)) {
+                            ASR::ttype_t* arr_type = ASRUtils::type_get_past_allocatable(member_type);
+                            if (ASRUtils::extract_physical_type(arr_type) == ASR::array_physical_typeType::DescriptorArray) {
+                                llvm::Type* array_llvm_type = llvm_utils->get_type_from_ttype_t_util(
+                                    arr_type, nullptr, module);
+                                llvm::Value* src_desc = llvm_utils->CreateLoad2(array_llvm_type->getPointerTo(), src_member);
+                                is_allocated = llvm_utils->arr_api->get_is_allocated_flag(src_desc, 
+                                    ASRUtils::EXPR(ASR::make_Var_t(al, mem_sym->base.loc, mem_sym)));
+                                needs_alloc_check = true;
+                            }
                         }
-                        llvm_utils->create_if_else(is_allocated, [&]() {
-                            llvm_utils->deepcopy(ASRUtils::EXPR(ASR::make_Var_t(al, mem_sym->base.loc, mem_sym)), src_member, dest_member,
-                            member_type, member_type,
-                            module);
-                        }, [=]() {});
+                        if (needs_alloc_check) {
+                            llvm_utils->create_if_else(is_allocated, [&]() {
+                                llvm_utils->deepcopy(ASRUtils::EXPR(ASR::make_Var_t(al, mem_sym->base.loc, mem_sym)), 
+                                    src_member, dest_member,
+                                    member_type, member_type, module);
+                            }, [&]() {
+                                if (ASRUtils::is_array(member_type)) {
+                                    ASR::ttype_t* arr_type = ASRUtils::type_get_past_allocatable(member_type);
+                                    llvm::Type* array_llvm_type = llvm_utils->get_type_from_ttype_t_util(
+                                        arr_type, nullptr, module);
+                                    llvm::Value* dest_desc = llvm_utils->CreateLoad2(array_llvm_type->getPointerTo(), dest_member);
+                                    // Reset the is_allocated flag to false
+                                    llvm_utils->arr_api->reset_is_allocated_flag(array_llvm_type, dest_desc,
+                                        llvm_utils->get_type_from_ttype_t_util(
+                                        ASRUtils::extract_type(arr_type), nullptr, module));
+                                }
+                            });
+                        } else {
+                            // Non-allocatable members perform direct deepcopy
+                            llvm_utils->deepcopy(ASRUtils::EXPR(ASR::make_Var_t(al, mem_sym->base.loc, mem_sym)), 
+                                src_member, dest_member,
+                                member_type, member_type, module);
+                        }
                     }
                 }
                 if( struct_sym->m_parent != nullptr ) {

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "21f342d0c1f2a06087362923a476a86757352fd56c842c9e19fdafc0",
+    "stdout_hash": "4490d6366cb63e3587b844af17d84b99ccc3b5d556c4ee9236fc3a0b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -177,16 +177,7 @@ entry:
   %4 = getelementptr %mytype, %mytype* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
   %6 = getelementptr %mytype, %mytype* %3, i32 0, i32 0
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   ret void
 }
 

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "a82d5f1e95a4cd3aaa333db823d7d21ebbdd152952a993b536bee7e6",
+    "stdout_hash": "9a1913b33f1ebdf760f2926891f3c48dc43b15b1c586fbd1ca825cf8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -84,16 +84,7 @@ entry:
   %4 = getelementptr %circle, %circle* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
   %6 = getelementptr %circle, %circle* %3, i32 0, i32 0
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   ret void
 }
 

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "1d8677d89b9918d2967dfa8db8af0dc2ebe503cbada6468d536c80af",
+    "stdout_hash": "fb26a94f120680c235af58725490f7ccbcd6dd9d92a257d2c8df1a40",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -107,16 +107,7 @@ entry:
   %4 = getelementptr %circle, %circle* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
   %6 = getelementptr %circle, %circle* %3, i32 0, i32 0
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   ret void
 }
 

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "d9095ccd658ad16fac5b41855d5995335bdea1bd006149267417f56d",
+    "stdout_hash": "ec855b6f296c8ddf9717870428bf370c198bfe079bbc09c30a1d26d5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -95,16 +95,7 @@ entry:
   %4 = getelementptr %base, %base* %2, i32 0, i32 0
   %5 = load i32, i32* %4, align 4
   %6 = getelementptr %base, %base* %3, i32 0, i32 0
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store i32 %5, i32* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   ret void
 }
 

--- a/tests/reference/llvm-classes2-f926d51.json
+++ b/tests/reference/llvm-classes2-f926d51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes2-f926d51.stdout",
-    "stdout_hash": "23aefb237cdf12153fca4e3be4a0a08e5feb149551669caf4dafda87",
+    "stdout_hash": "d200cd760f8b35ec8b89e1f134e5c03a584282aee8ed8871e88e6263",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes2-f926d51.stdout
+++ b/tests/reference/llvm-classes2-f926d51.stdout
@@ -148,29 +148,11 @@ entry:
   %4 = getelementptr %point2d, %point2d* %2, i32 0, i32 1
   %5 = load float, float* %4, align 4
   %6 = getelementptr %point2d, %point2d* %3, i32 0, i32 1
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   %7 = getelementptr %point2d, %point2d* %2, i32 0, i32 2
   %8 = load float, float* %7, align 4
   %9 = getelementptr %point2d, %point2d* %3, i32 0, i32 2
-  br i1 true, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
   store float %8, float* %9, align 4
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
   %10 = getelementptr %point2d, %point2d* %2, i32 0, i32 0
   %11 = getelementptr %point2d, %point2d* %3, i32 0, i32 0
   ret void

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_45-ae31b1c.stdout",
-    "stdout_hash": "c736832c1790900c4f427f66d29b5c3475cdcd11b93aa424595b12ed",
+    "stdout_hash": "2f610099f4ee255f36d36f4ce0d5e9caf6ae243708f8f277481bbce7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -39,45 +39,36 @@ ifcont:                                           ; preds = %else, %then
   %11 = getelementptr %myint, %myint* %temp_struct_var__, i32 0, i32 0
   %12 = load i32, i32* %11, align 4
   %13 = getelementptr %myint, %myint* %10, i32 0, i32 0
-  br i1 true, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
   store i32 %12, i32* %13, align 4
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
   %14 = load %myint*, %myint** %ins, align 8
   %15 = ptrtoint %myint* %14 to i64
   %16 = icmp eq i64 %15, 0
-  br i1 %16, label %then4, label %ifcont5
+  br i1 %16, label %then1, label %ifcont2
 
-then4:                                            ; preds = %ifcont3
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([132 x i8], [132 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont5:                                          ; preds = %ifcont3
+ifcont2:                                          ; preds = %ifcont
   %17 = getelementptr %myint, %myint* %14, i32 0, i32 0
   %18 = load i32, i32* %17, align 4
   %19 = icmp ne i32 %18, 44
-  br i1 %19, label %then6, label %else7
+  br i1 %19, label %then3, label %else4
 
-then6:                                            ; preds = %ifcont5
+then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont8
+  br label %ifcont5
 
-else7:                                            ; preds = %ifcont5
-  br label %ifcont8
+else4:                                            ; preds = %ifcont2
+  br label %ifcont5
 
-ifcont8:                                          ; preds = %else7, %then6
+ifcont5:                                          ; preds = %else4, %then3
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont8
+return:                                           ; preds = %ifcont5
   br label %FINALIZE_SYMTABLE_derived_types_45
 
 FINALIZE_SYMTABLE_derived_types_45:               ; preds = %return

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "a2b375a8aadaba48581a23ae175da79aa0c7a3640b91cb412d6fe005",
+    "stdout_hash": "9dd877dfaed1ac87777be30c2a2e37baab02b1e30da6151ae8a413da",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -260,29 +260,11 @@ entry:
   %4 = getelementptr %complextype, %complextype* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
   %6 = getelementptr %complextype, %complextype* %3, i32 0, i32 0
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   %7 = getelementptr %complextype, %complextype* %2, i32 0, i32 1
   %8 = load float, float* %7, align 4
   %9 = getelementptr %complextype, %complextype* %3, i32 0, i32 1
-  br i1 true, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
   store float %8, float* %9, align 4
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
   ret void
 }
 

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "8dd5cb578cc31a5905aaf44ef953192be262d2a099bf63306a236d5c",
+    "stdout_hash": "9bc91e623a2d2d3147447792ac71510563537f3c28af28d57afd861c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -361,16 +361,7 @@ entry:
   %4 = getelementptr %fpm_build_settings, %fpm_build_settings* %2, i32 0, i32 0
   %5 = load i1, i1* %4, align 1
   %6 = getelementptr %fpm_build_settings, %fpm_build_settings* %3, i32 0, i32 0
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store i1 %5, i1* %6, align 1
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   ret void
 }
 
@@ -402,80 +393,35 @@ entry:
   %3 = bitcast i8* %1 to %fpm_run_settings*
   %4 = getelementptr %fpm_run_settings, %fpm_run_settings* %2, i32 0, i32 1
   %5 = getelementptr %fpm_run_settings, %fpm_run_settings* %3, i32 0, i32 1
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   %6 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 0
   %7 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 1
   %8 = getelementptr %string_descriptor, %string_descriptor* %4, i32 0, i32 0
   %9 = load i8*, i8** %8, align 8
   call void @_lfortran_strcpy(i8** %6, i64* %7, i8 0, i8 0, i8* %9, i64 5)
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   %10 = getelementptr %fpm_run_settings, %fpm_run_settings* %2, i32 0, i32 2
   %11 = getelementptr %fpm_run_settings, %fpm_run_settings* %3, i32 0, i32 2
-  br i1 true, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
   %12 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 0
   %13 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 1
   %14 = getelementptr %string_descriptor, %string_descriptor* %10, i32 0, i32 0
   %15 = load i8*, i8** %14, align 8
   call void @_lfortran_strcpy(i8** %12, i64* %13, i8 0, i8 0, i8* %15, i64 4)
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
   %16 = getelementptr %fpm_run_settings, %fpm_run_settings* %2, i32 0, i32 3
   %17 = getelementptr %fpm_run_settings, %fpm_run_settings* %3, i32 0, i32 3
-  br i1 true, label %then4, label %else5
-
-then4:                                            ; preds = %ifcont3
   %18 = getelementptr %string_descriptor, %string_descriptor* %17, i32 0, i32 0
   %19 = getelementptr %string_descriptor, %string_descriptor* %17, i32 0, i32 1
   %20 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 0
   %21 = load i8*, i8** %20, align 8
   call void @_lfortran_strcpy(i8** %18, i64* %19, i8 0, i8 0, i8* %21, i64 6)
-  br label %ifcont6
-
-else5:                                            ; preds = %ifcont3
-  br label %ifcont6
-
-ifcont6:                                          ; preds = %else5, %then4
   %22 = getelementptr %fpm_run_settings, %fpm_run_settings* %2, i32 0, i32 4
   %23 = load i1, i1* %22, align 1
   %24 = getelementptr %fpm_run_settings, %fpm_run_settings* %3, i32 0, i32 4
-  br i1 true, label %then7, label %else8
-
-then7:                                            ; preds = %ifcont6
   store i1 %23, i1* %24, align 1
-  br label %ifcont9
-
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
-
-ifcont9:                                          ; preds = %else8, %then7
   %25 = getelementptr %fpm_run_settings, %fpm_run_settings* %2, i32 0, i32 0
   %26 = getelementptr %fpm_run_settings, %fpm_run_settings* %3, i32 0, i32 0
   %27 = getelementptr %fpm_build_settings, %fpm_build_settings* %25, i32 0, i32 0
   %28 = load i1, i1* %27, align 1
   %29 = getelementptr %fpm_build_settings, %fpm_build_settings* %26, i32 0, i32 0
-  br i1 true, label %then10, label %else11
-
-then10:                                           ; preds = %ifcont9
   store i1 %28, i1* %29, align 1
-  br label %ifcont12
-
-else11:                                           ; preds = %ifcont9
-  br label %ifcont12
-
-ifcont12:                                         ; preds = %else11, %then10
   ret void
 }
 

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "f42d68380da44fa0750c5418db02908bfd962e8e55a2933bb43f0775",
+    "stdout_hash": "0aa109ecd3de2293ff23d0d84093d527b73c1dbd6024edb659a265d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -635,16 +635,7 @@ entry:
   %4 = getelementptr %circle, %circle* %2, i32 0, i32 1
   %5 = load float, float* %4, align 4
   %6 = getelementptr %circle, %circle* %3, i32 0, i32 1
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   %7 = getelementptr %circle, %circle* %2, i32 0, i32 0
   %8 = getelementptr %circle, %circle* %3, i32 0, i32 0
   ret void
@@ -676,29 +667,11 @@ entry:
   %4 = getelementptr %rectangle, %rectangle* %2, i32 0, i32 1
   %5 = load float, float* %4, align 4
   %6 = getelementptr %rectangle, %rectangle* %3, i32 0, i32 1
-  br i1 true, label %then, label %else
-
-then:                                             ; preds = %entry
   store float %5, float* %6, align 4
-  br label %ifcont
-
-else:                                             ; preds = %entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
   %7 = getelementptr %rectangle, %rectangle* %2, i32 0, i32 2
   %8 = load float, float* %7, align 4
   %9 = getelementptr %rectangle, %rectangle* %3, i32 0, i32 2
-  br i1 true, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
   store float %8, float* %9, align 4
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
   %10 = getelementptr %rectangle, %rectangle* %2, i32 0, i32 0
   %11 = getelementptr %rectangle, %rectangle* %3, i32 0, i32 0
   ret void


### PR DESCRIPTION
## **Issue Fixed**
#9045 Bug : call to intrinsic allocated with wrong output

## **Summary**
The issue occurred because allocatable members (scalar strings and arrays) in derived types were being copied unconditionally without checking their allocation status. This led to runtime errors when attempting to deepcopy unallocated members

## **Reference Code**
```
module node_mod

  type :: dependency_config_t
      integer, allocatable :: arr(:)
  end type dependency_config_t
  type, extends(dependency_config_t) :: dependency_node_t
  end type dependency_node_t

end module node_mod


program demo
  use node_mod
  implicit none

  type(dependency_node_t), allocatable :: a, b
  allocate(a, b)
  b = a
  print *, allocated(b%arr)
end program demo

```

## **Behaviour before this PR**
```
(lf) opixdown@192 lfortran % lfortran t.f90
T

```


## **Behaviour after this PR**
```
(lf) opixdown@192 lfortran % lfortran t.f90
F
  
```

