### PR TITLE
tests: register equivalence_12.f90 integration test

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2696,6 +2696,7 @@ RUN(NAME equivalence_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME equivalence_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME fortran_primes_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 


### PR DESCRIPTION
## Summary
- Register missing equivalence_12.f90 test in CMakeLists.txt

Fixes #9134

## Why
The test file was added in PR #9121 but not registered, so it wasn't being run by CI.

**Stage:** Tests

## Changes
- [`integration_tests/CMakeLists.txt#L2699`](https://github.com/lfortran/lfortran/blob/bd0023cff81d017e7aa1c643a0abeda7507b0747/integration_tests/CMakeLists.txt#L2699): Add registration for equivalence_12

## Tests
- [`integration_tests/equivalence_12.f90`](https://github.com/lfortran/lfortran/blob/bd0023cff81d017e7aa1c643a0abeda7507b0747/integration_tests/equivalence_12.f90): Tests EQUIVALENCE 3D arrays with DATA containing mixed values