### PR TITLE
fix : mismatched argument and parameter doesn't raise error

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4776,19 +4776,19 @@ public:
                         ASR::expr_t* passed_arg = args[i].m_value;
                         ASR::ttype_t* passed_type = ASRUtils::expr_type(passed_arg);
                         ASR::ttype_t* param_type = v->m_type;
-                    // Check if parameter expects a procedure type 
-                    if (ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(param_type))){
-                        if (!ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(passed_type))){
-                            std::string passed_str =ASRUtils::type_to_str_fortran_expr(passed_type, nullptr);
-                            diag.add(diag::Diagnostic(
-                                "Type mismatch in argument `" + std::string(v->m_name) +
-                                "`: expected a procedure but got `" + passed_str + "`",
-                                diag::Level::Error, diag::Stage::Semantic, {
-                                    diag::Label("", {passed_arg->base.loc})
-                                }));
-                            throw SemanticAbort();
+                        // Check if parameter expects a procedure type 
+                        if (ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(param_type))){
+                            if (!ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(passed_type))){
+                                std::string passed_str =ASRUtils::type_to_str_fortran_expr(passed_type, nullptr);
+                                diag.add(diag::Diagnostic(
+                                    "Type mismatch in argument `" + std::string(v->m_name) +
+                                    "`: expected a procedure but got `" + passed_str + "`",
+                                    diag::Level::Error, diag::Stage::Semantic, {
+                                        diag::Label("", {passed_arg->base.loc})
+                                    }));
+                                throw SemanticAbort();
+                            }
                         }
-                    }
                         // Skip type checking for implicit argument_casting, 
                         // polymorphic types (class), function types, and intrinsics
                         bool skip_check = compiler_options.implicit_argument_casting ||

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -97,9 +97,9 @@ contains
         real :: a(*, 10)
     end subroutine
 
-
-
-
+    subroutine proc_param(p)
+        procedure(ubound_assumed_size_2) :: p
+    end subroutine proc_param
 
 
 
@@ -454,4 +454,7 @@ program continue_compilation_1
     assign 13 to fmt_i3
     13 format ()
     read (5, fmt_i3)
+
+    !passing non procedure to procedure parameter
+    call proc_param(42)
 end program 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "5dc4881ee9a9b5a9cbd40764a4747194c75de83278379959fcf4939d",
+    "infile_hash": "e078f288d43285bb909b0befb68aeb954dff6ebca00c500eebb67d54",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2ba234843a0f3b03f279f4c42064c0376b7527dad29dad7a2aa895dd",
+    "stderr_hash": "e3bbe41a1e1e7f9c0187c0c7a2fc96f87d875add4f12d94e51331a14",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -900,3 +900,9 @@ semantic error: Assigned format (using integer variable as format specifier) is 
     |
 456 |     read (5, fmt_i3)
     |     ^^^^^^^^^^^^^^^^ 
+
+semantic error: Type mismatch in argument `p`: expected a procedure but got `integer`
+   --> tests/errors/continue_compilation_1.f90:459:21
+    |
+459 |     call proc_param(42)
+    |                     ^^ 


### PR DESCRIPTION
## **Issue Fixed**
fixes #9177  mismatched argument and parameter doesn't raise error 

## **Summary**

After this PR, the type mismatch is caught during semantic analysis and reports a clear error message.

## **Reference Code**
```
module bench_mod
   interface
      integer function f()
      end function f
   end interface
contains
   subroutine run(m)
      procedure(f) :: m
   end subroutine run

end module bench_mod


program main
   use bench_mod
   implicit none
   call run(1)
end program main
```

## **Behaviour before this PR**
```
(lf) opixdown@Atharvs-MacBook-Air lfortran % lfortran ./t.f90
code generation error: asr_to_llvm: module failed verification. Error:
Call parameter type does not match function signature!
  %call_arg_value = alloca i32, align 4
```


## **Behaviour after this PR**
```
lf) opixdown@Atharvs-MacBook-Air lfortran % lfortran ./t.f90
semantic error: Type mismatch in argument `m`: expected a procedure but got `integer`
  --> ./t.f90:17:13
   |
17 |    call run(1)
   |             ^ 
```

