### PR TITLE
codegen: fix class(*) descriptor array pointer association

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1498,6 +1498,8 @@ RUN(NAME select_type_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME select_type_18 LABELS gfortran llvm)
+RUN(NAME select_type_19 LABELS gfortran llvm)
 
 RUN(NAME program_02 LABELS gfortran llvm)
 RUN(NAME program_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_type_18.f90
+++ b/integration_tests/select_type_18.f90
@@ -1,0 +1,20 @@
+program select_type_18
+    implicit none
+
+    logical, target :: l(3)
+    class(*), pointer :: generic(:)
+    logical, pointer :: p(:)
+
+    l = [.true., .false., .true.]
+    generic => l
+
+    select type (generic)
+    type is (logical)
+        p => generic
+        if (count(p) /= 2) error stop
+    class default
+        error stop
+    end select
+
+    print *, "ok"
+end program select_type_18

--- a/integration_tests/select_type_19.f90
+++ b/integration_tests/select_type_19.f90
@@ -1,0 +1,28 @@
+module select_type_19_m
+    implicit none
+contains
+    subroutine takes_logical_array(a)
+        logical, intent(in) :: a(:)
+        if (count(a) /= 2) error stop
+    end subroutine takes_logical_array
+end module select_type_19_m
+
+program select_type_19
+    use select_type_19_m, only: takes_logical_array
+    implicit none
+
+    logical, target :: l(3)
+    class(*), pointer :: generic(:)
+
+    l = [.true., .false., .true.]
+    generic => l
+
+    select type (generic)
+    type is (logical)
+        call takes_logical_array(generic)
+    class default
+        error stop
+    end select
+
+    print *, "ok"
+end program select_type_19


### PR DESCRIPTION
## Summary
- Handle class(*) unlimited polymorphic array pointer association in codegen
- Add LLVM <15 typed-pointer compatibility for array descriptor data fields

## Why
When associating a concrete array to a class(*) pointer (`generic => x`), the codegen needs to correctly set up the polymorphic wrapper and array descriptor. This also fixes select rank scalar association for the rank(0) case.

**Stage:** Codegen

## Changes
- [`asr_to_llvm.cpp#L7021-L7040`](https://github.com/lfortran/lfortran/blob/1967c31cd58a6218d56c632e158e06d40ac1a720/src/libasr/codegen/asr_to_llvm.cpp#L7021-L7040): Select rank scalar association (rank(0) case)
- [`asr_to_llvm.cpp#L7214-L7328`](https://github.com/lfortran/lfortran/blob/1967c31cd58a6218d56c632e158e06d40ac1a720/src/libasr/codegen/asr_to_llvm.cpp#L7214-L7328): class(*) array pointer association block
- [`asr_to_llvm.cpp#L7379-L7388`](https://github.com/lfortran/lfortran/blob/1967c31cd58a6218d56c632e158e06d40ac1a720/src/libasr/codegen/asr_to_llvm.cpp#L7379-L7388): LLVM <15 typed-pointer compatibility

## Tests
- [`select_type_18.f90`](https://github.com/lfortran/lfortran/blob/1967c31cd58a6218d56c632e158e06d40ac1a720/integration_tests/select_type_18.f90): Polymorphic logical array pointer association
- [`select_type_19.f90`](https://github.com/lfortran/lfortran/blob/1967c31cd58a6218d56c632e158e06d40ac1a720/integration_tests/select_type_19.f90): Polymorphic logical array passed to subroutine