### PR TITLE
docs: document disabled LLVM11 test failures

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -772,6 +772,7 @@ RUN(NAME arrays_98 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_99 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_100 LABELS gfortran llvm)
 RUN(NAME arrays_101 LABELS gfortran llvm)
+# DISABLED: #8115 - ICE: get_struct_sym_from_struct_expr returns nullptr for empty struct array constructors [tp ::]
 # RUN(NAME array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME assumed_rank_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
@@ -2232,6 +2233,7 @@ RUN(NAME conv_complex2real LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 RUN(NAME template_02 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME template_03 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
+# DISABLED: #8115 - ASR verify: FunctionType contains types tied to scope after template instantiation
 # RUN(NAME template_04 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME template_05 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME template_add_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
@@ -2250,7 +2252,9 @@ RUN(NAME template_array_02 LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray w
 RUN(NAME template_array_03 LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME template_array_04 LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME template_array_04b LABELS llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
+# DISABLED: #8115 - ASR verify: FunctionType contains types tied to scope after template instantiation
 # RUN(NAME template_matrix_01 LABELS llvm llvm_wasm llvm_wasm_emcc)
+# DISABLED: #8115 - ASR verify: FunctionType contains types tied to scope after template instantiation
 # RUN(NAME template_matrix_test LABELS llvm llvm_wasm llvm_wasm_emcc EXTRAFILES
 #     template_semigroup.f90
 #     template_monoid.f90


### PR DESCRIPTION
## Summary
- Document why 4 LLVM11 tests are disabled with references to #8115
- Add detailed analysis as comment on #8115

Part of #8115

## Why
The 4 remaining LLVM11 failures are non-trivial issues requiring architectural changes. This PR documents the root causes.

**Stage:** Documentation

## Changes
- [`integration_tests/CMakeLists.txt#L775-L776`](https://github.com/lfortran/lfortran/blob/5c2f8469726168a7f5f0853157293f780fc52d12/integration_tests/CMakeLists.txt#L775-L776): Document array_init failure
- [`integration_tests/CMakeLists.txt#L2236-L2237`](https://github.com/lfortran/lfortran/blob/5c2f8469726168a7f5f0853157293f780fc52d12/integration_tests/CMakeLists.txt#L2236-L2237): Document template_04 failure  
- [`integration_tests/CMakeLists.txt#L2255-L2258`](https://github.com/lfortran/lfortran/blob/5c2f8469726168a7f5f0853157293f780fc52d12/integration_tests/CMakeLists.txt#L2255-L2258): Document template_matrix failures

## Issue Analysis

### Template Tests (template_04, template_matrix_01, template_matrix_test)
**Error:** ASR verify: FunctionType contains types tied to scope
**Root Cause:** Template instantiation produces FunctionTypes with types referencing local/scoped symbols

### Empty Array Constructor (array_init)
**Error:** ICE in down_cast() - nullptr from get_struct_sym_from_struct_expr
**Root Cause:** Empty struct array constructors `[tp ::]` don't preserve struct symbol for later lookup

See detailed analysis: https://github.com/lfortran/lfortran/issues/8115#issuecomment-3728248963