### PR TITLE
Handle keyword argument to struct constructor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1782,6 +1782,8 @@ RUN(NAME derived_types_92 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_93 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_94 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_96 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME derived_types_97 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
+        EXTRAFILES derived_types_97_mod1.f90 derived_types_97_mod2.f90)
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME multi_file_member_access_01 LABELS gfortran llvm llvm_single_invocation EXTRAFILES multi_file_member_access_01_mod.f90)

--- a/integration_tests/derived_types_97.f90
+++ b/integration_tests/derived_types_97.f90
@@ -1,0 +1,13 @@
+program test_derived_types_97
+    use derived_types_97_mod2
+    implicit none
+    
+    type(point_t) :: p
+    
+    call create_point(p)
+    
+    if (p%x /= 10) error stop
+    if (p%y /= 20) error stop
+    
+    print *, "OK"
+end program test_derived_types_97

--- a/integration_tests/derived_types_97_mod1.f90
+++ b/integration_tests/derived_types_97_mod1.f90
@@ -1,0 +1,20 @@
+module derived_types_97_mod1
+    implicit none
+    
+    type :: point_t
+        integer :: x
+        integer :: y
+    end type point_t
+
+    interface point_t
+        module procedure point_new
+    end interface point_t
+
+contains
+
+    type(point_t) function point_new() result(p)
+        p%x = 0
+        p%y = 0
+    end function point_new
+    
+end module derived_types_97_mod1

--- a/integration_tests/derived_types_97_mod2.f90
+++ b/integration_tests/derived_types_97_mod2.f90
@@ -1,0 +1,13 @@
+module derived_types_97_mod2
+    use derived_types_97_mod1
+    implicit none
+    
+contains
+    
+    subroutine create_point(p)
+        type(point_t), intent(out) :: p
+        ! This uses keyword arguments with a type that has a generic interface
+        p = point_t(x = 10, y = 20)
+    end subroutine create_point
+    
+end module derived_types_97_mod2

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -12127,12 +12127,12 @@ public:
                     }
                     if( !function_found ) {
                         // First check if default structConstructor is there
-                        ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(
-                            current_scope->resolve_symbol(var_name));
+                        ASR::symbol_t* local_sym = current_scope->resolve_symbol(var_name);
+                        ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(local_sym);
                         if (struct_sym &&
                                 ASR::is_a<ASR::Struct_t>(*struct_sym)) {
                             tmp = create_DerivedTypeConstructor(x.base.base.loc, x.m_args, x.n_args,
-                                                    x.m_keywords, x.n_keywords, struct_sym);
+                                                    x.m_keywords, x.n_keywords, local_sym);
                             return;
                         }
                         bool is_function = true;


### PR DESCRIPTION
The new test fails in main, and passes in this PR.

Fixes #9551.