### PR TITLE
Implement lazy initialization of intrinsic tables

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -5833,8 +5833,10 @@ namespace Transpose {
 
 namespace IntrinsicArrayFunctionRegistry {
 
-    static const std::map<int64_t, std::tuple<impl_function,
-            verify_array_function>>& intrinsic_function_by_id_db = {
+    inline const std::map<int64_t, std::tuple<impl_function,
+            verify_array_function>>& get_intrinsic_function_by_id_db() {
+        static const std::map<int64_t, std::tuple<impl_function,
+                verify_array_function>> intrinsic_function_by_id_db = {
         {static_cast<int64_t>(IntrinsicArrayFunctions::Any),
             {&Any::instantiate_Any, &Any::verify_args}},
         {static_cast<int64_t>(IntrinsicArrayFunctions::All),
@@ -5883,10 +5885,14 @@ namespace IntrinsicArrayFunctionRegistry {
             {&Eoshift::instantiate_Eoshift, &Eoshift::verify_args}},
         {static_cast<int64_t>(IntrinsicArrayFunctions::Spread),
             {&Spread::instantiate_Spread, &Spread::verify_args}},
-    };
+        };
+        return intrinsic_function_by_id_db;
+    }
 
-    static const std::map<std::string, std::tuple<create_intrinsic_function,
-            eval_intrinsic_function>>& function_by_name_db = {
+    inline const std::map<std::string, std::tuple<create_intrinsic_function,
+            eval_intrinsic_function>>& get_function_by_name_db() {
+        static const std::map<std::string, std::tuple<create_intrinsic_function,
+                eval_intrinsic_function>> function_by_name_db = {
         {"any", {&Any::create_Any, &Any::eval_Any}},
         {"all", {&All::create_All, &All::eval_All}},
         {"iany", {&Iany::create_Iany, &Iany::eval_Iany}},
@@ -5911,25 +5917,27 @@ namespace IntrinsicArrayFunctionRegistry {
         {"count", {&Count::create_Count, &Count::eval_Count}},
         {"parity", {&Parity::create_Parity, &Parity::eval_Parity}},
         {"dot_product", {&DotProduct::create_DotProduct, &DotProduct::eval_DotProduct}},
-    };
+        };
+        return function_by_name_db;
+    }
 
     static inline bool is_intrinsic_function(const std::string& name) {
-        return function_by_name_db.find(name) != function_by_name_db.end();
+        return get_function_by_name_db().find(name) != get_function_by_name_db().end();
     }
 
     static inline create_intrinsic_function get_create_function(const std::string& name) {
-        return  std::get<0>(function_by_name_db.at(name));
+        return  std::get<0>(get_function_by_name_db().at(name));
     }
 
     static inline impl_function get_instantiate_function(int64_t id) {
-        if( intrinsic_function_by_id_db.find(id) == intrinsic_function_by_id_db.end() ) {
+        if( get_intrinsic_function_by_id_db().find(id) == get_intrinsic_function_by_id_db().end() ) {
             return nullptr;
         }
-        return std::get<0>(intrinsic_function_by_id_db.at(id));
+        return std::get<0>(get_intrinsic_function_by_id_db().at(id));
     }
 
     static inline verify_array_function get_verify_function(int64_t id) {
-        return std::get<1>(intrinsic_function_by_id_db.at(id));
+        return std::get<1>(get_intrinsic_function_by_id_db().at(id));
     }
 
     /*

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -204,9 +204,12 @@ inline std::string get_intrinsic_name(int64_t x) {
 
 namespace IntrinsicElementalFunctionRegistry {
 
-    static const std::map<int64_t,
+    inline const std::map<int64_t,
         std::tuple<impl_function,
-                   verify_function>>& intrinsic_function_by_id_db = {
+                   verify_function>>& get_intrinsic_function_by_id_db() {
+        static const std::map<int64_t,
+            std::tuple<impl_function,
+                       verify_function>> intrinsic_function_by_id_db = {
         {static_cast<int64_t>(IntrinsicElementalFunctions::ObjectType),
             {nullptr, &ObjectType::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Gamma),
@@ -565,9 +568,12 @@ namespace IntrinsicElementalFunctionRegistry {
             {&CommandArgumentCount::instantiate_CommandArgumentCount, &CommandArgumentCount::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Int),
             {&Int::instantiate_Int, &Int::verify_args}},
-    };
+        };
+        return intrinsic_function_by_id_db;
+    }
 
-    static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
+    inline const std::map<int64_t, std::string>& get_intrinsic_function_id_to_name() {
+        static const std::map<int64_t, std::string> intrinsic_function_id_to_name = {
         {static_cast<int64_t>(IntrinsicElementalFunctions::ObjectType),
             "type"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Gamma),
@@ -922,12 +928,16 @@ namespace IntrinsicElementalFunctionRegistry {
             "SymbolicGetArgument"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Int),
             "int"},
-    };
+        };
+        return intrinsic_function_id_to_name;
+    }
 
-
-    static const std::map<std::string,
+    inline const std::map<std::string,
         std::tuple<create_intrinsic_function,
-                    eval_intrinsic_function>>& intrinsic_function_by_name_db = {
+                    eval_intrinsic_function>>& get_intrinsic_function_by_name_db() {
+        static const std::map<std::string,
+            std::tuple<create_intrinsic_function,
+                        eval_intrinsic_function>> intrinsic_function_by_name_db = {
                 {"type", {&ObjectType::create_ObjectType, &ObjectType::eval_ObjectType}},
                 {"gamma", {&Gamma::create_Gamma, &Gamma::eval_Gamma}},
                 {"log", {&Log::create_Log, &Log::eval_Log}},
@@ -1106,37 +1116,39 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"SinQ", {&SymbolicSinQ::create_SymbolicSinQ, &SymbolicSinQ::eval_SymbolicSinQ}},
                 {"GetArgument", {&SymbolicGetArgument::create_SymbolicGetArgument, &SymbolicGetArgument::eval_SymbolicGetArgument}},
                 {"int", {&Int::create_Int, &Int::eval_Int}},
-    };
+        };
+        return intrinsic_function_by_name_db;
+    }
 
     static inline bool is_intrinsic_function(const std::string& name) {
-        return intrinsic_function_by_name_db.find(name) != intrinsic_function_by_name_db.end();
+        return get_intrinsic_function_by_name_db().find(name) != get_intrinsic_function_by_name_db().end();
     }
 
     static inline bool is_intrinsic_function(int64_t id) {
-        return intrinsic_function_by_id_db.find(id) != intrinsic_function_by_id_db.end();
+        return get_intrinsic_function_by_id_db().find(id) != get_intrinsic_function_by_id_db().end();
     }
 
     static inline create_intrinsic_function get_create_function(const std::string& name) {
-        return std::get<0>(intrinsic_function_by_name_db.at(name));
+        return std::get<0>(get_intrinsic_function_by_name_db().at(name));
     }
 
     static inline verify_function get_verify_function(int64_t id) {
-        return std::get<1>(intrinsic_function_by_id_db.at(id));
+        return std::get<1>(get_intrinsic_function_by_id_db().at(id));
     }
 
     static inline impl_function get_instantiate_function(int64_t id) {
-        if( intrinsic_function_by_id_db.find(id) == intrinsic_function_by_id_db.end() ) {
+        if( get_intrinsic_function_by_id_db().find(id) == get_intrinsic_function_by_id_db().end() ) {
             return nullptr;
         }
-        return std::get<0>(intrinsic_function_by_id_db.at(id));
+        return std::get<0>(get_intrinsic_function_by_id_db().at(id));
     }
 
     static inline std::string get_intrinsic_function_name(int64_t id) {
-        if( intrinsic_function_id_to_name.find(id) == intrinsic_function_id_to_name.end() ) {
+        if( get_intrinsic_function_id_to_name().find(id) == get_intrinsic_function_id_to_name().end() ) {
             throw LCompilersException("IntrinsicFunction with ID " + std::to_string(id) +
                                       " has no name registered for it");
         }
-        return intrinsic_function_id_to_name.at(id);
+        return get_intrinsic_function_id_to_name().at(id);
     }
 
 } // namespace IntrinsicElementalFunctionRegistry
@@ -1199,19 +1211,23 @@ namespace IsIostatEor {
 
 namespace IntrinsicImpureFunctionRegistry {
 
-    static const std::map<std::string, std::tuple<create_intrinsic_function,
-            eval_intrinsic_function>>& function_by_name_db = {
-        {"is_iostat_end", {&IsIostatEnd::create_IsIostatEnd, nullptr}},
-        {"is_iostat_eor", {&IsIostatEor::create_IsIostatEor, nullptr}},
-        {"allocated", {&Allocated::create_Allocated, nullptr}},
-    };
+    inline const std::map<std::string, std::tuple<create_intrinsic_function,
+            eval_intrinsic_function>>& get_function_by_name_db() {
+        static const std::map<std::string, std::tuple<create_intrinsic_function,
+                eval_intrinsic_function>> function_by_name_db = {
+            {"is_iostat_end", {&IsIostatEnd::create_IsIostatEnd, nullptr}},
+            {"is_iostat_eor", {&IsIostatEor::create_IsIostatEor, nullptr}},
+            {"allocated", {&Allocated::create_Allocated, nullptr}},
+        };
+        return function_by_name_db;
+    }
 
     static inline bool is_intrinsic_function(const std::string& name) {
-        return function_by_name_db.find(name) != function_by_name_db.end();
+        return get_function_by_name_db().find(name) != get_function_by_name_db().end();
     }
 
     static inline create_intrinsic_function get_create_function(const std::string& name) {
-        return  std::get<0>(function_by_name_db.at(name));
+        return  std::get<0>(get_function_by_name_db().at(name));
     }
 
 } // namespace IntrinsicImpureFunctionRegistry

--- a/src/libasr/pass/intrinsic_subroutine_registry.h
+++ b/src/libasr/pass/intrinsic_subroutine_registry.h
@@ -42,9 +42,12 @@ inline std::string get_intrinsic_subroutine_name(int x) {
 
 namespace IntrinsicImpureSubroutineRegistry {
 
-    static const std::map<int64_t,
+    inline const std::map<int64_t,
         std::tuple<impl_subroutine,
-                   verify_subroutine>>& intrinsic_subroutine_by_id_db = {
+                   verify_subroutine>>& get_intrinsic_subroutine_by_id_db() {
+        static const std::map<int64_t,
+            std::tuple<impl_subroutine,
+                       verify_subroutine>> intrinsic_subroutine_by_id_db = {
         {static_cast<int64_t>(IntrinsicImpureSubroutines::RandomNumber),
             {&RandomNumber::instantiate_RandomNumber, &RandomNumber::verify_args}},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::RandomInit),
@@ -71,9 +74,12 @@ namespace IntrinsicImpureSubroutineRegistry {
             {&MoveAlloc::instantiate_MoveAlloc, &MoveAlloc::verify_args}},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::Mvbits),
             {&Mvbits::instantiate_Mvbits, &Mvbits::verify_args}},
-    };
+        };
+        return intrinsic_subroutine_by_id_db;
+    }
 
-    static const std::map<int64_t, std::string>& intrinsic_subroutine_id_to_name = {
+    inline const std::map<int64_t, std::string>& get_intrinsic_subroutine_id_to_name() {
+        static const std::map<int64_t, std::string> intrinsic_subroutine_id_to_name = {
         {static_cast<int64_t>(IntrinsicImpureSubroutines::RandomNumber),
             "random_number"},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::RandomInit),
@@ -100,11 +106,14 @@ namespace IntrinsicImpureSubroutineRegistry {
             "move_alloc"},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::Mvbits),
             "mvbits"},
-    };
+        };
+        return intrinsic_subroutine_id_to_name;
+    }
 
-
-    static const std::map<std::string,
-        create_intrinsic_subroutine>& intrinsic_subroutine_by_name_db = {
+    inline const std::map<std::string,
+        create_intrinsic_subroutine>& get_intrinsic_subroutine_by_name_db() {
+        static const std::map<std::string,
+            create_intrinsic_subroutine> intrinsic_subroutine_by_name_db = {
                 {"random_number", &RandomNumber::create_RandomNumber},
                 {"random_init", &RandomInit::create_RandomInit},
                 {"random_seed", &RandomSeed::create_RandomSeed},
@@ -118,37 +127,39 @@ namespace IntrinsicImpureSubroutineRegistry {
                 {"date_and_time", &DateAndTime::create_DateAndTime},
                 {"move_alloc", &MoveAlloc::create_MoveAlloc},
                 {"mvbits", &Mvbits::create_Mvbits},
-    };
+        };
+        return intrinsic_subroutine_by_name_db;
+    }
 
     static inline bool is_intrinsic_subroutine(const std::string& name) {
-        return intrinsic_subroutine_by_name_db.find(name) != intrinsic_subroutine_by_name_db.end();
+        return get_intrinsic_subroutine_by_name_db().find(name) != get_intrinsic_subroutine_by_name_db().end();
     }
 
     static inline bool is_intrinsic_subroutine(int64_t id) {
-        return intrinsic_subroutine_by_id_db.find(id) != intrinsic_subroutine_by_id_db.end();
+        return get_intrinsic_subroutine_by_id_db().find(id) != get_intrinsic_subroutine_by_id_db().end();
     }
 
     static inline create_intrinsic_subroutine get_create_subroutine(const std::string& name) {
-        return  intrinsic_subroutine_by_name_db.at(name);
+        return  get_intrinsic_subroutine_by_name_db().at(name);
     }
 
     static inline verify_subroutine get_verify_subroutine(int64_t id) {
-        return std::get<1>(intrinsic_subroutine_by_id_db.at(id));
+        return std::get<1>(get_intrinsic_subroutine_by_id_db().at(id));
     }
 
     static inline impl_subroutine get_instantiate_subroutine(int64_t id) {
-        if( intrinsic_subroutine_by_id_db.find(id) == intrinsic_subroutine_by_id_db.end() ) {
+        if( get_intrinsic_subroutine_by_id_db().find(id) == get_intrinsic_subroutine_by_id_db().end() ) {
             return nullptr;
         }
-        return std::get<0>(intrinsic_subroutine_by_id_db.at(id));
+        return std::get<0>(get_intrinsic_subroutine_by_id_db().at(id));
     }
 
     inline std::string get_intrinsic_subroutine_name(int64_t id) {
-        if( intrinsic_subroutine_id_to_name.find(id) == intrinsic_subroutine_id_to_name.end() ) {
+        if( get_intrinsic_subroutine_id_to_name().find(id) == get_intrinsic_subroutine_id_to_name().end() ) {
             throw LCompilersException("IntrinsicSubroutine with ID " + std::to_string(id) +
                                       " has no name registered for it");
         }
-        return intrinsic_subroutine_id_to_name.at(id);
+        return get_intrinsic_subroutine_id_to_name().at(id);
     }
 
 } // namespace IntrinsicImpureSubroutineRegistry


### PR DESCRIPTION
This speeds up startup of Release mode from 20ms to 17ms. Before:
```
$ time ./src/bin/lfortran --version
LFortran version: 0.58.0-761-g542284693
Platform: macOS ARM
LLVM: 11.1.0
Default target: arm64-apple-darwin24.6.0
LSP Version: 3.17.0
JSON_RPC Version: 2.0

real    0.020s
user    0.011s
sys     0.006s
cpu     84.3%
```
After:
```
$ time ./src/bin/lfortran --version
LFortran version: 0.58.0-761-g542284693
Platform: macOS ARM
LLVM: 11.1.0
Default target: arm64-apple-darwin24.6.0
LSP Version: 3.17.0
JSON_RPC Version: 2.0

real    0.017s
user    0.009s
sys     0.005s
cpu     84.7%
```

And in Debug mode from 126ms to 119ms. Before:
```
$ time ./src/bin/lfortran --version
LFortran version: 0.58.0-761-gfb0e8b339
Platform: macOS ARM
LLVM: 11.1.0
Default target: arm64-apple-darwin24.6.0

real    0.126s
user    0.120s
sys     0.003s
cpu     97.9%
```
After:
```
$ time ./src/bin/lfortran --version
LFortran version: 0.58.0-761-gfb0e8b339
Platform: macOS ARM
LLVM: 11.1.0
Default target: arm64-apple-darwin24.6.0

real    0.119s
user    0.113s
sys     0.003s
cpu     97.9%
```

However, when we actually need to use these later in the compilation, the speed is the same. Consequently, we'll have to implement a faster solution. This PR is just to show where the bottleneck is.