### PR TITLE
chore: serialization cleanup

### DIFF
--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -1,5 +1,3 @@
-#include <string>
-
 #include <libasr/config.h>
 #include <libasr/serialization.h>
 #include <libasr/asr_utils.h>
@@ -34,9 +32,12 @@ public:
     }
 
     void write_symbol(const ASR::symbol_t &x) {
-        write_int64(symbol_parent_symtab(&x)->counter);
-        write_int8(x.type);
-        write_string(symbol_name(&x));
+        uint64_t symtab_counter = symbol_parent_symtab(&x)->counter;
+        uint8_t sym_type = static_cast<uint8_t>(x.type);
+        std::string sym_name = symbol_name(&x);
+        write_int64(symtab_counter);
+        write_int8(sym_type);
+        write_string(sym_name);
     }
 };
 
@@ -48,7 +49,10 @@ std::string serialize(const ASR::asr_t &asr) {
 }
 
 std::string serialize(const ASR::TranslationUnit_t &unit) {
-    return serialize((ASR::asr_t&)(unit));
+    ASRSerializationVisitor v;
+    v.write_int8(unit.base.type);
+    v.visit_TranslationUnit(unit);
+    return v.get_str();
 }
 
 class ASRDeserializationVisitor :


### PR DESCRIPTION
## Summary
- Make TranslationUnit serialization explicit without C-style casting
- Capture symbol fields in locals before writing

## Why
Avoids C-style casts and makes serialization steps easier to follow in debugging.

**Stage:** Serialization

## Changes
- [`src/libasr/serialization.cpp#L34-L55`](https://github.com/lfortran/lfortran/blob/33f615a0823dcf4191929a2e0be0d2f6c2c3307a/src/libasr/serialization.cpp#L34-L55): store symbol fields locally and serialize TranslationUnit explicitly

## Tests
- Not run (no functional change)
