### PR TITLE
enh: misleading 'not defined' error for assumed-size

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2142,7 +2142,6 @@ public:
 	                "Assumed-size '*' is only permitted in the last dimension",
 	                diag::Level::Error, diag::Stage::Semantic, {
 	                    diag::Label("", {m_dim[i].loc})}));
-	            throw SemanticAbort();
 	        }
 	        ASR::dimension_t dim_dummy; dims.push_back(al, dim_dummy);
 	        ASR::dimension_t &dim  = const_cast<ASR::dimension_t&>(dims[dims.size()-1]);

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "4a7cb161af7e459768210ff6aaaa9e985f451b19fd35dedfb2f61472",
+    "stderr_hash": "836f0339a329130c5131a482b3ed031162513765a240f4a13f8c385b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -26,31 +26,11 @@ semantic error: Assumed-size '*' is only permitted in the last dimension
 88 |         real, intent(in) :: a(*, 10)
    |                               ^ 
 
-semantic error: Dummy argument 'a' not defined
-  --> tests/errors/continue_compilation_1.f90:87:5 - 89:18
-   |
-87 |        subroutine assumed_size_star_pos_1(a)
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
-...
-   |
-89 |        end subroutine
-   | ...^^^^^^^^^^^^^^^^^^ 
-
 semantic error: Assumed-size '*' is only permitted in the last dimension
   --> tests/errors/continue_compilation_1.f90:92:19
    |
 92 |         real :: a(*, 10)
    |                   ^ 
-
-semantic error: Dummy argument 'a' not defined
-  --> tests/errors/continue_compilation_1.f90:91:5 - 93:18
-   |
-91 |        subroutine assumed_size_star_pos_2(a)
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
-...
-   |
-93 |        end subroutine
-   | ...^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Interface 'f_missing' is referenced but not defined
   --> tests/errors/continue_compilation_1.f90:21:9


### PR DESCRIPTION
fixes #9105