### PR TITLE
fix: treat common block string members as allocatable in strcpy

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2824,6 +2824,8 @@ RUN(NAME separate_compilation_24 LABELS gfortran llvm_submodule EXTRAFILES separ
 RUN(NAME separate_compilation_25 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_25a.f90 separate_compilation_25b.f90)
 RUN(NAME separate_compilation_26 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_26a.f90 separate_compilation_26b.f90)
 RUN(NAME separate_compilation_27 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_27a.f90 separate_compilation_27b.f90)
+RUN(NAME separate_compilation_28 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
+    EXTRAFILES separate_compilation_28a.f90 separate_compilation_28b.f90)
 
 
 

--- a/integration_tests/separate_compilation_28.f90
+++ b/integration_tests/separate_compilation_28.f90
@@ -1,0 +1,13 @@
+! Test: passing string literal to CHARACTER(*) parameter in separate compilation
+! with common block containing CHARACTER variable.
+! This tests the fix for a bug where common block struct members caused
+! "Non-allocatable string isn't allocated" error when the struct was
+! initialized with zeroinitializer (NULL pointer in string descriptor).
+program separate_compilation_28
+    implicit none
+    call caller_one()
+    call caller_two()
+    call caller_one()
+    call caller_two()
+    print *, "All tests passed"
+end program

--- a/integration_tests/separate_compilation_28a.f90
+++ b/integration_tests/separate_compilation_28a.f90
@@ -1,0 +1,5 @@
+subroutine string_handler(name, info)
+    character(*), intent(in) :: name
+    integer, intent(in) :: info
+    print *, "Handler got: '", name, "' info=", info
+end subroutine

--- a/integration_tests/separate_compilation_28b.f90
+++ b/integration_tests/separate_compilation_28b.f90
@@ -1,0 +1,13 @@
+subroutine caller_one()
+    character(32) :: cvar
+    common /cblk/ cvar
+    cvar = 'CALLER_ONE'
+    call string_handler('CALLER_ONE', 1)
+end subroutine
+
+subroutine caller_two()
+    character(32) :: cvar
+    common /cblk/ cvar
+    cvar = 'CALLER_TWO'
+    call string_handler('CALLER_TWO', 2)
+end subroutine

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7605,10 +7605,16 @@ public:
             }
         }
         if ( ASRUtils::is_string_only(ASRUtils::expr_type(x.m_value))) {
+            // For struct members (especially common blocks), treat as allocatable
+            // so _lfortran_strcpy allocates memory if the pointer is NULL.
+            // Common block structs are initialized with zeroinitializer, so
+            // their string descriptor pointers start as NULL.
+            bool is_dest_allocatable = ASRUtils::is_allocatable(asr_target_type) ||
+                                       ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target);
             llvm_utils->lfortran_str_copy(target, value,
                 ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(asr_target_type)),
                 ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(asr_value_type)),
-                ASRUtils::is_allocatable(asr_target_type));
+                is_dest_allocatable);
             tmp = nullptr;
             return;
         }


### PR DESCRIPTION
## Summary

Fix "Non-allocatable string isn't allocated" error when passing string literals to `CHARACTER(*)` parameters in separate compilation with common blocks containing CHARACTER variables.

## Problem

When a subroutine has a common block with a CHARACTER variable and passes a string literal to another subroutine with a `CHARACTER(*)` parameter, the LLVM backend crashes with:

```
Non-allocatable string isn't allocated
```

This occurs because common block structs are initialized with `zeroinitializer`, which sets string descriptor pointers to NULL. The `_lfortran_strcpy` runtime function then fails when it encounters the NULL pointer for non-allocatable strings.

## Fix

In `asr_to_llvm.cpp`, treat `StructInstanceMember` targets (which includes common block variables) as allocatable when calling `lfortran_str_copy`. This allows the runtime to allocate memory for the string descriptor if the pointer is NULL.

## Test

Added `separate_compilation_28` integration test that reproduces the exact scenario:
- Main program calls subroutines
- Subroutines have common block with CHARACTER variable
- Subroutines pass string literals to a handler with `CHARACTER(*)` parameter
