### PR TITLE
refactor: use call-arg helpers for abs/max/min LLVM codegen

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2618,8 +2618,8 @@ public:
         tmp = builder->CreateFSub(exp, one);
     }
 
-    void generate_abs(ASR::call_arg_t* m_args) {
-        this->visit_expr_wrapper(m_args[0].m_value, true);
+    void generate_Abs(ASR::expr_t* m_arg) {
+        this->visit_expr_wrapper(m_arg, true);
         llvm::Value *item = tmp;
         llvm::Type *item_type = item->getType();
         if (item_type->isFloatingPointTy()) {
@@ -2633,8 +2633,7 @@ public:
             tmp = builder->CreateCall(fn, {item});
 #endif
         } else if (item_type->isIntegerTy()) {
-            // For integers: abs(x) = x >= 0 ? x : -x
-            // Using select is branchless and efficient
+            // abs(x) = x >= 0 ? x : -x (branchless with select)
             llvm::Value *zero = llvm::ConstantInt::get(item_type, 0);
             llvm::Value *neg = builder->CreateNeg(item);
             llvm::Value *cmp = builder->CreateICmpSGE(item, zero);
@@ -2642,82 +2641,29 @@ public:
         }
     }
 
-    void generate_Abs(ASR::expr_t* m_arg) {
-        ASR::call_arg_t args[1];
-        args[0].loc = m_arg->base.loc;
-        args[0].m_value = m_arg;
-        generate_abs(args);
-    }
-
-    void generate_max(ASR::call_arg_t* m_args, size_t n_args) {
+    void generate_MinMax(ASR::expr_t** m_args, size_t n_args, bool is_max) {
         LCOMPILERS_ASSERT(n_args >= 2);
-        this->visit_expr_wrapper(m_args[0].m_value, true);
+        this->visit_expr_wrapper(m_args[0], true);
         llvm::Value *result = tmp;
         llvm::Type *val_type = result->getType();
         for (size_t i = 1; i < n_args; i++) {
-            this->visit_expr_wrapper(m_args[i].m_value, true);
+            this->visit_expr_wrapper(m_args[i], true);
             llvm::Value *arg = tmp;
             if (val_type->isFloatingPointTy()) {
-                // Use FCmpOGT (ordered greater than) for Fortran-compatible NaN propagation
+                // Use ordered comparison for Fortran-compatible NaN propagation
                 // If either operand is NaN, comparison returns false, preserving result
-                // This matches the original Fortran if-then-else semantics where
-                // max(NaN, x) = x but max(x, NaN) = NaN (asymmetric, GFortran-compatible)
-                llvm::Value *cmp = builder->CreateFCmpOGT(arg, result);
+                llvm::Value *cmp = is_max
+                    ? builder->CreateFCmpOGT(arg, result)
+                    : builder->CreateFCmpOLT(arg, result);
                 result = builder->CreateSelect(cmp, arg, result);
             } else if (val_type->isIntegerTy()) {
-                // max(a, b) = a > b ? a : b (branchless with select)
-                llvm::Value *cmp = builder->CreateICmpSGT(result, arg);
+                llvm::Value *cmp = is_max
+                    ? builder->CreateICmpSGT(result, arg)
+                    : builder->CreateICmpSLT(result, arg);
                 result = builder->CreateSelect(cmp, result, arg);
             }
         }
         tmp = result;
-    }
-
-    void generate_Max(ASR::expr_t** m_args, size_t n_args) {
-        Vec<ASR::call_arg_t> args;
-        args.reserve(al, n_args);
-        for (size_t i = 0; i < n_args; i++) {
-            ASR::call_arg_t arg;
-            arg.loc = m_args[i]->base.loc;
-            arg.m_value = m_args[i];
-            args.push_back(al, arg);
-        }
-        generate_max(args.p, args.n);
-    }
-
-    void generate_min(ASR::call_arg_t* m_args, size_t n_args) {
-        LCOMPILERS_ASSERT(n_args >= 2);
-        this->visit_expr_wrapper(m_args[0].m_value, true);
-        llvm::Value *result = tmp;
-        llvm::Type *val_type = result->getType();
-        for (size_t i = 1; i < n_args; i++) {
-            this->visit_expr_wrapper(m_args[i].m_value, true);
-            llvm::Value *arg = tmp;
-            if (val_type->isFloatingPointTy()) {
-                // Use FCmpOLT (ordered less than) for Fortran-compatible NaN propagation
-                // If either operand is NaN, comparison returns false, preserving result
-                // This matches the original Fortran if-then-else semantics
-                llvm::Value *cmp = builder->CreateFCmpOLT(arg, result);
-                result = builder->CreateSelect(cmp, arg, result);
-            } else if (val_type->isIntegerTy()) {
-                // min(a, b) = a < b ? a : b (branchless with select)
-                llvm::Value *cmp = builder->CreateICmpSLT(result, arg);
-                result = builder->CreateSelect(cmp, result, arg);
-            }
-        }
-        tmp = result;
-    }
-
-    void generate_Min(ASR::expr_t** m_args, size_t n_args) {
-        Vec<ASR::call_arg_t> args;
-        args.reserve(al, n_args);
-        for (size_t i = 0; i < n_args; i++) {
-            ASR::call_arg_t arg;
-            arg.loc = m_args[i]->base.loc;
-            arg.m_value = m_args[i];
-            args.push_back(al, arg);
-        }
-        generate_min(args.p, args.n);
     }
 
     void generate_ListReverse(ASR::expr_t* m_arg) {
@@ -3002,11 +2948,11 @@ public:
                 break;
             }
             case ASRUtils::IntrinsicElementalFunctions::Max: {
-                generate_Max(x.m_args, x.n_args);
+                generate_MinMax(x.m_args, x.n_args, true);
                 break;
             }
             case ASRUtils::IntrinsicElementalFunctions::Min: {
-                generate_Min(x.m_args, x.n_args);
+                generate_MinMax(x.m_args, x.n_args, false);
                 break;
             }
             default: {


### PR DESCRIPTION
Follow-up to review feedback on #9274.

- Refactors LLVM codegen for `abs`, `max`, `min` to use the same call-arg helper style as other intrinsic codegen helpers.
- No intended behavior change; this is a structural cleanup to make the implementation less ad-hoc and easier to extend.

