### PR TITLE
CI: enable more tests for FPM

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -266,9 +266,9 @@ time_section "🧪 Testing FPM" '
   git clone https://github.com/jinangshah21/fpm.git
   cd fpm
   export PATH="$(pwd)/../src/bin:$PATH"
-  git checkout lf-14
+  git checkout lf-15
   micromamba install -c conda-forge fpm
-  git checkout ed292d67826c17e91503941ddd3d2ad7fa5d2139
+  git checkout e709edb424807d8d0b565169fea494c1f8f02471
   fpm --compiler=$FC build --flag "--cpp --realloc-lhs-arrays --use-loop-variable-after-loop"
   fpm --compiler=$FC test --flag "--cpp --realloc-lhs-arrays --use-loop-variable-after-loop"
   print_success "Done with FPM"


### PR DESCRIPTION
Towards #6840 

With this we have all test enable at CI except 4 tests, 1 of them uses namelist, other 3 also fails with GFortran (Needs to be investigated)