### PR TITLE
ICE when FORMAT precedes READ statement (#9519)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3017,6 +3017,7 @@ RUN(NAME logical_testing LABELS gfortran llvm)
 
 RUN(NAME formatted_read_01 LABELS gfortran llvm COPY_TO_BIN formatted_read_input_01.txt)
 
+RUN(NAME format_before_read_01 LABELS gfortran llvm)
 
 
 # LFortran extensions (lists, dicts, etc.)

--- a/integration_tests/format_before_read_01.f90
+++ b/integration_tests/format_before_read_01.f90
@@ -1,0 +1,21 @@
+program format_before_read_01
+  implicit none
+  integer :: i, j, k
+  character(len=7) :: input_string
+
+  ! Test case: FORMAT statement precedes the READ statement
+  ! This tests that the compiler correctly handles forward references
+  ! to FORMAT statements
+
+  input_string = "123 45 "
+
+100 format (I3, I2, I2)
+  read(input_string, 100) i, j, k
+
+  if (i /= 123) error stop "Expected i = 123"
+  if (j /= 4) error stop "Expected j = 4"
+  if (k /= 5) error stop "Expected k = 5"
+
+  print *, "Test passed: FORMAT before READ works correctly"
+
+end program format_before_read_01

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1533,6 +1533,18 @@ public:
                 a_iomsg, a_iostat, a_id, a_values_vec.p,
                 a_values_vec.size(), a_separator, a_end, overloaded_stmt, formatted, nullptr);
         } else if( _type == AST::stmtType::Read ) {
+            if (formatted && a_fmt_constant) {
+                ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
+                    ASRUtils::TYPE(ASR::make_String_t(
+                        al, loc, 1, nullptr,
+                        ASR::string_length_kindType::DeferredLength,
+                        ASR::string_physical_typeType::DescriptorString))));
+                ASR::expr_t* string_format = ASRUtils::EXPR(ASRUtils::make_StringFormat_t_util(al, a_fmt->base.loc,
+                    a_fmt_constant, a_values_vec.p, a_values_vec.size(), ASR::string_format_kindType::FormatFortran,
+                    type, nullptr));
+                a_values_vec.reserve(al, 1);
+                a_values_vec.push_back(al, string_format);
+            }
             tmp = ASR::make_FileRead_t(al, loc, m_label, a_unit, a_fmt, a_iomsg,
                a_iostat, a_advance, a_size, a_id, a_values_vec.p, a_values_vec.size(), overloaded_stmt, formatted, nullptr);
         }


### PR DESCRIPTION
Fixes: #9519

When a READ statement referenced a FORMAT label that was already processed (FORMAT before READ), the code set `a_fmt_constant` but never wrapped the values in a `StringFormat` expression for READ statements.Added the same StringFormat wrapping logic for READ statements when `a_fmt_constant` is set.


Added minor fix and integration test.
