### PR TITLE
fix: statement function arguments to use implicit typing rules

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2460,8 +2460,7 @@ RUN(NAME statement_03 LABELS gfortran llvmImplicit)
 RUN(NAME statement_04 LABELS llvm gfortran llvmImplicit)
 RUN(NAME statement_05 LABELS llvm gfortran llvmImplicit)
 RUN(NAME statement_06 LABELS llvm gfortran)
-RUN(NAME statement_07 LABELS llvm gfortran llvmImplicit
-    EXTRA_ARGS --implicit-typing)
+RUN(NAME statement_07 LABELS llvm gfortran llvmImplicit)
 
 RUN(NAME data_implied_do_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2460,6 +2460,8 @@ RUN(NAME statement_03 LABELS gfortran llvmImplicit)
 RUN(NAME statement_04 LABELS llvm gfortran llvmImplicit)
 RUN(NAME statement_05 LABELS llvm gfortran llvmImplicit)
 RUN(NAME statement_06 LABELS llvm gfortran)
+RUN(NAME statement_07 LABELS llvm gfortran llvmImplicit
+    EXTRA_ARGS --implicit-typing)
 
 RUN(NAME data_implied_do_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/statement_07.f90
+++ b/integration_tests/statement_07.f90
@@ -1,0 +1,10 @@
+program statement_07
+  implicit logical (l)
+  
+  ! Both function and argument 'l' should be implicitly logical
+  lfis01(l) = .not. l
+  
+  if (lfis01(.true.)) error stop "Statement function returned wrong value"
+  
+  print *, "All tests passed!"
+end program statement_07

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3344,7 +3344,7 @@ public:
                         Label("",{x.base.base.loc})
                     }));
                 throw SemanticAbort();
-            }
+            }  
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, 

--- a/tests/errors/statement_func.f90
+++ b/tests/errors/statement_func.f90
@@ -1,0 +1,5 @@
+program statement_func
+    implicit none
+    ! Error: x has no implicit type
+    stmt_func(x) = x + 1
+end program statement_func

--- a/tests/reference/asr-statement_func-5e8c970.json
+++ b/tests/reference/asr-statement_func-5e8c970.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-statement_func-5e8c970",
+    "cmd": "lfortran --show-asr --implicit-typing --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/statement_func.f90",
+    "infile_hash": "a16c3f4170936f7a0bef684ec36fc1247342784e7c05af9372eef082",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-statement_func-5e8c970.stderr",
+    "stderr_hash": "9e33bae2f7b9dcac90e959ec7e8337168371a3d6618e44ad1a5a9de8",
+    "returncode": 2
+}

--- a/tests/reference/asr-statement_func-5e8c970.stderr
+++ b/tests/reference/asr-statement_func-5e8c970.stderr
@@ -1,0 +1,5 @@
+semantic error: No implicit type found for variable 'x'
+ --> tests/errors/statement_func.f90:4:5
+  |
+4 |     stmt_func(x) = x + 1
+  |     ^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3672,6 +3672,10 @@ filename = "../integration_tests/statement1.f90"
 asr = true
 
 [[test]]
+filename = "errors/statement_func.f90"
+asr_implicit_typing = true
+
+[[test]]
 filename = "no_prescan_include1.f90"
 interactive = true
 ast = true


### PR DESCRIPTION
## **Issue Fixed**
fixes #9324 Semantic error: Statement function argument doesn't get implicitly typed 

## **Summary**

This PR fixes a bug where statement function arguments were not being typed according to implicit statements in the parent scope, causing incorrect type errors.

## **Reference code**

```
      PROGRAM lstfn
      IMPLICIT LOGICAL (L)

!Both the statement function and the dummy argument should be implicitly typed logical
      LFIS01 ( L ) = .NOT. L

      END
```

## **Behaviour before PR**

```
(lf) opixdown@Atharvs-MacBook-Air lfortran % lfortran -c --implicit-typing stfn.f
semantic error: Operand of .not. operator is integer
 --> stfn.f
  |
5 |       LFIS01 ( L ) = .NOT. L
  |                      ^^^^^^^ 

```

## **Behaviour after PR**
```
(base) opixdown@Atharvs-MacBook-Air lfortran % lfortran -c --implicit-typing stfn.f
(base) opixdown@Atharvs-MacBook-Air lfortran % 
```

The code compiles successfully, with argument L correctly typed as logical according to the implicit logical (l) statement.
