### PR TITLE
Add integration test for abs(complex) underflow

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1351,6 +1351,7 @@ RUN(NAME intrinsics_404 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_405 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_406 LABELS gfortran llvm) # iachar with array arguments
 RUN(NAME intrinsics_407 LABELS gfortran llvm) # complex abs() overflow
+RUN(NAME intrinsics_408 LABELS gfortran llvm) # complex abs() underflow
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_408.f90
+++ b/integration_tests/intrinsics_408.f90
@@ -1,0 +1,17 @@
+program intrinsics_408
+    use iso_fortran_env, only: real64
+    implicit none
+
+    complex(real64) :: z
+    real(real64) :: r
+
+    ! This stresses abs(complex) lowering for very small magnitudes:
+    ! naive hypot = sqrt(x*x + y*y) underflows to 0.0 for x=y=1e-200 (real64),
+    ! while a scaled hypot algorithm must return a positive value.
+    z = cmplx(1.0e-200_real64, 1.0e-200_real64, kind=real64)
+    r = abs(z)
+
+    if (r == 0.0_real64) error stop
+
+    print *, "ok"
+end program intrinsics_408


### PR DESCRIPTION
## Summary
Add integration test for `abs(complex)` underflow regression.

Fixes #9630.

## Why
The fix for `abs(complex)` underflow was merged in #9582. This PR adds the corresponding integration test to lock in the fix and prevent future regressions.

## Changes
- [`integration_tests/intrinsics_408.f90`](https://github.com/lfortran/lfortran/blob/4e1498c77/integration_tests/intrinsics_408.f90): regression test verifying `abs(cmplx(1e-200, 1e-200))` does not underflow to zero.
- [`integration_tests/CMakeLists.txt`](https://github.com/lfortran/lfortran/blob/4e1498c77/integration_tests/CMakeLists.txt): register `intrinsics_408`.

## Tests
- `lfortran --backend=llvm --fast integration_tests/intrinsics_408.f90` (runs without `ERROR STOP`)