### PR TITLE
fix: guard intent(out) dealloc for lowered optional args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2375,6 +2375,7 @@ RUN(NAME allocate_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME allocate_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME dealloc_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME intentout_optional_deallocate_01 LABELS gfortran llvm)
 RUN(NAME dealloc_02 LABELS gfortran)
 RUN(NAME dealloc_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME dealloc_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intentout_optional_deallocate_01.f90
+++ b/integration_tests/intentout_optional_deallocate_01.f90
@@ -1,0 +1,35 @@
+module intentout_optional_deallocate_01_mod
+    implicit none
+
+    type :: msg_t
+        character(len=:), allocatable :: msg
+    end type msg_t
+
+contains
+
+    subroutine set_msg(x, s)
+        type(msg_t), intent(out), optional :: x
+        character(len=*), intent(in) :: s
+        if (present(x)) then
+            x%msg = s
+        end if
+    end subroutine set_msg
+
+end module intentout_optional_deallocate_01_mod
+
+program intentout_optional_deallocate_01
+    use intentout_optional_deallocate_01_mod, only: msg_t, set_msg
+    implicit none
+
+    type(msg_t) :: v
+
+    call set_msg(v, "hello")
+    if (.not. allocated(v%msg)) error stop
+    if (v%msg /= "hello") error stop
+
+    call set_msg(s="skip")
+
+    if (.not. allocated(v%msg)) error stop
+    if (v%msg /= "hello") error stop
+end program intentout_optional_deallocate_01
+


### PR DESCRIPTION
This PR fixes a crash in optional-argument lowering when a compiler-generated optional wrapper is created and later treated like a real optional dummy.

What changes
- Makes the intent(out) allocatable deallocation guard robust for transformed optional arguments so we do not unconditionally deallocate when the original argument is absent.

Why
- Prevents runtime crashes and incorrect deallocation for code paths created by transform_optional_argument_functions.

Where
- Primarily in the optional-argument transformation and intent(out) deallocation logic, plus an integration test.

Test
- Adds integration test intentout_optional_deallocate_01 exercising the missing-optional path.
