### PR TITLE
fix: support multi-dimensional array implied-do in READ

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2300,6 +2300,7 @@ RUN(NAME read_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN read_
 RUN(NAME read_08 LABELS gfortran llvm)
 RUN(NAME read_09 LABELS gfortran llvm)
 RUN(NAME read_10 LABELS gfortran llvm)
+RUN(NAME read_11 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_11.f90
+++ b/integration_tests/read_11.f90
@@ -1,0 +1,25 @@
+program read_11
+    implicit none
+    integer :: i, j, n
+    real :: a(3, 4)
+
+    n = 4
+    open(10, status='scratch')
+    write(10, *) 1.0, 2.0, 3.0, 4.0
+    write(10, *) 5.0, 6.0, 7.0, 8.0
+    rewind(10)
+
+    read(10, *) (a(1,j), j = 1, n)
+    read(10, *) (a(2,j), j = 1, n)
+    close(10)
+
+    if (abs(a(1,1) - 1.0) > 1e-6) error stop "a(1,1) should be 1.0"
+    if (abs(a(1,2) - 2.0) > 1e-6) error stop "a(1,2) should be 2.0"
+    if (abs(a(1,3) - 3.0) > 1e-6) error stop "a(1,3) should be 3.0"
+    if (abs(a(1,4) - 4.0) > 1e-6) error stop "a(1,4) should be 4.0"
+    if (abs(a(2,1) - 5.0) > 1e-6) error stop "a(2,1) should be 5.0"
+    if (abs(a(2,2) - 6.0) > 1e-6) error stop "a(2,2) should be 6.0"
+    if (abs(a(2,3) - 7.0) > 1e-6) error stop "a(2,3) should be 7.0"
+    if (abs(a(2,4) - 8.0) > 1e-6) error stop "a(2,4) should be 8.0"
+    print *, "PASS"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11595,6 +11595,82 @@ public:
                             }
                         }
                     }
+                    // General case: generate a loop to read elements one by one
+                    // This handles multi-dimensional arrays like (a(i,j), j=1,n)
+                    if (idl->n_values == 1 && ASR::is_a<ASR::ArrayItem_t>(*idl->m_values[0])) {
+                        ASR::Variable_t* loop_var_sym = ASR::down_cast<ASR::Variable_t>(
+                            ASR::down_cast<ASR::Var_t>(idl->m_var)->m_v);
+
+                        // Get loop bounds
+                        this->visit_expr_wrapper(idl->m_start, true);
+                        llvm::Value* start_val = tmp;
+                        this->visit_expr_wrapper(idl->m_end, true);
+                        llvm::Value* end_val = tmp;
+                        llvm::Value* inc_val;
+                        if (idl->m_increment) {
+                            this->visit_expr_wrapper(idl->m_increment, true);
+                            inc_val = tmp;
+                        } else {
+                            inc_val = llvm::ConstantInt::get(start_val->getType(), 1);
+                        }
+
+                        // Create loop variable alloca if not already in symtab
+                        uint32_t loop_var_hash = get_hash((ASR::asr_t*)loop_var_sym);
+                        llvm::Value* loop_var_ptr;
+                        if (llvm_symtab.find(loop_var_hash) == llvm_symtab.end()) {
+                            loop_var_ptr = builder->CreateAlloca(start_val->getType(), nullptr,
+                                loop_var_sym->m_name);
+                            llvm_symtab[loop_var_hash] = loop_var_ptr;
+                        } else {
+                            loop_var_ptr = llvm_symtab[loop_var_hash];
+                        }
+
+                        // Initialize loop variable
+                        builder->CreateStore(start_val, loop_var_ptr);
+
+                        // Create loop blocks
+                        llvm::Function* fn = builder->GetInsertBlock()->getParent();
+                        llvm::BasicBlock* loop_cond = llvm::BasicBlock::Create(context, "idl.cond", fn);
+                        llvm::BasicBlock* loop_body = llvm::BasicBlock::Create(context, "idl.body", fn);
+                        llvm::BasicBlock* loop_inc = llvm::BasicBlock::Create(context, "idl.inc", fn);
+                        llvm::BasicBlock* loop_end = llvm::BasicBlock::Create(context, "idl.end", fn);
+
+                        builder->CreateBr(loop_cond);
+
+                        // Loop condition
+                        builder->SetInsertPoint(loop_cond);
+                        llvm::Value* curr_val = builder->CreateLoad(start_val->getType(), loop_var_ptr);
+                        llvm::Value* cond = builder->CreateICmpSLE(curr_val, end_val);
+                        builder->CreateCondBr(cond, loop_body, loop_end);
+
+                        // Loop body - read one element
+                        builder->SetInsertPoint(loop_body);
+
+                        // Get pointer to array element
+                        int ptr_loads_copy = ptr_loads;
+                        ptr_loads = 0;
+                        this->visit_expr(*idl->m_values[0]);
+                        llvm::Value* elem_ptr = tmp;
+                        ptr_loads = ptr_loads_copy;
+
+                        // Read into this element (scalar read takes 2 args: ptr, unit)
+                        ASR::ttype_t* elem_type = ASRUtils::expr_type(idl->m_values[0]);
+                        llvm::Function* read_fn = get_read_function(elem_type);
+                        builder->CreateCall(read_fn, {elem_ptr, unit_val});
+
+                        builder->CreateBr(loop_inc);
+
+                        // Loop increment
+                        builder->SetInsertPoint(loop_inc);
+                        llvm::Value* next_val = builder->CreateAdd(
+                            builder->CreateLoad(start_val->getType(), loop_var_ptr), inc_val);
+                        builder->CreateStore(next_val, loop_var_ptr);
+                        builder->CreateBr(loop_cond);
+
+                        // Continue after loop
+                        builder->SetInsertPoint(loop_end);
+                        continue;
+                    }
                     // Unsupported ImpliedDoLoop pattern - fall through to default handling
                 }
 


### PR DESCRIPTION
## Summary

Handle 2D array patterns like `(a(i,j), j=1,n)` in READ statements by generating a loop that reads elements one at a time.

Previous PRs (#9258, #9261) only handled 1D arrays with a single index. This extends support to multi-dimensional array subscripts.

## Test

- `read_11.f90` - tests 2D array implied-do READ with variable bounds