### PR TITLE
fix: create do loop for trimmed idl in `StringFormat`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2120,6 +2120,7 @@ RUN(NAME file_42 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_43 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_44 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME file_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_46.f90
+++ b/integration_tests/file_46.f90
@@ -1,0 +1,25 @@
+program file_46
+    implicit none
+
+    character(len=40), parameter :: help_text(2) = [character(len=40) :: &
+        'NAME', 'DESCRIPTION']
+
+    integer :: i, lun
+    character(len=200) :: line
+    integer :: expected_len
+    integer :: filesize
+
+    open(newunit=lun, file='out.txt', status='replace', action='write')
+    write(lun,'(g0)') (trim(help_text(i)), i=1, size(help_text))
+
+    expected_len = len('NAME'//new_line('a')//'DESCRIPTION'//new_line('a'))
+
+    inquire(file='out.txt', size=filesize)
+    if (filesize /= expected_len) then
+        error stop 'EXTRA BYTES WRITTEN (LIKELY SPACES)'
+    end if
+
+    print *, 'PASSED: no trailing spaces written'
+    close(lun, status='delete')
+
+end program file_46

--- a/tests/reference/run-implied_do_loop3-52d2c18.json
+++ b/tests/reference/run-implied_do_loop3-52d2c18.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run-implied_do_loop3-52d2c18.stdout",
-    "stdout_hash": "c6b7839a39e676dd67f2c0a5cdf1a1fa17a7412ea2f9af55bb03bb24",
+    "stdout_hash": "e5ed6b2560462ad761ad4c1d21a15281c018a7519b5fa493fc62f3fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/run-implied_do_loop3-52d2c18.stdout
+++ b/tests/reference/run-implied_do_loop3-52d2c18.stdout
@@ -1,7 +1,7 @@
-Hello               
-Hello               
-Hello               
+Hello
+Hello
+Hello
 H    H    H
-Hello               
-Hello               
-Hello               
+Hello
+Hello
+Hello


### PR DESCRIPTION
Fixes #9631