### PR TITLE
fix: propagate ABI from Implementation to implicit interface

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1574,6 +1574,7 @@ RUN(NAME implicit_interface_23 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_24 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_25 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_26 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_27 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_27.f90
+++ b/integration_tests/implicit_interface_27.f90
@@ -1,0 +1,44 @@
+! Test that complex function return values work correctly with implicit interfaces
+! when calling LFortran-compiled Fortran functions.
+! This tests the ABI propagation fix: implicit interfaces should use the
+! Implementation's ABI (Source) when calling internal functions, not BindC.
+
+program test_implicit_interface_complex_return
+    implicit none
+    complex :: result, cdotc_test
+    external cdotc_test
+    complex :: x(3), y(3)
+
+    x = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+    y = [(1.0, 1.0), (1.0, 1.0), (1.0, 1.0)]
+
+    result = cdotc_test(3, x, 1, y, 1)
+
+    ! Expected: conjugate(x) dot y
+    ! = (1-2i)(1+i) + (3-4i)(1+i) + (5-6i)(1+i)
+    ! = (1-2i+i-2i^2) + (3-4i+3i-4i^2) + (5-6i+5i-6i^2)
+    ! = (1-i+2) + (3-i+4) + (5-i+6)
+    ! = 3-i + 7-i + 11-i
+    ! = 21 - 3i
+
+    if (abs(real(result) - 21.0) > 1.0e-5) error stop "real part wrong"
+    if (abs(aimag(result) - (-3.0)) > 1.0e-5) error stop "imaginary part wrong"
+
+    print *, "PASS: complex return via implicit interface works correctly"
+end program
+
+complex function cdotc_test(n, x, incx, y, incy)
+    implicit none
+    integer, intent(in) :: n, incx, incy
+    complex, intent(in) :: x(*), y(*)
+    integer :: i, ix, iy
+
+    cdotc_test = (0.0, 0.0)
+    ix = 1
+    iy = 1
+    do i = 1, n
+        cdotc_test = cdotc_test + conjg(x(ix)) * y(iy)
+        ix = ix + incx
+        iy = iy + incy
+    end do
+end function

--- a/tests/reference/asr-func_parameter_type_02-cef1ab3.json
+++ b/tests/reference/asr-func_parameter_type_02-cef1ab3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-func_parameter_type_02-cef1ab3.stdout",
-    "stdout_hash": "fac0f27024144b01889f59ac999b6b2115061d22ecc34dcd106898c2",
+    "stdout_hash": "fb59ed74b422aadf92b669885ab9060a11eb6964fa43b03b39d66226",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-func_parameter_type_02-cef1ab3.stdout
+++ b/tests/reference/asr-func_parameter_type_02-cef1ab3.stdout
@@ -122,7 +122,7 @@
                                                     Default
                                                     (Real 4)
                                                     ()
-                                                    BindC
+                                                    Source
                                                     Public
                                                     Required
                                                     .false.
@@ -137,7 +137,7 @@
                                     (FunctionType
                                         [(Real 4)]
                                         (Real 4)
-                                        BindC
+                                        Source
                                         Interface
                                         ()
                                         .false.


### PR DESCRIPTION
## Summary
- Fix ABI mismatch for complex function returns when calling LFortran-compiled functions via implicit interfaces
- When an Implementation is found in the global scope, use its ABI instead of defaulting to BindC

Fixes #9575

## Why
Implicit interfaces default to BindC ABI for external linkage compatibility. However, when calling internal LFortran-compiled functions, this causes an ABI mismatch: BindC uses `<2 x float>` for complex4 returns on Linux, while Source ABI uses `{float, float}`. This results in the imaginary part being lost.

**Stage:** Semantics

## Changes
- [`ast_common_visitor.h#L11118-L11138`](https://github.com/lfortran/lfortran/blob/254385642802d0f4cb987b6fcfa542b4f163dced/src/lfortran/semantics/ast_common_visitor.h#L11118-L11138): Look up Implementation and extract its ABI
- [`ast_common_visitor.h#L11267`](https://github.com/lfortran/lfortran/blob/254385642802d0f4cb987b6fcfa542b4f163dced/src/lfortran/semantics/ast_common_visitor.h#L11267): Use `impl_abi` for return variable
- [`ast_common_visitor.h#L11284`](https://github.com/lfortran/lfortran/blob/254385642802d0f4cb987b6fcfa542b4f163dced/src/lfortran/semantics/ast_common_visitor.h#L11284): Use `impl_abi` for function creation
- `tests/reference/*`: Updated reference output where ABI changed from BindC to Source

## Tests
- [`implicit_interface_27.f90`](https://github.com/lfortran/lfortran/blob/254385642802d0f4cb987b6fcfa542b4f163dced/integration_tests/implicit_interface_27.f90): Tests complex function return via implicit interface calling internal function

## Limitations
This fix works when the Implementation is visible in the same compilation unit (e.g., multiple functions in the same file). It does NOT fix the LAPACK test failures because:
1. LAPACK is compiled with `--separate-compilation`
2. BLAS functions (CDOTC, etc.) are in separate files from the test drivers
3. At semantic analysis time, the Implementation is not in the global scope

Future work may require:
- A compiler flag to force Source ABI for all implicit interfaces (e.g., `--assume-source-abi-external`)
- Link-time ABI matching
- Module files that record ABI information

## Verification
- All unit tests pass
- All 2197 LLVM integration tests pass