### PR TITLE
fix: implement READ for scalar complex values

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2315,6 +2315,7 @@ RUN(NAME read_08 LABELS gfortran llvm)
 RUN(NAME read_09 LABELS gfortran llvm)
 RUN(NAME read_10 LABELS gfortran llvm)
 RUN(NAME read_11 LABELS gfortran llvm)
+RUN(NAME read_12 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_12.f90
+++ b/integration_tests/read_12.f90
@@ -1,0 +1,23 @@
+program read_12
+    implicit none
+    complex :: z4
+    complex(8) :: z8
+
+    open(10, file='_read_12_test.dat', status='replace')
+    write(10, *) (1.0, 2.0)
+    write(10, *) (3.0d0, 4.0d0)
+    close(10)
+
+    open(10, file='_read_12_test.dat', status='old')
+    read(10, *) z4
+    read(10, *) z8
+    close(10, status='delete')
+
+    if (abs(real(z4) - 1.0) > 1e-5) error stop
+    if (abs(aimag(z4) - 2.0) > 1e-5) error stop
+
+    if (abs(real(z8) - 3.0d0) > 1d-10) error stop
+    if (abs(aimag(z8) - 4.0d0) > 1d-10) error stop
+
+    print *, "OK"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11449,6 +11449,32 @@ public:
                 }
                 break;
             }
+            case (ASR::ttypeType::Complex): {
+                std::string runtime_func_name;
+                llvm::Type *type_arg;
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(type);
+                if (a_kind == 4) {
+                    runtime_func_name = "_lfortran_read_complex_float";
+                    type_arg = complex_type_4;
+                } else if (a_kind == 8) {
+                    runtime_func_name = "_lfortran_read_complex_double";
+                    type_arg = complex_type_8;
+                } else {
+                    throw CodeGenError("Read Complex function not implemented "
+                        "for complex kind: " + std::to_string(a_kind));
+                }
+                fn = module->getFunction(runtime_func_name);
+                if (!fn) {
+                    llvm::FunctionType *function_type = llvm::FunctionType::get(
+                            llvm::Type::getVoidTy(context), {
+                                type_arg->getPointerTo(),
+                                llvm::Type::getInt32Ty(context)
+                            }, false);
+                    fn = llvm::Function::Create(function_type,
+                            llvm::Function::ExternalLinkage, runtime_func_name, module.get());
+                }
+                break;
+            }
             case (ASR::ttypeType::Array): {
                 type = ASRUtils::type_get_past_array(type);
                 int a_kind = ASRUtils::extract_kind_from_ttype_t(type);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -4932,6 +4932,126 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num)
     }
 }
 
+LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, int32_t unit_num)
+{
+    if (unit_num == -1) {
+        (void)!scanf("%f %f", &p->re, &p->im);
+        return;
+    }
+
+    bool unit_file_bin;
+    FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin, NULL, NULL, NULL, NULL);
+    if (!filep) {
+        printf("No file found with given unit\n");
+        exit(1);
+    }
+
+    if (unit_file_bin) {
+        (void)!fread(p, sizeof(struct _lfortran_complex_32), 1, filep);
+    } else {
+        char buffer[100];
+        if (fscanf(filep, "%s", buffer) != 1) {
+            fprintf(stderr, "Error: Invalid input for complex float from file.\n");
+            exit(1);
+        }
+        char *start = strchr(buffer, '(');
+        char *end = strchr(buffer, ')');
+        if (start && end && end > start) {
+            *end = '\0';
+            start++;
+            char *comma = strchr(start, ',');
+            if (comma) {
+                *comma = '\0';
+                while (isspace((unsigned char)*start)) start++;
+                p->re = strtof(start, NULL);
+                p->im = strtof(comma + 1, NULL);
+            } else {
+                fprintf(stderr, "Error: Invalid complex float format '%s'.\n", buffer);
+                exit(1);
+            }
+        } else if (start) {
+            start++;
+            char *comma = strchr(start, ',');
+            if (comma) *comma = '\0';
+            p->re = strtof(start, NULL);
+            char buffer2[100];
+            if (fscanf(filep, "%s", buffer2) != 1) {
+                fprintf(stderr, "Error: Failed to read imaginary part.\n");
+                exit(1);
+            }
+            end = strchr(buffer2, ')');
+            if (end) *end = '\0';
+            p->im = strtof(buffer2, NULL);
+        } else {
+            p->re = strtof(buffer, NULL);
+            if (fscanf(filep, "%f", &p->im) != 1) {
+                fprintf(stderr, "Error: Failed to read imaginary part of complex float.\n");
+                exit(1);
+            }
+        }
+    }
+}
+
+LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, int32_t unit_num)
+{
+    if (unit_num == -1) {
+        (void)!scanf("%lf %lf", &p->re, &p->im);
+        return;
+    }
+
+    bool unit_file_bin;
+    FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin, NULL, NULL, NULL, NULL);
+    if (!filep) {
+        printf("No file found with given unit\n");
+        exit(1);
+    }
+
+    if (unit_file_bin) {
+        (void)!fread(p, sizeof(struct _lfortran_complex_64), 1, filep);
+    } else {
+        char buffer[100];
+        if (fscanf(filep, "%s", buffer) != 1) {
+            fprintf(stderr, "Error: Invalid input for complex double from file.\n");
+            exit(1);
+        }
+        char *start = strchr(buffer, '(');
+        char *end = strchr(buffer, ')');
+        if (start && end && end > start) {
+            *end = '\0';
+            start++;
+            char *comma = strchr(start, ',');
+            if (comma) {
+                *comma = '\0';
+                while (isspace((unsigned char)*start)) start++;
+                p->re = strtod(start, NULL);
+                p->im = strtod(comma + 1, NULL);
+            } else {
+                fprintf(stderr, "Error: Invalid complex double format '%s'.\n", buffer);
+                exit(1);
+            }
+        } else if (start) {
+            start++;
+            char *comma = strchr(start, ',');
+            if (comma) *comma = '\0';
+            p->re = strtod(start, NULL);
+            char buffer2[100];
+            if (fscanf(filep, "%s", buffer2) != 1) {
+                fprintf(stderr, "Error: Failed to read imaginary part.\n");
+                exit(1);
+            }
+            end = strchr(buffer2, ')');
+            if (end) *end = '\0';
+            p->im = strtod(buffer2, NULL);
+        } else {
+            p->re = strtod(buffer, NULL);
+            if (fscanf(filep, "%lf", &p->im) != 1) {
+                fprintf(stderr, "Error: Failed to read imaginary part of complex double.\n");
+                exit(1);
+            }
+        }
+    }
+}
+
 LFORTRAN_API void _lfortran_read_array_complex_float(struct _lfortran_complex_32 *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -257,6 +257,8 @@ LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t
 LFORTRAN_API void _lfortran_read_array_int64(int64_t *p, int array_size, int32_t unit_num);
 LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num);
 LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num);
+LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, int32_t unit_num);
+LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, int32_t unit_num);
 LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t unit_num);
 LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t unit_num);
 LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num);


### PR DESCRIPTION
## Summary
- Add runtime functions `_lfortran_read_complex_float` and `_lfortran_read_complex_double` for scalar complex I/O
- Add codegen support for `ASR::ttypeType::Complex` in `get_read_function()`
- Handle both parenthesized formats: `(1.0,2.0)` and `(1.0, 2.0)` (with space after comma)

## Test
- Added `read_12.f90` integration test that verifies reading complex(4) and complex(8) scalars from files

## Verification
```
$ gfortran integration_tests/read_12.f90 -o /tmp/read_12 && /tmp/read_12
 OK
$ lfortran integration_tests/read_12.f90 -o /tmp/read_12 && /tmp/read_12
OK
```

Fixes #9331