### PR TITLE
fix: throw runtime error for unallocated arguments in StringFormat

### DIFF
--- a/integration_tests/modules_38.f90
+++ b/integration_tests/modules_38.f90
@@ -43,6 +43,8 @@ function enumerate_libraries(self, prefix, libs) result(r)
         self%id == id_intel_llvm_windows) then
     end if
 
+    allocate(character(len=1) :: r)
+
 end function enumerate_libraries
 
 end module fpm_compiler

--- a/tests/errors/array_bounds_check_15.f90
+++ b/tests/errors/array_bounds_check_15.f90
@@ -1,0 +1,7 @@
+program array_bounds_check_15
+    implicit none
+
+    integer, allocatable :: x(:)
+
+    print *, x
+end

--- a/tests/errors/scalar_allocation_check_05.f90
+++ b/tests/errors/scalar_allocation_check_05.f90
@@ -1,0 +1,11 @@
+program scalar_allocation_check_05
+    implicit none
+
+    type m
+        integer, allocatable :: x
+    end type
+
+    type(m) :: m1
+
+    print *, m1%x
+end

--- a/tests/errors/scalar_allocation_check_06.f90
+++ b/tests/errors/scalar_allocation_check_06.f90
@@ -1,0 +1,7 @@
+program scalar_allocation_check_06
+    implicit none
+
+    integer, allocatable :: x
+
+    print *, x
+end

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "3b2e634ffc1db161974df76f62bb6ad38cfdb74af24fe5a12632f9da",
+    "stdout_hash": "950da6c9ba39ba2449a72e3a3a69118fd971c9e9ac9de0654728cb2f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -14,12 +14,13 @@ source_filename = "LFortran"
 @string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.1, i32 0, i32 0), i64 1 }>
 @3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.3 = private unnamed_addr constant [7 x i8] c"S-DESC\00", align 1
-@4 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@4 = private unnamed_addr constant [109 x i8] c"At 30:10 of file tests/../integration_tests/derived_types_32.f90\0ARuntime error: Argument %d is unallocated.\0A\00", align 1
+@5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @string_const_data.4 = private constant [18 x i8] c"10.000000000000000"
 @string_const.5 = private global %string_descriptor <{ i8* getelementptr inbounds ([18 x i8], [18 x i8]* @string_const_data.4, i32 0, i32 0), i64 18 }>
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
-@5 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@6 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
 .entry:
@@ -264,69 +265,81 @@ define i32 @main(i32 %0, i8** %1) {
   store i64 0, i64* %3, align 4
   call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__0_return_slot)
   %5 = alloca i64, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %7 = load i64, i64* %6, align 4
-  %8 = load %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
-  %9 = alloca %string_descriptor, align 8
-  store %string_descriptor %8, %string_descriptor* %9, align 1
-  %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %5, i32 0, i32 1, i64 %7, %string_descriptor* %9)
-  %11 = load i64, i64* %5, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %10, i8** %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %11, i64* %13, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %15 = load i8*, i8** %14, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %17 = load i64, i64* %16, align 4
-  %18 = trunc i64 %17 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %15, i32 %18, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
-  call void @_lfortran_free(i8* %10)
-  %19 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %20 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %21 = load i8*, i8** %19, align 8
-  call void @_lfortran_free(i8* %21)
-  store i8* null, i8** %19, align 8
-  store i64 0, i64* %20, align 4
-  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__1_return_slot)
-  %22 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %25 = load i64, i64* %24, align 4
-  %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.5, i32 0, i32 0), align 8
-  %27 = call i32 @str_compare(i8* %23, i64 %25, i8* %26, i64 18)
-  %28 = icmp ne i32 %27, 0
-  br i1 %28, label %then, label %else
+  %6 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %7 = load i8*, i8** %6, align 8
+  %8 = ptrtoint i8* %7 to i64
+  %9 = icmp eq i64 %8, 0
+  br i1 %9, label %then, label %ifcont
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([109 x i8], [109 x i8]* @4, i32 0, i32 0), i32 1)
   call void @exit(i32 1)
-  br label %ifcont
+  unreachable
 
-else:                                             ; preds = %.entry
-  br label %ifcont
+ifcont:                                           ; preds = %.entry
+  %10 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %11 = load i64, i64* %10, align 4
+  %12 = load %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
+  %13 = alloca %string_descriptor, align 8
+  store %string_descriptor %12, %string_descriptor* %13, align 1
+  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %5, i32 0, i32 1, i64 %11, %string_descriptor* %13)
+  %15 = load i64, i64* %5, align 4
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %14, i8** %16, align 8
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %15, i64* %17, align 4
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %19 = load i8*, i8** %18, align 8
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %21 = load i64, i64* %20, align 4
+  %22 = trunc i64 %21 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
+  call void @_lfortran_free(i8* %14)
+  %23 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %24 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
+  %25 = load i8*, i8** %23, align 8
+  call void @_lfortran_free(i8* %25)
+  store i8* null, i8** %23, align 8
+  store i64 0, i64* %24, align 4
+  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__1_return_slot)
+  %26 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %27 = load i8*, i8** %26, align 8
+  %28 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
+  %29 = load i64, i64* %28, align 4
+  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.5, i32 0, i32 0), align 8
+  %31 = call i32 @str_compare(i8* %27, i64 %29, i8* %30, i64 18)
+  %32 = icmp ne i32 %31, 0
+  br i1 %32, label %then1, label %else
 
-ifcont:                                           ; preds = %else, %then
+then1:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont2
+
+else:                                             ; preds = %ifcont
+  br label %ifcont2
+
+ifcont2:                                          ; preds = %else, %then1
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont
+return:                                           ; preds = %ifcont2
   br label %FINALIZE_SYMTABLE_main
 
 FINALIZE_SYMTABLE_main:                           ; preds = %return
   br label %Finalize_Variable___libasr__created__var__0_return_slot
 
 Finalize_Variable___libasr__created__var__0_return_slot: ; preds = %FINALIZE_SYMTABLE_main
-  %29 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %30 = load i8*, i8** %29, align 8
-  call void @_lfortran_free(i8* %30)
+  %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %34 = load i8*, i8** %33, align 8
+  call void @_lfortran_free(i8* %34)
   br label %Finalize_Variable___libasr__created__var__1_return_slot
 
 Finalize_Variable___libasr__created__var__1_return_slot: ; preds = %Finalize_Variable___libasr__created__var__0_return_slot
-  %31 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %32 = load i8*, i8** %31, align 8
-  call void @_lfortran_free(i8* %32)
+  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %36 = load i8*, i8** %35, align 8
+  call void @_lfortran_free(i8* %36)
   ret i32 0
 }
 

--- a/tests/reference/run-array_bounds_check_15-9f619ed.json
+++ b/tests/reference/run-array_bounds_check_15-9f619ed.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-array_bounds_check_15-9f619ed",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/array_bounds_check_15.f90",
+    "infile_hash": "ae2dee1b53ed7b6e4496aca841d2401fbe69cfcc430f41676ed79607",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-array_bounds_check_15-9f619ed.stderr",
+    "stderr_hash": "038af67f075dd3c20f48f2895070e72c076c2f11d2e716ce33025a1b",
+    "returncode": 1
+}

--- a/tests/reference/run-array_bounds_check_15-9f619ed.stderr
+++ b/tests/reference/run-array_bounds_check_15-9f619ed.stderr
@@ -1,0 +1,2 @@
+At 6:14 of file tests/errors/array_bounds_check_15.f90
+Runtime error: Argument 1 is unallocated.

--- a/tests/reference/run-scalar_allocation_check_05-e3b524c.json
+++ b/tests/reference/run-scalar_allocation_check_05-e3b524c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-scalar_allocation_check_05-e3b524c",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/scalar_allocation_check_05.f90",
+    "infile_hash": "91825bf77fdb8c4fefb42a24592cd3e1e2f6039bbe91ba027bcd061e",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-scalar_allocation_check_05-e3b524c.stderr",
+    "stderr_hash": "f946b287b929b6f4e394093cd2477e302d04e30260f2cd7411baffee",
+    "returncode": 1
+}

--- a/tests/reference/run-scalar_allocation_check_05-e3b524c.stderr
+++ b/tests/reference/run-scalar_allocation_check_05-e3b524c.stderr
@@ -1,0 +1,2 @@
+At 10:14 of file tests/errors/scalar_allocation_check_05.f90
+Runtime error: Argument 1 is unallocated.

--- a/tests/reference/run-scalar_allocation_check_06-2a9502c.json
+++ b/tests/reference/run-scalar_allocation_check_06-2a9502c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-scalar_allocation_check_06-2a9502c",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/scalar_allocation_check_06.f90",
+    "infile_hash": "23810657fc4e5777acd91a7cce76b5b3bb2e5e3ff87d25d44e4d80fa",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-scalar_allocation_check_06-2a9502c.stderr",
+    "stderr_hash": "1958aff4cfe481d796d74511ad5c078026d3b050e8cbb25add1eea1d",
+    "returncode": 1
+}

--- a/tests/reference/run-scalar_allocation_check_06-2a9502c.stderr
+++ b/tests/reference/run-scalar_allocation_check_06-2a9502c.stderr
@@ -1,0 +1,2 @@
+At 6:14 of file tests/errors/scalar_allocation_check_06.f90
+Runtime error: Argument 1 is unallocated.

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3943,6 +3943,14 @@ filename = "errors/scalar_allocation_check_04.f90"
 run = true
 
 [[test]]
+filename = "errors/scalar_allocation_check_05.f90"
+run = true
+
+[[test]]
+filename = "errors/scalar_allocation_check_06.f90"
+run = true
+
+[[test]]
 filename = "errors/matmul_unallocated_01.f90"
 run = true
 
@@ -4001,6 +4009,10 @@ run = true
 
 [[test]]
 filename = "errors/array_bounds_check_14.f90"
+run = true
+
+[[test]]
+filename = "errors/array_bounds_check_15.f90"
 run = true
 
 [[test]]


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/8593