### PR TITLE
fix: handle READ implied-do for assumed-size arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2326,6 +2326,7 @@ RUN(NAME read_10 LABELS gfortran llvm)
 RUN(NAME read_11 LABELS gfortran llvm)
 RUN(NAME read_12 LABELS gfortran llvm)
 RUN(NAME read_13 LABELS gfortran llvm)
+RUN(NAME read_14 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_14.f90
+++ b/integration_tests/read_14.f90
@@ -1,0 +1,35 @@
+program read_14
+    ! Test READ with implied-do loop into assumed-size array parameter
+    ! This tests the fix for READ into assumed-size arrays using implied-do
+    implicit none
+    real :: work(100)
+    integer :: i
+
+    open(10, file='_read_14_test.dat', status='replace')
+    write(10, *) 1.5, 2.5, 3.5, 4.5
+    close(10)
+
+    call read_into_assumed(work, 4)
+
+    close(10, status='delete')
+
+    if (abs(work(1) - 1.5) > 1e-5) error stop
+    if (abs(work(2) - 2.5) > 1e-5) error stop
+    if (abs(work(3) - 3.5) > 1e-5) error stop
+    if (abs(work(4) - 4.5) > 1e-5) error stop
+
+    print *, "OK"
+
+contains
+
+    subroutine read_into_assumed(arr, n)
+        integer, intent(in) :: n
+        real, intent(out) :: arr(*)
+        integer :: i
+
+        open(10, file='_read_14_test.dat', status='old')
+        read(10, *) (arr(i), i = 1, n)
+        close(10)
+    end subroutine
+
+end program


### PR DESCRIPTION
## Summary
- Fix READ with implied-do loop crashing for assumed-size array parameters
- Add integration test for the fixed behavior

## Details
The implied-do loop code for READ was incorrectly handling PointerArray and UnboundedPointerArray (assumed-size arrays). For these array types, `visit_expr` with `ptr_loads=0` returns the data pointer directly, not a pointer to a descriptor.

### Changes
- Handle PointerArray/UnboundedPointerArray explicitly by using `arr_ptr` directly as the data pointer
- For DescriptorArray, load the data pointer from the descriptor
- Use `create_ptr_gep2` instead of `create_gep2` for pointer arithmetic on flat data pointers

### LAPACK Pattern Fixed
Fixes LAPACK sdrgvx.f READ pattern:
```fortran
REAL STRU(*)
READ(NIN, FMT=*) (STRU(I), I=1,N)
```

## Test Plan
- [x] New integration test `read_13.f90` passes with both gfortran and llvm
- [x] All reference tests pass
- [ ] CI passes