### PR TITLE
Fix stack growth in BindC complex returns

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1470,6 +1470,7 @@ RUN(NAME bindc_07 LABELS gfortran llvm EXTRAFILES bindc_07.c)
 RUN(NAME bindc_08 LABELS gfortran llvm EXTRAFILES bindc_08.c EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME bindc_09 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME bindc_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME bindc_11 LABELS gfortran llvm)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/bindc_11.f90
+++ b/integration_tests/bindc_11.f90
@@ -1,0 +1,41 @@
+module bindc_11_mod
+use, intrinsic :: iso_c_binding, only: c_float
+implicit none
+contains
+
+    complex(c_float) function twice(z) result(r) bind(c)
+        complex(c_float), value, intent(in) :: z
+        r = z + z
+    end function twice
+
+end module bindc_11_mod
+
+program bindc_11
+use, intrinsic :: iso_c_binding, only: c_float
+use bindc_11_mod, only: twice
+implicit none
+
+    complex(c_float) :: z, r
+    real(c_float) :: re, im
+    integer :: i
+
+    z = cmplx(5.0_c_float, 7.0_c_float, kind=c_float)
+
+    r = twice(z)
+    re = real(r, kind=c_float)
+    im = aimag(r)
+    if (abs(re - 10.0_c_float) > 1.0e-6_c_float) error stop
+    if (abs(im - 14.0_c_float) > 1.0e-6_c_float) error stop
+
+    r = cmplx(0.0_c_float, 0.0_c_float, kind=c_float)
+    do i = 1, 700000
+        r = r + twice(z)
+    end do
+
+    re = real(r, kind=c_float)
+    im = aimag(r)
+    if (abs(re - 7000000.0_c_float) > 1.0_c_float) error stop
+    if (abs(im - 9800000.0_c_float) > 1.0_c_float) error stop
+    print *, "PASSED"
+
+end program bindc_11

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16134,7 +16134,7 @@ public:
                     int a_kind = down_cast<ASR::Complex_t>(return_var_type0)->m_kind;
                     if (a_kind == 8) {
                         if (compiler_options.platform == Platform::Windows) {
-                            tmp = llvm_utils->CreateAlloca(*builder, complex_type_8);
+                            tmp = llvm_utils->CreateAlloca(complex_type_8, nullptr, "complex_ret_tmp");
                             args.insert(args.begin(), tmp);
                             builder->CreateCall(fn, args);
                             // Convert {double,double}* to {double,double}
@@ -16175,7 +16175,7 @@ public:
                         // i64
                         llvm::Type* type_fx2 = llvm::Type::getInt64Ty(context);
                         // Convert i64 to i64*
-                        llvm::AllocaInst *p_fx2 = llvm_utils->CreateAlloca(*builder, type_fx2);
+                        llvm::AllocaInst *p_fx2 = llvm_utils->CreateAlloca(type_fx2, nullptr, "complex_ret_tmp");
                         builder->CreateStore(tmp, p_fx2);
                         // Convert i64* to {float,float}* using bitcast
                         tmp = builder->CreateBitCast(p_fx2, complex_type_4->getPointerTo());
@@ -16191,7 +16191,7 @@ public:
                             // <2 x float>
                             llvm::Type* type_fx2 = FIXED_VECTOR_TYPE::get(llvm::Type::getFloatTy(context), 2);
                             // Convert <2 x float> to <2 x float>*
-                            llvm::AllocaInst *p_fx2 = llvm_utils->CreateAlloca(*builder, type_fx2);
+                            llvm::AllocaInst *p_fx2 = llvm_utils->CreateAlloca(type_fx2, nullptr, "complex_ret_tmp");
                             builder->CreateStore(tmp, p_fx2);
                             // Convert <2 x float>* to {float,float}* using bitcast
                             tmp = builder->CreateBitCast(p_fx2, complex_type_4->getPointerTo());

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1976,8 +1976,9 @@ namespace LCompilers {
                 break;
             }
             case ASR::CChar:{
-                llvm::Value* char_ptr = builder->CreateAlloca(llvm::Type::getInt8Ty(context));
-                ptr_to_data = builder->CreateStore(str, char_ptr);
+                llvm::Value* char_ptr = CreateAlloca(llvm::Type::getInt8Ty(context), nullptr, "cchar_ptr");
+                builder->CreateStore(str, char_ptr);
+                ptr_to_data = char_ptr;
                 break;
             }
             default:


### PR DESCRIPTION
## Summary
- Avoid stack growth when lowering BindC complex return conversions by hoisting temporary allocas to the entry block.
- Add a regression test for BindC complex return values in a loop.

Fixes a stack overflow seen when compiling/running complex-heavy third-party code.

## Why
Some BindC complex returns are lowered as vectors (e.g. <2 x float>) and then converted to the internal complex representation using a temporary stack slot. If that alloca is emitted inside a loop, the stack grows per-iteration.

**Stage:** Codegen

## Changes
- https://github.com/krystophny/lfortran/blob/9f6270f6454b053cd1d4cad3f731e9d94f244dad/src/libasr/codegen/asr_to_llvm.cpp#L16005-L16074
- https://github.com/krystophny/lfortran/blob/9f6270f6454b053cd1d4cad3f731e9d94f244dad/integration_tests/bindc_11.f90#L1-L37

## Tests
- ./run_tests.py
