### PR TITLE
fix: Handle class to class deepcopy in `struct_deepcopy`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2107,8 +2107,8 @@ RUN(NAME class_86 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_87 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_88 LABELS llvm)
 RUN(NAME class_89 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-
 RUN(NAME class_90 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
+RUN(NAME class_91 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_91.f90
+++ b/integration_tests/class_91.f90
@@ -1,0 +1,51 @@
+module class_91_mod
+    implicit none
+
+    ! Base abstract type
+    type, abstract :: toml_value
+    end type toml_value
+
+    ! Concrete extended type
+    type, extends(toml_value) :: toml_integer
+        integer :: value
+    end type toml_integer
+
+end module class_91_mod
+
+
+program class_91
+    use class_91_mod
+    implicit none
+
+    type(toml_integer), target :: i
+    class(toml_value), pointer :: src
+    class(toml_value), allocatable :: tmp
+
+    ! Initialize concrete object
+    i%value = 42
+
+    ! Pointer must associate with extended type
+    src => i
+    if (.not. associated(src)) then
+        error stop "ERROR: src pointer not associated"
+    end if
+
+    ! Allocate polymorphic allocatable from pointer source
+    allocate(tmp, source=src)
+
+    if (.not. allocated(tmp)) then
+        error stop "ERROR: tmp not allocated"
+    end if
+
+    ! Validate dynamic type and value
+    select type (tmp)
+    type is (toml_integer)
+        if (tmp%value /= 42) then
+            error stop "ERROR: value mismatch after allocate(source=)"
+        end if
+        print *, "Copied value:", tmp%value
+    class default
+        error stop "ERROR: wrong dynamic type in tmp"
+    end select
+
+end program class_91

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -8972,9 +8972,11 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                     }
                 }
             }
-
-            if ((std::string)struct_sym->m_name == "~unlimited_polymorphic_type") {
-                // For unlimited polymorphic structs, we need to copy from vtable copy function
+            
+            bool is_unlimited_polymorphic = (std::string)struct_sym->m_name == "~unlimited_polymorphic_type";
+            if (is_unlimited_polymorphic || (is_src_class && is_dest_class)) {
+                // For unlimited polymorphic structs or class-to-class copy,
+                // we need to copy from vtable copy function to handle derived types
                 llvm::Value* vptr = builder->CreateBitCast(src, llvm_utils->vptr_type->getPointerTo());
                 vptr = llvm_utils->CreateLoad2(llvm_utils->vptr_type, vptr);
                 llvm::FunctionType* fnTy = llvm_utils->struct_copy_functype;
@@ -8983,10 +8985,23 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                     llvm::FunctionType::get(llvm_utils->getIntType(4), {}, true)->getPointerTo(), vptr);
                 fn = builder->CreateBitCast(fn, fnPtrTy);
                 llvm::Type* poly_llvm_type = llvm_utils->getClassType(struct_sym, false);
-                llvm::Value* src_ptr = llvm_utils->CreateLoad2(llvm_utils->i8_ptr,
-                    llvm_utils->create_gep2(poly_llvm_type, src, 1));
-                llvm::Value* dest_ptr = llvm_utils->CreateLoad2(llvm_utils->i8_ptr,
-                    llvm_utils->create_gep2(poly_llvm_type, dest, 1));
+                llvm::Value* src_ptr;
+                llvm::Value* dest_ptr;
+                if (is_unlimited_polymorphic) {
+                    src_ptr = llvm_utils->CreateLoad2(llvm_utils->i8_ptr,
+                        llvm_utils->create_gep2(poly_llvm_type, src, 1));
+                    dest_ptr = llvm_utils->CreateLoad2(llvm_utils->i8_ptr,
+                        llvm_utils->create_gep2(poly_llvm_type, dest, 1));
+                } else {
+                    llvm::Type* struct_llvm_type = llvm_utils->getStructType(struct_sym, module);
+                    src_ptr = llvm_utils->CreateLoad2(struct_llvm_type->getPointerTo(),
+                        llvm_utils->create_gep2(poly_llvm_type, src, 1));
+                    dest_ptr = llvm_utils->CreateLoad2(struct_llvm_type->getPointerTo(),
+                        llvm_utils->create_gep2(poly_llvm_type, dest, 1));
+                    src_ptr = builder->CreateBitCast(src_ptr, llvm_utils->i8_ptr);
+                    dest_ptr = builder->CreateBitCast(dest_ptr, llvm_utils->i8_ptr);
+                }
+
                 builder->CreateCall(fnTy, fn, {src_ptr, dest_ptr});
                 return ;
             }


### PR DESCRIPTION
Fixes #9291 