### PR TITLE
test: add test for handle unallocated struct instance member in string concat

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1982,6 +1982,7 @@ RUN(NAME string_90 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_91 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_92 LABELS gfortran llvm)
 RUN(NAME string_93 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_94 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc  EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_94.f90
+++ b/integration_tests/string_94.f90
@@ -1,0 +1,17 @@
+program test_string_concat
+    implicit none
+
+    type :: string_t
+        character(5) :: s
+    end type string_t
+
+    type(string_t) :: t
+    character(:), allocatable :: result
+
+    t%s = "World"
+    result = "Hello " // t%s
+    if (result /= "Hello World") error stop "wrong string"
+    if (len(result) /= 11)      error stop "wrong length"
+
+    print *, "test passed"
+end program test_string_concat


### PR DESCRIPTION
fixes #9081
see https://github.com/lfortran/lfortran/issues/9081#issuecomment-3724491776