### PR TITLE
codegen: fix PointerArray to FixedSizeArray cast

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8210,6 +8210,18 @@ public:
             llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(m_arg, m_type, module.get())->getPointerTo();
             tmp = builder->CreateBitCast(tmp, target_type);
         } else if(
+            m_new == ASR::array_physical_typeType::FixedSizeArray &&
+            (m_old == ASR::array_physical_typeType::PointerArray ||
+             m_old == ASR::array_physical_typeType::UnboundedPointerArray)) {
+            if( ASR::is_a<ASR::StructInstanceMember_t>(*m_arg) ) {
+                tmp = llvm_utils->CreateLoad2(m_arg_llvm_type, arg);
+            } else {
+                tmp = arg;
+            }
+            llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(m_arg,
+                m_type, module.get())->getPointerTo();
+            tmp = builder->CreateBitCast(tmp, target_type);
+        } else if(
             m_new == ASR::array_physical_typeType::DescriptorArray &&
             m_old == ASR::array_physical_typeType::DescriptorArray) {
             // TODO: For allocatables, first check if its allocated (generate code for it)


### PR DESCRIPTION
Fix LLVM codegen for `ArrayPhysicalCast` from `PointerArray`/`UnboundedPointerArray` to `FixedSizeArray`.

Why
- When a call expects a fixed-size array but the value is represented as a pointer-to-data array, codegen currently hits `LCOMPILERS_ASSERT(false)` in `visit_ArrayPhysicalCastUtil`.

What changed
- Teach `visit_ArrayPhysicalCastUtil` to bitcast pointer-to-data arrays to the fixed-size array pointer type (and load through struct members when needed).

Local evidence (stdlib logger repro)
- `stdlib_quadrature_simps.f90` now compiles with `--generate-object-code -c`:
  - before: abort in `visit_ArrayPhysicalCastUtil` (line shown in `/tmp/lfortran-dev/stdlib_quadrature_simps_gdb_bt_2025-12-28.log`)
  - after: `/tmp/lfortran-dev/repro_stdlib_quadrature_simps_after_codegen_fix_2025-12-28.log`
