### PR TITLE
fix: remove allocas from array deallocation and allocation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1822,6 +1822,7 @@ RUN(NAME allocate_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME allocate_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME allocate_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)

--- a/integration_tests/allocate_34.f90
+++ b/integration_tests/allocate_34.f90
@@ -1,0 +1,10 @@
+program allocate_34
+    implicit none
+    integer, allocatable :: arr(:)
+    integer :: i
+    allocate(arr(1))
+    do i = 1, 1000000
+        deallocate(arr)
+        allocate(arr(1))
+    end do
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1976,9 +1976,7 @@ public:
 
     inline void call_lfortran_free(llvm::Function* fn, llvm::Type* tmp_typ,  llvm::Type* llvm_data_type) {
         llvm::Value* arr = llvm_utils->CreateLoad2(llvm_data_type->getPointerTo(), arr_descr->get_pointer_to_data(tmp_typ, tmp));
-        llvm::AllocaInst *arg_arr = llvm_utils->CreateAlloca(*builder, character_type);
-        builder->CreateStore(builder->CreateBitCast(arr, character_type), arg_arr);
-        std::vector<llvm::Value*> args = { llvm_utils->CreateLoad2(character_type, arg_arr) };
+        std::vector<llvm::Value*> args = { builder->CreateBitCast(arr, character_type) };
         builder->CreateCall(fn, args);
         arr_descr->reset_is_allocated_flag(tmp_typ, tmp, llvm_data_type);
     }

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -375,7 +375,6 @@ namespace LCompilers {
                 prod = builder->CreateMul(prod, dim_size);
             }
             llvm::Value* ptr2firstptr = get_pointer_to_data(arr_type,  arr);
-            llvm::AllocaInst *arg_size = llvm_utils->CreateAlloca(*builder, llvm::Type::getInt32Ty(context));
 
             // Handle special allocation for strings. All Other types are handled the same.
             if(ASRUtils::is_character(*asr_type)){
@@ -391,15 +390,15 @@ namespace LCompilers {
                 uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
                 llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
                 prod = builder->CreateMul(prod, llvm_size);
-                builder->CreateStore(prod, arg_size);
+                llvm::Value* arg_size = builder->CreateBitCast(prod, llvm::Type::getInt32Ty(context));
                 llvm::Value* ptr_as_char_ptr = nullptr;
                 if( realloc ) {
                     ptr_as_char_ptr = lfortran_realloc(context, *module,
                         *builder, llvm_utils->CreateLoad2(llvm_data_type->getPointerTo(), ptr2firstptr),
-                        llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), arg_size));
+                        arg_size);
                 } else {
                     ptr_as_char_ptr = lfortran_malloc(context, *module,
-                        *builder, llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), arg_size));
+                        *builder, arg_size);
                 }
                 llvm::Value* first_ptr = builder->CreateBitCast(ptr_as_char_ptr, ptr_type);
                 builder->CreateStore(first_ptr, ptr2firstptr);

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "0b1a494e0d8e747a0ee55402e2168d041ca4f32a15447422c4fb0e28",
+    "stdout_hash": "9b747440ed33691ce98960e80a8ce0e6852f7a04d846f4c2c52ccdca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -206,17 +206,13 @@ ifcont:                                           ; preds = %merge_allocated
   store i32 1, i32* %31, align 4
   store i32 3, i32* %32, align 4
   %33 = getelementptr %array, %array* %17, i32 0, i32 0
-  %34 = alloca i32, align 4
-  store i32 108, i32* %34, align 4
-  %35 = load i32, i32* %34, align 4
-  %36 = sext i32 %35 to i64
-  %37 = call i8* @_lfortran_malloc(i64 %36)
-  %38 = bitcast i8* %37 to i32*
-  store i32* %38, i32** %33, align 8
+  %34 = call i8* @_lfortran_malloc(i64 108)
+  %35 = bitcast i8* %34 to i32*
+  store i32* %35, i32** %33, align 8
   store i32 0, i32* %stat2, align 4
-  %39 = load i32, i32* %stat2, align 4
-  %40 = icmp ne i32 %39, 0
-  br i1 %40, label %then3, label %else
+  %36 = load i32, i32* %stat2, align 4
+  %37 = icmp ne i32 %36, 0
+  br i1 %37, label %then3, label %else
 
 then3:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
@@ -227,22 +223,22 @@ else:                                             ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else, %then3
-  %41 = load %array*, %array** %c, align 8
-  %42 = ptrtoint %array* %41 to i64
-  %43 = icmp eq i64 %42, 0
-  br i1 %43, label %merge_allocated6, label %check_data5
+  %38 = load %array*, %array** %c, align 8
+  %39 = ptrtoint %array* %38 to i64
+  %40 = icmp eq i64 %39, 0
+  br i1 %40, label %merge_allocated6, label %check_data5
 
 check_data5:                                      ; preds = %ifcont4
-  %44 = getelementptr %array, %array* %41, i32 0, i32 0
-  %45 = load i32*, i32** %44, align 8
-  %46 = ptrtoint i32* %45 to i64
-  %47 = icmp ne i64 %46, 0
+  %41 = getelementptr %array, %array* %38, i32 0, i32 0
+  %42 = load i32*, i32** %41, align 8
+  %43 = ptrtoint i32* %42 to i64
+  %44 = icmp ne i64 %43, 0
   br label %merge_allocated6
 
 merge_allocated6:                                 ; preds = %check_data5, %ifcont4
-  %is_allocated7 = phi i1 [ false, %ifcont4 ], [ %47, %check_data5 ]
-  %48 = xor i1 %is_allocated7, true
-  br i1 %48, label %then8, label %ifcont9
+  %is_allocated7 = phi i1 [ false, %ifcont4 ], [ %44, %check_data5 ]
+  %45 = xor i1 %is_allocated7, true
+  br i1 %45, label %then8, label %ifcont9
 
 then8:                                            ; preds = %merge_allocated6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0))
@@ -250,110 +246,107 @@ then8:                                            ; preds = %merge_allocated6
   unreachable
 
 ifcont9:                                          ; preds = %merge_allocated6
-  %49 = getelementptr %array, %array* %41, i32 0, i32 2
-  %50 = load %dimension_descriptor*, %dimension_descriptor** %49, align 8
-  %51 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %50, i32 0
-  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 1
-  %53 = load i32, i32* %52, align 4
-  %54 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 2
-  %55 = load i32, i32* %54, align 4
-  %56 = sub i32 1, %53
-  %57 = add i32 %53, %55
-  %58 = sub i32 %57, 1
-  %59 = icmp slt i32 1, %53
-  %60 = icmp sgt i32 1, %58
-  %61 = or i1 %59, %60
-  br i1 %61, label %then10, label %ifcont11
+  %46 = getelementptr %array, %array* %38, i32 0, i32 2
+  %47 = load %dimension_descriptor*, %dimension_descriptor** %46, align 8
+  %48 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %47, i32 0
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 1
+  %50 = load i32, i32* %49, align 4
+  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 2
+  %52 = load i32, i32* %51, align 4
+  %53 = sub i32 1, %50
+  %54 = add i32 %50, %52
+  %55 = sub i32 %54, 1
+  %56 = icmp slt i32 1, %50
+  %57 = icmp sgt i32 1, %55
+  %58 = or i1 %56, %57
+  br i1 %58, label %then10, label %ifcont11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @94, i32 0, i32 0), i32 1, i32 1, i32 %53, i32 %58)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @94, i32 0, i32 0), i32 1, i32 1, i32 %50, i32 %55)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 0
-  %63 = load i32, i32* %62, align 4
-  %64 = mul i32 %63, %56
-  %65 = add i32 0, %64
-  %66 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %50, i32 1
-  %67 = getelementptr %dimension_descriptor, %dimension_descriptor* %66, i32 0, i32 1
-  %68 = load i32, i32* %67, align 4
-  %69 = getelementptr %dimension_descriptor, %dimension_descriptor* %66, i32 0, i32 2
-  %70 = load i32, i32* %69, align 4
-  %71 = sub i32 1, %68
-  %72 = add i32 %68, %70
-  %73 = sub i32 %72, 1
-  %74 = icmp slt i32 1, %68
-  %75 = icmp sgt i32 1, %73
-  %76 = or i1 %74, %75
-  br i1 %76, label %then12, label %ifcont13
+  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 0
+  %60 = load i32, i32* %59, align 4
+  %61 = mul i32 %60, %53
+  %62 = add i32 0, %61
+  %63 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %47, i32 1
+  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 1
+  %65 = load i32, i32* %64, align 4
+  %66 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 2
+  %67 = load i32, i32* %66, align 4
+  %68 = sub i32 1, %65
+  %69 = add i32 %65, %67
+  %70 = sub i32 %69, 1
+  %71 = icmp slt i32 1, %65
+  %72 = icmp sgt i32 1, %70
+  %73 = or i1 %71, %72
+  br i1 %73, label %then12, label %ifcont13
 
 then12:                                           ; preds = %ifcont11
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i32 1, i32 2, i32 %68, i32 %73)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i32 1, i32 2, i32 %65, i32 %70)
   call void @exit(i32 1)
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %77 = getelementptr %dimension_descriptor, %dimension_descriptor* %66, i32 0, i32 0
-  %78 = load i32, i32* %77, align 4
-  %79 = mul i32 %78, %71
-  %80 = add i32 %65, %79
-  %81 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %50, i32 2
-  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %81, i32 0, i32 1
-  %83 = load i32, i32* %82, align 4
-  %84 = getelementptr %dimension_descriptor, %dimension_descriptor* %81, i32 0, i32 2
-  %85 = load i32, i32* %84, align 4
-  %86 = sub i32 1, %83
-  %87 = add i32 %83, %85
-  %88 = sub i32 %87, 1
-  %89 = icmp slt i32 1, %83
-  %90 = icmp sgt i32 1, %88
-  %91 = or i1 %89, %90
-  br i1 %91, label %then14, label %ifcont15
+  %74 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 0
+  %75 = load i32, i32* %74, align 4
+  %76 = mul i32 %75, %68
+  %77 = add i32 %62, %76
+  %78 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %47, i32 2
+  %79 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 1
+  %80 = load i32, i32* %79, align 4
+  %81 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 2
+  %82 = load i32, i32* %81, align 4
+  %83 = sub i32 1, %80
+  %84 = add i32 %80, %82
+  %85 = sub i32 %84, 1
+  %86 = icmp slt i32 1, %80
+  %87 = icmp sgt i32 1, %85
+  %88 = or i1 %86, %87
+  br i1 %88, label %then14, label %ifcont15
 
 then14:                                           ; preds = %ifcont13
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @98, i32 0, i32 0), i32 1, i32 3, i32 %83, i32 %88)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @98, i32 0, i32 0), i32 1, i32 3, i32 %80, i32 %85)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
-  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %81, i32 0, i32 0
-  %93 = load i32, i32* %92, align 4
-  %94 = mul i32 %93, %86
-  %95 = add i32 %80, %94
-  %96 = getelementptr %array, %array* %41, i32 0, i32 1
-  %97 = load i32, i32* %96, align 4
-  %98 = add i32 %95, %97
-  %99 = getelementptr %array, %array* %41, i32 0, i32 0
-  %100 = load i32*, i32** %99, align 8
-  %101 = getelementptr inbounds i32, i32* %100, i32 %98
-  store i32 3, i32* %101, align 4
-  %102 = load %array*, %array** %c, align 8
-  %103 = ptrtoint %array* %102 to i64
-  %104 = icmp eq i64 %103, 0
-  br i1 %104, label %merge_allocated17, label %check_data16
+  %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 0
+  %90 = load i32, i32* %89, align 4
+  %91 = mul i32 %90, %83
+  %92 = add i32 %77, %91
+  %93 = getelementptr %array, %array* %38, i32 0, i32 1
+  %94 = load i32, i32* %93, align 4
+  %95 = add i32 %92, %94
+  %96 = getelementptr %array, %array* %38, i32 0, i32 0
+  %97 = load i32*, i32** %96, align 8
+  %98 = getelementptr inbounds i32, i32* %97, i32 %95
+  store i32 3, i32* %98, align 4
+  %99 = load %array*, %array** %c, align 8
+  %100 = ptrtoint %array* %99 to i64
+  %101 = icmp eq i64 %100, 0
+  br i1 %101, label %merge_allocated17, label %check_data16
 
 check_data16:                                     ; preds = %ifcont15
-  %105 = getelementptr %array, %array* %102, i32 0, i32 0
-  %106 = load i32*, i32** %105, align 8
-  %107 = ptrtoint i32* %106 to i64
-  %108 = icmp ne i64 %107, 0
+  %102 = getelementptr %array, %array* %99, i32 0, i32 0
+  %103 = load i32*, i32** %102, align 8
+  %104 = ptrtoint i32* %103 to i64
+  %105 = icmp ne i64 %104, 0
   br label %merge_allocated17
 
 merge_allocated17:                                ; preds = %check_data16, %ifcont15
-  %is_allocated18 = phi i1 [ false, %ifcont15 ], [ %108, %check_data16 ]
+  %is_allocated18 = phi i1 [ false, %ifcont15 ], [ %105, %check_data16 ]
   br i1 %is_allocated18, label %then19, label %else20
 
 then19:                                           ; preds = %merge_allocated17
-  %109 = getelementptr %array, %array* %102, i32 0, i32 0
-  %110 = load i32*, i32** %109, align 8
-  %111 = alloca i8*, align 8
-  %112 = bitcast i32* %110 to i8*
-  store i8* %112, i8** %111, align 8
-  %113 = load i8*, i8** %111, align 8
-  call void @_lfortran_free(i8* %113)
-  %114 = getelementptr %array, %array* %102, i32 0, i32 0
-  store i32* null, i32** %114, align 8
+  %106 = getelementptr %array, %array* %99, i32 0, i32 0
+  %107 = load i32*, i32** %106, align 8
+  %108 = bitcast i32* %107 to i8*
+  call void @_lfortran_free(i8* %108)
+  %109 = getelementptr %array, %array* %99, i32 0, i32 0
+  store i32* null, i32** %109, align 8
   br label %ifcont21
 
 else20:                                           ; preds = %merge_allocated17
@@ -361,24 +354,24 @@ else20:                                           ; preds = %merge_allocated17
 
 ifcont21:                                         ; preds = %else20, %then19
   call void @h(%array** %c)
-  %115 = call i32 @g(%array** %c)
-  store i32 %115, i32* %r1, align 4
-  %116 = load %array*, %array** %c, align 8
-  %117 = ptrtoint %array* %116 to i64
-  %118 = icmp eq i64 %117, 0
-  br i1 %118, label %merge_allocated23, label %check_data22
+  %110 = call i32 @g(%array** %c)
+  store i32 %110, i32* %r1, align 4
+  %111 = load %array*, %array** %c, align 8
+  %112 = ptrtoint %array* %111 to i64
+  %113 = icmp eq i64 %112, 0
+  br i1 %113, label %merge_allocated23, label %check_data22
 
 check_data22:                                     ; preds = %ifcont21
-  %119 = getelementptr %array, %array* %116, i32 0, i32 0
-  %120 = load i32*, i32** %119, align 8
-  %121 = ptrtoint i32* %120 to i64
-  %122 = icmp ne i64 %121, 0
+  %114 = getelementptr %array, %array* %111, i32 0, i32 0
+  %115 = load i32*, i32** %114, align 8
+  %116 = ptrtoint i32* %115 to i64
+  %117 = icmp ne i64 %116, 0
   br label %merge_allocated23
 
 merge_allocated23:                                ; preds = %check_data22, %ifcont21
-  %is_allocated24 = phi i1 [ false, %ifcont21 ], [ %122, %check_data22 ]
-  %123 = xor i1 %is_allocated24, true
-  br i1 %123, label %then25, label %ifcont26
+  %is_allocated24 = phi i1 [ false, %ifcont21 ], [ %117, %check_data22 ]
+  %118 = xor i1 %is_allocated24, true
+  br i1 %118, label %then25, label %ifcont26
 
 then25:                                           ; preds = %merge_allocated23
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
@@ -386,86 +379,86 @@ then25:                                           ; preds = %merge_allocated23
   unreachable
 
 ifcont26:                                         ; preds = %merge_allocated23
-  %124 = getelementptr %array, %array* %116, i32 0, i32 2
-  %125 = load %dimension_descriptor*, %dimension_descriptor** %124, align 8
-  %126 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %125, i32 0
-  %127 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 1
-  %128 = load i32, i32* %127, align 4
-  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 2
-  %130 = load i32, i32* %129, align 4
-  %131 = sub i32 1, %128
-  %132 = add i32 %128, %130
-  %133 = sub i32 %132, 1
-  %134 = icmp slt i32 1, %128
-  %135 = icmp sgt i32 1, %133
-  %136 = or i1 %134, %135
-  br i1 %136, label %then27, label %ifcont28
+  %119 = getelementptr %array, %array* %111, i32 0, i32 2
+  %120 = load %dimension_descriptor*, %dimension_descriptor** %119, align 8
+  %121 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 0
+  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 1
+  %123 = load i32, i32* %122, align 4
+  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 2
+  %125 = load i32, i32* %124, align 4
+  %126 = sub i32 1, %123
+  %127 = add i32 %123, %125
+  %128 = sub i32 %127, 1
+  %129 = icmp slt i32 1, %123
+  %130 = icmp sgt i32 1, %128
+  %131 = or i1 %129, %130
+  br i1 %131, label %then27, label %ifcont28
 
 then27:                                           ; preds = %ifcont26
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i32 1, i32 1, i32 %128, i32 %133)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i32 1, i32 1, i32 %123, i32 %128)
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %ifcont26
-  %137 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 0
+  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
+  %133 = load i32, i32* %132, align 4
+  %134 = mul i32 %133, %126
+  %135 = add i32 0, %134
+  %136 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 1
+  %137 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 1
   %138 = load i32, i32* %137, align 4
-  %139 = mul i32 %138, %131
-  %140 = add i32 0, %139
-  %141 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %125, i32 1
-  %142 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 1
-  %143 = load i32, i32* %142, align 4
-  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 2
-  %145 = load i32, i32* %144, align 4
-  %146 = sub i32 1, %143
-  %147 = add i32 %143, %145
-  %148 = sub i32 %147, 1
-  %149 = icmp slt i32 1, %143
-  %150 = icmp sgt i32 1, %148
-  %151 = or i1 %149, %150
-  br i1 %151, label %then29, label %ifcont30
+  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 2
+  %140 = load i32, i32* %139, align 4
+  %141 = sub i32 1, %138
+  %142 = add i32 %138, %140
+  %143 = sub i32 %142, 1
+  %144 = icmp slt i32 1, %138
+  %145 = icmp sgt i32 1, %143
+  %146 = or i1 %144, %145
+  br i1 %146, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i32 1, i32 2, i32 %143, i32 %148)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i32 1, i32 2, i32 %138, i32 %143)
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %152 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 0
+  %147 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 0
+  %148 = load i32, i32* %147, align 4
+  %149 = mul i32 %148, %141
+  %150 = add i32 %135, %149
+  %151 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 2
+  %152 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 1
   %153 = load i32, i32* %152, align 4
-  %154 = mul i32 %153, %146
-  %155 = add i32 %140, %154
-  %156 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %125, i32 2
-  %157 = getelementptr %dimension_descriptor, %dimension_descriptor* %156, i32 0, i32 1
-  %158 = load i32, i32* %157, align 4
-  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %156, i32 0, i32 2
-  %160 = load i32, i32* %159, align 4
-  %161 = sub i32 1, %158
-  %162 = add i32 %158, %160
-  %163 = sub i32 %162, 1
-  %164 = icmp slt i32 1, %158
-  %165 = icmp sgt i32 1, %163
-  %166 = or i1 %164, %165
-  br i1 %166, label %then31, label %ifcont32
+  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 2
+  %155 = load i32, i32* %154, align 4
+  %156 = sub i32 1, %153
+  %157 = add i32 %153, %155
+  %158 = sub i32 %157, 1
+  %159 = icmp slt i32 1, %153
+  %160 = icmp sgt i32 1, %158
+  %161 = or i1 %159, %160
+  br i1 %161, label %then31, label %ifcont32
 
 then31:                                           ; preds = %ifcont30
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i32 1, i32 3, i32 %158, i32 %163)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i32 1, i32 3, i32 %153, i32 %158)
   call void @exit(i32 1)
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %167 = getelementptr %dimension_descriptor, %dimension_descriptor* %156, i32 0, i32 0
-  %168 = load i32, i32* %167, align 4
-  %169 = mul i32 %168, %161
-  %170 = add i32 %155, %169
-  %171 = getelementptr %array, %array* %116, i32 0, i32 1
+  %162 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 0
+  %163 = load i32, i32* %162, align 4
+  %164 = mul i32 %163, %156
+  %165 = add i32 %150, %164
+  %166 = getelementptr %array, %array* %111, i32 0, i32 1
+  %167 = load i32, i32* %166, align 4
+  %168 = add i32 %165, %167
+  %169 = getelementptr %array, %array* %111, i32 0, i32 0
+  %170 = load i32*, i32** %169, align 8
+  %171 = getelementptr inbounds i32, i32* %170, i32 %168
   %172 = load i32, i32* %171, align 4
-  %173 = add i32 %170, %172
-  %174 = getelementptr %array, %array* %116, i32 0, i32 0
-  %175 = load i32*, i32** %174, align 8
-  %176 = getelementptr inbounds i32, i32* %175, i32 %173
-  %177 = load i32, i32* %176, align 4
-  %178 = icmp ne i32 %177, 8
-  br i1 %178, label %then33, label %else34
+  %173 = icmp ne i32 %172, 8
+  br i1 %173, label %then33, label %else34
 
 then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0))
@@ -476,23 +469,23 @@ else34:                                           ; preds = %ifcont32
   br label %ifcont35
 
 ifcont35:                                         ; preds = %else34, %then33
-  %179 = alloca i64, align 8
-  %180 = load %array*, %array** %c, align 8
-  %181 = ptrtoint %array* %180 to i64
-  %182 = icmp eq i64 %181, 0
-  br i1 %182, label %merge_allocated37, label %check_data36
+  %174 = alloca i64, align 8
+  %175 = load %array*, %array** %c, align 8
+  %176 = ptrtoint %array* %175 to i64
+  %177 = icmp eq i64 %176, 0
+  br i1 %177, label %merge_allocated37, label %check_data36
 
 check_data36:                                     ; preds = %ifcont35
-  %183 = getelementptr %array, %array* %180, i32 0, i32 0
-  %184 = load i32*, i32** %183, align 8
-  %185 = ptrtoint i32* %184 to i64
-  %186 = icmp ne i64 %185, 0
+  %178 = getelementptr %array, %array* %175, i32 0, i32 0
+  %179 = load i32*, i32** %178, align 8
+  %180 = ptrtoint i32* %179 to i64
+  %181 = icmp ne i64 %180, 0
   br label %merge_allocated37
 
 merge_allocated37:                                ; preds = %check_data36, %ifcont35
-  %is_allocated38 = phi i1 [ false, %ifcont35 ], [ %186, %check_data36 ]
-  %187 = xor i1 %is_allocated38, true
-  br i1 %187, label %then39, label %ifcont40
+  %is_allocated38 = phi i1 [ false, %ifcont35 ], [ %181, %check_data36 ]
+  %182 = xor i1 %is_allocated38, true
+  br i1 %182, label %then39, label %ifcont40
 
 then39:                                           ; preds = %merge_allocated37
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @112, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @111, i32 0, i32 0))
@@ -500,100 +493,100 @@ then39:                                           ; preds = %merge_allocated37
   unreachable
 
 ifcont40:                                         ; preds = %merge_allocated37
-  %188 = getelementptr %array, %array* %180, i32 0, i32 2
-  %189 = load %dimension_descriptor*, %dimension_descriptor** %188, align 8
-  %190 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %189, i32 0
-  %191 = getelementptr %dimension_descriptor, %dimension_descriptor* %190, i32 0, i32 1
-  %192 = load i32, i32* %191, align 4
-  %193 = getelementptr %dimension_descriptor, %dimension_descriptor* %190, i32 0, i32 2
-  %194 = load i32, i32* %193, align 4
-  %195 = sub i32 1, %192
-  %196 = add i32 %192, %194
-  %197 = sub i32 %196, 1
-  %198 = icmp slt i32 1, %192
-  %199 = icmp sgt i32 1, %197
-  %200 = or i1 %198, %199
-  br i1 %200, label %then41, label %ifcont42
+  %183 = getelementptr %array, %array* %175, i32 0, i32 2
+  %184 = load %dimension_descriptor*, %dimension_descriptor** %183, align 8
+  %185 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 0
+  %186 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 1
+  %187 = load i32, i32* %186, align 4
+  %188 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 2
+  %189 = load i32, i32* %188, align 4
+  %190 = sub i32 1, %187
+  %191 = add i32 %187, %189
+  %192 = sub i32 %191, 1
+  %193 = icmp slt i32 1, %187
+  %194 = icmp sgt i32 1, %192
+  %195 = or i1 %193, %194
+  br i1 %195, label %then41, label %ifcont42
 
 then41:                                           ; preds = %ifcont40
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @114, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @113, i32 0, i32 0), i32 1, i32 1, i32 %192, i32 %197)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @114, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @113, i32 0, i32 0), i32 1, i32 1, i32 %187, i32 %192)
   call void @exit(i32 1)
   unreachable
 
 ifcont42:                                         ; preds = %ifcont40
-  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %190, i32 0, i32 0
+  %196 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 0
+  %197 = load i32, i32* %196, align 4
+  %198 = mul i32 %197, %190
+  %199 = add i32 0, %198
+  %200 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 1
+  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 1
   %202 = load i32, i32* %201, align 4
-  %203 = mul i32 %202, %195
-  %204 = add i32 0, %203
-  %205 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %189, i32 1
-  %206 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 1
-  %207 = load i32, i32* %206, align 4
-  %208 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 2
-  %209 = load i32, i32* %208, align 4
-  %210 = sub i32 1, %207
-  %211 = add i32 %207, %209
-  %212 = sub i32 %211, 1
-  %213 = icmp slt i32 1, %207
-  %214 = icmp sgt i32 1, %212
-  %215 = or i1 %213, %214
-  br i1 %215, label %then43, label %ifcont44
+  %203 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 2
+  %204 = load i32, i32* %203, align 4
+  %205 = sub i32 1, %202
+  %206 = add i32 %202, %204
+  %207 = sub i32 %206, 1
+  %208 = icmp slt i32 1, %202
+  %209 = icmp sgt i32 1, %207
+  %210 = or i1 %208, %209
+  br i1 %210, label %then43, label %ifcont44
 
 then43:                                           ; preds = %ifcont42
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @116, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @115, i32 0, i32 0), i32 1, i32 2, i32 %207, i32 %212)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @116, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @115, i32 0, i32 0), i32 1, i32 2, i32 %202, i32 %207)
   call void @exit(i32 1)
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %216 = getelementptr %dimension_descriptor, %dimension_descriptor* %205, i32 0, i32 0
+  %211 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 0
+  %212 = load i32, i32* %211, align 4
+  %213 = mul i32 %212, %205
+  %214 = add i32 %199, %213
+  %215 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 2
+  %216 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 1
   %217 = load i32, i32* %216, align 4
-  %218 = mul i32 %217, %210
-  %219 = add i32 %204, %218
-  %220 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %189, i32 2
-  %221 = getelementptr %dimension_descriptor, %dimension_descriptor* %220, i32 0, i32 1
-  %222 = load i32, i32* %221, align 4
-  %223 = getelementptr %dimension_descriptor, %dimension_descriptor* %220, i32 0, i32 2
-  %224 = load i32, i32* %223, align 4
-  %225 = sub i32 1, %222
-  %226 = add i32 %222, %224
-  %227 = sub i32 %226, 1
-  %228 = icmp slt i32 1, %222
-  %229 = icmp sgt i32 1, %227
-  %230 = or i1 %228, %229
-  br i1 %230, label %then45, label %ifcont46
+  %218 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 2
+  %219 = load i32, i32* %218, align 4
+  %220 = sub i32 1, %217
+  %221 = add i32 %217, %219
+  %222 = sub i32 %221, 1
+  %223 = icmp slt i32 1, %217
+  %224 = icmp sgt i32 1, %222
+  %225 = or i1 %223, %224
+  br i1 %225, label %then45, label %ifcont46
 
 then45:                                           ; preds = %ifcont44
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @118, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @117, i32 0, i32 0), i32 1, i32 3, i32 %222, i32 %227)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @118, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @117, i32 0, i32 0), i32 1, i32 3, i32 %217, i32 %222)
   call void @exit(i32 1)
   unreachable
 
 ifcont46:                                         ; preds = %ifcont44
-  %231 = getelementptr %dimension_descriptor, %dimension_descriptor* %220, i32 0, i32 0
-  %232 = load i32, i32* %231, align 4
-  %233 = mul i32 %232, %225
-  %234 = add i32 %219, %233
-  %235 = getelementptr %array, %array* %180, i32 0, i32 1
+  %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 0
+  %227 = load i32, i32* %226, align 4
+  %228 = mul i32 %227, %220
+  %229 = add i32 %214, %228
+  %230 = getelementptr %array, %array* %175, i32 0, i32 1
+  %231 = load i32, i32* %230, align 4
+  %232 = add i32 %229, %231
+  %233 = getelementptr %array, %array* %175, i32 0, i32 0
+  %234 = load i32*, i32** %233, align 8
+  %235 = getelementptr inbounds i32, i32* %234, i32 %232
   %236 = load i32, i32* %235, align 4
-  %237 = add i32 %234, %236
-  %238 = getelementptr %array, %array* %180, i32 0, i32 0
-  %239 = load i32*, i32** %238, align 8
-  %240 = getelementptr inbounds i32, i32* %239, i32 %237
-  %241 = load i32, i32* %240, align 4
-  %242 = alloca i32, align 4
-  store i32 %241, i32* %242, align 4
-  %243 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %179, i32 0, i32 0, i32* %242)
-  %244 = load i64, i64* %179, align 4
+  %237 = alloca i32, align 4
+  store i32 %236, i32* %237, align 4
+  %238 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %174, i32 0, i32 0, i32* %237)
+  %239 = load i64, i64* %174, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %245 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %243, i8** %245, align 8
-  %246 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %244, i64* %246, align 4
-  %247 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %248 = load i8*, i8** %247, align 8
-  %249 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %250 = load i64, i64* %249, align 4
-  %251 = trunc i64 %250 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @119, i32 0, i32 0), i8* %248, i32 %251, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
-  call void @_lfortran_free(i8* %243)
+  %240 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %238, i8** %240, align 8
+  %241 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %239, i64* %241, align 4
+  %242 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %243 = load i8*, i8** %242, align 8
+  %244 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %245 = load i64, i64* %244, align 4
+  %246 = trunc i64 %245 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @119, i32 0, i32 0), i8* %243, i32 %246, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
+  call void @_lfortran_free(i8* %238)
   call void @_lpython_free_argv()
   br label %return
 
@@ -604,11 +597,11 @@ FINALIZE_SYMTABLE_allocate_03:                    ; preds = %return
   br label %Finalize_Variable_c
 
 Finalize_Variable_c:                              ; preds = %FINALIZE_SYMTABLE_allocate_03
-  %252 = load %array*, %array** %c, align 8
-  %253 = getelementptr %array, %array* %252, i32 0, i32 0
-  %254 = load i32*, i32** %253, align 8
-  %255 = bitcast i32* %254 to i8*
-  call void @_lfortran_free(i8* %255)
+  %247 = load %array*, %array** %c, align 8
+  %248 = getelementptr %array, %array* %247, i32 0, i32 0
+  %249 = load i32*, i32** %248, align 8
+  %250 = bitcast i32* %249 to i8*
+  call void @_lfortran_free(i8* %250)
   ret i32 0
 }
 
@@ -651,13 +644,10 @@ merge_allocated2:                                 ; preds = %check_data1, %then
 then4:                                            ; preds = %merge_allocated2
   %15 = getelementptr %array, %array* %8, i32 0, i32 0
   %16 = load i32*, i32** %15, align 8
-  %17 = alloca i8*, align 8
-  %18 = bitcast i32* %16 to i8*
-  store i8* %18, i8** %17, align 8
-  %19 = load i8*, i8** %17, align 8
-  call void @_lfortran_free(i8* %19)
-  %20 = getelementptr %array, %array* %8, i32 0, i32 0
-  store i32* null, i32** %20, align 8
+  %17 = bitcast i32* %16 to i8*
+  call void @_lfortran_free(i8* %17)
+  %18 = getelementptr %array, %array* %8, i32 0, i32 0
+  store i32* null, i32** %18, align 8
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated2
@@ -670,20 +660,20 @@ else5:                                            ; preds = %merge_allocated
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %ifcont
-  %21 = load %array*, %array** %c, align 8
-  %22 = ptrtoint %array* %21 to i64
-  %23 = icmp eq i64 %22, 0
-  br i1 %23, label %merge_allocated8, label %check_data7
+  %19 = load %array*, %array** %c, align 8
+  %20 = ptrtoint %array* %19 to i64
+  %21 = icmp eq i64 %20, 0
+  br i1 %21, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %ifcont6
-  %24 = getelementptr %array, %array* %21, i32 0, i32 0
-  %25 = load i32*, i32** %24, align 8
-  %26 = ptrtoint i32* %25 to i64
-  %27 = icmp ne i64 %26, 0
+  %22 = getelementptr %array, %array* %19, i32 0, i32 0
+  %23 = load i32*, i32** %22, align 8
+  %24 = ptrtoint i32* %23 to i64
+  %25 = icmp ne i64 %24, 0
   br label %merge_allocated8
 
 merge_allocated8:                                 ; preds = %check_data7, %ifcont6
-  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %27, %check_data7 ]
+  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %25, %check_data7 ]
   br i1 %is_allocated9, label %then10, label %ifcont11
 
 then10:                                           ; preds = %merge_allocated8
@@ -692,56 +682,52 @@ then10:                                           ; preds = %merge_allocated8
   unreachable
 
 ifcont11:                                         ; preds = %merge_allocated8
-  %28 = load %array*, %array** %c, align 8
-  %29 = getelementptr %array, %array* %28, i32 0, i32 1
-  store i32 0, i32* %29, align 4
-  %30 = getelementptr %array, %array* %28, i32 0, i32 2
-  %31 = load %dimension_descriptor*, %dimension_descriptor** %30, align 8
-  %32 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 0
-  %33 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 0
-  %34 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 1
-  %35 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 2
-  store i32 1, i32* %33, align 4
-  store i32 1, i32* %34, align 4
+  %26 = load %array*, %array** %c, align 8
+  %27 = getelementptr %array, %array* %26, i32 0, i32 1
+  store i32 0, i32* %27, align 4
+  %28 = getelementptr %array, %array* %26, i32 0, i32 2
+  %29 = load %dimension_descriptor*, %dimension_descriptor** %28, align 8
+  %30 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %29, i32 0
+  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %30, i32 0, i32 0
+  %32 = getelementptr %dimension_descriptor, %dimension_descriptor* %30, i32 0, i32 1
+  %33 = getelementptr %dimension_descriptor, %dimension_descriptor* %30, i32 0, i32 2
+  store i32 1, i32* %31, align 4
+  store i32 1, i32* %32, align 4
+  store i32 3, i32* %33, align 4
+  %34 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %29, i32 1
+  %35 = getelementptr %dimension_descriptor, %dimension_descriptor* %34, i32 0, i32 0
+  %36 = getelementptr %dimension_descriptor, %dimension_descriptor* %34, i32 0, i32 1
+  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %34, i32 0, i32 2
   store i32 3, i32* %35, align 4
-  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 1
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
+  store i32 1, i32* %36, align 4
   store i32 3, i32* %37, align 4
-  store i32 1, i32* %38, align 4
-  store i32 3, i32* %39, align 4
-  %40 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 2
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 0
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 1
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 2
-  store i32 9, i32* %41, align 4
-  store i32 1, i32* %42, align 4
-  store i32 3, i32* %43, align 4
-  %44 = getelementptr %array, %array* %28, i32 0, i32 0
-  %45 = alloca i32, align 4
-  store i32 108, i32* %45, align 4
-  %46 = load i32, i32* %45, align 4
-  %47 = sext i32 %46 to i64
-  %48 = call i8* @_lfortran_malloc(i64 %47)
-  %49 = bitcast i8* %48 to i32*
-  store i32* %49, i32** %44, align 8
-  %50 = load %array*, %array** %c, align 8
-  %51 = ptrtoint %array* %50 to i64
-  %52 = icmp eq i64 %51, 0
-  br i1 %52, label %merge_allocated13, label %check_data12
+  %38 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %29, i32 2
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 0
+  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 1
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 2
+  store i32 9, i32* %39, align 4
+  store i32 1, i32* %40, align 4
+  store i32 3, i32* %41, align 4
+  %42 = getelementptr %array, %array* %26, i32 0, i32 0
+  %43 = call i8* @_lfortran_malloc(i64 108)
+  %44 = bitcast i8* %43 to i32*
+  store i32* %44, i32** %42, align 8
+  %45 = load %array*, %array** %c, align 8
+  %46 = ptrtoint %array* %45 to i64
+  %47 = icmp eq i64 %46, 0
+  br i1 %47, label %merge_allocated13, label %check_data12
 
 check_data12:                                     ; preds = %ifcont11
-  %53 = getelementptr %array, %array* %50, i32 0, i32 0
-  %54 = load i32*, i32** %53, align 8
-  %55 = ptrtoint i32* %54 to i64
-  %56 = icmp ne i64 %55, 0
+  %48 = getelementptr %array, %array* %45, i32 0, i32 0
+  %49 = load i32*, i32** %48, align 8
+  %50 = ptrtoint i32* %49 to i64
+  %51 = icmp ne i64 %50, 0
   br label %merge_allocated13
 
 merge_allocated13:                                ; preds = %check_data12, %ifcont11
-  %is_allocated14 = phi i1 [ false, %ifcont11 ], [ %56, %check_data12 ]
-  %57 = xor i1 %is_allocated14, true
-  br i1 %57, label %then15, label %ifcont16
+  %is_allocated14 = phi i1 [ false, %ifcont11 ], [ %51, %check_data12 ]
+  %52 = xor i1 %is_allocated14, true
+  br i1 %52, label %then15, label %ifcont16
 
 then15:                                           ; preds = %merge_allocated13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
@@ -749,84 +735,84 @@ then15:                                           ; preds = %merge_allocated13
   unreachable
 
 ifcont16:                                         ; preds = %merge_allocated13
-  %58 = getelementptr %array, %array* %50, i32 0, i32 2
-  %59 = load %dimension_descriptor*, %dimension_descriptor** %58, align 8
-  %60 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %59, i32 0
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 1
-  %62 = load i32, i32* %61, align 4
-  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 2
-  %64 = load i32, i32* %63, align 4
-  %65 = sub i32 1, %62
-  %66 = add i32 %62, %64
-  %67 = sub i32 %66, 1
-  %68 = icmp slt i32 1, %62
-  %69 = icmp sgt i32 1, %67
-  %70 = or i1 %68, %69
-  br i1 %70, label %then17, label %ifcont18
+  %53 = getelementptr %array, %array* %45, i32 0, i32 2
+  %54 = load %dimension_descriptor*, %dimension_descriptor** %53, align 8
+  %55 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 0
+  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 1
+  %57 = load i32, i32* %56, align 4
+  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 2
+  %59 = load i32, i32* %58, align 4
+  %60 = sub i32 1, %57
+  %61 = add i32 %57, %59
+  %62 = sub i32 %61, 1
+  %63 = icmp slt i32 1, %57
+  %64 = icmp sgt i32 1, %62
+  %65 = or i1 %63, %64
+  br i1 %65, label %then17, label %ifcont18
 
 then17:                                           ; preds = %ifcont16
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1, i32 1, i32 %62, i32 %67)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1, i32 1, i32 %57, i32 %62)
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %ifcont16
-  %71 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 0
+  %66 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 0
+  %67 = load i32, i32* %66, align 4
+  %68 = mul i32 %67, %60
+  %69 = add i32 0, %68
+  %70 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 1
+  %71 = getelementptr %dimension_descriptor, %dimension_descriptor* %70, i32 0, i32 1
   %72 = load i32, i32* %71, align 4
-  %73 = mul i32 %72, %65
-  %74 = add i32 0, %73
-  %75 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %59, i32 1
-  %76 = getelementptr %dimension_descriptor, %dimension_descriptor* %75, i32 0, i32 1
-  %77 = load i32, i32* %76, align 4
-  %78 = getelementptr %dimension_descriptor, %dimension_descriptor* %75, i32 0, i32 2
-  %79 = load i32, i32* %78, align 4
-  %80 = sub i32 1, %77
-  %81 = add i32 %77, %79
-  %82 = sub i32 %81, 1
-  %83 = icmp slt i32 1, %77
-  %84 = icmp sgt i32 1, %82
-  %85 = or i1 %83, %84
-  br i1 %85, label %then19, label %ifcont20
+  %73 = getelementptr %dimension_descriptor, %dimension_descriptor* %70, i32 0, i32 2
+  %74 = load i32, i32* %73, align 4
+  %75 = sub i32 1, %72
+  %76 = add i32 %72, %74
+  %77 = sub i32 %76, 1
+  %78 = icmp slt i32 1, %72
+  %79 = icmp sgt i32 1, %77
+  %80 = or i1 %78, %79
+  br i1 %80, label %then19, label %ifcont20
 
 then19:                                           ; preds = %ifcont18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1, i32 2, i32 %77, i32 %82)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1, i32 2, i32 %72, i32 %77)
   call void @exit(i32 1)
   unreachable
 
 ifcont20:                                         ; preds = %ifcont18
-  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %75, i32 0, i32 0
+  %81 = getelementptr %dimension_descriptor, %dimension_descriptor* %70, i32 0, i32 0
+  %82 = load i32, i32* %81, align 4
+  %83 = mul i32 %82, %75
+  %84 = add i32 %69, %83
+  %85 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 2
+  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %85, i32 0, i32 1
   %87 = load i32, i32* %86, align 4
-  %88 = mul i32 %87, %80
-  %89 = add i32 %74, %88
-  %90 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %59, i32 2
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
-  %92 = load i32, i32* %91, align 4
-  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
-  %94 = load i32, i32* %93, align 4
-  %95 = sub i32 1, %92
-  %96 = add i32 %92, %94
-  %97 = sub i32 %96, 1
-  %98 = icmp slt i32 1, %92
-  %99 = icmp sgt i32 1, %97
-  %100 = or i1 %98, %99
-  br i1 %100, label %then21, label %ifcont22
+  %88 = getelementptr %dimension_descriptor, %dimension_descriptor* %85, i32 0, i32 2
+  %89 = load i32, i32* %88, align 4
+  %90 = sub i32 1, %87
+  %91 = add i32 %87, %89
+  %92 = sub i32 %91, 1
+  %93 = icmp slt i32 1, %87
+  %94 = icmp sgt i32 1, %92
+  %95 = or i1 %93, %94
+  br i1 %95, label %then21, label %ifcont22
 
 then21:                                           ; preds = %ifcont20
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1, i32 3, i32 %92, i32 %97)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1, i32 3, i32 %87, i32 %92)
   call void @exit(i32 1)
   unreachable
 
 ifcont22:                                         ; preds = %ifcont20
-  %101 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
-  %102 = load i32, i32* %101, align 4
-  %103 = mul i32 %102, %95
-  %104 = add i32 %89, %103
-  %105 = getelementptr %array, %array* %50, i32 0, i32 1
-  %106 = load i32, i32* %105, align 4
-  %107 = add i32 %104, %106
-  %108 = getelementptr %array, %array* %50, i32 0, i32 0
-  %109 = load i32*, i32** %108, align 8
-  %110 = getelementptr inbounds i32, i32* %109, i32 %107
-  store i32 99, i32* %110, align 4
+  %96 = getelementptr %dimension_descriptor, %dimension_descriptor* %85, i32 0, i32 0
+  %97 = load i32, i32* %96, align 4
+  %98 = mul i32 %97, %90
+  %99 = add i32 %84, %98
+  %100 = getelementptr %array, %array* %45, i32 0, i32 1
+  %101 = load i32, i32* %100, align 4
+  %102 = add i32 %99, %101
+  %103 = getelementptr %array, %array* %45, i32 0, i32 0
+  %104 = load i32*, i32** %103, align 8
+  %105 = getelementptr inbounds i32, i32* %104, i32 %102
+  store i32 99, i32* %105, align 4
   br label %return
 
 return:                                           ; preds = %ifcont22
@@ -1089,13 +1075,10 @@ merge_allocated21:                                ; preds = %check_data20, %ifco
 then23:                                           ; preds = %merge_allocated21
   %143 = getelementptr %array, %array* %136, i32 0, i32 0
   %144 = load i32*, i32** %143, align 8
-  %145 = alloca i8*, align 8
-  %146 = bitcast i32* %144 to i8*
-  store i8* %146, i8** %145, align 8
-  %147 = load i8*, i8** %145, align 8
-  call void @_lfortran_free(i8* %147)
-  %148 = getelementptr %array, %array* %136, i32 0, i32 0
-  store i32* null, i32** %148, align 8
+  %145 = bitcast i32* %144 to i8*
+  call void @_lfortran_free(i8* %145)
+  %146 = getelementptr %array, %array* %136, i32 0, i32 0
+  store i32* null, i32** %146, align 8
   br label %ifcont25
 
 else24:                                           ; preds = %merge_allocated21
@@ -1103,23 +1086,23 @@ else24:                                           ; preds = %merge_allocated21
 
 ifcont25:                                         ; preds = %else24, %then23
   call void @f(%array** %x)
-  %149 = alloca i64, align 8
-  %150 = load %array*, %array** %x, align 8
-  %151 = ptrtoint %array* %150 to i64
-  %152 = icmp eq i64 %151, 0
-  br i1 %152, label %merge_allocated27, label %check_data26
+  %147 = alloca i64, align 8
+  %148 = load %array*, %array** %x, align 8
+  %149 = ptrtoint %array* %148 to i64
+  %150 = icmp eq i64 %149, 0
+  br i1 %150, label %merge_allocated27, label %check_data26
 
 check_data26:                                     ; preds = %ifcont25
-  %153 = getelementptr %array, %array* %150, i32 0, i32 0
-  %154 = load i32*, i32** %153, align 8
-  %155 = ptrtoint i32* %154 to i64
-  %156 = icmp ne i64 %155, 0
+  %151 = getelementptr %array, %array* %148, i32 0, i32 0
+  %152 = load i32*, i32** %151, align 8
+  %153 = ptrtoint i32* %152 to i64
+  %154 = icmp ne i64 %153, 0
   br label %merge_allocated27
 
 merge_allocated27:                                ; preds = %check_data26, %ifcont25
-  %is_allocated28 = phi i1 [ false, %ifcont25 ], [ %156, %check_data26 ]
-  %157 = xor i1 %is_allocated28, true
-  br i1 %157, label %then29, label %ifcont30
+  %is_allocated28 = phi i1 [ false, %ifcont25 ], [ %154, %check_data26 ]
+  %155 = xor i1 %is_allocated28, true
+  br i1 %155, label %then29, label %ifcont30
 
 then29:                                           ; preds = %merge_allocated27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
@@ -1127,116 +1110,116 @@ then29:                                           ; preds = %merge_allocated27
   unreachable
 
 ifcont30:                                         ; preds = %merge_allocated27
-  %158 = getelementptr %array, %array* %150, i32 0, i32 2
-  %159 = load %dimension_descriptor*, %dimension_descriptor** %158, align 8
-  %160 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %159, i32 0
-  %161 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 1
+  %156 = getelementptr %array, %array* %148, i32 0, i32 2
+  %157 = load %dimension_descriptor*, %dimension_descriptor** %156, align 8
+  %158 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %157, i32 0
+  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 1
+  %160 = load i32, i32* %159, align 4
+  %161 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 2
   %162 = load i32, i32* %161, align 4
-  %163 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 2
-  %164 = load i32, i32* %163, align 4
-  %165 = sub i32 1, %162
-  %166 = add i32 %162, %164
-  %167 = sub i32 %166, 1
-  %168 = icmp slt i32 1, %162
-  %169 = icmp sgt i32 1, %167
-  %170 = or i1 %168, %169
-  br i1 %170, label %then31, label %ifcont32
+  %163 = sub i32 1, %160
+  %164 = add i32 %160, %162
+  %165 = sub i32 %164, 1
+  %166 = icmp slt i32 1, %160
+  %167 = icmp sgt i32 1, %165
+  %168 = or i1 %166, %167
+  br i1 %168, label %then31, label %ifcont32
 
 then31:                                           ; preds = %ifcont30
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @34, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i32 1, i32 1, i32 %162, i32 %167)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @34, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i32 1, i32 1, i32 %160, i32 %165)
   call void @exit(i32 1)
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %171 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 0
-  %172 = load i32, i32* %171, align 4
-  %173 = mul i32 %172, %165
-  %174 = add i32 0, %173
-  %175 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %159, i32 1
-  %176 = getelementptr %dimension_descriptor, %dimension_descriptor* %175, i32 0, i32 1
+  %169 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 0
+  %170 = load i32, i32* %169, align 4
+  %171 = mul i32 %170, %163
+  %172 = add i32 0, %171
+  %173 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %157, i32 1
+  %174 = getelementptr %dimension_descriptor, %dimension_descriptor* %173, i32 0, i32 1
+  %175 = load i32, i32* %174, align 4
+  %176 = getelementptr %dimension_descriptor, %dimension_descriptor* %173, i32 0, i32 2
   %177 = load i32, i32* %176, align 4
-  %178 = getelementptr %dimension_descriptor, %dimension_descriptor* %175, i32 0, i32 2
-  %179 = load i32, i32* %178, align 4
-  %180 = sub i32 1, %177
-  %181 = add i32 %177, %179
-  %182 = sub i32 %181, 1
-  %183 = icmp slt i32 1, %177
-  %184 = icmp sgt i32 1, %182
-  %185 = or i1 %183, %184
-  br i1 %185, label %then33, label %ifcont34
+  %178 = sub i32 1, %175
+  %179 = add i32 %175, %177
+  %180 = sub i32 %179, 1
+  %181 = icmp slt i32 1, %175
+  %182 = icmp sgt i32 1, %180
+  %183 = or i1 %181, %182
+  br i1 %183, label %then33, label %ifcont34
 
 then33:                                           ; preds = %ifcont32
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0), i32 1, i32 2, i32 %177, i32 %182)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0), i32 1, i32 2, i32 %175, i32 %180)
   call void @exit(i32 1)
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %186 = getelementptr %dimension_descriptor, %dimension_descriptor* %175, i32 0, i32 0
-  %187 = load i32, i32* %186, align 4
-  %188 = mul i32 %187, %180
-  %189 = add i32 %174, %188
-  %190 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %159, i32 2
-  %191 = getelementptr %dimension_descriptor, %dimension_descriptor* %190, i32 0, i32 1
+  %184 = getelementptr %dimension_descriptor, %dimension_descriptor* %173, i32 0, i32 0
+  %185 = load i32, i32* %184, align 4
+  %186 = mul i32 %185, %178
+  %187 = add i32 %172, %186
+  %188 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %157, i32 2
+  %189 = getelementptr %dimension_descriptor, %dimension_descriptor* %188, i32 0, i32 1
+  %190 = load i32, i32* %189, align 4
+  %191 = getelementptr %dimension_descriptor, %dimension_descriptor* %188, i32 0, i32 2
   %192 = load i32, i32* %191, align 4
-  %193 = getelementptr %dimension_descriptor, %dimension_descriptor* %190, i32 0, i32 2
-  %194 = load i32, i32* %193, align 4
-  %195 = sub i32 1, %192
-  %196 = add i32 %192, %194
-  %197 = sub i32 %196, 1
-  %198 = icmp slt i32 1, %192
-  %199 = icmp sgt i32 1, %197
-  %200 = or i1 %198, %199
-  br i1 %200, label %then35, label %ifcont36
+  %193 = sub i32 1, %190
+  %194 = add i32 %190, %192
+  %195 = sub i32 %194, 1
+  %196 = icmp slt i32 1, %190
+  %197 = icmp sgt i32 1, %195
+  %198 = or i1 %196, %197
+  br i1 %198, label %then35, label %ifcont36
 
 then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0), i32 1, i32 3, i32 %192, i32 %197)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0), i32 1, i32 3, i32 %190, i32 %195)
   call void @exit(i32 1)
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %190, i32 0, i32 0
-  %202 = load i32, i32* %201, align 4
-  %203 = mul i32 %202, %195
-  %204 = add i32 %189, %203
-  %205 = getelementptr %array, %array* %150, i32 0, i32 1
-  %206 = load i32, i32* %205, align 4
-  %207 = add i32 %204, %206
-  %208 = getelementptr %array, %array* %150, i32 0, i32 0
-  %209 = load i32*, i32** %208, align 8
-  %210 = getelementptr inbounds i32, i32* %209, i32 %207
-  %211 = load i32, i32* %210, align 4
-  %212 = alloca i32, align 4
-  store i32 %211, i32* %212, align 4
-  %213 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %149, i32 0, i32 0, i32* %212)
-  %214 = load i64, i64* %149, align 4
+  %199 = getelementptr %dimension_descriptor, %dimension_descriptor* %188, i32 0, i32 0
+  %200 = load i32, i32* %199, align 4
+  %201 = mul i32 %200, %193
+  %202 = add i32 %187, %201
+  %203 = getelementptr %array, %array* %148, i32 0, i32 1
+  %204 = load i32, i32* %203, align 4
+  %205 = add i32 %202, %204
+  %206 = getelementptr %array, %array* %148, i32 0, i32 0
+  %207 = load i32*, i32** %206, align 8
+  %208 = getelementptr inbounds i32, i32* %207, i32 %205
+  %209 = load i32, i32* %208, align 4
+  %210 = alloca i32, align 4
+  store i32 %209, i32* %210, align 4
+  %211 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %147, i32 0, i32 0, i32* %210)
+  %212 = load i64, i64* %147, align 4
   %stringFormat_desc37 = alloca %string_descriptor, align 8
+  %213 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
+  store i8* %211, i8** %213, align 8
+  %214 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
+  store i64 %212, i64* %214, align 4
   %215 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  store i8* %213, i8** %215, align 8
-  %216 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  store i64 %214, i64* %216, align 4
-  %217 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  %218 = load i8*, i8** %217, align 8
-  %219 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  %220 = load i64, i64* %219, align 4
-  %221 = trunc i64 %220 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %218, i32 %221, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
-  call void @_lfortran_free(i8* %213)
-  %222 = load %array*, %array** %x, align 8
-  %223 = ptrtoint %array* %222 to i64
-  %224 = icmp eq i64 %223, 0
-  br i1 %224, label %merge_allocated39, label %check_data38
+  %216 = load i8*, i8** %215, align 8
+  %217 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
+  %218 = load i64, i64* %217, align 4
+  %219 = trunc i64 %218 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %216, i32 %219, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  call void @_lfortran_free(i8* %211)
+  %220 = load %array*, %array** %x, align 8
+  %221 = ptrtoint %array* %220 to i64
+  %222 = icmp eq i64 %221, 0
+  br i1 %222, label %merge_allocated39, label %check_data38
 
 check_data38:                                     ; preds = %ifcont36
-  %225 = getelementptr %array, %array* %222, i32 0, i32 0
-  %226 = load i32*, i32** %225, align 8
-  %227 = ptrtoint i32* %226 to i64
-  %228 = icmp ne i64 %227, 0
+  %223 = getelementptr %array, %array* %220, i32 0, i32 0
+  %224 = load i32*, i32** %223, align 8
+  %225 = ptrtoint i32* %224 to i64
+  %226 = icmp ne i64 %225, 0
   br label %merge_allocated39
 
 merge_allocated39:                                ; preds = %check_data38, %ifcont36
-  %is_allocated40 = phi i1 [ false, %ifcont36 ], [ %228, %check_data38 ]
-  %229 = xor i1 %is_allocated40, true
-  br i1 %229, label %then41, label %ifcont42
+  %is_allocated40 = phi i1 [ false, %ifcont36 ], [ %226, %check_data38 ]
+  %227 = xor i1 %is_allocated40, true
+  br i1 %227, label %then41, label %ifcont42
 
 then41:                                           ; preds = %merge_allocated39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
@@ -1244,86 +1227,86 @@ then41:                                           ; preds = %merge_allocated39
   unreachable
 
 ifcont42:                                         ; preds = %merge_allocated39
-  %230 = getelementptr %array, %array* %222, i32 0, i32 2
-  %231 = load %dimension_descriptor*, %dimension_descriptor** %230, align 8
-  %232 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %231, i32 0
-  %233 = getelementptr %dimension_descriptor, %dimension_descriptor* %232, i32 0, i32 1
+  %228 = getelementptr %array, %array* %220, i32 0, i32 2
+  %229 = load %dimension_descriptor*, %dimension_descriptor** %228, align 8
+  %230 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %229, i32 0
+  %231 = getelementptr %dimension_descriptor, %dimension_descriptor* %230, i32 0, i32 1
+  %232 = load i32, i32* %231, align 4
+  %233 = getelementptr %dimension_descriptor, %dimension_descriptor* %230, i32 0, i32 2
   %234 = load i32, i32* %233, align 4
-  %235 = getelementptr %dimension_descriptor, %dimension_descriptor* %232, i32 0, i32 2
-  %236 = load i32, i32* %235, align 4
-  %237 = sub i32 1, %234
-  %238 = add i32 %234, %236
-  %239 = sub i32 %238, 1
-  %240 = icmp slt i32 1, %234
-  %241 = icmp sgt i32 1, %239
-  %242 = or i1 %240, %241
-  br i1 %242, label %then43, label %ifcont44
+  %235 = sub i32 1, %232
+  %236 = add i32 %232, %234
+  %237 = sub i32 %236, 1
+  %238 = icmp slt i32 1, %232
+  %239 = icmp sgt i32 1, %237
+  %240 = or i1 %238, %239
+  br i1 %240, label %then43, label %ifcont44
 
 then43:                                           ; preds = %ifcont42
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1, i32 1, i32 %234, i32 %239)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1, i32 1, i32 %232, i32 %237)
   call void @exit(i32 1)
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %232, i32 0, i32 0
-  %244 = load i32, i32* %243, align 4
-  %245 = mul i32 %244, %237
-  %246 = add i32 0, %245
-  %247 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %231, i32 1
-  %248 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 1
+  %241 = getelementptr %dimension_descriptor, %dimension_descriptor* %230, i32 0, i32 0
+  %242 = load i32, i32* %241, align 4
+  %243 = mul i32 %242, %235
+  %244 = add i32 0, %243
+  %245 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %229, i32 1
+  %246 = getelementptr %dimension_descriptor, %dimension_descriptor* %245, i32 0, i32 1
+  %247 = load i32, i32* %246, align 4
+  %248 = getelementptr %dimension_descriptor, %dimension_descriptor* %245, i32 0, i32 2
   %249 = load i32, i32* %248, align 4
-  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 2
-  %251 = load i32, i32* %250, align 4
-  %252 = sub i32 1, %249
-  %253 = add i32 %249, %251
-  %254 = sub i32 %253, 1
-  %255 = icmp slt i32 1, %249
-  %256 = icmp sgt i32 1, %254
-  %257 = or i1 %255, %256
-  br i1 %257, label %then45, label %ifcont46
+  %250 = sub i32 1, %247
+  %251 = add i32 %247, %249
+  %252 = sub i32 %251, 1
+  %253 = icmp slt i32 1, %247
+  %254 = icmp sgt i32 1, %252
+  %255 = or i1 %253, %254
+  br i1 %255, label %then45, label %ifcont46
 
 then45:                                           ; preds = %ifcont44
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1, i32 2, i32 %249, i32 %254)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1, i32 2, i32 %247, i32 %252)
   call void @exit(i32 1)
   unreachable
 
 ifcont46:                                         ; preds = %ifcont44
-  %258 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 0
-  %259 = load i32, i32* %258, align 4
-  %260 = mul i32 %259, %252
-  %261 = add i32 %246, %260
-  %262 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %231, i32 2
-  %263 = getelementptr %dimension_descriptor, %dimension_descriptor* %262, i32 0, i32 1
+  %256 = getelementptr %dimension_descriptor, %dimension_descriptor* %245, i32 0, i32 0
+  %257 = load i32, i32* %256, align 4
+  %258 = mul i32 %257, %250
+  %259 = add i32 %244, %258
+  %260 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %229, i32 2
+  %261 = getelementptr %dimension_descriptor, %dimension_descriptor* %260, i32 0, i32 1
+  %262 = load i32, i32* %261, align 4
+  %263 = getelementptr %dimension_descriptor, %dimension_descriptor* %260, i32 0, i32 2
   %264 = load i32, i32* %263, align 4
-  %265 = getelementptr %dimension_descriptor, %dimension_descriptor* %262, i32 0, i32 2
-  %266 = load i32, i32* %265, align 4
-  %267 = sub i32 1, %264
-  %268 = add i32 %264, %266
-  %269 = sub i32 %268, 1
-  %270 = icmp slt i32 1, %264
-  %271 = icmp sgt i32 1, %269
-  %272 = or i1 %270, %271
-  br i1 %272, label %then47, label %ifcont48
+  %265 = sub i32 1, %262
+  %266 = add i32 %262, %264
+  %267 = sub i32 %266, 1
+  %268 = icmp slt i32 1, %262
+  %269 = icmp sgt i32 1, %267
+  %270 = or i1 %268, %269
+  br i1 %270, label %then47, label %ifcont48
 
 then47:                                           ; preds = %ifcont46
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1, i32 3, i32 %264, i32 %269)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1, i32 3, i32 %262, i32 %267)
   call void @exit(i32 1)
   unreachable
 
 ifcont48:                                         ; preds = %ifcont46
-  %273 = getelementptr %dimension_descriptor, %dimension_descriptor* %262, i32 0, i32 0
-  %274 = load i32, i32* %273, align 4
-  %275 = mul i32 %274, %267
-  %276 = add i32 %261, %275
-  %277 = getelementptr %array, %array* %222, i32 0, i32 1
-  %278 = load i32, i32* %277, align 4
-  %279 = add i32 %276, %278
-  %280 = getelementptr %array, %array* %222, i32 0, i32 0
-  %281 = load i32*, i32** %280, align 8
-  %282 = getelementptr inbounds i32, i32* %281, i32 %279
-  %283 = load i32, i32* %282, align 4
-  %284 = icmp ne i32 %283, 99
-  br i1 %284, label %then49, label %else50
+  %271 = getelementptr %dimension_descriptor, %dimension_descriptor* %260, i32 0, i32 0
+  %272 = load i32, i32* %271, align 4
+  %273 = mul i32 %272, %265
+  %274 = add i32 %259, %273
+  %275 = getelementptr %array, %array* %220, i32 0, i32 1
+  %276 = load i32, i32* %275, align 4
+  %277 = add i32 %274, %276
+  %278 = getelementptr %array, %array* %220, i32 0, i32 0
+  %279 = load i32*, i32** %278, align 8
+  %280 = getelementptr inbounds i32, i32* %279, i32 %277
+  %281 = load i32, i32* %280, align 4
+  %282 = icmp ne i32 %281, 99
+  br i1 %282, label %then49, label %else50
 
 then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
@@ -1334,22 +1317,22 @@ else50:                                           ; preds = %ifcont48
   br label %ifcont51
 
 ifcont51:                                         ; preds = %else50, %then49
-  %285 = load %array*, %array** %x, align 8
-  %286 = ptrtoint %array* %285 to i64
-  %287 = icmp eq i64 %286, 0
-  br i1 %287, label %merge_allocated53, label %check_data52
+  %283 = load %array*, %array** %x, align 8
+  %284 = ptrtoint %array* %283 to i64
+  %285 = icmp eq i64 %284, 0
+  br i1 %285, label %merge_allocated53, label %check_data52
 
 check_data52:                                     ; preds = %ifcont51
-  %288 = getelementptr %array, %array* %285, i32 0, i32 0
-  %289 = load i32*, i32** %288, align 8
-  %290 = ptrtoint i32* %289 to i64
-  %291 = icmp ne i64 %290, 0
+  %286 = getelementptr %array, %array* %283, i32 0, i32 0
+  %287 = load i32*, i32** %286, align 8
+  %288 = ptrtoint i32* %287 to i64
+  %289 = icmp ne i64 %288, 0
   br label %merge_allocated53
 
 merge_allocated53:                                ; preds = %check_data52, %ifcont51
-  %is_allocated54 = phi i1 [ false, %ifcont51 ], [ %291, %check_data52 ]
-  %292 = xor i1 %is_allocated54, true
-  br i1 %292, label %then55, label %ifcont56
+  %is_allocated54 = phi i1 [ false, %ifcont51 ], [ %289, %check_data52 ]
+  %290 = xor i1 %is_allocated54, true
+  br i1 %290, label %then55, label %ifcont56
 
 then55:                                           ; preds = %merge_allocated53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
@@ -1357,84 +1340,84 @@ then55:                                           ; preds = %merge_allocated53
   unreachable
 
 ifcont56:                                         ; preds = %merge_allocated53
-  %293 = getelementptr %array, %array* %285, i32 0, i32 2
-  %294 = load %dimension_descriptor*, %dimension_descriptor** %293, align 8
-  %295 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %294, i32 0
-  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %295, i32 0, i32 1
+  %291 = getelementptr %array, %array* %283, i32 0, i32 2
+  %292 = load %dimension_descriptor*, %dimension_descriptor** %291, align 8
+  %293 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 0
+  %294 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 1
+  %295 = load i32, i32* %294, align 4
+  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 2
   %297 = load i32, i32* %296, align 4
-  %298 = getelementptr %dimension_descriptor, %dimension_descriptor* %295, i32 0, i32 2
-  %299 = load i32, i32* %298, align 4
-  %300 = sub i32 1, %297
-  %301 = add i32 %297, %299
-  %302 = sub i32 %301, 1
-  %303 = icmp slt i32 1, %297
-  %304 = icmp sgt i32 1, %302
-  %305 = or i1 %303, %304
-  br i1 %305, label %then57, label %ifcont58
+  %298 = sub i32 1, %295
+  %299 = add i32 %295, %297
+  %300 = sub i32 %299, 1
+  %301 = icmp slt i32 1, %295
+  %302 = icmp sgt i32 1, %300
+  %303 = or i1 %301, %302
+  br i1 %303, label %then57, label %ifcont58
 
 then57:                                           ; preds = %ifcont56
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1, i32 1, i32 %297, i32 %302)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1, i32 1, i32 %295, i32 %300)
   call void @exit(i32 1)
   unreachable
 
 ifcont58:                                         ; preds = %ifcont56
-  %306 = getelementptr %dimension_descriptor, %dimension_descriptor* %295, i32 0, i32 0
-  %307 = load i32, i32* %306, align 4
-  %308 = mul i32 %307, %300
-  %309 = add i32 0, %308
-  %310 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %294, i32 1
-  %311 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 1
+  %304 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 0
+  %305 = load i32, i32* %304, align 4
+  %306 = mul i32 %305, %298
+  %307 = add i32 0, %306
+  %308 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 1
+  %309 = getelementptr %dimension_descriptor, %dimension_descriptor* %308, i32 0, i32 1
+  %310 = load i32, i32* %309, align 4
+  %311 = getelementptr %dimension_descriptor, %dimension_descriptor* %308, i32 0, i32 2
   %312 = load i32, i32* %311, align 4
-  %313 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 2
-  %314 = load i32, i32* %313, align 4
-  %315 = sub i32 1, %312
-  %316 = add i32 %312, %314
-  %317 = sub i32 %316, 1
-  %318 = icmp slt i32 1, %312
-  %319 = icmp sgt i32 1, %317
-  %320 = or i1 %318, %319
-  br i1 %320, label %then59, label %ifcont60
+  %313 = sub i32 1, %310
+  %314 = add i32 %310, %312
+  %315 = sub i32 %314, 1
+  %316 = icmp slt i32 1, %310
+  %317 = icmp sgt i32 1, %315
+  %318 = or i1 %316, %317
+  br i1 %318, label %then59, label %ifcont60
 
 then59:                                           ; preds = %ifcont58
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 1, i32 2, i32 %312, i32 %317)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 1, i32 2, i32 %310, i32 %315)
   call void @exit(i32 1)
   unreachable
 
 ifcont60:                                         ; preds = %ifcont58
-  %321 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 0
-  %322 = load i32, i32* %321, align 4
-  %323 = mul i32 %322, %315
-  %324 = add i32 %309, %323
-  %325 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %294, i32 2
-  %326 = getelementptr %dimension_descriptor, %dimension_descriptor* %325, i32 0, i32 1
+  %319 = getelementptr %dimension_descriptor, %dimension_descriptor* %308, i32 0, i32 0
+  %320 = load i32, i32* %319, align 4
+  %321 = mul i32 %320, %313
+  %322 = add i32 %307, %321
+  %323 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 2
+  %324 = getelementptr %dimension_descriptor, %dimension_descriptor* %323, i32 0, i32 1
+  %325 = load i32, i32* %324, align 4
+  %326 = getelementptr %dimension_descriptor, %dimension_descriptor* %323, i32 0, i32 2
   %327 = load i32, i32* %326, align 4
-  %328 = getelementptr %dimension_descriptor, %dimension_descriptor* %325, i32 0, i32 2
-  %329 = load i32, i32* %328, align 4
-  %330 = sub i32 1, %327
-  %331 = add i32 %327, %329
-  %332 = sub i32 %331, 1
-  %333 = icmp slt i32 1, %327
-  %334 = icmp sgt i32 1, %332
-  %335 = or i1 %333, %334
-  br i1 %335, label %then61, label %ifcont62
+  %328 = sub i32 1, %325
+  %329 = add i32 %325, %327
+  %330 = sub i32 %329, 1
+  %331 = icmp slt i32 1, %325
+  %332 = icmp sgt i32 1, %330
+  %333 = or i1 %331, %332
+  br i1 %333, label %then61, label %ifcont62
 
 then61:                                           ; preds = %ifcont60
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 3, i32 %327, i32 %332)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 3, i32 %325, i32 %330)
   call void @exit(i32 1)
   unreachable
 
 ifcont62:                                         ; preds = %ifcont60
-  %336 = getelementptr %dimension_descriptor, %dimension_descriptor* %325, i32 0, i32 0
-  %337 = load i32, i32* %336, align 4
-  %338 = mul i32 %337, %330
-  %339 = add i32 %324, %338
-  %340 = getelementptr %array, %array* %285, i32 0, i32 1
-  %341 = load i32, i32* %340, align 4
-  %342 = add i32 %339, %341
-  %343 = getelementptr %array, %array* %285, i32 0, i32 0
-  %344 = load i32*, i32** %343, align 8
-  %345 = getelementptr inbounds i32, i32* %344, i32 %342
-  store i32 8, i32* %345, align 4
+  %334 = getelementptr %dimension_descriptor, %dimension_descriptor* %323, i32 0, i32 0
+  %335 = load i32, i32* %334, align 4
+  %336 = mul i32 %335, %328
+  %337 = add i32 %322, %336
+  %338 = getelementptr %array, %array* %283, i32 0, i32 1
+  %339 = load i32, i32* %338, align 4
+  %340 = add i32 %337, %339
+  %341 = getelementptr %array, %array* %283, i32 0, i32 0
+  %342 = load i32*, i32** %341, align 8
+  %343 = getelementptr inbounds i32, i32* %342, i32 %340
+  store i32 8, i32* %343, align 4
   store i32 0, i32* %r, align 4
   br label %return
 
@@ -1442,8 +1425,8 @@ return:                                           ; preds = %ifcont62
   br label %FINALIZE_SYMTABLE_g
 
 FINALIZE_SYMTABLE_g:                              ; preds = %return
-  %346 = load i32, i32* %r, align 4
-  ret i32 %346
+  %344 = load i32, i32* %r, align 4
+  ret i32 %344
 }
 
 define void @h(%array** %c) {
@@ -1485,13 +1468,10 @@ merge_allocated2:                                 ; preds = %check_data1, %then
 then4:                                            ; preds = %merge_allocated2
   %15 = getelementptr %array, %array* %8, i32 0, i32 0
   %16 = load i32*, i32** %15, align 8
-  %17 = alloca i8*, align 8
-  %18 = bitcast i32* %16 to i8*
-  store i8* %18, i8** %17, align 8
-  %19 = load i8*, i8** %17, align 8
-  call void @_lfortran_free(i8* %19)
-  %20 = getelementptr %array, %array* %8, i32 0, i32 0
-  store i32* null, i32** %20, align 8
+  %17 = bitcast i32* %16 to i8*
+  call void @_lfortran_free(i8* %17)
+  %18 = getelementptr %array, %array* %8, i32 0, i32 0
+  store i32* null, i32** %18, align 8
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated2
@@ -1504,21 +1484,21 @@ else5:                                            ; preds = %merge_allocated
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %ifcont
-  %21 = load %array*, %array** %c, align 8
-  %22 = load %array*, %array** %c, align 8
-  %23 = ptrtoint %array* %22 to i64
-  %24 = icmp eq i64 %23, 0
-  br i1 %24, label %merge_allocated8, label %check_data7
+  %19 = load %array*, %array** %c, align 8
+  %20 = load %array*, %array** %c, align 8
+  %21 = ptrtoint %array* %20 to i64
+  %22 = icmp eq i64 %21, 0
+  br i1 %22, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %ifcont6
-  %25 = getelementptr %array, %array* %22, i32 0, i32 0
-  %26 = load i32*, i32** %25, align 8
-  %27 = ptrtoint i32* %26 to i64
-  %28 = icmp ne i64 %27, 0
+  %23 = getelementptr %array, %array* %20, i32 0, i32 0
+  %24 = load i32*, i32** %23, align 8
+  %25 = ptrtoint i32* %24 to i64
+  %26 = icmp ne i64 %25, 0
   br label %merge_allocated8
 
 merge_allocated8:                                 ; preds = %check_data7, %ifcont6
-  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %28, %check_data7 ]
+  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %26, %check_data7 ]
   br i1 %is_allocated9, label %then10, label %else11
 
 then10:                                           ; preds = %merge_allocated8
@@ -1530,32 +1510,29 @@ else11:                                           ; preds = %merge_allocated8
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %29 = load %array*, %array** %c, align 8
-  %30 = ptrtoint %array* %29 to i64
-  %31 = icmp eq i64 %30, 0
-  br i1 %31, label %merge_allocated14, label %check_data13
+  %27 = load %array*, %array** %c, align 8
+  %28 = ptrtoint %array* %27 to i64
+  %29 = icmp eq i64 %28, 0
+  br i1 %29, label %merge_allocated14, label %check_data13
 
 check_data13:                                     ; preds = %ifcont12
-  %32 = getelementptr %array, %array* %29, i32 0, i32 0
-  %33 = load i32*, i32** %32, align 8
-  %34 = ptrtoint i32* %33 to i64
-  %35 = icmp ne i64 %34, 0
+  %30 = getelementptr %array, %array* %27, i32 0, i32 0
+  %31 = load i32*, i32** %30, align 8
+  %32 = ptrtoint i32* %31 to i64
+  %33 = icmp ne i64 %32, 0
   br label %merge_allocated14
 
 merge_allocated14:                                ; preds = %check_data13, %ifcont12
-  %is_allocated15 = phi i1 [ false, %ifcont12 ], [ %35, %check_data13 ]
+  %is_allocated15 = phi i1 [ false, %ifcont12 ], [ %33, %check_data13 ]
   br i1 %is_allocated15, label %then16, label %else17
 
 then16:                                           ; preds = %merge_allocated14
-  %36 = getelementptr %array, %array* %29, i32 0, i32 0
-  %37 = load i32*, i32** %36, align 8
-  %38 = alloca i8*, align 8
-  %39 = bitcast i32* %37 to i8*
-  store i8* %39, i8** %38, align 8
-  %40 = load i8*, i8** %38, align 8
-  call void @_lfortran_free(i8* %40)
-  %41 = getelementptr %array, %array* %29, i32 0, i32 0
-  store i32* null, i32** %41, align 8
+  %34 = getelementptr %array, %array* %27, i32 0, i32 0
+  %35 = load i32*, i32** %34, align 8
+  %36 = bitcast i32* %35 to i8*
+  call void @_lfortran_free(i8* %36)
+  %37 = getelementptr %array, %array* %27, i32 0, i32 0
+  store i32* null, i32** %37, align 8
   br label %ifcont18
 
 else17:                                           ; preds = %merge_allocated14
@@ -1563,23 +1540,23 @@ else17:                                           ; preds = %merge_allocated14
 
 ifcont18:                                         ; preds = %else17, %then16
   call void @f(%array** %c)
-  %42 = alloca i64, align 8
-  %43 = load %array*, %array** %c, align 8
-  %44 = ptrtoint %array* %43 to i64
-  %45 = icmp eq i64 %44, 0
-  br i1 %45, label %merge_allocated20, label %check_data19
+  %38 = alloca i64, align 8
+  %39 = load %array*, %array** %c, align 8
+  %40 = ptrtoint %array* %39 to i64
+  %41 = icmp eq i64 %40, 0
+  br i1 %41, label %merge_allocated20, label %check_data19
 
 check_data19:                                     ; preds = %ifcont18
-  %46 = getelementptr %array, %array* %43, i32 0, i32 0
-  %47 = load i32*, i32** %46, align 8
-  %48 = ptrtoint i32* %47 to i64
-  %49 = icmp ne i64 %48, 0
+  %42 = getelementptr %array, %array* %39, i32 0, i32 0
+  %43 = load i32*, i32** %42, align 8
+  %44 = ptrtoint i32* %43 to i64
+  %45 = icmp ne i64 %44, 0
   br label %merge_allocated20
 
 merge_allocated20:                                ; preds = %check_data19, %ifcont18
-  %is_allocated21 = phi i1 [ false, %ifcont18 ], [ %49, %check_data19 ]
-  %50 = xor i1 %is_allocated21, true
-  br i1 %50, label %then22, label %ifcont23
+  %is_allocated21 = phi i1 [ false, %ifcont18 ], [ %45, %check_data19 ]
+  %46 = xor i1 %is_allocated21, true
+  br i1 %46, label %then22, label %ifcont23
 
 then22:                                           ; preds = %merge_allocated20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
@@ -1587,116 +1564,116 @@ then22:                                           ; preds = %merge_allocated20
   unreachable
 
 ifcont23:                                         ; preds = %merge_allocated20
-  %51 = getelementptr %array, %array* %43, i32 0, i32 2
-  %52 = load %dimension_descriptor*, %dimension_descriptor** %51, align 8
-  %53 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %52, i32 0
-  %54 = getelementptr %dimension_descriptor, %dimension_descriptor* %53, i32 0, i32 1
-  %55 = load i32, i32* %54, align 4
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %53, i32 0, i32 2
-  %57 = load i32, i32* %56, align 4
-  %58 = sub i32 1, %55
-  %59 = add i32 %55, %57
-  %60 = sub i32 %59, 1
-  %61 = icmp slt i32 1, %55
-  %62 = icmp sgt i32 1, %60
-  %63 = or i1 %61, %62
-  br i1 %63, label %then24, label %ifcont25
+  %47 = getelementptr %array, %array* %39, i32 0, i32 2
+  %48 = load %dimension_descriptor*, %dimension_descriptor** %47, align 8
+  %49 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 0
+  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 1
+  %51 = load i32, i32* %50, align 4
+  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 2
+  %53 = load i32, i32* %52, align 4
+  %54 = sub i32 1, %51
+  %55 = add i32 %51, %53
+  %56 = sub i32 %55, 1
+  %57 = icmp slt i32 1, %51
+  %58 = icmp sgt i32 1, %56
+  %59 = or i1 %57, %58
+  br i1 %59, label %then24, label %ifcont25
 
 then24:                                           ; preds = %ifcont23
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @64, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @63, i32 0, i32 0), i32 1, i32 1, i32 %55, i32 %60)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @64, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @63, i32 0, i32 0), i32 1, i32 1, i32 %51, i32 %56)
   call void @exit(i32 1)
   unreachable
 
 ifcont25:                                         ; preds = %ifcont23
-  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %53, i32 0, i32 0
-  %65 = load i32, i32* %64, align 4
-  %66 = mul i32 %65, %58
-  %67 = add i32 0, %66
-  %68 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %52, i32 1
-  %69 = getelementptr %dimension_descriptor, %dimension_descriptor* %68, i32 0, i32 1
-  %70 = load i32, i32* %69, align 4
-  %71 = getelementptr %dimension_descriptor, %dimension_descriptor* %68, i32 0, i32 2
-  %72 = load i32, i32* %71, align 4
-  %73 = sub i32 1, %70
-  %74 = add i32 %70, %72
-  %75 = sub i32 %74, 1
-  %76 = icmp slt i32 1, %70
-  %77 = icmp sgt i32 1, %75
-  %78 = or i1 %76, %77
-  br i1 %78, label %then26, label %ifcont27
+  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 0
+  %61 = load i32, i32* %60, align 4
+  %62 = mul i32 %61, %54
+  %63 = add i32 0, %62
+  %64 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 1
+  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 1
+  %66 = load i32, i32* %65, align 4
+  %67 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 2
+  %68 = load i32, i32* %67, align 4
+  %69 = sub i32 1, %66
+  %70 = add i32 %66, %68
+  %71 = sub i32 %70, 1
+  %72 = icmp slt i32 1, %66
+  %73 = icmp sgt i32 1, %71
+  %74 = or i1 %72, %73
+  br i1 %74, label %then26, label %ifcont27
 
 then26:                                           ; preds = %ifcont25
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @65, i32 0, i32 0), i32 1, i32 2, i32 %70, i32 %75)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @65, i32 0, i32 0), i32 1, i32 2, i32 %66, i32 %71)
   call void @exit(i32 1)
   unreachable
 
 ifcont27:                                         ; preds = %ifcont25
-  %79 = getelementptr %dimension_descriptor, %dimension_descriptor* %68, i32 0, i32 0
-  %80 = load i32, i32* %79, align 4
-  %81 = mul i32 %80, %73
-  %82 = add i32 %67, %81
-  %83 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %52, i32 2
-  %84 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 1
-  %85 = load i32, i32* %84, align 4
-  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 2
-  %87 = load i32, i32* %86, align 4
-  %88 = sub i32 1, %85
-  %89 = add i32 %85, %87
-  %90 = sub i32 %89, 1
-  %91 = icmp slt i32 1, %85
-  %92 = icmp sgt i32 1, %90
-  %93 = or i1 %91, %92
-  br i1 %93, label %then28, label %ifcont29
+  %75 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 0
+  %76 = load i32, i32* %75, align 4
+  %77 = mul i32 %76, %69
+  %78 = add i32 %63, %77
+  %79 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 2
+  %80 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 1
+  %81 = load i32, i32* %80, align 4
+  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 2
+  %83 = load i32, i32* %82, align 4
+  %84 = sub i32 1, %81
+  %85 = add i32 %81, %83
+  %86 = sub i32 %85, 1
+  %87 = icmp slt i32 1, %81
+  %88 = icmp sgt i32 1, %86
+  %89 = or i1 %87, %88
+  br i1 %89, label %then28, label %ifcont29
 
 then28:                                           ; preds = %ifcont27
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0), i32 1, i32 3, i32 %85, i32 %90)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([180 x i8], [180 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0), i32 1, i32 3, i32 %81, i32 %86)
   call void @exit(i32 1)
   unreachable
 
 ifcont29:                                         ; preds = %ifcont27
-  %94 = getelementptr %dimension_descriptor, %dimension_descriptor* %83, i32 0, i32 0
+  %90 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 0
+  %91 = load i32, i32* %90, align 4
+  %92 = mul i32 %91, %84
+  %93 = add i32 %78, %92
+  %94 = getelementptr %array, %array* %39, i32 0, i32 1
   %95 = load i32, i32* %94, align 4
-  %96 = mul i32 %95, %88
-  %97 = add i32 %82, %96
-  %98 = getelementptr %array, %array* %43, i32 0, i32 1
-  %99 = load i32, i32* %98, align 4
-  %100 = add i32 %97, %99
-  %101 = getelementptr %array, %array* %43, i32 0, i32 0
-  %102 = load i32*, i32** %101, align 8
-  %103 = getelementptr inbounds i32, i32* %102, i32 %100
-  %104 = load i32, i32* %103, align 4
-  %105 = alloca i32, align 4
-  store i32 %104, i32* %105, align 4
-  %106 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %42, i32 0, i32 0, i32* %105)
-  %107 = load i64, i64* %42, align 4
+  %96 = add i32 %93, %95
+  %97 = getelementptr %array, %array* %39, i32 0, i32 0
+  %98 = load i32*, i32** %97, align 8
+  %99 = getelementptr inbounds i32, i32* %98, i32 %96
+  %100 = load i32, i32* %99, align 4
+  %101 = alloca i32, align 4
+  store i32 %100, i32* %101, align 4
+  %102 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %38, i32 0, i32 0, i32* %101)
+  %103 = load i64, i64* %38, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %108 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %106, i8** %108, align 8
-  %109 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %107, i64* %109, align 4
-  %110 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %111 = load i8*, i8** %110, align 8
-  %112 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %113 = load i64, i64* %112, align 4
-  %114 = trunc i64 %113 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* %111, i32 %114, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i32 1)
-  call void @_lfortran_free(i8* %106)
-  %115 = load %array*, %array** %c, align 8
-  %116 = ptrtoint %array* %115 to i64
-  %117 = icmp eq i64 %116, 0
-  br i1 %117, label %merge_allocated31, label %check_data30
+  %104 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %102, i8** %104, align 8
+  %105 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %103, i64* %105, align 4
+  %106 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %107 = load i8*, i8** %106, align 8
+  %108 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %109 = load i64, i64* %108, align 4
+  %110 = trunc i64 %109 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* %107, i32 %110, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i32 1)
+  call void @_lfortran_free(i8* %102)
+  %111 = load %array*, %array** %c, align 8
+  %112 = ptrtoint %array* %111 to i64
+  %113 = icmp eq i64 %112, 0
+  br i1 %113, label %merge_allocated31, label %check_data30
 
 check_data30:                                     ; preds = %ifcont29
-  %118 = getelementptr %array, %array* %115, i32 0, i32 0
-  %119 = load i32*, i32** %118, align 8
-  %120 = ptrtoint i32* %119 to i64
-  %121 = icmp ne i64 %120, 0
+  %114 = getelementptr %array, %array* %111, i32 0, i32 0
+  %115 = load i32*, i32** %114, align 8
+  %116 = ptrtoint i32* %115 to i64
+  %117 = icmp ne i64 %116, 0
   br label %merge_allocated31
 
 merge_allocated31:                                ; preds = %check_data30, %ifcont29
-  %is_allocated32 = phi i1 [ false, %ifcont29 ], [ %121, %check_data30 ]
-  %122 = xor i1 %is_allocated32, true
-  br i1 %122, label %then33, label %ifcont34
+  %is_allocated32 = phi i1 [ false, %ifcont29 ], [ %117, %check_data30 ]
+  %118 = xor i1 %is_allocated32, true
+  br i1 %118, label %then33, label %ifcont34
 
 then33:                                           ; preds = %merge_allocated31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0))
@@ -1704,86 +1681,86 @@ then33:                                           ; preds = %merge_allocated31
   unreachable
 
 ifcont34:                                         ; preds = %merge_allocated31
-  %123 = getelementptr %array, %array* %115, i32 0, i32 2
-  %124 = load %dimension_descriptor*, %dimension_descriptor** %123, align 8
-  %125 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %124, i32 0
-  %126 = getelementptr %dimension_descriptor, %dimension_descriptor* %125, i32 0, i32 1
-  %127 = load i32, i32* %126, align 4
-  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %125, i32 0, i32 2
-  %129 = load i32, i32* %128, align 4
-  %130 = sub i32 1, %127
-  %131 = add i32 %127, %129
-  %132 = sub i32 %131, 1
-  %133 = icmp slt i32 1, %127
-  %134 = icmp sgt i32 1, %132
-  %135 = or i1 %133, %134
-  br i1 %135, label %then35, label %ifcont36
+  %119 = getelementptr %array, %array* %111, i32 0, i32 2
+  %120 = load %dimension_descriptor*, %dimension_descriptor** %119, align 8
+  %121 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 0
+  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 1
+  %123 = load i32, i32* %122, align 4
+  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 2
+  %125 = load i32, i32* %124, align 4
+  %126 = sub i32 1, %123
+  %127 = add i32 %123, %125
+  %128 = sub i32 %127, 1
+  %129 = icmp slt i32 1, %123
+  %130 = icmp sgt i32 1, %128
+  %131 = or i1 %129, %130
+  br i1 %131, label %then35, label %ifcont36
 
 then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 1, i32 1, i32 %127, i32 %132)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 1, i32 1, i32 %123, i32 %128)
   call void @exit(i32 1)
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %136 = getelementptr %dimension_descriptor, %dimension_descriptor* %125, i32 0, i32 0
-  %137 = load i32, i32* %136, align 4
-  %138 = mul i32 %137, %130
-  %139 = add i32 0, %138
-  %140 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %124, i32 1
-  %141 = getelementptr %dimension_descriptor, %dimension_descriptor* %140, i32 0, i32 1
-  %142 = load i32, i32* %141, align 4
-  %143 = getelementptr %dimension_descriptor, %dimension_descriptor* %140, i32 0, i32 2
-  %144 = load i32, i32* %143, align 4
-  %145 = sub i32 1, %142
-  %146 = add i32 %142, %144
-  %147 = sub i32 %146, 1
-  %148 = icmp slt i32 1, %142
-  %149 = icmp sgt i32 1, %147
-  %150 = or i1 %148, %149
-  br i1 %150, label %then37, label %ifcont38
+  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
+  %133 = load i32, i32* %132, align 4
+  %134 = mul i32 %133, %126
+  %135 = add i32 0, %134
+  %136 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 1
+  %137 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 1
+  %138 = load i32, i32* %137, align 4
+  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 2
+  %140 = load i32, i32* %139, align 4
+  %141 = sub i32 1, %138
+  %142 = add i32 %138, %140
+  %143 = sub i32 %142, 1
+  %144 = icmp slt i32 1, %138
+  %145 = icmp sgt i32 1, %143
+  %146 = or i1 %144, %145
+  br i1 %146, label %then37, label %ifcont38
 
 then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 1, i32 2, i32 %142, i32 %147)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 1, i32 2, i32 %138, i32 %143)
   call void @exit(i32 1)
   unreachable
 
 ifcont38:                                         ; preds = %ifcont36
-  %151 = getelementptr %dimension_descriptor, %dimension_descriptor* %140, i32 0, i32 0
-  %152 = load i32, i32* %151, align 4
-  %153 = mul i32 %152, %145
-  %154 = add i32 %139, %153
-  %155 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %124, i32 2
-  %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 1
-  %157 = load i32, i32* %156, align 4
-  %158 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 2
-  %159 = load i32, i32* %158, align 4
-  %160 = sub i32 1, %157
-  %161 = add i32 %157, %159
-  %162 = sub i32 %161, 1
-  %163 = icmp slt i32 1, %157
-  %164 = icmp sgt i32 1, %162
-  %165 = or i1 %163, %164
-  br i1 %165, label %then39, label %ifcont40
+  %147 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 0
+  %148 = load i32, i32* %147, align 4
+  %149 = mul i32 %148, %141
+  %150 = add i32 %135, %149
+  %151 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 2
+  %152 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 1
+  %153 = load i32, i32* %152, align 4
+  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 2
+  %155 = load i32, i32* %154, align 4
+  %156 = sub i32 1, %153
+  %157 = add i32 %153, %155
+  %158 = sub i32 %157, 1
+  %159 = icmp slt i32 1, %153
+  %160 = icmp sgt i32 1, %158
+  %161 = or i1 %159, %160
+  br i1 %161, label %then39, label %ifcont40
 
 then39:                                           ; preds = %ifcont38
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i32 1, i32 3, i32 %157, i32 %162)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i32 1, i32 3, i32 %153, i32 %158)
   call void @exit(i32 1)
   unreachable
 
 ifcont40:                                         ; preds = %ifcont38
-  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %155, i32 0, i32 0
+  %162 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 0
+  %163 = load i32, i32* %162, align 4
+  %164 = mul i32 %163, %156
+  %165 = add i32 %150, %164
+  %166 = getelementptr %array, %array* %111, i32 0, i32 1
   %167 = load i32, i32* %166, align 4
-  %168 = mul i32 %167, %160
-  %169 = add i32 %154, %168
-  %170 = getelementptr %array, %array* %115, i32 0, i32 1
-  %171 = load i32, i32* %170, align 4
-  %172 = add i32 %169, %171
-  %173 = getelementptr %array, %array* %115, i32 0, i32 0
-  %174 = load i32*, i32** %173, align 8
-  %175 = getelementptr inbounds i32, i32* %174, i32 %172
-  %176 = load i32, i32* %175, align 4
-  %177 = icmp ne i32 %176, 99
-  br i1 %177, label %then41, label %else42
+  %168 = add i32 %165, %167
+  %169 = getelementptr %array, %array* %111, i32 0, i32 0
+  %170 = load i32*, i32** %169, align 8
+  %171 = getelementptr inbounds i32, i32* %170, i32 %168
+  %172 = load i32, i32* %171, align 4
+  %173 = icmp ne i32 %172, 99
+  br i1 %173, label %then41, label %else42
 
 then41:                                           ; preds = %ifcont40
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
@@ -1794,22 +1771,22 @@ else42:                                           ; preds = %ifcont40
   br label %ifcont43
 
 ifcont43:                                         ; preds = %else42, %then41
-  %178 = load %array*, %array** %c, align 8
-  %179 = ptrtoint %array* %178 to i64
-  %180 = icmp eq i64 %179, 0
-  br i1 %180, label %merge_allocated45, label %check_data44
+  %174 = load %array*, %array** %c, align 8
+  %175 = ptrtoint %array* %174 to i64
+  %176 = icmp eq i64 %175, 0
+  br i1 %176, label %merge_allocated45, label %check_data44
 
 check_data44:                                     ; preds = %ifcont43
-  %181 = getelementptr %array, %array* %178, i32 0, i32 0
-  %182 = load i32*, i32** %181, align 8
-  %183 = ptrtoint i32* %182 to i64
-  %184 = icmp ne i64 %183, 0
+  %177 = getelementptr %array, %array* %174, i32 0, i32 0
+  %178 = load i32*, i32** %177, align 8
+  %179 = ptrtoint i32* %178 to i64
+  %180 = icmp ne i64 %179, 0
   br label %merge_allocated45
 
 merge_allocated45:                                ; preds = %check_data44, %ifcont43
-  %is_allocated46 = phi i1 [ false, %ifcont43 ], [ %184, %check_data44 ]
-  %185 = xor i1 %is_allocated46, true
-  br i1 %185, label %then47, label %ifcont48
+  %is_allocated46 = phi i1 [ false, %ifcont43 ], [ %180, %check_data44 ]
+  %181 = xor i1 %is_allocated46, true
+  br i1 %181, label %then47, label %ifcont48
 
 then47:                                           ; preds = %merge_allocated45
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([116 x i8], [116 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0))
@@ -1817,84 +1794,84 @@ then47:                                           ; preds = %merge_allocated45
   unreachable
 
 ifcont48:                                         ; preds = %merge_allocated45
-  %186 = getelementptr %array, %array* %178, i32 0, i32 2
-  %187 = load %dimension_descriptor*, %dimension_descriptor** %186, align 8
-  %188 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %187, i32 0
-  %189 = getelementptr %dimension_descriptor, %dimension_descriptor* %188, i32 0, i32 1
-  %190 = load i32, i32* %189, align 4
-  %191 = getelementptr %dimension_descriptor, %dimension_descriptor* %188, i32 0, i32 2
-  %192 = load i32, i32* %191, align 4
-  %193 = sub i32 1, %190
-  %194 = add i32 %190, %192
-  %195 = sub i32 %194, 1
-  %196 = icmp slt i32 1, %190
-  %197 = icmp sgt i32 1, %195
-  %198 = or i1 %196, %197
-  br i1 %198, label %then49, label %ifcont50
+  %182 = getelementptr %array, %array* %174, i32 0, i32 2
+  %183 = load %dimension_descriptor*, %dimension_descriptor** %182, align 8
+  %184 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %183, i32 0
+  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %184, i32 0, i32 1
+  %186 = load i32, i32* %185, align 4
+  %187 = getelementptr %dimension_descriptor, %dimension_descriptor* %184, i32 0, i32 2
+  %188 = load i32, i32* %187, align 4
+  %189 = sub i32 1, %186
+  %190 = add i32 %186, %188
+  %191 = sub i32 %190, 1
+  %192 = icmp slt i32 1, %186
+  %193 = icmp sgt i32 1, %191
+  %194 = or i1 %192, %193
+  br i1 %194, label %then49, label %ifcont50
 
 then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 1, i32 1, i32 %190, i32 %195)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 1, i32 1, i32 %186, i32 %191)
   call void @exit(i32 1)
   unreachable
 
 ifcont50:                                         ; preds = %ifcont48
-  %199 = getelementptr %dimension_descriptor, %dimension_descriptor* %188, i32 0, i32 0
-  %200 = load i32, i32* %199, align 4
-  %201 = mul i32 %200, %193
-  %202 = add i32 0, %201
-  %203 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %187, i32 1
-  %204 = getelementptr %dimension_descriptor, %dimension_descriptor* %203, i32 0, i32 1
-  %205 = load i32, i32* %204, align 4
-  %206 = getelementptr %dimension_descriptor, %dimension_descriptor* %203, i32 0, i32 2
-  %207 = load i32, i32* %206, align 4
-  %208 = sub i32 1, %205
-  %209 = add i32 %205, %207
-  %210 = sub i32 %209, 1
-  %211 = icmp slt i32 1, %205
-  %212 = icmp sgt i32 1, %210
-  %213 = or i1 %211, %212
-  br i1 %213, label %then51, label %ifcont52
+  %195 = getelementptr %dimension_descriptor, %dimension_descriptor* %184, i32 0, i32 0
+  %196 = load i32, i32* %195, align 4
+  %197 = mul i32 %196, %189
+  %198 = add i32 0, %197
+  %199 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %183, i32 1
+  %200 = getelementptr %dimension_descriptor, %dimension_descriptor* %199, i32 0, i32 1
+  %201 = load i32, i32* %200, align 4
+  %202 = getelementptr %dimension_descriptor, %dimension_descriptor* %199, i32 0, i32 2
+  %203 = load i32, i32* %202, align 4
+  %204 = sub i32 1, %201
+  %205 = add i32 %201, %203
+  %206 = sub i32 %205, 1
+  %207 = icmp slt i32 1, %201
+  %208 = icmp sgt i32 1, %206
+  %209 = or i1 %207, %208
+  br i1 %209, label %then51, label %ifcont52
 
 then51:                                           ; preds = %ifcont50
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i32 1, i32 2, i32 %205, i32 %210)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i32 1, i32 2, i32 %201, i32 %206)
   call void @exit(i32 1)
   unreachable
 
 ifcont52:                                         ; preds = %ifcont50
-  %214 = getelementptr %dimension_descriptor, %dimension_descriptor* %203, i32 0, i32 0
-  %215 = load i32, i32* %214, align 4
-  %216 = mul i32 %215, %208
-  %217 = add i32 %202, %216
-  %218 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %187, i32 2
-  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %218, i32 0, i32 1
-  %220 = load i32, i32* %219, align 4
-  %221 = getelementptr %dimension_descriptor, %dimension_descriptor* %218, i32 0, i32 2
-  %222 = load i32, i32* %221, align 4
-  %223 = sub i32 1, %220
-  %224 = add i32 %220, %222
-  %225 = sub i32 %224, 1
-  %226 = icmp slt i32 1, %220
-  %227 = icmp sgt i32 1, %225
-  %228 = or i1 %226, %227
-  br i1 %228, label %then53, label %ifcont54
+  %210 = getelementptr %dimension_descriptor, %dimension_descriptor* %199, i32 0, i32 0
+  %211 = load i32, i32* %210, align 4
+  %212 = mul i32 %211, %204
+  %213 = add i32 %198, %212
+  %214 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %183, i32 2
+  %215 = getelementptr %dimension_descriptor, %dimension_descriptor* %214, i32 0, i32 1
+  %216 = load i32, i32* %215, align 4
+  %217 = getelementptr %dimension_descriptor, %dimension_descriptor* %214, i32 0, i32 2
+  %218 = load i32, i32* %217, align 4
+  %219 = sub i32 1, %216
+  %220 = add i32 %216, %218
+  %221 = sub i32 %220, 1
+  %222 = icmp slt i32 1, %216
+  %223 = icmp sgt i32 1, %221
+  %224 = or i1 %222, %223
+  br i1 %224, label %then53, label %ifcont54
 
 then53:                                           ; preds = %ifcont52
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 1, i32 3, i32 %220, i32 %225)
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 1, i32 3, i32 %216, i32 %221)
   call void @exit(i32 1)
   unreachable
 
 ifcont54:                                         ; preds = %ifcont52
-  %229 = getelementptr %dimension_descriptor, %dimension_descriptor* %218, i32 0, i32 0
+  %225 = getelementptr %dimension_descriptor, %dimension_descriptor* %214, i32 0, i32 0
+  %226 = load i32, i32* %225, align 4
+  %227 = mul i32 %226, %219
+  %228 = add i32 %213, %227
+  %229 = getelementptr %array, %array* %174, i32 0, i32 1
   %230 = load i32, i32* %229, align 4
-  %231 = mul i32 %230, %223
-  %232 = add i32 %217, %231
-  %233 = getelementptr %array, %array* %178, i32 0, i32 1
-  %234 = load i32, i32* %233, align 4
-  %235 = add i32 %232, %234
-  %236 = getelementptr %array, %array* %178, i32 0, i32 0
-  %237 = load i32*, i32** %236, align 8
-  %238 = getelementptr inbounds i32, i32* %237, i32 %235
-  store i32 8, i32* %238, align 4
+  %231 = add i32 %228, %230
+  %232 = getelementptr %array, %array* %174, i32 0, i32 0
+  %233 = load i32*, i32** %232, align 8
+  %234 = getelementptr inbounds i32, i32* %233, i32 %231
+  store i32 8, i32* %234, align 4
   br label %return
 
 return:                                           ; preds = %ifcont54

--- a/tests/reference/llvm-finalize_01-5496007.json
+++ b/tests/reference/llvm-finalize_01-5496007.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_01-5496007.stdout",
-    "stdout_hash": "c9c69fad62dbb54b9ab7ead13cdb2868a54ef27bd7aeb839e19a1551",
+    "stdout_hash": "629c8847e919084e8739c8e71c71a25203da6b29d01d9ce857d01c09",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_01-5496007.stdout
+++ b/tests/reference/llvm-finalize_01-5496007.stdout
@@ -65,13 +65,9 @@ ifcont:                                           ; preds = %merge_allocated
   store i32 1, i32* %21, align 4
   store i32 10, i32* %22, align 4
   %23 = getelementptr %array, %array* %15, i32 0, i32 0
-  %24 = alloca i32, align 4
-  store i32 40, i32* %24, align 4
-  %25 = load i32, i32* %24, align 4
-  %26 = sext i32 %25 to i64
-  %27 = call i8* @_lfortran_malloc(i64 %26)
-  %28 = bitcast i8* %27 to i32*
-  store i32* %28, i32** %23, align 8
+  %24 = call i8* @_lfortran_malloc(i64 40)
+  %25 = bitcast i8* %24 to i32*
+  store i32* %25, i32** %23, align 8
   br i1 true, label %then1, label %else
 
 then1:                                            ; preds = %ifcont
@@ -96,11 +92,11 @@ FINALIZE_SYMTABLE_ss:                             ; preds = %return
   br label %Finalize_Variable_arr
 
 Finalize_Variable_arr:                            ; preds = %FINALIZE_SYMTABLE_ss
-  %29 = load %array*, %array** %arr, align 8
-  %30 = getelementptr %array, %array* %29, i32 0, i32 0
-  %31 = load i32*, i32** %30, align 8
-  %32 = bitcast i32* %31 to i8*
-  call void @_lfortran_free(i8* %32)
+  %26 = load %array*, %array** %arr, align 8
+  %27 = getelementptr %array, %array* %26, i32 0, i32 0
+  %28 = load i32*, i32** %27, align 8
+  %29 = bitcast i32* %28 to i8*
+  call void @_lfortran_free(i8* %29)
   ret void
 }
 


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/8926

Reduced MRE from the issue:
```fortran
program allocate_34
    implicit none
    integer, allocatable :: arr(:)
    integer :: i
    allocate(arr(1))
    do i = 1, 1000000
        deallocate(arr)
        allocate(arr(1))
    end do
end program
```

In llvm generation of `deallocate` and `allocate` we had `alloca` statements. This caused a large amount of memory allocation on the stack. This led to a segfault in `malloc.c`.

