### PR TITLE
Implement --time-report in all compilation paths

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1190,6 +1190,7 @@ int compile_src_to_object_file(const std::string &infile,
     t1 = std::chrono::high_resolution_clock::now();
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
+    t2 = std::chrono::high_resolution_clock::now();
     lcompilers_unique_ID_separate_compilation = compiler_options.separate_compilation ? LCOMPILERS_UNIQUE_ID : "";
 
     time_src_to_asr = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();


### PR DESCRIPTION
Improve the look and colors, fix bugs.

An example output now for fpm in Debug mode:
```console
$ time lfortran -c app/main.f90  --cpp --cpp --realloc-lhs-arrays --use-loop-variable-after-loop -DFPM_RELEASE_VERSION=0.12.0 -Ibuild/dependencies/fortran-regex/src -J build/lfortran_29F2E0FA2D75FE0A -Ibuild/lfortran_29F2E0FA2D75FE0A -Ibuild/lfortran_5D5DD1C987059777 -o build/lfortran_29F2E0FA2D75FE0A/fpm/app_main.f90.o --time-report
Allocator usage of last chunk (MB)                    20.830
Allocator chunks                                       6.000
------------------------------------------------------------
Component name                                     Time (ms)
------------------------------------------------------------
File reading                                           0.590
Src -> ASR                                          1541.199
ASR passes (total)                                  4802.773
    global_stmts                                      99.670
    init_expr                                        106.780
    function_call_in_declaration                     104.523
    openmp                                            98.421
    implied_do_loops                                 120.964
    array_struct_temporary                           155.703
    transform_optional_argument_functions            168.587
    nested_vars                                      153.390
    forall                                           123.731
    class_constructor                                135.121
    pass_list_expr                                   134.905
    where                                            126.316
    array_op                                         150.458
    symbolic                                         132.856
    intrinsic_function                               241.688
    intrinsic_subroutine                             181.672
    subroutine_from_function                         205.664
    array_op                                         198.430
    pass_array_by_data                               274.443
    array_passed_in_function_call                    213.770
    print_list_tuple                                 196.135
    array_dim_intrinsics_update                      210.380
    do_loops                                         222.250
    while_else                                       216.787
    select_case                                      229.375
    unused_functions                                 258.439
    unique_symbols                                   165.805
    insert_deallocate                                176.442
    other processing time                              0.069
ASR -> mod                                             0.511
LLVM IR creation                                    1133.275
LLVM opt                                               0.000
LLVM -> BIN                                         7617.278
------------------------------------------------------------
Total time                                         15139.701
------------------------------------------------------------

real    15.259s
user    14.912s
sys     0.200s
cpu     99.0%
```

And Release mode:
```console
(gfortran) ~/repos/3rd-party/fpm(lf-15)$ time lfortran -c app/main.f90  --cpp --cpp --realloc-lhs-arrays --use-loop-variable-after-loop -DFPM_RELEASE_VERSION=0.12.0 -Ibuild/dependencies/fortran-regex/src -J build/lfortran_29F2E0FA2D75FE0A -Ibuild/lfortran_29F2E0FA2D75FE0A -Ibuild/lfortran_5D5DD1C987059777 -o build/lfortran_29F2E0FA2D75FE0A/fpm/app_main.f90.o --time-report
Allocator usage of last chunk (MB)                    20.822
Allocator chunks                                       6.000
------------------------------------------------------------
Component name                                     Time (ms)
------------------------------------------------------------
File reading                                           0.640
Src -> ASR                                            80.492
ASR passes (total)                                   133.295
    global_stmts                                       0.000
    init_expr                                          1.608
    function_call_in_declaration                       2.303
    openmp                                             0.000
    implied_do_loops                                   3.732
    array_struct_temporary                            10.298
    transform_optional_argument_functions              9.277
    nested_vars                                        6.394
    forall                                             0.976
    class_constructor                                  3.579
    pass_list_expr                                     3.606
    where                                              1.294
    array_op                                           4.234
    symbolic                                           0.631
    intrinsic_function                                14.619
    intrinsic_subroutine                               4.210
    subroutine_from_function                           5.666
    array_op                                           4.108
    pass_array_by_data                                14.143
    array_passed_in_function_call                      5.191
    print_list_tuple                                   1.483
    array_dim_intrinsics_update                        5.196
    do_loops                                           5.459
    while_else                                         2.587
    select_case                                        2.802
    unused_functions                                  17.432
    unique_symbols                                     0.000
    insert_deallocate                                  2.439
    other processing time                              0.028
ASR -> mod                                             0.390
LLVM IR creation                                     210.692
LLVM opt                                               0.000
LLVM -> BIN                                         7062.332
------------------------------------------------------------
Total time                                          7532.395
------------------------------------------------------------

real    7.556s
user    7.447s
sys     0.100s
cpu     99.9%
```