### PR TITLE
Fix : Allocate struct memory for each element in an array of type `class`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1768,6 +1768,7 @@ RUN(NAME derived_types_88 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_AR
 RUN(NAME derived_types_89 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME derived_types_90 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME derived_types_91 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_92 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME multi_file_member_access_01 LABELS gfortran llvm llvm_single_invocation EXTRAFILES multi_file_member_access_01_mod.f90)

--- a/integration_tests/derived_types_92.f90
+++ b/integration_tests/derived_types_92.f90
@@ -1,0 +1,31 @@
+program derived_types_92
+    implicit none
+    type :: package_t
+        integer :: num
+        character(:),allocatable :: str
+    end type package_t
+
+    class(package_t), allocatable :: instance(:)
+
+    allocate(instance(1))
+    instance(1)%num = 1
+    instance(1)%str = "Hi"
+
+    print *, instance(1)%num
+    if(instance(1)%num /= 1) error stop
+    
+    print *, instance(1)%str
+    if(instance(1)%str /= "Hi") error stop
+    
+    call foo(instance)
+
+    contains
+    subroutine foo(arg)
+        class(package_t), allocatable :: arg(:)
+        print *, arg(1)%num
+        if(arg(1)%num /= 1) error stop
+    
+        print *, arg(1)%str
+        if(arg(1)%str /= "Hi") error stop
+    end subroutine 
+end program 


### PR DESCRIPTION
fixes #9461