### PR TITLE
fix: handle self-referencing struct array section assignments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1763,6 +1763,8 @@ RUN(NAME allocate_array_descriptor_01 LABELS gfortran llvm llvm_wasm llvm_wasm_e
 RUN(NAME allocate_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME allocate_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
+    EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)

--- a/integration_tests/allocate_32.f90
+++ b/integration_tests/allocate_32.f90
@@ -1,0 +1,35 @@
+program allocate_32
+    implicit none
+    type :: item_t
+        character(len=:), allocatable :: name
+        integer :: value
+    end type item_t
+    type(item_t), allocatable :: items(:)
+    integer :: i
+
+    allocate(items(3))
+    do i = 1, 3
+        allocate(character(len=10) :: items(i)%name)
+        items(i)%name = "item" // char(48 + i)
+        items(i)%value = i * 10
+    end do
+
+    print *, "Before: size =", size(items)
+    do i = 1, size(items)
+        print *, "  items(", i, ")%name =", trim(items(i)%name), &
+                 ", value =", items(i)%value
+    end do
+
+    items = items(2:3)
+
+    print *, "After: size =", size(items)
+    do i = 1, size(items)
+        print *, "  items(", i, ")%name =", trim(items(i)%name), &
+                 ", value =", items(i)%value
+    end do
+
+    if (size(items) /= 2) error stop "Expected size 2"
+    if (items(1)%value /= 20) error stop "Expected items(1)%value = 20"
+    if (items(2)%value /= 30) error stop "Expected items(2)%value = 30"
+    print *, "PASS"
+end program allocate_32


### PR DESCRIPTION
## Summary
- Fix use-after-free bug in self-referencing allocatable struct array section assignments (e.g., `items = items(2:3)`)
- Add detection in `array_struct_temporary` pass to create temporary for struct arrays before the assignment, avoiding the codegen's `struct_deepcopy` use-after-free issue
- Add integration test `allocate_32` to verify the fix

## Root Cause
When handling `items = items(2:3)` where `items` is an allocatable struct array with allocatable members, the `struct_deepcopy` in codegen would:
1. Reallocate the destination array (freeing the old memory)
2. Copy from source (which pointed to the now-freed destination memory)

This caused use-after-free / double-free crashes.

## Fix
The fix adds a check in `array_struct_temporary.cpp` `visit_Assignment()` to detect self-referencing allocatable struct array assignments BEFORE `call_replacer()` transforms the value. When detected, a temporary is created to hold the source data, preventing the use-after-free.

## Test Plan
- [ ] Integration test `allocate_32` passes (verifies `items = items(2:3)` with struct arrays)
- [ ] Existing tests pass (no regressions in `derived_types_*`, `allocate_*` tests)
- [ ] Valgrind shows no memory errors on the test case

Fixes #9275
