### PR TITLE
semantics: fix legacy array element to 2D array dummy

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2560,6 +2560,8 @@ RUN(NAME legacy_array_sections_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc 
 RUN(NAME legacy_array_sections_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 RUN(NAME legacy_array_sections_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)
 
+RUN(NAME lapack_testing_03 LABELS gfortran llvm2 EXTRA_ARGS --separate-compilation --implicit-interface --legacy-array-sections EXTRAFILES lapack_testing_03_sqrt16.f90)
+
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/lapack_testing_03.f90
+++ b/integration_tests/lapack_testing_03.f90
@@ -1,0 +1,20 @@
+program lapack_testing_03
+    implicit none
+
+    integer :: m, n, nrhs, ldwork, lwork
+    real, allocatable :: work(:)
+    real :: result
+
+    m = 2
+    n = 1
+    nrhs = 3
+    ldwork = m
+    lwork = m*nrhs + m + 10
+
+    allocate(work(lwork))
+    work = 0.0
+
+    call sqrt16(m, n, nrhs, work, ldwork, work(m*nrhs+1), result)
+
+    if (abs(result - 2.0) > 1e-6) error stop
+end program lapack_testing_03

--- a/integration_tests/lapack_testing_03_sqrt16.f90
+++ b/integration_tests/lapack_testing_03_sqrt16.f90
@@ -1,0 +1,11 @@
+subroutine sqrt16(m, n, nrhs, work, ldwork, work2, result)
+    implicit none
+
+    integer, intent(in) :: m, n, nrhs, ldwork
+    real, intent(inout) :: work(ldwork, *)
+    real, intent(inout) :: work2(*)
+    real, intent(out) :: result
+
+    work2(1) = 2.0
+    result = work2(1)
+end subroutine sqrt16

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6945,14 +6945,20 @@ public:
                     for( int arg_i: array_arg_index ) {
                         ASR::expr_t* arg_expr = x.m_args[arg_i].m_value;
                         ASR::ttype_t* dummy_type = ASRUtils::expr_type(f->m_args[arg_i]);
-                        ASR::array_physical_typeType expected_phys_type = ASRUtils::extract_physical_type(dummy_type);
+                        ASR::ttype_t* dummy_array_type =
+                            ASRUtils::type_get_past_allocatable_pointer(dummy_type);
+                        ASR::array_physical_typeType expected_phys_type =
+                            ASRUtils::extract_physical_type(dummy_array_type);
                         bool expected_unbounded = (expected_phys_type == ASR::array_physical_typeType::UnboundedPointerArray);
                         // Only convert top-level ArrayItem to ArraySection.
                         // Do NOT recurse into nested ArrayItem expressions in indices.
                         if ( arg_expr != nullptr && ASR::is_a<ASR::ArrayItem_t>(*arg_expr) ) {
                             ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(arg_expr);
                             ASR::ttype_t* array_type = ASRUtils::expr_type(array_item->m_v);
-                            ASR::array_physical_typeType actual_phys_type = ASRUtils::extract_physical_type(array_type);
+                            ASR::ttype_t* section_type =
+                                ASRUtils::type_get_past_allocatable_pointer(array_type);
+                            ASR::array_physical_typeType actual_phys_type =
+                                ASRUtils::extract_physical_type(section_type);
                             bool unbounded_tail = expected_unbounded ||
                                 (actual_phys_type == ASR::array_physical_typeType::UnboundedPointerArray);
                             Vec<ASR::array_index_t> array_indices;
@@ -6979,7 +6985,7 @@ public:
                                 ASR::array_physical_typeType::UnboundedPointerArray :
                                 ASR::array_physical_typeType::DescriptorArray;
                             ASR::ttype_t* new_type = ASRUtils::duplicate_type_with_empty_dims(
-                                al, array_type, section_phys_type, unbounded_tail);
+                                al, section_type, section_phys_type, unbounded_tail);
                             x.m_args[arg_i].m_value = ASRUtils::EXPR(ASR::make_ArraySection_t(
                                 al, array_item->base.base.loc, array_item->m_v,
                                 array_indices.p, array_indices.n, new_type, nullptr));


### PR DESCRIPTION
## Summary
Create ArraySection with all dimension indices when array element A(i,j) is passed to 2D array dummy.

## Fix
In `legacy_array_sections_helper` (`ast_common_visitor.h`):
```cpp
for (size_t dim_i = 0; dim_i < array_item->n_args; dim_i++) {
    array_idx.m_left = array_item->m_args[dim_i].m_right;
    array_idx.m_right = ASRUtils::get_bound(array_expr, dim_i + 1, "ubound", ...);
}
```

## Test
`lapack_testing_01`: LAPACK-style 2D array element association.

## Merge Order
Independent - can merge anytime.
