### PR TITLE
feat: new runtime error API

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3952,7 +3952,7 @@ public:
                     builder->CreatePtrToInt(llvm::ConstantPointerNull::get(x_mv_llvm_type->getPointerTo()),
                         llvm::Type::getInt64Ty(context)));
                 llvm_utils->generate_runtime_error(cond,
-                        "Runtime error: Tried to access member of unallocated variable '%s'\n",
+                        "Tried to access member of unallocated variable '%s'\n",
                         infile,
                         x.m_v->base.loc,
                         location_manager,
@@ -16157,10 +16157,12 @@ public:
                             } else {
                                 cond = builder->CreateICmpSLT(descriptor_length, pointer_length);
                             }
-                            llvm_utils->generate_runtime_error(cond,
+                            llvm_utils->generate_runtime_error2(cond,
                                     "Array shape mismatch in subroutine '%s'. Tried to match size %d of dimension %d of argument number %d, but expected size is %d",
+                                    {diag::Label("", {arg_expr->base.loc}),
+                                        function->m_start_name ? diag::Label("Here", {*function->m_start_name}, false): diag::Label("", {}),
+                                        diag::Label("Expected size", {m_dims[j].loc}, false)},
                                     infile,
-                                    arg_expr->base.loc,
                                     location_manager,
                                     LCompilers::create_global_string_ptr(context, *module, *builder, ASRUtils::symbol_name(x.m_name)),
                                     descriptor_length,

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2105,6 +2105,7 @@ namespace LCompilers {
                 if(!fmt_ptr){fmt_ptr = builder->CreateGlobalString("Attempting to allocate already allocated variable!", GLOBAL_ERROR_ID);}
                 fmt_ptr = builder->CreateBitCast(fmt_ptr, llvm::Type::getInt8Ty(context)->getPointerTo());
             }
+            // TODO: Use new llvm_utils->generate_runtime_error api here
             print_error(context, *module, *builder, {fmt_ptr});
             const int exit_code_int = 1;
             llvm::Value *exit_code = llvm::ConstantInt::get(context, llvm::APInt(32, exit_code_int));

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -336,6 +336,100 @@ class ASRToLLVMVisitor;
                 }
                 start_new_block(mergeBB);
             }
+
+            template<typename... Args>
+            void generate_runtime_error2(llvm::Value* cond, std::string message, std::vector<diag::Label> labels, std::string &infile, LocationManager& lm, Args... args)
+            {
+                llvm::Function *fn = builder->GetInsertBlock()->getParent();
+
+                llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
+                llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
+
+                builder->CreateCondBr(cond, thenBB, mergeBB);
+                builder->SetInsertPoint(thenBB); {
+                        llvm::Type *span_type = llvm::StructType::get(context, llvm::ArrayRef<llvm::Type *>({
+                            llvm::Type::getInt8Ty(context)->getPointerTo(),
+                            llvm::Type::getInt32Ty(context),
+                            llvm::Type::getInt32Ty(context),
+                            llvm::Type::getInt32Ty(context),
+                            llvm::Type::getInt32Ty(context),
+                        }));
+                        llvm::Type *label_type = llvm::StructType::get(context, llvm::ArrayRef<llvm::Type *>({
+                            llvm::Type::getInt1Ty(context),
+                            llvm::Type::getInt8Ty(context)->getPointerTo(),
+                            span_type->getPointerTo(),
+                            llvm::Type::getInt32Ty(context),
+                        }));
+
+                        // Allocate and populate labels and spans
+                        llvm::Type *label_arr_type = llvm::ArrayType::get(label_type, labels.size());
+                        llvm::Value *labels_v = builder->CreateAlloca(label_arr_type);
+                        for (size_t i = 0; i < labels.size(); i++) {
+                            llvm::Value *idx = llvm::ConstantInt::get(context, llvm::APInt(32, i));
+
+                            llvm::Type *span_arr_type = llvm::ArrayType::get(span_type, labels[i].spans.size());
+                            llvm::Value *spans_v = builder->CreateAlloca(span_arr_type);
+                            for (size_t j = 0; j < labels[i].spans.size(); j++) {
+                                llvm::Value *span_idx = llvm::ConstantInt::get(context, llvm::APInt(32, j));
+                                llvm::Value *span_j = LLVMUtils::CreateInBoundsGEP2(span_arr_type, spans_v, {llvm::ConstantInt::get(context, llvm::APInt(32, 0)), span_idx});
+
+                                uint32_t start_l, start_c, last_l, last_c;
+                                lm.pos_to_linecol(lm.output_to_input_pos(labels[i].spans[j].loc.first, false), start_l, start_c, infile);
+                                lm.pos_to_linecol(lm.output_to_input_pos(labels[i].spans[j].loc.last, false), last_l, last_c, infile);
+
+                                builder->CreateStore(LCompilers::create_global_string_ptr(context, *module, *builder, infile),
+                                        LLVMUtils::CreateGEP2(span_type, span_j, 0));
+                                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, start_l)),
+                                        LLVMUtils::CreateGEP2(span_type, span_j, 1));
+                                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, start_c)),
+                                        LLVMUtils::CreateGEP2(span_type, span_j, 2));
+                                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, last_l)),
+                                        LLVMUtils::CreateGEP2(span_type, span_j, 3));
+                                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, last_c)),
+                                        LLVMUtils::CreateGEP2(span_type, span_j, 4));
+                            }
+
+                            llvm::Value *label_i = LLVMUtils::CreateInBoundsGEP2(label_arr_type, labels_v, {llvm::ConstantInt::get(context, llvm::APInt(32, 0)), idx});
+                            builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(1, labels[i].primary)),
+                                    LLVMUtils::CreateGEP2(label_type, label_i, 0));
+                            builder->CreateStore(LCompilers::create_global_string_ptr(context, *module, *builder, labels[i].message),
+                                    LLVMUtils::CreateGEP2(label_type, label_i, 1));
+                            builder->CreateStore(LLVMUtils::CreateGEP2(span_arr_type, spans_v, 0),
+                                    LLVMUtils::CreateGEP2(label_type, label_i, 2));
+                            builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, labels[i].spans.size())),
+                                    LLVMUtils::CreateGEP2(label_type, label_i, 3));
+                        }
+
+
+                        llvm::Value* formatted_msg = create_global_string_ptr(context, *module, *builder, message);
+                        llvm::Function* print_error_fn = module->getFunction("_lcompilers_runtime_error");
+                        if (!print_error_fn) {
+                            llvm::FunctionType* error_fn_type = llvm::FunctionType::get(
+                                llvm::Type::getVoidTy(context),
+                                {label_type->getPointerTo(), llvm::Type::getInt32Ty(context), llvm::Type::getInt8Ty(context)->getPointerTo()},
+                                true);
+                            print_error_fn = llvm::Function::Create(error_fn_type,
+                                llvm::Function::ExternalLinkage, "_lcompilers_runtime_error", module);
+                        }
+
+                        std::vector<llvm::Value*> vec = {LLVMUtils::CreateGEP2(label_arr_type, labels_v, 0), llvm::ConstantInt::get(context, llvm::APInt(32, labels.size())), formatted_msg, args...};
+                        builder->CreateCall(print_error_fn, vec);
+
+                        llvm::Function* exit_fn = module->getFunction("exit");
+                        if (!exit_fn) {
+                            llvm::FunctionType* exit_fn_type = llvm::FunctionType::get(
+                                llvm::Type::getVoidTy(context),
+                                {llvm::Type::getInt32Ty(context)},
+                                false);
+                            exit_fn = llvm::Function::Create(exit_fn_type,
+                                llvm::Function::ExternalLinkage, "exit", module);
+                        }
+
+                        builder->CreateCall(exit_fn, {llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 1)});
+                        builder->CreateUnreachable();
+                }
+                start_new_block(mergeBB);
+            }
             std::string get_llvm_type_as_string(llvm::Type* type);
             /*
                 * Checker for the desired type while operating on array of strings.

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -370,6 +370,21 @@ LFORTRAN_API void _lfortran_namelist_read_str(
     lfortran_nml_group_t *group
 );
 
+typedef struct Span {
+    const char *filename;
+    uint32_t start_l, start_c;
+    uint32_t last_l, last_c;
+} Span;
+
+typedef struct Label {
+    bool primary;
+    const char *message;
+    Span *spans;
+    uint32_t n_spans;
+} Label;
+
+LFORTRAN_API void _lcompilers_runtime_error(Label *labels, uint32_t n_labels, const char* format, ...);
+
 // IOSTAT error codes for namelist operations
 #define LFORTRAN_IOSTAT_NML_FORMATTED_FILE_REQUIRED 5001  // Binary file (formatted required)
 #define LFORTRAN_IOSTAT_NML_READ_NOT_ALLOWED        5002  // Read access not allowed

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_45-ae31b1c.stdout",
-    "stdout_hash": "3eaf80f773641f175779f0607c05883d15a19674c63d8ec13deff587",
+    "stdout_hash": "b4435b2f653dd727492accbe652816ca097d681e7dc5f1d32affcd43",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -4,7 +4,7 @@ source_filename = "LFortran"
 %myint = type { i32 }
 
 @0 = private unnamed_addr constant [4 x i8] c"ins\00", align 1
-@1 = private unnamed_addr constant [132 x i8] c"At 15:9 of file tests/../integration_tests/derived_types_45.f90\0ARuntime error: Tried to access member of unallocated variable '%s'\0A\00", align 1
+@1 = private unnamed_addr constant [117 x i8] c"At 15:9 of file tests/../integration_tests/derived_types_45.f90\0ATried to access member of unallocated variable '%s'\0A\00", align 1
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -55,7 +55,7 @@ ifcont3:                                          ; preds = %else2, %then1
   br i1 %16, label %then4, label %ifcont5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([132 x i8], [132 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 

--- a/tests/reference/run-array_bounds_check_04-2e3d8fb.json
+++ b/tests/reference/run-array_bounds_check_04-2e3d8fb.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-array_bounds_check_04-2e3d8fb.stderr",
-    "stderr_hash": "f1dcf250cd3801e0db325b853cb73dd4c501e9cd7c4601abb6f7a6b2",
+    "stderr_hash": "c778c1673e461f4dd300f5de7467455536dc0888887ea0b01bb0ee3e",
     "returncode": 1
 }

--- a/tests/reference/run-array_bounds_check_04-2e3d8fb.stderr
+++ b/tests/reference/run-array_bounds_check_04-2e3d8fb.stderr
@@ -2,4 +2,7 @@ runtime error: Array shape mismatch in subroutine 'my'. Tried to match size 4 of
  --> tests/errors/array_bounds_check_04.f90:5:13
   |
 5 |     call my(x)
-  |             ^^ 
+  |             ^
+   |
+10 |             integer, intent(in) :: x(3, 1)
+   |                                         ~ Expected size

--- a/tests/reference/run-array_bounds_check_05-d584fab.json
+++ b/tests/reference/run-array_bounds_check_05-d584fab.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-array_bounds_check_05-d584fab.stderr",
-    "stderr_hash": "b14af37d75ce122d7893b31f0ee5c8eaa77caa6cbb359700e8721711",
+    "stderr_hash": "69eb012c41f31bdbfc6e598a8297991a41eb8520fcb2b0da4f440108",
     "returncode": 1
 }

--- a/tests/reference/run-array_bounds_check_05-d584fab.stderr
+++ b/tests/reference/run-array_bounds_check_05-d584fab.stderr
@@ -2,4 +2,7 @@ runtime error: Array shape mismatch in subroutine 'my'. Tried to match size 3 of
  --> tests/errors/array_bounds_check_05.f90:7:13
   |
 7 |     call my(x, 5)
-  |             ^^ 
+  |             ^
+  |
+7 |     call my(x, 5)
+  |             ~ Expected size

--- a/tests/reference/run-array_bounds_check_08-7f7acdd.json
+++ b/tests/reference/run-array_bounds_check_08-7f7acdd.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-array_bounds_check_08-7f7acdd.stderr",
-    "stderr_hash": "4d95ef5d21613c332503741401d3418164c7fcba702c6b7ace50b80a",
+    "stderr_hash": "b7a76901c54befdd081b5c0540c7b45a8db729d29b1526e60cc9936e",
     "returncode": 1
 }

--- a/tests/reference/run-array_bounds_check_08-7f7acdd.stderr
+++ b/tests/reference/run-array_bounds_check_08-7f7acdd.stderr
@@ -2,4 +2,10 @@ runtime error: Array shape mismatch in subroutine 'ff'. Tried to match size 5 of
  --> tests/errors/array_bounds_check_08.f90:4:3
   |
 4 |   arr = ff()
-  |   ^^^ 
+  |   ^^^
+  |
+8 |     function ff() result(res)
+  |              ~~ Here
+  |
+9 |         integer :: res(100000)
+  |                        ~~~~~~ Expected size

--- a/tests/reference/run-array_bounds_check_12-4cdd01e.json
+++ b/tests/reference/run-array_bounds_check_12-4cdd01e.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-array_bounds_check_12-4cdd01e.stderr",
-    "stderr_hash": "b265a4ac0f9d31a03396b122604180fda2cbe95a9673cea509b66c15",
+    "stderr_hash": "4d031a17be5cda4d79776c0a721bc6100c766428d0b0ba18329d39bf",
     "returncode": 1
 }

--- a/tests/reference/run-array_bounds_check_12-4cdd01e.stderr
+++ b/tests/reference/run-array_bounds_check_12-4cdd01e.stderr
@@ -2,4 +2,7 @@ runtime error: Array shape mismatch in subroutine 'f_integer____0'. Tried to mat
  --> tests/errors/array_bounds_check_12.f90:8:5
   |
 8 |     e = f(a)
-  |     ^ 
+  |     ^
+  |
+8 |     e = f(a)
+  |     ~ Expected size

--- a/tests/reference/run-scalar_allocation_check_03-a66333c.json
+++ b/tests/reference/run-scalar_allocation_check_03-a66333c.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-scalar_allocation_check_03-a66333c.stderr",
-    "stderr_hash": "e874d277b26d81511c96df7a67afc3010ec313dd9d8b120bfef45d54",
+    "stderr_hash": "af018038d9c7ebbafdd09b0e04a876cf371595d7349e982bf850349d",
     "returncode": 1
 }

--- a/tests/reference/run-scalar_allocation_check_03-a66333c.stderr
+++ b/tests/reference/run-scalar_allocation_check_03-a66333c.stderr
@@ -1,4 +1,4 @@
-runtime error: Runtime error: Tried to access member of unallocated variable 'var'
+runtime error: Tried to access member of unallocated variable 'var'
 
   --> tests/errors/scalar_allocation_check_03.f90:10:14
    |


### PR DESCRIPTION
Fix https://github.com/lfortran/lfortran/issues/9526

I've modified one call of `llvm_utils->generate_runtime_error()` to the new api call `llvm_utils->generate_runtime_error2()` for demonstration. In some cases the location info is wrong, that needs fixing.
