### PR TITLE
fix: handle CHARACTER array type mismatch in implicit interface calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2582,6 +2582,10 @@ RUN(NAME implicit_argument_casting_03 LABELS gfortran llvm
     EXTRA_ARGS --implicit-interface --implicit-argument-casting
     GFORTRAN_ARGS -fallow-argument-mismatch)
 
+RUN(NAME implicit_argument_casting_04 LABELS gfortran llvm
+    EXTRA_ARGS --implicit-interface --implicit-argument-casting
+    GFORTRAN_ARGS -fallow-argument-mismatch)
+
 RUN(NAME specfun_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --use-loop-variable-after-loop --implicit-typing)
 

--- a/integration_tests/implicit_argument_casting_04.f90
+++ b/integration_tests/implicit_argument_casting_04.f90
@@ -1,0 +1,96 @@
+! Test CHARACTER array type conversion for implicit interface
+! When caller has CHARACTER(n) array with PointerArray physical type
+! and callee has CHARACTER(*) array with DescriptorArray physical type,
+! the codegen must create proper array descriptor.
+!
+! This test covers:
+! 1. CHARACTER(1) array with size 1 (basic case)
+! 2. CHARACTER(10) array with size 3 (string length > 1, multiple elements)
+! 3. 2D CHARACTER array (multi-dimensional)
+program implicit_argument_casting_04
+    implicit none
+    character(1) :: single_char(1)
+    character(10) :: multi_char(3)
+    character(5) :: matrix(2, 3)
+    external sub_char_1d_single
+    external sub_char_1d_multi
+    external sub_char_2d
+
+    ! Test 1: Single element CHARACTER(1) array
+    single_char(1) = 'A'
+    call sub_char_1d_single(single_char)
+
+    ! Test 2: CHARACTER(10) array with 3 elements
+    multi_char(1) = 'First     '
+    multi_char(2) = 'Second    '
+    multi_char(3) = 'Third     '
+    call sub_char_1d_multi(multi_char)
+
+    ! Test 3: 2D CHARACTER(5) array
+    matrix(1, 1) = 'R1C1 '
+    matrix(2, 1) = 'R2C1 '
+    matrix(1, 2) = 'R1C2 '
+    matrix(2, 2) = 'R2C2 '
+    matrix(1, 3) = 'R1C3 '
+    matrix(2, 3) = 'R2C3 '
+    call sub_char_2d(matrix)
+
+    print *, "PASS"
+end program
+
+subroutine sub_char_1d_single(arr)
+    implicit none
+    character(*) :: arr(*)
+    logical :: lsame
+    external lsame
+
+    if (.not. lsame(arr(1), 'A')) then
+        error stop "Test 1 failed: arr(1) is not A"
+    end if
+end subroutine
+
+subroutine sub_char_1d_multi(arr)
+    implicit none
+    character(*) :: arr(*)
+
+    if (arr(1)(1:5) /= 'First') then
+        error stop "Test 2 failed: arr(1) is not First"
+    end if
+    if (arr(2)(1:6) /= 'Second') then
+        error stop "Test 2 failed: arr(2) is not Second"
+    end if
+    if (arr(3)(1:5) /= 'Third') then
+        error stop "Test 2 failed: arr(3) is not Third"
+    end if
+end subroutine
+
+subroutine sub_char_2d(arr)
+    implicit none
+    character(*) :: arr(2, *)
+
+    ! Check column-major order (Fortran)
+    if (arr(1, 1) /= 'R1C1 ') then
+        error stop "Test 3 failed: arr(1,1) is not R1C1"
+    end if
+    if (arr(2, 1) /= 'R2C1 ') then
+        error stop "Test 3 failed: arr(2,1) is not R2C1"
+    end if
+    if (arr(1, 2) /= 'R1C2 ') then
+        error stop "Test 3 failed: arr(1,2) is not R1C2"
+    end if
+    if (arr(2, 2) /= 'R2C2 ') then
+        error stop "Test 3 failed: arr(2,2) is not R2C2"
+    end if
+    if (arr(1, 3) /= 'R1C3 ') then
+        error stop "Test 3 failed: arr(1,3) is not R1C3"
+    end if
+    if (arr(2, 3) /= 'R2C3 ') then
+        error stop "Test 3 failed: arr(2,3) is not R2C3"
+    end if
+end subroutine
+
+logical function lsame(ca, cb)
+    implicit none
+    character(1), intent(in) :: ca, cb
+    lsame = ca == cb
+end function


### PR DESCRIPTION
## Summary

When calling through an implicit interface with CHARACTER array arguments,
the interface may have a different array physical type (PointerArray) than
the actual implementation (DescriptorArray). This caused LLVM verification
errors.

**Fix approach (AST->ASR level):**

When handling a call through an implicit interface, look up the actual
implementation in parent scopes. If found, use the implementation's array
physical type for the ArrayPhysicalCast comparison, ensuring the correct
cast is inserted.

This is a minimal fix in `Call_t_body` in `asr_utils.h` that:
1. Detects when calling through an Interface (implicit interface)
2. Searches parent scopes for the actual Implementation
3. Uses the implementation's physical type for array cast decisions

## Test Plan

- [x] All reference tests pass (`scripts/lf.sh test`)
- [x] New integration test `implicit_argument_casting_04.f90` passes with LFortran
- [x] New integration test passes with gfortran (validates test correctness)
- [x] Test covers 1D CHARACTER(1), 1D CHARACTER(10), and 2D CHARACTER(5) arrays