### PR TITLE
fix: handle polymorphic variables inside intrinsic `trim()` intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1332,6 +1332,7 @@ RUN(NAME intrinsics_401 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # minloc
 RUN(NAME intrinsics_402 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # intrinsic statement with procedure argument
 RUN(NAME intrinsics_403 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # min1, max1
 RUN(NAME intrinsics_404 LABELS llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME intrinsics_405 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_405.f90
+++ b/integration_tests/intrinsics_405.f90
@@ -1,0 +1,17 @@
+program intrinsics_405
+    implicit none
+
+    call print_any("  Hello World  ")
+    contains
+    subroutine print_any(generic)
+        class(*), intent(in) :: generic
+        character(len = 15) :: a
+        select type (generic)
+        type is (character(len=*))
+            a = trim(generic)
+            print *, trim(generic)
+        end select
+        if (a /= trim("  Hello World  ")) error stop
+    end subroutine print_any
+
+end program intrinsics_405

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2689,7 +2689,11 @@ public:
                                                     al, type_stmt_type->base.base.loc,
                                                     current_scope, s2c(al, block_name),
                                                     nullptr, 0));
+                    // Track type guard context for polymorphic intrinsic validation
+                    ASR::ttype_t* prev_select_type_guard = current_select_type_guard;
+                    current_select_type_guard = selector_type;
                     transform_stmts(type_stmt_type_body, type_stmt_type->n_body, type_stmt_type->m_body);
+                    current_select_type_guard = prev_select_type_guard;
                     ASR::Block_t* block_t_ = ASR::down_cast<ASR::Block_t>(block_sym);
                     block_t_->m_body = type_stmt_type_body.p;
                     block_t_->n_body = type_stmt_type_body.size();

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1591,6 +1591,7 @@ public:
     SetChar current_function_dependencies;
     ASR::ttype_t* current_variable_type_;
     ASR::expr_t* current_struct_type_var_expr = nullptr; // used for setting the struct symbol in `PointerNullConstant`
+    ASR::ttype_t* current_select_type_guard = nullptr; // tracks type guard in select type statements for polymorphic statements
 
     int32_t enum_init_val;
     bool default_storage_save = false;
@@ -10546,6 +10547,30 @@ public:
                     fill_optional_kind_arg(var_name, args);
                     tmp = nullptr;
                     scalar_kind_arg(var_name, args);
+                    // Validate trim character intrinsics with unlimited polymorphic arguments
+                    if (var_name == "trim")  {
+                        // Check if any argument is unlimited polymorphic
+                        bool has_polymorphic_arg = false;
+                        for (size_t i = 0; i < args.size(); i++) {
+                            if (args[i] && ASRUtils::is_unlimited_polymorphic_type(args[i])) {
+                                has_polymorphic_arg = true;
+                                break;
+                            }
+                        }
+                        if (has_polymorphic_arg) {
+                            // Must be inside character type guard
+                            if (current_select_type_guard == nullptr ||
+                                !ASRUtils::is_character(*current_select_type_guard)) {
+                                diag.add(Diagnostic(
+                                    "Character intrinsic '" + var_name +
+                                    "' with class(*) argument must be inside 'type is (character(len=*))' guard",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("invalid use of character intrinsic with polymorphic argument", {x.base.base.loc})
+                                    }));
+                                throw SemanticAbort();
+                            }
+                        }
+                    }
                     ASRUtils::create_intrinsic_function create_func =
                         ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function(var_name);
 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -101,10 +101,10 @@ contains
         deallocate(s)
     end subroutine modify_and_deallocate
 
-
-
-
-
+    subroutine intrinsic_polymorphic(generic)
+        class(*), intent(in) :: generic
+        print *, trim(generic)
+    end subroutine intrinsic_polymorphic
 
 
 
@@ -482,6 +482,8 @@ program continue_compilation_1
     strx = "hello12345"
     call modify_and_deallocate(strx)
     print *, allocated(strx)
+
+    call intrinsic_polymorphic("  Hello World  ")
 
     contains
     subroutine sub(f)

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "9c28c0e93a697c270d1365fc1767bcb83940b4429e73d8b8753844ab",
+    "infile_hash": "00be0f23bbd3390fab9f8efb8ba306eaae3397a5c908d6a31d495bf8",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "3c85ae0ecb5bb7f1ff7d4de51e2d2bec0355e1d7a9e2e1a545901ea1",
+    "stderr_hash": "00abd21244e408bfb30fea53b940cb8f1467141903052eebdc71de20",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -251,6 +251,12 @@ semantic error: The upper bound of an assumed-size array's last dimension is not
 84 |         print *, ubound(c, 2)
    |                  ^^^^^^^^^^^^ 
 
+semantic error: Character intrinsic 'trim' with class(*) argument must be inside 'type is (character(len=*))' guard
+   --> tests/errors/continue_compilation_1.f90:106:18
+    |
+106 |         print *, trim(generic)
+    |                  ^^^^^^^^^^^^^ invalid use of character intrinsic with polymorphic argument
+
 semantic error: Intrinsic 'not_real' is not recognized
    --> tests/errors/continue_compilation_1.f90:179:14
     |


### PR DESCRIPTION
Towards #9328

Changes made:
- Add support for polymorphic variables inside `trim()`
- Add guardrails for using this behavior only inside select statements for characters, throw semantic error for using directly