### PR TITLE
Use unique filenames

### DIFF
--- a/integration_tests/file_16.f90
+++ b/integration_tests/file_16.f90
@@ -3,7 +3,7 @@ program file_16
     integer :: j = 11
     character(len=10) :: str, x
     str = "LFortran"
-    open(j, file="test.txt")
+    open(j, file="file_16_test.txt")
     write(j, *) str
     str = ""
     rewind(j)

--- a/integration_tests/file_35.f90
+++ b/integration_tests/file_35.f90
@@ -3,7 +3,7 @@ program file_35
     integer :: lun, ios = 8
     character(len=100) :: message
 
-    open(newunit=lun, file="test.txt", status="replace")
+    open(newunit=lun, file="file_35_test.txt", status="replace")
 
     close(unit=lun, iostat=ios, iomsg=message)
     print *, ios

--- a/integration_tests/file_36.f90
+++ b/integration_tests/file_36.f90
@@ -3,7 +3,7 @@ program file_36
     integer :: unit_num
     character(len=100) :: result
 
-    open(file="test.txt", newunit=unit_num, delim="quote")
+    open(file="file_36_test.txt", newunit=unit_num, delim="quote")
     write(unit_num,*) "hello world"
 
     rewind(unit_num)


### PR DESCRIPTION
To prevent clashes when running tests in parallel.

Fixes #9356.