### PR TITLE
Fix: convert logical to i1 for branch condition in optional presence check

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -15037,12 +15037,15 @@ public:
                             ASR::is_a<ASR::Logical_t>(*var_type)) {
                           
                             this->visit_expr_wrapper(next_arg, true);
-                            is_present_flag = tmp; 
-                            
+                            is_present_flag = tmp;
+
                             llvm::Function *fn = builder->GetInsertBlock()->getParent();
                             llvm::BasicBlock *present_checkBB = llvm::BasicBlock::Create(context, "optional_present", fn);
                             optional_check_mergeBB = llvm::BasicBlock::Create(context, "optional_merge");
-                            builder->CreateCondBr(is_present_flag, present_checkBB, optional_check_mergeBB);
+                            // Convert logical (i8/i32) to i1 for branch condition
+                            llvm::Value* is_present_i1 = builder->CreateICmpNE(
+                                is_present_flag, llvm::ConstantInt::get(is_present_flag->getType(), 0));
+                            builder->CreateCondBr(is_present_i1, present_checkBB, optional_check_mergeBB);
                             builder->SetInsertPoint(present_checkBB);
                         }
                     }


### PR DESCRIPTION
## Summary
- Fix branch condition type mismatch in optional argument presence checking
- Convert logical value (i8/i32) to i1 before use in LLVM CreateCondBr

## Why
LLVM's `CreateCondBr` requires an `i1` (boolean) type for the branch condition. The `is_present_flag` loaded from a LOGICAL variable may be `i8` or `i32` depending on the kind, causing LLVM verifier errors like:
```
Branch condition is not 'i1' type!
  br i8 %281, label %optional_present, label %optional_merge
```

**Stage:** Codegen

## Changes
- `asr_to_llvm.cpp`: Add `CreateICmpNE(value, 0)` to convert logical to i1 before branch

## Tests
Existing integration tests cover optional argument handling. This is a type-safety fix that prevents LLVM IR verification failures.
