### PR TITLE
fix: handle scalar variables passing for functions inside do-loop conditions

### DIFF
--- a/integration_tests/nested_18.f90
+++ b/integration_tests/nested_18.f90
@@ -1,37 +1,71 @@
-! Checking Nested Variables Pass: Host variable from a subroutine 
-! used in nested function, Passed through Do-While loop check & If block checks
-module temp
+! Test for nested function global variables passes 
+! with function calls in conditions
+! Test for both, scalars and arrays
+! Test 1: Do-while loop with function call in condition (3 iterations)
+! Test 2: IF block with function call in condition
+
+module nested_18_temp
   contains
     subroutine demo()
       implicit none
-      integer :: a       ! Host variable
+      integer :: a
+      integer :: arr(5)
+      integer :: counter
+
+      ! Test 1: Do-While loop - runs 6 times
+      ! Check Upodates from Main to Function
+      ! And from function to Main
+      a = 0
+      arr(1:5) = 0
+      counter = 0
+      GET_ARGS: do while(increment())
+        ! Check updates from function to main
+        counter = counter + 1
+        if (counter == 1 .and. a /= 1 .and. arr(1) /= 1) error stop
+        if (counter == 3 .and. a /= 3 .and. arr(3) /= 3) error stop
+        if (counter == 5 .and. a /= 5 .and. arr(5) /= 3) error stop
+        print *, "Iteration", counter, ": a =", a, ": arr =", arr
+        
+        ! Update a inside main to check from main to function
+        a = a + 1
+        arr = arr + 1
+        counter = counter + 1
+        print *, "Iteration", counter, ": a =", a, ": arr =", arr
+        if (counter == 6) exit GET_ARGS
+      end do GET_ARGS
+      print *, "a =", a
+      print *, "arr =", arr
+      if (a /= 6) error stop
+      if (arr(1) /= 6) error stop
+
+      ! Test 2: IF block with function call in condition
       a = 10
-      do while(f())  ! While Loop access
-        a = 5
-      end do
-      if (f2()) then ! If Block executes
-        a = 10
+      if (set_value(25)) then
+        print *, "In IF body: a =", a
+        if (a /= 25) error stop
+        a = a + 5
       end if
-    contains
-      logical function f()
-          character(len=5) :: str1
-          write(str1, "(I0)") a
-          if ((trim(str1)) /= "10") error stop
-          print *, a, str1
-          f = .false.
-      end function f
-      logical function f2()
-          character(len=5) :: str1
-          write(str1, "(I0)") a
-          if ((trim(str1)) /= "10") error stop
-          print *, a, str1
-          f2 = .true.
-      end function f2
-    end subroutine demo 
-end module
+      print *, a
+      if (a /= 30) error stop
+
+      contains
+      logical function increment()
+        arr = arr + 1
+        a = a + 1
+        increment = .true.
+      end function increment
+
+      logical function set_value(val)
+        integer, intent(in) :: val
+        a = val
+        set_value = .true.
+      end function set_value
+
+    end subroutine demo
+end module nested_18_temp
 
 program nested_18
-  use temp
+  use nested_18_temp
   implicit none
   call demo()
   print *, "Nested variable test passed"

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "8ea8d1e2dc9f3da27eeea53ed95f580dd37b5d54fdfc525f25879d4c",
+    "stdout_hash": "9c7d7e22a1411f2b90da8d139fc05ce3a50ff551a2e7f5ad9db989b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -55,10 +55,8 @@ loop.body:                                        ; preds = %loop.head
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %22 = load i32, i32* %z1, align 4
-  store i32 %22, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
-  %23 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
-  store i32 %23, i32* %z1, align 4
+  %22 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest____lcompilers_created__nested_context__closuretest_z, align 4
+  store i32 %22, i32* %z1, align 4
   call void @_lpython_free_argv()
   br label %return
 


### PR DESCRIPTION
Fixes #9437

Building on #8952, Modify the logic for this task to account for following cases for functions inside do-loop conditions
- Assign scalar variables from main to function temporary variables before function execution
- After the function executes, assign temporaries from function to main before starting loop execution
- At the end of the loop, again assign scalar from main to temporaries for next iteration

Similarly, for if block, perform the following:
- Assign scalar variables from main to function temporary variables
- After the function executes, assign temporaries from function to main before starting if block execution