### PR TITLE
Fix : Resolve var to a callback function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2346,6 +2346,7 @@ RUN(NAME procedure_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRAFILES procedure_22_a.f90)
 RUN(NAME procedure_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME procedure_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_25.f90
+++ b/integration_tests/procedure_25.f90
@@ -1,0 +1,31 @@
+module procedure_25_module
+   implicit none
+contains
+   subroutine run(f)
+      implicit none
+      interface
+         integer function f()
+         end function f
+      end interface
+
+      procedure(f), pointer :: func_ptr
+      integer :: x
+
+      func_ptr => f
+      x = func_ptr()
+      print *, x
+      if(x /= 42) error stop
+   end subroutine run
+end module
+
+
+program procedure_25
+   use procedure_25_module
+   implicit none
+   call run(test_func)
+contains
+   integer function test_func()
+      test_func = 42
+   end function test_func
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10467,14 +10467,18 @@ public:
             case ASR::symbolType::Variable: {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(x_m_v);
                 fetch_var(v);
-                return ;
+            break;
             }
             case ASR::symbolType::Function: {
-                uint32_t h = get_hash((ASR::asr_t*)x_m_v);
-                if( llvm_symtab_fn.find(h) != llvm_symtab_fn.end() ) {
+                const uint32_t h = get_hash((ASR::asr_t*)x_m_v);
+                if(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end()){ // Callback fn arg.
+                    tmp = llvm_symtab_fn_arg[h];
+                } else if( llvm_symtab_fn.find(h) != llvm_symtab_fn.end() ) {
                     tmp = llvm_symtab_fn[h];
+                } else {
+                    throw CodeGenError(std::string("Can't resolve var to Function '") + ASRUtils::symbol_name(x_m_v) + "'");
                 }
-                return;
+            break;
             }
             default: {
                 throw CodeGenError("Only function and variables supported so far");


### PR DESCRIPTION
Fixes #8777 

***
## Issue
when `Var` is pointing to a callback function (symbol), `Var` resolves to an external function symbol, hence symbol definition doesn't exist when linking; 
Instead, it should check first if that symbol is bounded to an argument (callback function argument)
## Fix
Check `llvm_symtab_fn_arg` map when resolving `Var` node. 