### PR TITLE
semantics: expand constant-bounds implied-do in READ

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2289,6 +2289,7 @@ RUN(NAME read_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME read_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN read_07_data.txt)
+RUN(NAME read_10 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_10.f90
+++ b/integration_tests/read_10.f90
@@ -1,0 +1,17 @@
+program read_10
+    implicit none
+    integer :: vals(3)
+    integer :: i
+
+    open(10, status='scratch')
+    write(10, *) 10, 20, 30
+    rewind(10)
+
+    read(10, *) (vals(i), i=1, 3)
+    close(10)
+
+    if (vals(1) /= 10) error stop "vals(1) should be 10"
+    if (vals(2) /= 20) error stop "vals(2) should be 20"
+    if (vals(3) /= 30) error stop "vals(3) should be 30"
+    print *, "PASS"
+end program


### PR DESCRIPTION
## Summary

Expand implied-do loops with constant bounds in READ statements at semantic analysis time.

**Before**: `read(5,*) (vals(i), i=1,3)` was left unexpanded
**After**: Expanded to `read(5,*) vals(1), vals(2), vals(3)` at semantic time

## Changes

- Add `expand_implied_do_for_read()` helper in `ast_body_visitor.cpp`
- For constant bounds: expand to individual ArrayItem elements at semantic analysis
- For variable bounds: pass through unchanged for codegen to handle (see #9261)

## Test Plan

- [x] `read_10.f90` - tests constant-bounds implied-do in READ

## Merge Order

Merge after #9255 and #9261 (uses `read_10` assuming `read_08` and `read_09` exist).
