### PR TITLE
Fix ILP64 (-fdefault-integer-8) array bound type mismatch

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2407,6 +2407,10 @@ RUN(NAME array_section_09 LABELS gfortran llvm
     EXTRA_ARGS -fdefault-integer-8
     GFORTRAN_ARGS -fdefault-integer-8)
 RUN(NAME array_section_10 LABELS gfortran llvm)
+RUN(NAME array_section_11 LABELS gfortran llvm
+    EXTRA_ARGS --implicit-interface --legacy-array-sections -fdefault-integer-8
+    GFORTRAN_ARGS -fdefault-integer-8
+    EXTRAFILES array_section_11b.f90)
 
 RUN(NAME nested_vars_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 

--- a/integration_tests/array_section_11.f90
+++ b/integration_tests/array_section_11.f90
@@ -1,0 +1,23 @@
+! Test array section bounds with -fdefault-integer-8 (ILP64 mode)
+! This tests that array bounds computation uses consistent integer types
+! when the default integer kind is 64-bit.
+
+program array_section_11
+    implicit none
+    integer, parameter :: n = 5, lwork = 10
+    real :: work(lwork)
+    integer :: i
+
+    work = 0.0
+    call caller(work, lwork, n)
+
+    ! Check: elements 1-5 should be 0, elements 6-10 should be 1-5
+    do i = 1, n
+        if (work(i) /= 0.0) error stop
+    end do
+    do i = n+1, lwork
+        if (work(i) /= real(i - n)) error stop
+    end do
+
+    print *, "PASSED"
+end program

--- a/integration_tests/array_section_11b.f90
+++ b/integration_tests/array_section_11b.f90
@@ -1,0 +1,22 @@
+! Companion file for array_section_11 - ILP64 array section bounds test
+! This file is compiled separately to create an implicit interface scenario.
+
+subroutine caller(work, lwork, n)
+    implicit none
+    integer, intent(in) :: lwork, n
+    real, intent(inout) :: work(lwork)
+    ! Pass array element to implicit interface subroutine.
+    ! With --legacy-array-sections this becomes an array section.
+    ! The bound computation must use consistent integer types.
+    call callee(work(n+1), lwork-n)
+end subroutine
+
+subroutine callee(x, m)
+    implicit none
+    integer, intent(in) :: m
+    real, intent(inout) :: x(m)
+    integer :: i
+    do i = 1, m
+        x(i) = real(i)
+    end do
+end subroutine

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2953,7 +2953,7 @@ public:
         v->m_body = body.p;
         v->n_body = body.size();
 
-        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope, compiler_options.po.default_integer_kind);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
@@ -3447,7 +3447,7 @@ public:
         v->m_dependencies = func_deps.p;
         v->n_dependencies = func_deps.size();
 
-        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope, compiler_options.po.default_integer_kind);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
@@ -3521,7 +3521,7 @@ public:
         v->m_dependencies = func_deps.p;
         v->n_dependencies = func_deps.size();
 
-        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope, compiler_options.po.default_integer_kind);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -14,10 +14,12 @@ class ASRBuilder {
     Allocator& al;
     // TODO: use the location to point C++ code in `intrinsic_function_registry`
     const Location &loc;
+    int default_int_kind;
 
     public:
 
-    ASRBuilder(Allocator& al_, const Location& loc_): al(al_), loc(loc_) {}
+    ASRBuilder(Allocator& al_, const Location& loc_, int default_int_kind_ = 4)
+        : al(al_), loc(loc_), default_int_kind(default_int_kind_) {}
 
     #define make_ConstantWithKind(Constructor, TypeConstructor, value, kind, loc) ASRUtils::EXPR( \
         ASR::Constructor( al, loc, value, \
@@ -218,11 +220,11 @@ class ASRBuilder {
                     if( !ASRUtils::extract_value(length, const_length) ) {
                         LCOMPILERS_ASSERT(false);
                     }
-                    value = i32(const_lbound + const_length - 1);
+                    value = i_default(const_lbound + const_length - 1);
                 }
             }
         }
-        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i32(dim), int32, ASR::arrayboundType::UBound, value));
+        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i_default(dim), intDefault(), ASR::arrayboundType::UBound, value));
     }
 
     ASR::expr_t* ArrayLBound(ASR::expr_t* x, int64_t dim) {
@@ -240,11 +242,11 @@ class ASRBuilder {
                     if( !ASRUtils::extract_value(start, const_lbound) ) {
                         LCOMPILERS_ASSERT(false);
                     }
-                    value = i32(const_lbound);
+                    value = i_default(const_lbound);
                 }
             }
         }
-        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i32(dim), int32, ASR::arrayboundType::LBound, value));
+        return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, loc, x, i_default(dim), intDefault(), ASR::arrayboundType::LBound, value));
     }
 
     inline ASR::expr_t* i_t(int64_t x, ASR::ttype_t* t) {
@@ -265,6 +267,14 @@ class ASRBuilder {
 
     inline ASR::expr_t* i64(int64_t x) {
         return EXPR(ASR::make_IntegerConstant_t(al, loc, x, int64));
+    }
+
+    inline ASR::ttype_t* intDefault() {
+        return TYPE(ASR::make_Integer_t(al, loc, default_int_kind));
+    }
+
+    inline ASR::expr_t* i_default(int64_t x) {
+        return EXPR(ASR::make_IntegerConstant_t(al, loc, x, intDefault()));
     }
 
     inline ASR::expr_t* i_neg(ASR::expr_t* x, ASR::ttype_t* t) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5678,10 +5678,11 @@ static inline bool is_pass_array_by_data_possible(ASR::Function_t* x, std::vecto
 
 template <typename SemanticAbort>
 static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
-                                     std::string bound, Allocator& al, diag::Diagnostics &diag) {
-    ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, 4));
+                                     std::string bound, Allocator& al, diag::Diagnostics &diag,
+                                     int default_int_kind = 4) {
+    ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, default_int_kind));
     ASR::expr_t* dim_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_expr->base.loc,
-                                                                       dim, int32_type));
+                                                                       dim, int_type));
     ASR::arrayboundType bound_type = ASR::arrayboundType::LBound;
     if( bound == "ubound" ) {
         bound_type = ASR::arrayboundType::UBound;
@@ -5742,7 +5743,7 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
                 LCOMPILERS_ASSERT(false);
             }
             bound_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                            al, arr_expr->base.loc, const_lbound, int32_type));
+                            al, arr_expr->base.loc, const_lbound, int_type));
         } else if( bound_type == ASR::arrayboundType::UBound &&
             ASRUtils::is_value_constant(arr_start) &&
             ASRUtils::is_value_constant(arr_length) ) {
@@ -5756,11 +5757,11 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
             }
             bound_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
                             al, arr_expr->base.loc,
-                            const_lbound + const_length - 1, int32_type));
+                            const_lbound + const_length - 1, int_type));
         }
     }
     return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, arr_expr->base.loc, arr_expr, dim_expr,
-                int32_type, bound_type, bound_value));
+                int_type, bound_type, bound_value));
 }
 
 static inline ASR::expr_t* get_size(ASR::expr_t* arr_expr, int dim,

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -901,23 +901,23 @@ namespace LCompilers {
             }
         }
 
-        ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim, std::string bound, Allocator& al) {
+        ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim, std::string bound, Allocator& al, int default_int_kind) {
             ASR::ttype_t* x_mv_type = ASRUtils::expr_type(arr_expr);
             ASR::dimension_t* m_dims;
             int n_dims = ASRUtils::extract_dimensions_from_ttype(x_mv_type, m_dims);
             bool is_data_only_array = ASRUtils::is_fixed_size_array(m_dims, n_dims) && ASRUtils::get_asr_owner(arr_expr) &&
                                     ASR::is_a<ASR::Struct_t>(*ASRUtils::get_asr_owner(arr_expr));
-            ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, 4));
+            ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, default_int_kind));
             if (is_data_only_array) {
                 const Location& loc = arr_expr->base.loc;
-                ASR::expr_t* zero = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 0, int32_type));
-                ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int32_type));
+                ASR::expr_t* zero = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 0, int_type));
+                ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int_type));
                 if( bound == "ubound" ) {
                     return ASRUtils::EXPR(
                             ASR::make_IntegerBinOp_t(al, arr_expr->base.loc,
                                 ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_expr->base.loc,
-                                    m_dims[dim - 1].m_length, ASR::binopType::Sub, one, int32_type, nullptr)),
-                                ASR::binopType::Add, m_dims[dim - 1].m_start, int32_type, nullptr)
+                                    m_dims[dim - 1].m_length, ASR::binopType::Sub, one, int_type, nullptr)),
+                                ASR::binopType::Add, m_dims[dim - 1].m_start, int_type, nullptr)
                         );
                 }
                 if ( m_dims[dim - 1].m_start != nullptr ) {
@@ -925,13 +925,13 @@ namespace LCompilers {
                 }
                 return  zero;
             }
-            ASR::expr_t* dim_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_expr->base.loc, dim, int32_type));
+            ASR::expr_t* dim_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_expr->base.loc, dim, int_type));
             ASR::arrayboundType bound_type = ASR::arrayboundType::LBound;
             if( bound == "ubound" ) {
                 bound_type = ASR::arrayboundType::UBound;
             }
             return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, arr_expr->base.loc, arr_expr, dim_expr,
-                        int32_type, bound_type, nullptr));
+                        int_type, bound_type, nullptr));
         }
 
         bool skip_instantiation(PassOptions pass_options, int64_t id) {

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -76,7 +76,7 @@ namespace LCompilers {
                                             ASR::binopType op);
 
         ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim, std::string bound,
-                                Allocator& al);
+                                Allocator& al, int default_int_kind = 4);
 
         ASR::expr_t* get_flipsign(ASR::expr_t* arg0, ASR::expr_t* arg1,
                              Allocator& al, ASR::TranslationUnit_t& unit, const Location& loc,


### PR DESCRIPTION
## Summary
- Add `default_integer_kind` parameter to `ASRBuilder` and bound utilities
- Ensures array sections use `Integer 8` bounds in ILP64 mode
- Add integration tests for `-fdefault-integer-8 --legacy-array-sections`

Fixes #2844
Fixes #9640

**Stage:** Semantics/ASR passes

## Changes
- [`src/libasr/asr_builder.h#L36-L55`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/src/libasr/asr_builder.h#L36-L55): Add `default_int_kind` parameter to `ASRBuilder`, add `i_default()` helper
- [`src/libasr/pass/pass_utils.h`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/src/libasr/pass/pass_utils.h#L126): Add `default_int_kind` parameter to `get_bound()`
- [`src/libasr/asr_utils.h#L1621-L1688`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/src/libasr/asr_utils.h#L1621-L1688): Add `default_int_kind` to `ASRUtils::get_bound()`
- [`src/lfortran/semantics/ast_common_visitor.h`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/src/lfortran/semantics/ast_common_visitor.h): Pass `default_integer_kind` to bound calls
- [`src/libasr/pass/array_passed_in_function_call.cpp`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/src/libasr/pass/array_passed_in_function_call.cpp): Use `ASRBuilder` methods with correct integer kind

## Tests
- [`integration_tests/array_section_11.f90`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/integration_tests/array_section_11.f90): Basic ILP64 array section test
- [`integration_tests/array_section_11b.f90`](https://github.com/lfortran/lfortran/blob/f3dcd4ff425c39973a256e76f4166a67e6efd077/integration_tests/array_section_11b.f90): Array section with expressions in bounds