### PR TITLE
fix: add support for substrings inside write statements

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2319,6 +2319,7 @@ RUN(NAME write_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME write_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME write_fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME write_fortran_02 LABELS gfortran llvm fortran)

--- a/integration_tests/write_13.f90
+++ b/integration_tests/write_13.f90
@@ -1,0 +1,14 @@
+! Test writes into substrings inside FileWrite Nodes
+program write_13
+    implicit none
+    character(10):: string = 'ABCDEFGHIJ'
+    character(len=5) :: string2
+
+    write(string2(1:),'(a)') "Hello"
+    write(string(1:4),'(A)') 'abcd'
+
+    print *, string, string2
+
+    if (string/='abcdEFGHIJ') error stop
+    if (string2/='Hello') error stop
+end program write_13

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -12266,7 +12266,15 @@ public:
         } else {
             throw CodeGenError("Unsupported type for `unit` in write(..)");
         }
-        this->visit_expr_wrapper(x.m_unit);
+        // Don't use constant value optimization for assignments to string-sections
+        if (is_string && ASR::is_a<ASR::StringSection_t>(*x.m_unit)) {
+            bool is_assignment_target_temp = is_assignment_target;
+            is_assignment_target = true;
+            this->visit_expr_wrapper(x.m_unit);
+            is_assignment_target = is_assignment_target_temp;
+        } else {
+            this->visit_expr_wrapper(x.m_unit);
+        }
         ptr_loads = ptr_loads_copy;
 
         llvm::Value* string_len;

--- a/src/libasr/pass/replace_with_compile_time_values.cpp
+++ b/src/libasr/pass/replace_with_compile_time_values.cpp
@@ -145,6 +145,63 @@ class ExprVisitor: public ASR::CallReplacerOnExpressionsVisitor<ExprVisitor> {
         current_expr = current_expr_copy;
     }
 
+        void visit_FileWrite(const ASR::FileWrite_t& x) {
+        // Don't replace string write targets as compile-time constants
+        ASR::FileWrite_t& xx = const_cast<ASR::FileWrite_t&>(x);
+        ASR::expr_t** current_expr_copy = current_expr;
+        // Check if writing to a string (not a file unit)
+        bool is_string_write = xx.m_unit && ASRUtils::is_character(*ASRUtils::expr_type(xx.m_unit));
+        if (is_string_write) {
+            // Visit the unit (write target) without calling the replacer
+            bool inside_prohibited_expression_copy = replacer.inside_prohibited_expression;
+            replacer.inside_prohibited_expression = true;
+            current_expr = &(xx.m_unit);
+            replacer.current_expr = current_expr;
+            ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+            replacer.inside_prohibited_expression = inside_prohibited_expression_copy;
+        } else {
+            // Unit can be replaced normally
+            if (xx.m_unit) {
+                current_expr = &(xx.m_unit);
+                replacer.current_expr = current_expr;
+                ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+            }
+        }
+        // Visit other expr_t* fields normally
+        if (xx.m_iomsg) {
+            current_expr = &(xx.m_iomsg);
+            replacer.current_expr = current_expr;
+            ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+        }
+        if (xx.m_iostat) {
+            current_expr = &(xx.m_iostat);
+            replacer.current_expr = current_expr;
+            ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+        }
+        if (xx.m_id) {
+            current_expr = &(xx.m_id);
+            replacer.current_expr = current_expr;
+            ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+        }
+        // Visit values (can be replaced)
+        for (size_t i = 0; i < xx.n_values; i++) {
+            current_expr = &(xx.m_values[i]);
+            replacer.current_expr = current_expr;
+            this->visit_expr(*xx.m_values[i]);
+        }
+        if (xx.m_separator) {
+            current_expr = &(xx.m_separator);
+            replacer.current_expr = current_expr;
+            ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+        }
+        if (xx.m_end) {
+            current_expr = &(xx.m_end);
+            replacer.current_expr = current_expr;
+            ASR::CallReplacerOnExpressionsVisitor<ExprVisitor>::visit_expr(**current_expr);
+        }
+        current_expr = current_expr_copy;
+    }
+    
 };
 
 void pass_replace_with_compile_time_values(


### PR DESCRIPTION
Fixes #7787 & Fixes #8369
Add support for writing into StringSections inside write statements by marking them as assignment targets.