### PR TITLE
fix: handle length calculation using expressions for allocatable strings

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2025,6 +2025,7 @@ RUN(NAME string_91 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_92 LABELS gfortran llvm)
 RUN(NAME string_93 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_94 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc  EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME string_95 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_95.f90
+++ b/integration_tests/string_95.f90
@@ -1,0 +1,19 @@
+program string_95
+  character(2), allocatable :: str
+
+  str = f1(5)
+  print *, len(str), str
+  if (len(str) /= 2) error stop
+  if (str /= "ab") error stop
+
+  contains 
+  function f1(n) result(res)
+    integer :: n
+    character(n), allocatable :: res
+    allocate(res)
+    res = "abcde"
+    print *, len(res), res
+    if (len(res) /= 5) error stop
+    if (res /= "abcde") error stop
+  end function
+end program string_95

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6325,6 +6325,15 @@ public:
                     allocate_array_members_of_struct(struct_sym, st_desc, ASR::down_cast<ASR::Variable_t>(sym.second)->m_type, true);
                 }
             }
+            if (ASRUtils::is_string_only(symbol_type) && ASRUtils::is_allocatable(symbol_type)) {                                                                  
+                ASR::String_t* str_t = ASRUtils::get_string_type(symbol_type);                                             
+                if (str_t->m_len_kind == ASR::ExpressionLength && str_t->m_len) {                                      
+                    uint32_t h = get_hash((ASR::asr_t*)sym.second);                                                   
+                    LCOMPILERS_ASSERT(llvm_symtab.find(h) != llvm_symtab.end());                                           
+                    llvm::Value* str_desc = llvm_symtab[h];                                                         
+                    setup_string_length(str_desc, str_t, str_t->m_len);                                     
+                }                                                                                            
+            }                                                                                                              
             if( !(ASRUtils::is_pointer(symbol_type) || ASRUtils::is_allocatable(symbol_type)) &&
                 ASRUtils::is_array(symbol_type) &&
                 ASRUtils::extract_physical_type(symbol_type)


### PR DESCRIPTION
Fixes #8620 

Changes made:
- calculate length for `ExpressionLength` strings having allocatable attributes