### PR TITLE
CI: Enable more tests for fpm and remove workarounds

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -266,9 +266,9 @@ time_section "🧪 Testing FPM" '
   git clone https://github.com/jinangshah21/fpm.git
   cd fpm
   export PATH="$(pwd)/../src/bin:$PATH"
-  git checkout lf-13
+  git checkout lf-14
   micromamba install -c conda-forge fpm
-  git checkout 867992868bbf86e8f3d5bee90993c30f17d2fc62
+  git checkout ed292d67826c17e91503941ddd3d2ad7fa5d2139
   fpm --compiler=$FC build --flag "--cpp --realloc-lhs-arrays --use-loop-variable-after-loop"
   fpm --compiler=$FC test --flag "--cpp --realloc-lhs-arrays --use-loop-variable-after-loop"
   print_success "Done with FPM"


### PR DESCRIPTION
Towards #6840 

With this we have 235/238 tests working