### PR TITLE
Fix: Preserve embedded null bytes in string formatting

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -871,6 +871,7 @@ RUN(NAME format_41 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_42 LABELS gfortran llvm)
 RUN(NAME format_43 LABELS gfortran llvm)
 RUN(NAME format_44 LABELS gfortran llvm)
+RUN(NAME format_45 LABELS gfortran llvm)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran fortran)

--- a/integration_tests/format_45.f90
+++ b/integration_tests/format_45.f90
@@ -1,0 +1,35 @@
+! Test that embedded null bytes in strings are preserved during formatting
+program format_45
+    implicit none
+    character(len=20) :: result_str
+    character(len=10) :: prefix
+    real :: value
+    integer :: i
+
+    ! Set prefix to null bytes
+    do i = 1, 10
+        prefix(i:i) = char(0)
+    end do
+    value = 1.5
+
+    write(result_str, '(A,F5.2)') prefix, value
+
+    ! Verify first 10 bytes are null
+    do i = 1, 10
+        if (ichar(result_str(i:i)) /= 0) error stop
+    end do
+
+    ! Verify float " 1.50" at positions 11-15
+    if (ichar(result_str(11:11)) /= 32) error stop  ! space
+    if (ichar(result_str(12:12)) /= 49) error stop  ! '1'
+    if (ichar(result_str(13:13)) /= 46) error stop  ! '.'
+    if (ichar(result_str(14:14)) /= 53) error stop  ! '5'
+    if (ichar(result_str(15:15)) /= 48) error stop  ! '0'
+
+    ! Verify trailing spaces at positions 16-20
+    do i = 16, 20
+        if (ichar(result_str(i:i)) /= 32) error stop
+    end do
+
+    print *, "PASS: Null bytes preserved correctly in formatted output"
+end program


### PR DESCRIPTION
## Summary

Fix runtime string formatting to preserve embedded null bytes in CHARACTER variables.

The root cause of LAPACK SQK threshold test failures was that the runtime string formatting function `_lcompilers_string_format_fortran` used `strlen(result)` to track result length, which stops at the first null byte. This caused incorrect output when formatting CHARACTER variables containing embedded nulls.

## Changes

- Track `result_len` explicitly throughout `_lcompilers_string_format_fortran`
- Use `append_to_string_NTI` with explicit lengths instead of `append_to_string`
- Use temp buffer pattern for handler functions (handle_integer, handle_float, etc.)

## Context

Fortran CHARACTER variables that are declared but not explicitly initialized contain undefined values (often null bytes). When these variables are formatted and concatenated with other values, the null bytes must be preserved to maintain correct positioning of subsequent data.

## Verification

- All reference tests pass
- All integration tests pass (2098/2098)
- New integration test `format_45.f90` verifies null byte preservation in formatted output
- LFortran output now matches gfortran for CHARACTER variables with embedded null bytes

Fixes #9371
