### PR TITLE
llvm: only hoist constant-size allocas to entry block

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2369,6 +2369,7 @@ RUN(NAME array_section_09 LABELS gfortran llvm
     EXTRA_ARGS -fdefault-integer-8
     GFORTRAN_ARGS -fdefault-integer-8)
 RUN(NAME array_section_10 LABELS gfortran llvm)
+RUN(NAME array_section_11 LABELS gfortran llvm)
 
 RUN(NAME nested_vars_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 

--- a/integration_tests/array_section_11.f90
+++ b/integration_tests/array_section_11.f90
@@ -1,0 +1,34 @@
+program array_section_11
+    ! Test that variable-size allocas in loops don't cause stack overflow.
+    ! When array sections are passed to subroutines inside loops, variable-size
+    ! allocas are created. These should NOT be hoisted to entry block to avoid
+    ! stack growth on each iteration.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+    integer, parameter :: n = 4
+    integer, parameter :: iterations = 100000
+    real(dp) :: a(n, n), b(n, n)
+    integer :: i, j
+
+    do j = 1, n
+        do i = 1, n
+            a(i, j) = real(i + j, dp)
+            b(i, j) = 0.0d0
+        end do
+    end do
+
+    do i = 1, iterations
+        call consume(a(:, 1), b(:, 2))
+    end do
+
+    if (abs(b(1, 2) - real(iterations, dp) * a(1, 1)) > 1.0d-6) error stop
+
+contains
+
+    subroutine consume(x, y)
+        real(dp), intent(in) :: x(:)
+        real(dp), intent(inout) :: y(:)
+        y(1) = y(1) + x(1)
+    end subroutine
+
+end program

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1580,19 +1580,31 @@ namespace LCompilers {
             /*is_llvm_ptr*/
 #endif
         ) {
-        llvm::BasicBlock &entry_block = builder->GetInsertBlock()->getParent()->getEntryBlock();
-        llvm::IRBuilder<> builder0(context);
-        builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
         llvm::AllocaInst *alloca;
 #if LLVM_VERSION_MAJOR >= 15
         llvm::Type *type_ = is_llvm_ptr ? type->getPointerTo() : type;
 #else
         llvm::Type *type_ = type;
 #endif
-        if (Name != "") {
-            alloca = builder0.CreateAlloca(type_, size, Name);
+        // Only hoist constant-size allocas to entry block. Variable-size
+        // allocas stay at current insertion point to avoid stack growth
+        // when created inside loops.
+        bool use_entry_block = (size == nullptr) || llvm::isa<llvm::Constant>(size);
+        if (use_entry_block) {
+            llvm::BasicBlock &entry_block = builder->GetInsertBlock()->getParent()->getEntryBlock();
+            llvm::IRBuilder<> builder0(context);
+            builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
+            if (Name != "") {
+                alloca = builder0.CreateAlloca(type_, size, Name);
+            } else {
+                alloca = builder0.CreateAlloca(type_, size);
+            }
         } else {
-            alloca = builder0.CreateAlloca(type_, size);
+            if (Name != "") {
+                alloca = builder->CreateAlloca(type_, size, Name);
+            } else {
+                alloca = builder->CreateAlloca(type_, size);
+            }
         }
         return alloca;
     }


### PR DESCRIPTION
## Summary
- Modify CreateAlloca to only hoist constant-size allocas to entry block
- Variable-size allocas stay at current insertion point to avoid stack growth in loops

## Changes
- [`llvm_utils.cpp#L1589-L1608`](https://github.com/lfortran/lfortran/blob/a879dcd6abc79a67bb3792efe6b2318c751cee16/src/libasr/codegen/llvm_utils.cpp#L1589-L1608): Add check for constant size before hoisting to entry block

## Tests
- [`array_section_11.f90`](https://github.com/lfortran/lfortran/blob/a879dcd6abc79a67bb3792efe6b2318c751cee16/integration_tests/array_section_11.f90): 100k iterations of array section operations
