### PR TITLE
Support nested implied do loops in DATA statements

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2465,6 +2465,7 @@ RUN(NAME data_implied_do_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortra
 RUN(NAME data_implied_do_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME data_implied_do_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME save_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME save_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/data_implied_do_05.f90
+++ b/integration_tests/data_implied_do_05.f90
@@ -1,0 +1,32 @@
+program data_implied_do_05
+    implicit none
+    integer :: a(2, 3)
+    integer :: b(2, 3)
+    integer :: i, j
+
+    ! Nested implied do loop: inner loop varies i, outer loop varies j
+    ! Order: (1,1)=1, (2,1)=2, (1,2)=3, (2,2)=4, (1,3)=5, (2,3)=6
+    data ((a(i,j),i=1,2),j=1,3) / 1, 2, 3, 4, 5, 6 /
+
+    ! Nested implied do loop: inner loop varies j, outer loop varies i
+    ! Order: (1,1)=1, (1,2)=2, (1,3)=3, (2,1)=4, (2,2)=5, (2,3)=6
+    data ((b(i,j),j=1,3),i=1,2) / 1, 2, 3, 4, 5, 6 /
+
+    ! Verify a
+    if (a(1,1) /= 1) error stop
+    if (a(2,1) /= 2) error stop
+    if (a(1,2) /= 3) error stop
+    if (a(2,2) /= 4) error stop
+    if (a(1,3) /= 5) error stop
+    if (a(2,3) /= 6) error stop
+
+    ! Verify b
+    if (b(1,1) /= 1) error stop
+    if (b(1,2) /= 2) error stop
+    if (b(1,3) /= 3) error stop
+    if (b(2,1) /= 4) error stop
+    if (b(2,2) /= 5) error stop
+    if (b(2,3) /= 6) error stop
+
+    print *, "PASS"
+end program


### PR DESCRIPTION
## Summary
- Add `substitute_var_in_implied_do_loop()` helper to substitute outer loop variables in nested loops before recursing
- This allows DATA statements like `((a(i,j),j=1,3),i=1,2)` to correctly initialize multi-dimensional arrays

## Test
- Added `data_implied_do_05.f90` integration test with nested implied do loops

Fixes #9332