### PR TITLE
Fix infinity/NaN formatting in G, E, ES, EN formats

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -867,6 +867,7 @@ RUN(NAME format_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_42 LABELS gfortran llvm)
+RUN(NAME format_44 LABELS gfortran llvm)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran fortran)

--- a/integration_tests/format_44.f90
+++ b/integration_tests/format_44.f90
@@ -1,0 +1,43 @@
+program format_44
+    ! Test formatting of special floating-point values (Infinity, NaN)
+    implicit none
+    real :: zero, pos_inf, neg_inf, nan_val
+    character(20) :: str
+
+    zero = 0.0
+    pos_inf = 1.0 / zero
+    neg_inf = -1.0 / zero
+    nan_val = zero / zero
+
+    ! Test G format with Infinity
+    write(str, '(G12.5)') pos_inf
+    if (trim(adjustl(str)) /= "Infinity") error stop "G12.5 +Inf failed"
+
+    write(str, '(G12.5)') neg_inf
+    if (trim(adjustl(str)) /= "-Infinity") error stop "G12.5 -Inf failed"
+
+    ! Test E format with Infinity
+    write(str, '(E12.5)') pos_inf
+    if (trim(adjustl(str)) /= "Infinity") error stop "E12.5 +Inf failed"
+
+    write(str, '(E12.5)') neg_inf
+    if (trim(adjustl(str)) /= "-Infinity") error stop "E12.5 -Inf failed"
+
+    ! Test ES format with Infinity
+    write(str, '(ES12.5)') pos_inf
+    if (trim(adjustl(str)) /= "Infinity") error stop "ES12.5 +Inf failed"
+
+    ! Test EN format with Infinity
+    write(str, '(EN12.5)') pos_inf
+    if (trim(adjustl(str)) /= "Infinity") error stop "EN12.5 +Inf failed"
+
+    ! Test G format with NaN
+    write(str, '(G12.5)') nan_val
+    if (trim(adjustl(str)) /= "NaN") error stop "G12.5 NaN failed"
+
+    ! Test E format with NaN
+    write(str, '(E12.5)') nan_val
+    if (trim(adjustl(str)) /= "NaN") error stop "E12.5 NaN failed"
+
+    print *, "PASS"
+end program


### PR DESCRIPTION
## Summary
- Handle special floating-point values (Infinity, NaN) in G, E, ES, EN formatted output
- Add checks for `isinf()` and `isnan()` before computing `log10()`, which produces undefined behavior for these values
- Output "Infinity", "-Infinity", or "NaN" with proper width padding

## Test
- Add `format_44.f90` integration test covering all affected formats with infinity and NaN values

Fixes #4554