### PR TITLE
fix: fixed the compiler crash in SymbolTableVisitor and added a test

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -23,11 +23,11 @@ module continue_compilation_1_mod
 
     procedure(missing_global_interface), pointer :: p => null()
 
-
-
-
-
-
+    interface
+        module function f() result(i)
+            integer :: i
+        end function
+    end interface
 
 
 
@@ -96,10 +96,10 @@ contains
         procedure(ubound_assumed_size) :: p
     end subroutine proc_param
 
-
-
-
-
+    module function f() result(r)
+        real :: r
+        r = 5.5
+    end function
 
 
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "441065bb589114066785d0eb26c1b2d418a955ffda8d4e7373832ec0",
+    "infile_hash": "43a5492f14e91deb66e032d9516b7c9e378a64aee35d0eb256840078",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "4a7cb161af7e459768210ff6aaaa9e985f451b19fd35dedfb2f61472",
+    "stderr_hash": "4937ac9a86979e6df5cc4b718037011eab1e99c43399c89d7c8d2739",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -52,6 +52,16 @@ semantic error: Dummy argument 'a' not defined
 93 |        end subroutine
    | ...^^^^^^^^^^^^^^^^^^ 
 
+semantic error: Argument(s) or return type mismatch in interface and implementation
+   --> tests/errors/continue_compilation_1.f90:99:5 - 102:16
+    |
+ 99 |        module function f() result(r)
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+    |
+102 |        end function
+    | ...^^^^^^^^^^^^^^^^ 
+
 semantic error: Interface 'f_missing' is referenced but not defined
   --> tests/errors/continue_compilation_1.f90:21:9
    |
@@ -202,6 +212,12 @@ semantic error: The upper bound of an assumed-size array's last dimension is not
    |
 84 |         print *, ubound(c, 2)
    |                  ^^^^^^^^^^^^ 
+
+semantic error: Variable 'r' is not declared
+   --> tests/errors/continue_compilation_1.f90:101:9
+    |
+101 |         r = 5.5
+    |         ^ 'r' is undeclared
 
 semantic error: Assignment to loop variable `i` is not allowed
    --> tests/errors/continue_compilation_1.f90:226:8


### PR DESCRIPTION
**Fixes:** #9222 

This PR fixes a compiler crash that occurred when semantic errors were encountered inside module, function, or subroutine blocks while using the --continue-compilation flag.

Previously, if a SemanticAbort was thrown inside these visitors, the scope management logic was interrupted, leaving current_scope pointing to an invalid or unfinished symbol table. This caused the compiler to crash or segfault when attempting to process subsequent errors.

Basically I added try-catch blocks in ast_symboltable_visitor.cpp and also added a regression test case for interface mismatches in tests/errors/continue_compilation_1.f90

Input: test_program.f90 - 
```
program test_crash
    implicit integer(a-f), real(e-z)
end program
```
Output - 
```
(lf) $ src/bin/lfortran test_program.f90 --continue-compilation
semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
 --> test_program.f90:2:5
  |
2 |      implicit integer(a-f), real(e-z)
  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Input - test_crash.f90 - 
```
module test_crash
    implicit integer(a-f), real(e-z)
end module
```
Output - 
```
(lf) $ src/bin/lfortran -c test_crash.f90 --continue-compilation
semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
 --> maintainer_crash.f90:2:5
  |
2 |      implicit integer(a-f), real(e-z)
  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Input - test_fix.f90 
```
module test_crash
    implicit none
    interface
        module function f() result(i)
            integer :: i
        end function
    end interface
contains
    module function f() result(r)
        real :: r
        r = 5.5
    end function
end module
```

Output - 
```
(lf) $ src/bin/lfortran test_fix.f90 --continue-compilation
semantic error: Argument(s) or return type mismatch in interface and implementation
  --> test_fix.f90:9:5 - 12:16
   |
 9 |         module function f() result(r)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
...
   |
12 |         end function
   | ...^^^^^^^^^^^^^^^^ 

semantic error: Variable 'r' is not declared
  --> test_fix.f90:11:9
   |
11 |          r = 5.5
   |          ^ 'r' is undeclared
```