### PR TITLE
fix: unhandled case of accept '+' sign in scale factor

### DIFF
--- a/integration_tests/format_38.f90
+++ b/integration_tests/format_38.f90
@@ -20,5 +20,10 @@ program format_38
     write(output, '(+1p, f10.3)') value
     if (output /= "   424.300         ") error stop
 
+    ! Test format statement with + sign
+    write(output, 100) value
+    if (output /= "   424.300         ") error stop
+    100 format (+1p, f10.3)
+
     print *, "All tests passed"
 end program

--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -875,7 +875,7 @@ void lex_format(unsigned char *&cur, Location &loc,
             "&" ws_comment+ whitespace? "&"? { continue; }
             '"' ('""'|[^"\x00])* '"' { continue; }
             "'" ("''"|[^'\x00])* "'" { continue; }
-            '-' { continue; }
+            '-' | '+' { continue; }
             (int)? whitespace? data_edit_desc { continue; }
             control_edit_desc { continue; }
         */


### PR DESCRIPTION
fixes #9200 
extension of #9195 
## **Reference Code**
```
program scale_factor
  implicit none

! First two forms (unsigned and negative) were legal in Fortran-66:
  print '( 1p, f10.3)', 42.43
  print '(-1p, f10.3)', 42.43
!
! Signed (+ in addition to -) has been legal since Fortran-77:
  print '(+2p, f10.3)', 42.43

100 format (+1p, f10.3)

end program
```

## **Behaviour before this PR**
```
(lf) opixdown@Atharvs-MacBook-Air lfortran % lfortran ./t.f90
tokenizer error: Token '+' is not recognized in `format` statement
  --> scale_factor_9192.f90:11:13
   |
11 | 100 format (+1p, f10.3)
   |             ^ 
```


## **Behaviour after this PR**
```
(lf) opixdown@Atharvs-MacBook-Air lfortran % lfortran ./t.f90
   424.300
     4.243
  4243.000
```

