### PR TITLE
fix: add WASI version for Node.js v20+ compatibility

### DIFF
--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -59,7 +59,7 @@ void save_js_glue_wasi(std::string filename) {
 R"(async function main() {
     const fs = require("fs");
     const { WASI } = require("wasi");
-    const wasi = new WASI();
+    const wasi = new WASI({ version: 'preview1' });
     const importObject = {
         wasi_snapshot_preview1: wasi.wasiImport,
         js: {


### PR DESCRIPTION
## Summary
- Add `version: 'preview1'` option to WASI constructor for Node.js v20+ compatibility

Fixes wasm backend tests in #8115

## Why
Node.js v20+ changed the WASI API to require the `version` option. Without it, all wasm tests fail with:
```
TypeError: The "options.version" property must be of type string
```

**Stage:** Codegen

## Changes
- [`wasm_assembler.h#L62`](https://github.com/lfortran/lfortran/blob/09a9094babedb2129904ad565478550c17de669e/src/libasr/codegen/wasm_assembler.h#L62): Add WASI version option to `new WASI()` call

## Tests
- All 226 wasm integration tests pass (5 expected failures with FAIL label)
- Manual verification: `lfortran --backend=wasm test.f90` generates correct JS with `version: 'preview1'`
