### PR TITLE
llvm: apply --mangle-underscore to external calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2657,6 +2657,7 @@ RUN(NAME optional_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME end_name_match LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME mangle_underscore_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --mangle-underscore --all-mangling)
+RUN(NAME mangle_underscore_extern_01 LABELS llvm EXTRAFILES mangle_underscore_extern_01_def.f90 EXTRA_ARGS --implicit-interface --mangle-underscore)
 
 RUN(NAME nan_handling_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/mangle_underscore_extern_01.f90
+++ b/integration_tests/mangle_underscore_extern_01.f90
@@ -1,0 +1,7 @@
+program mangle_underscore_extern_01
+    implicit none
+
+    call foo()
+    print *, 1
+end program mangle_underscore_extern_01
+

--- a/integration_tests/mangle_underscore_extern_01_def.f90
+++ b/integration_tests/mangle_underscore_extern_01_def.f90
@@ -1,0 +1,4 @@
+subroutine foo_()
+    implicit none
+end subroutine foo_
+

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -68,6 +68,18 @@ using ASRUtils::determine_module_dependencies;
 using ASRUtils::is_arg_dummy;
 using ASRUtils::is_argument_of_type_CPtr;
 
+static inline std::string maybe_mangle_underscore_external(
+    const std::string &name, const LCompilers::CompilerOptions &compiler_options)
+{
+    if (!compiler_options.po.mangle_underscore) {
+        return name;
+    }
+    if (!name.empty() && name.back() == '_') {
+        return name;
+    }
+    return name + "_";
+}
+
 class ASRToLLVMVisitor : public ASR::BaseVisitor<ASRToLLVMVisitor>
 {
 private:
@@ -6008,7 +6020,7 @@ public:
                 }
             } else if (ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface &&
                 ASRUtils::get_FunctionType(x)->m_abi != ASR::abiType::Intrinsic && !ASRUtils::get_FunctionType(x)->m_module) {
-                fn_name = sym_name;
+                fn_name = maybe_mangle_underscore_external(sym_name, compiler_options);
             } else {
                 fn_name = mangle_prefix + sym_name;
             }
@@ -6086,7 +6098,7 @@ public:
                         }
                     } else if (ASRUtils::get_FunctionType(*var)->m_deftype == ASR::deftypeType::Interface &&
                         ASRUtils::get_FunctionType(*var)->m_abi != ASR::abiType::Intrinsic) {
-                        fn_name = sym_name;
+                        fn_name = maybe_mangle_underscore_external(sym_name, compiler_options);
                     } else {
                         fn_name = mangle_prefix + sym_name;
                     }


### PR DESCRIPTION
## Summary
- Make `--mangle-underscore` also apply to external (interface) procedure symbols in the LLVM backend, so common system BLAS/LAPACK symbols like `dptsv_` can resolve.

Fixes: #9446

## Tests
- `./run_tests.py -t mangle_underscore_extern_01 -s`
