### PR TITLE
fix: memory leak in formatted write (cleaned_format not freed)

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1777,6 +1777,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(const char* format, int64_t
     strncpy(modified_input_string, cleaned_format, len);
     modified_input_string[len] = '\0';
     strip_outer_parenthesis(cleaned_format, len, modified_input_string);
+    free(cleaned_format);
     format_values = parse_fortran_format((const fchar*)modified_input_string, strlen(modified_input_string), &format_values_count, &item_start_idx);
     /*
     is_SP_specifier = false  --> 'S' OR 'SS'


### PR DESCRIPTION
## Summary
- Free `cleaned_format` in `_lcompilers_string_format_fortran` after use

## Problem
The `remove_spaces_except_quotes` function allocates memory for `cleaned_format` which was never freed. This caused a memory leak of ~15 bytes per formatted write operation, eventually exhausting memory in long-running loops.

## Evidence
Valgrind output before fix:
```
7,500 bytes in 500 blocks are definitely lost in loss record 2 of 2
   at 0x48527D8: malloc
   by remove_spaces_except_quotes (lfortran_intrinsics.c:807)
   by _lcompilers_string_format_fortran (lfortran_intrinsics.c:1797)
```

After fix:
```
All heap blocks were freed -- no leaks are possible
```

## Test
Programs with 174k+ formatted writes would crash due to memory exhaustion. After this fix, they complete successfully.