### PR TITLE
Fix integer types for ArrayUBound in ILP64 mode

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2820,6 +2820,9 @@ RUN(NAME legacy_array_sections_13 LABELS gfortran llvm EXTRA_ARGS --legacy-array
 RUN(NAME legacy_array_sections_14 LABELS gfortran llvm
     EXTRAFILES legacy_array_sections_14_foo.f90
     EXTRA_ARGS --legacy-array-sections --implicit-interface --separate-compilation)
+RUN(NAME legacy_array_sections_15 LABELS gfortran llvm
+    EXTRA_ARGS --legacy-array-sections -fdefault-integer-8
+    GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME cmake_minimal_test_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME char_array_initialization_declaration LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/legacy_array_sections_15.f90
+++ b/integration_tests/legacy_array_sections_15.f90
@@ -1,0 +1,24 @@
+! Test legacy array sections with 64-bit default integers
+! Tests that ArrayBound nodes use correct integer kind when -fdefault-integer-8 is used
+
+subroutine caller(work, lwork, n)
+    integer :: lwork, n
+    real :: work(lwork)
+    call callee(work(n+1), lwork-n)
+end subroutine
+
+subroutine callee(x, m)
+    integer :: m
+    real :: x(m)
+    x(1) = 42.0
+end subroutine
+
+program legacy_array_sections_15
+    implicit none
+    real :: w(100)
+    integer :: i
+    w = 0.0
+    call caller(w, 100, 10)
+    if (abs(w(11) - 42.0) > 1e-6) error stop "Test failed: w(11) should be 42.0"
+    print *, "PASS"
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3226,7 +3226,7 @@ public:
         v->m_body = body.p;
         v->n_body = body.size();
 
-        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope, compiler_options.po.default_integer_kind);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
@@ -3720,7 +3720,7 @@ public:
         v->m_dependencies = func_deps.p;
         v->n_dependencies = func_deps.size();
 
-        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope, compiler_options.po.default_integer_kind);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);
@@ -3794,7 +3794,7 @@ public:
         v->m_dependencies = func_deps.p;
         v->n_dependencies = func_deps.size();
 
-        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope);
+        replace_ArrayItem_in_SubroutineCall(al, compiler_options.legacy_array_sections, current_scope, compiler_options.po.default_integer_kind);
 
         for (size_t i=0; i<x.n_contains; i++) {
             visit_program_unit(*x.m_contains[i]);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7767,16 +7767,17 @@ public:
         }
     }
 
-    void replace_ArrayItem_in_SubroutineCall(Allocator &al, bool legacy_array_sections, SymbolTable* current_scope) {
+    void replace_ArrayItem_in_SubroutineCall(Allocator &al, bool legacy_array_sections, SymbolTable* current_scope, int default_integer_kind) {
 
     class ReplaceArrayItemWithArraySection: public ASR::BaseExprReplacer<ReplaceArrayItemWithArraySection> {
         private:
             Allocator& al;
+            int default_integer_kind;
         public:
             ASR::expr_t** current_expr;
 
-            ReplaceArrayItemWithArraySection(Allocator& al_) :
-                al(al_), current_expr(nullptr) {}
+            ReplaceArrayItemWithArraySection(Allocator& al_, int default_integer_kind_) :
+                al(al_), default_integer_kind(default_integer_kind_), current_expr(nullptr) {}
 
             void replace_ArrayItem(ASR::ArrayItem_t* x) {
                 ASR::ttype_t* array_type = ASRUtils::expr_type(x->m_v);
@@ -7784,6 +7785,7 @@ public:
                 bool is_unbounded = (phys_type == ASR::array_physical_typeType::UnboundedPointerArray);
                 Vec<ASR::array_index_t> array_indices; array_indices.reserve(al, x->n_args);
                 ASRUtils::ASRBuilder b(al, x->base.base.loc);
+                ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x->base.base.loc, default_integer_kind));
 
                 for ( size_t i = 0; i < x->n_args; i++ ) {
                     ASR::array_index_t array_index;
@@ -7791,13 +7793,13 @@ public:
                     array_index.m_left = x->m_args[i].m_right;
                     if (is_unbounded && i == x->n_args - 1) {
                         array_index.m_right = array_index.m_left;
-                        array_index.m_step = b.i32(1);
+                        array_index.m_step = b.i_t(1, int_type);
                     } else {
-                        array_index.m_right = b.ArrayUBound(x->m_v, i + 1);
+                        array_index.m_right = b.ArrayUBound(x->m_v, i + 1, default_integer_kind);
                         if ( ASRUtils::expr_value(array_index.m_right) ) {
                             array_index.m_right = ASRUtils::expr_value(array_index.m_right);
                         }
-                        array_index.m_step = b.i32( i + 1 );
+                        array_index.m_step = b.i_t(i + 1, int_type);
                     }
                     array_indices.push_back(al, array_index);
                 }
@@ -7814,11 +7816,12 @@ public:
     class LegacyArraySectionsVisitor : public ASR::CallReplacerOnExpressionsVisitor<LegacyArraySectionsVisitor> {
         private:
             Allocator& al;
+            int default_integer_kind;
             ReplaceArrayItemWithArraySection replacer;
         public:
             ASR::expr_t** current_expr;
-            LegacyArraySectionsVisitor(Allocator& al_) :
-                al(al_), replacer(al_), current_expr(nullptr) {}
+            LegacyArraySectionsVisitor(Allocator& al_, int default_integer_kind_) :
+                al(al_), default_integer_kind(default_integer_kind_), replacer(al_, default_integer_kind_), current_expr(nullptr) {}
 
             void call_replacer_() {
                 replacer.current_expr = current_expr;
@@ -7890,6 +7893,7 @@ public:
                             Vec<ASR::array_index_t> array_indices;
                             array_indices.reserve(al, array_item->n_args);
                             ASRUtils::ASRBuilder b(al, array_item->base.base.loc);
+                            ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, array_item->base.base.loc, default_integer_kind));
 
                             for ( size_t j = 0; j < array_item->n_args; j++ ) {
                                 ASR::array_index_t array_index;
@@ -7897,13 +7901,13 @@ public:
                                 array_index.m_left = array_item->m_args[j].m_right;
                                 if (unbounded_tail && j == array_item->n_args - 1) {
                                     array_index.m_right = array_index.m_left;
-                                    array_index.m_step = b.i32(1);
+                                    array_index.m_step = b.i_t(1, int_type);
                                 } else {
-                                    array_index.m_right = b.ArrayUBound(array_item->m_v, j + 1);
+                                    array_index.m_right = b.ArrayUBound(array_item->m_v, j + 1, default_integer_kind);
                                     if ( ASRUtils::expr_value(array_index.m_right) ) {
                                         array_index.m_right = ASRUtils::expr_value(array_index.m_right);
                                     }
-                                    array_index.m_step = b.i32( j + 1 );
+                                    array_index.m_step = b.i_t(j + 1, int_type);
                                 }
                                 array_indices.push_back(al, array_index);
                             }
@@ -7926,11 +7930,11 @@ public:
                                         // size = right - left + 1
                                         dim_size = b.Add(b.Sub(array_indices.p[j].m_right,
                                                                array_indices.p[j].m_left),
-                                                        b.i32(1));
+                                                        b.i_t(1, int_type));
                                     } else if (array_indices.p[j].m_right) {
                                         dim_size = array_indices.p[j].m_right;
                                     } else {
-                                        dim_size = b.i32(1);
+                                        dim_size = b.i_t(1, int_type);
                                     }
                                     if (total_size == nullptr) {
                                         total_size = dim_size;
@@ -7943,7 +7947,7 @@ public:
                                 dims.reserve(al, 1);
                                 ASR::dimension_t dim;
                                 dim.loc = array_item->base.base.loc;
-                                dim.m_start = b.i32(1);
+                                dim.m_start = b.i_t(1, int_type);
                                 dim.m_length = total_size;
                                 dims.push_back(al, dim);
                                 ASR::ttype_t* elem_type = ASRUtils::type_get_past_array(section_type);
@@ -7964,7 +7968,7 @@ public:
     };
 
         if ( legacy_array_sections ) {
-            LegacyArraySectionsVisitor v(al);
+            LegacyArraySectionsVisitor v(al, default_integer_kind);
             ASR::asr_t* asr_owner = current_scope->asr_owner;
             if ( ASR::is_a<ASR::symbol_t>(*asr_owner) ) {
                 ASR::symbol_t* sym = ASR::down_cast<ASR::symbol_t>(asr_owner);
@@ -8158,12 +8162,13 @@ public:
 
                         ASR::array_physical_typeType expected_phys_type = ASRUtils::extract_physical_type(expected_arg_type);
                         ASRUtils::ASRBuilder builder(al, loc);
-                        ASR::expr_t* one = builder.i32(1);
+                        ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, compiler_options.po.default_integer_kind));
+                        ASR::expr_t* one = builder.i_t(1, int_type);
                         for (size_t dim_i = 0; dim_i < array_item->n_args; dim_i++) {
                             ASR::array_index_t array_idx;
                             array_idx.loc = array_item->m_args[dim_i].loc;
                             array_idx.m_left = array_item->m_args[dim_i].m_right;
-                            array_idx.m_right = ASRUtils::get_bound<SemanticAbort>(array_expr, dim_i + 1, "ubound", al, diag);
+                            array_idx.m_right = ASRUtils::get_bound<SemanticAbort>(array_expr, dim_i + 1, "ubound", al, diag, compiler_options.po.default_integer_kind);
                             array_idx.m_step = one;
                             array_indices.push_back(al, array_idx);
                         }
@@ -8190,11 +8195,11 @@ public:
                                     // size = right - left + 1
                                     dim_size = builder.Add(builder.Sub(array_indices.p[dim_i].m_right,
                                                                       array_indices.p[dim_i].m_left),
-                                                          builder.i32(1));
+                                                          one);
                                 } else if (array_indices.p[dim_i].m_right) {
                                     dim_size = array_indices.p[dim_i].m_right;
                                 } else {
-                                    dim_size = builder.i32(1);
+                                    dim_size = one;
                                 }
                                 if (total_size == nullptr) {
                                     total_size = dim_size;
@@ -8207,7 +8212,7 @@ public:
                             dims.reserve(al, 1);
                             ASR::dimension_t dim;
                             dim.loc = array_item->base.base.loc;
-                            dim.m_start = builder.i32(1);
+                            dim.m_start = one;
                             dim.m_length = total_size;
                             dims.push_back(al, dim);
                             ASR::ttype_t* elem_type = ASRUtils::type_get_past_array(expected_arg_type);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5751,10 +5751,10 @@ static inline bool is_pass_array_by_data_possible(ASR::Function_t* x, std::vecto
 
 template <typename SemanticAbort>
 static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
-                                     std::string bound, Allocator& al, diag::Diagnostics &diag) {
-    ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, 4));
+                                     std::string bound, Allocator& al, diag::Diagnostics &diag, int index_kind = 4) {
+    ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, arr_expr->base.loc, index_kind));
     ASR::expr_t* dim_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_expr->base.loc,
-                                                                       dim, int32_type));
+                                                                       dim, int_type));
     ASR::arrayboundType bound_type = ASR::arrayboundType::LBound;
     if( bound == "ubound" ) {
         bound_type = ASR::arrayboundType::UBound;
@@ -5815,7 +5815,7 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
                 LCOMPILERS_ASSERT(false);
             }
             bound_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                            al, arr_expr->base.loc, const_lbound, int32_type));
+                            al, arr_expr->base.loc, const_lbound, int_type));
         } else if( bound_type == ASR::arrayboundType::UBound &&
             ASRUtils::is_value_constant(arr_start) &&
             ASRUtils::is_value_constant(arr_length) ) {
@@ -5829,11 +5829,11 @@ static inline ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim,
             }
             bound_value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
                             al, arr_expr->base.loc,
-                            const_lbound + const_length - 1, int32_type));
+                            const_lbound + const_length - 1, int_type));
         }
     }
     return ASRUtils::EXPR(ASR::make_ArrayBound_t(al, arr_expr->base.loc, arr_expr, dim_expr,
-                int32_type, bound_type, bound_value));
+                int_type, bound_type, bound_value));
 }
 
 static inline ASR::expr_t* get_size(ASR::expr_t* arr_expr, int dim,


### PR DESCRIPTION
## Summary

Fix integer type mismatches in ILP64 mode (`-fdefault-integer-8`) for legacy array section operations.

Part of ILP64 support for LFortran/LAPACK. Tracked in issue #9640.

## Why

Legacy array sections used hardcoded `Integer(4)` constants for array bound operations, causing LLVM verification errors when `-fdefault-integer-8` is used:

```
Both operands to a binary operator are not of the same type!
  %23 = sub i64 %22, i32 1
```

**Stage:** Semantics

## Changes

- `src/lfortran/semantics/ast_common_visitor.h`: Pass `default_integer_kind` to `ArrayUBound` calls and replace `b.i32()` with `b.i_t()` in legacy array section code
- `src/lfortran/semantics/ast_body_visitor.cpp`: Pass `default_integer_kind` parameter to visitor classes
- `src/libasr/asr_utils.h`: Add `index_kind` parameter to `get_bound` template

## Tests

- `legacy_array_sections_15.f90`: Legacy array sections with `-fdefault-integer-8` (verified: fails on main, passes with fix)
