### PR TITLE
fix: dict_test_01 to not use --no-array-bounds-checking

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2948,7 +2948,7 @@ RUN(NAME formatted_read_01 LABELS gfortran llvm COPY_TO_BIN formatted_read_input
 RUN(NAME list_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
 RUN(NAME list_of_lists_test LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
 RUN(NAME set_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
-RUN(NAME dict_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --no-array-bounds-checking) # No gfortran
+RUN(NAME dict_test_01 LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
 # RUN(NAME list_of_tuples_test LABELS llvm llvm_wasm llvm_wasm_emcc) # No gfortran
 
 

--- a/integration_tests/dict_test_01.f90
+++ b/integration_tests/dict_test_01.f90
@@ -25,8 +25,8 @@ program dict_test_01
    call _lfortran_set_item(dict_r, -14, 6.4)
    if (_lfortran_len(dict_r) /= 4) error stop
 
-   if (abs(_lfortran_get_item(dict_i, -14) - 6.4) < eps) error stop
-   if (abs(_lfortran_get_item(dict_i, 2) - 2.5) < eps) error stop
+   if (abs(_lfortran_get_item(dict_r, -14) - 6.4) > eps) error stop
+   if (abs(_lfortran_get_item(dict_r, 2) - 2.5) > eps) error stop
 
 end program dict_test_01
 


### PR DESCRIPTION
Towards https://github.com/lfortran/lfortran/issues/8306

This removes the use of `--no-array-bounds-checking` in the integration tests.

The only use of `--no-array-bounds-checking` is now in our CI for `Numerical Methods Fortran`. It also fails with gfortran with `-fcheck=all` so we can keep it.