### PR TITLE
fix: create proper Cast nodes for Complex PARAMETER with Real/Integer initializer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1612,6 +1612,7 @@ RUN(NAME complex_sub_test LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm for
 RUN(NAME complex_mul_test LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME complex_div_test LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME complex_pow_test LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME complex_unary_minus_03 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME logical1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME logical2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)

--- a/integration_tests/complex_unary_minus_03.f90
+++ b/integration_tests/complex_unary_minus_03.f90
@@ -1,0 +1,20 @@
+! Test for complex unary minus in implicit interface call with PARAMETER
+! Reproduces ICE from LAPACK clasyf_aa.f
+subroutine csub(alpha, n, ok)
+    implicit none
+    integer, intent(in) :: n
+    complex, intent(in) :: alpha
+    logical, intent(out) :: ok
+    ok = (real(alpha) == -1.0) .and. (aimag(alpha) == 0.0)
+end subroutine
+
+program complex_unary_minus_03
+    implicit none
+    complex, parameter :: zero = 0.0e+0, one = 1.0e+0
+    logical :: ok
+    external :: csub
+    ok = .false.
+    call csub(-one, 1, ok)
+    if (.not. ok) error stop
+    print *, 'PASS'
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3571,10 +3571,38 @@ public:
                                                 v->m_storage = ASR::storage_typeType::Parameter;
                                                 if (ASR::is_a<ASR::RealConstant_t>(*init_val)) {
                                                     ASR::RealConstant_t* rc = ASR::down_cast<ASR::RealConstant_t>(init_val);
-                                                    init_val = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, rc->m_r, v->m_type));
+                                                    if (ASRUtils::is_complex(*v->m_type)) {
+                                                        ASR::expr_t* complex_value = ASRUtils::EXPR(
+                                                            ASR::make_ComplexConstant_t(al, x.base.base.loc,
+                                                                rc->m_r, 0.0, v->m_type));
+                                                        init_val = ASRUtils::EXPR(ASR::make_Cast_t(al, x.base.base.loc,
+                                                            ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc,
+                                                                rc->m_r, rc->m_type)),
+                                                            ASR::cast_kindType::RealToComplex, v->m_type, complex_value));
+                                                    } else {
+                                                        init_val = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, rc->m_r, v->m_type));
+                                                    }
                                                 } else if (ASR::is_a<ASR::IntegerConstant_t>(*init_val)) {
                                                     ASR::IntegerConstant_t* ic = ASR::down_cast<ASR::IntegerConstant_t>(init_val);
-                                                    init_val = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, ic->m_n, v->m_type));
+                                                    if (ASRUtils::is_complex(*v->m_type)) {
+                                                        ASR::expr_t* complex_value = ASRUtils::EXPR(
+                                                            ASR::make_ComplexConstant_t(al, x.base.base.loc,
+                                                                (double)ic->m_n, 0.0, v->m_type));
+                                                        init_val = ASRUtils::EXPR(ASR::make_Cast_t(al, x.base.base.loc,
+                                                            ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc,
+                                                                ic->m_n, ic->m_type)),
+                                                            ASR::cast_kindType::IntegerToComplex, v->m_type, complex_value));
+                                                    } else if (ASRUtils::is_real(*v->m_type)) {
+                                                        ASR::expr_t* real_value = ASRUtils::EXPR(
+                                                            ASR::make_RealConstant_t(al, x.base.base.loc,
+                                                                (double)ic->m_n, v->m_type));
+                                                        init_val = ASRUtils::EXPR(ASR::make_Cast_t(al, x.base.base.loc,
+                                                            ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc,
+                                                                ic->m_n, ic->m_type)),
+                                                            ASR::cast_kindType::IntegerToReal, v->m_type, real_value));
+                                                    } else {
+                                                        init_val = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, ic->m_n, v->m_type));
+                                                    }
                                                 }
                                                 v->m_symbolic_value = init_val;
                                                 v->m_value = ASRUtils::expr_value(init_val);


### PR DESCRIPTION
## Summary
- Create proper Cast nodes when Complex PARAMETER is initialized with Real or Integer constant
- Fixes ICE in LAPACK `clasyf_aa.f` where Complex PARAMETER `ONE = 1.0E+0` caused assertion failure when used as `-ONE` in implicit interface call

## Root Cause
When a Complex PARAMETER was initialized with a Real constant (e.g., `complex, parameter :: one = 1.0e+0`), the ASR contained an invalid `RealConstant` with `Complex` type instead of a proper Cast node. This violated ASR type invariants and caused an ICE when the parameter was used with unary minus in implicit interface calls.

## Fix
Create proper Cast nodes (RealToComplex, IntegerToComplex, IntegerToReal) with explicit constant values at lines 3572-3606 in `ast_common_visitor.h`.

## Test Plan
- Added `complex_unary_minus_03.f90` integration test that reproduces the ICE
- All 2051 llvm backend tests pass