### PR TITLE
fix: don't delete struct method declarations in `pass_array_by_data`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2080,6 +2080,7 @@ RUN(NAME class_82 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_83 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME class_84 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME class_85 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME class_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_86.f90
+++ b/integration_tests/class_86.f90
@@ -1,0 +1,31 @@
+module class_86_mod
+  type :: downloader_t
+        integer, allocatable :: arr(:)
+    contains
+        procedure, nopass :: upload_form
+  end type downloader_t
+
+contains
+
+ subroutine upload_form(strs)
+        integer, dimension(:), intent(in) :: strs
+    end subroutine upload_form
+
+  subroutine get_from_registry(downloader_)
+    class(downloader_t), intent(inout) :: downloader_
+    integer :: i
+    allocate(downloader_%arr(10))
+    downloader_%arr = [(i, i=1,10)]
+  end subroutine get_from_registry
+
+end module class_86_mod
+
+
+program class_86
+  use class_86_mod
+  implicit none
+  type(downloader_t) :: dl
+  integer :: i
+  call get_from_registry(dl)
+  if (any(dl%arr /= [(i, i=1,10)])) error stop
+end program class_86

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -1044,6 +1044,11 @@ class RemoveArrayByDescriptorProceduresVisitor : public PassUtils::PassVisitor<R
                 if (ASR::is_a<ASR::ExternalSymbol_t>(*item.second)) {
                     sym = ASR::down_cast<ASR::ExternalSymbol_t>(item.second)->m_external;
                 }
+                // Don't delete struct method declarations
+                if (ASR::is_a<ASR::StructMethodDeclaration_t>(*sym)) {
+                    ASR::StructMethodDeclaration_t* func_type = ASR::down_cast<ASR::StructMethodDeclaration_t>(sym);
+                    not_to_be_erased.insert(ASRUtils::symbol_get_past_external(func_type->m_proc));
+                }
                 if( v.proc2newproc.find(sym) != v.proc2newproc.end() &&
                     not_to_be_erased.find(sym) == not_to_be_erased.end() ) {
                     LCOMPILERS_ASSERT(item.first == ASRUtils::symbol_name(item.second))


### PR DESCRIPTION
Fixes #9145