### PR TITLE
fix: handle character parameter declaration using `type()` syntax

### DIFF
--- a/integration_tests/declaration_03.f90
+++ b/integration_tests/declaration_03.f90
@@ -2,11 +2,10 @@ program declaration_03
     implicit none
     type(character(len=4)) :: str1 = 'abcd'
     type(real):: r1 = 1.53
-    ! TODO: Uncomment for parameter initializations
-    ! type(character(len=*)),parameter:: str2='(*(g0))'
-    ! if (str2 /= '(*(g0))') error stop
+    type(character(len=*)),parameter:: str2='(*(g0))'
     
-    print *, str1, r1
+    print *, str1, str2, r1
     if (str1 /= 'abcd') error stop
     if ((r1 - 1.53) > 1e-4) error stop
+    if (str2 /= '(*(g0))') error stop
 end program declaration_03


### PR DESCRIPTION
Fixes #7783
Changes made:
- Handling `type()` syntax for character parameters in AST-ASR conversions.
- Move the current logic to set and validate character lengths for parameter strings to a separate function to avoid code duplication.