### PR TITLE
ci: fix LAPACK dgd.in test by patching random seed

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -887,6 +887,10 @@ time_section "🧪 Testing Reference-LAPACK v3.12.1 with BUILD_TESTING (Full Sui
     # Patch to skip FortranCInterface_VERIFY (requires mixed Fortran/C linking)
     sed -i "/FortranCInterface_VERIFY/d" LAPACKE/include/CMakeLists.txt
 
+    # Patch dgd.in to use custom seed that avoids FMA-sensitive ill-conditioned matrix
+    # See: https://github.com/Reference-LAPACK/lapack/issues/1186
+    sed -i "s/^0                 Code to interpret the seed$/2                 Code to interpret the seed\n1234 5678 9012 3456/" TESTING/dgd.in
+
     # CMake < 3.31 needs CMAKE_Fortran_PREPROCESS_SOURCE for LFortran
     CMAKE_VERSION=$(cmake --version | head -1 | grep -oE "[0-9]+\.[0-9]+")
     TOOLCHAIN_OPT=""
@@ -965,8 +969,7 @@ time_section "🧪 Testing Reference-LAPACK v3.12.1 with BUILD_TESTING (Full Sui
     done
 
     # Double Real Eigenvalue Tests
-    # NOTE: dgd.in currently fails due to DGGES/DTGSEN reordering (INFO=N+3). See #9619.
-    for input in nep sep se2 svd sec ded dgg dsb dsg dbal dbak dgbal dgbak dbb glm gqr gsv csd lse ddmd; do
+    for input in nep sep se2 svd sec ded dgg dgd dsb dsg dbal dbak dgbal dgbak dbb glm gqr gsv csd lse ddmd; do
         if [ -f "../TESTING/${input}.in" ]; then
             run_lapack_test xeigtstd ${input}.in "Double Real Eigenvalue: ${input}"
         fi


### PR DESCRIPTION
## Summary

Patches the LAPACK dgd.in test input to use a custom random seed that avoids an FMA-sensitive ill-conditioned matrix, enabling the full LAPACK eigenvalue test suite in CI.

Fixes #9619

## Details

The default seed `(3618, 381, 2331, 3777)` generates a matrix for N=6, JTYPE=21 that causes DGGES to fail (INFO=9) when compiled without FMA (Fused Multiply-Add) instructions. LFortran does not enable FMA contraction, producing the same result as gfortran with `-ffp-contract=off` or debug builds.

The fix patches `TESTING/dgd.in` after cloning to use seed `(1234, 5678, 9012, 3456)` which avoids the ill-conditioned case while maintaining full test coverage.

Upstream LAPACK issue: https://github.com/Reference-LAPACK/lapack/issues/1186
Upstream LAPACK PR: https://github.com/Reference-LAPACK/lapack/pull/1187

## Test plan

- [x] CI passes with full LAPACK eigenvalue test suite (dgd.in now included)
