### PR TITLE
fix: copy all UNIT_FILE fields in remove_from_unit_to_file

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2020,6 +2020,7 @@ RUN(NAME file_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_STD_F23)
 RUN(NAME file_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME file_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_40.f90
+++ b/integration_tests/file_40.f90
@@ -1,0 +1,17 @@
+! Test that closing a file does not corrupt pre-connected unit properties.
+! Bug: remove_from_unit_to_file() was not copying all struct fields when
+! shifting entries, causing unit 6 (stdout) to inherit wrong access flags
+! from subsequent entries after any file close operation.
+program file_40
+    implicit none
+    integer :: u
+
+    ! Open and close a file - this triggers remove_from_unit_to_file
+    open(newunit=u, file='file_40_test.txt', status='replace')
+    write(u, *) 'test'
+    close(u, status='delete')
+
+    ! Now write to stdout (unit 6) - should still work
+    ! Before fix: "Runtime Error: Write operation not allowed on unit 6"
+    write(6, *) 'PASS'
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3868,10 +3868,7 @@ void remove_from_unit_to_file(int32_t unit_num) {
         return ;
     }
     for( int i = index; i < last_index_used; i++ ) {
-        unit_to_file[i].unit = unit_to_file[i + 1].unit;
-        unit_to_file[i].filename = unit_to_file[i + 1].filename;
-        unit_to_file[i].filep = unit_to_file[i + 1].filep;
-        unit_to_file[i].unit_file_bin = unit_to_file[i + 1].unit_file_bin;
+        unit_to_file[i] = unit_to_file[i + 1];
     }
     last_index_used -= 1;
 }


### PR DESCRIPTION
## Summary
When closing a file, `remove_from_unit_to_file()` shifts remaining entries but was only copying 4 of 8 struct fields (`unit`, `filename`, `filep`, `unit_file_bin`). This left `access_id`, `read_access`, `write_access`, and `delim` uninitialized, causing pre-connected units like stdout (unit 6) to inherit wrong access flags from subsequent array entries.

## Symptom
After closing any file, writes to unit 6 fail with:
```
Runtime Error: Write operation not allowed on unit 6 (opened with action='read').
```

## Test
- `file_40.f90` - Opens/closes a file, then writes to stdout

## Verification
```bash
cd integration_tests && ./run_tests.py -b llvm -t file_40
```