### PR TITLE
fix: treat .F as fixed form with --fixed-form-infer

### DIFF
--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -359,7 +359,7 @@ namespace LCompilers::CommandLineInterface {
 
         // Decide if a file is fixed format based on the extension
         // Gfortran does the same thing
-        if (opts.fixed_form_infer && endswith(opts.arg_file, ".f")) {
+        if (opts.fixed_form_infer && (endswith(opts.arg_file, ".f") || endswith(opts.arg_file, ".F"))) {
             compiler_options.fixed_form = true;
         }
 


### PR DESCRIPTION
When --fixed-form-infer is enabled, treat .F sources as fixed form (same as .f).

This matches common fixed-form + preprocessor usage in LAPACK-style code.