### PR TITLE
semantics: strip allocatable wrapper in implicit interface args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2559,6 +2559,7 @@ RUN(NAME legacy_array_sections_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc 
 RUN(NAME legacy_array_sections_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
+RUN(NAME legacy_array_sections_10 LABELS gfortran llvm llvm2 EXTRAFILES legacy_array_sections_10_foo.f90 EXTRA_ARGS --legacy-array-sections --implicit-interface --separate-compilation)
 
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/legacy_array_sections_10.f90
+++ b/integration_tests/legacy_array_sections_10.f90
@@ -1,0 +1,14 @@
+program legacy_array_sections_10
+    implicit none
+
+    real, allocatable :: a(:)
+
+    allocate(a(4))
+    a = [1.0, 2.0, 3.0, 4.0]
+
+    call foo(a)
+    call foo(a(2))
+
+    if (abs(a(1) - 11.0) > 1e-6) error stop
+    if (abs(a(2) - 12.0) > 1e-6) error stop
+end program legacy_array_sections_10

--- a/integration_tests/legacy_array_sections_10_foo.f90
+++ b/integration_tests/legacy_array_sections_10_foo.f90
@@ -1,0 +1,6 @@
+subroutine foo(x)
+    implicit none
+    real, intent(inout) :: x(*)
+
+    x(1) = x(1) + 10.0
+end subroutine foo

--- a/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.json
+++ b/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implicit_interface_allocatable_array-38d4afe.stdout",
-    "stdout_hash": "65715abfe3348216210383f2795445bb7b3f81c14570c8f7d9d83924",
+    "stdout_hash": "5bbc44002adcb0a4ba3d914be1226f6b0f74bb71e910ba1fdc0588a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.stdout
+++ b/tests/reference/asr-implicit_interface_allocatable_array-38d4afe.stdout
@@ -98,13 +98,11 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Allocatable
-                                                        (Array
-                                                            (Real 4)
-                                                            [(()
-                                                            ())]
-                                                            PointerArray
-                                                        )
+                                                    (Array
+                                                        (Real 4)
+                                                        [(()
+                                                        ())]
+                                                        PointerArray
                                                     )
                                                     ()
                                                     BindC
@@ -121,13 +119,11 @@
                                     sub1
                                     (FunctionType
                                         [(Integer 4)
-                                        (Allocatable
-                                            (Array
-                                                (Real 4)
-                                                [(()
-                                                ())]
-                                                PointerArray
-                                            )
+                                        (Array
+                                            (Real 4)
+                                            [(()
+                                            ())]
+                                            PointerArray
                                         )]
                                         ()
                                         BindC


### PR DESCRIPTION
## Summary
Strip allocatable/pointer wrappers when creating implicit interface dummy arguments.

## Fix
In `create_implicit_interface_function` (`ast_common_visitor.h:10041`):
```cpp
ASR::ttype_t* array_var_type = ASRUtils::type_get_past_allocatable(
    ASRUtils::type_get_past_pointer(var_type));
```

## Test
- `legacy_array_sections_10`: Allocatable array passed to implicit interface subroutine
- `lapack_testing_02`: Allocatable 1D array passed to assumed-size dummy

## Merge Order
Independent - can merge anytime.
